### PR TITLE
Make a default data directory

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,7 +14,7 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)/*
-	-rm -rf source/reference/generated
+	-rm -rf source/code-documentation/generated
 
 .PHONY: help Makefile
 

--- a/docs/source/code-documentation/index.rst
+++ b/docs/source/code-documentation/index.rst
@@ -22,8 +22,30 @@ Instruments
    hi
    swapi
 
-
 Utility functions can be found in modules within the top package level.
+
+Processing
+----------
+
+To process an instrument, a command line utility is installed with the
+package.  The command line utility is called ``imap_cli`` and
+takes the instrument and level as arguments.  For example, to process
+the CODICE instrument at level 1, the command would be
+
+.. code:: text
+
+    imap_cli --instrument codice --level 1
+
+This will write output files to the default location, which is
+the current working directory + "/imap-data". To change the data
+directory, use the ``--data-dir`` option, or the environment
+variable ``IMAP_DATA_DIR``. For example to use a temporary directory
+
+.. code:: text
+
+      imap_cli --instrument codice --level 1 --data-dir /tmp/imap-data
+      # or equivalently with an environment variable
+      IMAP_DATA_DIR=/tmp/imap-data imap_cli --instrument codice --level 1
 
 Tools
 -----

--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -13,12 +13,25 @@ __version__ = "0.1.0"
 # packet definitions directory path.
 #
 # This directory is used by the imap_processing package to find the packet definitions.
+import os
 from pathlib import Path
+
+# NOTE: Use a config dictionary, so it is a mutable global object,
+#       otherwise updating previous imports from other modules
+#       wouldn't have been updated globally (for example if referencing a string).
+config = {"DATA_DIR": Path(os.getenv("IMAP_DATA_DIR") or Path.cwd() / "imap-data")}
+"""imap_processing configuration dictionary.
+
+DATA_DIR : This is where the file data is stored and organized by instrument and level.
+    The default location is in the current working directory, but can be
+    set on the command line using the --data-dir option, or through
+    the environment variable IMAP_DATA_DIR.
+"""
 
 # Eg. imap_module_directory = /usr/local/lib/python3.11/site-packages/imap_processing
 imap_module_directory = Path(__file__).parent
 
-instruments = [
+INSTRUMENTS = [
     "codice",
     "glows",
     "hi",
@@ -31,7 +44,7 @@ instruments = [
     "ultra",
 ]
 
-processing_levels = {
+PROCESSING_LEVELS = {
     "codice": ["l0", "l1a", "l1b", "l2"],
     "glows": ["l0", "l1a", "l1b", "l2"],
     "hi": ["l0", "l1a", "l1b", "l1c", "l2"],

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -21,17 +21,13 @@ from imap_processing.codice.utils import CODICEAPID, create_dataset
 from imap_processing.utils import group_by_apid, sort_by_time
 
 
-def codice_l1a(
-    packets: list[space_packet_parser.parser.Packet], cdf_directory: str
-) -> str:
+def codice_l1a(packets: list[space_packet_parser.parser.Packet]) -> str:
     """Process CoDICE l0 data to create l1a data products.
 
     Parameters
     ----------
     packets : list[space_packet_parser.parser.Packet]
         Decom data list that contains all APIDs
-    cdf_directory : str
-        The directory in which to write the output CDF file.
 
     Returns
     -------
@@ -51,9 +47,7 @@ def codice_l1a(
     # Write data to CDF
     cdf_filename = write_cdf(
         data,
-        mode="",
         description="hk",
-        directory=cdf_directory,
     )
 
     return cdf_filename

--- a/imap_processing/swe/l1a/swe_l1a.py
+++ b/imap_processing/swe/l1a/swe_l1a.py
@@ -12,7 +12,7 @@ from imap_processing.swe.utils.swe_utils import (
 from imap_processing.utils import group_by_apid, sort_by_time
 
 
-def swe_l1a(packets, cdf_filepath):
+def swe_l1a(packets):
     """Process SWE l0 data into l1a data.
 
     Receive all L0 data file. Based on appId, it
@@ -23,13 +23,11 @@ def swe_l1a(packets, cdf_filepath):
     ----------
     packets: list
         Decom data list that contains all appIds
-    cdf_filepath: str
-        Folder path of where to write CDF file
 
     Returns
     -------
-    str
-        Path name of where CDF file was created.
+    pathlib.Path
+        Path to where the CDF file was created.
         This is used to upload file from local to s3.
         TODO: test this later.
     """
@@ -51,9 +49,8 @@ def swe_l1a(packets, cdf_filepath):
             data = create_dataset(packets=sorted_packets)
 
         # write data to CDF
+        mode = f"{data['APP_MODE'].data[0]}-" if apid == SWEAPID.SWE_APP_HK else ""
         return write_cdf(
             data,
-            mode=f"{data['APP_MODE'].data[0]}" if apid == SWEAPID.SWE_APP_HK else "",
-            description=filename_descriptors.get(apid),
-            directory=cdf_filepath,
+            description=f"{mode}{filename_descriptors.get(apid)}",
         )

--- a/imap_processing/swe/l1b/swe_l1b.py
+++ b/imap_processing/swe/l1b/swe_l1b.py
@@ -10,19 +10,17 @@ from imap_processing.swe.utils.swe_utils import SWEAPID, filename_descriptors
 from imap_processing.utils import convert_raw_to_eu
 
 
-def swe_l1b(l1a_dataset: xr.Dataset, cdf_filepath: str):
+def swe_l1b(l1a_dataset: xr.Dataset):
     """Process data to L1B.
 
     Parameters
     ----------
     l1a_dataset : xarray.Dataset
         l1a data input
-    cdf_filepath: str
-        Folder path of where to write CDF file
 
     Returns
     -------
-    str
+    pathlib.Path
         Path to the L1B file.
 
     Raises
@@ -50,10 +48,8 @@ def swe_l1b(l1a_dataset: xr.Dataset, cdf_filepath: str):
         data = eu_data
         # Update global attributes to l1b global attributes
         data.attrs.update(swe_cdf_attrs.swe_l1b_global_attrs.output())
-
+    mode = f"{data['APP_MODE'].data[0]}-" if apid == SWEAPID.SWE_APP_HK else ""
     return write_cdf(
         data,
-        mode=f"{data['APP_MODE'].data[0]}" if apid == SWEAPID.SWE_APP_HK else "",
-        description=filename_descriptors.get(apid),
-        directory=cdf_filepath,
+        description=f"{mode}{filename_descriptors.get(apid)}",
     )

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -1,0 +1,41 @@
+import numpy as np
+import xarray as xr
+
+from imap_processing.cdf.global_attrs import ConstantCoordinates
+from imap_processing.cdf.utils import calc_start_time, write_cdf
+from imap_processing.swe.swe_cdf_attrs import swe_l1a_global_attrs
+
+
+def test_calc_start_time():
+    # TODO: Update this when launch time is updated
+    launch_time = np.datetime64("2010-01-01T00:01:06.184")
+    assert calc_start_time(0) == launch_time
+    assert calc_start_time(1) == launch_time + np.timedelta64(1, "s")
+
+
+def test_write_cdf(tmp_path):
+    # Set up a fake dataset
+    # lots of requirements on attributes, so depend on SWE for now
+    dataset = xr.Dataset(
+        {"Epoch": ("Epoch", [1, 2, 3])},
+        attrs=swe_l1a_global_attrs.output()
+        | {"Logical_source": "imap_test_l1", "Data_version": "01"},
+    )
+    dataset["Epoch"].attrs = ConstantCoordinates.EPOCH
+
+    fname = write_cdf(dataset, description="test-description")
+    assert fname.exists()
+    assert fname.name == "imap_test_l1_test-description_20100101_v01.cdf"
+    # Created automatically for us
+    dir_structure = fname.parts[-5:-1]
+    # instrument, level, year, month
+    assert dir_structure == ("test", "l1", "2010", "01")
+
+    # Test an explicit directory doesn't create that structure
+    filename = write_cdf(dataset, description="test-description", directory=tmp_path)
+    assert filename.exists()
+    assert filename.name == "imap_test_l1_test-description_20100101_v01.cdf"
+    # Created automatically for us
+    dir_structure = filename.parts[-5:-1]
+    # It should be the same as the tmp_path structure (minus the file name)
+    assert dir_structure == tmp_path.parts[-4:]

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -29,9 +29,7 @@ def l0_test_data() -> list:
     return packets
 
 
-def test_codice_l1a(
-    l0_test_data: list[space_packet_parser.parser.Packet], tmp_path: Path
-) -> str:
+def test_codice_l1a(l0_test_data: list[space_packet_parser.parser.Packet]) -> str:
     """Tests the ``codice_l1a`` function and ensured that a proper CDF file
     was created
 
@@ -43,6 +41,6 @@ def test_codice_l1a(
         pytest fixture used to provide a temporary directory during testing
     """
 
-    cdf_filename = codice_l1a(l0_test_data, tmp_path)
+    cdf_filename = codice_l1a(l0_test_data)
 
     assert Path(cdf_filename).name == "imap_codice_l1a_hk_20100101_v01.cdf"

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Global pytest configuration for the package."""
+import pytest
+
+import imap_processing
+
+
+@pytest.fixture(autouse=True)
+def _set_global_data_dir(tmp_path):
+    """Set the global data directory to a temporary directory."""
+    _original_data_dir = imap_processing.config["DATA_DIR"]
+    imap_processing.config["DATA_DIR"] = tmp_path
+    yield
+    imap_processing.config["DATA_DIR"] = _original_data_dir

--- a/imap_processing/tests/swe/test_swe_l1a.py
+++ b/imap_processing/tests/swe/test_swe_l1a.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from imap_processing import imap_module_directory
@@ -47,11 +45,9 @@ def test_group_by_apid(decom_test_data):
     assert len(total_event_message_data) == 15
 
 
-def test_cdf_creation(decom_test_data, tmp_path):
-    cdf_filepath = tmp_path / "cdf_files"
-    cdf_filepath.mkdir()
+def test_cdf_creation(decom_test_data):
     grouped_data = group_by_apid(decom_test_data)
-    sci_cdf_filepath = swe_l1a(grouped_data[SWEAPID.SWE_SCIENCE], cdf_filepath)
-    hk_cdf_filepath = swe_l1a(grouped_data[SWEAPID.SWE_APP_HK], cdf_filepath)
-    assert os.path.basename(sci_cdf_filepath) == "imap_swe_l1a_sci_20230927_v01.cdf"
-    assert os.path.basename(hk_cdf_filepath) == "imap_swe_l1a_lveng_hk_20230927_v01.cdf"
+    sci_cdf_filepath = swe_l1a(grouped_data[SWEAPID.SWE_SCIENCE])
+    hk_cdf_filepath = swe_l1a(grouped_data[SWEAPID.SWE_APP_HK])
+    assert sci_cdf_filepath.name == "imap_swe_l1a_sci_20230927_v01.cdf"
+    assert hk_cdf_filepath.name == "imap_swe_l1a_lveng-hk_20230927_v01.cdf"

--- a/imap_processing/tests/swe/test_swe_l1b.py
+++ b/imap_processing/tests/swe/test_swe_l1b.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pandas as pd
 import pytest
 from cdflib.xarray import cdf_to_xarray
@@ -141,18 +139,16 @@ def test_swe_l1b(decom_test_data):
         assert round(hk_l1b[field].data[1], 5) == round(validation_data[field], 5)
 
 
-def test_cdf_creation(decom_test_data, l1a_test_data, tmp_path):
-    cdf_filepath = tmp_path / "cdf_files"
-    cdf_filepath.mkdir()
-    sci_l1b_filepath = swe_l1b(l1a_test_data, cdf_filepath)
+def test_cdf_creation(decom_test_data, l1a_test_data):
+    sci_l1b_filepath = swe_l1b(l1a_test_data)
 
     # process hk data to l1a and then pass to l1b
     grouped_data = group_by_apid(decom_test_data)
     # writes data to CDF file
-    hk_l1a_filepath = swe_l1a(grouped_data[SWEAPID.SWE_APP_HK], cdf_filepath)
+    hk_l1a_filepath = swe_l1a(grouped_data[SWEAPID.SWE_APP_HK])
     # reads data from CDF file and passes to l1b
     l1a_dataset = cdf_to_xarray(hk_l1a_filepath)
-    hk_l1b_filepath = swe_l1b(l1a_dataset, cdf_filepath)
+    hk_l1b_filepath = swe_l1b(l1a_dataset)
 
-    assert Path(hk_l1b_filepath).name == "imap_swe_l1b_lveng_hk_20230927_v01.cdf"
-    assert Path(sci_l1b_filepath).name == "imap_swe_l1b_sci_20230927_v01.cdf"
+    assert hk_l1b_filepath.name == "imap_swe_l1b_lveng-hk_20230927_v01.cdf"
+    assert sci_l1b_filepath.name == "imap_swe_l1b_sci_20230927_v01.cdf"

--- a/imap_processing/tests/test_data_access.py
+++ b/imap_processing/tests/test_data_access.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_data_dir():
+    """Test that the data directory is set correctly."""
+    command = [
+        sys.executable,
+        "-c",
+        "import imap_processing; print(imap_processing.config['DATA_DIR'])",
+    ]
+    # Default import should be current working directory.
+    proc = subprocess.run(
+        command,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    expected = str(Path.cwd() / "imap-data")
+    assert proc.stdout.strip() == expected
+
+    # Setting the environment variable should change the data directory
+    proc = subprocess.run(
+        command,
+        env={**os.environ, "IMAP_DATA_DIR": "/test/path"},
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    assert proc.stdout.strip() == str(Path("/test/path"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ select = ["B", "D", "E", "F", "I", "N", "S", "W", "PL", "PT", "UP", "RUF"]
 ignore = ["D104", "PLR2004", "S101"]
 
 [tool.ruff.per-file-ignores]
-"*/tests/*" = ["D"]
+# S603 unchecked input in subprocess call is fine in our tests
+"*/tests/*" = ["D", "S603"]
 "tools/xtce*" = ["D"]
 # TODO: Too many statements, this could be refactored and removed
 # by creating a loop over a predefined mapping


### PR DESCRIPTION
# Change Summary

## Overview

This adds a global data directory to maintain all files underneath that is user-settable via an environment variable or command line argument. The purpose is to start moving towards the same logical folder structure we are using in AWS, but locally so all our file management is consistent. I ended up touching more than I wanted to here to try and add some tests and bring the current tests into pathlib parity. I'm happy to try and break some of this out if it is too large for a review now.

## New Dependencies
n/a

## New Files
n/a

## Deleted Files
n/a

## Updated Files
Many updates to various path handling functions.

## Testing
I added a few subprocess calls to verify that instantiating via environment variable works as expected.