### PR TITLE
MNT: Remove directory option from write_cdf

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -1,8 +1,6 @@
 """Various utility functions to support creation of CDF files."""
 
 import logging
-from pathlib import Path
-from typing import Optional
 
 import imap_data_access
 import numpy as np
@@ -42,7 +40,7 @@ def calc_start_time(shcoarse_time: int):
     return launch_time + time_delta
 
 
-def write_cdf(dataset: xr.Dataset, directory: Optional[Path] = None):
+def write_cdf(dataset: xr.Dataset):
     """Write the contents of "data" to a CDF file using cdflib.xarray_to_cdf.
 
     This function determines the file name to use from the global attributes,
@@ -56,17 +54,12 @@ def write_cdf(dataset: xr.Dataset, directory: Optional[Path] = None):
     ----------
         dataset : xarray.Dataset
             The dataset object to convert to a CDF
-        filepath: Path
-            The output path, including filename, to write the CDF to.
 
     Returns
     -------
         pathlib.Path
             Path to the file created
     """
-    # Use the directory if provided, otherwise use the default
-    directory = directory or imap_data_access.config["DATA_DIR"]
-
     # Create the filename from the global attributes
     # Logical_source looks like "imap_swe_l2_counts-1min"
     instrument, data_level, descriptor = dataset.attrs["Logical_source"].split("_")[1:]
@@ -83,9 +76,11 @@ def write_cdf(dataset: xr.Dataset, directory: Optional[Path] = None):
         version=version,
         repointing=repointing,
     )
-    file_path = directory / science_file.construct_path()
+    file_path = science_file.construct_path()
     if not file_path.parent.exists():
-        logger.info("The directory does not exist, creating directory %s", directory)
+        logger.info(
+            "The directory does not exist, creating directory %s", file_path.parent
+        )
         file_path.parent.mkdir(parents=True)
     # Insert the final attribute:
     # The Logical_file_id is always the name of the file without the extension

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -364,15 +364,8 @@ class Swe(ProcessInstrument):
             # read CDF file
             l1a_dataset = cdf_to_xarray(dependencies[0])
             processed_data = swe_l1b(l1a_dataset)
-            # TODO: Update this descriptor
-            descriptor = "test"
-            file = imap_data_access.ScienceFilePath.generate_from_inputs(
-                "swe", "l1b", descriptor, self.start_date, self.version
-            )
-
-            cdf_file_path = write_cdf(
-                data=processed_data, filepath=file.construct_path()
-            )
+            # TODO: Pass in the proper version and descriptor
+            cdf_file_path = write_cdf(data=processed_data)
             print(f"processed file path: {cdf_file_path}")
             if self.upload_to_sdc:
                 imap_data_access.upload(cdf_file_path)

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -1,3 +1,4 @@
+import imap_data_access
 import numpy as np
 import xarray as xr
 
@@ -34,3 +35,4 @@ def test_write_cdf():
     file_path = write_cdf(dataset)
     assert file_path.exists()
     assert file_path.name == "imap_swe_l1_sci_20100101_v001.cdf"
+    assert file_path.relative_to(imap_data_access.config["DATA_DIR"])


### PR DESCRIPTION
# Change Summary

## Overview

We are now explicitly requiring a directory structure for the science files to be written to. A user should update the `imap_data_access.config["DATA_DIR"]` location if they want to write to a different location because the `ScienceFilePath` uses that field to construct the path.

Note that previously `directory` was not working how we were expecting because of the `ScienceFilePath.construct_path()` usage, so this doesn't change behavior, just removes code that didn't do what it was supposed to.