### PR TITLE
Update CLI for HIT L1A

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -34,6 +34,7 @@ from imap_processing.cdf.utils import load_cdf, write_cdf
 #   call cdf.utils.write_cdf
 from imap_processing.codice import codice_l1a
 from imap_processing.hi.l1a import hi_l1a
+from imap_processing.hit.l1a.hit_l1a import hit_l1a
 from imap_processing.idex.idex_packet_parser import PacketParser
 from imap_processing.mag.l1a.mag_l1a import mag_l1a
 from imap_processing.swapi.l1.swapi_l1 import swapi_l1
@@ -418,6 +419,16 @@ class Hit(ProcessInstrument):
     def do_processing(self, dependencies):
         """Perform HIT specific processing."""
         print(f"Processing HIT {self.data_level}")
+
+        if self.data_level == "l1a":
+            if len(dependencies) > 1:
+                raise ValueError(
+                    f"Unexpected dependencies found for HIT L1A:"
+                    f"{dependencies}. Expected only one dependency."
+                )
+            # process data and write all processed data to CDF files
+            products = hit_l1a(dependencies[0])
+            return products
 
 
 class Idex(ProcessInstrument):

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -40,7 +40,7 @@ class HitAPID(IntEnum):
     HIT_IALRT = 1253
 
 
-def hit_l1a_data(packet_file: typing.Union[Path, str]):
+def hit_l1a(packet_file: typing.Union[Path, str]):
     """
     Process HIT L0 data into L1A data products.
 

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -85,7 +85,7 @@ def test_hit_l1a(packet_filepath):
     packet_filepath : str
         Path to ccsds file
     """
-    cdf_filepaths = hit_l1a.hit_l1a_data(packet_filepath)
+    cdf_filepaths = hit_l1a.hit_l1a(packet_filepath)
     assert len(cdf_filepaths) == 1
     assert isinstance(cdf_filepaths[0], pathlib.PurePath)
     assert cdf_filepaths[0].name == "imap_hit_l1a_hk_20100105_v001.cdf"

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 import xarray as xr
 
-from imap_processing.cli import Codice, Hi, Ultra, _validate_args, main
+from imap_processing.cli import Codice, Hi, Hit, Ultra, _validate_args, main
 
 
 @pytest.fixture()
@@ -190,4 +190,30 @@ def test_ultra_l1c(mock_ultra_l1c, mock_instrument_dependencies):
     assert mocks["mock_query"].call_count == 0
     assert mocks["mock_download"].call_count == 0
     assert mock_ultra_l1c.call_count == 1
+    assert mocks["mock_upload"].call_count == 2
+
+
+@mock.patch("imap_processing.cli.hit_l1a")
+def test_hit_l1a(mock_hit_l1a, mock_instrument_dependencies):
+    """Test coverage for cli.Hit class with l1a data level"""
+    mocks = mock_instrument_dependencies
+    mocks["mock_query"].return_value = [{"file_path": "/path/to/file0"}]
+    mocks["mock_download"].return_value = "dependency0"
+    mock_hit_l1a.return_value = ["l1a_dataset0", "l1a_dataset1"]
+    mocks["mock_write_cdf"].side_effect = ["/path/to/product0", "/path/to/product1"]
+
+    dependency_str = (
+        "[{"
+        "'instrument': 'hit',"
+        "'data_level': 'l0',"
+        "'descriptor': 'raw',"
+        "'version': 'v001',"
+        "'start_date': '20100105'"
+        "}]"
+    )
+    instrument = Hit("l1a", dependency_str, "20100105", "20100101", "v001", True)
+    instrument.process()
+    assert mocks["mock_query"].call_count == 1
+    assert mocks["mock_download"].call_count == 1
+    assert mock_hit_l1a.call_count == 1
     assert mocks["mock_upload"].call_count == 2


### PR DESCRIPTION
# Change Summary

## Overview
Updated the HIT section in cli.py to handle L1A data processing

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
- cli.py
   - Updated Hit class for l1a data processing
- hit_l1a.py
   - Updated data processing function name from hit_l1a_data() to hit_l1a() to match convention used by other instruments
- test_hit_l1a.py
   - Updated call to data processing function to reflect function name update noted above
-test_cli.py
   - Added test coverage for cli.Hit class for l1a data level

## Testing
Added test to test_cli.py
Ran cli command from the terminal and successfully created a L1A CDF file locally
