### PR TITLE
Add back in File_naming_convention to CDF global attribute schema file

### DIFF
--- a/imap_processing/cdf/config/shared/default_global_cdf_attrs_schema.yaml
+++ b/imap_processing/cdf/config/shared/default_global_cdf_attrs_schema.yaml
@@ -69,6 +69,14 @@ Discipline:
   required: true
   validate: true
   overwrite: false
+File_naming_convention:
+  description: >
+    If File_naming_convention was not set, it uses default setting:
+      source_datatype_descriptor_yyyyMMdd
+  default: source_datatype_descriptor_yyyyMMdd
+  required: false
+  validate: false
+  overwrite: true
 Generation_date:
   description: >
     Date stamps the creation of the file using the syntax yyyymmdd, e.g., "


### PR DESCRIPTION
# Change Summary
Tim messed up a rebase and undid a change that @tech3371 had put in to fix the file naming convention issue. This is a small ticket to put that change back in.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/cdf/config/shared/default_global_cdf_attrs_schema.yaml
   - Re-add File_naming_convention to schema