### PR TITLE
Dynamic version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,11 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          # We need the full history to generate the proper version number
+          fetch-depth: 0
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install dependencies and app
         run: |
+          # Need to install extra plugins first
+          poetry self add "poetry-dynamic-versioning[plugin]"
           poetry install --extras "test"
 
       - name: Testing

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ data/imap/
 *.xlsx
 *.xls
 
+# poetry dynamic version creation
+_version.py
+
 # Documentation ignore
 docs/source/**/generated
 

--- a/docs/source/external-tools/poetry.rst
+++ b/docs/source/external-tools/poetry.rst
@@ -83,6 +83,9 @@ Installing and the Poetry Shell
 
 To install the Poetry project, you can use the `install <https://python-poetry.org/docs/cli/#install>`_ command::
 
+    # We use dynamic versioning, which requires a plugin to be installed first
+    poetry self add "poetry-dynamic-versioning[plugin]"
+
     # Install main dependencies and any dependency groups which are installed by default
     poetry install
 

--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -8,8 +8,6 @@ There are utilities to read and write IMAP data files in
 the CDF file format, and to interact with the SPICE toolkit.
 """
 
-__version__ = "0.2.0"
-
 # When imap_processing is installed using pip, we need to be able to find the
 # packet definitions directory path.
 #
@@ -17,6 +15,8 @@ __version__ = "0.2.0"
 from pathlib import Path
 
 import numpy as np
+
+from imap_processing._version import __version__, __version_tuple__  # noqa: F401
 
 # Eg. imap_module_directory = /usr/local/lib/python3.11/site-packages/imap_processing
 imap_module_directory = Path(__file__).parent

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -10,13 +10,14 @@ import numpy as np
 import xarray as xr
 from cdflib.xarray import cdf_to_xarray, xarray_to_cdf
 
-from imap_processing import launch_time
+import imap_processing
 
 logger = logging.getLogger(__name__)
 
 
 def calc_start_time(
-    shcoarse_time: float, launch_time: Optional[np.datetime64] = launch_time
+    shcoarse_time: float,
+    launch_time: Optional[np.datetime64] = imap_processing.launch_time,
 ) -> np.datetime64:
     """Calculate the datetime64 from the CCSDS secondary header information.
 
@@ -129,6 +130,8 @@ def write_cdf(dataset: xr.Dataset):
     # Insert the final attribute:
     # The Logical_file_id is always the name of the file without the extension
     dataset.attrs["Logical_file_id"] = file_path.stem
+    # Add the processing version to the dataset attributes
+    dataset.attrs["ground_software_version"] = imap_processing.__version__
 
     # Convert the xarray object to a CDF
     xarray_to_cdf(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -52,6 +52,7 @@ def _parse_args():
     --instrument "mag"
     --data-level "l1a"
     --start-date "20231212"
+    --end-date "20231212"
     --version "v001"
     --dependency "[
         {
@@ -101,6 +102,29 @@ def _parse_args():
     )
 
     parser = argparse.ArgumentParser(prog="imap_cli", description=description)
+    # TODO: Add version here and change our current "version" to "data-version"?
+    # parser.add_argument(
+    #     "--version",
+    #     action="version",
+    #     version=f"%(prog)s {imap_processing.__version__}",
+    # )
+    # Logging level
+    parser.add_argument(
+        "--debug",
+        help="Print lots of debugging statements",
+        action="store_const",
+        dest="loglevel",
+        const=logging.DEBUG,
+        default=logging.WARNING,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Add verbose output",
+        action="store_const",
+        dest="loglevel",
+        const=logging.INFO,
+    )
     parser.add_argument("--instrument", type=str, required=True, help=instrument_help)
     parser.add_argument("--data-level", type=str, required=True, help=level_help)
 
@@ -275,9 +299,15 @@ class ProcessInstrument(ABC):
         of new products (files).
         3. Post-processing actions such as uploading files to the IMAP SDC.
         """
+        logger.info(f"IMAP Processing Version: {imap_processing.__version__}")
+        logger.info(f"Processing {self.__class__.__name__} level {self.data_level}")
+        logger.info("Beginning preprocessing (download dependencies)")
         dependencies = self.pre_processing()
+        logger.info("Beginning actual processing")
         products = self.do_processing(dependencies)
+        logger.info("Beginning postprocessing (uploading data products)")
         self.post_processing(products)
+        logger.info("Processing complete")
 
     def pre_processing(self):
         """

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -52,7 +52,6 @@ def _parse_args():
     --instrument "mag"
     --data-level "l1a"
     --start-date "20231212"
-    --end-date "20231212"
     --version "v001"
     --dependency "[
         {

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -48,7 +48,7 @@ def test_main(mock_instrument):
         "--end-date",
         "20240501",
         "--version",
-        "v00-01",
+        "v001",
         "--upload-to-sdc",
     ]
     with mock.patch.object(sys, "argv", test_args):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -219,7 +219,8 @@ def test_cdf_aux(
     dataset_aux = create_dataset({ULTRA_AUX.apid[0]: decom_ultra_aux})
     input_xarray_aux = load_cdf(test_data_path)
 
-    assert input_xarray_aux.attrs.keys() == dataset_aux.attrs.keys()
+    # write_cdf() injects some attributes that are not in the xarray
+    assert set(dataset_aux.attrs.keys()).issubset(set(input_xarray_aux.attrs.keys()))
 
 
 @pytest.mark.parametrize(
@@ -247,7 +248,10 @@ def test_cdf_rates(ccsds_path_theta_0, decom_test_data):
     dataset_rates = create_dataset({ULTRA_RATES.apid[0]: decom_ultra_rates})
     input_xarray_rates = load_cdf(test_data_path)
 
-    assert input_xarray_rates.attrs.keys() == dataset_rates.attrs.keys()
+    # write_cdf() injects some attributes that are not in the xarray
+    assert set(dataset_rates.attrs.keys()).issubset(
+        set(input_xarray_rates.attrs.keys())
+    )
 
 
 @pytest.mark.parametrize(
@@ -274,8 +278,8 @@ def test_cdf_tof(ccsds_path_theta_0, decom_test_data):
 
     dataset_tof = create_dataset({ULTRA_TOF.apid[0]: decom_ultra_tof})
     input_xarray_tof = load_cdf(test_data_path)
-
-    assert input_xarray_tof.attrs.keys() == dataset_tof.attrs.keys()
+    # write_cdf() injects some attributes that are not in the xarray
+    assert set(dataset_tof.attrs.keys()).issubset(set(input_xarray_tof.attrs.keys()))
 
 
 @pytest.mark.parametrize(
@@ -305,4 +309,7 @@ def test_cdf_events(ccsds_path_theta_0, decom_ultra_aux, decom_test_data):
     )
     input_xarray_events = load_cdf(test_data_path, to_datetime=True)
 
-    assert input_xarray_events.attrs.keys() == dataset_events.attrs.keys()
+    # write_cdf() injects some attributes that are not in the xarray
+    assert set(dataset_events.attrs.keys()).issubset(
+        set(input_xarray_events.attrs.keys())
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "imap-processing"
-version = "0.2.0"
+version = "0.0.0"
 description = "IMAP Science Operations Center Processing"
 authors = ["IMAP SDC Developers <imap-sdc@lists.lasp.colorado.edu>"]
 readme = "README.md"
+include = ["imap_processing/_version.py"]
 license = "MIT"
 keywords = ["IMAP", "SDC", "SOC", "Science Operations"]
 classifiers = [
@@ -92,3 +93,15 @@ imap_cli = 'imap_processing.cli:main'
 
 [tool.codespell]
 ignore-words-list = "livetime"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+
+[tool.poetry-dynamic-versioning.files."imap_processing/_version.py"]
+persistent-substitution = true
+initial-content = """
+  # These version placeholders will be replaced later during substitution.
+  __version__ = "0.0.0"
+  __version_tuple__ = (0, 0, 0)
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "imap-processing"
+# Gets updated dynamically by the poetry-dynamic-versioning plugin
 version = "0.0.0"
 description = "IMAP Science Operations Center Processing"
 authors = ["IMAP SDC Developers <imap-sdc@lists.lasp.colorado.edu>"]


### PR DESCRIPTION
# Change Summary

## Overview

This adds dynamic version resolution from the git tag/git commit.

* Add log messages during processing to indicate the version
* Add the version to `write_cdf()` so it is output in our saved datasets as a dataset attribute.

## New Dependencies

It adds a new build system dependency on `poetry-dynamic-versioning` that injects the metadata resolution during build-time but is not a package dependency.


