### PR TITLE
TST: Re-use test fixtures within the module if possible

### DIFF
--- a/imap_processing/tests/glows/test_glows_decom.py
+++ b/imap_processing/tests/glows/test_glows_decom.py
@@ -8,7 +8,7 @@ from imap_processing.ccsds.ccsds_data import CcsdsData
 from imap_processing.glows.l0 import decom_glows
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def decom_test_data():
     """Read test data from file"""
     current_directory = Path(__file__).parent

--- a/imap_processing/tests/glows/test_glows_l1a_data.py
+++ b/imap_processing/tests/glows/test_glows_l1a_data.py
@@ -13,7 +13,7 @@ from imap_processing.glows.l1.glows_l1a_data import (
 from imap_processing.glows.utils.constants import DirectEvent, TimeTuple
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def decom_test_data():
     """Read test data from file"""
     current_directory = Path(__file__).parent


### PR DESCRIPTION
# Change Summary

## Overview

This speeds things up by not having to read the data so often.

Luckily or unluckily GLOWS was the only one that was easy to update and tests still passed. IDEX mutated their read-in data, so had to it has to be re-read each time, and Ultra was using function-level fixtures which can't be increased in scope, but seemingly those could be updated as well.