### PR TITLE
MNT: Minimize warnings and prepare for the future

### DIFF
--- a/imap_processing/lo/l1a/lo_l1a_write_cdfs.py
+++ b/imap_processing/lo/l1a/lo_l1a_write_cdfs.py
@@ -56,7 +56,7 @@ def create_lo_scide_dataset(sci_de: list):
         sci_de_times, dims="epoch", attrs=lo_cdf_attrs.lo_tof_attrs.output()
     )
     sci_de_epoch = xr.DataArray(
-        np.array(sci_de_times, dtype="datetime64[s]"),
+        np.array(sci_de_times, dtype="datetime64[s]").astype("datetime64[ns]"),
         dims=["epoch"],
         name="epoch",
         attrs=ConstantCoordinates.EPOCH,

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -172,8 +172,8 @@ def test_allocate_histogram_dataset():
     n_packets = 5
     dataset = hist.allocate_histogram_dataset(n_packets)
 
-    assert dataset.dims["epoch"] == n_packets
-    assert dataset.dims["angle"] == 90
+    assert dataset.sizes["epoch"] == n_packets
+    assert dataset.sizes["angle"] == 90
     for var_name in (
         "ccsds_met",
         "esa_step",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ testpaths = [
   "imap_processing/tests",
 ]
 addopts = "-ra"
+filterwarnings = [
+    "ignore:Converting non-nanosecond:UserWarning:cdflib",
+    "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:cdflib",
+]
 
 
 [tool.ruff]


### PR DESCRIPTION

# Change Summary

## Overview

There were over 4000+ warnings thrown before, so this is to remove those and make sure the useful warnings do appear and don't get lost in the noise.

- This ignores warnings that cdflib is throwing and have already been fixed upstream.
- Hi: change from dims -> sizes as xarray suggests
- Lo: cast to nanosecond precision when creating xarray datetime64
