### PR TITLE
REL/CI: Add build job dependency to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
 
   pypi-publish:
     name: Upload release to PyPI
+    needs: build_sdist
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
# Change Summary

## Overview

Adds an explicit dependency on building the sdist before deploying to PyPI.