### PR TITLE
CoDICE L1A cli

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -344,7 +344,6 @@ class Codice(ProcessInstrument):
             # process data
             dataset = codice_l1a.process_codice_l1a(dependencies[0])
             cdf_file_path = dataset.attrs["cdf_filename"]
-            print(f"processed file path: {cdf_file_path}")
             return [cdf_file_path]
 
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -22,6 +22,7 @@ from urllib.error import HTTPError
 import imap_data_access
 
 import imap_processing
+from imap_processing.cdf.utils import load_cdf, write_cdf
 
 # TODO: change how we import things and also folder
 # structure may?
@@ -31,7 +32,7 @@ import imap_processing
 #   from imap_processing import cdf
 # In code:
 #   call cdf.utils.write_cdf
-from imap_processing.cdf.utils import load_cdf, write_cdf
+from imap_processing.codice import codice_l1a
 from imap_processing.hi.l1a import hi_l1a
 from imap_processing.idex.idex_packet_parser import PacketParser
 from imap_processing.mag.l1a.mag_l1a import mag_l1a
@@ -333,6 +334,18 @@ class Codice(ProcessInstrument):
     def do_processing(self, dependencies):
         """Perform CoDICE specific processing."""
         print(f"Processing CoDICE {self.data_level}")
+
+        if self.data_level == "l1a":
+            if len(dependencies) > 1:
+                raise ValueError(
+                    f"Unexpected dependencies found for CoDICE L1a:"
+                    f"{dependencies}. Expected only one dependency."
+                )
+            # process data
+            dataset = codice_l1a.process_codice_l1a(dependencies[0])
+            cdf_file_path = dataset.attrs["cdf_filename"]
+            print(f"processed file path: {cdf_file_path}")
+            return [cdf_file_path]
 
 
 class Glows(ProcessInstrument):

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -22,6 +22,7 @@ from imap_processing import imap_module_directory
 from imap_processing.cdf.global_attrs import ConstantCoordinates
 from imap_processing.cdf.utils import calc_start_time, write_cdf
 from imap_processing.codice import cdf_attrs
+from imap_processing.codice.codice_l0 import decom_packets
 from imap_processing.codice.constants import (
     ESA_SWEEP_TABLE_ID_LOOKUP,
     LO_COLLAPSE_TABLE_ID_LOOKUP,
@@ -349,13 +350,13 @@ def get_params(packet) -> tuple[int, int, int, int]:
     return table_id, plan_id, plan_step, view_id
 
 
-def process_codice_l1a(packets) -> xr.Dataset:
+def process_codice_l1a(file_path: str) -> xr.Dataset:
     """Process CoDICE l0 data to create l1a data products.
 
     Parameters
     ----------
-    packets : list[space_packet_parser.parser.Packet]
-        Decom data list that contains all APIDs
+    file_path : str
+        Path to the CoDICE L0 file to process
 
     Returns
     -------
@@ -370,7 +371,8 @@ def process_codice_l1a(packets) -> xr.Dataset:
         CODICEAPID.COD_LO_SW_ANGULAR_COUNTS,
     ]
 
-    # Group data by APID and sort by time
+    # Decom the packets, group data by APID, and sort by time
+    packets = decom_packets(file_path)
     grouped_data = group_by_apid(packets)
 
     for apid in grouped_data.keys():

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -350,7 +350,7 @@ def get_params(packet) -> tuple[int, int, int, int]:
     return table_id, plan_id, plan_step, view_id
 
 
-def process_codice_l1a(file_path: str) -> xr.Dataset:
+def process_codice_l1a(file_path: Path | str) -> xr.Dataset:
     """Process CoDICE l0 data to create l1a data products.
 
     Parameters

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -357,7 +357,7 @@ def process_codice_l1a(file_path: Path | str) -> xr.Dataset:
 
     Parameters
     ----------
-    file_path : Path | str
+    file_path : pathlib.Path | str
         Path to the CoDICE L0 file to process
 
     Returns

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -11,6 +11,8 @@ Use
     dataset = process_codice_l1a(packets)
 """
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 
@@ -355,7 +357,7 @@ def process_codice_l1a(file_path: Path | str) -> xr.Dataset:
 
     Parameters
     ----------
-    file_path : str
+    file_path : Path | str
         Path to the CoDICE L0 file to process
 
     Returns

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -8,7 +8,6 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import load_cdf
-from imap_processing.codice.codice_l0 import decom_packets
 from imap_processing.codice.codice_l1a import process_codice_l1a
 
 EXPECTED_ARRAY_SHAPES = [
@@ -61,8 +60,8 @@ def test_l1a_data(request) -> xr.Dataset:
     dataset : xr.Dataset
         A ``xarray`` dataset containing the test data
     """
-    packets = decom_packets(request.param)
-    dataset = process_codice_l1a(packets)
+
+    dataset = process_codice_l1a(request.param)
     return dataset
 
 


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
This PR adds CoDICE L1A processing to the cli. I also made a few changes to the CoDICE pipeline to be more consistent with how other instruments are running their processing (namely passing in a file path to the L0 file instead of passing in already-decommed packets)

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->

This appears to be working for housekeeping data when I test this locally, but fails on other data products, I think because the `descriptor` field is not yet fully implemented as a parameter in `cli.py`. 
