### PR TITLE
TST: Rely on temp directory for test file cleanup

### DIFF
--- a/imap_processing/tests/swe/test_swe_l1a.py
+++ b/imap_processing/tests/swe/test_swe_l1a.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from imap_processing import imap_module_directory
@@ -48,16 +46,13 @@ def test_group_by_apid(decom_test_data):
     assert len(total_event_message_data) == 15
 
 
-def test_cdf_creation(decom_test_data):
+def test_cdf_creation(decom_test_data, tmp_path):
     test_data_path = "tests/swe/l0_data/20230927100425_SWE_CEM_RAW_packet.bin"
     processed_data = swe_l1a(imap_module_directory / test_data_path)
 
     l1a_cdf_filename = "imap_swe_l1a_cemraw_20230927_20230927_v01.cdf"
-    current_directory = Path(__file__).parent
 
-    cdf_filepath = current_directory / l1a_cdf_filename
+    cdf_filepath = tmp_path / l1a_cdf_filename
     cem_raw_cdf_filepath = write_cdf(processed_data[0]["data"], cdf_filepath)
 
     assert cem_raw_cdf_filepath.name == l1a_cdf_filename
-
-    Path.unlink(cem_raw_cdf_filepath)

--- a/imap_processing/tests/swe/test_swe_l1b.py
+++ b/imap_processing/tests/swe/test_swe_l1b.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pandas as pd
 import pytest
 from cdflib.xarray import cdf_to_xarray
@@ -114,15 +112,12 @@ def test_swe_l1b(decom_test_data):
         assert round(hk_l1b[field].data[1], 5) == round(validation_data[field], 5)
 
 
-def test_cdf_creation(decom_test_data):
+def test_cdf_creation(decom_test_data, tmp_path):
     """Test that CDF file is created and has the correct name."""
-    current_directory = Path(__file__).parent
 
     test_data_path = "tests/swe/l0_data/20230927100248_SWE_HK_packet.bin"
     l1a_datasets = swe_l1a(imap_module_directory / test_data_path)
-    hk_l1a_cdf_file_path = (
-        current_directory / "imap_swe_l1a_lveng-hk_20230927_20230927_v01.cdf"
-    )
+    hk_l1a_cdf_file_path = tmp_path / "imap_swe_l1a_lveng-hk_20230927_20230927_v01.cdf"
 
     for i in range(len(l1a_datasets)):
         if l1a_datasets[i]["descriptor"] == "lveng-hk":
@@ -136,13 +131,8 @@ def test_cdf_creation(decom_test_data):
     # reads data from CDF file and passes to l1b
     l1a_cdf_dataset = cdf_to_xarray(hk_l1a_filepath, to_datetime=True)
     l1b_dataset = swe_l1b(l1a_cdf_dataset)
-    cdf_file_path = (
-        current_directory / "imap_swe_l1b_lveng-hk_20230927_20230927_v01.cdf"
-    )
+    cdf_file_path = tmp_path / "imap_swe_l1b_lveng-hk_20230927_20230927_v01.cdf"
 
     hk_l1b_filepath = write_cdf(l1b_dataset, cdf_file_path)
 
     assert hk_l1b_filepath.name == "imap_swe_l1b_lveng-hk_20230927_20230927_v01.cdf"
-    # remove the file after reading for local testing
-    Path.unlink(hk_l1a_filepath)
-    Path.unlink(hk_l1b_filepath)


### PR DESCRIPTION
When these files failed before the unlink() step, the files got left behind in the local directory. Use pytest's tmppath fixture to clean this up automatically.