### PR TITLE
Ruff docs

### DIFF
--- a/imap_processing/codice/decom.py
+++ b/imap_processing/codice/decom.py
@@ -1,4 +1,6 @@
-""" This is an example of how to use the 'space_packet_parser' module to parse with a
+"""Decommutate CODICE L0 data.
+
+This is an example of how to use the 'space_packet_parser' module to parse with a
 XTCE file specifically for the CODICE L0 data. This is a modified version of the
 example found in the 'space_packet_parser' module documentation.
 This is the start of CODICE L0 data processing.

--- a/imap_processing/decom.py
+++ b/imap_processing/decom.py
@@ -2,10 +2,10 @@ from space_packet_parser import parser, xtcedef
 
 
 def decom_packets(packet_file: str, xtce_packet_definition: str):
-    """
-    Unpack CCSDS data packets from a binary file.
+    """Unpack CCSDS data packet.
 
-    Unpack and return the data as it is. No data manipulation is done at this step.
+    In this function, we unpack and return data
+    as it is. Data modification will not be done at this step.
 
     Parameters
     ----------

--- a/imap_processing/swe/l0/decom_swe.py
+++ b/imap_processing/swe/l0/decom_swe.py
@@ -2,13 +2,12 @@ from imap_processing import decom, imap_module_directory
 
 
 def decom_packets(packet_file: str):
-    """
-    Decom SWE data packets using SWE packet definition
+    """Decom SWE data packets using SWE packet definition.
 
     Parameters
     ----------
     packet_file : str
-        Path to data packet path with filename
+        Path to data packet path with filename.
 
     Returns
     -------

--- a/imap_processing/swe/l1a/swe_l1a.py
+++ b/imap_processing/swe/l1a/swe_l1a.py
@@ -5,7 +5,9 @@ from imap_processing.swe.l1a.swe_science import swe_science
 
 
 def swe_l1a(packet_file: str):
-    """This function receives all L0 data file. Based on appId, it
+    """Process SWE l0 data into l1a data.
+
+    Receive all L0 data file. Based on appId, it
     call its function to process. If appId is science, it requires more work
     than other appId such as appId of housekeeping.
 

--- a/imap_processing/swe/l1a/swe_science.py
+++ b/imap_processing/swe/l1a/swe_science.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 
 def uncompress_counts(cem_count):
-    """This function uncompress counts data.
+    """Uncompress counts from the CEMs.
 
     Parameters
     ----------
@@ -56,7 +56,7 @@ def uncompress_counts(cem_count):
 
 
 def add_metadata_to_array(data_packet, metadata_arrays):
-    """This function add metadata to metadata_arrays.
+    """Add metadata to the metadata_arrays.
 
     Parameters
     ----------
@@ -74,11 +74,13 @@ def add_metadata_to_array(data_packet, metadata_arrays):
 
 
 def swe_science(decom_data):
-    """SWE L1A algorithm steps:
+    """SWE L1a science processing.
+
+    SWE L1A algorithm steps:
         - Read data from each SWE packet file
         - Uncompress counts data
         - Store metadata fields and data in DataArray of xarray
-        - Save data to dataset
+        - Save data to dataset.
 
     In each packet, SWE collects data for 15 seconds. In each second,
     it collect data for 12 energy steps and at each energy step,

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -20,14 +20,16 @@ class PacketProperties(NamedTuple):
 
 
 class UltraParams(Enum):
+    """Enumerated packet properties for ULTRA."""
+
     ULTRA_AUX = PacketProperties(apid=880, width=None, block=None, len_array=None)
     ULTRA_IMG_RATES = PacketProperties(apid=881, width=5, block=16, len_array=48)
 
 
 def read_n_bits(binary: str, n: int, current_position: int):
-    """
-    Extract a specified number of bits from a binary string,
-    starting from a given position. This is used twice.
+    """Extract the specified number of bits from a binary string.
+
+    Starting from the current position, it reads n bits. This is used twice.
     The first time it reads the first 5 bits to determine the width.
     The second time it uses the width to determine the value of the bitstring.
 
@@ -49,7 +51,6 @@ def read_n_bits(binary: str, n: int, current_position: int):
     current_position + n
         - The updated position in the binary string after reading the bits.
     """
-
     # Ensure we don't read past the end
     if current_position + n > len(binary):
         raise IndexError(
@@ -91,7 +92,8 @@ def log_decompression(value: int) -> int:
 
 
 def decompress_binary(binary: str, width_bit: int, block: int) -> list:
-    """
+    """Decompress a binary string.
+
     Decompress a binary string based on block-width encoding and
     logarithmic compression.
 
@@ -161,7 +163,6 @@ def decom_ultra_packets(packet_file: str, xtce: str):
         A dataset containing the decoded data fields with 'time' as the coordinating
         dimension.
     """
-
     packets = decom.decom_packets(packet_file, xtce)
 
     met_data, science_id, spin_data, abortflag_data, startdelay_data, fastdata_00 = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,13 @@ addopts = "-ra"
 
 [tool.ruff]
 target-version = "py39"
-select = ["B", "E", "F", "I", "N", "S", "W", "PL", "PT", "UP", "RUF"]
-# Ignore import sorting for now until lines_after_imports is respected
-# by ruff and we can replace isort
-ignore = ["D203", "D212", "PLR0913", "PLR2004", "S101"]
+select = ["B", "D", "E", "F", "I", "N", "S", "W", "PL", "PT", "UP", "RUF"]
+
+ignore = ["D100", "D104", "PLR0913", "PLR2004", "S101"]
+
+[tool.ruff.per-file-ignores]
+"*/tests/*" = ["D"]
+"tools/xtce*" = ["D"]
+
+[tool.ruff.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
# Change Summary

NOTE: This is a proposal. Do we want to follow all of these conventions? Are some of these too annoying and will make too much noise and therefore we should ignore them? I went through and made the changes I thought made sense for now and they didn't seem _too_ bad, and it is better to start these checks sooner rather than later IMO.

## Overview

Add numpydoc conventions to our continuous integration setup to
start enforcing documentation standards.

Have chosen to ignore module-level and package-level docstrings
for now. We can add those rules later if we want. We also ignore
these for the tools and tests directory, which can be added later
as well if we think they are needed.

## Updated Files
Many, I updated the docstrings to meet the ruff enforced standards.

## Testing
Ignored docstrings in our tests directory.