### PR TITLE
CI: remove minor/patch version pin from codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,6 @@ jobs:
           poetry run pytest --color=yes --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Change Summary

## Overview

This removes the minor/patch version pin from the codecov action allowing us to keep getting minor updates along the way, but still restricting the major version updates.

Hopefully this will help with codecov running on the dev branch. I have also changed over to an organization-level secret instead of repository-level to see if that helps anything as well.