### PR TITLE
Add launch_time parameter to cdf.utils.calc_start_time

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from pathlib import Path
+from typing import Optional
 
 import imap_data_access
 import numpy as np
@@ -14,7 +15,9 @@ from imap_processing import launch_time
 logger = logging.getLogger(__name__)
 
 
-def calc_start_time(shcoarse_time: float) -> np.datetime64:
+def calc_start_time(
+    shcoarse_time: float, launch_time: Optional[np.datetime64] = launch_time
+) -> np.datetime64:
     """Calculate the datetime64 from the CCSDS secondary header information.
 
     Since all instrument has SHCOARSE or MET seconds, we need convert it to
@@ -24,6 +27,8 @@ def calc_start_time(shcoarse_time: float) -> np.datetime64:
     ----------
     shcoarse_time: float
         Number of seconds since epoch (nominally the launch time)
+    launch_time : np.datetime64
+        The time of launch to use as the baseline
 
     Returns
     -------

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -50,6 +50,10 @@ def test_calc_start_time():
 
     assert calc_start_time(0) == launch_time
     assert calc_start_time(1) == launch_time + np.timedelta64(1, "s")
+    different_launch_time = launch_time + np.timedelta64(2, "s")
+    assert calc_start_time(
+        0, launch_time=different_launch_time
+    ) == launch_time + np.timedelta64(2, "s")
 
 
 def test_load_cdf(test_dataset):


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
This PR adds an optional parameter to `cdf.utils.calc_start_time` for a user-specified launch time. This change is motivated by the desire from CoDICE to use their own launch time that is slightly different from the one we define in `imap_processing.__init__.py`.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- `imap_processing/cdf/utils.py`
   - Added new `launch_time` parameter, which defaults to using the `launch_time` specified at the package level
- `imap_processing/tests/cdf/test_utils.py`
   - Expanded test to test the new parameter

