### PR TITLE
Doc configuration updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,32 +27,3 @@ jobs:
         # SPHINXOPTS="-W --keep-going" is used to turn warnings into errors
         # but keep going, so we don't fail on the first one.
         make -C docs html SPHINXOPTS="-W --keep-going"
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: DocumentationHTML
-        path: docs/build/html/
-
-    # Publish built docs to gh-pages branch
-    - name: Commit documentation changes
-      # push docs only when a GitHub Release is made
-      if: github.event_name == 'release' && github.event.action == 'published'
-      run: |
-        git clone https://github.com/IMAP-Science-Operations-Center/imap_processing.git --branch gh-pages --single-branch gh-pages
-        cp -r docs/build/html/* gh-pages/
-        cd gh-pages
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add .
-        git commit -m "Update documentation" -a || true
-        # The above command will fail if no changes were present, so we ignore that.
-
-    - name: Publish docs
-      # push docs only when a GitHub Release is made
-      if: github.event_name == 'release' && github.event.action == 'published'
-
-      uses: ad-m/github-push-action@master
-      with:
-        branch: gh-pages
-        directory: gh-pages
-        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |
@@ -24,9 +24,9 @@ jobs:
 
     - name: Build documentation
       run: |
-        # SPHINXOPTS="-W --keep-going -n" is used to turn warnings into errors
+        # SPHINXOPTS="-W --keep-going" is used to turn warnings into errors
         # but keep going, so we don't fail on the first one.
-        make -C docs html SPHINXOPTS="-W --keep-going -n"
+        make -C docs html SPHINXOPTS="-W --keep-going"
 
     - uses: actions/upload-artifact@v2
       with:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,3 +84,12 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
 }
+
+# Reference targets not found
+nitpicky = True
+# IntEnum inherited method targets aren't found through intershpinx
+nitpick_ignore_regex = [(r"py:.*", r".*APID\..*")]
+# Ignore the inherited members from the HitAPID IntEnum class
+numpydoc_show_inherited_class_members = {
+    "imap_processing.hit.l0.hit_l1a_decom.HitAPID": False
+}


### PR DESCRIPTION
# Change Summary

In #271 we identified that we had to build documentation on Python 3.10 or lower due to IntEnum inheritance. Instead of pinning the lower Python version, we can instead ignore the places that cause the issues directly with numpydoc and `nitpick_ignore` options.
https://numpydoc.readthedocs.io/en/latest/install.html

The inherited methods are `to_bytes()` and the like from the `Int` class, which we don't really need/want to show up anyways. They still show up in the documentation, they just aren't clickable.

Additionally, put the `nitpicky = True` into the configuration, so that anyone building the docs gets that locally as well.

closes #271