### PR TITLE
609 imap hi l1c pointing set cdf

### DIFF
--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -25,3 +25,9 @@ imap_hi_l1b_de_attrs:
     Data_type: L1B_DE>Level-1B Direct Event
     Logical_source: imap_hi_l1b_{sensor}-de
     Logical_source_description: IMAP-Hi Instrument Level-1B Direct Event Data.
+
+imap_hi_l1c_pset_attrs:
+    Data_level: 1C
+    Data_type: L1C_PSET>Level-1C Pointing Set
+    Logical_source: imap_hi_l1c_{sensor}-pset
+    Logical_source_description: IMAP-Hi Instrument Level-1C Pointing Set Data.

--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -9,7 +9,7 @@ default_attrs: &default
 
 default_uint8_attrs: &default_uint8
   <<: *default
-  FILLVAL: 0
+  FILLVAL: 255
   FORMAT: I3
   VALIDMIN: 0
   VALIDMAX: 255
@@ -17,7 +17,7 @@ default_uint8_attrs: &default_uint8
 
 default_uint16_attrs: &default_uint16
   <<: *default
-  FILLVAL: 0
+  FILLVAL: 65535
   FORMAT: I5
   VALIDMIN: 0
   VALIDMAX: 65535
@@ -25,7 +25,7 @@ default_uint16_attrs: &default_uint16
 
 default_uint32_attrs: &default_uint32
   <<: *default
-  FILLVAL: 0
+  FILLVAL: 4294967295
   FORMAT: I10
   VALIDMIN: 0
   VALIDMAX: 4294967295
@@ -33,7 +33,7 @@ default_uint32_attrs: &default_uint32
 
 default_uint64_attrs: &default_uint64
   <<: *default
-  FILLVAL: 0
+  FILLVAL: 18446744073709551615
   FORMAT: I20
   VALIDMIN: 0
   VALIDMAX: 18446744073709551615
@@ -54,6 +54,23 @@ default_float32_attrs: &default_float32
   VALIDMIN: -3.4028235e+38
   VALIDMAX: 3.4028235e+38
   dtype: float32
+
+default_epoch: &default_epoch
+  CATDESC: Time, number of nanoseconds since J2000 with leap seconds included
+  FIELDNAM: epoch
+  LABLAXIS: epoch
+  FILLVAL: -9223372036854775808
+  FORMAT: " " # Supposedly not required, fails in xarray_to_cdf
+  VALIDMIN: -9223372036854775808
+  VALIDMAX: 9223372036854775807
+  UNITS: ns
+  VAR_TYPE: support_data
+  SCALETYP: linear
+  MONOTON: INCREASE
+  TIME_BASE: J2000
+  TIME_SCALE: Terrestrial Time
+  REFERENCE_POSITION: Rotating Earth Geoid
+  dtype: datetime64[ns]
 
 # ------- L1A DE Section -------
 hi_de_ccsds_met:
@@ -181,15 +198,18 @@ hi_de_coincidence_type:
     made up of the ORed quantities: (A hit? 8:0) | (B hit? 4:0)
     | (C1 hit? 2:0) | (C2 hit? 1 : 0)
 
-hi_de_esa_step:
-  <<: *default_uint8
+default_esa_step: &default_esa_step
   CATDESC: Zero based energy step index
   FIELDNAM: ESA energy step
   FILLVAL: 255
   FORMAT: I2
-  LABLAXIS: Energy Step
   VALIDMIN: 0
   VALIDMAX: 12
+
+hi_de_esa_step:
+  <<: *default_uint8
+  <<: *default_esa_step
+  LABLAXIS: Energy Step
 
 default_delta_t: &default_delta_t
   <<: *default_int32
@@ -269,3 +289,147 @@ hi_de_nominal_bin:
   LABLAXIS: Hist Bin \#
   VALIDMIN: 0
   VALIDMAX: 89
+
+# ------- L1C PSET Section -------
+hi_pset_epoch:
+  <<: *default_epoch
+
+hi_pset_esa_step:
+  <<: *default_esa_step
+  LABLAXIS: Energy Step
+  UNITS: " "
+  VALIDMIN: 0
+  VALIDMAX: 12
+  SCALE_TYP: linear
+  MONOTON: INCREASE
+  VAR_TYPE: support_data
+  dtype: uint8
+
+hi_pset_spin_angle_bin:
+  CATDESC: 0.1 degree spin angle bins
+  FIELDNAM: Spin angle bin index
+  FILLVAL: 65535
+  FORMAT: I3
+  LABLAXIS: Bin Index
+  UNITS: deg
+  SCALE_TYP: linear
+  MONOTON: INCREASE
+  VALIDMIN: 0
+  VALIDMAX: 3599
+  VAR_TYPE: support_data
+  VAR_NOTES: >
+    Bins are defined by spin angle about the mean axis of rotation for the pointing set.
+    Spin angle bins start at closest to ecliptic North. Bin zero is centered at 0.05 degrees
+    spinward of ecliptic North and all bins are 0.1 degrees wide.
+  dtype: uint16
+
+# Based on SPDF example of a vector magnetic field variable at the following link,
+# despun_z does not need a DEPEND_1 because it does not depend on any support_data
+# https://spdf.gsfc.nasa.gov/istp_guide/variables.html#data_eg2
+hi_pset_despun_z:
+  <<: *default_float32
+  CATDESC: Unit vector corresponding to Despun Pointing Frame z-axis in HAE Ecliptic coordinates
+  FIELDNAM: Despun Frame z-axis in HAE coordinates
+  FORMAT: F5.3
+  LABL_PTR_1: label_vector_HAE
+  UNITS: " "
+  VALIDMIN: -1
+  VALIDMAX: 1
+  DISPLAY_TYPE: no_plot
+  VAR_TYPE: support_data
+
+hi_pset_hae_latitude:
+  <<: *default_float32
+  CATDESC: Latitude of bin center in HAE coordinates
+  FIELDNAM: HAE Latitude
+  DEPEND_0: epoch
+  DEPEND_1: spin_angle_bin
+  DISPLAY_TYPE: no_plot
+  FORMAT: F5.2
+  LABLAXIS: Latitude
+  UNITS: deg
+  VALIDMIN: 0
+  VALIDMAX: 180
+
+hi_pset_hae_longitude:
+  <<: *default_float32
+  CATDESC: Longitude of bin center in HAE coordinates
+  FIELDNAM: HAE Longitude
+  DEPEND_0: epoch
+  DEPEND_1: spin_angle_bin
+  DISPLAY_TYPE: no_plot
+  FORMAT: F5.2
+  LABLAXIS: Latitude
+  UNITS: deg
+  VALIDMIN: 0
+  VALIDMAX: 360
+
+hi_pset_counts:
+  <<: *default_uint16
+  CATDESC: Binned direct events counts during good times
+  FIELDNAM: Binned DE counts
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
+  DEPEND_2: spin_angle_bin
+  LABL_PTR_1: esa_step_label
+  LABL_PTR_2: spin_bin_label
+  DISPLAY_TYPE: stack_plot
+  FORMAT: I5
+
+hi_pset_exposure_times:
+  <<: *default_float32
+  CATDESC: Exposure times for each bin during good times
+  FIELDNAM: Bin exposure times
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
+  DEPEND_2: spin_angle_bin
+  LABL_PTR_1: esa_step_label
+  LABL_PTR_2: spin_bin_label
+  UNITS: sec
+  DISPLAY_TYPE: stack_plot
+  FORMAT: F6.2
+
+hi_pset_background_rates:
+  <<: *default_float32
+  CATDESC: Background count rates
+  FIELDNAM: Background count rates
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
+  DEPEND_2: spin_angle_bin
+  LABL_PTR_1: esa_step_label
+  LABL_PTR_2: spin_bin_label
+  UNITS: counts / s
+  DISPLAY_TYPE: stack_plot
+  FORMAT: F4.2
+
+hi_pset_background_rates_uncertainty:
+  <<: *default_float32
+  CATDESC: Background count rate uncertainties
+  FIELDNAM: Background count rate uncertainties
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
+  DEPEND_2: spin_angle_bin
+  LABL_PTR_1: esa_step_label
+  LABL_PTR_2: spin_bin_label
+  UNITS: counts / s
+  DISPLAY_TYPE: stack_plot
+  FORMAT: F4.2
+
+# <=== pset label Attributes ===>
+hi_pset_spin_bin_label:
+  CATDESC: Label spin angle bin
+  FIELDNAM: Label spin angle bin
+  FORMAT: A4
+  VAR_TYPE: metadata
+
+hi_pset_esa_step_label:
+  CATDESC: Label esa step
+  FIELDNAM: Label esa step
+  FORMAT: A4
+  VAR_TYPE: metadata
+
+hi_pset_label_vector_HAE:
+  CATDESC: Label cartesian despun_z
+  FIELDNAM: Label cartesian despun_z
+  FORMAT: A5
+  VAR_TYPE: metadata

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -443,7 +443,7 @@ class Hi(ProcessInstrument):
             dataset = hi_l1b.hi_l1b(dependencies[0], self.version)
             products = [write_cdf(dataset)]
         elif self.data_level == "l1c":
-            dataset = hi_l1c.hi_l1c(dependencies[0])
+            dataset = hi_l1c.hi_l1c(dependencies, self.version)
             products = [write_cdf(dataset)]
         else:
             raise NotImplementedError(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -37,6 +37,7 @@ from imap_processing.glows.l1a.glows_l1a import glows_l1a
 from imap_processing.glows.l1b.glows_l1b import glows_l1b
 from imap_processing.hi.l1a import hi_l1a
 from imap_processing.hi.l1b import hi_l1b
+from imap_processing.hi.l1c import hi_l1c
 from imap_processing.hit.l1a.hit_l1a import hit_l1a
 from imap_processing.hit.l1b.hit_l1b import hit_l1b
 from imap_processing.idex.idex_packet_parser import PacketParser
@@ -440,6 +441,9 @@ class Hi(ProcessInstrument):
             products = [write_cdf(dataset) for dataset in datasets]
         elif self.data_level == "l1b":
             dataset = hi_l1b.hi_l1b(dependencies[0], self.version)
+            products = [write_cdf(dataset)]
+        elif self.data_level == "l1c":
+            dataset = hi_l1c.hi_l1c(dependencies[0])
             products = [write_cdf(dataset)]
         else:
             raise NotImplementedError(

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -7,10 +7,14 @@ from typing import Union
 import numpy as np
 import xarray as xr
 
+from imap_processing import imap_module_directory
+from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
 from imap_processing.cdf.utils import load_cdf
-from imap_processing.hi.utils import CDF_MANAGER
 
 logger = logging.getLogger(__name__)
+CDF_MANAGER = CdfAttributeManager(imap_module_directory / "cdf" / "config")
+CDF_MANAGER.load_global_attributes("imap_hi_global_cdf_attrs.yaml")
+CDF_MANAGER.load_variable_attributes("imap_hi_variable_attrs.yaml")
 
 
 def hi_l1c(l1b_de_path: Union[Path, str], data_version: str):

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -1,0 +1,188 @@
+"""IMAP-HI L1C processing module."""
+
+import logging
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import xarray as xr
+
+from imap_processing.cdf.utils import load_cdf
+from imap_processing.hi.utils import CDF_MANAGER
+
+logger = logging.getLogger(__name__)
+
+
+def hi_l1c(l1b_de_path: Union[Path, str], data_version: str):
+    """
+    High level IMAP-Hi L1C processing function.
+
+    This function will be expanded once the L1C processing is better defined. It
+    will need to add inputs such as Ephemerides, Goodtimes inputs, and
+    instrument status summary and will output a Pointing Set CDF as well as a
+    Goodtimes list (CDF?).
+
+    Parameters
+    ----------
+    l1b_de_path : pathlib.Path
+        Location of l1b annotated direct event file.
+
+    data_version : str
+        Data version to write to CDF files and the Data_version CDF attribute.
+        Should be in the format Vxxx
+
+    Returns
+    -------
+    processed_data : xarray.Dataset
+        Processed xarray dataset
+    """
+    logger.info("Running Hi L1C processing")
+
+    de_dataset = load_cdf(l1b_de_path)
+    sensor_str = de_dataset.attrs["Logical_source"].split("_")[-1].split("-")[0]
+
+    # determine the number of unique esa_stepping_numbers
+    # NOTE: it is possible that multiple esa_stepping_numbers will correspond
+    #     to a single esa_step. These should be bookkept as unique entries in
+    #     the esa_step coordinate.
+    n_esa_step = np.unique(de_dataset.esa_stepping_num.data).size
+
+    pset_dataset = allocate_pset_dataset(n_esa_step, sensor_str)
+
+    # TODO: Stored epoch value needs to be consistent across ENA instruments.
+    #    SPDF says this should be the center of the time bin, but instrument
+    #    teams may disagree.
+    pset_dataset.epoch.data[0] = de_dataset.epoch.data[0]
+
+    return pset_dataset
+
+
+def allocate_pset_dataset(n_esa_steps: int, sensor_str: str):
+    """
+    Allocate an empty xarray.Dataset.
+
+    Parameters
+    ----------
+    n_esa_steps : int
+        Number of Electrostatic Analyzer steps to allocate
+    sensor_str : str
+        '45sensor' or '90sensor'
+
+    Returns
+    -------
+    xarray.Dataset
+        Empty xarray.Dataset ready to be filled with data
+    """
+    # preallocate coordinates xr.DataArrays
+    coords = dict()
+    # epoch coordinate has only 1 entry for pointing set
+    attrs = CDF_MANAGER.get_variable_attributes("hi_pset_epoch").copy()
+    dtype = attrs.pop("dtype")
+    coords["epoch"] = xr.DataArray(
+        np.empty(1, dtype=dtype),
+        name="epoch",
+        dims=["epoch"],
+        attrs=attrs,
+    )
+    attrs = CDF_MANAGER.get_variable_attributes("hi_pset_esa_step").copy()
+    dtype = attrs.pop("dtype")
+    coords["esa_step"] = xr.DataArray(
+        np.full(n_esa_steps, attrs["FILLVAL"], dtype=dtype),
+        name="esa_step",
+        dims=["esa_step"],
+        attrs=attrs,
+    )
+    # spin angle bins are 0.1 degree bins for full 360 degree spin
+    attrs = CDF_MANAGER.get_variable_attributes("hi_pset_spin_angle_bin").copy()
+    dtype = attrs.pop("dtype")
+    coords["spin_angle_bin"] = xr.DataArray(
+        np.arange(int(360 / 0.1), dtype=dtype),
+        name="spin_angle_bin",
+        dims=["spin_angle_bin"],
+        attrs=attrs,
+    )
+
+    # Allocate the variables
+    data_vars = dict()
+    # despun_z is a 1x3 unit vector
+    data_vars["despun_z"] = full_dataarray("despun_z", coords, shape=(1, 3))
+    data_vars["hae_latitude"] = full_dataarray("hae_latitude", coords)
+    data_vars["hae_longitude"] = full_dataarray("hae_longitude", coords)
+    data_vars["counts"] = full_dataarray("counts", coords)
+    data_vars["exposure_times"] = full_dataarray("exposure_times", coords)
+    data_vars["background_rates"] = full_dataarray("background_rates", coords)
+    data_vars["background_rates_uncertainty"] = full_dataarray(
+        "background_rates_uncertainty", coords
+    )
+
+    # Generate label variables
+    data_vars["esa_step_label"] = xr.DataArray(
+        coords["esa_step"].values.astype(str),
+        name="esa_step_label",
+        dims=["esa_step"],
+        attrs=CDF_MANAGER.get_variable_attributes("hi_pset_esa_step_label"),
+    )
+    data_vars["spin_bin_label"] = xr.DataArray(
+        coords["spin_angle_bin"].values.astype(str),
+        name="spin_bin_label",
+        dims=["spin_angle_bin"],
+        attrs=CDF_MANAGER.get_variable_attributes("hi_pset_spin_bin_label"),
+    )
+    data_vars["label_vector_HAE"] = xr.DataArray(
+        np.array(["x HAE", "y HAE", "z HAE"], dtype=str),
+        name="label_vector_HAE",
+        dims=[" "],
+        attrs=CDF_MANAGER.get_variable_attributes("hi_pset_label_vector_HAE"),
+    )
+
+    pset_global_attrs = CDF_MANAGER.get_global_attributes(
+        "imap_hi_l1c_pset_attrs"
+    ).copy()
+    pset_global_attrs["Logical_source"] = pset_global_attrs["Logical_source"].format(
+        sensor=sensor_str
+    )
+    dataset = xr.Dataset(data_vars=data_vars, coords=coords, attrs=pset_global_attrs)
+    return dataset
+
+
+def full_dataarray(name, coords: dict, shape=None):
+    """
+    Generate an empty xarray.DataArray with appropriate attributes.
+
+    Data in DataArray are filled with FILLVAL defined in attributes
+    retrieved from CDF_MANAGER with shape matching coordinates defined by
+    dims or overridden by optional `shape` input.
+
+    Parameters
+    ----------
+    name : str
+        Variable name
+    coords : dict
+        Coordinate variables for the Dataset.
+    shape : int or tuple
+        Shape of ndarray data array to instantiate in the xarray.DataArray.
+
+    Returns
+    -------
+    xarray.DataArray meeting input specifications
+    """
+    attrs = CDF_MANAGER.get_variable_attributes(f"hi_pset_{name}").copy()
+    dtype = attrs.pop("dtype")
+
+    # extract dims keyword argument from DEPEND_i attributes
+    dims = [v for k, v in attrs.items() if k.startswith("DEPEND")]
+    # define shape of the ndarray to generate
+    if shape is None:
+        shape = [coords[k].data.size for k in dims]
+    if len(shape) > len(dims):
+        dims.append("")
+
+    print(f"{name=}, {shape=}, {dims=}")
+
+    data_array = xr.DataArray(
+        np.full(shape, attrs["FILLVAL"], dtype=dtype),
+        name=name,
+        dims=dims,
+        attrs=attrs,
+    )
+    return data_array

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -1,4 +1,4 @@
-"""Test coverage for imap_processing.hi.hi_l1b.py"""
+"""Test coverage for imap_processing.hi.l1b.hi_l1b.py"""
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import write_cdf

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -1,38 +1,73 @@
 """Test coverage for imap_processing.hi.l1c.hi_l1c.py"""
 
 import numpy as np
+import pytest
+import xarray as xr
 
+from imap_processing import imap_module_directory
+from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
 from imap_processing.cdf.utils import write_cdf
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.l1b.hi_l1b import hi_l1b
-from imap_processing.hi.l1c.hi_l1c import hi_l1c
+from imap_processing.hi.l1c import hi_l1c
 from imap_processing.hi.utils import HIAPID
 
 
-def test_hi_l1c_pset(create_de_data):
-    """Test coverage for hi_l1c function"""
+def test_generate_pset_dataset(create_de_data):
+    """Test coverage for generate_pset_dataset function"""
     # TODO: once things are more stable, check in an L1B DE file as test data?
     # For now, test using false de data run through l1a and l1b processing
     bin_data_path = create_de_data(HIAPID.H45_SCI_DE.value)
-    processed_data = hi_l1a(packet_file_path=bin_data_path)
+    processed_data = hi_l1a(bin_data_path, "002")
     l1a_cdf_path = write_cdf(processed_data[0])
-    l1b_dataset = hi_l1b(l1a_cdf_path)
+    l1b_dataset = hi_l1b(l1a_cdf_path, "002")
     l1b_cdf_path = write_cdf(l1b_dataset)
 
-    l1c_dataset = hi_l1c(l1b_cdf_path, "002")
+    l1c_dataset = hi_l1c.generate_pset_dataset(l1b_cdf_path)
 
-    assert l1c_dataset.epoch.size == 1
-    assert l1c_dataset.spin_angle_bin.size == 3600
-    np.testing.assert_array_equal(l1c_dataset.despun_z.data.shape, (1, 3))
-    np.testing.assert_array_equal(l1c_dataset.hae_latitude.data.shape, (1, 3600))
-    np.testing.assert_array_equal(l1c_dataset.hae_longitude.data.shape, (1, 3600))
-    n_esa_step = l1c_dataset.esa_step.data.size
+    assert l1c_dataset.epoch.data[0] == l1b_dataset.epoch.data[0]
+
+
+def test_allocate_pset_dataset():
+    """Test coverage for allocate_pset_dataset function"""
+    n_esa_steps = 10
+    sensor_str = HIAPID.H90_SCI_DE.sensor
+    dataset = hi_l1c.allocate_pset_dataset(n_esa_steps, sensor_str)
+
+    assert dataset.epoch.size == 1
+    assert dataset.spin_angle_bin.size == 3600
+    np.testing.assert_array_equal(dataset.despun_z.data.shape, (1, 3))
+    np.testing.assert_array_equal(dataset.hae_latitude.data.shape, (1, 3600))
+    np.testing.assert_array_equal(dataset.hae_longitude.data.shape, (1, 3600))
+    n_esa_step = dataset.esa_step.data.size
     for var in [
         "counts",
         "exposure_times",
         "background_rates",
         "background_rates_uncertainty",
     ]:
-        np.testing.assert_array_equal(
-            l1c_dataset[var].data.shape, (1, n_esa_step, 3600)
-        )
+        np.testing.assert_array_equal(dataset[var].data.shape, (1, n_esa_step, 3600))
+
+
+@pytest.mark.parametrize(
+    "name, shape, expected_shape",
+    [
+        ("despun_z", (1, 3), (1, 3)),
+        ("hae_latitude", None, (1, 360)),
+        ("counts", None, (1, 10, 360)),
+    ],
+)
+def test_full_dataarray(name, shape, expected_shape):
+    """Test coverage for full_dataarray function"""
+    coords = {
+        "epoch": xr.DataArray(np.array([0])),
+        "esa_step": xr.DataArray(np.arange(10)),
+        "spin_angle_bin": xr.DataArray(np.arange(360)),
+    }
+    cdf_manager = CdfAttributeManager(imap_module_directory / "cdf" / "config")
+    cdf_manager.load_variable_attributes("imap_hi_variable_attrs.yaml")
+
+    dataarray = hi_l1c.full_dataarray(
+        name, cdf_manager.get_variable_attributes(f"hi_pset_{name}"), coords, shape
+    )
+    assert dataarray.data.shape == expected_shape

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -1,0 +1,38 @@
+"""Test coverage for imap_processing.hi.l1c.hi_l1c.py"""
+
+import numpy as np
+
+from imap_processing.cdf.utils import write_cdf
+from imap_processing.hi.l1a.hi_l1a import hi_l1a
+from imap_processing.hi.l1b.hi_l1b import hi_l1b
+from imap_processing.hi.l1c.hi_l1c import hi_l1c
+from imap_processing.hi.utils import HIAPID
+
+
+def test_hi_l1c_pset(create_de_data):
+    """Test coverage for hi_l1c function"""
+    # TODO: once things are more stable, check in an L1B DE file as test data?
+    # For now, test using false de data run through l1a and l1b processing
+    bin_data_path = create_de_data(HIAPID.H45_SCI_DE.value)
+    processed_data = hi_l1a(packet_file_path=bin_data_path)
+    l1a_cdf_path = write_cdf(processed_data[0])
+    l1b_dataset = hi_l1b(l1a_cdf_path)
+    l1b_cdf_path = write_cdf(l1b_dataset)
+
+    l1c_dataset = hi_l1c(l1b_cdf_path, "002")
+
+    assert l1c_dataset.epoch.size == 1
+    assert l1c_dataset.spin_angle_bin.size == 3600
+    np.testing.assert_array_equal(l1c_dataset.despun_z.data.shape, (1, 3))
+    np.testing.assert_array_equal(l1c_dataset.hae_latitude.data.shape, (1, 3600))
+    np.testing.assert_array_equal(l1c_dataset.hae_longitude.data.shape, (1, 3600))
+    n_esa_step = l1c_dataset.esa_step.data.size
+    for var in [
+        "counts",
+        "exposure_times",
+        "background_rates",
+        "background_rates_uncertainty",
+    ]:
+        np.testing.assert_array_equal(
+            l1c_dataset[var].data.shape, (1, n_esa_step, 3600)
+        )

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -115,7 +115,11 @@ def test_hi_l1(mock_instrument_dependencies, data_level, n_prods):
     mocks["mock_download"].return_value = "file0"
     mocks["mock_write_cdf"].side_effect = ["/path/to/file0", "/path/to/file1"]
 
-    with mock.patch(f"imap_processing.cli.hi_{data_level}.hi_{data_level}") as mock_hi:
+    # patch autospec=True makes this test confirm that the function call in cli.py
+    # matches the mocked function signature.
+    with mock.patch(
+        f"imap_processing.cli.hi_{data_level}.hi_{data_level}", autospec=True
+    ) as mock_hi:
         mock_hi.return_value = [f"{data_level}_file{n}" for n in range(n_prods)]
         dependency_str = (
             "[{"

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -107,56 +107,33 @@ def test_codice(mock_codice_l1a, mock_instrument_dependencies):
     assert mocks["mock_upload"].call_count == 1
 
 
-@mock.patch("imap_processing.cli.hi_l1a.hi_l1a")
-def test_hi_l1a(mock_hi_l1a, mock_instrument_dependencies):
+@pytest.mark.parametrize("data_level, n_prods", [("l1a", 2), ("l1b", 1), ("l1c", 1)])
+def test_hi_l1(mock_instrument_dependencies, data_level, n_prods):
     """Test coverage for cli.Hi class"""
     mocks = mock_instrument_dependencies
     mocks["mock_query"].return_value = [{"file_path": "/path/to/file0"}]
     mocks["mock_download"].return_value = "file0"
-    mock_hi_l1a.return_value = ["l1a_file0", "l1a_file1"]
     mocks["mock_write_cdf"].side_effect = ["/path/to/file0", "/path/to/file1"]
 
-    dependency_str = (
-        "[{"
-        "'instrument': 'lo',"
-        "'data_level': 'l0',"
-        "'descriptor': 'sci',"
-        "'version': 'v00-01',"
-        "'start_date': '20231212'"
-        "}]"
-    )
-    instrument = Hi("l1a", dependency_str, "20231212", "20231213", "v005", True)
-    instrument.process()
-    assert mocks["mock_query"].call_count == 1
-    assert mocks["mock_download"].call_count == 1
-    assert mock_hi_l1a.call_count == 1
-    assert mocks["mock_upload"].call_count == 2
-
-
-@mock.patch("imap_processing.cli.hi_l1b.hi_l1b")
-def test_hi_l1b(mock_hi_l1b, mock_instrument_dependencies):
-    """Test coverage for cli.Hi class"""
-    mocks = mock_instrument_dependencies
-    mocks["mock_query"].return_value = [{"file_path": "/path/to/file0"}]
-    mocks["mock_download"].return_value = "file0"
-    mock_hi_l1b.return_value = "hi_l1b_dataset"
-    mocks["mock_write_cdf"].return_value = "/path/to/file0"
-
-    dependency_str = (
-        "[{"
-        "'instrument': 'hi',"
-        "'data_level': 'l1a',"
-        "'descriptor': 'sci',"
-        "'version': 'v00-01',"
-        "'start_date': '20231212'"
-        "}]"
-    )
-    instrument = Hi("l1b", dependency_str, "20231212", "20231213", "v005", True)
-    instrument.process()
-    assert mocks["mock_query"].call_count == 1
-    assert mocks["mock_download"].call_count == 1
-    assert mock_hi_l1b.call_count == 1
-    assert mocks["mock_upload"].call_count == 1
+    with mock.patch(f"imap_processing.cli.hi_{data_level}.hi_{data_level}") as mock_hi:
+        mock_hi.return_value = [f"{data_level}_file{n}" for n in range(n_prods)]
+        dependency_str = (
+            "[{"
+            "'instrument': 'lo',"
+            "'data_level': 'l0',"
+            "'descriptor': 'sci',"
+            "'version': 'v00-01',"
+            "'start_date': '20231212'"
+            "}]"
+        )
+        instrument = Hi(
+            data_level, dependency_str, "20231212", "20231213", "v005", True
+        )
+        instrument.process()
+        assert mocks["mock_query"].call_count == 1
+        assert mocks["mock_download"].call_count == 1
+        assert mock_hi.call_count == 1
+        assert mocks["mock_upload"].call_count == n_prods
 
 
 @mock.patch("imap_processing.cli.ultra_l1a.ultra_l1a")


### PR DESCRIPTION
# Change Summary
Adds Hi l1c processing for pset data

## Overview
Adds generation of empty l1c pset product to Hi processing.

## New Dependencies
None

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- imap_processing/hi/l1c/__init__.py
   - added l1c directory
- imap_processing/hi/l1c/hi_l1c.py
   - added processing for l1b_de -> l1c_pset
- imap_processing/tests/hi/test_hi_l1c.py
   - added test coverage for all functions in imap_processing/hi/l1c/hi_l1c.py

## Deleted Files
None

## Updated Files
- imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
   - added global attributes for Hi l1c pset products
- imap_processing/cdf/config/imap_hi_variable_attrs.yaml
   - Updated default fill values to match SPDF recommended values
   - Added default epoch definition for reuse
   - Added pset specific variable attribute definitions
- imap_processing/cli.py
   - Added logic for Hi l1c processing
- imap_processing/tests/test_cli.py
   - Parameterized tests for Hi l1a/l1b/l1c coverage into a single test
   - Added autospec=True to mock that mocks hi l1a/l1b/l1c function calls to ensure coverage of correct function signature in cli call

## Testing
- Full test coverage of new hi_l1c.py functions
- Improved Hi tests in test_cli.py
