### PR TITLE
SIT-2 Release [dev] [v0.1.x]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Build and upload to PyPI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
+# (Temporary) To test this, trigger on pull request
+on: [push, pull_request]
+
+#on:
+#  release:
+#    types:
+#      - published
+
+jobs:
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    outputs:
+      SDIST_NAME: ${{ steps.sdist.outputs.SDIST_NAME }}
+
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            # We need the full history to generate the proper version number
+            fetch-depth: 0
+
+        - uses: actions/setup-python@v4
+          name: Install Python
+          with:
+            python-version: '3.11'
+
+        - name: Install dependencies
+          run: python -m pip install build twine
+
+        - name: Build sdist
+          id: sdist
+          run: |
+            python -m build --sdist
+            # Get the name of the build sdist file for later use
+            echo "SDIST_NAME=$(ls -1 dist)" >> $GITHUB_OUTPUT
+
+        - name: Check README rendering for PyPI
+          run: twine check dist/*
+
+        - name: Upload sdist result
+          uses: actions/upload-artifact@v3
+          with:
+            name: sdist
+            path: dist/*.tar.gz
+            if-no-files-found: error
+
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/imap_processing
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    # retrieve your distributions here
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.8.10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
 
-# (Temporary) To test this, trigger on pull request
-on: [push, pull_request]
-
-#on:
-#  release:
-#    types:
-#      - published
+on:
+  release:
+    types:
+      - published
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,36 +20,36 @@ jobs:
     outputs:
       SDIST_NAME: ${{ steps.sdist.outputs.SDIST_NAME }}
 
-      steps:
-        - uses: actions/checkout@v4
-          with:
-            # We need the full history to generate the proper version number
-            fetch-depth: 0
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # We need the full history to generate the proper version number
+          fetch-depth: 0
 
-        - uses: actions/setup-python@v4
-          name: Install Python
-          with:
-            python-version: '3.11'
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.11'
 
-        - name: Install dependencies
-          run: python -m pip install build twine
+      - name: Install dependencies
+        run: python -m pip install build twine
 
-        - name: Build sdist
-          id: sdist
-          run: |
-            python -m build --sdist
-            # Get the name of the build sdist file for later use
-            echo "SDIST_NAME=$(ls -1 dist)" >> $GITHUB_OUTPUT
+      - name: Build sdist
+        id: sdist
+        run: |
+          python -m build --sdist
+          # Get the name of the build sdist file for later use
+          echo "SDIST_NAME=$(ls -1 dist)" >> $GITHUB_OUTPUT
 
-        - name: Check README rendering for PyPI
-          run: twine check dist/*
+      - name: Check README rendering for PyPI
+        run: twine check dist/*
 
-        - name: Upload sdist result
-          uses: actions/upload-artifact@v3
-          with:
-            name: sdist
-            path: dist/*.tar.gz
-            if-no-files-found: error
+      - name: Upload sdist result
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
 
   pypi-publish:
     name: Upload release to PyPI
@@ -59,8 +59,13 @@ jobs:
       url: https://pypi.org/p/imap_processing
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-    steps:
-    # retrieve your distributions here
 
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v3
+        with:
+          name: sdist
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.10


### PR DESCRIPTION
**Note: This PR is essentially the same as #83 and #177, but follows a new release procedure in which there is no `main` branch and uses the branch naming convention of `vX.Y.x`.**

# Change Summary

## Overview

This PR marks the release of version `0.1.0` (which is the first release of `imap_processing`), which corresponds to the completion of SIT-2. This PR is being merged back into `dev` per the nominal [git & GitHub workflow](https://imap-processing.readthedocs.io/en/latest/development/style-guide/git-and-github-workflow.html#git-and-github-workflow) and [release workflow](https://imap-processing.readthedocs.io/en/latest/development/release-workflow.html).

These are the release notes that will go into the GitHub release:

```
This release marks the successful completion of SIT-2. Further information about what was tested in SIT-2 can be found in this [galaxy page](https://lasp.colorado.edu/galaxy/display/IMAP/SDC-SIT-2) and the [SIT-2 GitHub Project Board](https://github.com/orgs/IMAP-Science-Operations-Center/projects/2/views/4).

## Features
* Added project documentation (via Sphinx & ReadTheDocs), including Style Guide, development practices, and API reference
* Added Actions workflow to automatic documentation builds
* Added Actions workflow to automatic deployment to PyPI upon release
* Added pre-commit hooks
* Added Issue and Pull Request templates
* Added all-contributors section in README
```

## New Dependencies
- `pydata-sphinx-theme`
- `sphinx`
- `myst-parser`

## New Files
The only new file to actually review is `.github/workflows/release.yml`, which is a workflow for uploading the release to PyPI.


## Testing
The new `release.yml` workflow was tested by triggering the workflow upon `push`. The workflow successfully completed (see here: https://github.com/IMAP-Science-Operations-Center/imap_processing/actions/runs/6341963633).

The `0.1.0` version of the package was uploaded to PyPI: https://pypi.org/project/imap-processing/

To test this, one can `pip install imap-processing` in a new environment and make sure `0.1.0` gets successfully installed.