### PR TITLE
MNT: Change IDEX packet definition to be formatted like others

### DIFF
--- a/imap_processing/idex/packet_definitions/idex_packet_definition.xml
+++ b/imap_processing/idex/packet_definitions/idex_packet_definition.xml
@@ -3,35 +3,31 @@
   <xtce:Header classification="BuildType=FLIGHT,CreatedBy=XTCEEditor" date="Created=2023/01/12 15:27:45" version="DocumentVersion=FSW Build ,DocumentVersion=20190109v1,LASPXTCESchemaVersion=1.2,XTCEEditorVersion=0.47"/>
   <xtce:TelemetryMetaData>
     <xtce:ParameterTypeSet>
-      <xtce:IntegerParameterType signed="false" name="VERSION_Type">
+      <xtce:IntegerParameterType signed="false" name="UINT3">
         <xtce:UnitSet/>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="3"/>
       </xtce:IntegerParameterType>
-      <xtce:IntegerParameterType signed="false" name="TYPE_Type">
+      <xtce:IntegerParameterType signed="false" name="UINT1">
         <xtce:UnitSet/>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="1"/>
       </xtce:IntegerParameterType>
-      <xtce:IntegerParameterType signed="false" name="SEC_HDR_FLG_Type">
-        <xtce:UnitSet/>
-        <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="1"/>
-      </xtce:IntegerParameterType>
-      <xtce:IntegerParameterType signed="false" name="PKT_APID_Type">
+      <xtce:IntegerParameterType signed="false" name="UINT11">
         <xtce:UnitSet/>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="11"/>
       </xtce:IntegerParameterType>
-      <xtce:IntegerParameterType signed="false" name="SEQ_FLGS_Type">
+      <xtce:IntegerParameterType signed="false" name="UINT2">
         <xtce:UnitSet/>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="2"/>
       </xtce:IntegerParameterType>
-      <xtce:IntegerParameterType signed="false" name="SRC_SEQ_CTR_Type">
+      <xtce:IntegerParameterType signed="false" name="UINT14">
         <xtce:UnitSet/>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="14"/>
       </xtce:IntegerParameterType>
-      <xtce:IntegerParameterType signed="false" name="PKT_LEN_Type">
+      <xtce:IntegerParameterType signed="false" name="UINT16">
         <xtce:UnitSet/>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="16"/>
       </xtce:IntegerParameterType>
-      <xtce:FloatParameterType name="SHCOARSE_Type">
+      <xtce:FloatParameterType name="UINT32">
         <xtce:UnitSet>
           <xtce:Unit>dn</xtce:Unit>
         </xtce:UnitSet>
@@ -1081,20 +1077,31 @@
       </xtce:IntegerParameterType>
     </xtce:ParameterTypeSet>
     <xtce:ParameterSet>
-      <xtce:Parameter name="VERSION" parameterTypeRef="VERSION_Type"/>
-      <xtce:Parameter name="TYPE" parameterTypeRef="TYPE_Type"/>
-      <xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="SEC_HDR_FLG_Type"/>
-      <xtce:Parameter name="PKT_APID" parameterTypeRef="PKT_APID_Type"/>
-      <xtce:Parameter name="SEQ_FLGS" parameterTypeRef="SEQ_FLGS_Type"/>
-      <xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="SRC_SEQ_CTR_Type"/>
-      <xtce:Parameter name="PKT_LEN" parameterTypeRef="PKT_LEN_Type"/>
-      <xtce:Parameter shortDescription="Secondary Header Coarse Time" name="SHCOARSE" parameterTypeRef="SHCOARSE_Type">
-        <xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
-        <xtce:AliasSet>
-          <xtce:Alias nameSpace="itemName" alias="SHCOARSE"/>
-        </xtce:AliasSet>
-        <xtce:ParameterProperties dataSource="telemetered"/>
-      </xtce:Parameter>
+      <!--CCSDS Header Elements-->
+      <xtce:Parameter name="VERSION" parameterTypeRef="UINT3">
+				<xtce:LongDescription>CCSDS Packet Version Number (always 0)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="TYPE" parameterTypeRef="UINT1">
+				<xtce:LongDescription>CCSDS Packet Type Indicator (0=telemetry)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEC_HDR_FLG" parameterTypeRef="UINT1">
+				<xtce:LongDescription>CCSDS Packet Secondary Header Flag (always 1)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_APID" parameterTypeRef="UINT11">
+				<xtce:LongDescription>CCSDS Packet Application Process ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SEQ_FLGS" parameterTypeRef="UINT2">
+				<xtce:LongDescription>CCSDS Packet Grouping Flags (3=not part of group)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="SRC_SEQ_CTR" parameterTypeRef="UINT14">
+				<xtce:LongDescription>CCSDS Packet Sequence Count (increments with each new packet)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="PKT_LEN" parameterTypeRef="UINT16">
+				<xtce:LongDescription>CCSDS Packet Length (number of bytes after Packet length minus 1)</xtce:LongDescription>
+			</xtce:Parameter>
+            <xtce:Parameter name="SHCOARSE" parameterTypeRef="UINT32">
+				<xtce:LongDescription>CCSDS Packet Time Stamp (coarse time)</xtce:LongDescription>
+			</xtce:Parameter>
       <xtce:Parameter shortDescription="Secondary Header Fine Time" name="SHFINE" parameterTypeRef="SHFINE_Type">
         <xtce:LongDescription>CCSDS Packet 2nd Header Fine Time</xtce:LongDescription>
         <xtce:AliasSet>

--- a/imap_processing/tests/test_decom.py
+++ b/imap_processing/tests/test_decom.py
@@ -8,16 +8,7 @@ from imap_processing import imap_module_directory
 xtce_document_list = imap_module_directory.glob("*/packet_definitions/*.xml")
 
 
-@pytest.fixture(params=xtce_document_list, scope="session")
-def xtce_document(request):
-    if "idex" in str(request.param):
-        pytest.xfail(
-            "Packet Definition does not include properly formatted CCSDS Header"
-        )
-    else:
-        return request.param
-
-
+@pytest.mark.parametrize("xtce_document", xtce_document_list)
 def test_ccsds_header(xtce_document):
     """Test if the XTCE document contains the proper CCSDS header information"""
 


### PR DESCRIPTION
# Change Summary

## Overview

The IDEX CCSDS Header elements were formatted with different types. This updates to use the UINT[N] naming convention that all the other instruments use for consistency and so we don't have to xfail this instrument in the tests.

<!--Add a list or paragraph giving an overview of your changes-->

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- new file 1
   - description of new file 1's purpose

## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->
- deleted file 1
   - explanation for why file was deleted

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- updated file 1
   - description of change 1 in file 1
   - description of change 2 in file 2
- updated file 2
   - descipriton of change 1 in file 2

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
