### PR TITLE
Cleaning up some L1A hist CDF issues found when reviewing output file

### DIFF
--- a/imap_processing/hi/hi_cdf_attrs.py
+++ b/imap_processing/hi/hi_cdf_attrs.py
@@ -161,20 +161,10 @@ hi_hist_l1a_angle_attrs = AttrBase(
     units="deg",
     label_axis="ANGLE",
     display_type="time_series",
-    catdesc="Angle bin centers for Histogram data.",
+    catdesc="Angle bin centers for histogram data.",
     fieldname="ANGLE",
     fill_val=GlobalConstants.INT_FILLVAL,
     var_type="support_data",
-)
-
-hi_hist_l1a_esa_step_attrs = ScienceAttrs(
-    validmin=0,
-    validmax=2**4 - 1,
-    depend_0="epoch",
-    format="I2",
-    catdesc="4-bit ESA Step Number",
-    var_type="support_data",
-    variable_purpose="PRIMARY",
 )
 
 hi_hist_l1a_counter_attrs = ScienceAttrs(
@@ -183,6 +173,6 @@ hi_hist_l1a_counter_attrs = ScienceAttrs(
     depend_0="epoch",
     depend_1="angle",
     format="I4",
-    var_type="support_data",
+    var_type="data",
     variable_purpose="PRIMARY",
 )

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -128,8 +128,7 @@ def allocate_histogram_dataset(num_packets: int) -> xr.Dataset:
             dims=["epoch", "angle"],
             attrs=dataclasses.replace(
                 hi_cdf_attrs.hi_hist_l1a_counter_attrs,
-                catdesc=f"Angular histogram of {counter} type events "
-                f"that occurred for a single ESA step.",
+                catdesc=f"Angular histogram of {counter} type events",
                 fieldname=f"{counter} histogram",
                 label_axis=counter,
             ).output(),

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -119,21 +119,18 @@ def allocate_histogram_dataset(num_packets: int) -> xr.Dataset:
     data_vars["esa_step"] = xr.DataArray(
         np.empty(num_packets, dtype=np.uint8),
         dims=["epoch"],
-        attrs=dataclasses.replace(
-            hi_cdf_attrs.hi_hist_l1a_esa_step_attrs,
-            fieldname="ESA_STEP",
-            label_axis="ESA_STEP",
-        ).output(),
+        attrs=hi_cdf_attrs.esa_step_attrs.output(),
     )
 
     for counter in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
         data_vars[counter] = xr.DataArray(
-            data=np.empty((num_packets, len(coords["angle"])), np.dtype("uint16")),
+            data=np.empty((num_packets, len(coords["angle"])), np.uint16),
             dims=["epoch", "angle"],
             attrs=dataclasses.replace(
                 hi_cdf_attrs.hi_hist_l1a_counter_attrs,
-                catdesc=f"Counts for {counter} counter",
-                fieldname=counter,
+                catdesc=f"Angular histogram of {counter} type events "
+                f"that occurred for a single ESA step.",
+                fieldname=f"{counter} histogram",
                 label_axis=counter,
             ).output(),
         )


### PR DESCRIPTION
# Change Summary
- Change histogram counter `var_type` to `data`
- Use common cdf attributes definition for ESA_STEP
- Extend text in `catdesc` for histogram counter variables

## Overview
This just cleans up a few loose ends that I noticed when reviewing the Hi L1a Histogram CDF files.

## Updated Files
- imap_processing.hi.hi_cdf_attrs.py
   - Change histogram counter `var_type` to `data`
   - Remove hist specific esa_step attributes definition
- imap_processing.hi.l1a.histogram.py
   - Use common cdf attributes definition for ESA_STEP
   - Extend text in `catdesc` for histogram counter variables
