### PR TITLE
Fixed typo in pypi URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/imap_processing
+      url: https://pypi.org/p/imap-processing
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 


### PR DESCRIPTION
PyPI expects a hyphen instead of an underscore (though somehow an underscore still works!)