### PR TITLE
PERF: Remove buffer size limitation

### DIFF
--- a/imap_processing/glows/l0/decom_glows.py
+++ b/imap_processing/glows/l0/decom_glows.py
@@ -58,10 +58,7 @@ def decom_packets(
 
     with open(packet_file_path, "rb") as binary_data:
         try:
-            glows_packets = glows_parser.generator(
-                binary_data,
-                buffer_read_size_bytes=5790778,
-            )
+            glows_packets = glows_parser.generator(binary_data)
 
             for packet in glows_packets:
                 apid = packet.header["PKT_APID"].derived_value

--- a/imap_processing/mag/l0/decom_mag.py
+++ b/imap_processing/mag/l0/decom_mag.py
@@ -40,10 +40,7 @@ def decom_packets(packet_file_path: str) -> list[MagL0]:
 
     with open(packet_file_path, "rb") as binary_data:
         try:
-            mag_packets = mag_parser.generator(
-                binary_data,
-                buffer_read_size_bytes=5790778,  # Todo: what size?
-            )
+            mag_packets = mag_parser.generator(binary_data)
 
             for packet in mag_packets:
                 apid = packet.header["PKT_APID"].derived_value


### PR DESCRIPTION
# Change Summary

## Overview

No need to explicitly overwrite the default size.

Similar to #309 and seeing things got slower, but a different solution here.

`python -m cProfile -o orig.prof -m pytest imap_processing/tests/glows`
Goes from 60s down to 20s on my local machine.

From the docs: https://space-packet-parser.readthedocs.io/en/latest/autoapi/space_packet_parser/parser/index.html

> buffer_read_size_bytes (int, Optional) – Number of bytes to read from e.g. a BufferedReader or socket binary data source on each read attempt. Default is 4096 bytes.

I wonder if this should be set globally for everyone if we do want to update the size of the reads...