### PR TITLE
MNT: Change default display_type to be no_plot

### DIFF
--- a/imap_processing/cdf/global_attrs.py
+++ b/imap_processing/cdf/global_attrs.py
@@ -191,7 +191,7 @@ class AttrBase:
         The valid minimum value, required
     validmax : np.float64 | np.int64
         The valid maximum value, required
-    display_type : str default=None
+    display_type : str default="no_plot"
         The display type of the plot (ex "no_plot"), required
     catdesc : str, default=None
         The category description, "CATDESC" attribute, required
@@ -213,7 +213,7 @@ class AttrBase:
 
     validmin: Union[np.float64, np.int64]
     validmax: Union[np.float64, np.int64]
-    display_type: str = None
+    display_type: str = "no_plot"
     catdesc: str = None
     fieldname: str = None
     var_type: str = "support_data"

--- a/imap_processing/tests/cdf/test_attr_classes.py
+++ b/imap_processing/tests/cdf/test_attr_classes.py
@@ -55,7 +55,7 @@ def test_science_attr():
 
     expected = {
         "CATDESC": None,
-        "DISPLAY_TYPE": None,
+        "DISPLAY_TYPE": "no_plot",
         "FIELDNAM": "1",
         "FILLVAL": GlobalConstants.INT_FILLVAL,
         "FORMAT": None,

--- a/imap_processing/tests/idex/test_l1_cdfs.py
+++ b/imap_processing/tests/idex/test_l1_cdfs.py
@@ -21,13 +21,13 @@ def decom_test_data():
     return PacketParser(test_file).data
 
 
-@pytest.mark.xfail(reason="Need to fix new ISTP error in IDEX CDF")
 def test_idex_cdf_file(decom_test_data):
     # Verify that a CDF file can be created with no errors thrown by xarray_to_cdf
 
     file_name = write_cdf(decom_test_data)
 
     assert file_name.exists()
+    assert file_name.name == "imap_idex_l1_sci_20250724_v001.cdf"
 
 
 def test_bad_cdf_attributes(decom_test_data):
@@ -67,7 +67,6 @@ def test_bad_cdf_file_data(decom_test_data):
         write_cdf(decom_test_data)
 
 
-@pytest.mark.skip(reason="Need to fix new ISTP error in IDEX CDF")
 def test_idex_tof_high_data_from_cdf(decom_test_data):
     # Verify that a sample of the data is correct inside the CDF file
     # impact_14_tof_high_data.txt has been verified correct by the IDEX team


### PR DESCRIPTION

# Change Summary

ISTP compliance requires a string for display_type, so default to `no_plot` and then people can override it later if they want. But this at least gives an ISTP compliant default.

Remove the skips from IDEX now that it is compliant
