### PR TITLE
TST: Avoid xarray.dims deprecation

### DIFF
--- a/imap_processing/tests/mag/test_mag_decom.py
+++ b/imap_processing/tests/mag/test_mag_decom.py
@@ -53,10 +53,10 @@ def test_mag_raw_xarray():
     assert all([item is not None for _, item in burst_data.attrs.items()])
 
     expected_norm_len = 17
-    assert norm_data.dims["epoch"] == expected_norm_len
+    assert norm_data.sizes["epoch"] == expected_norm_len
 
     expected_burst_len = 19
-    assert burst_data.dims["epoch"] == expected_burst_len
+    assert burst_data.sizes["epoch"] == expected_burst_len
 
 
 def test_mag_raw_cdf_generation():


### PR DESCRIPTION
Use sizes instead as the deprecation warning suggests.

https://docs.xarray.dev/en/stable/whats-new.html#id38

> Raise a FutureWarning warning that the type of [Dataset.dims()](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.dims.html#xarray.Dataset.dims) will be changed from a mapping of dimension names to lengths to a set of dimension names. This is to increase consistency with [DataArray.dims()](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.dims.html#xarray.DataArray.dims). To access a mapping of dimension names to lengths please use [Dataset.sizes()](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.sizes.html#xarray.Dataset.sizes). The same change also applies to DatasetGroupBy.dims. ([GH8496](https://github.com/pydata/xarray/issues/8496), [PR8500](https://github.com/pydata/xarray/pull/8500)) By [Tom Nicholas](https://github.com/TomNicholas).
