### PR TITLE
Add All Contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![All Contributors](https://img.shields.io/github/all-contributors/IMAP-Science-Operations-Center/imap_processing?color=ee8449&style=flat-square)](#contributors)
+
 # IMAP (Interstellar Mapping and Acceleration Probe)
 The Interstellar Mapping and Acceleration Probe (IMAP) is an exciting project aimed at studying the interstellar medium and investigating the acceleration mechanisms of particles within our galaxy. IMAP utilizes cutting-edge technology and advanced instrumentation to gather valuable data and expand our understanding of space.
 
@@ -11,3 +13,15 @@ Join the IMAP Git repository to be part of an exciting scientific endeavor, cont
 
 # Credits
 [LASP (Laboratory of Atmospheric and Space Physics)](https://lasp.colorado.edu/)
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds a section to the README that should us to use the `@all-contributors` bot to automatically add contributors to the repo (whether by direct code changes, or by other means) in the form of a nice looking table.

## Updated Files
- `README.md`
   - A new `Contributors` section is added to the bottom of the file containing boiler-plate configuration needed by `@all-contributors` bot

## Testing
We can hopefully test this by summoning the `@all-contributors` bot (e.g. comment on the PR with `@all-contributors please add @bourque for code` (See [usage docs](https://allcontributors.org/docs/en/bot/usage))

Closes #22 