### PR TITLE
IMAP Hi Histogram L1A processing

### DIFF
--- a/imap_processing/hi/hi_cdf_attrs.py
+++ b/imap_processing/hi/hi_cdf_attrs.py
@@ -2,6 +2,7 @@
 
 from imap_processing.cdf.defaults import GlobalConstants
 from imap_processing.cdf.global_attrs import (
+    AttrBase,
     GlobalDataLevelAttrs,
     GlobalInstrumentAttrs,
     ScienceAttrs,
@@ -138,13 +139,64 @@ ccsds_met_attrs = ScienceAttrs(
 hi_de_l1a_attrs = GlobalDataLevelAttrs(
     data_type="L1A_DE>Level-1A Direct Event",
     logical_source="imap_hi_l1a_de",
-    logical_source_desc=("IMAP-HI Instrument Level-1A Direct Event Data."),
+    logical_source_desc=("IMAP-Hi Instrument Level-1A Direct Event Data."),
     instrument_base=hi_base,
 )
 
 hi_hk_l1a_attrs = GlobalDataLevelAttrs(
     data_type="L1A_HK>Level-1A Housekeeping",
     logical_source="imap_hi_l1a_hk",
-    logical_source_desc=("IMAP-HI Instrument Level-1A Housekeeping Data."),
+    logical_source_desc=("IMAP-Hi Instrument Level-1A Housekeeping Data."),
     instrument_base=hi_base,
+)
+
+hi_hk_l1a_metadata_attrs = ScienceAttrs(
+    validmin=0,
+    validmax=GlobalConstants.INT_MAXVAL,
+    depend_0="epoch",
+    format="I12",
+    units="int",
+    var_type="support_data",
+    variable_purpose="PRIMARY",
+)
+
+# Histogram attributes
+hi_hist_l1a_global_attrs = GlobalDataLevelAttrs(
+    data_type="L1A_CNT>Level-1A Histogram",
+    logical_source="imap_hi_l1a_hist",
+    logical_source_desc=("IMAP-Hi Instrument Level-1A Histogram Data."),
+    instrument_base=hi_base,
+)
+
+hi_hist_l1a_angle_attrs = AttrBase(
+    validmin=0,
+    validmax=360,
+    format="I3",
+    units="deg",
+    label_axis="ANGLE",
+    display_type="time_series",
+    catdesc="Angle bin centers for Histogram data.",
+    fieldname="ANGLE",
+    fill_val=GlobalConstants.INT_FILLVAL,
+    var_type="support_data",
+)
+
+hi_hist_l1a_esa_step_attrs = ScienceAttrs(
+    validmin=0,
+    validmax=2**4 - 1,
+    depend_0="epoch",
+    format="I2",
+    catdesc="4-bit ESA Step Number",
+    var_type="support_data",
+    variable_purpose="PRIMARY",
+)
+
+hi_hist_l1a_counter_attrs = ScienceAttrs(
+    validmin=0,
+    validmax=2**12 - 1,
+    depend_0="epoch",
+    depend_1="angle",
+    format="I4",
+    var_type="support_data",
+    variable_purpose="PRIMARY",
 )

--- a/imap_processing/hi/l1a/hi_l1a.py
+++ b/imap_processing/hi/l1a/hi_l1a.py
@@ -3,6 +3,7 @@
 import logging
 
 from imap_processing.hi.l0 import decom_hi
+from imap_processing.hi.l1a.histogram import create_dataset as hist_create_dataset
 from imap_processing.hi.l1a.housekeeping import process_housekeeping
 from imap_processing.hi.l1a.science_direct_event import science_direct_event
 from imap_processing.hi.utils import HIAPID
@@ -26,27 +27,29 @@ def hi_l1a(packet_file_path: str):
     """
     unpacked_data = decom_hi.decom_packets(packet_file_path)
 
-    # group data by appId
+    # group data by apid
     grouped_data = group_by_apid(unpacked_data)
 
     # Process science to l1a.
     processed_data = []
     for apid in grouped_data.keys():
         if apid == HIAPID.H45_SCI_CNT:
-            # TODO: Add processing for science count data
-            continue
+            logger.info(
+                "Processing histogram data for [%s] packets", HIAPID.H45_SCI_CNT.name
+            )
+            data = hist_create_dataset(grouped_data[apid])
         elif apid == HIAPID.H45_SCI_DE:
             logger.info(
-                "Processing direct event data for [%s] packets", HIAPID.H45_SCI_CNT.name
+                "Processing direct event data for [%s] packets", HIAPID.H45_SCI_DE.name
             )
 
             data = science_direct_event(grouped_data[apid])
-            processed_data.append(data)
         elif apid == HIAPID.H45_APP_NHK:
             logger.info(
                 "Processing housekeeping data for [%s] packets", HIAPID.H45_APP_NHK.name
             )
             data = process_housekeeping(grouped_data[apid])
-            processed_data.append(data)
-
+        else:
+            raise RuntimeError(f"Encountered unexpected APID [{apid}]")
+        processed_data.append(data)
     return processed_data

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -1,0 +1,145 @@
+"""Unpack IMAP-Hi histogram data."""
+
+import dataclasses
+
+import numpy as np
+import xarray as xr
+from space_packet_parser.parser import Packet
+
+from imap_processing.cdf.global_attrs import ConstantCoordinates
+from imap_processing.cdf.utils import calc_start_time
+from imap_processing.hi import hi_cdf_attrs
+
+# TODO: Verify that these names are OK for counter variables in the CDF
+# define the names of the 24 counter arrays
+# contained in the histogram packet
+QUALIFIED_COUNTERS = (
+    "qual_ab",
+    "qual_c1c2",
+    "qual_ac1",
+    "qual_bc1",
+    "qual_abc1",
+    "qual_ac1c2",
+    "qual_bc1c2",
+    "qual_abc1c2",
+)
+LONG_COUNTERS = (
+    "long_a",
+    "long_b",
+    "long_c",
+    "long_ab",
+    "long_c1c2",
+    "long_ac1",
+    "long_bc1",
+    "long_abc1",
+    "long_ac1c2",
+    "long_bc1c2",
+    "long_abc1c2",
+)
+TOTAL_COUNTERS = ("total_a", "total_b", "total_c", "fee_de_sent", "fee_de_recd")
+
+
+def create_dataset(packets: list[Packet]) -> xr.Dataset:
+    """Create dataset for a number of Hi Histogram packets.
+
+    Parameters
+    ----------
+    packets : list[Packet]
+        packet list
+
+    Returns
+    -------
+    xr.dataset
+        dataset with all metadata field data in xr.DataArray
+    """
+    dataset = allocate_histogram_dataset(len(packets))
+
+    # unpack the packets data into the Dataset
+    for i_epoch, packet in enumerate(packets):
+        dataset.epoch.data[i_epoch] = calc_start_time(
+            packet.data["CCSDS_MET"].raw_value
+        )
+        dataset.ccsds_met[i_epoch] = packet.data["CCSDS_MET"].raw_value
+        dataset.esa_step[i_epoch] = packet.data["ESA_STEP"].raw_value
+
+        # unpack 24 arrays of 90 12-bit unsigned integers
+        counters_binary_data = packet.data["COUNTERS"].raw_value
+        counter_ints = [
+            int(counters_binary_data[i * 12 : (i + 1) * 12], 2) for i in range(90 * 24)
+        ]
+        # populate the dataset with the unpacked integers
+        for i_counter, counter in enumerate(
+            (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS)
+        ):
+            dataset[counter][i_epoch] = counter_ints[
+                i_counter * 90 : (i_counter + 1) * 90
+            ]
+
+    return dataset
+
+
+def allocate_histogram_dataset(num_packets: int) -> xr.Dataset:
+    """
+    Allocate empty xr.Dataset for specified number of Hi Histogram packets.
+
+    Parameters
+    ----------
+    num_packets : int
+        The number of Hi Histogram packets to allocate space for
+        in the xr.Dataset.
+
+    Returns
+    -------
+    xr.Dataset
+        Empty xr.Dataset ready to be filled with packet data
+    """
+    # preallocate the xr.DataArrays for all CDF attributes based on number of packets
+    coords = dict()
+    coords["epoch"] = xr.DataArray(
+        np.empty(num_packets, dtype="datetime64[ns]"),
+        name="epoch",
+        dims=["epoch"],
+        attrs=ConstantCoordinates.EPOCH,
+    )
+    # Histogram data is binned in 90, 4-degree bins
+    # TODO: Confirm whether to define bins by centers or edges. For now centers
+    #    are assumed.
+    coords["angle"] = xr.DataArray(
+        np.arange(2, 360, 4),
+        name="angle",
+        dims=["angle"],
+        attrs=hi_cdf_attrs.hi_hist_l1a_angle_attrs.output(),
+    )
+    data_vars = dict()
+    data_vars["ccsds_met"] = xr.DataArray(
+        np.empty(num_packets, dtype=np.uint32),
+        dims=["epoch"],
+        attrs=hi_cdf_attrs.ccsds_met_attrs.output(),
+    )
+    data_vars["esa_step"] = xr.DataArray(
+        np.empty(num_packets, dtype=np.uint8),
+        dims=["epoch"],
+        attrs=dataclasses.replace(
+            hi_cdf_attrs.hi_hist_l1a_esa_step_attrs,
+            fieldname="ESA_STEP",
+            label_axis="ESA_STEP",
+        ).output(),
+    )
+
+    for counter in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
+        data_vars[counter] = xr.DataArray(
+            data=np.empty((num_packets, len(coords["angle"])), np.dtype("uint16")),
+            dims=["epoch", "angle"],
+            attrs=dataclasses.replace(
+                hi_cdf_attrs.hi_hist_l1a_counter_attrs,
+                catdesc=f"Counts for {counter} counter",
+                fieldname=counter,
+                label_axis=counter,
+            ).output(),
+        )
+    dataset = xr.Dataset(
+        data_vars=data_vars,
+        coords=coords,
+        attrs=hi_cdf_attrs.hi_hist_l1a_global_attrs.output(),
+    )
+    return dataset

--- a/imap_processing/hi/packet_definitions/hi_packet_definition.xml
+++ b/imap_processing/hi/packet_definitions/hi_packet_definition.xml
@@ -123,12 +123,9 @@
 			</xtce:Parameter>
             <!-- SCI_DE end -->
             <!-- SCI_CNT start -->
-            <xtce:Parameter name="ESA_STEP" parameterTypeRef="UINT16" shortDescription="Lower 4-bits represent the ESA Step Number: 4-bit ESA Step Enumeration 12-bit Start of Acquisition Time">
-				<xtce:LongDescription>
-					Lower 4-bits represent the ESA Step Number:
-					4-bit ESA Step Enumeration
-					12-bit Start of Acquisition Time
-				</xtce:LongDescription>
+			<xtce:Parameter name="ESA_STEP" parameterTypeRef="UINT16">
+				<xtce:ShortDescription>ESA Step Number</xtce:ShortDescription>
+				<xtce:LongDescription>ESA Step Number</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="COUNTERS" parameterTypeRef="BYTE25920" shortDescription="An array of 90 counters, each counter being 12-bits: 8 12-bit qualified counters (AB, C1C2, AC1, BC1, ABC1, AC1C2, BC1C2, ABC1C2); 11 12-bit long counters (A, B, C, AB, C1C2, AC1, BC1, ABC1, AC1C2, BC1C2, ABC1C2); 5 12-bit counters (totalA, totalB, totalC, FEE_DE_SENT, FEE_DE_RECD)">
 				<xtce:LongDescription>

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -5,6 +5,7 @@ import pytest
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import write_cdf
+from imap_processing.hi.l1a import histogram as hist
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.utils import HIAPID
 from imap_processing.tests.conftest import ccsds_header_data, check_sum
@@ -149,3 +150,35 @@ def test_app_nhk_decom():
     # TODO: ask Vivek about this date mismatch between the file name
     # and the data. May get resolved when we have good sample data.
     assert cem_raw_cdf_filepath.name == "imap_hi_l1a_hk_20100313_v001.cdf"
+
+
+def test_app_hist_decom():
+    """Test histogram (SCI_CNT) data"""
+    test_path = imap_module_directory / "tests/hi/l0_test_data"
+    bin_data_path = test_path / "20231030_H45_SCI_CNT.bin"
+    processed_data = hi_l1a(packet_file_path=bin_data_path)
+
+    assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_hist"
+    # TODO: compare with validation data once we have it
+
+    # Write CDF
+    cem_raw_cdf_filepath = write_cdf(processed_data[0])
+
+    assert cem_raw_cdf_filepath.name.startswith("imap_hi_l1a_hist_")
+
+
+def test_allocate_histogram_dataset():
+    """Test hi.l1a.histogram.allocate_histogram_dataset()"""
+    n_packets = 5
+    dataset = hist.allocate_histogram_dataset(n_packets)
+
+    assert dataset.dims["epoch"] == n_packets
+    assert dataset.dims["angle"] == 90
+    for var_name in (
+        "ccsds_met",
+        "esa_step",
+        *hist.QUALIFIED_COUNTERS,
+        *hist.LONG_COUNTERS,
+        *hist.TOTAL_COUNTERS,
+    ):
+        assert var_name in dataset


### PR DESCRIPTION
# Change Summary
Add L1A processing of Hi Hist packets.

## Overview
I am opening this PR before finalizing test coverage in order to get feedback before fully fleshing out test coverage.

## New Dependencies
None

## New Files
- imap_processing/hi/l1a/histogram.py
   - House the L1A processing specific to the hist packet (SCI_CNT)

## Deleted Files
None

## Updated Files
- imap_processing/hi/hi_cdf_attrs.py
   - add histogram specific cdf attributes
- imap_processing/hi/l1a/hi_l1a.py
   - add code into branch for processing histogram packets
   - add branch for unexpected APIDs with logging
- imap_processing/hi/packet_definitions/hi_packet_definition.xml
   - Remove comment about Acquisition Start Time in description of ESA_STEP. This was an artifact from IBEX.
- imap_processing/test/hi/test_l1a.py
   - preliminary test coverage for L1A processing of histogram packets

## Testing
One unit test added - I plan to refine this test and possibly add more after getting initial feedback
