### PR TITLE
Refactor imap_processing.cli.ProcessInstrument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,5 +37,7 @@ jobs:
           # Ignore the network marks from the remote test environment
           poetry run pytest --color=yes --cov --cov-report=xml
 
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 [![readthedocs](https://readthedocs.org/projects/imap-processing/badge/?version=latest)](https://imap-processing.readthedocs.io/en/latest/)
+<!-- DOI-BADGE -->
+[![DOI](https://zenodo.org/badge/654679818.svg)](https://zenodo.org/badge/latestdoi/654679818)
 
 The Interstellar Mapping and Acceleration Probe (IMAP) is an exciting project aimed at studying the interstellar medium and investigating the acceleration mechanisms of particles within our galaxy. IMAP utilizes cutting-edge technology and advanced instrumentation to gather valuable data and expand our understanding of space.
 

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from pathlib import Path
+from typing import Optional
 
 import imap_data_access
 import numpy as np
@@ -14,7 +15,9 @@ from imap_processing import launch_time
 logger = logging.getLogger(__name__)
 
 
-def calc_start_time(shcoarse_time: float) -> np.datetime64:
+def calc_start_time(
+    shcoarse_time: float, launch_time: Optional[np.datetime64] = launch_time
+) -> np.datetime64:
     """Calculate the datetime64 from the CCSDS secondary header information.
 
     Since all instrument has SHCOARSE or MET seconds, we need convert it to
@@ -24,6 +27,8 @@ def calc_start_time(shcoarse_time: float) -> np.datetime64:
     ----------
     shcoarse_time: float
         Number of seconds since epoch (nominally the launch time)
+    launch_time : np.datetime64
+        The time of launch to use as the baseline
 
     Returns
     -------

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -249,7 +249,7 @@ class ProcessInstrument(ABC):
 
         Attributes
         ----------
-        products: list[str]
+        products : list[str]
         A list of file paths to upload to the SDC.
         """
         if self.upload_to_sdc:
@@ -278,9 +278,9 @@ class ProcessInstrument(ABC):
         """
         Complete pre-processing.
 
-        For this baseclass, pre-processing consists of downloading
-        dependencies for processing. Child classes can override this
-        method to customize the pre-processing actions.
+        For this baseclass, pre-processing consists of downloading dependencies
+        for processing. Child classes can override this method to customize the
+        pre-processing actions.
 
         Returns
         -------
@@ -299,12 +299,13 @@ class ProcessInstrument(ABC):
 
         Attributes
         ----------
-        dependencies: list
-        List of dependencies to process
+        dependencies : list
+            List of dependencies to process
 
         Returns
         -------
-        List of products produced
+        list
+            List of products produced
         """
         raise NotImplementedError
 
@@ -318,8 +319,8 @@ class ProcessInstrument(ABC):
 
         Attributes
         ----------
-        products: list[str]
-        A list of file paths (products) produced by do_processing method.
+        products : list[str]
+            A list of file paths (products) produced by do_processing method.
         """
         self.upload_products(products)
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -16,6 +16,7 @@ import sys
 from abc import ABC, abstractmethod
 from json import loads
 from pathlib import Path
+from typing import final
 from urllib.error import HTTPError
 
 import imap_data_access
@@ -31,6 +32,7 @@ import imap_processing
 # In code:
 #   call cdf.utils.write_cdf
 from imap_processing.cdf.utils import load_cdf, write_cdf
+from imap_processing.hi.l1a import hi_l1a
 from imap_processing.mag.l1a.mag_l1a import mag_l1a
 from imap_processing.swe.l1a.swe_l1a import swe_l1a
 from imap_processing.swe.l1b.swe_l1b import swe_l1b
@@ -241,16 +243,91 @@ class ProcessInstrument(ABC):
             file_list.append(imap_data_access.download(return_query[0]["file_path"]))
         return file_list
 
-    @abstractmethod
+    def upload_products(self, products: list[str]):
+        """
+        Upload data products to the IMAP SDC.
+
+        Attributes
+        ----------
+        products: list[str]
+        A list of file paths to upload to the SDC.
+        """
+        if self.upload_to_sdc:
+            if len(products) == 0:
+                logger.info("No files to upload.")
+            for filename in products:
+                logger.info(f"Uploading file: {filename}")
+                imap_data_access.upload(filename)
+
+    @final
     def process(self):
-        """Perform instrument specific processing."""
+        """
+        Run the processing workflow and cannot be overridden by subclasses.
+
+        Each IMAP processing step consists of three steps:
+        1. Pre-processing actions such as downloading dependencies for processing.
+        2. Do the data processing. The result of this step will usually be a list
+        of new products (files).
+        3. Post-processing actions such as uploading files to the IMAP SDC.
+        """
+        dependencies = self.pre_processing()
+        products = self.do_processing(dependencies)
+        self.post_processing(products)
+
+    def pre_processing(self):
+        """
+        Complete pre-processing.
+
+        For this baseclass, pre-processing consists of downloading
+        dependencies for processing. Child classes can override this
+        method to customize the pre-processing actions.
+
+        Returns
+        -------
+        List of dependencies downloaded from the IMAP SDC.
+        """
+        return self.download_dependencies()
+
+    @abstractmethod
+    def do_processing(self, dependencies: list):
+        """
+        Abstract method that processes the IMAP processing steps.
+
+        All child classes must implement this method. Input and
+        outputs are typically lists of file paths but are free to
+        any list.
+
+        Attributes
+        ----------
+        dependencies: list
+        List of dependencies to process
+
+        Returns
+        -------
+        List of products produced
+        """
         raise NotImplementedError
+
+    def post_processing(self, products: list[str]):
+        """
+        Complete post-processing.
+
+        Default post-processing consists of uploading newly generated
+        products to the IMAP SDC. Child classes can override this method
+        to customize the post-processing actions.
+
+        Attributes
+        ----------
+        products: list[str]
+        A list of file paths (products) produced by do_processing method.
+        """
+        self.upload_products(products)
 
 
 class Codice(ProcessInstrument):
     """Process CoDICE."""
 
-    def process(self):
+    def do_processing(self, dependencies):
         """Perform CoDICE specific processing."""
         print(f"Processing CoDICE {self.data_level}")
 
@@ -258,7 +335,7 @@ class Codice(ProcessInstrument):
 class Glows(ProcessInstrument):
     """Process GLOWS."""
 
-    def process(self):
+    def do_processing(self, dependencies):
         """Perform GLOWS specific processing."""
         print(f"Processing GLOWS {self.data_level}")
 
@@ -266,15 +343,33 @@ class Glows(ProcessInstrument):
 class Hi(ProcessInstrument):
     """Process IMAP-Hi."""
 
-    def process(self):
-        """Perform IMAP-Hi specific processing."""
+    def do_processing(self, dependencies: list):
+        """
+        Perform IMAP-Hi specific processing.
+
+        Attributes
+        ----------
+        dependencies: list
+        List of dependencies to process
+        """
         print(f"Processing IMAP-Hi {self.data_level}")
+
+        if self.data_level == "l1a":
+            # File path is expected output file path
+            if len(dependencies) > 1:
+                raise ValueError(
+                    f"Unexpected dependencies found for Hi L1A:"
+                    f"{dependencies}. Expected only one dependency."
+                )
+            datasets = hi_l1a.hi_l1a(dependencies[0])
+            products = [write_cdf(dataset) for dataset in datasets]
+            return products
 
 
 class Hit(ProcessInstrument):
     """Process HIT."""
 
-    def process(self):
+    def do_processing(self, dependencies):
         """Perform HIT specific processing."""
         print(f"Processing HIT {self.data_level}")
 
@@ -282,7 +377,7 @@ class Hit(ProcessInstrument):
 class Idex(ProcessInstrument):
     """Process IDEX."""
 
-    def process(self):
+    def do_processing(self, dependencies):
         """Perform IDEX specific processing."""
         print(f"Processing IDEX {self.data_level}")
 
@@ -290,7 +385,7 @@ class Idex(ProcessInstrument):
 class Lo(ProcessInstrument):
     """Process IMAP-Lo."""
 
-    def process(self):
+    def do_processing(self, dependencies):
         """Perform IMAP-Lo specific processing."""
         print(f"Processing IMAP-Lo {self.data_level}")
 
@@ -298,10 +393,9 @@ class Lo(ProcessInstrument):
 class Mag(ProcessInstrument):
     """Process MAG."""
 
-    def process(self):
+    def do_processing(self, file_paths):
         """Perform MAG specific processing."""
         print(f"Processing MAG {self.data_level}")
-        file_paths = self.download_dependencies()
 
         if self.data_level == "l1a":
             # File path is expected output file path
@@ -311,18 +405,13 @@ class Mag(ProcessInstrument):
                     f"{file_paths}. Expected only one dependency."
                 )
             output_files = mag_l1a(file_paths[0], data_version=self.version)
-            if self.upload_to_sdc:
-                if len(output_files) == 0:
-                    print("No files to upload.")
-                for filename in output_files:
-                    print(f"Uploading file: {filename}")
-                    imap_data_access.upload(filename)
+            return output_files
 
 
 class Swapi(ProcessInstrument):
     """Process SWAPI."""
 
-    def process(self):
+    def do_processing(self, dependencies):
         """Perform SWAPI specific processing."""
         print(f"Processing SWAPI {self.data_level}")
 
@@ -330,24 +419,21 @@ class Swapi(ProcessInstrument):
 class Swe(ProcessInstrument):
     """Process SWE."""
 
-    def process(self):
+    def do_processing(self, dependencies):
         """Perform SWE specific processing."""
         # self.file_path example:
         # imap/swe/l1a/2023/09/imap_swe_l1a_sci_20230927_v001.cdf
-        dependencies = self.download_dependencies()
         print(f"Processing SWE {self.data_level}")
 
         # TODO: currently assumes just the first path returned is the one to use
 
+        products = []
         if self.data_level == "l1a":
             processed_data = swe_l1a(Path(dependencies[0]))
             for data in processed_data:
                 cdf_file_path = write_cdf(data)
                 print(f"processed file path: {cdf_file_path}")
-
-                if self.upload_to_sdc:
-                    imap_data_access.upload(cdf_file_path)
-                    print(f"Uploading file: {cdf_file_path}")
+                products.append(cdf_file_path)
 
         elif self.data_level == "l1b":
             # read CDF file
@@ -356,9 +442,7 @@ class Swe(ProcessInstrument):
             # TODO: Pass in the proper version and descriptor
             cdf_file_path = write_cdf(data=processed_data)
             print(f"processed file path: {cdf_file_path}")
-            if self.upload_to_sdc:
-                imap_data_access.upload(cdf_file_path)
-                print(f"Uploading file: {cdf_file_path}")
+            products.append(cdf_file_path)
 
         else:
             print("No code to process this level")
@@ -367,7 +451,7 @@ class Swe(ProcessInstrument):
 class Ultra(ProcessInstrument):
     """Process IMAP-Ultra."""
 
-    def process(self):
+    def do_processing(self, dependencies):
         """Perform IMAP-Ultra specific processing."""
         print(f"Processing IMAP-Ultra {self.data_level}")
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -293,9 +293,8 @@ class ProcessInstrument(ABC):
         """
         Abstract method that processes the IMAP processing steps.
 
-        All child classes must implement this method. Input and
-        outputs are typically lists of file paths but are free to
-        any list.
+        All child classes must implement this method. Input and outputs are
+        typically lists of file paths but are free to any list.
 
         Attributes
         ----------
@@ -313,9 +312,9 @@ class ProcessInstrument(ABC):
         """
         Complete post-processing.
 
-        Default post-processing consists of uploading newly generated
-        products to the IMAP SDC. Child classes can override this method
-        to customize the post-processing actions.
+        Default post-processing consists of uploading newly generated products
+        to the IMAP SDC. Child classes can override this method to customize the
+        post-processing actions.
 
         Attributes
         ----------

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -50,6 +50,10 @@ def test_calc_start_time():
 
     assert calc_start_time(0) == launch_time
     assert calc_start_time(1) == launch_time + np.timedelta64(1, "s")
+    different_launch_time = launch_time + np.timedelta64(2, "s")
+    assert calc_start_time(
+        0, launch_time=different_launch_time
+    ) == launch_time + np.timedelta64(2, "s")
 
 
 def test_load_cdf(test_dataset):

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -1,0 +1,89 @@
+"""Tests coverage for imap_processing.cli."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+from imap_processing.cli import Hi, _validate_args, main
+
+
+@mock.patch("imap_processing.cli.Mag")
+def test_main(mock_instrument):
+    """Test imap_processing.cli.main()"""
+    test_args = [
+        "imap_cli",
+        "--instrument",
+        "mag",
+        "--dependency",
+        (
+            '[{"instrument": "mag", '
+            '"data_level": "l0", '
+            '"descriptor": "sci", '
+            '"version": "v001", '
+            '"start_date": "20240430"}]'
+        ),
+        "--data-level",
+        "l1a",
+        "--start-date",
+        "20240430",
+        "--end-date",
+        "20240501",
+        "--version",
+        "v00-01",
+        "--upload-to-sdc",
+    ]
+    with mock.patch.object(sys, "argv", test_args):
+        # Running without raising an exception is a pass.
+        # No asserts needed.
+        main()
+
+
+@pytest.mark.parametrize(
+    "instrument, data_level, raises_value_error",
+    [
+        ("mag", "l0", ""),
+        ("foo", "l0", "foo is not in the supported .*"),
+        ("codice", "l1z", "l1z is not a supported .*"),
+    ],
+)
+def test_validate_args(instrument, data_level, raises_value_error):
+    """Test coverage for imap_processing.cli._validate_args()"""
+    args = mock.Mock
+    args.instrument = instrument
+    args.data_level = data_level
+
+    if raises_value_error:
+        with pytest.raises(ValueError, match=raises_value_error):
+            _validate_args(args)
+    else:
+        _validate_args(args)
+
+
+@mock.patch("imap_processing.cli.imap_data_access.query")
+@mock.patch("imap_processing.cli.imap_data_access.download")
+@mock.patch("imap_processing.cli.imap_data_access.upload")
+@mock.patch("imap_processing.cli.hi_l1a.hi_l1a")
+@mock.patch("imap_processing.cli.write_cdf")
+def test_hi(mock_write_cdf, mock_hi_l1a, mock_upload, mock_download, mock_query):
+    """Test coverage for cli.Hi class"""
+    mock_query.return_value = [{"file_path": "/path/to/file0"}]
+    mock_download.return_value = "file0"
+    mock_hi_l1a.return_value = ["l1a_file0", "l1a_file1"]
+    mock_write_cdf.side_effect = ["/path/to/file0", "/path/to/file1"]
+
+    dependency_str = (
+        "[{"
+        "'instrument': 'lo',"
+        "'data_level': 'l0',"
+        "'descriptor': 'sci',"
+        "'version': 'v00-01',"
+        "'start_date': '20231212'"
+        "}]"
+    )
+    instrument = Hi("l1a", dependency_str, "20231212", "20231213", "v005", True)
+    instrument.process()
+    assert mock_query.call_count == 1
+    assert mock_download.call_count == 1
+    assert mock_hi_l1a.call_count == 1
+    assert mock_upload.call_count == 2


### PR DESCRIPTION
# Change Summary
Refactor `ProcessInstrument` base class
Add Hi L1a processing to cli Hi class
Add test coverage for cli.py

## Overview
### Refactor `ProcessInstrument`
I modified the ProcessInstrument.process method to be a `final` method which cannot be overridden in inheriting classes. The method calls three methods that can be overridden: `pre_processing`, `do_processing`, and `post_processing`. 
- `pre_processing` is defined so that default behavior is to download dependencies
- `do_processing` is an abstractmethod that must be defined in any inheriting class
- `post_processing` is defined so that default behavior is to upload any results from `do_processing` to the SDC if the `--upload-to-sdc` argument is set to True.
### Add Hi L1a processing
After the refactor I added Hi L1a processing using the new methods in the base class.

## New Files
- tests/test_cli.py
   - Added some test coverage for the cli.py module

## Updated Files
- imap_processing/cli.py
   - refactor ProcessInstrument class
   - add L1a processing to Hi class
   - modify other instrument classes to use refactored ProcessInstrument class

## Testing
Added some test coverage for cli.py. I am interested in getting feedback on whether my `@mock.patch` and `@pytest.mark.parameterize` use is up to standards/best practices that you all use.
