### PR TITLE
BUGFIX - load_cdf results in added xarray specific attributes

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -82,9 +82,8 @@ def load_cdf(
     # TODO: This can be removed if/when feature is added to cdf_to_xarray to
     #      make adding these attributes optional
     if remove_xarray_attrs:
-        xarray_attrs = [v for k, v in ISTP_TO_XARRAY_ATTRS.items()]
         for key in dataset.variables.keys():
-            for xarray_key in xarray_attrs:
+            for xarray_key in  ISTP_TO_XARRAY_ATTRS.values():
                 dataset[key].attrs.pop(xarray_key, None)
 
     return dataset

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -2,7 +2,6 @@
 
 import logging
 import re
-from collections import ChainMap
 from pathlib import Path
 from typing import Optional
 
@@ -84,9 +83,9 @@ def load_cdf(
     #      make adding these attributes optional
     if remove_xarray_attrs:
         xarray_attrs = [v for k, v in ISTP_TO_XARRAY_ATTRS.items()]
-        for _, data_array in ChainMap(dataset.data_vars, dataset.coords).items():
-            for key in xarray_attrs:
-                data_array.attrs.pop(key, None)
+        for key in dataset.variables.keys():
+            for xarray_key in xarray_attrs:
+                dataset[key].attrs.pop(xarray_key, None)
 
     return dataset
 

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -83,7 +83,7 @@ def load_cdf(
     #      make adding these attributes optional
     if remove_xarray_attrs:
         for key in dataset.variables.keys():
-            for xarray_key in  ISTP_TO_XARRAY_ATTRS.values():
+            for xarray_key in ISTP_TO_XARRAY_ATTRS.values():
                 dataset[key].attrs.pop(xarray_key, None)
 
     return dataset

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -62,13 +62,16 @@ def load_cdf(
         Whether to remove the xarray attributes that get injected by the
         cdf_to_xarray function from the output xarray.Dataset. Default is True.
     **kwargs : dict, optional
-        Keyword arguments for ``cdf_to_xarray``
+        Keyword arguments for ``cdf_to_xarray``. This function overrides the
+        ``cdf_to_xarray`` default keyword value `to_datetime=False` with
+        ``to_datetime=True`.
 
     Returns
     -------
     dataset : xr.Dataset
         The ``xarray`` dataset for the CDF file
     """
+    # TODO: remove this when cdflib is updated to version >1.3.0
     if "to_datetime" not in kwargs:
         kwargs["to_datetime"] = True
     dataset = cdf_to_xarray(file_path, kwargs)

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -69,6 +69,8 @@ def load_cdf(
     dataset : xr.Dataset
         The ``xarray`` dataset for the CDF file
     """
+    if "to_datetime" not in kwargs:
+        kwargs["to_datetime"] = True
     dataset = cdf_to_xarray(file_path, kwargs)
 
     # cdf_to_xarray converts single-value attributes to lists

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -536,7 +536,7 @@ class Swe(ProcessInstrument):
                     f"{dependencies}. Expected only one dependency."
                 )
             # read CDF file
-            l1a_dataset = load_cdf(dependencies[0], to_datetime=True)
+            l1a_dataset = load_cdf(dependencies[0])
             processed_data = swe_l1b(l1a_dataset)
             cdf_file_path = write_cdf(processed_data)
             print(f"processed file path: {cdf_file_path}")
@@ -573,7 +573,7 @@ class Ultra(ProcessInstrument):
         elif self.data_level == "l1b":
             data_dict = {}
             for dependency in dependencies:
-                dataset = load_cdf(dependency, to_datetime=True)
+                dataset = load_cdf(dependency)
                 data_dict[dataset.attrs["Logical_source"]] = dataset
             datasets = ultra_l1b.ultra_l1b(data_dict)
             products = [write_cdf(dataset) for dataset in datasets]
@@ -581,7 +581,7 @@ class Ultra(ProcessInstrument):
         elif self.data_level == "l1c":
             data_dict = {}
             for dependency in dependencies:
-                dataset = load_cdf(dependency, to_datetime=True)
+                dataset = load_cdf(dependency)
                 data_dict[dataset.attrs["Logical_source"]] = dataset
             datasets = ultra_l1c.ultra_l1c(data_dict)
             products = [write_cdf(dataset) for dataset in datasets]

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for the ``cdf.utils`` module."""
 
+from collections import ChainMap
+
 import imap_data_access
 import numpy as np
 import pytest
@@ -66,6 +68,13 @@ def test_load_cdf(test_dataset):
     # Load the CDF and ensure the function returns a dataset
     dataset = load_cdf(file_path)
     assert isinstance(dataset, xr.core.dataset.Dataset)
+
+    # Test removal of attributes that are added on by cdf_to_xarray and
+    # are specific to xarray plotting
+    xarray_attrs = ["units", "standard_name", "long_name"]
+    for _, data_array in ChainMap(dataset.data_vars, dataset.coords).items():
+        for attr in xarray_attrs:
+            assert attr not in data_array.attrs.keys()
 
 
 def test_write_cdf(test_dataset):

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -1,7 +1,5 @@
 """Tests for the ``cdf.utils`` module."""
 
-from collections import ChainMap
-
 import imap_data_access
 import numpy as np
 import pytest
@@ -72,9 +70,9 @@ def test_load_cdf(test_dataset):
     # Test removal of attributes that are added on by cdf_to_xarray and
     # are specific to xarray plotting
     xarray_attrs = ["units", "standard_name", "long_name"]
-    for _, data_array in ChainMap(dataset.data_vars, dataset.coords).items():
+    for _, data_array in dataset.variables.items():
         for attr in xarray_attrs:
-            assert attr not in data_array.attrs.keys()
+            assert attr not in data_array.attrs
 
 
 def test_write_cdf(test_dataset):

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -67,6 +67,8 @@ def test_load_cdf(test_dataset):
     dataset = load_cdf(file_path)
     assert isinstance(dataset, xr.core.dataset.Dataset)
 
+    # Test that epoch is converted to datetime64 by default
+    assert dataset["epoch"].data.dtype == np.dtype("datetime64[ns]")
     # Test removal of attributes that are added on by cdf_to_xarray and
     # are specific to xarray plotting
     xarray_attrs = ["units", "standard_name", "long_name"]

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -102,5 +102,5 @@ def test_written_and_loaded_dataset(test_dataset):
         An ``xarray`` dataset object to test with
     """
 
-    new_dataset = load_cdf(write_cdf(test_dataset), to_datetime=True)
+    new_dataset = load_cdf(write_cdf(test_dataset))
     assert str(test_dataset) == str(new_dataset)

--- a/imap_processing/tests/swe/test_swe_l1b.py
+++ b/imap_processing/tests/swe/test_swe_l1b.py
@@ -76,7 +76,7 @@ def test_cdf_creation():
     assert sci_l1a_filepath.name == "imap_swe_l1a_sci_20240510_v001.cdf"
 
     # reads data from CDF file and passes to l1b
-    l1a_cdf_dataset = load_cdf(sci_l1a_filepath, to_datetime=True)
+    l1a_cdf_dataset = load_cdf(sci_l1a_filepath)
     l1b_dataset = swe_l1b(l1a_cdf_dataset)
 
     sci_l1b_filepath = write_cdf(l1b_dataset)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -313,7 +313,7 @@ def test_cdf_events(ccsds_path_theta_0, decom_ultra_aux, decom_test_data):
     dataset_events = create_dataset(
         {ULTRA_EVENTS.apid[0]: decom_ultra_events, ULTRA_AUX.apid[0]: decom_ultra_aux}
     )
-    input_xarray_events = load_cdf(test_data_path, to_datetime=True)
+    input_xarray_events = load_cdf(test_data_path)
 
     # write_cdf() injects some attributes that are not in the xarray
     assert set(dataset_events.attrs.keys()).issubset(


### PR DESCRIPTION
Remove xarray variable and coordinate attributes that get injected by… cdf_to_xarray

# Change Summary
* Added optional keyword `remove_xarray_attrs` that defaults to True to `load_cdf`. When set True, attributes that the current version of cdflib `cdf_to_xarray` injects into the coordinate and variable attributes of the xarray.Dataset will be removed.

## Overview
Using SKTEditor to verify ISTP compliance, I discovered a 'units' attribute that was being added to the CDF file generated by loading a CDF to xarray.Dataset and then writing the xarray.Dataset back out to CDF. Digging further, I found that three attributes are added: ["units", "standard_name", "long_name"]. These will now be stripped off in the `load_cdf` function.

## Updated Files
- imap_processing/cdf/utils.py
   - Added optional keyword `remove_xarray_attrs` that defaults to True to `load_cdf`
   - Added code to strip off unwanted variable and coordinate attributes if `remove_xarray_attrs` is truthy
- imap_processing/tests/cdf/test_utils.py
   - Added test coverage for removal of unwanted attributes

## Testing
Test coverage added
