### PR TITLE
adding module path in imap_processing - fixes

### DIFF
--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -1,1 +1,13 @@
 __version__ = "0.1.0"
+
+# When imap_processing is installed using pip, we need to be able to find the
+# packet definitions directory path.
+#
+# This directory is used by the imap_processing package to find the packet definitions.
+from pathlib import Path
+
+# Eg. imap_module_directory = /usr/local/lib/python3.11/site-packages/imap_processing
+imap_module_directory = Path(__file__).parent
+
+# Relative to imap_module_directory, set path of packet definitions directory.
+packet_definition_directory = f"{imap_module_directory}/packet_definitions/"

--- a/imap_processing/swe/decom_swe.py
+++ b/imap_processing/swe/decom_swe.py
@@ -1,4 +1,4 @@
-from imap_processing import decom
+from imap_processing import decom, packet_definition_directory
 
 
 def decom_packets(packet_file: str):
@@ -13,5 +13,5 @@ def decom_packets(packet_file: str):
     List
         List of all the unpacked data
     """
-    xtce_document = "imap_processing/packet_definitions/swe_packet_definition.xml"
+    xtce_document = f"{packet_definition_directory}/swe_packet_definition.xml"
     return decom.decom_packets(packet_file, xtce_document)


### PR DESCRIPTION
# Change Summary
Adding imap_processing module path in the imap_processing __init__.py file and using it in decom code. 

## Overview
This issue came up when I was trying to install imap_processing in a dockerfile using pip and then calling decom code. Previously, I have hard coded the path and it become irrelevant when it was installed using pip.

## Updated Files
- imap_processing/__init__.py
   - Add way to get current path where imap-procesing pip module is located
- imap_processing/swe/decom_swe.py
   - use above path to point to swe's decom packet definition

