### PR TITLE
Added yaml file for read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc
+
+


### PR DESCRIPTION
# Change Summary

## Overview
Added a yaml file `.readthedocs.yaml` to the root directory so readthedocs.org knows to install the optional dependencies for building documentation

## New Dependencies
None

## New Files
- .readthedocs.yaml
   - yaml file to tell readthedocs.org to pip install the optional doc dependencies

## Deleted Files
None

## Updated Files
None

## Testing
I added my forked repository to readthedocs and it was able to build the documentation 
https://imap-processing-fork.readthedocs.io/en/latest/
