### PR TITLE
Lo Packet Definitions

### DIFF
--- a/imap_processing/lo/l0/packet_definitions/BOOT_HK.xml
+++ b/imap_processing/lo/l0/packet_definitions/BOOT_HK.xml
@@ -1,0 +1,324 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_BOOT_HK">
+	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint4" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint5" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="5" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint8" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary header, mission elapsed time</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BOOT_VER" parameterTypeRef="uint8">
+				<xtce:LongDescription>Boot FSW version</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BOOT_CNT" parameterTypeRef="uint8">
+				<xtce:LongDescription>Number of boot attempts</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BIST_STAT" parameterTypeRef="uint32">
+				<xtce:LongDescription>Built-In-Self-Test status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BIST_ABUS" parameterTypeRef="uint32">
+				<xtce:LongDescription>Built-In-Self-Test Address bus fail mask</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BIST_DBUS" parameterTypeRef="uint32">
+				<xtce:LongDescription>Built-In-Self-Test Data bus fail mask</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BIST_MEM_FF" parameterTypeRef="uint32">
+				<xtce:LongDescription>Built-In-Self-Test memory fail first location</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BIST_MEM_FL" parameterTypeRef="uint32">
+				<xtce:LongDescription>Built-In-Self-Test memory fail last location</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BIST_MEM_MAP" parameterTypeRef="uint32">
+				<xtce:LongDescription>Built-In-Self-Test memory map</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BIST_MEM_CNT" parameterTypeRef="uint32">
+				<xtce:LongDescription>Built-In-Self-Test memory error count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IMG_1_STAT" parameterTypeRef="uint1">
+				<xtce:LongDescription>App FSW image 1 checksum status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IMG_2_STAT" parameterTypeRef="uint1">
+				<xtce:LongDescription>App FSW image 2 checksum status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TAB_1_STAT" parameterTypeRef="uint1">
+				<xtce:LongDescription>Table 1 checksum status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TAB_2_STAT" parameterTypeRef="uint1">
+				<xtce:LongDescription>Table 2 checksum status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE_0" parameterTypeRef="uint4">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FSW_IMG_VER" parameterTypeRef="uint8">
+				<xtce:LongDescription>BOOT_HK.FSW_IMG_VER</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TABLE_IMG_VER" parameterTypeRef="uint8">
+				<xtce:LongDescription>BOOT_HK.TABLE_IMG_VER</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INSTR_ID" parameterTypeRef="uint4">
+				<xtce:LongDescription>Instrument ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE_1" parameterTypeRef="uint4">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FPGA_VER" parameterTypeRef="uint8">
+				<xtce:LongDescription>CDH FPGA version</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HV_LIM" parameterTypeRef="uint1">
+				<xtce:LongDescription>High voltage limit plug status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HV_DIS" parameterTypeRef="uint1">
+				<xtce:LongDescription>High voltage disable plug status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DOOR_DIS" parameterTypeRef="uint1">
+				<xtce:LongDescription>Front panel door disable plug status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE_2" parameterTypeRef="uint5">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP_1" parameterTypeRef="uint16">
+				<xtce:LongDescription>System temperature monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP_2" parameterTypeRef="uint16">
+				<xtce:LongDescription>System temperature monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP_3" parameterTypeRef="uint16">
+				<xtce:LongDescription>System temperature monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP_1" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS temperature monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP_2" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS temperature monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP_3" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS temperature monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V1" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS voltage monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V2" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS voltage monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V3" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS voltage monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V4" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS voltage monitor 4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V5" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS voltage monitor 5</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I1" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS current monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I2" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS current monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I3" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS current monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I4" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS current monitor 4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I5" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS current monitor 5</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_1P5V" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH 1.5V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_1P8V" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH 1.8V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_3P3V" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH 3.3V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_N12V" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH +12V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_P12V" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH -12V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_5V" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH 5V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_ANA_REF" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH analog ref voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP_1" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH temperature 1 monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP_2" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH temperature 2 monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP_3" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH temperature 3 monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP_4" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH temperature 4 monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="OP_MODE" parameterTypeRef="uint8">
+				<xtce:LongDescription>Current operating mode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_ACC_CNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>Accepted commands count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_REJ_CNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>Rejected commands count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_ACC_OPC" parameterTypeRef="uint16">
+				<xtce:LongDescription>Accepted command opcode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_REJ_OPC" parameterTypeRef="uint16">
+				<xtce:LongDescription>Rejected command opcode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_RESULT" parameterTypeRef="uint32">
+				<xtce:LongDescription>Command result</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ITF_ERR_CNT" parameterTypeRef="uint8">
+				<xtce:LongDescription>ITF error counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_BOOT_HK">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="BOOT_VER"/>
+					<xtce:ParameterRefEntry parameterRef="BOOT_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="BIST_STAT"/>
+					<xtce:ParameterRefEntry parameterRef="BIST_ABUS"/>
+					<xtce:ParameterRefEntry parameterRef="BIST_DBUS"/>
+					<xtce:ParameterRefEntry parameterRef="BIST_MEM_FF"/>
+					<xtce:ParameterRefEntry parameterRef="BIST_MEM_FL"/>
+					<xtce:ParameterRefEntry parameterRef="BIST_MEM_MAP"/>
+					<xtce:ParameterRefEntry parameterRef="BIST_MEM_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="IMG_1_STAT"/>
+					<xtce:ParameterRefEntry parameterRef="IMG_2_STAT"/>
+					<xtce:ParameterRefEntry parameterRef="TAB_1_STAT"/>
+					<xtce:ParameterRefEntry parameterRef="TAB_2_STAT"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE_0"/>
+					<xtce:ParameterRefEntry parameterRef="FSW_IMG_VER"/>
+					<xtce:ParameterRefEntry parameterRef="TABLE_IMG_VER"/>
+					<xtce:ParameterRefEntry parameterRef="INSTR_ID"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE_1"/>
+					<xtce:ParameterRefEntry parameterRef="FPGA_VER"/>
+					<xtce:ParameterRefEntry parameterRef="HV_LIM"/>
+					<xtce:ParameterRefEntry parameterRef="HV_DIS"/>
+					<xtce:ParameterRefEntry parameterRef="DOOR_DIS"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE_2"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP_1"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP_2"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP_3"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP_1"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP_2"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP_3"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V1"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V2"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V3"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V4"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V5"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I1"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I2"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I3"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I4"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I5"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_1P5V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_1P8V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_3P3V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_N12V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_P12V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_5V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_ANA_REF"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP_1"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP_2"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP_3"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP_4"/>
+					<xtce:ParameterRefEntry parameterRef="OP_MODE"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_ACC_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_REJ_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_ACC_OPC"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_REJ_OPC"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_RESULT"/>
+					<xtce:ParameterRefEntry parameterRef="ITF_ERR_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/BOOT_HK.xml
+++ b/imap_processing/lo/l0/packet_definitions/BOOT_HK.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_BOOT_HK">
-	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/BOOT_MEMDMP.xml
+++ b/imap_processing/lo/l0/packet_definitions/BOOT_MEMDMP.xml
@@ -1,0 +1,107 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_BOOT_MEMDMP">
+	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte16384" shortDescription="Binary data type">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN"/>
+              				<xtce:LinearAdjustment intercept="-160" slope="8"/>
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary header, mission elapsed time</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ADDR" parameterTypeRef="uint32">
+				<xtce:LongDescription>Starting address of memory dump</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LEN" parameterTypeRef="uint32">
+				<xtce:LongDescription>Byte length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DATA" parameterTypeRef="byte16384">
+				<xtce:LongDescription>Memory dump data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_BOOT_MEMDMP">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="ADDR"/>
+					<xtce:ParameterRefEntry parameterRef="LEN"/>
+					<xtce:ParameterRefEntry parameterRef="DATA"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/BOOT_MEMDMP.xml
+++ b/imap_processing/lo/l0/packet_definitions/BOOT_MEMDMP.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_BOOT_MEMDMP">
-	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_APP_NHK.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_APP_NHK.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_APP_NHK">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_APP_NHK.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_APP_NHK.xml
@@ -1,0 +1,732 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_APP_NHK">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint4" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint8" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint15" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="OP_MODE" parameterTypeRef="uint8">
+				<xtce:LongDescription>Current operating mode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MEM_OP_STATE" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_NHK.MEM_OP_STATE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MEM_DUMP_STATE" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_NHK.MEM_DUMP_STATE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_EXE_CNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>Accepted commands count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_REJ_CNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>Rejected commands count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_EXE_OPC" parameterTypeRef="uint16">
+				<xtce:LongDescription>Accepted command opcode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ITF_ERR_CNT" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.ITF_ERR_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_CNT" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_APP_NHK.SPIN_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MISSED_PPS_CNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.MISSED_PPS_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CPU_UTIL" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CPU_UTIL</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="WATCHDOG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_WATCHDOG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP1" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_SYS_TEMP1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP2" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_SYS_TEMP2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP3" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_SYS_TEMP3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LO_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_LO_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP1" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_TEMP1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP2" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_TEMP2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP3" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_TEMP3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V1" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_V1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V2" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_V2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V3" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_V3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V4" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_V4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V5" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_V5</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I1" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_I1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I2" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_I2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I3" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_I3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I4" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_I4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I5" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LVPS_I5</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_1P5V" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_1P5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_1P8V" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_1P8V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_3P3V" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_3P3V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_12VP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_12VP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_12VN" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_12VN</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_5V" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_ANA_REF" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_ANA_REF</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP1" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_TEMP1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP2" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_TEMP2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP3" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_TEMP3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP4" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_TEMP4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SC_CMD_FIFO_STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>S/C Command FIFO error flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SC_TLM_FIFO_STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>S/C Telemetry FIFO error flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_BIN_PERIOD" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.SPIN_BIN_PERIOD</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_BIN_IDX" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.SPIN_BIN_IDX</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_PERIOD" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.SPIN_PERIOD</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_PERIOD_TIMER" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.SPIN_PERIOD_TIMER</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_TIME_STAMP_SEC" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_APP_NHK.SPIN_TIME_STAMP_SECONDS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_TIME_STAMP_SUBSEC" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_APP_NHK.SPIN_TIME_STAMP_SUBSECONDS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_HEATER_STATUS" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_HEATER_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INSTR_PWR_STATUS" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_INSTR_PWR_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_INTERFACE_CTRL_STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_IFB_INTERFACE_CTRL_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_ADC_TLM_STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_IFB_ADC_TLM_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_TLM_STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_IFB_TLM_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_INTERFACE_STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_TOF_INTERFACE_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DE_TIME_TAG_CTRL_STATUS" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_DE_TIME_TAG_CTRL_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DE_FIFO_CTRL_STATUS" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_DE_FIFO_CTRL_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HVPS_STATUS" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_HVPS_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PIVOT_INTERFACE_CTRL" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_PIVOT_INTERFACE_CTRL</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PIVOT_INTERFACE_STATUS" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_NHK.CDH_PIVOT_INTERFACE_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_CMD_COUNT" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.CMD_COUNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_CTRL" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_CTRL</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_DATA_INTERVAL" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_DATA_INTERVAL</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_HVPS_CTRL" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_HVPS_CTRL</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_VSET" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.PAC_VSET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_OCP" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.PAC_OCP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_VSET" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.MCP_VSET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_OCP" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.MCP_OCP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STAR_OFFSET_ADJUST" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.STAR_OFFSET_ADJUST</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="OSCOPE_CH_SEL" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.OSCOPE_CH_SEL</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_TEMP1" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_TEMP1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_TEMP0" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_TEMP0</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V5P0_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_V5P0_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V3P3_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_V3P3_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V12P0_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_V12P0_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V12N0_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_V12N0_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LV_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LV_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LV_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LV_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LV_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.LV_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.MCP_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.MCP_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.MCP_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PAC_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PAC_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PAC_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_AUX_ADC" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.IFB_AUX_ADC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_CMD_ERROR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.CMD_ERROR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_CFD_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_CFD_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_PRE_TM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_PRE_TM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_TM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_TM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_MCP_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_MCP_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_MCP_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_MCP_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_P5_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_P5_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_P6_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_P6_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_A_THR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.AN_A_THR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_B0_THR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.AN_B0_THR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_B3_THR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.AN_B3_THR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_C_THR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.AN_C_THR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_BD_CTRL" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.TOF_BD_CTRL</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STIM_CTRL" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.STIM_CTRL</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STIM_CNFG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.STIM_CNFG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_TOF3_THR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.AN_TOF3_THR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_TOF2_THR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.AN_TOF2_THR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_TOF1_THR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.AN_TOF1_THR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_TOF0_THR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.AN_TOF0_THR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_STATUS" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_GPO" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_GPO</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DAC0" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DAC0</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DAC1" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DAC1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DAC2" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DAC2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DAC3" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DAC3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DAC4" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DAC4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_ADC_CTRL_STATUS" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_ADC_CTRL_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_HVPS_BULK_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_HVPS_BULK_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_U_NEG_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_U_NEG_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_U_POS_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_U_POS_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DEF_NEG_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DEF_NEG_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DEF_POS_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DEF_POS_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_PMT_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_PMT_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_PMT_IMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_PMT_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_BULK_IMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_BULK_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DEF_NEG_IMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DEF_NEG_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_DEF_POS_IMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_DEF_POS_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_REF1_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_REF1_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_REF2_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_REF2_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_P12P0_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_P12P0_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_N12P0_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_N12P0_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_P3P3_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_P3P3_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_P1P5_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.BULK_HVPS_P1P5_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_COARSE_POT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_COARSE_POT_PRI</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_FINE_POT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_FINE_POT_PRI</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_COARSE_POT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_COARSE_POT_RED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_FINE_POT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_FINE_POT_RED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_ACTUATOR_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_ACTUATOR_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_PCC_BOARD_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_PCC_BOARD_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_MOTOR_CURRENT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_MOTOR_CURRENT_PRI</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_MOTOR_CURRENT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_MOTOR_CURRENT_RED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_CUMULATIVE_CNT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_CUMULATIVE_CNT_PRI</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_CUMULATIVE_CNT_SGN_PRI" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_PRI</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_CUMULATIVE_CNT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_CUMULATIVE_CNT_RED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_CUMULATIVE_CNT_SGN_RED" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_RED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_CURRENT_STEP_CNT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_CURRENT_STEP_CNT_PRI</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_CURRENT_STEP_CNT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_CURRENT_STEP_CNT_RED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_CURRENT_SETPT_PRI" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_CURRENT_SETPT_PRI</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_CURRENT_SETPT_RED" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_CURRENT_SETPT_RED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.PCC_STATUS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MACRO_STATUS" parameterTypeRef="uint32">
+				<xtce:LongDescription>TBD - Placeholder for Macro status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_TRIGGER_CNT_CAT_1" parameterTypeRef="uint2">
+				<xtce:LongDescription>Indicates whether any CATEGORY 1 limits have triggered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_TRIGGER_CNT_CAT_2" parameterTypeRef="uint2">
+				<xtce:LongDescription>Indicates whether any CATEGORY 2 limits have triggered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_TRIGGER_CNT_CAT_3" parameterTypeRef="uint2">
+				<xtce:LongDescription>Indicates whether any CATEGORY 3 limits have triggered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_TRIGGER_CNT_CAT_4" parameterTypeRef="uint2">
+				<xtce:LongDescription>Indicates whether any CATEGORY 4 limits have triggered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_TRIGGER_CNT_CAT_5" parameterTypeRef="uint2">
+				<xtce:LongDescription>Indicates whether any CATEGORY 5 limits have triggered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_TRIGGER_CNT_CAT_6" parameterTypeRef="uint2">
+				<xtce:LongDescription>Indicates whether any CATEGORY 6 limits have triggered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_TRIGGER_CNT_CAT_7" parameterTypeRef="uint2">
+				<xtce:LongDescription>Indicates whether any CATEGORY 7 limits have triggered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_TRIGGER_CNT_CAT_8" parameterTypeRef="uint2">
+				<xtce:LongDescription>Indicates whether any CATEGORY 8 limits have triggered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_LAST_TRIGGER_MINMAX" parameterTypeRef="uint1">
+				<xtce:LongDescription>Indicates whether the most recent trigger was a minimum or maximum limit</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_LAST_TRIGGER_ID" parameterTypeRef="uint15">
+				<xtce:LongDescription>Indicates the ID of the most recent FDC trigger</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FDR_LAST_TRIGGER_ACTION" parameterTypeRef="uint8">
+				<xtce:LongDescription>Indicates the action that was taken for the most recent FDC trigger</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_NHK.SPARE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>CRC-16 Checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_APP_NHK">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="OP_MODE"/>
+					<xtce:ParameterRefEntry parameterRef="MEM_OP_STATE"/>
+					<xtce:ParameterRefEntry parameterRef="MEM_DUMP_STATE"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_EXE_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_REJ_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_EXE_OPC"/>
+					<xtce:ParameterRefEntry parameterRef="ITF_ERR_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="MISSED_PPS_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="CPU_UTIL"/>
+					<xtce:ParameterRefEntry parameterRef="WATCHDOG"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP1"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP2"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP3"/>
+					<xtce:ParameterRefEntry parameterRef="LO_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP1"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP2"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP3"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V1"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V2"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V3"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V4"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V5"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I1"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I2"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I3"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I4"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I5"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_1P5V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_1P8V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_3P3V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_12VP"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_12VN"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_5V"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_ANA_REF"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP1"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP2"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP3"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP4"/>
+					<xtce:ParameterRefEntry parameterRef="SC_CMD_FIFO_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="SC_TLM_FIFO_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_BIN_PERIOD"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_BIN_IDX"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_PERIOD"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_PERIOD_TIMER"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_TIME_STAMP_SEC"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_TIME_STAMP_SUBSEC"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_HEATER_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="INSTR_PWR_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_INTERFACE_CTRL_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_ADC_TLM_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_TLM_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_INTERFACE_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="DE_TIME_TAG_CTRL_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="DE_FIFO_CTRL_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="HVPS_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="PIVOT_INTERFACE_CTRL"/>
+					<xtce:ParameterRefEntry parameterRef="PIVOT_INTERFACE_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_CMD_COUNT"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_CTRL"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_DATA_INTERVAL"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_HVPS_CTRL"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_VSET"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_OCP"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_VSET"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_OCP"/>
+					<xtce:ParameterRefEntry parameterRef="STAR_OFFSET_ADJUST"/>
+					<xtce:ParameterRefEntry parameterRef="OSCOPE_CH_SEL"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_TEMP1"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_TEMP0"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V5P0_VM"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V3P3_VM"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V12P0_VM"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V12N0_VM"/>
+					<xtce:ParameterRefEntry parameterRef="LV_CM"/>
+					<xtce:ParameterRefEntry parameterRef="LV_VM"/>
+					<xtce:ParameterRefEntry parameterRef="LV_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_CM"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_VM"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_CM"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_VM"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_AUX_ADC"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_CMD_ERROR"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_CFD_VM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_PRE_TM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_TM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_MCP_CM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_MCP_VM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_CM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_P5_VM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_P6_VM"/>
+					<xtce:ParameterRefEntry parameterRef="AN_A_THR"/>
+					<xtce:ParameterRefEntry parameterRef="AN_B0_THR"/>
+					<xtce:ParameterRefEntry parameterRef="AN_B3_THR"/>
+					<xtce:ParameterRefEntry parameterRef="AN_C_THR"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_BD_CTRL"/>
+					<xtce:ParameterRefEntry parameterRef="STIM_CTRL"/>
+					<xtce:ParameterRefEntry parameterRef="STIM_CNFG"/>
+					<xtce:ParameterRefEntry parameterRef="AN_TOF3_THR"/>
+					<xtce:ParameterRefEntry parameterRef="AN_TOF2_THR"/>
+					<xtce:ParameterRefEntry parameterRef="AN_TOF1_THR"/>
+					<xtce:ParameterRefEntry parameterRef="AN_TOF0_THR"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_GPO"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DAC0"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DAC1"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DAC2"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DAC3"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DAC4"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_ADC_CTRL_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_HVPS_BULK_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_U_NEG_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_U_POS_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DEF_NEG_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DEF_POS_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_PMT_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_PMT_IMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_BULK_IMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DEF_NEG_IMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_DEF_POS_IMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_REF1_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_REF2_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_P12P0_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_N12P0_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_P3P3_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_P1P5_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_COARSE_POT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_FINE_POT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_COARSE_POT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_FINE_POT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_ACTUATOR_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_PCC_BOARD_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_MOTOR_CURRENT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_MOTOR_CURRENT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_CUMULATIVE_CNT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_CUMULATIVE_CNT_SGN_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_CUMULATIVE_CNT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_CUMULATIVE_CNT_SGN_RED"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_CURRENT_STEP_CNT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_CURRENT_STEP_CNT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_CURRENT_SETPT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_CURRENT_SETPT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="MACRO_STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_TRIGGER_CNT_CAT_1"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_TRIGGER_CNT_CAT_2"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_TRIGGER_CNT_CAT_3"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_TRIGGER_CNT_CAT_4"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_TRIGGER_CNT_CAT_5"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_TRIGGER_CNT_CAT_6"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_TRIGGER_CNT_CAT_7"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_TRIGGER_CNT_CAT_8"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_LAST_TRIGGER_MINMAX"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_LAST_TRIGGER_ID"/>
+					<xtce:ParameterRefEntry parameterRef="FDR_LAST_TRIGGER_ACTION"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_APP_SHK.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_APP_SHK.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_APP_SHK">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_APP_SHK.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_APP_SHK.xml
@@ -1,0 +1,156 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_APP_SHK">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint4" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint8" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_JUMPER_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_APP_SHK.CDH_JUMPER_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INSTR_ID" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.INSTR_ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_FPGA_VERSION" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.CDH_FPGA_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_FPGA_VERSION" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.IFB_FPGA_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_HVPS_VERSION" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_SHK.BULK_HVPS_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FSW_VERSION" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.FSW_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TABLE_VERSION" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.TABLE_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SELECTED_CODE_IMAGE" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.SELECTED_CODE_IMAGE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SELECTED_TABLE_IMAGE" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.SELECTED_TABLE_IMAGE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BOOT_COUNTER" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.BOOT_COUNTER</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HV_LIMIT" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_SHK.HV_LIMIT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HV_DISABLE" parameterTypeRef="uint4">
+				<xtce:LongDescription>ILO_APP_SHK.HV_DISABLE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FSW_VER_STR" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_APP_SHK.FSW_VER_STR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ENG_LUT_VER_STR" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_APP_SHK.ENG_LUT_VER_STR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SCI_LUT_VER_STR" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_APP_SHK.SCI_LUT_VER_STR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TIME_TAG_RES" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_APP_SHK.TIME_TAG_RES</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_APP_SHK.CHKSUM</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_APP_SHK">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_JUMPER_REG"/>
+					<xtce:ParameterRefEntry parameterRef="INSTR_ID"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_FPGA_VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_FPGA_VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_HVPS_VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="FSW_VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TABLE_VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="SELECTED_CODE_IMAGE"/>
+					<xtce:ParameterRefEntry parameterRef="SELECTED_TABLE_IMAGE"/>
+					<xtce:ParameterRefEntry parameterRef="BOOT_COUNTER"/>
+					<xtce:ParameterRefEntry parameterRef="HV_LIMIT"/>
+					<xtce:ParameterRefEntry parameterRef="HV_DISABLE"/>
+					<xtce:ParameterRefEntry parameterRef="FSW_VER_STR"/>
+					<xtce:ParameterRefEntry parameterRef="ENG_LUT_VER_STR"/>
+					<xtce:ParameterRefEntry parameterRef="SCI_LUT_VER_STR"/>
+					<xtce:ParameterRefEntry parameterRef="TIME_TAG_RES"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_AUTO.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_AUTO.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_AUTO">
-	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_AUTO.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_AUTO.xml
@@ -1,0 +1,120 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_AUTO">
+	<xtce:Header date="2023-04-25T14:43:03UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint5" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="5" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint6" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE" parameterTypeRef="uint6">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="POWER_CYCLE_REQ" parameterTypeRef="uint1">
+				<xtce:LongDescription>Power cycle request</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="POWER_OFF_REQ" parameterTypeRef="uint1">
+				<xtce:LongDescription>Power off request</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HEATER_CTRL_EN" parameterTypeRef="uint1">
+				<xtce:LongDescription>Wheather FSW heater control is enabled</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HEATER_1_STATE" parameterTypeRef="uint1">
+				<xtce:LongDescription>Current state of Heater 1 output</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HEATER_2_STATE" parameterTypeRef="uint1">
+				<xtce:LongDescription>Current state of Heater 1 output</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE2" parameterTypeRef="uint5">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_AUTO">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE"/>
+					<xtce:ParameterRefEntry parameterRef="POWER_CYCLE_REQ"/>
+					<xtce:ParameterRefEntry parameterRef="POWER_OFF_REQ"/>
+					<xtce:ParameterRefEntry parameterRef="HEATER_CTRL_EN"/>
+					<xtce:ParameterRefEntry parameterRef="HEATER_1_STATE"/>
+					<xtce:ParameterRefEntry parameterRef="HEATER_2_STATE"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE2"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_BULK_HVPS.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_BULK_HVPS.xml
@@ -1,0 +1,196 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_BULK_HVPS">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="VERSION_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.VERSION_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STATUS_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MASTER_EN_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.MASTER_EN_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="GPO_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.GPO_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DAC0_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC0_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DAC1_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC1_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DAC2_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC2_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DAC3_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC3_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DAC4_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC4_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ADC_CTRL_STATUS_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.ADC_CTRL_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ADC1_WAIT_CNT_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.ADC1_WAIT_CNT_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ADC2_WAIT_CNT_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.ADC2_WAIT_CNT_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HVPS_BULK_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.HVPS_BULK_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="U_NEG_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.U_NEG_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="U_POS_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.U_POS_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DEF_NEG_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DEF_NEG_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DEF_POS_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DEF_POS_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PMT_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.PMT_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PMT_IMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.PMT_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="BULK_IMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.BULK_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DEF_NEG_IMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DEF_NEG_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DEF_POS_IMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DEF_POS_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="REF1_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.REF1_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="REF2_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.REF2_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="P12P0_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.P12P0_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="N12P0_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.N12P0_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="P3P3_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.P3P3_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="P1P5_VMON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.P1P5_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_DIAG_BULK_HVPS">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="VERSION_REG"/>
+					<xtce:ParameterRefEntry parameterRef="STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="MASTER_EN_REG"/>
+					<xtce:ParameterRefEntry parameterRef="GPO_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DAC0_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DAC1_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DAC2_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DAC3_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DAC4_REG"/>
+					<xtce:ParameterRefEntry parameterRef="ADC_CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="ADC1_WAIT_CNT_REG"/>
+					<xtce:ParameterRefEntry parameterRef="ADC2_WAIT_CNT_REG"/>
+					<xtce:ParameterRefEntry parameterRef="HVPS_BULK_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="U_NEG_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="U_POS_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="DEF_NEG_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="DEF_POS_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="PMT_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="PMT_IMON"/>
+					<xtce:ParameterRefEntry parameterRef="BULK_IMON"/>
+					<xtce:ParameterRefEntry parameterRef="DEF_NEG_IMON"/>
+					<xtce:ParameterRefEntry parameterRef="DEF_POS_IMON"/>
+					<xtce:ParameterRefEntry parameterRef="REF1_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="REF2_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="P12P0_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="N12P0_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="P3P3_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="P1P5_VMON"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_BULK_HVPS.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_BULK_HVPS.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_BULK_HVPS">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_CDH.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_CDH.xml
@@ -1,0 +1,424 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_CDH">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint8" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="JUMPER_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Control registers - Jumper</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="RESET_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Control registers - Reset</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="WATCHDOG_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Control registers - Watchdog</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CTRL_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Control registers - Control and Status (lower two bytes)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SCRATCHPAD_1_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Scratchpad registers - 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SCRATCHPAD_2_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Scratchpad registers - 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CPU_UART_CLOCK_BAUD_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH CPU UART Clock Buad</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TICK_TIMER_CTRL_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Tick Timers - Tick Timers Control and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TICK_TIMER_RELOAD_COUNT_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Tick Timers - Tick Timer n Reload Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TICK_TIMER_COUNTER_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Tick Timers - Tick Timer n Counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MET_CTRL_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH MET Control - MET Control</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MET_STATUS_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH MET Control - MET Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MET_COARSE_COUNTER_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH MET Control - MET Coarse Counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MET_FINE_COUNTER_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH MET Control - MET Fine Counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP1_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>System temperature monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP2_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>System temperature monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SYS_TEMP3_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>System temperature monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LO_TEMP_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LO temperature monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP1_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS temperature monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP2_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS temperature monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_TEMP3_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS temperature monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V1_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital voltage monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V2_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital voltage monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V3_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital voltage monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V4_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital voltage monitor 4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_V5_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital voltage monitor 5</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I1_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital current monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I2_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital current monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I3_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital current monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I4_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital current monitor 4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LVPS_I5_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>LVPS digital current monitor 5</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_1P5V_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH 1.5V monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_1P8V_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH 1.8V monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_3P3V_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH 3.3V monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_12VP_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH +12V monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_12VN_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH -12V monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_5V_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH 5V monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_ANA_REF_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH analog reference monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP1_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH temperature monitor 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP2_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH temperature monitor 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP3_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH temperature monitor 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CDH_TEMP4_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH temperature monitor 4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ADC_CTRL_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH ADC Control and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SC_CMD_FIFO_CTRL_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Spacecraft Data Interface - Spacecraft Command FIFO Control and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SC_TLM_FIFO_CTRL_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Spacecraft Data Interface - Spacecraft Telemetry FIFO Control and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INTERRUPT_LEVEL_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Interrupts - Interrupt Level</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INTERRUPT_PENDING_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH Interrupts - Interrupt Pending</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INTERRUPT_ENABLE_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH Interrupts - Interrupt Enable</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_ENABLE_AND_STATUS_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH Spin - Spin Enable and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_BIN_PERIOD_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH Spin - Spin Bin Period</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_BIN_INDEX_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH Spin - Spin Bin Index</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_PERIOD_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH Spin - Spin Period</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_PERIOD_TIMER_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH Spin - Spin Period Timer</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_PERIOD_TIMER_AT_NXT_PPS_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH Spin - Spin Period Timer at Next 1PPS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_TIME_STAMP_SECONDS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Spin - Spin Time Stamp Seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_TIME_STAMP_SUBSECONDS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Spin - Spin Time Stamp Subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LOOPBACK_CTRL_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH External Loopback - Loopback Control</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LOOPBACK_STATUS_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>CDH External Loopback - Loopback Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LOOPBACK_TX_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH External Loopback - Loopback Transmit</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LOOPBACK_RX_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH External Loopback - Loopback Receive</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISCRETE_IO_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Discrete IO</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HEATER_CTRL_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Heater Control - Heater Control</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HEATER_STATUS_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>CDH Heater Control - Heater Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INSTR_PWR_CTRL_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>CDH Instrument Power Control - Instrument Power Control</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INSTR_PWR_STATUS_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>CDH Instrument Power Control - Instrument Power Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_INTERFACE_CTRL_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_DIAG_CDH.IFB_INTERFACE_CTRL_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_INTERFACE_CMD_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_CDH.IFB_INTERFACE_CMD_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_ADC_TLM_STATUS_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_CDH.IFB_ADC_TLM_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_REG_TLM_STATUS_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_CDH.IFB_REG_TLM_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_INTERFACE_STATUS_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_CDH.TOF_INTERFACE_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DE_TIME_TAG_RESOLUTION_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_CDH.DE_TIME_TAG_RESOLUTION_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DE_TIME_TAG_CTRL_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_DIAG_CDH.DE_TIME_TAG_CTRL_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DE_FIFO_CTRL_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_DIAG_CDH.DE_FIFO_CTRL_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FEE_RESET_STATUS_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_CDH.FEE_RESET_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FEE_RESET_CMD_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_DIAG_CDH.FEE_RESET_CMD_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FEE_RESET_DURATION_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_CDH.FEE_RESET_DURATION_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPIN_PULSE_DURATION_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_CDH.SPIN_PULSE_DURATION_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HVPS_CTRL_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_CDH.HVPS_CTRL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HVPS_STATUS_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_DIAG_CDH.HVPS_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HVPS_CMD_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_DIAG_CDH.HVPS_CMD_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PIVOT_INTERFACE_CTRL_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_CDH.PIVOT_INTERFACE_CTRL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PIVOT_INTERFACE_STATUS_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_CDH.PIVOT_INTERFACE_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PIVOT_CMD_DATA_REG" parameterTypeRef="uint32">
+				<xtce:LongDescription>ILO_DIAG_CDH.PIVOT_CMD_DATA_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PIVOT_CMD_OPCODE_REG" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_CDH.PIVOT_CMD_OPCODE_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_DIAG_CDH">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="JUMPER_REG"/>
+					<xtce:ParameterRefEntry parameterRef="RESET_REG"/>
+					<xtce:ParameterRefEntry parameterRef="WATCHDOG_REG"/>
+					<xtce:ParameterRefEntry parameterRef="CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SCRATCHPAD_1_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SCRATCHPAD_2_REG"/>
+					<xtce:ParameterRefEntry parameterRef="CPU_UART_CLOCK_BAUD_REG"/>
+					<xtce:ParameterRefEntry parameterRef="TICK_TIMER_CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="TICK_TIMER_RELOAD_COUNT_REG"/>
+					<xtce:ParameterRefEntry parameterRef="TICK_TIMER_COUNTER_REG"/>
+					<xtce:ParameterRefEntry parameterRef="MET_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="MET_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="MET_COARSE_COUNTER_REG"/>
+					<xtce:ParameterRefEntry parameterRef="MET_FINE_COUNTER_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP1_MON"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP2_MON"/>
+					<xtce:ParameterRefEntry parameterRef="SYS_TEMP3_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LO_TEMP_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP1_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP2_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_TEMP3_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V1_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V2_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V3_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V4_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_V5_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I1_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I2_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I3_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I4_MON"/>
+					<xtce:ParameterRefEntry parameterRef="LVPS_I5_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_1P5V_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_1P8V_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_3P3V_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_12VP_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_12VN_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_5V_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_ANA_REF_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP1_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP2_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP3_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CDH_TEMP4_MON"/>
+					<xtce:ParameterRefEntry parameterRef="ADC_CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SC_CMD_FIFO_CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SC_TLM_FIFO_CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="INTERRUPT_LEVEL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="INTERRUPT_PENDING_REG"/>
+					<xtce:ParameterRefEntry parameterRef="INTERRUPT_ENABLE_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_ENABLE_AND_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_BIN_PERIOD_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_BIN_INDEX_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_PERIOD_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_PERIOD_TIMER_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_PERIOD_TIMER_AT_NXT_PPS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_TIME_STAMP_SECONDS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_TIME_STAMP_SUBSECONDS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="LOOPBACK_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="LOOPBACK_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="LOOPBACK_TX_REG"/>
+					<xtce:ParameterRefEntry parameterRef="LOOPBACK_RX_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DISCRETE_IO_REG"/>
+					<xtce:ParameterRefEntry parameterRef="HEATER_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="HEATER_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="INSTR_PWR_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="INSTR_PWR_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_INTERFACE_CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_INTERFACE_CMD_REG"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_ADC_TLM_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_REG_TLM_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_INTERFACE_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DE_TIME_TAG_RESOLUTION_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DE_TIME_TAG_CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="DE_FIFO_CTRL_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="FEE_RESET_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="FEE_RESET_CMD_REG"/>
+					<xtce:ParameterRefEntry parameterRef="FEE_RESET_DURATION_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPIN_PULSE_DURATION_REG"/>
+					<xtce:ParameterRefEntry parameterRef="HVPS_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="HVPS_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="HVPS_CMD_REG"/>
+					<xtce:ParameterRefEntry parameterRef="PIVOT_INTERFACE_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="PIVOT_INTERFACE_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="PIVOT_CMD_DATA_REG"/>
+					<xtce:ParameterRefEntry parameterRef="PIVOT_CMD_OPCODE_REG"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_CDH.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_CDH.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_CDH">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_IFB.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_IFB.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_IFB">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_IFB.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_IFB.xml
@@ -1,0 +1,228 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_IFB">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint8" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FPGA_VERSION_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.FPGA_VERSION_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_STATUS_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_COUNT_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.CMD_COUNT_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_CTRL_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_CTRL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_DATA_INTERVAL_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_DATA_INTERVAL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_HVPS_CTRL_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.TOF_HVPS_CTRL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_VSET_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.PAC_VSET_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_OCP_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.PAC_OCP_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_VSET_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.MCP_VSET_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_OCP_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.MCP_OCP_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STAR_OFFSET_ADJUST_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.STAR_OFFSET_ADJUST_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="OSCOPE_CH_SEL_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_IFB.OSCOPE_CH_SEL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STAR_BRIGHT" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.STAR_BRIGHT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_TEMP1" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_TEMP1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_TEMP0" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_TEMP0</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V5P0_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_V5P0_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V3P3_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_V3P3_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V12P0_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_V12P0_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V12N0_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_V12N0_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LV_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.LV_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LV_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.LV_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LV_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.LV_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.MCP_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.MCP_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.MCP_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.PAC_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.PAC_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.PAC_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V5P0ANA_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_V5P0ANA_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="IFB_V2P5_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.IFB_V2P5_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STAR_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.STAR_MON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_VSET_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.PAC_VSET_MON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PAC_OCP_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.PAC_OCP_MON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_VSET_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.MCP_VSET_MON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MCP_OCP_MON" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_IFB.MCP_OCP_MON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_DIAG_IFB">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="FPGA_VERSION_REG"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_STATUS_REG"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_COUNT_REG"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_DATA_INTERVAL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_HVPS_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_VSET_REG"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_OCP_REG"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_VSET_REG"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_OCP_REG"/>
+					<xtce:ParameterRefEntry parameterRef="STAR_OFFSET_ADJUST_REG"/>
+					<xtce:ParameterRefEntry parameterRef="OSCOPE_CH_SEL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="STAR_BRIGHT"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_TEMP1"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_TEMP0"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V5P0_VM"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V3P3_VM"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V12P0_VM"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V12N0_VM"/>
+					<xtce:ParameterRefEntry parameterRef="LV_CM"/>
+					<xtce:ParameterRefEntry parameterRef="LV_VM"/>
+					<xtce:ParameterRefEntry parameterRef="LV_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_CM"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_VM"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_CM"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_VM"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V5P0ANA_VM"/>
+					<xtce:ParameterRefEntry parameterRef="IFB_V2P5_VM"/>
+					<xtce:ParameterRefEntry parameterRef="STAR_MON"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_VSET_MON"/>
+					<xtce:ParameterRefEntry parameterRef="PAC_OCP_MON"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_VSET_MON"/>
+					<xtce:ParameterRefEntry parameterRef="MCP_OCP_MON"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_PCC.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_PCC.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_PCC">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_PCC.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_PCC.xml
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_PCC">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint8" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COARSE_POT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>Primary motor coarse pot</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FINE_POT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>Primary motor fine pot</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COARSE_POT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>Redundant motor coarse pot</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="FINE_POT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>Redundant motor fine pot</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ACTUATOR_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>Actuator temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PCC_BOARD_TEMP" parameterTypeRef="uint16">
+				<xtce:LongDescription>PCC Board temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MOTOR_CURRENT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>Primary motor current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MOTOR_CURRENT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>Redundant motor current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CUMULATIVE_CNT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>Cummulative step count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CUMULATIVE_CNT_SGN_PRI" parameterTypeRef="uint8">
+				<xtce:LongDescription>Cumulative step count sign enumeration</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CUMULATIVE_CNT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>Cummulative step count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CUMULATIVE_CNT_SGN_RED" parameterTypeRef="uint8">
+				<xtce:LongDescription>Cumulative step count sign enumeration</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CURRENT_STEP_CNT_PRI" parameterTypeRef="uint16">
+				<xtce:LongDescription>Primary motor axis countdown counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CURRENT_STEP_CNT_RED" parameterTypeRef="uint16">
+				<xtce:LongDescription>Redundant motor axis countdown counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CURRENT_SETPT_PRI" parameterTypeRef="uint8">
+				<xtce:LongDescription>Current setpoint value</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CURRENT_SETPT_RED" parameterTypeRef="uint8">
+				<xtce:LongDescription>Current setpoint value</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STATUS" parameterTypeRef="uint8">
+				<xtce:LongDescription>PCC Status Byte</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_PCC.SPARE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_DIAG_PCC">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="COARSE_POT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="FINE_POT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="COARSE_POT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="FINE_POT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="ACTUATOR_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="PCC_BOARD_TEMP"/>
+					<xtce:ParameterRefEntry parameterRef="MOTOR_CURRENT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="MOTOR_CURRENT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="CUMULATIVE_CNT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="CUMULATIVE_CNT_SGN_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="CUMULATIVE_CNT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="CUMULATIVE_CNT_SGN_RED"/>
+					<xtce:ParameterRefEntry parameterRef="CURRENT_STEP_CNT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="CURRENT_STEP_CNT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="CURRENT_SETPT_PRI"/>
+					<xtce:ParameterRefEntry parameterRef="CURRENT_SETPT_RED"/>
+					<xtce:ParameterRefEntry parameterRef="STATUS"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+                    <xtce:RestrictionCriteria>
+                        <xtce:ComparisonList>
+                            <xtce:Comparison parameterRef="PKT_APID" value="725" useCalibratedValue="false"/>
+                        </xtce:ComparisonList>
+                    </xtce:RestrictionCriteria>
+                </xtce:BaseContainer>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_TOF_BD.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_TOF_BD.xml
@@ -1,0 +1,176 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_TOF_BD">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint8" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CMD_ERROR" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.CMD_ERROR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_CFD_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_CFD_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_PRE_TM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_PRE_TM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_REG_TM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_REG_TM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_MCP_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_MCP_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_MCP_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_MCP_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_CM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_CM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_P5_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_P5_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_P6_VM" parameterTypeRef="uint16">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_P6_VM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_A_THR_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.AN_A_THR_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_B0_THR_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.AN_B0_THR_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_B3_THR_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.AN_B3_THR_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_C_THR_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.AN_C_THR_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF_BD_CTRL_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.TOF_BD_CTRL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STIM_CTRL_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.STIMULUS_CTRL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STIM_CNFG_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.STIMULUS_CNFG_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_TOF3_THR_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.AN_TOF3_THR_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_TOF2_THR_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.AN_TOF2_THR_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_TOF1_THR_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.AN_TOF1_THR_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="AN_TOF0_THR_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.AN_TOF0_THR_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE_REG" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.SPARE_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE" parameterTypeRef="uint8">
+				<xtce:LongDescription>ILO_DIAG_TOF_BD.SPARE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_DIAG_TOF_BD">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="CMD_ERROR"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_CFD_VM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_PRE_TM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_REG_TM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_MCP_CM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_MCP_VM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_CM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_P5_VM"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_P6_VM"/>
+					<xtce:ParameterRefEntry parameterRef="AN_A_THR_REG"/>
+					<xtce:ParameterRefEntry parameterRef="AN_B0_THR_REG"/>
+					<xtce:ParameterRefEntry parameterRef="AN_B3_THR_REG"/>
+					<xtce:ParameterRefEntry parameterRef="AN_C_THR_REG"/>
+					<xtce:ParameterRefEntry parameterRef="TOF_BD_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="STIM_CTRL_REG"/>
+					<xtce:ParameterRefEntry parameterRef="STIM_CNFG_REG"/>
+					<xtce:ParameterRefEntry parameterRef="AN_TOF3_THR_REG"/>
+					<xtce:ParameterRefEntry parameterRef="AN_TOF2_THR_REG"/>
+					<xtce:ParameterRefEntry parameterRef="AN_TOF1_THR_REG"/>
+					<xtce:ParameterRefEntry parameterRef="AN_TOF0_THR_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE_REG"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_DIAG_TOF_BD.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_DIAG_TOF_BD.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_DIAG_TOF_BD">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_EVTMSG.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_EVTMSG.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_EVTMSG">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_EVTMSG.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_EVTMSG.xml
@@ -1,0 +1,140 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_EVTMSG">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint8" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="QMSG_CNT" parameterTypeRef="uint8">
+				<xtce:LongDescription>Number of queued event messages</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="EVENT_TIME" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event time seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="EVENT_TIME_SUBSEC" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event time subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="EVENT_ID" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_1" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_2" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_3" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_4" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 4</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_5" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 5</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_6" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 6</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_7" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 7</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_8" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 8</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PARAM_9" parameterTypeRef="uint32">
+				<xtce:LongDescription>Event parameter 9</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint8">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_EVTMSG">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="QMSG_CNT"/>
+					<xtce:ParameterRefEntry parameterRef="EVENT_TIME"/>
+					<xtce:ParameterRefEntry parameterRef="EVENT_TIME_SUBSEC"/>
+					<xtce:ParameterRefEntry parameterRef="EVENT_ID"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_1"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_2"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_3"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_4"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_5"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_6"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_7"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_8"/>
+					<xtce:ParameterRefEntry parameterRef="PARAM_9"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_MEMDMP.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_MEMDMP.xml
@@ -1,0 +1,107 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_MEMDMP">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte32608" shortDescription="Binary data type">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN"/>
+              				<xtce:LinearAdjustment intercept="-160" slope="8"/>
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary header, mission elapsed time</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ADDR" parameterTypeRef="uint32">
+				<xtce:LongDescription>Starting address of memory dump</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="LEN" parameterTypeRef="uint32">
+				<xtce:LongDescription>Data length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DATA" parameterTypeRef="byte32608">
+				<xtce:LongDescription>Memory dump data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_MEMDMP">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="ADDR"/>
+					<xtce:ParameterRefEntry parameterRef="LEN"/>
+					<xtce:ParameterRefEntry parameterRef="DATA"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_MEMDMP.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_MEMDMP.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_MEMDMP">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_RAW_CNT.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_RAW_CNT.xml
@@ -1,0 +1,193 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_RAW_CNT">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte16" sizeInBits="16">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding>
+    				<xtce:SizeInBits>
+						<xtce:FixedValue>16</xtce:FixedValue>
+					</xtce:SizeInBits>
+  				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte96" sizeInBits="96">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding>
+    				<xtce:SizeInBits>
+						<xtce:FixedValue>96</xtce:FixedValue>
+					</xtce:SizeInBits>
+  				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+			<xtce:BinaryParameterType name="byte960" sizeInBits="960">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding>
+    				<xtce:SizeInBits>
+						<xtce:FixedValue>960</xtce:FixedValue>
+					</xtce:SizeInBits>
+  				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="MET_SUB" parameterTypeRef="uint16">
+				<xtce:LongDescription>Mission Elapsed Time subsecond</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="START_A" parameterTypeRef="byte96">
+				<xtce:LongDescription>Electron, anode A, single</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="START_C" parameterTypeRef="byte96">
+				<xtce:LongDescription>Electron, anode C, single</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STOP_B0" parameterTypeRef="byte96">
+				<xtce:LongDescription>Ion, anode B0, single</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STOP_B3" parameterTypeRef="byte96">
+				<xtce:LongDescription>Ion, anode B3, single</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF0" parameterTypeRef="byte96">
+				<xtce:LongDescription>Electron anode A / Ion anode B0, TOF0</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF1" parameterTypeRef="byte96">
+				<xtce:LongDescription>Electron anode C / Ion anode B3, TOF1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF2" parameterTypeRef="byte96">
+				<xtce:LongDescription>Electron anode A / Ion anode C, TOF2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF3" parameterTypeRef="byte16">
+				<xtce:LongDescription>Ion anode B0 / Ion anode B3, TOF3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ACCUM_MS" parameterTypeRef="byte960">
+				<xtce:LongDescription>Array for fast triples accumulation time</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF0_TOF1" parameterTypeRef="byte960">
+				<xtce:LongDescription>Electron anode A / Ion anode B0
+Electron anode C / Ion anode B3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF0_TOF2" parameterTypeRef="byte960">
+				<xtce:LongDescription>Electron anode A / Ion anode B0
+Electron anode A / Electron anode C</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF1_TOF2" parameterTypeRef="byte960">
+				<xtce:LongDescription>Electron anode C / Ion anode B3
+Electron anode A / Electron anode C</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SILVER_TRIPLE" parameterTypeRef="byte960">
+				<xtce:LongDescription>Electron anode A / Ion anode B0
+Electron anode C / Ion anode B3
+Electron anode A / Electron anode C
+Ion anode B0 / Ion anode B3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISC_TOF0" parameterTypeRef="byte96">
+				<xtce:LongDescription>TOF0 value less than TOF0 threshold setting</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISC_TOF1" parameterTypeRef="byte96">
+				<xtce:LongDescription>TOF1 value less than TOF1 threshold setting</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISC_TOF2" parameterTypeRef="byte96">
+				<xtce:LongDescription>TOF2 value less than TOF2 threshold setting</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISC_TOF3" parameterTypeRef="byte96">
+				<xtce:LongDescription>TOF3 value less than TOF3 threshold setting</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer abstract="true" name="P_ILO_RAW_CNT">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="MET_SUB"/>
+					<xtce:ParameterRefEntry parameterRef="START_A"/>
+					<xtce:ParameterRefEntry parameterRef="START_C"/>
+					<xtce:ParameterRefEntry parameterRef="STOP_B0"/>
+					<xtce:ParameterRefEntry parameterRef="STOP_B3"/>
+					<xtce:ParameterRefEntry parameterRef="TOF0"/>
+					<xtce:ParameterRefEntry parameterRef="TOF1"/>
+					<xtce:ParameterRefEntry parameterRef="TOF2"/>
+					<xtce:ParameterRefEntry parameterRef="TOF3"/>
+					<xtce:ParameterRefEntry parameterRef="ACCUM_MS"/>
+					<xtce:ParameterRefEntry parameterRef="TOF0_TOF1"/>
+					<xtce:ParameterRefEntry parameterRef="TOF0_TOF2"/>
+					<xtce:ParameterRefEntry parameterRef="TOF1_TOF2"/>
+					<xtce:ParameterRefEntry parameterRef="SILVER_TRIPLE"/>
+					<xtce:ParameterRefEntry parameterRef="DISC_TOF0"/>
+					<xtce:ParameterRefEntry parameterRef="DISC_TOF1"/>
+					<xtce:ParameterRefEntry parameterRef="DISC_TOF2"/>
+					<xtce:ParameterRefEntry parameterRef="DISC_TOF3"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+                    <xtce:RestrictionCriteria>
+                        <xtce:ComparisonList>
+                            <xtce:Comparison parameterRef="PKT_APID" value="689" useCalibratedValue="false"/>
+                        </xtce:ComparisonList>
+                    </xtce:RestrictionCriteria>
+                </xtce:BaseContainer>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_RAW_CNT.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_RAW_CNT.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_RAW_CNT">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_RAW_DE.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_RAW_DE.xml
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_RAW_DE">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte102400" shortDescription="Binary data type">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN"/>
+              				<xtce:LinearAdjustment intercept="-112" slope="8"/>
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COUNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>Number of direct events</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DATA" parameterTypeRef="byte102400">
+				<xtce:LongDescription>TOF Direct Event Time Tagged data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_RAW_DE">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="COUNT"/>
+					<xtce:ParameterRefEntry parameterRef="DATA"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+                    <xtce:RestrictionCriteria>
+                        <xtce:ComparisonList>
+                            <xtce:Comparison parameterRef="PKT_APID" value="690" useCalibratedValue="false"/>
+                        </xtce:ComparisonList>
+                    </xtce:RestrictionCriteria>
+                </xtce:BaseContainer>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_RAW_DE.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_RAW_DE.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_RAW_DE">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_RAW_STAR.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_RAW_STAR.xml
@@ -1,0 +1,103 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_RAW_STAR">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte15440" shortDescription="Binary data type">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN"/>
+              				<xtce:LinearAdjustment intercept="-112" slope="8"/>
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COUNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>Number of star sensor samples</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DATA" parameterTypeRef="byte15440">
+				<xtce:LongDescription>Star Sensor FIFO Data raw12 bit</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_RAW_STAR">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="COUNT"/>
+					<xtce:ParameterRefEntry parameterRef="DATA"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_RAW_STAR.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_RAW_STAR.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_RAW_STAR">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_SCI_CNT.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_SCI_CNT.xml
@@ -1,0 +1,202 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_SCI_CNT">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte336" sizeInBits="226">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding>
+    				<xtce:SizeInBits>
+						<xtce:FixedValue>336</xtce:FixedValue>
+					</xtce:SizeInBits>
+  				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+			<xtce:BinaryParameterType name="byte504" sizeInBits="504">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding>
+    				<xtce:SizeInBits>
+						<xtce:FixedValue>504</xtce:FixedValue>
+					</xtce:SizeInBits>
+  				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+			<xtce:BinaryParameterType name="byte3360" sizeInBits="3360">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding>
+    				<xtce:SizeInBits>
+						<xtce:FixedValue>3360</xtce:FixedValue>
+					</xtce:SizeInBits>
+  				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="START_A" parameterTypeRef="byte504">
+				<xtce:LongDescription>Electron, anode A, single</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="START_C" parameterTypeRef="byte504">
+				<xtce:LongDescription>Electron, anode C, single</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STOP_B0" parameterTypeRef="byte504">
+				<xtce:LongDescription>Ion, anode B0, single</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="STOP_B3" parameterTypeRef="byte504">
+				<xtce:LongDescription>Ion, anode B3, single</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF0" parameterTypeRef="byte336">
+				<xtce:LongDescription>Electron anode A / Ion anode B0, TOF0</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF1" parameterTypeRef="byte336">
+				<xtce:LongDescription>Electron anode C / Ion anode B3, TOF1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF2" parameterTypeRef="byte336">
+				<xtce:LongDescription>Electron anode A / Ion anode C, TOF2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF3" parameterTypeRef="byte336">
+				<xtce:LongDescription>Ion anode B0 / Ion anode B3, TOF3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF0_TOF1" parameterTypeRef="byte3360">
+				<xtce:LongDescription>Electron anode A / Ion anode B0
+Electron anode C / Ion anode B3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF0_TOF2" parameterTypeRef="byte3360">
+				<xtce:LongDescription>Electron anode A / Ion anode B0
+Electron anode A / Electron anode C</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TOF1_TOF2" parameterTypeRef="byte3360">
+				<xtce:LongDescription>Electron anode C / Ion anode B3
+Electron anode A / Electron anode C</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SILVER_TRIPLE" parameterTypeRef="byte3360">
+				<xtce:LongDescription>Electron anode A / Ion anode B0
+Electron anode C / Ion anode B3
+Electron anode A / Electron anode C
+Ion anode B0 / Ion anode B3</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISC_TOF0" parameterTypeRef="byte336">
+				<xtce:LongDescription>TOF0 value less than TOF0 threshold setting</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISC_TOF1" parameterTypeRef="byte336">
+				<xtce:LongDescription>TOF1 value less than TOF1 threshold setting</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISC_TOF2" parameterTypeRef="byte336">
+				<xtce:LongDescription>TOF2 value less than TOF2 threshold setting</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DISC_TOF3" parameterTypeRef="byte336">
+				<xtce:LongDescription>TOF3 value less than TOF3 threshold setting</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="POS0" parameterTypeRef="byte504">
+				<xtce:LongDescription>ion_anode_b0 (ICE derived from TOF3 based on LUT for B0, 1, 2 and 3)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="POS1" parameterTypeRef="byte504">
+				<xtce:LongDescription>ion_anode_b1 (ICE derived from TOF3 based on LUT for B0, 1, 2 and 3)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="POS2" parameterTypeRef="byte504">
+				<xtce:LongDescription>ion_anode_b2 (ICE derived from TOF3 based on LUT for B0, 1, 2 and 3)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="POS3" parameterTypeRef="byte504">
+				<xtce:LongDescription>ion_anode_b3 (ICE derived from TOF3 based on LUT for B0, 1, 2 and 3)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="HYDROGEN" parameterTypeRef="byte3360">
+				<xtce:LongDescription>Hydrogen species histogram </xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="OXYGEN" parameterTypeRef="byte3360">
+				<xtce:LongDescription>Oxygen species histogram</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_SCI_CNT">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="START_A"/>
+					<xtce:ParameterRefEntry parameterRef="START_C"/>
+					<xtce:ParameterRefEntry parameterRef="STOP_B0"/>
+					<xtce:ParameterRefEntry parameterRef="STOP_B3"/>
+					<xtce:ParameterRefEntry parameterRef="TOF0"/>
+					<xtce:ParameterRefEntry parameterRef="TOF1"/>
+					<xtce:ParameterRefEntry parameterRef="TOF2"/>
+					<xtce:ParameterRefEntry parameterRef="TOF3"/>
+					<xtce:ParameterRefEntry parameterRef="TOF0_TOF1"/>
+					<xtce:ParameterRefEntry parameterRef="TOF0_TOF2"/>
+					<xtce:ParameterRefEntry parameterRef="TOF1_TOF2"/>
+					<xtce:ParameterRefEntry parameterRef="SILVER_TRIPLE"/>
+					<xtce:ParameterRefEntry parameterRef="DISC_TOF0"/>
+					<xtce:ParameterRefEntry parameterRef="DISC_TOF1"/>
+					<xtce:ParameterRefEntry parameterRef="DISC_TOF2"/>
+					<xtce:ParameterRefEntry parameterRef="DISC_TOF3"/>
+					<xtce:ParameterRefEntry parameterRef="POS0"/>
+					<xtce:ParameterRefEntry parameterRef="POS1"/>
+					<xtce:ParameterRefEntry parameterRef="POS2"/>
+					<xtce:ParameterRefEntry parameterRef="POS3"/>
+					<xtce:ParameterRefEntry parameterRef="HYDROGEN"/>
+					<xtce:ParameterRefEntry parameterRef="OXYGEN"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_SCI_CNT.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_SCI_CNT.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_SCI_CNT">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_SCI_DE.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_SCI_DE.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_SCI_DE">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_SCI_DE.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_SCI_DE.xml
@@ -1,0 +1,103 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_SCI_DE">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte85680" shortDescription="Binary data type">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN"/>
+              				<xtce:LinearAdjustment intercept="-112" slope="8"/>
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COUNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>Number of direct events</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DATA" parameterTypeRef="byte85680">
+				<xtce:LongDescription>TOF Direct Event Time Tagged data</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_SCI_DE">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="COUNT"/>
+					<xtce:ParameterRefEntry parameterRef="DATA"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_SPIN.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_SPIN.xml
@@ -1,0 +1,131 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_SPIN">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint4" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint5" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="5" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint20" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="20" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte2240" shortDescription="Binary data type">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN"/>
+              				<xtce:LinearAdjustment intercept="-160" slope="8"/>
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="NUM_COMPLETED" parameterTypeRef="uint5">
+				<xtce:LongDescription>Number of spins completed</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE1" parameterTypeRef="uint3">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ACQ_END_SEC" parameterTypeRef="uint32">
+				<xtce:LongDescription>Acquisition end whole seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ACQ_END_SUBSEC" parameterTypeRef="uint20">
+				<xtce:LongDescription>Acquisition end subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SPARE2" parameterTypeRef="uint4">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="INFO" parameterTypeRef="byte2240">
+				<xtce:LongDescription>Spin Info array</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_SPIN">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="NUM_COMPLETED"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE1"/>
+					<xtce:ParameterRefEntry parameterRef="ACQ_END_SEC"/>
+					<xtce:ParameterRefEntry parameterRef="ACQ_END_SUBSEC"/>
+					<xtce:ParameterRefEntry parameterRef="SPARE2"/>
+					<xtce:ParameterRefEntry parameterRef="INFO"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/imap_processing/lo/l0/packet_definitions/ILO_SPIN.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_SPIN.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_SPIN">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_STAR.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_STAR.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_STAR">
-	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="IMAP SDC"/>
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="uint1" signed="false">

--- a/imap_processing/lo/l0/packet_definitions/ILO_STAR.xml
+++ b/imap_processing/lo/l0/packet_definitions/ILO_STAR.xml
@@ -1,0 +1,103 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="P_ILO_STAR">
+	<xtce:Header date="2023-04-25T14:43:04UTC" version="1.0" author="Sean Hoyt"/>
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterTypeSet>
+			<xtce:IntegerParameterType name="uint1" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint2" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint3" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint11" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint14" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint16" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="uint32" signed="false">
+				<xtce:UnitSet/>
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+			</xtce:IntegerParameterType>
+			<xtce:BinaryParameterType name="byte10288" shortDescription="Binary data type">
+				<xtce:UnitSet/>
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN"/>
+              				<xtce:LinearAdjustment intercept="-112" slope="8"/>
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+		</xtce:ParameterTypeSet>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="VERSION" parameterTypeRef="uint3">
+				<xtce:LongDescription>CCSDS Packet Version Number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="uint1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="uint11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEG_FLGS" parameterTypeRef="uint2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="uint14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="uint16">
+				<xtce:LongDescription>CCSDS Packet Length</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SHCOARSE" parameterTypeRef="uint32">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COUNT" parameterTypeRef="uint16">
+				<xtce:LongDescription>Number of star sensor samples</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="DATA" parameterTypeRef="byte10288">
+				<xtce:LongDescription>Star Sensor FIFO Data 8 bit</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="CHKSUM" parameterTypeRef="uint16">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="CCSDSPacket">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="VERSION"/>
+					<xtce:ParameterRefEntry parameterRef="TYPE"/>
+					<xtce:ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_APID"/>
+					<xtce:ParameterRefEntry parameterRef="SEG_FLGS"/>
+					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+					<xtce:ParameterRefEntry parameterRef="PKT_LEN"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="P_ILO_STAR">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="SHCOARSE"/>
+					<xtce:ParameterRefEntry parameterRef="COUNT"/>
+					<xtce:ParameterRefEntry parameterRef="DATA"/>
+					<xtce:ParameterRefEntry parameterRef="CHKSUM"/>
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>


### PR DESCRIPTION
# Change Summary

## Overview
These updates add the IMAP-Lo packet definitions. This feels like a lot for one PR, so I can break this up if requested, but I thought this was better than adding all these with the decom code since that code will probably be common for these anyway.

Packet definitions for the following packets have been created:
- ILO_AUTO: Autonomy
- BOOT_HK: Boot housekeeping
- BOOT_MEMDMP: Boot memory dump
- ILO_APP_SHK: Static housekeeping (values that don't change)
- ILO_APP_NHK: Nominal housekeeping (engineering, health and status)
- ILO_EVTMSG: Event message
- ILO_MEMDMP: App memory dump
- ILO_RAW_CNT: Raw counter values, intended for use in engineering modes
- ILO_RAW_DE: Raw direct events, intended for use in engineering modes
- ILO_RAW_STAR: Raw star sensor, intended for use in HVENG, every spin
- ILO_SCI_CNT: Science rates, including derived and histograms
- ILO_SCI_DE: Science direct event data
- ILO_STAR: Science star sensor data, every spin
- ILO_SPIN: Spin information for each science cycle (28 spins)
- ILO_DIAG_CDH: Diagnostic CDH (raw register dumps)
- ILO_DIAG_IFB: Diagnostic IFB (raw register dumps)
- ILO_DIAG_TOF_BD: Diagnostic TOF Board (raw register dumps)
- ILO_DIAG_BULK_HVPS: Diagnostic bulk HVPS (raw register dumps)
- ILO_DIAG_PCC: Diagnostic PCC (raw register dumps)

## New Dependencies
None

## New Files
- packet definitions
   - One xml file for each of the packets listed above

## Deleted Files
None

## Updated Files
None

## Testing
ILO_RAW_DE was tested and the rest will be tested during L0 decom development 
