### PR TITLE
Add instructions for rebasing in git workflow docs

### DIFF
--- a/docs/source/development-guide/style-guide/git-and-github-workflow.rst
+++ b/docs/source/development-guide/style-guide/git-and-github-workflow.rst
@@ -114,13 +114,20 @@ Keeping your fork updated
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can keep your personal fork up-to-date with the ``IMAP-Science-Operations-Center`` ``imap_processing`` repository by
-fetching and rebasing with the ``upstream`` remote:
+either fetching and rebasing with the ``upstream`` remote, or fetching and pulling with the ``upstream`` remote:
 
 .. code-block:: bash
 
     git checkout dev
     git fetch upstream
     git rebase -i upstream/dev
+
+or
+
+.. code-block:: bash
+
+    git fetch upstream dev
+    git pull upstream/dev
 
 
 .. _collaborating-on-someone-elses-fork:

--- a/docs/source/development-guide/style-guide/git-and-github-workflow.rst
+++ b/docs/source/development-guide/style-guide/git-and-github-workflow.rst
@@ -114,13 +114,13 @@ Keeping your fork updated
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can keep your personal fork up-to-date with the ``IMAP-Science-Operations-Center`` ``imap_processing`` repository by
-fetching and pulling the ``upstream`` remote:
+fetching and rebasing with the ``upstream`` remote:
 
 .. code-block:: bash
 
     git checkout dev
-    git fetch upstream dev
-    git pull upstream/dev
+    git fetch upstream
+    git rebase -i upstream/dev
 
 
 .. _collaborating-on-someone-elses-fork:


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Updates the git workflow docs to use rebasing instead of pulling/merging, as I think that is our preferred method? (Might be opening a can of worms here 😅)

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
-`docs/source/development-guide/style-guide/git-and-github-workflow.rst`
   - Updated 'keeping your fork updated' section to use rebasing
