### PR TITLE
MNT: Rename description to descriptor in filename variable

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -41,7 +41,7 @@ def calc_start_time(shcoarse_time: int):
 
 def write_cdf(
     data: xr.Dataset,
-    description: str = "",
+    descriptor: str,
     directory: Optional[Path] = None,
 ):
     """Write the contents of "data" to a CDF file using cdflib.xarray_to_cdf.
@@ -57,10 +57,10 @@ def write_cdf(
     ----------
         data : xarray.Dataset
             The dataset object to convert to a CDF
-        description : str, optional
-            The description to insert into the file name after the
-                            orbit, before the SPICE field.  No underscores allowed.
-        directory : pathlib.Path
+        descriptor : str
+            The descriptor to insert into the file name after the
+            orbit, before the SPICE field.  No underscores allowed.
+        directory : pathlib.Path, optional
             The directory to write the file to. The default is obtained
             from the global imap_processing.config["DATA_DIR"].
 
@@ -84,13 +84,6 @@ def write_cdf(
 
     date_string = np.datetime_as_string(file_start_date, unit="D").replace("-", "")
 
-    # Determine the optional "description" field
-    description = (
-        description
-        if (description.startswith("_") or not description)
-        else f"_{description}"
-    )
-
     # Determine the file name based on the attributes in the xarray
     # Set file name based on this convention:
     # imap_<instrument>_<datalevel>_<descriptor>_<startdate>_
@@ -99,11 +92,10 @@ def write_cdf(
     # like this:
     #   imap_idex_l1
     filename = (
-        data.attrs["Logical_source"]
-        + description
-        + "_"
-        + date_string
-        + f"_v{data.attrs['Data_version']}.cdf"
+        f"{data.attrs['Logical_source']}"
+        f"_{descriptor}"
+        f"_{date_string}"
+        f"_v{data.attrs['Data_version']}.cdf"
     )
 
     if directory is None:

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -47,7 +47,7 @@ def codice_l1a(packets: list[space_packet_parser.parser.Packet]) -> str:
     # Write data to CDF
     cdf_filename = write_cdf(
         data,
-        description="hk",
+        descriptor="hk",
     )
 
     return cdf_filename

--- a/imap_processing/swe/l1a/swe_l1a.py
+++ b/imap_processing/swe/l1a/swe_l1a.py
@@ -52,5 +52,5 @@ def swe_l1a(packets):
         mode = f"{data['APP_MODE'].data[0]}-" if apid == SWEAPID.SWE_APP_HK else ""
         return write_cdf(
             data,
-            description=f"{mode}{filename_descriptors.get(apid)}",
+            descriptor=f"{mode}{filename_descriptors.get(apid)}",
         )

--- a/imap_processing/swe/l1b/swe_l1b.py
+++ b/imap_processing/swe/l1b/swe_l1b.py
@@ -51,5 +51,5 @@ def swe_l1b(l1a_dataset: xr.Dataset):
     mode = f"{data['APP_MODE'].data[0]}-" if apid == SWEAPID.SWE_APP_HK else ""
     return write_cdf(
         data,
-        description=f"{mode}{filename_descriptors.get(apid)}",
+        descriptor=f"{mode}{filename_descriptors.get(apid)}",
     )

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -23,18 +23,18 @@ def test_write_cdf(tmp_path):
     )
     dataset["Epoch"].attrs = ConstantCoordinates.EPOCH
 
-    fname = write_cdf(dataset, description="test-description")
+    fname = write_cdf(dataset, descriptor="test-descriptor")
     assert fname.exists()
-    assert fname.name == "imap_test_l1_test-description_20100101_v01.cdf"
+    assert fname.name == "imap_test_l1_test-descriptor_20100101_v01.cdf"
     # Created automatically for us
     dir_structure = fname.parts[-5:-1]
     # instrument, level, year, month
     assert dir_structure == ("test", "l1", "2010", "01")
 
     # Test an explicit directory doesn't create that structure
-    filename = write_cdf(dataset, description="test-description", directory=tmp_path)
+    filename = write_cdf(dataset, descriptor="test-descriptor", directory=tmp_path)
     assert filename.exists()
-    assert filename.name == "imap_test_l1_test-description_20100101_v01.cdf"
+    assert filename.name == "imap_test_l1_test-descriptor_20100101_v01.cdf"
     # Created automatically for us
     dir_structure = filename.parts[-5:-1]
     # It should be the same as the tmp_path structure (minus the file name)

--- a/imap_processing/tests/idex/test_l1_cdfs.py
+++ b/imap_processing/tests/idex/test_l1_cdfs.py
@@ -16,10 +16,10 @@ def decom_test_data():
 
 def test_idex_cdf_file(decom_test_data):
     # Verify that a CDF file can be created with no errors thrown by xarray_to_cdf
-    file_name = write_cdf(decom_test_data.data)
+    file_name = write_cdf(decom_test_data.data, descriptor="test")
     date_to_test = "20250724"
     assert file_name.name == (
-        f"{decom_test_data.data.attrs['Logical_source']}_"
+        f"{decom_test_data.data.attrs['Logical_source']}_test_"
         f"{date_to_test}_v{idex.__version__}.cdf"
     )
     assert file_name.exists()
@@ -29,7 +29,7 @@ def test_bad_cdf_attributes(decom_test_data):
     # Deliberately mess up the attributes to verify that an ISTPError is raised
     del decom_test_data.data["TOF_High"].attrs["DEPEND_1"]
     with pytest.raises(ISTPError):
-        write_cdf(decom_test_data.data)
+        write_cdf(decom_test_data.data, descriptor="test")
 
 
 def test_bad_cdf_file_data(decom_test_data):
@@ -58,12 +58,12 @@ def test_bad_cdf_file_data(decom_test_data):
     decom_test_data.data["Bad_data"] = bad_data_xr
 
     with pytest.raises(ISTPError):
-        write_cdf(decom_test_data.data)
+        write_cdf(decom_test_data.data, descriptor="test")
 
 
 def test_descriptor_in_file_name(decom_test_data):
     # Deliberately mess up the data to verify no CDF is created
-    file_name = write_cdf(decom_test_data.data, description="impact-lab-test001")
+    file_name = write_cdf(decom_test_data.data, descriptor="impact-lab-test001")
     date_to_test = "20250724"
     assert file_name.name == (
         f"{decom_test_data.data.attrs['Logical_source']}_"
@@ -78,7 +78,7 @@ def test_idex_tof_high_data_from_cdf(decom_test_data):
     with open("imap_processing/tests/idex/impact_14_tof_high_data.txt") as f:
         data = np.array([int(line.rstrip()) for line in f])
 
-    file_name = write_cdf(decom_test_data.data)
+    file_name = write_cdf(decom_test_data.data, descriptor="test")
     l1_data = cdf_to_xarray(
         file_name
     )  # Read in the data from the CDF file to an xarray object


### PR DESCRIPTION
# Change Summary

## Overview

Change "description" to "descriptor" for the filenames.

Additionally, `descriptor` is not optional anymore, so set a default of `sci` in the field. Or do we want to just force everyone to input this when calling `write_cdf()`?