### PR TITLE
MNT/TST: Prepare for cdflib upgrade

### DIFF
--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -126,6 +126,8 @@ def test_sci_de_decom(create_de_data, tmp_path):
 
     # Write to CDF
     cdf_filename = "imap_hi_l1a_de_20230927_v001.cdf"
+    # TODO: Dropping duplicates to ignore ISTP for now. Need to update test data
+    processed_data[0] = processed_data[0].sortby("epoch").groupby("epoch").first()
     cdf_filepath = write_cdf(processed_data[0])
 
     assert cdf_filepath.name == cdf_filename
@@ -160,6 +162,8 @@ def test_app_hist_decom():
 
     assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_hist"
     # TODO: compare with validation data once we have it
+    # TODO: Dropping duplicates to ignore ISTP for now. Need to update test data
+    processed_data[0] = processed_data[0].sortby("epoch").groupby("epoch").first()
 
     # Write CDF
     cem_raw_cdf_filepath = write_cdf(processed_data[0])

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -240,6 +240,9 @@ def test_cdf_rates(ccsds_path_theta_0, decom_test_data):
     """Tests that CDF file is created and contains same attributes as xarray."""
     decom_ultra_rates, _ = decom_test_data
     test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_RATES.apid[0])
+    # TODO: Dropping duplicates to ignore ISTP for now. Need to update test data
+    # or wait for an update to cdflib
+    test_data[0] = test_data[0].sortby("epoch").groupby("epoch").first()
     test_data_path = write_cdf(test_data[0])
 
     assert test_data_path.exists()
@@ -299,6 +302,9 @@ def test_cdf_events(ccsds_path_theta_0, decom_ultra_aux, decom_test_data):
     """Tests that CDF file is created and contains same attributes as xarray."""
     decom_ultra_events, _ = decom_test_data
     test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_EVENTS.apid[0])
+    # TODO: Dropping duplicates to ignore ISTP for now. Need to update test data
+    # or wait for an update to cdflib
+    test_data[0] = test_data[0].sortby("epoch").groupby("epoch").first()
     test_data_path = write_cdf(test_data[0])
 
     assert test_data_path.exists()


### PR DESCRIPTION

# Change Summary

## Overview

When writing a cdf file out, the data needs to be monotonically increasing. Until we get good validation data we can remove the duplicates to appease the newer cdflib versions.