### PR TITLE
Lo SciDE data class fix - multiple DEs in a packet 

### DIFF
--- a/imap_processing/lo/l0/science_direct_events.py
+++ b/imap_processing/lo/l0/science_direct_events.py
@@ -3,9 +3,11 @@ from dataclasses import dataclass
 from itertools import compress
 
 import bitstring
+import numpy as np
 from bitarray import bitarray
 
 import imap_processing.lo.l0.decompression_tables as decompress_tables
+from imap_processing.ccsds.ccsds_data import CcsdsData
 from imap_processing.lo.l0.lo_base import LoBase
 
 
@@ -24,21 +26,21 @@ class ScienceDirectEvents(LoBase):
         Number of direct events.
     CHKSUM: int
         Checksum for the packet.
-    DATA: bitstring.Bits
+    DATA: str
         Compressed TOF Direct Event time tagged data.
-    TOF0: int
+    TOF0: numpy.ndarray
         Time of Flight 0 value for direct event.
-    TOF1: int
+    TOF1: numpy.ndarray
         Time of Flight 1 value for direct event.
-    TOF2: int
+    TOF2: numpy.ndarray
         Time of Flight 2 value for direct event.
-    TOF3: int
+    TOF3: numpy.ndarray
         Time of Flight 3 value for direct event.
-    TIME: int
+    TIME: numpy.ndarray
         time tag for the direct event
-    ENERGY: int
+    ENERGY: numpy.ndarray
         energy of the direct event ENA.
-    POS: int
+    POS: numpy.ndarray
         Stop position for the direct event. There are 4 quadrants
         on the at the stop position.
     CKSM: int
@@ -49,18 +51,6 @@ class ScienceDirectEvents(LoBase):
         for golden triples because it's used to recover TOF1 because
         compression scheme to save space on golden triples doesn't send
         down TOF1 so it's recovered on the ground using the checksum
-    case_number: int
-        The compression case number for the direct event. The case number
-        determines how the bits are arranged in the compressed data.
-    tof_calculation_binary: dict
-        Binary used to determine which TOF coefficients should be used
-        for decompressing the binary.
-    tof_decoder: list
-        Shows how the fields in the binary are split up by bit length and order.
-    remaining_bits: dict
-        The TOF coefficients that should be used for decompression
-    parsed_bits: dict
-        The binary bits split up by TOF field.
 
     Methods
     -------
@@ -77,19 +67,26 @@ class ScienceDirectEvents(LoBase):
     COUNT: int
     DATA: str
     CHKSUM: int
-    TOF0: float
-    TOF1: float
-    TOF2: float
-    TOF3: float
-    TIME: float
-    ENERGY: float
-    POS: float
+    TOF0: np.ndarray
+    TOF1: np.ndarray
+    TOF2: np.ndarray
+    TOF3: np.ndarray
+    TIME: np.ndarray
+    ENERGY: np.ndarray
+    POS: np.ndarray
 
     def __init__(self, packet, software_version: str, packet_file_name: str):
         """Intialization method for Science Direct Events Data class."""
-        # super().__init__(software_version, packet_file_name, CcsdsData(packet.header))
-        # self.parse_data(packet)
-        # self._decompress_data()
+        super().__init__(software_version, packet_file_name, CcsdsData(packet.header))
+        self.parse_data(packet)
+        self.TOF0 = np.array([])
+        self.TOF1 = np.array([])
+        self.TOF2 = np.array([])
+        self.TOF3 = np.array([])
+        self.TIME = np.array([])
+        self.ENERGY = np.array([])
+        self.POS = np.array([])
+        self._decompress_data()
 
     def _decompress_data(self):
         """Decompress the Lo Science Direct Events data."""
@@ -113,8 +110,6 @@ class ScienceDirectEvents(LoBase):
         The case number is used to determine how to
         decompress the TOF values.
         """
-        # TODO: Do I need to set the new bitpos or does the read
-        # do that automatically?
         return bitstream.read(4).uint
 
     def _find_tof_decoder_for_case(self, case_number, bitstream):
@@ -202,29 +197,70 @@ class ScienceDirectEvents(LoBase):
         """
         # separate the binary data into its parts
         parsed_bits = {}
+
         # Use the TOF decoder to chunk the data binary into its componenets
         # TOF0, TOF1, TOF2, etc.
         for field, bit_length in tof_decoder._asdict().items():
-            print(f"bit length: {bit_length}")
             parsed_bits[field] = bitstream.read(bit_length)
-            print(f"{field} : {parsed_bits[field].bin}")
         return parsed_bits
 
-    def _decode_fields(self, remaining_bit_coefficients, parsed_bits):
+    def _decode_fields(self, remaining_bit_coefficients, field, tof_bits):
         """Use the parsed data and TOF coefficients to decode the binary."""
-        for field, tof_bits in parsed_bits.items():
-            needed_bits = tof_bits[-len(remaining_bit_coefficients[field]) :]
-            # Use the TOF coefficients and the bits for the current field to
-            # calculate the decompressed value. Also round to 2 because the TOF
-            # coefficients only have 2 decimals.
-            decompressed_data = round(
-                sum(
-                    bit[0] * bit[1]
-                    for bit in zip(
-                        bitarray(needed_bits).tolist(),
-                        remaining_bit_coefficients[field],
-                    )
-                ),
-                2,
-            )
-            setattr(self, field, decompressed_data)
+        needed_bits = tof_bits[-len(remaining_bit_coefficients[field]) :]
+        # Use the TOF coefficients and the bits for the current field to
+        # calculate the decompressed value. Also round to 2 because the TOF
+        # coefficients only have 2 decimals.
+        decompressed_data = round(
+            sum(
+                bit[0] * bit[1]
+                for bit in zip(
+                    bitarray(needed_bits).tolist(),
+                    remaining_bit_coefficients[field],
+                )
+            ),
+            2,
+        )
+        return decompressed_data
+
+    def _set_tofs(self, remaining_bit_coefficients, parsed_bits):
+        """Set the TOF values after decoding the binary field."""
+        self.TOF0 = np.append(
+            self.TOF0,
+            self._decode_fields(
+                remaining_bit_coefficients, "TOF0", parsed_bits["TOF0"]
+            ),
+        )
+        self.TOF1 = np.append(
+            self.TOF1,
+            self._decode_fields(
+                remaining_bit_coefficients, "TOF1", parsed_bits["TOF1"]
+            ),
+        )
+        self.TOF2 = np.append(
+            self.TOF2,
+            self._decode_fields(
+                remaining_bit_coefficients, "TOF2", parsed_bits["TOF2"]
+            ),
+        )
+        self.TOF3 = np.append(
+            self.TOF3,
+            self._decode_fields(
+                remaining_bit_coefficients, "TOF3", parsed_bits["TOF3"]
+            ),
+        )
+        self.TIME = np.append(
+            self.TIME,
+            self._decode_fields(
+                remaining_bit_coefficients, "TIME", parsed_bits["TIME"]
+            ),
+        )
+        self.ENERGY = np.append(
+            self.ENERGY,
+            self._decode_fields(
+                remaining_bit_coefficients, "ENERGY", parsed_bits["ENERGY"]
+            ),
+        )
+        self.POS = np.append(
+            self.POS,
+            self._decode_fields(remaining_bit_coefficients, "POS", parsed_bits["POS"]),
+        )

--- a/imap_processing/tests/lo/test_science_direct_events.py
+++ b/imap_processing/tests/lo/test_science_direct_events.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 import bitstring
+import numpy as np
 import pytest
 
 from imap_processing.lo.l0.science_direct_events import ScienceDirectEvents
@@ -11,15 +12,23 @@ from imap_processing.lo.l0.science_direct_events import ScienceDirectEvents
 # the need for the bitstring import will also go away.
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
+@pytest.mark.skip(reason="no data to initialize with")
 @pytest.fixture()
-def de():
+def single_de():
     de = ScienceDirectEvents("fake_packet", "0", "fakepacketname")
     de.COUNT = 1
     return de
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
+@pytest.mark.skip(reason="no data to initialize with")
+@pytest.fixture()
+def multi_de():
+    de = ScienceDirectEvents("fake_packet", "0", "fakepacketname")
+    de.COUNT = 2
+    return de
+
+
+@pytest.mark.skip(reason="no data to initialize with")
 @pytest.fixture()
 def tof_data():
     TOFData = namedtuple(
@@ -28,42 +37,42 @@ def tof_data():
     return TOFData
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_find_decompression_case(de):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_find_decompression_case(single_de):
     # Arrange
-    de.DATA = "000100010101"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    single_de.DATA = "000100010101"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
     case_number_expected = 1
 
     # Act
-    case_number = de._find_decompression_case(bitstream)
+    case_number = single_de._find_decompression_case(bitstream)
 
     # Assert
     assert case_number == case_number_expected
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_find_tof_decoder_for_case(de, tof_data):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_find_tof_decoder_for_case(single_de, tof_data):
     # Arrange
-    de.DATA = "000100010101"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    single_de.DATA = "000100010101"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
     tof_decoder_expected = tof_data(3, 0, 10, 9, 9, 0, 0, 12)
 
-    case_number = de._find_decompression_case(bitstream)
+    case_number = single_de._find_decompression_case(bitstream)
 
     # Act
-    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
+    tof_decoder = single_de._find_tof_decoder_for_case(case_number, bitstream)
 
     # Assert
     assert tof_decoder == tof_decoder_expected
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_read_tof_calculation_table(de):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_read_tof_calculation_table(single_de):
     # Arrange
-    de.DATA = "000100010101"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
-    case_number = de._find_decompression_case(bitstream)
+    single_de.DATA = "000100010101"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
+    case_number = single_de._find_decompression_case(bitstream)
     binary_strings_expected = {
         "ENERGY": bitstring.Bits(bin="0000000000000011"),
         "POS": bitstring.Bits(bin=""),
@@ -76,19 +85,19 @@ def test_read_tof_calculation_table(de):
     }
 
     # Act
-    tof_calc_bin = de._read_tof_calculation_table(case_number)
+    tof_calc_bin = single_de._read_tof_calculation_table(case_number)
 
     # Assert
     assert tof_calc_bin == binary_strings_expected
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_find_remaining_bits(de):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_find_remaining_bits(single_de):
     # Arrange
-    de.DATA = "000100010101"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
-    case_number = de._find_decompression_case(bitstream)
-    tof_calc = de._read_tof_calculation_table(case_number)
+    single_de.DATA = "000100010101"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
+    case_number = single_de._find_decompression_case(bitstream)
+    tof_calc = single_de._read_tof_calculation_table(case_number)
     remaining_coeff_expected = {
         "TIME": [
             327.68,
@@ -148,19 +157,19 @@ def test_find_remaining_bits(de):
     }
 
     # Act
-    remaining_coeff = de._find_remaining_bit_coefficients(tof_calc)
+    remaining_coeff = single_de._find_remaining_bit_coefficients(tof_calc)
 
     # Assert
     assert remaining_coeff == remaining_coeff_expected
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_parse_binary_for_gold_triple(de):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_parse_binary_for_gold_triple(single_de):
     # Arrange
-    de.DATA = "000010010101001101011100111100111011101001111101"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
-    case_number = de._find_decompression_case(bitstream)
-    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
+    single_de.DATA = "000010010101001101011100111100111011101001111101"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
+    case_number = single_de._find_decompression_case(bitstream)
+    tof_decoder = single_de._find_tof_decoder_for_case(case_number, bitstream)
     parsed_bits_expected = {
         "ENERGY": bitstring.Bits(bin="001"),
         "POS": bitstring.Bits(bin=""),
@@ -173,19 +182,19 @@ def test_parse_binary_for_gold_triple(de):
     }
 
     # Act
-    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
+    parsed_bits = single_de._parse_binary(case_number, tof_decoder, bitstream)
     # Assert
     assert parsed_bits == parsed_bits_expected
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_parse_binary_for_silver_triple(de):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_parse_binary_for_silver_triple(single_de):
     # Arrange
 
-    de.DATA = "000000010101001101011100111100111011101001111101101101"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
-    case_number = de._find_decompression_case(bitstream)
-    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
+    single_de.DATA = "000000010101001101011100111100111011101001111101101101"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
+    case_number = single_de._find_decompression_case(bitstream)
+    tof_decoder = single_de._find_tof_decoder_for_case(case_number, bitstream)
     parsed_bits_expected = {
         "ENERGY": bitstring.Bits(bin="001"),
         "POS": bitstring.Bits(bin=""),
@@ -198,19 +207,19 @@ def test_parse_binary_for_silver_triple(de):
     }
 
     # Act
-    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
+    parsed_bits = single_de._parse_binary(case_number, tof_decoder, bitstream)
 
     # Assert
     assert parsed_bits == parsed_bits_expected
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_parse_binary_for_bronze_triple(de):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_parse_binary_for_bronze_triple(single_de):
     # Arrange
-    de.DATA = "01001001010100110101110011110010"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
-    case_number = de._find_decompression_case(bitstream)
-    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
+    single_de.DATA = "01001001010100110101110011110010"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
+    case_number = single_de._find_decompression_case(bitstream)
+    tof_decoder = single_de._find_tof_decoder_for_case(case_number, bitstream)
     parsed_bits_expected = {
         "ENERGY": bitstring.Bits(bin="001"),
         "POS": bitstring.Bits(bin="01"),
@@ -223,20 +232,20 @@ def test_parse_binary_for_bronze_triple(de):
     }
 
     # Act
-    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
+    parsed_bits = single_de._parse_binary(case_number, tof_decoder, bitstream)
     print(parsed_bits)
 
     # Assert
     assert parsed_bits == parsed_bits_expected
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_parse_binary_for_not_bronze_triple(de):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_parse_binary_for_not_bronze_triple(single_de):
     # Arrange
-    de.DATA = "010000010101001101011100111100101110"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
-    case_number = de._find_decompression_case(bitstream)
-    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
+    single_de.DATA = "010000010101001101011100111100101110"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
+    case_number = single_de._find_decompression_case(bitstream)
+    tof_decoder = single_de._find_tof_decoder_for_case(case_number, bitstream)
     parsed_bits_expected = {
         "ENERGY": bitstring.Bits(bin="001"),
         "POS": bitstring.Bits(bin=""),
@@ -249,39 +258,73 @@ def test_parse_binary_for_not_bronze_triple(de):
     }
 
     # Act
-    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
+    parsed_bits = single_de._parse_binary(case_number, tof_decoder, bitstream)
 
     # Assert
     assert parsed_bits == parsed_bits_expected
 
 
-# @pytest.mark.skip(reason="no data to initialize with")
-def test_decode_fields(de):
+@pytest.mark.skip(reason="no data to initialize with")
+def test_set_tofs(single_de):
     # Arrange
-    de.DATA = "000010010101001101011100111100111011101001111101"
-    bitstream = bitstring.ConstBitStream(bin=de.DATA)
-    case_number = de._find_decompression_case(bitstream)
-    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
-    tof_calc = de._read_tof_calculation_table(case_number)
-    remaining_coeffs = de._find_remaining_bit_coefficients(tof_calc)
-    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
+    single_de.DATA = "000010010101001101011100111100111011101001111101"
+    bitstream = bitstring.ConstBitStream(bin=single_de.DATA)
+    case_number = single_de._find_decompression_case(bitstream)
+    tof_decoder = single_de._find_tof_decoder_for_case(case_number, bitstream)
+    tof_calc = single_de._read_tof_calculation_table(case_number)
+    remaining_coeffs = single_de._find_remaining_bit_coefficients(tof_calc)
+    parsed_bits = single_de._parse_binary(case_number, tof_decoder, bitstream)
 
-    energy_expected = 0.16
-    position_expected = 0
-    tof0_expected = 106.46
-    tof1_expected = 0
-    tof2_expected = 73.92
-    tof3_expected = 12.48
-    time_expected = 429.5
+    energy_expected = np.array(0.16)
+    position_expected = np.array(0)
+    tof0_expected = np.array(106.46)
+    tof1_expected = np.array(0)
+    tof2_expected = np.array(73.92)
+    tof3_expected = np.array(12.48)
+    time_expected = np.array(429.5)
 
     # Act
-    de._decode_fields(remaining_coeffs, parsed_bits)
+    single_de._set_tofs(remaining_coeffs, parsed_bits)
 
     # Assert
-    assert de.ENERGY == energy_expected
-    assert de.POS == position_expected
-    assert de.TOF0 == tof0_expected
-    assert de.TOF1 == tof1_expected
-    assert de.TOF2 == tof2_expected
-    assert de.TOF3 == tof3_expected
-    assert de.TIME == time_expected
+    assert single_de.ENERGY == energy_expected
+    assert single_de.POS == position_expected
+    assert single_de.TOF0 == tof0_expected
+    assert single_de.TOF1 == tof1_expected
+    assert single_de.TOF2 == tof2_expected
+    assert single_de.TOF3 == tof3_expected
+    assert single_de.TIME == time_expected
+
+
+@pytest.mark.skip(reason="no data to initialize with")
+def test_multiple_events(multi_de):
+    multi_de.DATA = (
+        "000010010101001101011100111100111011101001111101"
+        + "000010010101001101011100111100111011101001111101"
+    )
+    bitstream = bitstring.ConstBitStream(bin=multi_de.DATA)
+    case_number = multi_de._find_decompression_case(bitstream)
+    tof_decoder = multi_de._find_tof_decoder_for_case(case_number, bitstream)
+    tof_calc = multi_de._read_tof_calculation_table(case_number)
+    remaining_coeffs = multi_de._find_remaining_bit_coefficients(tof_calc)
+    parsed_bits = multi_de._parse_binary(case_number, tof_decoder, bitstream)
+
+    energy_expected = np.array([0.16, 0.16])
+    position_expected = np.array([0, 0])
+    tof0_expected = np.array([106.46, 106.46])
+    tof1_expected = np.array([0, 0])
+    tof2_expected = np.array([73.92, 73.92])
+    tof3_expected = np.array([12.48, 12.48])
+    time_expected = np.array([429.5, 429.5])
+
+    # Act
+    multi_de._set_tofs(remaining_coeffs, parsed_bits)
+
+    # Assert
+    assert (multi_de.ENERGY == energy_expected).all()
+    assert (multi_de.POS == position_expected).all()
+    assert (multi_de.TOF0 == tof0_expected).all()
+    assert (multi_de.TOF1 == tof1_expected).all()
+    assert (multi_de.TOF2 == tof2_expected).all()
+    assert (multi_de.TOF3 == tof3_expected).all()
+    assert (multi_de.TIME == time_expected).all()

--- a/imap_processing/tests/lo/test_science_direct_events.py
+++ b/imap_processing/tests/lo/test_science_direct_events.py
@@ -11,14 +11,15 @@ from imap_processing.lo.l0.science_direct_events import ScienceDirectEvents
 # the need for the bitstring import will also go away.
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 @pytest.fixture()
 def de():
     de = ScienceDirectEvents("fake_packet", "0", "fakepacketname")
+    de.COUNT = 1
     return de
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 @pytest.fixture()
 def tof_data():
     TOFData = namedtuple(
@@ -27,39 +28,42 @@ def tof_data():
     return TOFData
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_find_decompression_case(de):
     # Arrange
-    de.DATA = bitstring.Bits(bin="000100010101")
+    de.DATA = "000100010101"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
     case_number_expected = 1
 
     # Act
-    case_number = de._find_decompression_case()
+    case_number = de._find_decompression_case(bitstream)
 
     # Assert
     assert case_number == case_number_expected
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_find_tof_decoder_for_case(de, tof_data):
     # Arrange
-    de.DATA = bitstring.Bits(bin="000100010101")
+    de.DATA = "000100010101"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
     tof_decoder_expected = tof_data(3, 0, 10, 9, 9, 0, 0, 12)
 
-    case_number = de._find_decompression_case()
+    case_number = de._find_decompression_case(bitstream)
 
     # Act
-    tof_decoder = de._find_tof_decoder_for_case(case_number)
+    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
 
     # Assert
     assert tof_decoder == tof_decoder_expected
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_read_tof_calculation_table(de):
     # Arrange
-    de.DATA = bitstring.Bits(bin="000100010101")
-    case_number = de._find_decompression_case()
+    de.DATA = "000100010101"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    case_number = de._find_decompression_case(bitstream)
     binary_strings_expected = {
         "ENERGY": bitstring.Bits(bin="0000000000000011"),
         "POS": bitstring.Bits(bin=""),
@@ -78,11 +82,12 @@ def test_read_tof_calculation_table(de):
     assert tof_calc_bin == binary_strings_expected
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_find_remaining_bits(de):
     # Arrange
-    de.DATA = bitstring.Bits(bin="000100010101")
-    case_number = de._find_decompression_case()
+    de.DATA = "000100010101"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    case_number = de._find_decompression_case(bitstream)
     tof_calc = de._read_tof_calculation_table(case_number)
     remaining_coeff_expected = {
         "TIME": [
@@ -149,12 +154,13 @@ def test_find_remaining_bits(de):
     assert remaining_coeff == remaining_coeff_expected
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_parse_binary_for_gold_triple(de):
     # Arrange
-    de.DATA = bitstring.Bits(bin="000010010101001101011100111100111011101001111101")
-    case_number = de._find_decompression_case()
-    tof_decoder = de._find_tof_decoder_for_case(case_number)
+    de.DATA = "000010010101001101011100111100111011101001111101"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    case_number = de._find_decompression_case(bitstream)
+    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
     parsed_bits_expected = {
         "ENERGY": bitstring.Bits(bin="001"),
         "POS": bitstring.Bits(bin=""),
@@ -167,20 +173,19 @@ def test_parse_binary_for_gold_triple(de):
     }
 
     # Act
-    parsed_bits = de._parse_binary(case_number, tof_decoder)
-
+    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
     # Assert
     assert parsed_bits == parsed_bits_expected
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_parse_binary_for_silver_triple(de):
     # Arrange
-    de.DATA = bitstring.Bits(
-        bin="000000010101001101011100111100111011101001111101101101"
-    )
-    case_number = de._find_decompression_case()
-    tof_decoder = de._find_tof_decoder_for_case(case_number)
+
+    de.DATA = "000000010101001101011100111100111011101001111101101101"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    case_number = de._find_decompression_case(bitstream)
+    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
     parsed_bits_expected = {
         "ENERGY": bitstring.Bits(bin="001"),
         "POS": bitstring.Bits(bin=""),
@@ -193,18 +198,19 @@ def test_parse_binary_for_silver_triple(de):
     }
 
     # Act
-    parsed_bits = de._parse_binary(case_number, tof_decoder)
+    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
 
     # Assert
     assert parsed_bits == parsed_bits_expected
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_parse_binary_for_bronze_triple(de):
     # Arrange
-    de.DATA = bitstring.Bits(bin="0100100101010011010111001111001")
-    case_number = de._find_decompression_case()
-    tof_decoder = de._find_tof_decoder_for_case(case_number)
+    de.DATA = "01001001010100110101110011110010"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    case_number = de._find_decompression_case(bitstream)
+    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
     parsed_bits_expected = {
         "ENERGY": bitstring.Bits(bin="001"),
         "POS": bitstring.Bits(bin="01"),
@@ -213,22 +219,24 @@ def test_parse_binary_for_bronze_triple(de):
         "TOF2": bitstring.Bits(bin=""),
         "TOF3": bitstring.Bits(bin=""),
         "CKSM": bitstring.Bits(bin=""),
-        "TIME": bitstring.Bits(bin="11001111001"),
+        "TIME": bitstring.Bits(bin="110011110010"),
     }
 
     # Act
-    parsed_bits = de._parse_binary(case_number, tof_decoder)
+    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
+    print(parsed_bits)
 
     # Assert
     assert parsed_bits == parsed_bits_expected
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_parse_binary_for_not_bronze_triple(de):
     # Arrange
-    de.DATA = bitstring.Bits(bin="010000010101001101011100111100101110")
-    case_number = de._find_decompression_case()
-    tof_decoder = de._find_tof_decoder_for_case(case_number)
+    de.DATA = "010000010101001101011100111100101110"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    case_number = de._find_decompression_case(bitstream)
+    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
     parsed_bits_expected = {
         "ENERGY": bitstring.Bits(bin="001"),
         "POS": bitstring.Bits(bin=""),
@@ -241,21 +249,22 @@ def test_parse_binary_for_not_bronze_triple(de):
     }
 
     # Act
-    parsed_bits = de._parse_binary(case_number, tof_decoder)
+    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
 
     # Assert
     assert parsed_bits == parsed_bits_expected
 
 
-@pytest.mark.skip(reason="no data to initialize with")
+# @pytest.mark.skip(reason="no data to initialize with")
 def test_decode_fields(de):
     # Arrange
-    de.DATA = bitstring.Bits(bin="000010010101001101011100111100111011101001111101")
-    case_number = de._find_decompression_case()
-    tof_decoder = de._find_tof_decoder_for_case(case_number)
+    de.DATA = "000010010101001101011100111100111011101001111101"
+    bitstream = bitstring.ConstBitStream(bin=de.DATA)
+    case_number = de._find_decompression_case(bitstream)
+    tof_decoder = de._find_tof_decoder_for_case(case_number, bitstream)
     tof_calc = de._read_tof_calculation_table(case_number)
     remaining_coeffs = de._find_remaining_bit_coefficients(tof_calc)
-    parsed_bits = de._parse_binary(case_number, tof_decoder)
+    parsed_bits = de._parse_binary(case_number, tof_decoder, bitstream)
 
     energy_expected = 0.16
     position_expected = 0


### PR DESCRIPTION
# Change Summary

## Overview
Updated the Science Direct Events data class for Lo to handled multiple direct events in a single packet.

closes #338 

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
- science_direct_events.py

## Testing
Updated test_science_direct_events unit tests and added a new test for multiple direct events in a binary chunk.
