### PR TITLE
MNT: Cleanup ruff codes

### DIFF
--- a/imap_processing/idex/idex_packet_parser.py
+++ b/imap_processing/idex/idex_packet_parser.py
@@ -26,6 +26,429 @@ SCITYPE_MAPPING_TO_NAMES = {
     64: "Ion_Grid",
 }
 
+"""
+Creates a large dictionary of values from the FPGA header
+that need to be captured into the CDF file.  They are lumped together because
+they share similar attributes.
+
+Notes about the variables are set here, acting as comments and will also be
+placed into the CDF in the VAR_NOTES attribute.
+"""
+TriggerDescription = namedtuple(
+    "TriggerDescription",
+    ["name", "packet_name", "num_bits", "field", "notes", "label", "units"],
+)
+trigger_description_dict = {
+    trigger.name: trigger
+    for trigger in [
+        TriggerDescription(
+            "event_number",
+            "IDX__TXHDREVTNUM",
+            16,
+            "Event Number",
+            "The unique number assigned to the impact by the FPGA",
+            "Event #",
+            "",
+        ),
+        TriggerDescription(
+            "tof_high_trigger_level",
+            "IDX__TXHDRHGTRIGLVL",
+            10,
+            "TOF High Trigger Level",
+            "Trigger level for the TOF High Channel",
+            "Level",
+            "",
+        ),
+        TriggerDescription(
+            "tof_high_trigger_num_max_1_2",
+            "IDX__TXHDRHGTRIGNMAX12",
+            11,
+            "TOF High Double Pulse Max Samples",
+            (
+                "Maximum number of samples between pulse 1 and 2 for TOF "
+                "High double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_high_trigger_num_min_1_2",
+            "IDX__TXHDRHGTRIGNMIN12",
+            11,
+            "TOF High Double Pulse Min Samples",
+            (
+                "Minimum number of samples between pulse 1 and 2 for TOF High "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_high_trigger_num_min_1",
+            "IDX__TXHDRHGTRIGNMIN1",
+            8,
+            "TOF High Pulse 1 Min Samples",
+            (
+                "Minimum number of samples for pulse 1 for TOF High single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_high_trigger_num_max_1",
+            "IDX__TXHDRHGTRIGNMAX1",
+            8,
+            "TOF High Pulse 1 Max Samples",
+            (
+                "Maximum number of samples for pulse 1 for TOF High single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_high_trigger_num_min_2",
+            "IDX__TXHDRHGTRIGNMIN2",
+            8,
+            "TOF High Pulse 2 Min Samples",
+            (
+                "Minimum number of samples for pulse 2 for TOF High single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_high_trigger_num_max_2",
+            "IDX__TXHDRHGTRIGNMAX2",
+            8,
+            "TOF High Pulse 2 Max Samples",
+            (
+                "Maximum number of samples for pulse 2 for TOF High single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_low_trigger_level",
+            "IDX__TXHDRLGTRIGLVL",
+            10,
+            "TOF Low Trigger Level",
+            "Trigger level for the TOF Low Channel",
+            "Level",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_low_trigger_num_max_1_2",
+            "IDX__TXHDRLGTRIGNMAX12",
+            11,
+            "TOF Low Double Pulse Max Samples",
+            (
+                "Maximum number of samples between pulse 1 and 2 for TOF Low "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_low_trigger_num_min_1_2",
+            "IDX__TXHDRLGTRIGNMIN12",
+            11,
+            "TOF Low Double Pulse Min Samples",
+            (
+                "Minimum number of samples between pulse 1 and 2 for TOF Low "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_low_trigger_num_min_1",
+            "IDX__TXHDRLGTRIGNMIN1",
+            8,
+            "TOF Low Pulse 1 Min Samples",
+            (
+                "Minimum number of samples for pulse 1 for TOF Low single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_low_trigger_num_max_1",
+            "IDX__TXHDRLGTRIGNMAX1",
+            8,
+            "TOF Low Pulse 1 Max Samples",
+            (
+                "Maximum number of samples for pulse 1 for TOF Low single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_low_trigger_num_min_2",
+            "IDX__TXHDRLGTRIGNMIN2",
+            8,
+            "TOF Low Pulse 2 Min Samples",
+            (
+                "Minimum number of samples for pulse 2 for TOF Low single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_low_trigger_num_max_2",
+            "IDX__TXHDRLGTRIGNMAX2",
+            16,
+            "TOF Low Pulse 2 Max Samples",
+            (
+                "Maximum number of samples for pulse 2 for TOF Low single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_mid_trigger_level",
+            "IDX__TXHDRMGTRIGLVL",
+            10,
+            "TOF Mid Trigger Level",
+            "Trigger level for the TOF Mid Channel",
+            "Level",
+            "# Samples",
+        ),
+        TriggerDescription(
+            "tof_mid_trigger_num_max_1_2",
+            "IDX__TXHDRMGTRIGNMAX12",
+            11,
+            "TOF Mid Double Pulse Max Samples",
+            (
+                "Maximum number of samples between pulse 1 and 2 for TOF Mid "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_mid_trigger_num_min_1_2",
+            "IDX__TXHDRMGTRIGNMIN12",
+            11,
+            "TOF Mid Double Pulse Min Samples",
+            (
+                "Minimum number of samples between pulse 1 and 2 for TOF Mid "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_mid_trigger_num_min_1",
+            "IDX__TXHDRMGTRIGNMIN1",
+            8,
+            "TOF Mid Pulse 1 Min Samples",
+            (
+                "Minimum number of samples for pulse 1 for TOF Mid single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_mid_trigger_num_max_1",
+            "IDX__TXHDRMGTRIGNMAX1",
+            8,
+            "TOF Mid Pulse 1 Max Samples",
+            (
+                "Maximum number of samples for pulse 1 for TOF Mid single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_mid_trigger_num_min_2",
+            "IDX__TXHDRMGTRIGNMIN2",
+            8,
+            "TOF Mid Pulse 2 Min Samples",
+            (
+                "Minimum number of samples for pulse 2 for TOF Mid single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "tof_mid_trigger_num_max_2",
+            "IDX__TXHDRMGTRIGNMAX2",
+            8,
+            "TOF Mid Pulse 2 Max Samples",
+            (
+                "Maximum number of samples for pulse 2 for TOF Mid single and "
+                "double pulse triggering"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "low_sample_coincidence_mode_blocks",
+            "IDX__TXHDRLSTRIGCMBLOCKS",
+            3,
+            "LS Coincidence Mode Blocks",
+            (
+                "Number of blocks coincidence window is enabled after "
+                "low sample trigger"
+            ),
+            "# Blocks",
+            "Blocks",
+        ),
+        TriggerDescription(
+            "low_sample_trigger_polarity",
+            "IDX__TXHDRLSTRIGPOL",
+            1,
+            "LS Trigger Polarity",
+            "The trigger polarity for low sample (0 = normal, 1 = inverted) ",
+            "Polarity",
+            "",
+        ),
+        TriggerDescription(
+            "low_sample_trigger_level",
+            "IDX__TXHDRLSTRIGLVL",
+            12,
+            "LS Trigger Level",
+            "Trigger level for the low sample",
+            "Level",
+            "",
+        ),
+        TriggerDescription(
+            "low_sample_trigger_num_min",
+            "IDX__TXHDRLSTRIGNMIN",
+            8,
+            "LS Trigger Min Num Samples",
+            (
+                "The minimum number of samples above/below the trigger level for "
+                "triggering the low sample"
+            ),
+            "# Samples",
+            "samples",
+        ),
+        TriggerDescription(
+            "low_sample_trigger_mode",
+            "IDX__TXHDRLSTRIGMODE",
+            1,
+            "LS Trigger Mode Enabled",
+            "Low sample trigger mode (0=disabled, 1=enabled)",
+            "Mode",
+            "",
+        ),
+        TriggerDescription(
+            "tof_low_trigger_mode",
+            "IDX__TXHDRLSTRIGMODE",
+            1,
+            "TOF Low Trigger Mode Enabled",
+            "TOF Low trigger mode (0=disabled, 1=enabled)",
+            "Mode",
+            "",
+        ),
+        TriggerDescription(
+            "tof_mid_trigger_mode",
+            "IDX__TXHDRMGTRIGMODE",
+            1,
+            "TOF Mid Trigger Mode Enabled",
+            "TOF Mid trigger mode (0=disabled, 1=enabled)",
+            "Mode",
+            "",
+        ),
+        TriggerDescription(
+            "tof_high_trigger_mode",
+            "IDX__TXHDRHGTRIGMODE",
+            2,
+            "TOF High Trigger Mode Enabled",
+            (
+                "TOF High trigger mode (0=disabled, 1=threshold mode, "
+                "2=single pulse mode, 3=double pulse mode)"
+            ),
+            "Mode",
+            "",
+        ),
+        TriggerDescription(
+            "detector_voltage",
+            "IDX__TXHDRHVPSHKCH0",
+            12,
+            "Detector Voltage",
+            (
+                "Last measurement in raw dN for processor board signal: "
+                "Detector Voltage"
+            ),
+            "Voltage",
+            "dN",
+        ),
+        TriggerDescription(
+            "sensor_voltage",
+            "IDX__TXHDRHVPSHKCH1",
+            12,
+            "Sensor Voltage",
+            (
+                "Last measurement in raw dN for processor board signal: "
+                "Sensor Voltage "
+            ),
+            "Voltage",
+            "dN",
+        ),
+        TriggerDescription(
+            "target_voltage",
+            "IDX__TXHDRHVPSHKCH2",
+            12,
+            "Target Voltage",
+            (
+                "Last measurement in raw dN for processor board signal: "
+                "Target Voltage"
+            ),
+            "Voltage",
+            "dN",
+        ),
+        TriggerDescription(
+            "reflectron_voltage",
+            "IDX__TXHDRHVPSHKCH3",
+            12,
+            "Reflectron Voltage",
+            (
+                "Last measurement in raw dN for processor board signal: "
+                "Reflectron Voltage"
+            ),
+            "Voltage",
+            "dN",
+        ),
+        TriggerDescription(
+            "rejection_voltage",
+            "IDX__TXHDRHVPSHKCH4",
+            12,
+            "Rejection Voltage",
+            (
+                "Last measurement in raw dN for processor board signal: "
+                "Rejection Voltage"
+            ),
+            "Voltage",
+            "dN",
+        ),
+        TriggerDescription(
+            "detector_current",
+            "IDX__TXHDRHVPSHKCH5",
+            12,
+            "Detector Current",
+            (
+                "Last measurement in raw dN for processor board signal: "
+                "Detector Current "
+            ),
+            "Current",
+            "dN",
+        ),
+    ]
+}
+
 
 class PacketParser:
     """IDEX packet parsing class.
@@ -146,20 +569,19 @@ class RawDustEvent:
 
         """
         # Calculate the impact time in seconds since Epoch
-        self.impact_time = self._calc_impact_time(header_packet)
+        self.impact_time = 0
+        self._set_impact_time(header_packet)
 
-        (
-            self.low_sample_trigger_time,
-            self.high_sample_trigger_time,
-        ) = self._calc_sample_trigger_times(header_packet)
-        (
-            self.trigger_values,
-            self.trigger_notes,
-            self.trigger_fields,
-            self.trigger_maxes,
-            self.trigger_labels,
-            self.trigger_units,
-        ) = self._get_trigger_dicts(header_packet)
+        # The actual trigger time for the low and high sample rate in
+        # microseconds since the impact time
+        self.low_sample_trigger_time = 0
+        self.high_sample_trigger_time = 0
+        self._set_sample_trigger_times(header_packet)
+        # Iterate through the trigger description dictionary and pull out the values
+        self.trigger_values = {
+            trigger.name: header_packet.data[trigger.packet_name].raw_value
+            for trigger in trigger_description_dict.values()
+        }
         logging.debug(
             f"trigger_values:\n{self.trigger_values}"
         )  # Log values here in case of error
@@ -172,565 +594,18 @@ class RawDustEvent:
         self.Target_High_bits = ""
         self.Ion_Grid_bits = ""
 
-    def _get_trigger_dicts(self, packet):
-        """Create trigger information dictionaries.
-
-        Creates a large dictionary of values from the FPGA header
-        that need to be captured into the CDF file.  They are lumped together because
-        they share similar attributes.
-
-        Notes about the variables are set here, acting as comments and will also be
-        placed into the CDF in the VAR_NOTES attribute.
-
-        Parameters
-        ----------
-            packet : The IDEX FPGA Header Packet
-
-        Returns
-        -------
-            dict
-                A dictionary of (CDF variable name : value) pairs
-            dict
-                A dictionary of (CDF variable name : variable notes) pairs
-            dict
-                A dictionary of (CDF variable name : variable fields) pairs
-            dict
-                A dictionary of (CDF variable name : variable maxes) pairs
-            dict
-                A dictionary of (CDF variable name : variable labels) pairs
-            dict
-                A dictionary of (CDF variable name : variable units) pairs
-        """
-        trigger_values = {}
-        trigger_notes = {}
-        trigger_maxes = {}
-        trigger_fields = {}
-        trigger_labels = {}
-        trigger_units = {}
-
-        TriggerDescription = namedtuple(
-            "TriggerDescription",
-            ["name", "packet_name", "num_bits", "field", "notes", "label", "units"],
-        )
-
-        def _insert_into_dicts(trigger_description):
-            # Cleans up inserting the values into the dictionaries
-            trigger_values[trigger_description.name] = packet.data[
-                trigger_description.packet_name
-            ].raw_value
-            trigger_notes[trigger_description.name] = trigger_description.notes
-            trigger_maxes[trigger_description.name] = (
-                2**trigger_description.num_bits - 1
-            )
-            trigger_fields[trigger_description.name] = trigger_description.field
-            trigger_labels[trigger_description.name] = trigger_description.label
-            trigger_units[trigger_description.name] = trigger_description.units
-
-        # Get Event Number
-        _insert_into_dicts(
-            TriggerDescription(
-                "event_number",
-                "IDX__TXHDREVTNUM",
-                16,
-                "Event Number",
-                "The unique number assigned to the impact by the FPGA",
-                "Event #",
-                "",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_high_trigger_level",
-                "IDX__TXHDRHGTRIGLVL",
-                10,
-                "TOF High Trigger Level",
-                "Trigger level for the TOF High Channel",
-                "Level",
-                "",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_high_trigger_num_max_1_2",
-                "IDX__TXHDRHGTRIGNMAX12",
-                11,
-                "TOF High Double Pulse Max Samples",
-                (
-                    "Maximum number of samples between pulse 1 and 2 for TOF "
-                    "High double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_high_trigger_num_min_1_2",
-                "IDX__TXHDRHGTRIGNMIN12",
-                11,
-                "TOF High Double Pulse Min Samples",
-                (
-                    "Minimum number of samples between pulse 1 and 2 for TOF High "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_high_trigger_num_min_1",
-                "IDX__TXHDRHGTRIGNMIN1",
-                8,
-                "TOF High Pulse 1 Min Samples",
-                (
-                    "Minimum number of samples for pulse 1 for TOF High single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_high_trigger_num_max_1",
-                "IDX__TXHDRHGTRIGNMAX1",
-                8,
-                "TOF High Pulse 1 Max Samples",
-                (
-                    "Maximum number of samples for pulse 1 for TOF High single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_high_trigger_num_min_2",
-                "IDX__TXHDRHGTRIGNMIN2",
-                8,
-                "TOF High Pulse 2 Min Samples",
-                (
-                    "Minimum number of samples for pulse 2 for TOF High single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_high_trigger_num_max_2",
-                "IDX__TXHDRHGTRIGNMAX2",
-                8,
-                "TOF High Pulse 2 Max Samples",
-                (
-                    "Maximum number of samples for pulse 2 for TOF High single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_low_trigger_level",
-                "IDX__TXHDRLGTRIGLVL",
-                10,
-                "TOF Low Trigger Level",
-                "Trigger level for the TOF Low Channel",
-                "Level",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_low_trigger_num_max_1_2",
-                "IDX__TXHDRLGTRIGNMAX12",
-                11,
-                "TOF Low Double Pulse Max Samples",
-                (
-                    "Maximum number of samples between pulse 1 and 2 for TOF Low "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_low_trigger_num_min_1_2",
-                "IDX__TXHDRLGTRIGNMIN12",
-                11,
-                "TOF Low Double Pulse Min Samples",
-                (
-                    "Minimum number of samples between pulse 1 and 2 for TOF Low "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_low_trigger_num_min_1",
-                "IDX__TXHDRLGTRIGNMIN1",
-                8,
-                "TOF Low Pulse 1 Min Samples",
-                (
-                    "Minimum number of samples for pulse 1 for TOF Low single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_low_trigger_num_max_1",
-                "IDX__TXHDRLGTRIGNMAX1",
-                8,
-                "TOF Low Pulse 1 Max Samples",
-                (
-                    "Maximum number of samples for pulse 1 for TOF Low single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_low_trigger_num_min_2",
-                "IDX__TXHDRLGTRIGNMIN2",
-                8,
-                "TOF Low Pulse 2 Min Samples",
-                (
-                    "Minimum number of samples for pulse 2 for TOF Low single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_low_trigger_num_max_2",
-                "IDX__TXHDRLGTRIGNMAX2",
-                16,
-                "TOF Low Pulse 2 Max Samples",
-                (
-                    "Maximum number of samples for pulse 2 for TOF Low single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_mid_trigger_level",
-                "IDX__TXHDRMGTRIGLVL",
-                10,
-                "TOF Mid Trigger Level",
-                "Trigger level for the TOF Mid Channel",
-                "Level",
-                "# Samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_mid_trigger_num_max_1_2",
-                "IDX__TXHDRMGTRIGNMAX12",
-                11,
-                "TOF Mid Double Pulse Max Samples",
-                (
-                    "Maximum number of samples between pulse 1 and 2 for TOF Mid "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_mid_trigger_num_min_1_2",
-                "IDX__TXHDRMGTRIGNMIN12",
-                11,
-                "TOF Mid Double Pulse Min Samples",
-                (
-                    "Minimum number of samples between pulse 1 and 2 for TOF Mid "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_mid_trigger_num_min_1",
-                "IDX__TXHDRMGTRIGNMIN1",
-                8,
-                "TOF Mid Pulse 1 Min Samples",
-                (
-                    "Minimum number of samples for pulse 1 for TOF Mid single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_mid_trigger_num_max_1",
-                "IDX__TXHDRMGTRIGNMAX1",
-                8,
-                "TOF Mid Pulse 1 Max Samples",
-                (
-                    "Maximum number of samples for pulse 1 for TOF Mid single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_mid_trigger_num_min_2",
-                "IDX__TXHDRMGTRIGNMIN2",
-                8,
-                "TOF Mid Pulse 2 Min Samples",
-                (
-                    "Minimum number of samples for pulse 2 for TOF Mid single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_mid_trigger_num_max_2",
-                "IDX__TXHDRMGTRIGNMAX2",
-                8,
-                "TOF Mid Pulse 2 Max Samples",
-                (
-                    "Maximum number of samples for pulse 2 for TOF Mid single and "
-                    "double pulse triggering"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "low_sample_coincidence_mode_blocks",
-                "IDX__TXHDRLSTRIGCMBLOCKS",
-                3,
-                "LS Coincidence Mode Blocks",
-                (
-                    "Number of blocks coincidence window is enabled after "
-                    "low sample trigger"
-                ),
-                "# Blocks",
-                "Blocks",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "low_sample_trigger_polarity",
-                "IDX__TXHDRLSTRIGPOL",
-                1,
-                "LS Trigger Polarity",
-                "The trigger polarity for low sample (0 = normal, 1 = inverted) ",
-                "Polarity",
-                "",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "low_sample_trigger_level",
-                "IDX__TXHDRLSTRIGLVL",
-                12,
-                "LS Trigger Level",
-                "Trigger level for the low sample",
-                "Level",
-                "",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "low_sample_trigger_num_min",
-                "IDX__TXHDRLSTRIGNMIN",
-                8,
-                "LS Trigger Min Num Samples",
-                (
-                    "The minimum number of samples above/below the trigger level for "
-                    "triggering the low sample"
-                ),
-                "# Samples",
-                "samples",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "low_sample_trigger_mode",
-                "IDX__TXHDRLSTRIGMODE",
-                1,
-                "LS Trigger Mode Enabled",
-                "Low sample trigger mode (0=disabled, 1=enabled)",
-                "Mode",
-                "",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_low_trigger_mode",
-                "IDX__TXHDRLSTRIGMODE",
-                1,
-                "TOF Low Trigger Mode Enabled",
-                "TOF Low trigger mode (0=disabled, 1=enabled)",
-                "Mode",
-                "",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_mid_trigger_mode",
-                "IDX__TXHDRMGTRIGMODE",
-                1,
-                "TOF Mid Trigger Mode Enabled",
-                "TOF Mid trigger mode (0=disabled, 1=enabled)",
-                "Mode",
-                "",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "tof_high_trigger_mode",
-                "IDX__TXHDRHGTRIGMODE",
-                2,
-                "TOF High Trigger Mode Enabled",
-                (
-                    "TOF High trigger mode (0=disabled, 1=threshold mode, "
-                    "2=single pulse mode, 3=double pulse mode)"
-                ),
-                "Mode",
-                "",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "detector_voltage",
-                "IDX__TXHDRHVPSHKCH0",
-                12,
-                "Detector Voltage",
-                (
-                    "Last measurement in raw dN for processor board signal: "
-                    "Detector Voltage"
-                ),
-                "Voltage",
-                "dN",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "sensor_voltage",
-                "IDX__TXHDRHVPSHKCH1",
-                12,
-                "Sensor Voltage",
-                (
-                    "Last measurement in raw dN for processor board signal: "
-                    "Sensor Voltage "
-                ),
-                "Voltage",
-                "dN",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "target_voltage",
-                "IDX__TXHDRHVPSHKCH2",
-                12,
-                "Target Voltage",
-                (
-                    "Last measurement in raw dN for processor board signal: "
-                    "Target Voltage"
-                ),
-                "Voltage",
-                "dN",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "reflectron_voltage",
-                "IDX__TXHDRHVPSHKCH3",
-                12,
-                "Reflectron Voltage",
-                (
-                    "Last measurement in raw dN for processor board signal: "
-                    "Reflectron Voltage"
-                ),
-                "Voltage",
-                "dN",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "rejection_voltage",
-                "IDX__TXHDRHVPSHKCH4",
-                12,
-                "Rejection Voltage",
-                (
-                    "Last measurement in raw dN for processor board signal: "
-                    "Rejection Voltage"
-                ),
-                "Voltage",
-                "dN",
-            )
-        )
-        _insert_into_dicts(
-            TriggerDescription(
-                "detector_current",
-                "IDX__TXHDRHVPSHKCH5",
-                12,
-                "Detector Current",
-                (
-                    "Last measurement in raw dN for processor board signal: "
-                    "Detector Current "
-                ),
-                "Current",
-                "dN",
-            )
-        )
-
-        return (
-            trigger_values,
-            trigger_notes,
-            trigger_fields,
-            trigger_maxes,
-            trigger_labels,
-            trigger_units,
-        )
-
-    def _calc_impact_time(self, packet):
+    def _set_impact_time(self, packet):
         """Calculate the datetime64 from the FPGA header information.
 
         We are given the MET seconds, we need convert it to UTC.
 
         Parameters
         ----------
-            packet: space_packet_parser.ParsedPacket
-                The IDEX FPGA header packet
-
-        Returns
-        -------
-            np.datetime64
-                The time of the event
+        packet : space_packet_parser.ParsedPacket
+            The IDEX FPGA header packet
 
         TODO
-        -----
+        ----
         This conversion is temporary for now, and will need SPICE in the future.
         IDEX has set the time launch to Jan 1 2012 for calibration testing.
 
@@ -744,13 +619,13 @@ class RawDustEvent:
         # Get the datetime of Jan 1 2012 as the start date
         launch_time = np.datetime64("2012-01-01T00:00:00.000000000")
 
-        return (
+        self.impact_time = (
             launch_time
             + np.timedelta64(seconds_since_launch, "s")
             + np.timedelta64(microseconds_since_last_second, "us")
         )
 
-    def _calc_sample_trigger_times(self, packet):
+    def _set_sample_trigger_times(self, packet):
         """Calculate the actual sample trigger time.
 
         Determines how many samples of data are included before the dust impact
@@ -760,12 +635,6 @@ class RawDustEvent:
         ----------
             packet : space_packet_parser.ParsedPacket
                 The IDEX FPGA header packet info
-
-        Returns
-        -------
-            (int, int)
-                The actual trigger time for the low and high sample rate in
-                microseconds
 
         Notes
         -----
@@ -797,19 +666,17 @@ class RawDustEvent:
 
         # Calculate the low and high sample trigger times based on the high gain delay
         # and the number of high sample/low sample pretrigger blocks
-        low_sample_trigger_time = (
+        self.low_sample_trigger_time = (
             self.LOW_SAMPLE_RATE
             * (num_low_sample_pretrigger_blocks + 1)
             * self.NUMBER_SAMPLES_PER_LOW_SAMPLE_BLOCK
             - self.HIGH_SAMPLE_RATE * high_gain_delay
         )
-        high_sample_trigger_time = (
+        self.high_sample_trigger_time = (
             self.HIGH_SAMPLE_RATE
             * (num_high_sample_pretrigger_blocks + 1)
             * self.NUMBER_SAMPLES_PER_HIGH_SAMPLE_BLOCK
         )
-
-        return low_sample_trigger_time, high_sample_trigger_time
 
     def _parse_high_sample_waveform(self, waveform_raw: str):
         """Process the high sample waveform.
@@ -927,18 +794,19 @@ class RawDustEvent:
         # Gather the huge number of trigger info metadata
         trigger_vars = {}
         for var, value in self.trigger_values.items():
+            trigger_description = trigger_description_dict[var]
             trigger_vars[var] = xr.DataArray(
                 name=var,
                 data=[value],
                 dims=("Epoch"),
                 attrs=dataclasses.replace(
                     idex_cdf_attrs.trigger_base,
-                    catdesc=self.trigger_notes[var],
-                    fieldname=self.trigger_fields[var],
-                    var_notes=self.trigger_notes[var],
-                    validmax=self.trigger_maxes[var],
-                    label_axis=self.trigger_labels[var],
-                    units=self.trigger_units[var],
+                    catdesc=trigger_description.notes,
+                    fieldname=trigger_description.field,
+                    var_notes=trigger_description.notes,
+                    validmax=2**trigger_description.num_bits - 1,
+                    label_axis=trigger_description.label,
+                    units=trigger_description.units,
                 ).output(),
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,15 +69,15 @@ addopts = "-ra"
 [tool.ruff]
 target-version = "py39"
 select = ["B", "D", "E", "F", "I", "N", "S", "W", "PL", "PT", "UP", "RUF"]
-ignore = ["D104", "PLR2004", "S101"]
+# D104: Missing docstring in public package
+# PLR2004: Magic value in comparison
+# RUF200: pyproject missing field (poetry doesn't follow the spec)
+ignore = ["D104", "PLR2004", "RUF200"]
 
 [tool.ruff.per-file-ignores]
 # S603 unchecked input in subprocess call is fine in our tests
-"*/tests/*" = ["D", "S603"]
+"*/tests/*" = ["D", "S101", "S603"]
 "tools/xtce*" = ["D"]
-# TODO: Too many statements, this could be refactored and removed
-# by creating a loop over a predefined mapping
-"imap_processing/idex/idex_packet_parser.py" = ["PLR0915"]
 
 [tool.ruff.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
# Change Summary

## Overview

Update the `pyproject.toml` ruff flags that we are ignoring.

This looks like a large diff, but is largely a reorganization within the IDEX code. There was a large trigger_dict block that was being set in each object, but it was more of a global constant with information. I pulled that outside the scope of the object and index into the NamedTuples later instead. I also updated it so that the "calc_*" functions don't return things now, but rather set the values to the attributes directly, so I changed the name of those to make it clear we are setting things.
