### PR TITLE
205 imap hi l1b annotated direct events

### DIFF
--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -1,4 +1,8 @@
-# YAML entries at the root level will overwrite the default global attributes
+# YAML entries at the root level are always returned from the global attribute
+# manager as long as they are defined in the global attribute schema. Instrument
+# level global attributes are thus defined at the root level.
+
+# TODO: remove Data_version. It should be dynamically generated
 Data_version: "001"
 Descriptor: &desc
   Hi>IMAP High-Energy (IMAP-Hi) Energetic Neutral Atom Imager
@@ -11,6 +15,7 @@ TEXT: &txt >
   more details.
 Instrument_type: Particles (space)
 
+# -------------- Product specific global attributes defined below --------------
 imap_hi_l1a_de_attrs:
     Data_level: 1A
     Data_type: L1A_DE>Level-1A Direct Event

--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -1,0 +1,24 @@
+# YAML entries at the root level will overwrite the default global attributes
+Data_version: "001"
+Descriptor: &desc
+  Hi>IMAP High-Energy (IMAP-Hi) Energetic Neutral Atom Imager
+TEXT: &txt >
+  IMAP-Hi consists of two identical, single-pixel high-energy energetic
+  neutral atom (ENA) imagers mounted at fixed angles of 90 and 45 degrees
+  relative to the spacecraft spin axis. These imagers measure neutral atoms
+  entering our solar system from the outer edge of the heliosphere as they
+  move towards the Sun. See https://imap.princeton.edu/instruments/imap-hi for
+  more details.
+Instrument_type: Particles (space)
+
+imap_hi_l1a_de_attrs:
+    Data_level: 1A
+    Data_type: L1A_DE>Level-1A Direct Event
+    Logical_source: imap_hi_l1a_{sensor}-de
+    Logical_source_description: IMAP-Hi Instrument Level-1A Direct Event Data.
+
+imap_hi_l1b_de_attrs:
+    Data_level: 1B
+    Data_type: L1B_DE>Level-1B Direct Event
+    Logical_source: imap_hi_l1b_{sensor}-de
+    Logical_source_description: IMAP-Hi Instrument Level-1B Direct Event Data.

--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -1,0 +1,205 @@
+default_attrs: &default
+  DEPEND_0: epoch
+  DISPLAY_TYPE: time_series
+  FORMAT: I12
+  UNITS: " "
+  VAR_TYPE: data
+  SCALE_TYPE: linear
+
+default_uint8_attrs: &default_uint8
+  <<: *default
+  FILLVAL: 0
+  FORMAT: I3
+  VALIDMIN: 0
+  VALIDMAX: 255
+  dtype: uint8
+
+default_uint16_attrs: &default_uint16
+  <<: *default
+  FILLVAL: 0
+  FORMAT: I5
+  VALIDMIN: 0
+  VALIDMAX: 65535
+  dtype: uint16
+
+default_uint32_attrs: &default_uint32
+  <<: *default
+  FILLVAL: 0
+  FORMAT: I10
+  VALIDMIN: 0
+  VALIDMAX: 4294967295
+  dtype: uint32
+
+default_int32_attrs: &default_int32
+  <<: *default
+  FILLVAL: -2147483648
+  FORMAT: I10
+  VALIDMIN: -2147483648
+  VALIDMAX: 2147483647
+  dtype: int32
+
+default_float32_attrs: &default_float32
+  <<: *default
+  FILLVAL: .NAN
+  FORMAT: F10.2
+  VALIDMIN: -3.4028235e+38
+  VALIDMAX: 3.4028235e+38
+  dtype: float32
+
+hi_de_epoch_attrs:
+  CATDESC: Direct Event time, number of nanoseconds since J2000 with leap seconds included
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: Time since January 1, 2000, 11:58:55.816 UTC
+  FILLVAL: 9999-12-31T23:59:59.999999999
+  LABLAXIS: epoch
+  UNITS: ns
+  VALIDMIN: 2000-12-01T11:58:55.816000000
+  VALIDMAX: 2099-12-31T00:00:00.000000000
+  VAR_TYPE: support_data
+  SCALE_TYP: linear
+  MONOTON: INCREASE
+  TIME_BASE: J2000
+  TIME_SCALE: Terrestrial Time
+  dtype: uint64
+  base: default_attrs
+
+hi_de_event_met_attrs:
+  <<: *default
+  CATDESC: Mission Elapsed Time (MET) of Direct Event
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: Time since (TODO - what is the def of MET?)
+  FILLVAL: NaN
+  FORMAT: F12.3
+  LABLAXIS: DE MET
+  UNITS: sec
+  VALIDMIN: 0
+  VALIDMAX: TODO
+  VAR_TYPE: support_data
+  SCALE_TYP: linear
+  dtype: float64
+
+hi_de_coincidence_type:
+  <<: *default_uint8
+  CATDESC: Bitmap of detectors hit for Direct Event
+  FIELDNAM: Coincidence Type
+  FILLVAL: 0
+  FORMAT: I2
+  LABLAXIS: Type
+  VALIDMIN: 0
+  VALIDMAX: 15
+  VAR_NOTES: >
+    A 4-bit quantity, representable as a hexadecimal digit,
+    made up of the ORed quantities: (A hit? 8:0) | (B hit? 4:0)
+    | (C1 hit? 2:0) | (C2 hit? 1 : 0)
+
+hi_de_trigger_id:
+  <<: *default_uint8
+  CATDESC: Trigger ID of the detector that was hit first
+  FIELDNAM: Trigger ID
+  FILLVAL: 0
+  FORMAT: I1
+  LABLAXIS: ID
+  VALIDMIN: 1
+  VALIDMAX: 3
+  VAR_NOTES: >
+    The trigger ID is 2-bits. It represents which detector was
+    hit first. It can be 1, 2, 3 for detector A, B, C respectively.
+
+hi_de_esa_stepping_num:
+  <<: *default_uint8
+  CATDESC: Zero based index indicates which row of onboard stepping table was used
+  FIELDNAM: ESA stepping number
+  FILLVAL:
+  FORMAT: I2
+  LABLAXIS: Stepping Num
+  VALIDMIN: 0
+  VALIDMAX: 16
+
+hi_de_esa_step:
+  <<: *default_uint8
+  CATDESC: Zero based energy step index
+  FIELDNAM: ESA energy step
+  FILLVAL: 255
+  FORMAT: I2
+  LABLAXIS: Energy Step
+  VALIDMIN: 0
+  VALIDMAX: 12
+
+default_delta_t: &default_delta_t
+  <<: *default_int32
+  FORMAT: I3
+  LABLAXIS: delta T
+  UNITS: ns
+  VALIDMIN: -512
+  VALIDMAX: 512
+
+hi_de_delta_t_ab:
+  <<: *default_delta_t
+  CATDESC: Time difference between detector A and B events (t_B - t_A)
+  FIELDNAM: Delta T, event A to B
+
+hi_de_delta_t_ac1:
+  <<: *default_delta_t
+  CATDESC: Time difference between detector A and C1 events (t_C1 - t_A)
+  FIELDNAM: Delta T, event A to C1
+
+hi_de_delta_t_bc1:
+  <<: *default_delta_t
+  CATDESC: Time difference between detector B and C1 events (t_C1 - t_B)
+  FIELDNAM: Delta T, event B to C1
+
+hi_de_delta_t_c1c2:
+  <<: *default_delta_t
+  CATDESC: Time difference between detector C1 and C2 events (t_C2 - t_C1)
+  FIELDNAM: Delta T, event C1 to C2
+
+hi_de_spin_phase:
+  <<: *default_float32
+  CATDESC: Floating point spin phase
+  FIELDNAM: Spin Phase
+  FORMAT: F4.3
+  LABLAXIS: Spin Phase
+  VALIDMIN: 0
+  VALIDMAX: 1
+
+hi_de_hae_latitude:
+  <<: *default_float32
+  CATDESC: Look direction HAE latitude
+  FIELDNAM: Ecliptic Lattitude
+  FORMAT: F5.2
+  LABLAXIS: Lat
+  VALIDMIN: -180
+  VALIDMAX: 180
+  UNITS: deg
+
+hi_de_hae_longitude:
+  <<: *default_float32
+  CATDESC: Look direction HAE longitude
+  FIELDNAM: Ecliptic Longitude
+  FORMAT: F5.2
+  LABLAXIS: Lon
+  VALIDMIN: 0
+  VALIDMAX: 360
+  UNITS: deg
+
+hi_de_quality_flag:
+  <<: *default_uint16
+  CATDESC: Direct event bitwise quality flag
+  FIELDNAM: DE quality flag
+  FILLVAL: 65535
+  FORMAT: I5
+  LABLAXIS: Qlt Flag
+  VALIDMIN: 0
+  VALIDMAX: 65535
+  VAR_NOTES: >
+    Bitwise quality flag {TODO: Store bitwise definition here?}
+
+hi_de_nominal_bin:
+  <<: *default_uint8
+  CATDESC: Corresponding histogram angle bin for this Direct Event
+  FIELDNAM: Histogram Bin Number
+  FILLVAL: 511
+  FORMAT: I2
+  LABLAXIS: Hist Bin \#
+  VALIDMIN: 0
+  VALIDMAX: 89

--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -1,3 +1,4 @@
+# ------- Default attributes section -------
 default_attrs: &default
   DEPEND_0: epoch
   DISPLAY_TYPE: time_series
@@ -30,6 +31,14 @@ default_uint32_attrs: &default_uint32
   VALIDMAX: 4294967295
   dtype: uint32
 
+default_uint64_attrs: &default_uint64
+  <<: *default
+  FILLVAL: 0
+  FORMAT: I20
+  VALIDMIN: 0
+  VALIDMAX: 18446744073709551615
+  dtype: uint64
+
 default_int32_attrs: &default_int32
   <<: *default
   FILLVAL: -2147483648
@@ -46,11 +55,27 @@ default_float32_attrs: &default_float32
   VALIDMAX: 3.4028235e+38
   dtype: float32
 
+# ------- L1A DE Section -------
+hi_de_ccsds_met:
+  <<: *default_uint32
+  CATDESC: CCSDS mission elapsed time (MET). 32-bit integer value that represents the MET in seconds.
+  FIELDNAM: Mission Elapsed Time(MET)
+  LABLAXIS: CCSDS MET
+  UNITS: sec
+  VAR_TYPE: support_data
+
+hi_de_de_tag:
+  <<: *default_uint16
+  CATDESC: Ticks (nominally 2 ms) since last meta-event
+  FIELDNAM: Direct Event Time Tag
+  LABLAXIS: DE Time Tag
+
 hi_de_epoch_attrs:
   CATDESC: Direct Event time, number of nanoseconds since J2000 with leap seconds included
   DISPLAY_TYPE: no_plot
   FIELDNAM: Time since January 1, 2000, 11:58:55.816 UTC
   FILLVAL: 9999-12-31T23:59:59.999999999
+  FORMAT: " "
   LABLAXIS: epoch
   UNITS: ns
   VALIDMIN: 2000-12-01T11:58:55.816000000
@@ -60,37 +85,43 @@ hi_de_epoch_attrs:
   MONOTON: INCREASE
   TIME_BASE: J2000
   TIME_SCALE: Terrestrial Time
-  dtype: uint64
-  base: default_attrs
 
-hi_de_event_met_attrs:
-  <<: *default
+hi_de_esa_stepping_num:
+  <<: *default_uint8
+  CATDESC: Zero based index indicates which row of onboard stepping table was used
+  FIELDNAM: ESA stepping number
+  FILLVAL: 255
+  FORMAT: I2
+  LABLAXIS: Stepping Num
+  VALIDMIN: 0
+  VALIDMAX: 16
+  VAR_NOTES: >
+    ESA (electrostatic analyzer) stepping number is 4-bit integer value that indicates
+    which row of the onboard stepping table was used to set voltages of the inner and
+    outter ESA surfaces.
+
+hi_de_event_met:
+  <<: *default_uint64
   CATDESC: Mission Elapsed Time (MET) of Direct Event
   DISPLAY_TYPE: no_plot
   FIELDNAM: Time since (TODO - what is the def of MET?)
-  FILLVAL: NaN
-  FORMAT: F12.3
   LABLAXIS: DE MET
-  UNITS: sec
-  VALIDMIN: 0
-  VALIDMAX: TODO
+  UNITS: ns
   VAR_TYPE: support_data
   SCALE_TYP: linear
-  dtype: float64
 
-hi_de_coincidence_type:
-  <<: *default_uint8
-  CATDESC: Bitmap of detectors hit for Direct Event
-  FIELDNAM: Coincidence Type
-  FILLVAL: 0
-  FORMAT: I2
-  LABLAXIS: Type
+hi_de_meta_event_met:
+  <<: *default_uint64
+  CATDESC: Mission elapsed time (MET) of last meta-event
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: Meta-event Mission Elapsed Time
+  LABLAXIS: Meta MET
+  UNITS: ns
   VALIDMIN: 0
-  VALIDMAX: 15
-  VAR_NOTES: >
-    A 4-bit quantity, representable as a hexadecimal digit,
-    made up of the ORed quantities: (A hit? 8:0) | (B hit? 4:0)
-    | (C1 hit? 2:0) | (C2 hit? 1 : 0)
+  VALIDMAX: 4294967295
+  VAR_TYPE: support_data
+  SCALE_TYP: linear
+  dtype: uint64
 
 hi_de_trigger_id:
   <<: *default_uint8
@@ -105,15 +136,50 @@ hi_de_trigger_id:
     The trigger ID is 2-bits. It represents which detector was
     hit first. It can be 1, 2, 3 for detector A, B, C respectively.
 
-hi_de_esa_stepping_num:
+default_tof: &default_tof
+  <<: *default_uint16
+  FORMAT: I4
+  UNITS: ticks
+  VALIDMAX: 1023
+  VAR_NOTES: >
+    Time of flight is 10-bit integer value that represents the time of flight of
+    the direct event. 1023 and 511 are values used to indicate no event was registered.
+
+hi_de_tof_1:
+  <<: *default_tof
+  CATDESC: Time of flight of direct event, 1023 or 511 indicates no event registered
+  FIELDNAM: Time of Flight (TOF) 1
+  LABLAXIS: TOF1
+
+hi_de_tof_2:
+  <<: *default_tof
+  CATDESC: Time of flight of direct event, 1023 or 511 indicates no event registered
+  FIELDNAM: Time of Flight (TOF) 2
+  LABLAXIS: TOF2
+
+hi_de_tof_3:
+  <<: *default_tof
+  CATDESC: Time of flight of direct event, 1023 indicates no event registered
+  FIELDNAM: Time of Flight (TOF) 3
+  LABLAXIS: TOF3
+  VAR_NOTES: >
+    Time of flight is 10-bit integer value that represents the time of flight of
+    the direct event. 1023 is the value used to indicate no event was registered.
+
+# ------- L1B DE Section -------
+hi_de_coincidence_type:
   <<: *default_uint8
-  CATDESC: Zero based index indicates which row of onboard stepping table was used
-  FIELDNAM: ESA stepping number
-  FILLVAL:
+  CATDESC: Bitmap of detectors hit for Direct Event
+  FIELDNAM: Coincidence Type
+  FILLVAL: 0
   FORMAT: I2
-  LABLAXIS: Stepping Num
+  LABLAXIS: Type
   VALIDMIN: 0
-  VALIDMAX: 16
+  VALIDMAX: 15
+  VAR_NOTES: >
+    A 4-bit quantity, representable as a hexadecimal digit,
+    made up of the ORed quantities: (A hit? 8:0) | (B hit? 4:0)
+    | (C1 hit? 2:0) | (C2 hit? 1 : 0)
 
 hi_de_esa_step:
   <<: *default_uint8

--- a/imap_processing/cdf/config/shared/default_global_cdf_attrs_schema.yaml
+++ b/imap_processing/cdf/config/shared/default_global_cdf_attrs_schema.yaml
@@ -71,9 +71,8 @@ Discipline:
   overwrite: false
 File_naming_convention:
   description: >
-    If File_naming_convention was not set, it uses default setting:
-      source_datatype_descriptor_yyyyMMdd
-  default: source_datatype_descriptor_yyyyMMdd
+    This attribute is not described in SPDF documentation.
+  default: source_descriptor_datatype_yyyyMMdd
   required: false
   validate: false
   overwrite: true

--- a/imap_processing/cdf/config/shared/default_global_cdf_attrs_schema.yaml
+++ b/imap_processing/cdf/config/shared/default_global_cdf_attrs_schema.yaml
@@ -69,13 +69,6 @@ Discipline:
   required: true
   validate: true
   overwrite: false
-File_naming_convention:
-  description: >
-    This attribute is not described in SPDF documentation.
-  default: source_descriptor_datatype_yyyyMMdd
-  required: false
-  validate: false
-  overwrite: true
 Generation_date:
   description: >
     Date stamps the creation of the file using the syntax yyyymmdd, e.g., "

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -34,6 +34,7 @@ from imap_processing.cdf.utils import load_cdf, write_cdf
 #   call cdf.utils.write_cdf
 from imap_processing.codice import codice_l1a
 from imap_processing.hi.l1a import hi_l1a
+from imap_processing.hi.l1b import hi_l1b
 from imap_processing.hit.l1a.hit_l1a import hit_l1a
 from imap_processing.idex.idex_packet_parser import PacketParser
 from imap_processing.lo.l1a import lo_l1a
@@ -411,7 +412,14 @@ class Hi(ProcessInstrument):
                 )
             datasets = hi_l1a.hi_l1a(dependencies[0])
             products = [write_cdf(dataset) for dataset in datasets]
-            return products
+        elif self.data_level == "l1b":
+            dataset = hi_l1b.hi_l1b(dependencies[0])
+            products = [write_cdf(dataset)]
+        else:
+            raise NotImplementedError(
+                f"Hi processing not implemented for level {self.data_level}"
+            )
+        return products
 
 
 class Hit(ProcessInstrument):

--- a/imap_processing/hi/l1a/hi_l1a.py
+++ b/imap_processing/hi/l1a/hi_l1a.py
@@ -1,6 +1,7 @@
 """IMAP-HI L1A processing module."""
 
 import logging
+from pathlib import Path
 
 from imap_processing.hi.l0 import decom_hi
 from imap_processing.hi.l1a.histogram import create_dataset as hist_create_dataset
@@ -12,7 +13,7 @@ from imap_processing.utils import group_by_apid
 logger = logging.getLogger(__name__)
 
 
-def hi_l1a(packet_file_path: str):
+def hi_l1a(packet_file_path: str | Path):
     """Process IMAP raw data to l1a.
 
     Parameters

--- a/imap_processing/hi/l1a/hi_l1a.py
+++ b/imap_processing/hi/l1a/hi_l1a.py
@@ -2,6 +2,7 @@
 
 import logging
 from pathlib import Path
+from typing import Union
 
 from imap_processing.hi.l0 import decom_hi
 from imap_processing.hi.l1a.histogram import create_dataset as hist_create_dataset
@@ -13,7 +14,7 @@ from imap_processing.utils import group_by_apid
 logger = logging.getLogger(__name__)
 
 
-def hi_l1a(packet_file_path: str | Path):
+def hi_l1a(packet_file_path: Union[str, Path]):
     """Process IMAP raw data to l1a.
 
     Parameters

--- a/imap_processing/hi/l1a/science_direct_event.py
+++ b/imap_processing/hi/l1a/science_direct_event.py
@@ -180,7 +180,7 @@ def create_dataset(
     packet_met_time : list
         List of packet MET time
     sensor_str : str
-        Sensor head: "45" or "90"
+        Sensor head: "45sensor" or "90sensor"
 
     Returns
     -------
@@ -280,11 +280,13 @@ def create_dataset(
     cdf_manager.load_variable_attributes("imap_hi_variable_attrs.yaml")
 
     # Inject sensor head into Logical_source
-    gattrs = cdf_manager.get_global_attributes("imap_hi_l1a_de_attrs")
-    gattrs["Logical_source"] = gattrs["Logical_source"].format(sensor=sensor_str)
+    de_global_attrs = cdf_manager.get_global_attributes("imap_hi_l1a_de_attrs").copy()
+    de_global_attrs["Logical_source"] = de_global_attrs["Logical_source"].format(
+        sensor=sensor_str
+    )
 
     epoch_time = xr.DataArray(
-        data_dict["epoch"],
+        data_dict.pop("epoch"),
         name="epoch",
         dims=["epoch"],
         attrs=ConstantCoordinates.EPOCH,
@@ -292,13 +294,11 @@ def create_dataset(
 
     dataset = xr.Dataset(
         coords={"epoch": epoch_time},
-        attrs=gattrs,
+        attrs=de_global_attrs,
     )
 
     for var_name, data in data_dict.items():
-        if var_name == "epoch":
-            continue
-        attrs = cdf_manager.get_variable_attributes(f"hi_de_{var_name}")
+        attrs = cdf_manager.get_variable_attributes(f"hi_de_{var_name}").copy()
         dtype = attrs.pop("dtype")
         dataset[var_name] = xr.DataArray(
             np.array(data, dtype=np.dtype(dtype)),

--- a/imap_processing/hi/l1a/science_direct_event.py
+++ b/imap_processing/hi/l1a/science_direct_event.py
@@ -1,7 +1,5 @@
 """IMAP-Hi direct event processing."""
 
-import dataclasses
-
 import numpy as np
 import xarray as xr
 from space_packet_parser.parser import Packet
@@ -9,7 +7,6 @@ from space_packet_parser.parser import Packet
 from imap_processing import imap_module_directory, launch_time
 from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
 from imap_processing.cdf.global_attrs import ConstantCoordinates
-from imap_processing.hi import hi_cdf_attrs
 from imap_processing.hi.utils import HIAPID
 
 # TODO: read LOOKED_UP_DURATION_OF_TICK from
@@ -191,15 +188,18 @@ def create_dataset(
         xarray dataset
     """
     # These are the variables that we will store in the dataset
-    meta_event_met = []
-    de_met_time = []
-    esa_step = []
-    trigger_id = []
-    tof_1 = []
-    tof_2 = []
-    tof_3 = []
-    de_tag = []
-    ccsds_met = []
+    data_dict = {
+        "epoch": list(),
+        "event_met": list(),
+        "ccsds_met": list(),
+        "meta_event_met": list(),
+        "esa_stepping_num": list(),
+        "trigger_id": list(),
+        "tof_1": list(),
+        "tof_2": list(),
+        "tof_3": list(),
+        "de_tag": list(),
+    }
 
     # How to handle if first event is not metaevent? This
     # means that current data file started with direct event.
@@ -252,27 +252,27 @@ def create_dataset(
             metaevent_time_in_ns += half_tick_ns
             continue
 
-        meta_event_met.append(metaevent_time_in_ns)
+        data_dict["meta_event_met"].append(metaevent_time_in_ns)
         # calculate direct event time using time information from metaevent
         # and de_tag. epoch in this dataset uses this time of the event
-        de_time_in_ns = (
+        de_met_in_ns = (
             metaevent_time_in_ns
             + event["de_tag"] * LOOKED_UP_DURATION_OF_TICK * MICROSECOND_TO_NS
         )
-        de_time = get_direct_event_time(de_time_in_ns)
-        de_met_time.append(de_time)
-        esa_step.append(current_esa_step)
+        data_dict["event_met"].append(de_met_in_ns)
+        data_dict["epoch"].append(get_direct_event_time(de_met_in_ns))
+        data_dict["esa_stepping_num"].append(current_esa_step)
         # start_bitmask_data is 1, 2, 3 for detector A, B, C
         # respectively. This is used to identify which detector
         # was hit first for this current direct event.
-        trigger_id.append(event["start_bitmask_data"])
-        tof_1.append(event["tof_1"])
-        tof_2.append(event["tof_2"])
-        tof_3.append(event["tof_3"])
+        data_dict["trigger_id"].append(event["start_bitmask_data"])
+        data_dict["tof_1"].append(event["tof_1"])
+        data_dict["tof_2"].append(event["tof_2"])
+        data_dict["tof_3"].append(event["tof_3"])
         # IMAP-Hi like to keep de_tag value for diagnostic purposes
-        de_tag.append(event["de_tag"])
+        data_dict["de_tag"].append(event["de_tag"])
         # add packet time to ccsds_met list
-        ccsds_met.append(packet_met_time[index])
+        data_dict["ccsds_met"].append(packet_met_time[index])
 
     # Load the CDF attributes
     cdf_manager = CdfAttributeManager(imap_module_directory / "cdf" / "config")
@@ -284,7 +284,7 @@ def create_dataset(
     gattrs["Logical_source"] = gattrs["Logical_source"].format(sensor=sensor_str)
 
     epoch_time = xr.DataArray(
-        de_met_time,
+        data_dict["epoch"],
         name="epoch",
         dims=["epoch"],
         attrs=ConstantCoordinates.EPOCH,
@@ -295,58 +295,17 @@ def create_dataset(
         attrs=gattrs,
     )
 
-    dataset["esa_step"] = xr.DataArray(
-        np.array(esa_step, dtype=np.uint8),
-        dims="epoch",
-        attrs=hi_cdf_attrs.esa_step_attrs.output(),
-    )
-    dataset["trigger_id"] = xr.DataArray(
-        np.array(trigger_id, dtype=np.uint8),
-        dims="epoch",
-        attrs=hi_cdf_attrs.trigger_id_attrs.output(),
-    )
-    dataset["tof_1"] = xr.DataArray(
-        np.array(tof_1, dtype=np.uint16),
-        dims="epoch",
-        attrs=dataclasses.replace(
-            hi_cdf_attrs.tof_attrs,
-            fieldname="Time of Flight (TOF) 1",
-            label_axis="TOF1",
-        ).output(),
-    )
-    dataset["tof_2"] = xr.DataArray(
-        np.array(tof_2, dtype=np.uint16),
-        dims="epoch",
-        attrs=dataclasses.replace(
-            hi_cdf_attrs.tof_attrs,
-            fieldname="Time of Flight (TOF) 2",
-            label_axis="TOF2",
-        ).output(),
-    )
-    dataset["tof_3"] = xr.DataArray(
-        np.array(tof_3, dtype=np.uint16),
-        dims="epoch",
-        attrs=dataclasses.replace(
-            hi_cdf_attrs.tof_attrs,
-            fieldname="Time of Flight (TOF) 3",
-            label_axis="TOF3",
-        ).output(),
-    )
-    dataset["de_tag"] = xr.DataArray(
-        np.array(de_tag, dtype=np.uint16),
-        dims="epoch",
-        attrs=hi_cdf_attrs.de_tag_attrs.output(),
-    )
-    dataset["ccsds_met"] = xr.DataArray(
-        np.array(ccsds_met, dtype=np.uint32),
-        dims="epoch",
-        attrs=hi_cdf_attrs.ccsds_met_attrs.output(),
-    )
-    dataset["meta_event_met"] = xr.DataArray(
-        np.array(ccsds_met, dtype=np.uint64),
-        dims="epoch",
-        attrs=hi_cdf_attrs.ccsds_met_attrs.output(),
-    )
+    for var_name, data in data_dict.items():
+        if var_name == "epoch":
+            continue
+        attrs = cdf_manager.get_variable_attributes(f"hi_de_{var_name}")
+        dtype = attrs.pop("dtype")
+        dataset[var_name] = xr.DataArray(
+            np.array(data, dtype=np.dtype(dtype)),
+            dims="epoch",
+            attrs=attrs,
+        )
+
     # TODO: figure out how to store information about
     # input data(one or more) it used to produce this dataset
     return dataset

--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -60,7 +60,7 @@ def hi_l1b(l1a_cdf_path: Path):
     else:
         raise NotImplementedError(
             f"No Hi L1B processing defined for file type: "
-            f"{l1a_dataset.attrs["Logical_source"]}"
+            f"{l1a_dataset.attrs['Logical_source']}"
         )
     return l1b_dataset
 

--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -34,7 +34,7 @@ def hi_l1b(l1a_cdf_path: Path):
         Processed xarray dataset
     """
     logger.info(f"Running Hi L1B processing on file: {l1a_cdf_path.name}")
-    l1a_dataset = load_cdf(l1a_cdf_path, to_datetime=True)
+    l1a_dataset = load_cdf(l1a_cdf_path)
     logical_source_parts = l1a_dataset.attrs["Logical_source"].split("_")
     # TODO: apid is not currently stored in all L1A data but should be.
     #    Use apid to determine what L1B processing function to call

--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -94,7 +94,7 @@ def annotate_direct_events(l1a_dataset):
         "quality_flag",
         "nominal_bin",
     ]:
-        attrs = CDF_MANAGER.variable_attributes[f"hi_de_{var}"]
+        attrs = CDF_MANAGER.get_variable_attributes(f"hi_de_{var}").copy()
         dtype = attrs.pop("dtype")
         if attrs["FILLVAL"] == "NaN":
             attrs["FILLVAL"] = np.nan
@@ -113,7 +113,9 @@ def annotate_direct_events(l1a_dataset):
     #    some functionality can be found in imap_data_access.file_validation but
     #    only works on full file names
     sensor_str = l1a_dataset.attrs["Logical_source"].split("_")[-1].split("-")[0]
-    gattrs = CDF_MANAGER.get_global_attributes("imap_hi_l1b_de_attrs")
-    gattrs["Logical_source"] = gattrs["Logical_source"].format(sensor=sensor_str)
-    l1b_dataset.attrs.update(**gattrs)
+    de_global_attrs = CDF_MANAGER.get_global_attributes("imap_hi_l1b_de_attrs").copy()
+    de_global_attrs["Logical_source"] = de_global_attrs["Logical_source"].format(
+        sensor=sensor_str
+    )
+    l1b_dataset.attrs.update(**de_global_attrs)
     return l1b_dataset

--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -3,6 +3,9 @@
 import logging
 from pathlib import Path
 
+import numpy as np
+import xarray as xr
+
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.hi.hi_cdf_attrs import hi_hk_l1b_global_attrs
@@ -26,12 +29,16 @@ def hi_l1b(l1a_cdf_path: Path):
     processed_data : xarray.Dataset
         Processed xarray dataset
     """
+    logger.info(f"Running Hi L1B processing on file: {l1a_cdf_path.name}")
     l1a_dataset = load_cdf(l1a_cdf_path)
-    packet_enum = HIAPID(l1a_dataset["pkt_apid"].data[0])
+    logical_source_parts = l1a_dataset["logical_source"].split("_")
+    # TODO: apid is not currently stored in all L1A data but should be.
+    #    Use apid to determine what L1B processing function to call
 
     # Housekeeping processing
-    if packet_enum in (HIAPID.H45_APP_NHK, HIAPID.H90_APP_NHK):
-        logger.info(f"Running Hi L1B processing on file: {l1a_cdf_path.name}")
+    if logical_source_parts[-1].endswith("hk"):
+        # if packet_enum in (HIAPID.H45_APP_NHK, HIAPID.H90_APP_NHK):
+        packet_enum = HIAPID(l1a_dataset["pkt_apid"].data[0])
         conversion_table_path = (
             imap_module_directory / "hi" / "l1b" / "hi_eng_unit_convert_table.csv"
         )
@@ -42,9 +49,34 @@ def hi_l1b(l1a_cdf_path: Path):
             comment="#",
             converters={"mnemonic": str.lower},
         )
+
         l1b_dataset.attrs.update(hi_hk_l1b_global_attrs.output())
         return l1b_dataset
-    elif packet_enum in (HIAPID.H45_SCI_DE, HIAPID.H90_SCI_DE):
-        raise NotImplementedError(
-            f"L1B processing not implemented for file: {l1a_cdf_path.name}"
-        )
+    elif logical_source_parts[-1].endswith("de"):
+        l1b_dataset = annotate_direct_events(l1a_dataset)
+
+
+def annotate_direct_events(l1a_dataset):
+    """
+    Perform Hi L1B processing on direct event data.
+
+    Parameters
+    ----------
+    l1a_dataset: xarray.Dataset
+        L1A direct event data.
+
+    Returns
+    -------
+    xarray.Dataset
+        L1B direct event data.
+    """
+    coords = dict()
+    # epoch contains a single element
+    # TODO: What value to use. SPDF says times should indicate the center
+    #    value of the time bin.
+    coords["epoch"] = xr.DataArray(
+        np.empty(1, dtype="datetime64[ns]"),
+        name="epoch",
+        dims=["epoch"],
+        # attrs=ConstantCoordinates.EPOCH,
+    )

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -18,3 +18,15 @@ class HIAPID(IntEnum):
     H90_APP_NHK = 818
     H90_SCI_CNT = 833
     H90_SCI_DE = 834
+
+    @property
+    def sensor(self):
+        """
+        Defines the sensor name attribute for this class.
+
+        Returns
+        -------
+        str
+            "45" or "90"
+        """
+        return self.name[1:3] + "sensor"

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -27,6 +27,6 @@ class HIAPID(IntEnum):
         Returns
         -------
         str
-            "45" or "90"
+            "45sensor" or "90sensor"
         """
         return self.name[1:3] + "sensor"

--- a/imap_processing/tests/hi/conftest.py
+++ b/imap_processing/tests/hi/conftest.py
@@ -19,74 +19,89 @@ def create_directevent(tof_1, tof_2, tof_3, de_tag):
 
 @pytest.fixture()
 def create_de_data(tmp_path):
-    """Create direct event data.
+    """Fixture to create fake direct event data. Note that there has been no
+    effort to make simulate this data meaning that packets are not self
+    consistent and values may not make sense.
 
     TODO: remove this once we have good sample data.
     TODO: remove "S311" from pyproject.toml when we remove this.
     """
-    num_packets = 4
-    packets_data = []
-    # This MET seconds evaluates to 2023-09-27T16:04:49.150
-    met_seconds = 433522962
-    esa_step = 0
-    spare = f"{0:032b}"
-    # To use a consistent random number
-    random.seed(0)
-    for index in range(num_packets):
-        current_data = []
-        if index % 2 == 0:
-            # Two packets per ESA step
-            # Every even index, event starts with metaevent
-            if esa_step == 9:
-                esa_step = 0
-            esa_step += 1
-            met_subseconds = random.randint(0, 1023)
-            met_seconds += 3600
-            current_data.append(create_metaevent(esa_step, met_subseconds, met_seconds))
-        # Random length for direct events. It could be empty
-        num_directevents = random.randint(0, 10)
-        for _ in range(num_directevents):
-            # We don't always get triple coincidence. To make data
-            # more realistic, we will use random.choices.
-            # This line will select a random integer between 0 and 1023
-            # with a probability of 0.xx and the value 1023 with a
-            # probability of 0.xx. The `k=1` argument specifies that one
-            # item should be chosen, and `[0]` is used to extract the
-            # single item from the resulting list.
-            tof_1 = random.choices(
-                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
-            )[0]  # nosec
-            tof_2 = random.choices(
-                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
-            )[0]  # nosec
-            tof_3 = random.choices(
-                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
-            )[0]  # nosec
-            de_tag = random.randint(1, 65535)
-            current_data.append(create_directevent(tof_1, tof_2, tof_3, de_tag))
 
-        # create a CCSDS data using current data
-        # pkt_len = 4 byte (MET seconds) + 4 byte (spare) +
-        # 6 byte (direct event) * number of direct event + 2 byte (checksum) - 1å
-        if index % 2 == 0:
-            # Add 6 bytes for metaevent
-            pkt_len = 4 + 4 + 6 + 6 * num_directevents + 2 - 1
-        else:
-            pkt_len = 4 + 4 + 6 * num_directevents + 2 - 1
-        ccsds_data = (
-            ccsds_header_data(770, pkt_len)
-            + f"{met_seconds:032b}"
-            + spare
-            + "".join(current_data)
-            + check_sum(bits_size=16)
-        )
-        packets_data.append(ccsds_data)
-    # Join all the events as one binary string
-    packets_data = "".join(packets_data)
-    # write data to pkts file
-    with open(tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts", "wb") as f:
-        byte_data = int(packets_data, 2).to_bytes(
-            (len(packets_data) + 7) // 8, byteorder="big"
-        )
-        f.write(byte_data)
-    return tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts"
+    def create_data(apid):
+        """
+        The function that generates the fake direct event data and returns
+        the Path to the binary file.
+
+        Parameters
+        ----------
+        apid : int
+            CCSDS packet apid
+
+        Returns
+        -------
+        Path to the binary file with fake direct event data
+        """
+        num_packets = 4
+        packets_data = []
+        # This MET seconds evaluates to 2023-09-27T16:04:49.150
+        met_seconds = 433522962
+        esa_step = 0
+        spare = f"{0:032b}"
+        # To use a consistent random number
+        random.seed(0)
+        for index in range(num_packets):
+            current_data = []
+            if index % 2 == 0:
+                # Two packets per ESA step
+                # Every even index, event starts with metaevent
+                if esa_step == 9:
+                    esa_step = 0
+                esa_step += 1
+                met_subseconds = random.randint(0, 1023)
+                met_seconds += 3600
+                current_data.append(
+                    create_metaevent(esa_step, met_subseconds, met_seconds)
+                )
+            # Random length for direct events. It could be empty
+            num_directevents = random.randint(0, 10)
+            for _ in range(num_directevents):
+                # We don't always get triple coincidence. To make data
+                # more realistic, we will use random.choices.
+                # This line will select a random integer between 0 and 1023
+                # with a probability of 0.xx and the value 1023 with a
+                # probability of 0.xx. The `k=1` argument specifies that one
+                # item should be chosen, and `[0]` is used to extract the
+                # single item from the resulting list.
+                tof_1, tof_2, tof_3 = random.choices(
+                    [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=3
+                )
+                de_tag = random.randint(1, 65535)
+                current_data.append(create_directevent(tof_1, tof_2, tof_3, de_tag))
+
+            # create a CCSDS data using current data
+            # pkt_len = 4 byte (MET seconds) + 4 byte (spare) +
+            # 6 byte (direct event) * number of direct event + 2 byte (checksum) - 1å
+            if index % 2 == 0:
+                # Add 6 bytes for metaevent
+                pkt_len = 4 + 4 + 6 + 6 * num_directevents + 2 - 1
+            else:
+                pkt_len = 4 + 4 + 6 * num_directevents + 2 - 1
+            ccsds_data = (
+                ccsds_header_data(apid, pkt_len)
+                + f"{met_seconds:032b}"
+                + spare
+                + "".join(current_data)
+                + check_sum(bits_size=16)
+            )
+            packets_data.append(ccsds_data)
+        # Join all the events as one binary string
+        packets_data = "".join(packets_data)
+        # write data to pkts file
+        with open(tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts", "wb") as f:
+            byte_data = int(packets_data, 2).to_bytes(
+                (len(packets_data) + 7) // 8, byteorder="big"
+            )
+            f.write(byte_data)
+        return tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts"
+
+    return create_data

--- a/imap_processing/tests/hi/conftest.py
+++ b/imap_processing/tests/hi/conftest.py
@@ -1,0 +1,92 @@
+import random
+
+import pytest
+
+from imap_processing.tests.conftest import ccsds_header_data, check_sum
+
+
+def create_metaevent(esa_step, met_subseconds, met_seconds):
+    start_bitmask_data = 0  # META
+    return (
+        f"{start_bitmask_data:02b}{esa_step:04b}{met_subseconds:010b}{met_seconds:032b}"
+    )
+
+
+def create_directevent(tof_1, tof_2, tof_3, de_tag):
+    start_bitmask_data = random.choice([1, 2, 3])  # Detector A, B, C
+    return f"{start_bitmask_data:02b}{tof_1:010b}{tof_2:010b}{tof_3:010b}{de_tag:016b}"
+
+
+@pytest.fixture()
+def create_de_data(tmp_path):
+    """Create direct event data.
+
+    TODO: remove this once we have good sample data.
+    TODO: remove "S311" from pyproject.toml when we remove this.
+    """
+    num_packets = 4
+    packets_data = []
+    # This MET seconds evaluates to 2023-09-27T16:04:49.150
+    met_seconds = 433522962
+    esa_step = 0
+    spare = f"{0:032b}"
+    # To use a consistent random number
+    random.seed(0)
+    for index in range(num_packets):
+        current_data = []
+        if index % 2 == 0:
+            # Two packets per ESA step
+            # Every even index, event starts with metaevent
+            if esa_step == 9:
+                esa_step = 0
+            esa_step += 1
+            met_subseconds = random.randint(0, 1023)
+            met_seconds += 3600
+            current_data.append(create_metaevent(esa_step, met_subseconds, met_seconds))
+        # Random length for direct events. It could be empty
+        num_directevents = random.randint(0, 10)
+        for _ in range(num_directevents):
+            # We don't always get triple coincidence. To make data
+            # more realistic, we will use random.choices.
+            # This line will select a random integer between 0 and 1023
+            # with a probability of 0.xx and the value 1023 with a
+            # probability of 0.xx. The `k=1` argument specifies that one
+            # item should be chosen, and `[0]` is used to extract the
+            # single item from the resulting list.
+            tof_1 = random.choices(
+                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
+            )[0]  # nosec
+            tof_2 = random.choices(
+                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
+            )[0]  # nosec
+            tof_3 = random.choices(
+                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
+            )[0]  # nosec
+            de_tag = random.randint(1, 65535)
+            current_data.append(create_directevent(tof_1, tof_2, tof_3, de_tag))
+
+        # create a CCSDS data using current data
+        # pkt_len = 4 byte (MET seconds) + 4 byte (spare) +
+        # 6 byte (direct event) * number of direct event + 2 byte (checksum) - 1å
+        if index % 2 == 0:
+            # Add 6 bytes for metaevent
+            pkt_len = 4 + 4 + 6 + 6 * num_directevents + 2 - 1
+        else:
+            pkt_len = 4 + 4 + 6 * num_directevents + 2 - 1
+        ccsds_data = (
+            ccsds_header_data(770, pkt_len)
+            + f"{met_seconds:032b}"
+            + spare
+            + "".join(current_data)
+            + check_sum(bits_size=16)
+        )
+        packets_data.append(ccsds_data)
+    # Join all the events as one binary string
+    packets_data = "".join(packets_data)
+    # write data to pkts file
+    with open(tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts", "wb") as f:
+        byte_data = int(packets_data, 2).to_bytes(
+            (len(packets_data) + 7) // 8, byteorder="big"
+        )
+        f.write(byte_data)
+    return tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts"

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -32,4 +32,3 @@ def test_hi_l1b_de(create_de_data, tmp_path):
     l1b_dataset = hi_l1b(l1a_cdf_path)
     assert l1b_dataset.attrs["Logical_source"] == "imap_hi_l1b_45sensor-de"
     assert len(l1b_dataset.data_vars) == 14
-    pass

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -5,6 +5,7 @@ from imap_processing.cdf.utils import write_cdf
 from imap_processing.hi.hi_cdf_attrs import hi_hk_l1b_global_attrs
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.l1b.hi_l1b import hi_l1b
+from imap_processing.hi.utils import HIAPID
 
 
 def test_hi_l1b_hk():
@@ -25,7 +26,7 @@ def test_hi_l1b_de(create_de_data, tmp_path):
     direct events L1A as input"""
     # TODO: once things are more stable, check in an L1A DE file as test data
     # Process using test data
-    bin_data_path = tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts"
+    bin_data_path = create_de_data(HIAPID.H45_SCI_DE.value)
     processed_data = hi_l1a(packet_file_path=bin_data_path)
     l1a_cdf_path = write_cdf(processed_data[0])
 

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -18,3 +18,18 @@ def test_hi_l1b_hk():
 
     l1b_dataset = hi_l1b(l1a_cdf_path)
     assert l1b_dataset.attrs["Logical_source"] == hi_hk_l1b_global_attrs.logical_source
+
+
+def test_hi_l1b_de(create_de_data, tmp_path):
+    """Test coverage for imap_processing.hi.hi_l1b.hi_l1b() with
+    direct events L1A as input"""
+    # TODO: once things are more stable, check in an L1A DE file as test data
+    # Process using test data
+    bin_data_path = tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts"
+    processed_data = hi_l1a(packet_file_path=bin_data_path)
+    l1a_cdf_path = write_cdf(processed_data[0])
+
+    l1b_dataset = hi_l1b(l1a_cdf_path)
+    assert l1b_dataset.attrs["Logical_source"] == "imap_hi_l1b_45sensor-de"
+    assert len(l1b_dataset.data_vars) == 14
+    pass

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -1,111 +1,19 @@
-import random
-
 import numpy as np
-import pytest
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import write_cdf
 from imap_processing.hi.l1a import histogram as hist
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.utils import HIAPID
-from imap_processing.tests.conftest import ccsds_header_data, check_sum
 
 
-def create_metaevent(esa_step, met_subseconds, met_seconds):
-    start_bitmask_data = 0  # META
-    return (
-        f"{start_bitmask_data:02b}{esa_step:04b}{met_subseconds:010b}{met_seconds:032b}"
-    )
-
-
-def create_directevent(tof_1, tof_2, tof_3, de_tag):
-    start_bitmask_data = random.choice([1, 2, 3])  # Detector A, B, C
-    return f"{start_bitmask_data:02b}{tof_1:010b}{tof_2:010b}{tof_3:010b}{de_tag:016b}"
-
-
-@pytest.fixture()
-def create_de_data(tmp_path):
-    """Create direct event data.
-
-    TODO: remove this once we have good sample data.
-    TODO: remove "S311" from pyproject.toml when we remove this.
-    """
-    num_packets = 4
-    packets_data = []
-    # This MET seconds evaluates to 2023-09-27T16:04:49.150
-    met_seconds = 433522962
-    esa_step = 0
-    spare = f"{0:032b}"
-    # To use a consistent random number
-    random.seed(0)
-    for index in range(num_packets):
-        current_data = []
-        if index % 2 == 0:
-            # Two packets per ESA step
-            # Every even index, event starts with metaevent
-            if esa_step == 9:
-                esa_step = 0
-            esa_step += 1
-            met_subseconds = random.randint(0, 1023)
-            met_seconds += 3600
-            current_data.append(create_metaevent(esa_step, met_subseconds, met_seconds))
-        # Random length for direct events. It could be empty
-        num_directevents = random.randint(0, 10)
-        for _ in range(num_directevents):
-            # We don't always get triple coincidence. To make data
-            # more realistic, we will use random.choices.
-            # This line will select a random integer between 0 and 1023
-            # with a probability of 0.xx and the value 1023 with a
-            # probability of 0.xx. The `k=1` argument specifies that one
-            # item should be chosen, and `[0]` is used to extract the
-            # single item from the resulting list.
-            tof_1 = random.choices(
-                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
-            )[0]  # nosec
-            tof_2 = random.choices(
-                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
-            )[0]  # nosec
-            tof_3 = random.choices(
-                [random.randint(0, 1022), 1023], weights=[0.45, 0.55], k=1
-            )[0]  # nosec
-            de_tag = random.randint(1, 65535)
-            current_data.append(create_directevent(tof_1, tof_2, tof_3, de_tag))
-
-        # create a CCSDS data using current data
-        # pkt_len = 4 byte (MET seconds) + 4 byte (spare) +
-        # 6 byte (direct event) * number of direct event + 2 byte (checksum) - 1å
-        if index % 2 == 0:
-            # Add 6 bytes for metaevent
-            pkt_len = 4 + 4 + 6 + 6 * num_directevents + 2 - 1
-        else:
-            pkt_len = 4 + 4 + 6 * num_directevents + 2 - 1
-        ccsds_data = (
-            ccsds_header_data(770, pkt_len)
-            + f"{met_seconds:032b}"
-            + spare
-            + "".join(current_data)
-            + check_sum(bits_size=16)
-        )
-        packets_data.append(ccsds_data)
-    # Join all the events as one binary string
-    packets_data = "".join(packets_data)
-    # write data to pkts file
-    with open(tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts", "wb") as f:
-        byte_data = int(packets_data, 2).to_bytes(
-            (len(packets_data) + 7) // 8, byteorder="big"
-        )
-        f.write(byte_data)
-    return tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts"
-
-
-def test_sci_de_decom(create_de_data, tmp_path):
+def test_sci_de_decom(create_de_data):
     """Test science direct event data"""
 
     # Process using test data
-    bin_data_path = tmp_path / "imap_hi_l0_sdc-test-data_20240318_v000.pkts"
-    processed_data = hi_l1a(packet_file_path=bin_data_path)
+    processed_data = hi_l1a(packet_file_path=create_de_data)
 
-    assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_de"
+    assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_45sensor-de"
     assert processed_data[0].attrs["Data_version"] == "001"
 
     # unique ESA steps should be [1, 2]
@@ -125,11 +33,10 @@ def test_sci_de_decom(create_de_data, tmp_path):
     assert processed_data[0]["tof_3"].max() <= 1023
 
     # Write to CDF
-    cdf_filename = "imap_hi_l1a_de_20230927_v001.cdf"
+    cdf_filename = "imap_hi_l1a_45sensor-de_20230927_v001.cdf"
     # TODO: Dropping duplicates to ignore ISTP for now. Need to update test data
     processed_data[0] = processed_data[0].sortby("epoch").groupby("epoch").first()
     cdf_filepath = write_cdf(processed_data[0])
-
     assert cdf_filepath.name == cdf_filename
 
 

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -11,7 +11,7 @@ def test_sci_de_decom(create_de_data):
     """Test science direct event data"""
 
     # Process using test data
-    processed_data = hi_l1a(packet_file_path=create_de_data)
+    processed_data = hi_l1a(packet_file_path=create_de_data(HIAPID.H45_SCI_DE.value))
 
     assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_45sensor-de"
     assert processed_data[0].attrs["Data_version"] == "001"

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -18,7 +18,8 @@ def test_sci_de_decom(create_de_data):
 
     # unique ESA steps should be [1, 2]
     assert np.array_equal(
-        np.sort(np.unique(processed_data[0]["esa_step"].values)), np.array([1, 2])
+        np.sort(np.unique(processed_data[0]["esa_stepping_num"].values)),
+        np.array([1, 2]),
     )
     # unique trigger_id should be [1, 2, 3]
     assert np.array_equal(

--- a/imap_processing/tests/hi/test_l1a_sci_de.py
+++ b/imap_processing/tests/hi/test_l1a_sci_de.py
@@ -36,13 +36,13 @@ def test_create_dataset():
     # Test for good data
     list_with_meta_first = [metaevent, directevent_1, directevent_2, directevent_3]
     packet_time = [123] * len(list_with_meta_first)
-    dataset = create_dataset(list_with_meta_first, packet_time)
+    dataset = create_dataset(list_with_meta_first, packet_time, "45sensor")
     assert dataset["epoch"].shape == (3,)
 
     # Test for missing metaevent
     list_with_no_meta = [directevent_1, directevent_2, directevent_3]
     packet_time = [123] * len(list_with_no_meta)
-    dataset = create_dataset(list_with_no_meta, packet_time)
+    dataset = create_dataset(list_with_no_meta, packet_time, "90sensor")
     assert dataset is None
 
     # test for first metaevent missing in the list
@@ -55,7 +55,7 @@ def test_create_dataset():
         directevent_3,
     ]
     packet_time = [123] * len(list_with_meta_middle)
-    dataset = create_dataset(list_with_meta_middle, packet_time)
+    dataset = create_dataset(list_with_meta_middle, packet_time, "45sensor")
     assert dataset["epoch"].shape == (3,)
     np.testing.assert_array_equal(dataset["trigger_id"].data, [1, 2, 3])
 
@@ -68,5 +68,5 @@ def test_create_dataset():
         metaevent,
     ]
     packet_time = [123] * len(list_with_meta_last)
-    dataset = create_dataset(list_with_meta_last, packet_time)
+    dataset = create_dataset(list_with_meta_last, packet_time, "90sensor")
     assert dataset["epoch"].shape == (0,)

--- a/imap_processing/tests/hi/test_utils.py
+++ b/imap_processing/tests/hi/test_utils.py
@@ -1,0 +1,15 @@
+"""Test coverage for imap_processing.hi.utils.py"""
+
+from imap_processing.hi.utils import HIAPID
+
+
+def test_hiapid():
+    """Test coverage for HIAPID class"""
+    hi_apid = HIAPID(754)
+    assert isinstance(hi_apid, HIAPID)
+    assert hi_apid.name == "H45_APP_NHK"
+    assert hi_apid.sensor == "45sensor"
+
+    hi_apid = HIAPID["H90_SCI_CNT"]
+    assert hi_apid.value == 833
+    assert hi_apid.sensor == "90sensor"

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -108,7 +108,7 @@ def test_codice(mock_codice_l1a, mock_instrument_dependencies):
 
 
 @mock.patch("imap_processing.cli.hi_l1a.hi_l1a")
-def test_hi(mock_hi_l1a, mock_instrument_dependencies):
+def test_hi_l1a(mock_hi_l1a, mock_instrument_dependencies):
     """Test coverage for cli.Hi class"""
     mocks = mock_instrument_dependencies
     mocks["mock_query"].return_value = [{"file_path": "/path/to/file0"}]
@@ -131,6 +131,32 @@ def test_hi(mock_hi_l1a, mock_instrument_dependencies):
     assert mocks["mock_download"].call_count == 1
     assert mock_hi_l1a.call_count == 1
     assert mocks["mock_upload"].call_count == 2
+
+
+@mock.patch("imap_processing.cli.hi_l1b.hi_l1b")
+def test_hi_l1b(mock_hi_l1b, mock_instrument_dependencies):
+    """Test coverage for cli.Hi class"""
+    mocks = mock_instrument_dependencies
+    mocks["mock_query"].return_value = [{"file_path": "/path/to/file0"}]
+    mocks["mock_download"].return_value = "file0"
+    mock_hi_l1b.return_value = "hi_l1b_dataset"
+    mocks["mock_write_cdf"].return_value = "/path/to/file0"
+
+    dependency_str = (
+        "[{"
+        "'instrument': 'hi',"
+        "'data_level': 'l1a',"
+        "'descriptor': 'sci',"
+        "'version': 'v00-01',"
+        "'start_date': '20231212'"
+        "}]"
+    )
+    instrument = Hi("l1b", dependency_str, "20231212", "20231213", "v005", True)
+    instrument.process()
+    assert mocks["mock_query"].call_count == 1
+    assert mocks["mock_download"].call_count == 1
+    assert mock_hi_l1b.call_count == 1
+    assert mocks["mock_upload"].call_count == 1
 
 
 @mock.patch("imap_processing.cli.ultra_l1a.ultra_l1a")


### PR DESCRIPTION
# Change Summary
Rework of Hi L1A DE processing 
Add  Hi L1B DE processing
Add Hi L1B processing to cli

## Overview
When I started, I was only planning on adding Hi L1B DE processing. I found some variables missing from the L1A DE product that had been added after the initial implementation so I had to update that code as well. Sorry for the large set of changes.

closes #205 

## New Dependencies

## New Files
- imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
   - hi global attributes yaml file
- imap_processing/cdf/config/imap_hi_variable_attrs.yaml
   - hi variable attributes yaml file
- imap_processing/hi/l1b/hi_l1b.py
   - add l1b processing of hi de product
- imap_processing/tests/hi/conftest.py
   - move fixture into conftest.py for reuse

## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->
- deleted file 1
   - explanation for why file was deleted

## Updated Files
- imap_processing/hi/l1a/hi_l1a.py
   - Allow Path as input to hi_l1a function
- imap_processing/hi/l1a/science_direct_event.py
   - Add some missing variables to hi_l1a_de products
   - Integrate yaml based attribute manager
- imap_processing/hi/utils.py
   - add `sensor` attribute to HIAPID class
- imap_processing/tests/hi/test_hi_l1a.py
   - update test coverage for l1a de testing
- imap_processing/tests/hi/test_hi_l1b.py
   - add l1b de test coverage
- imap_processing/tests/hi/test_utils.py
   - add test coverage for HIAPID class

## Testing
2 unit tests added