### PR TITLE
Xtce IntegerParameterType fixes

### DIFF
--- a/tools/xtce_generation/telemetry_generator.py
+++ b/tools/xtce_generation/telemetry_generator.py
@@ -106,7 +106,9 @@ class TelemetryGenerator:
         """
         for parameter_type_ref_name, size in unique_lengths.items():
             if "UINT" in parameter_type_ref_name:
-                parameter_type = Et.SubElement(parameter_type_set, "xtce:IntegerParameterType")
+                parameter_type = Et.SubElement(
+                    parameter_type_set, "xtce:IntegerParameterType"
+                )
                 parameter_type.attrib["name"] = parameter_type_ref_name
                 parameter_type.attrib["signed"] = "false"
 
@@ -114,7 +116,9 @@ class TelemetryGenerator:
                 encoding.attrib["sizeInBits"] = str(size)
                 encoding.attrib["encoding"] = "unsigned"
             elif "SINT" in parameter_type_ref_name:
-                parameter_type = Et.SubElement(parameter_type_set, "xtce:IntegerParameterType")
+                parameter_type = Et.SubElement(
+                    parameter_type_set, "xtce:IntegerParameterType"
+                )
                 parameter_type.attrib["name"] = parameter_type_ref_name
                 parameter_type.attrib["signed"] = "true"
 
@@ -246,12 +250,9 @@ class TelemetryGenerator:
 
             description = Et.SubElement(parameter, "xtce:LongDescription")
 
-            if row.get("longDescription") is None and row.get("shortDescription") is None:
-                description.text = ""
-            elif row.get("shortDescription"):
-                description.text = row["shortDescription"]
-            else:
-                description.text = row["longDescription"]
+            description.text = (
+                row.get("shortDescription") or row.get("longDescription") or ""
+            )
 
         return parameter_set
 
@@ -298,4 +299,4 @@ class TelemetryGenerator:
         Et.indent(tree, space="\t", level=0)
 
         # Use the provided output_xml_path
-        tree.write(output_xml_path, encoding="UTF-8", xml_declaration=True)
+        tree.write(output_xml_path, encoding="utf-8", xml_declaration=True)

--- a/tools/xtce_generation/telemetry_generator.py
+++ b/tools/xtce_generation/telemetry_generator.py
@@ -106,7 +106,7 @@ class TelemetryGenerator:
         """
         for parameter_type_ref_name, size in unique_lengths.items():
             if "UINT" in parameter_type_ref_name:
-                parameter_type = Et.SubElement(parameter_type_set, "xtce:ParameterType")
+                parameter_type = Et.SubElement(parameter_type_set, "xtce:IntegerParameterType")
                 parameter_type.attrib["name"] = parameter_type_ref_name
                 parameter_type.attrib["signed"] = "false"
 
@@ -114,7 +114,7 @@ class TelemetryGenerator:
                 encoding.attrib["sizeInBits"] = str(size)
                 encoding.attrib["encoding"] = "unsigned"
             elif "SINT" in parameter_type_ref_name:
-                parameter_type = Et.SubElement(parameter_type_set, "xtce:ParameterType")
+                parameter_type = Et.SubElement(parameter_type_set, "xtce:IntegerParameterType")
                 parameter_type.attrib["name"] = parameter_type_ref_name
                 parameter_type.attrib["signed"] = "true"
 
@@ -298,4 +298,4 @@ class TelemetryGenerator:
         Et.indent(tree, space="\t", level=0)
 
         # Use the provided output_xml_path
-        tree.write(output_xml_path, encoding="utf-8", xml_declaration=True)
+        tree.write(output_xml_path, encoding="UTF-8", xml_declaration=True)

--- a/tools/xtce_generation/telemetry_generator.py
+++ b/tools/xtce_generation/telemetry_generator.py
@@ -246,9 +246,9 @@ class TelemetryGenerator:
 
             description = Et.SubElement(parameter, "xtce:LongDescription")
 
-            if row["longDescription"] is None and row["shortDescription"] is None:
+            if row.get("longDescription") is None and row.get("shortDescription") is None:
                 description.text = ""
-            elif row["shortDescription"]:
+            elif row.get("shortDescription"):
                 description.text = row["shortDescription"]
             else:
                 description.text = row["longDescription"]

--- a/tools/xtce_generation/xtce_generator_template.py
+++ b/tools/xtce_generation/xtce_generator_template.py
@@ -9,31 +9,24 @@ def main():
     """
 
     # TODO: change instrument name
-    instrument_name = "codice"
+    instrument_name = "<instrument_name>"
     current_directory = Path(__file__).parent
     module_path = f"{current_directory}/../../imap_processing"
     packet_definition_path = f"{module_path}/{instrument_name}/packet_definitions"
     # TODO: Copy packet definition to tools/xtce_generation/ folder
-    # path_to_excel_file = f"{current_directory}/TLM_SWE_20230904.xlsx"
-    path_to_excel_file = f"{current_directory}/TLM_COD_20230629-110638.xlsx"
+    path_to_excel_file = f"{current_directory}/<excel_file_name>"
 
     # TODO: update packets dictionary with packet name and appId
-
-    # SWE packets
+    # Eg.
     # packets = {
-    #     "P_SWE_APP_HK": 1330,
-    #     "P_SWE_EVTMSG": 1317,
-    #     "P_SWE_CEM_RAW": 1334,
-    #     "P_SWE_SCIENCE": 1344,
+    #     "P_COD_HI_PHA": 1169,
+    #     "P_COD_LO_PHA": 1153,
+    #     "P_COD_LO_NSW_SPECIES_COUNTS": 1157,
+    #     "P_COD_HI_OMNI_SPECIES_COUNTS": 1172,
     # }
 
-    # CoDICE packets
     packets = {
-        "P_COD_HI_PHA": 1169,
-        "P_COD_LO_PHA": 1153,
-        "P_COD_LO_NSW_SPECIES_COUNTS": 1157,
-        "P_COD_HI_OMNI_SPECIES_COUNTS": 1172,
-        "P_COD_LO_SW_SPECIES_COUNTS": 1156,
+        "<packet_name>": "<app_id_number>",
     }
 
     for packet_name, app_id in packets.items():


### PR DESCRIPTION
# Change Summary
This fixes issue of using wrong parameter data types.
## Overview
Before, when we have `uint`, we were using `ParameterType` when it should be `IntegerParameterType`. Fixed that in this PR. Also made minor updates to template so that we can duplicate and modify easily.

## Updated Files
- tools/xtce_generation/telemetry_generator.py
   - It has fixes for data type
- tools/xtce_generation/xtce_generator_template.py
   - modify to make it easy to duplicate and modify

