### PR TITLE
ENH: Add i/o capability to communicate with the data archive

### DIFF
--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -19,9 +19,13 @@ from pathlib import Path
 # NOTE: Use a config dictionary, so it is a mutable global object,
 #       otherwise updating previous imports from other modules
 #       wouldn't have been updated globally (for example if referencing a string).
-config = {"DATA_DIR": Path(os.getenv("IMAP_DATA_DIR") or Path.cwd() / "imap-data")}
+config = {
+    "API_URL": "https://api.dev.imap-mission.com",
+    "DATA_DIR": Path(os.getenv("IMAP_DATA_DIR") or Path.cwd() / "imap-data"),
+}
 """imap_processing configuration dictionary.
 
+API_URL : This is the URL of the data archive API.
 DATA_DIR : This is where the file data is stored and organized by instrument and level.
     The default location is in the current working directory, but can be
     set on the command line using the --data-dir option, or through

--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -20,12 +20,12 @@ from pathlib import Path
 #       otherwise updating previous imports from other modules
 #       wouldn't have been updated globally (for example if referencing a string).
 config = {
-    "API_URL": "https://api.dev.imap-mission.com",
+    "DATA_ACCESS_API_URL": "https://api.dev.imap-mission.com",
     "DATA_DIR": Path(os.getenv("IMAP_DATA_DIR") or Path.cwd() / "imap-data"),
 }
 """imap_processing configuration dictionary.
 
-API_URL : This is the URL of the data archive API.
+DATA_ACCESS_API_URL : This is the URL of the data access API.
 DATA_DIR : This is where the file data is stored and organized by instrument and level.
     The default location is in the current working directory, but can be
     set on the command line using the --data-dir option, or through

--- a/imap_processing/io.py
+++ b/imap_processing/io.py
@@ -48,7 +48,7 @@ def download(filepath: str) -> Path:
         return destination
 
     # encode the query parameters
-    url = f"{imap_processing.config['API_URL']}"
+    url = f"{imap_processing.config['DATA_ACCESS_API_URL']}"
     url += f"/download?{urlencode({'filename': filepath})}"
     logger.info("Downloading file %s from %s to %s", filepath, url, destination)
 
@@ -106,7 +106,8 @@ def query(
     query_params = {key: value for key, value in locals().items() if value is not None}
     if not query_params:
         raise ValueError("At least one query parameter must be provided")
-    url = f"{imap_processing.config['API_URL']}/query?{urlencode(query_params)}"
+    url = f"{imap_processing.config['DATA_ACCESS_API_URL']}"
+    url += f"/query?{urlencode(query_params)}"
 
     logger.debug("Querying data archive for %s with url %s", query_params, url)
     request = urllib.request.Request(url, method="GET")
@@ -141,7 +142,7 @@ def upload(filepath: Path) -> None:
     # Strip off the data directory to get the upload path + name
     upload_name = str(filepath.relative_to(imap_processing.config["DATA_DIR"]))
 
-    url = f"{imap_processing.config['API_URL']}"
+    url = f"{imap_processing.config['DATA_ACCESS_API_URL']}"
     url += f"/upload?{urlencode({'filename': upload_name})}"
     logger.debug("Uploading file %s to %s", filepath, url)
 

--- a/imap_processing/io.py
+++ b/imap_processing/io.py
@@ -68,11 +68,12 @@ def download(filepath: str) -> Path:
 def query(
     *,
     instrument: Optional[str] = None,
-    level: Optional[str] = None,
+    data_level: Optional[str] = None,
     descriptor: Optional[str] = None,
-    startdate: Optional[str] = None,
-    enddate: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     version: Optional[str] = None,
+    extension: Optional[str] = None,
 ):
     """Query the data archive for files matching the parameters.
 

--- a/imap_processing/io.py
+++ b/imap_processing/io.py
@@ -1,0 +1,162 @@
+"""Input/output capabilities for the IMAP data processing pipeline."""
+# ruff: noqa: PLR0913 S310
+# too many arguments, but we want all of these explicitly listed
+# potentially unsafe usage of urlopen, but we aren't concerned here
+import json
+import logging
+import urllib.request
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlencode
+
+import imap_processing
+
+logger = logging.getLogger(__name__)
+
+
+def download(filepath: str) -> Path:
+    """Download a file from the data archive.
+
+    Parameters
+    ----------
+    filepath : str
+        Name of the file to download, optionally including the directory path
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the downloaded file
+    """
+    destination = imap_processing.config["DATA_DIR"]
+    if "/" not in filepath:
+        # Construct the directory structure from the filename
+        # This is for science files that contain the directory structure in the filename
+        # Otherwise, we assume the full path to the file was given
+        parts = filepath.split("_")
+        instrument = parts[1]
+        datalevel = parts[2]
+        startdate = parts[4]
+        year = startdate[:4]
+        month = startdate[4:6]
+        destination = destination / instrument / datalevel / year / month
+    destination /= filepath
+
+    # Only download if the file doesn't already exist
+    # TODO: Do we want to verify any hashes to make sure we have the right file?
+    if destination.exists():
+        logger.info("The file %s already exists, skipping download", destination)
+        return destination
+
+    # encode the query parameters
+    url = f"{imap_processing.config['API_URL']}"
+    url += f"/download?{urlencode({'filename': filepath})}"
+    logger.info("Downloading file %s from %s to %s", filepath, url, destination)
+
+    # Create a request with the provided URL
+    request = urllib.request.Request(url, method="GET")
+    # Open the URL and download the file
+    with urllib.request.urlopen(request) as response:
+        logger.debug("Received response: %s", response)
+        # Save the file locally with the same filename
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with open(destination, "wb") as local_file:
+            local_file.write(response.read())
+
+    return destination
+
+
+def query(
+    *,
+    instrument: Optional[str] = None,
+    level: Optional[str] = None,
+    descriptor: Optional[str] = None,
+    startdate: Optional[str] = None,
+    enddate: Optional[str] = None,
+    version: Optional[str] = None,
+):
+    """Query the data archive for files matching the parameters.
+
+    Parameters
+    ----------
+    instrument : str, optional
+        Instrument name
+    level : str, optional
+        Data level
+    descriptor : str, optional
+        Descriptor of the data product / product name
+    startdate : str, optional
+        Start date in YYYYMMDD format. Note this is to search for all files
+        with start dates on or after this value.
+    enddate : str, optional
+        End date in YYYYMMDD format. Note this is to search for all files
+        with start dates before the enddate, not the enddate of the file.
+        For example, if a file spans three months 20100101 to 20100330,
+        and the enddate query was 20100201, the file would still be returned
+        because the startdate is within the query range.
+    version : str, optional
+        Data version
+
+    Returns
+    -------
+    list
+        List of files matching the query
+    """
+    # locals() gives us the keyword arguments passed to the function
+    # and allows us to filter out the None values
+    query_params = {key: value for key, value in locals().items() if value is not None}
+    if not query_params:
+        raise ValueError("At least one query parameter must be provided")
+    url = f"{imap_processing.config['API_URL']}/query?{urlencode(query_params)}"
+
+    logger.debug("Querying data archive for %s with url %s", query_params, url)
+    request = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(request) as response:
+        # Retrieve the response as a list of files
+        items = response.read().decode("utf-8")
+        logger.debug("Received response: %s", items)
+        # Decode the JSON string into a list
+        items = json.loads(items)
+        logger.debug("Decoded JSON: %s", items)
+    return items
+
+
+def upload(filepath: Path) -> None:
+    """Upload a file to the data archive.
+
+    Parameters
+    ----------
+    filepath : pathlib.Path
+        Path to the file to upload. It must be located within
+        the ``imap_processing.config["DATA_DIR"]`` directory.
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(filepath)
+
+    if not filepath.is_relative_to(imap_processing.config["DATA_DIR"]):
+        raise ValueError(
+            f"File {filepath} is not within the data directory: "
+            f"{imap_processing.config['DATA_DIR']}"
+        )
+
+    # Strip off the data directory to get the upload path + name
+    upload_name = str(filepath.relative_to(imap_processing.config["DATA_DIR"]))
+
+    url = f"{imap_processing.config['API_URL']}"
+    url += f"/upload?{urlencode({'filename': upload_name})}"
+    logger.debug("Uploading file %s to %s", filepath, url)
+
+    # We send a GET request with the filename and the server
+    # will respond with an s3 presigned URL that we can use
+    # to upload the file to the data archive
+    request = urllib.request.Request(url, method="GET")
+
+    with urllib.request.urlopen(request) as response:
+        # Retrieve the key for the upload
+        s3_url = response.read().decode("utf-8")
+        logger.debug("Received s3 presigned URL: %s", s3_url)
+
+    # Follow the presigned URL to upload the file with a PUT request
+    with open(filepath, "rb") as local_file:
+        request = urllib.request.Request(s3_url, data=local_file.read(), method="PUT")
+        with urllib.request.urlopen(request) as response:
+            logger.debug("Received response: %s", response.read().decode("utf-8"))

--- a/imap_processing/io.py
+++ b/imap_processing/io.py
@@ -49,7 +49,7 @@ def download(filepath: str) -> Path:
 
     # encode the query parameters
     url = f"{imap_processing.config['DATA_ACCESS_API_URL']}"
-    url += f"/download?{urlencode({'filename': filepath})}"
+    url += f"/download/{filepath}"
     logger.info("Downloading file %s from %s to %s", filepath, url, destination)
 
     # Create a request with the provided URL
@@ -79,22 +79,24 @@ def query(
     Parameters
     ----------
     instrument : str, optional
-        Instrument name
-    level : str, optional
-        Data level
+        Instrument name (e.g. ``mag``)
+    data_level : str, optional
+        Data level (e.g. ``l1a``)
     descriptor : str, optional
-        Descriptor of the data product / product name
-    startdate : str, optional
+        Descriptor of the data product / product name (e.g. ``burst``)
+    start_date : str, optional
         Start date in YYYYMMDD format. Note this is to search for all files
         with start dates on or after this value.
-    enddate : str, optional
+    end_date : str, optional
         End date in YYYYMMDD format. Note this is to search for all files
         with start dates before the enddate, not the enddate of the file.
         For example, if a file spans three months 20100101 to 20100330,
         and the enddate query was 20100201, the file would still be returned
         because the startdate is within the query range.
     version : str, optional
-        Data version
+        Data version in the format ``vXX-YY``
+    extension : str, optional
+        File extension (``cdf``, ``pkts``)
 
     Returns
     -------
@@ -143,7 +145,8 @@ def upload(filepath: Path) -> None:
     upload_name = str(filepath.relative_to(imap_processing.config["DATA_DIR"]))
 
     url = f"{imap_processing.config['DATA_ACCESS_API_URL']}"
-    url += f"/upload?{urlencode({'filename': upload_name})}"
+    # The upload name needs to be given as a path parameter
+    url += f"/upload/science/{upload_name}"
     logger.debug("Uploading file %s to %s", filepath, url)
 
     # We send a GET request with the filename and the server

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -5,9 +5,7 @@ import imap_processing
 
 
 @pytest.fixture(autouse=True)
-def _set_global_data_dir(tmp_path):
+def _set_global_config(monkeypatch, tmp_path):
     """Set the global data directory to a temporary directory."""
-    _original_data_dir = imap_processing.config["DATA_DIR"]
-    imap_processing.config["DATA_DIR"] = tmp_path
-    yield
-    imap_processing.config["DATA_DIR"] = _original_data_dir
+    monkeypatch.setitem(imap_processing.config, "DATA_DIR", tmp_path)
+    monkeypatch.setitem(imap_processing.config, "API_URL", "https://api.test.com")

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -8,4 +8,6 @@ import imap_processing
 def _set_global_config(monkeypatch, tmp_path):
     """Set the global data directory to a temporary directory."""
     monkeypatch.setitem(imap_processing.config, "DATA_DIR", tmp_path)
-    monkeypatch.setitem(imap_processing.config, "API_URL", "https://api.test.com")
+    monkeypatch.setitem(
+        imap_processing.config, "DATA_ACCESS_API_URL", "https://api.test.com"
+    )

--- a/imap_processing/tests/test_io.py
+++ b/imap_processing/tests/test_io.py
@@ -86,14 +86,15 @@ def test_download_already_exists(mock_urlopen):
         # All parameters should send full query
         {
             "instrument": "test-instrument",
-            "level": "test-level",
+            "data_level": "test-level",
             "descriptor": "test-description",
-            "startdate": "20100101",
-            "enddate": "20100102",
+            "start_date": "20100101",
+            "end_date": "20100102",
             "version": "00-00",
+            "extension": "pkts",
         },
         # Make sure not all query params are sent if they are missing
-        {"instrument": "test-instrument", "level": "test-level"},
+        {"instrument": "test-instrument", "data_level": "test-level"},
     ],
 )
 def test_query(mock_urlopen, query_params):
@@ -114,6 +115,13 @@ def test_query(mock_urlopen, query_params):
 def test_query_no_params(mock_urlopen):
     with pytest.raises(ValueError, match="At least one query"):
         imap_processing.io.query()
+    # Should not have made any calls to urlopen
+    assert mock_urlopen.call_count == 0
+
+
+def test_query_bad_params(mock_urlopen):
+    with pytest.raises(TypeError, match="got an unexpected"):
+        imap_processing.io.query(bad_param="test")
     # Should not have made any calls to urlopen
     assert mock_urlopen.call_count == 0
 

--- a/imap_processing/tests/test_io.py
+++ b/imap_processing/tests/test_io.py
@@ -60,9 +60,8 @@ def test_download(mock_urlopen, filepath, destination):
     # We pass a Request object, so need to get that with args[0]
     request_sent = urlopen_calls[0].args[0]
     called_url = request_sent.full_url
-    expected_url_encoded = (
-        f'https://api.test.com/download?{urlencode({"filename": filepath})}'
-    )
+    # url should be provided as path parameters
+    expected_url_encoded = f"https://api.test.com/download/{filepath}"
     assert called_url == expected_url_encoded
     assert request_sent.method == "GET"
 
@@ -162,9 +161,7 @@ def test_upload(mock_urlopen):
     urlopen_call = mock_calls[0]
     request_sent = urlopen_call.args[0]
     called_url = request_sent.full_url
-    expected_url_encoded = (
-        f'https://api.test.com/upload?{urlencode({"filename": "test-file.txt"})}'
-    )
+    expected_url_encoded = "https://api.test.com/upload/science/test-file.txt"
     assert called_url == expected_url_encoded
     assert request_sent.method == "GET"
 

--- a/imap_processing/tests/test_io.py
+++ b/imap_processing/tests/test_io.py
@@ -1,0 +1,193 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import urlencode
+from urllib.request import Request
+
+import pytest
+
+import imap_processing.io
+
+
+@pytest.fixture()
+def mock_download_urlopen():
+    """Mock urlopen to return a file-like object."""
+    mock_data = b"Mock file content"
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = mock_urlopen.return_value.__enter__.return_value
+        mock_response.read.return_value = mock_data
+        yield mock_urlopen
+
+
+@pytest.fixture()
+def mock_query_urlopen():
+    """Mock urlopen to return a file-like object."""
+    # Mock data for response, empty list
+    mock_data = json.dumps([]).encode("utf-8")
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = mock_urlopen.return_value.__enter__.return_value
+        mock_response.read.return_value = mock_data
+        yield mock_urlopen
+
+
+@pytest.fixture()
+def mock_upload_urlopen():
+    """Mock urlopen to return a file-like object."""
+    # Mock data for response, empty list
+    mock_data = b"https://s3-test-bucket.com"
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = mock_urlopen.return_value.__enter__.return_value
+        mock_response.read.return_value = mock_data
+        yield mock_urlopen
+
+
+@pytest.mark.parametrize(
+    ("filepath", "destination"),
+    [
+        # Directory structure inferred
+        (
+            "imap_test_l1_test-description_20100101_20100102_v00-00.cdf",
+            "test/l1/2010/01/imap_test_l1_test-description_20100101_20100102_v00-00.cdf",
+        ),
+        # Directory structure provided in the request
+        ("imap/test/config/file.txt", "imap/test/config/file.txt"),
+    ],
+)
+def test_download(mock_download_urlopen, filepath, destination):
+    # Call the download function
+    result = imap_processing.io.download(filepath)
+
+    # Assert that the file was created
+    assert result.exists()
+    # Test that the file was saved in the correct location
+    expected_destination = imap_processing.config["DATA_DIR"] / destination
+    assert result == expected_destination
+
+    # Assert that the file content matches the mock data
+    with open(result, "rb") as f:
+        assert f.read() == b"Mock file content"
+
+    # Should have only been one call to urlopen
+    mock_download_urlopen.assert_called_once()
+
+    # Assert that the correct URL was used for the download
+    urlopen_calls = mock_download_urlopen.mock_calls
+    # Check the arguments passed to urlopen
+    # We pass a Request object, so need to get that with args[0]
+    request_sent = urlopen_calls[0].args[0]
+    called_url = request_sent.full_url
+    expected_url_encoded = (
+        f'https://api.test.com/download?{urlencode({"filename": filepath})}'
+    )
+    assert called_url == expected_url_encoded
+    assert request_sent.method == "GET"
+
+
+def test_download_already_exists(mock_download_urlopen):
+    # Call the download function
+    filepath = "a/b.txt"
+    # set up the destination and create a file
+    destination = Path(imap_processing.config["DATA_DIR"])
+    destination /= f"{filepath}"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.touch(exist_ok=True)
+    result = imap_processing.io.download(filepath)
+    assert result == destination
+    # Make sure we didn't make any requests
+    assert mock_download_urlopen.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "query_params",
+    [
+        # All parameters should send full query
+        {
+            "instrument": "test-instrument",
+            "level": "test-level",
+            "descriptor": "test-description",
+            "startdate": "20100101",
+            "enddate": "20100102",
+            "version": "00-00",
+        },
+        # Make sure not all query params are sent if they are missing
+        {"instrument": "test-instrument", "level": "test-level"},
+    ],
+)
+def test_query(mock_query_urlopen, query_params):
+    response = imap_processing.io.query(**query_params)
+    # No data found, and JSON decoding works as expected
+    assert response == list()
+
+    # Should have only been one call to urlopen
+    mock_query_urlopen.assert_called_once()
+    # Assert that the correct URL was used for the query
+    urlopen_call = mock_query_urlopen.mock_calls[0].args[0]
+    called_url = urlopen_call.full_url
+    expected_url_encoded = f"https://api.test.com/query?{urlencode(query_params)}"
+    assert called_url == expected_url_encoded
+
+
+def test_query_no_params(mock_query_urlopen):
+    with pytest.raises(ValueError, match="At least one query"):
+        imap_processing.io.query()
+    # Should not have made any calls to urlopen
+    assert mock_query_urlopen.call_count == 0
+
+
+def test_upload_no_file():
+    path = Path("/non-existant/file.txt")
+    assert not path.exists()
+    with pytest.raises(FileNotFoundError):
+        imap_processing.io.upload(path)
+
+
+def test_upload_not_relative_to_base(monkeypatch):
+    # Change the base directory to something else temporarily
+    monkeypatch.setitem(imap_processing.config, "DATA_DIR", Path.cwd() / "/a/b/c")
+    with pytest.raises(ValueError, match="File"):
+        imap_processing.io.upload(Path(__file__))
+
+
+def test_upload(mock_upload_urlopen):
+    # Call the upload function
+    file_to_upload = imap_processing.config["DATA_DIR"] / "test-file.txt"
+    with open(file_to_upload, "wb") as f:
+        f.write(b"test file content")
+    assert file_to_upload.exists()
+    imap_processing.io.upload(file_to_upload)
+
+    # Should have been two calls to urlopen
+    # 1. To get the s3 upload url
+    # 2. To upload the file to the url returned in 1.
+    assert mock_upload_urlopen.call_count == 2
+    print(mock_upload_urlopen.mock_calls)
+    # We get all returned calls, but we only need the calls
+    # where we sent requests
+    mock_calls = [
+        call
+        for call in mock_upload_urlopen.mock_calls
+        if len(call.args) and isinstance(call.args[0], Request)
+    ]
+
+    # First urlopen call should be to get the s3 upload url
+    urlopen_call = mock_calls[0]
+    request_sent = urlopen_call.args[0]
+    called_url = request_sent.full_url
+    expected_url_encoded = (
+        f'https://api.test.com/upload?{urlencode({"filename": "test-file.txt"})}'
+    )
+    assert called_url == expected_url_encoded
+    assert request_sent.method == "GET"
+
+    # Verify that we put that response into our second request
+    urlopen_call = mock_calls[1]
+    request_sent = urlopen_call.args[0]
+    called_url = request_sent.full_url
+    expected_url_encoded = "https://s3-test-bucket.com"
+    assert called_url == expected_url_encoded
+    assert request_sent.method == "PUT"
+
+    # Assert that the original data from the test file was sent
+    assert request_sent.data == b"test file content"

--- a/imap_processing/tests/test_io.py
+++ b/imap_processing/tests/test_io.py
@@ -10,7 +10,7 @@ import imap_processing.io
 
 
 @pytest.fixture()
-def mock_download_urlopen():
+def mock_urlopen():
     """Mock urlopen to return a file-like object."""
     mock_data = b"Mock file content"
     with patch("urllib.request.urlopen") as mock_urlopen:
@@ -19,28 +19,10 @@ def mock_download_urlopen():
         yield mock_urlopen
 
 
-@pytest.fixture()
-def mock_query_urlopen():
-    """Mock urlopen to return a file-like object."""
-    # Mock data for response, empty list
-    mock_data = json.dumps([]).encode("utf-8")
-
-    with patch("urllib.request.urlopen") as mock_urlopen:
-        mock_response = mock_urlopen.return_value.__enter__.return_value
-        mock_response.read.return_value = mock_data
-        yield mock_urlopen
-
-
-@pytest.fixture()
-def mock_upload_urlopen():
-    """Mock urlopen to return a file-like object."""
-    # Mock data for response, empty list
-    mock_data = b"https://s3-test-bucket.com"
-
-    with patch("urllib.request.urlopen") as mock_urlopen:
-        mock_response = mock_urlopen.return_value.__enter__.return_value
-        mock_response.read.return_value = mock_data
-        yield mock_urlopen
+def _set_mock_data(mock_urlopen, data):
+    """Set the data returned by the mock urlopen."""
+    mock_response = mock_urlopen.return_value.__enter__.return_value
+    mock_response.read.return_value = data
 
 
 @pytest.mark.parametrize(
@@ -55,7 +37,7 @@ def mock_upload_urlopen():
         ("imap/test/config/file.txt", "imap/test/config/file.txt"),
     ],
 )
-def test_download(mock_download_urlopen, filepath, destination):
+def test_download(mock_urlopen, filepath, destination):
     # Call the download function
     result = imap_processing.io.download(filepath)
 
@@ -70,10 +52,10 @@ def test_download(mock_download_urlopen, filepath, destination):
         assert f.read() == b"Mock file content"
 
     # Should have only been one call to urlopen
-    mock_download_urlopen.assert_called_once()
+    mock_urlopen.assert_called_once()
 
     # Assert that the correct URL was used for the download
-    urlopen_calls = mock_download_urlopen.mock_calls
+    urlopen_calls = mock_urlopen.mock_calls
     # Check the arguments passed to urlopen
     # We pass a Request object, so need to get that with args[0]
     request_sent = urlopen_calls[0].args[0]
@@ -85,7 +67,7 @@ def test_download(mock_download_urlopen, filepath, destination):
     assert request_sent.method == "GET"
 
 
-def test_download_already_exists(mock_download_urlopen):
+def test_download_already_exists(mock_urlopen):
     # Call the download function
     filepath = "a/b.txt"
     # set up the destination and create a file
@@ -96,7 +78,7 @@ def test_download_already_exists(mock_download_urlopen):
     result = imap_processing.io.download(filepath)
     assert result == destination
     # Make sure we didn't make any requests
-    assert mock_download_urlopen.call_count == 0
+    assert mock_urlopen.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -115,42 +97,47 @@ def test_download_already_exists(mock_download_urlopen):
         {"instrument": "test-instrument", "level": "test-level"},
     ],
 )
-def test_query(mock_query_urlopen, query_params):
+def test_query(mock_urlopen, query_params):
+    _set_mock_data(mock_urlopen, json.dumps([]).encode("utf-8"))
     response = imap_processing.io.query(**query_params)
     # No data found, and JSON decoding works as expected
     assert response == list()
 
     # Should have only been one call to urlopen
-    mock_query_urlopen.assert_called_once()
+    mock_urlopen.assert_called_once()
     # Assert that the correct URL was used for the query
-    urlopen_call = mock_query_urlopen.mock_calls[0].args[0]
+    urlopen_call = mock_urlopen.mock_calls[0].args[0]
     called_url = urlopen_call.full_url
     expected_url_encoded = f"https://api.test.com/query?{urlencode(query_params)}"
     assert called_url == expected_url_encoded
 
 
-def test_query_no_params(mock_query_urlopen):
+def test_query_no_params(mock_urlopen):
     with pytest.raises(ValueError, match="At least one query"):
         imap_processing.io.query()
     # Should not have made any calls to urlopen
-    assert mock_query_urlopen.call_count == 0
+    assert mock_urlopen.call_count == 0
 
 
-def test_upload_no_file():
+def test_upload_no_file(mock_urlopen):
     path = Path("/non-existant/file.txt")
     assert not path.exists()
     with pytest.raises(FileNotFoundError):
         imap_processing.io.upload(path)
+    # Should not have made any calls to urlopen
+    assert mock_urlopen.call_count == 0
 
 
-def test_upload_not_relative_to_base(monkeypatch):
+def test_upload_not_relative_to_base(monkeypatch, mock_urlopen):
     # Change the base directory to something else temporarily
     monkeypatch.setitem(imap_processing.config, "DATA_DIR", Path.cwd() / "/a/b/c")
     with pytest.raises(ValueError, match="File"):
         imap_processing.io.upload(Path(__file__))
+    assert mock_urlopen.call_count == 0
 
 
-def test_upload(mock_upload_urlopen):
+def test_upload(mock_urlopen):
+    _set_mock_data(mock_urlopen, b"https://s3-test-bucket.com")
     # Call the upload function
     file_to_upload = imap_processing.config["DATA_DIR"] / "test-file.txt"
     with open(file_to_upload, "wb") as f:
@@ -161,13 +148,13 @@ def test_upload(mock_upload_urlopen):
     # Should have been two calls to urlopen
     # 1. To get the s3 upload url
     # 2. To upload the file to the url returned in 1.
-    assert mock_upload_urlopen.call_count == 2
-    print(mock_upload_urlopen.mock_calls)
+    assert mock_urlopen.call_count == 2
+
     # We get all returned calls, but we only need the calls
     # where we sent requests
     mock_calls = [
         call
-        for call in mock_upload_urlopen.mock_calls
+        for call in mock_urlopen.mock_calls
         if len(call.args) and isinstance(call.args[0], Request)
     ]
 


### PR DESCRIPTION
# Change Summary

## Overview
This adds the ability to download, query, and upload files from the data archive. This is currently opinionated and requires all files to be located within the `DATA_DIR` global configuration directory. I purposefully left off a `url=` argument to the functions to try and make us go through a global configuration url. If people are against that we can remove it. But, it seems like it might be nice to start enforcing some of these limits rather than keeping too many options available.

Outside of this scope: Adding it to the cli, which would make sense after this is decided upon.


## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- io.py
   - Contains the download(), query(), upload() functions

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- __init__.py
   - added API_URL to the config dictionary

## Testing

Lots of mock url testing. But, it could be better once we know what our query endpoints will return and things like that. I've left that off for now though since it is still somewhat TBD and we can update/improve these later then.