### PR TITLE
PERF: Speed up bitstring conversions in idex

### DIFF
--- a/imap_processing/idex/idex_packet_parser.py
+++ b/imap_processing/idex/idex_packet_parser.py
@@ -821,11 +821,15 @@ class RawDustEvent:
 
         The very last 4 numbers are bad usually, so remove those
         """
-        w = bitstring.ConstBitStream(bin=waveform_raw)
         ints = []
-        while w.pos < len(w):
-            w.read("pad:2")  # skip 2
-            ints += w.readlist(["uint:10"] * 3)
+        for i in range(0, len(waveform_raw), 32):
+            # 32 bit chunks, divided up into 2, 10, 10, 10
+            # skip first two bits
+            ints += [
+                int(waveform_raw[i + 2 : i + 12], 2),
+                int(waveform_raw[i + 12 : i + 22], 2),
+                int(waveform_raw[i + 22 : i + 32], 2),
+            ]
         return ints[:-4]  # Remove last 4 numbers
 
     def _parse_low_sample_waveform(self, waveform_raw: str):
@@ -836,11 +840,12 @@ class RawDustEvent:
             * 8 bits of padding
             * 2x12 bits of integer data.
         """
-        w = bitstring.ConstBitStream(bin=waveform_raw)
         ints = []
-        while w.pos < len(w):
-            w.read("pad:8")  # skip 8
-            ints += w.readlist(["uint:12"] * 2)
+        for i in range(0, len(waveform_raw), 32):
+            ints += [
+                int(waveform_raw[i + 8 : i + 20], 2),
+                int(waveform_raw[i + 20 : i + 32], 2),
+            ]
         return ints
 
     def _calc_low_sample_resolution(self, num_samples: int):


### PR DESCRIPTION
# Change Summary

## Overview

Bitstring was allocating many new objects which added significant overhead. We can just use Python's native int conversions and indexing into strings to achieve the same result.

performance script:
`python -m cProfile -o orig.prof -m pytest imap_processing/idex/tests`

**current version**
![image](https://github.com/IMAP-Science-Operations-Center/imap_processing/assets/12417828/af902553-8e68-4768-94d6-b67b785dc957)

**new version**
![image](https://github.com/IMAP-Science-Operations-Center/imap_processing/assets/12417828/e082a488-dcc9-4302-8909-348606465c5a)

There are originally over 3M calls to ba2int and over 1M calls to _readlist, versus 228k and 0 in the new version.