### PR TITLE
630 final hi updates for sit 3

### DIFF
--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -87,21 +87,9 @@ hi_de_de_tag:
   FIELDNAM: Direct Event Time Tag
   LABLAXIS: DE Time Tag
 
-hi_de_epoch_attrs:
+hi_de_epoch:
+  <<: *default_epoch
   CATDESC: Direct Event time, number of nanoseconds since J2000 with leap seconds included
-  DISPLAY_TYPE: no_plot
-  FIELDNAM: Time since January 1, 2000, 11:58:55.816 UTC
-  FILLVAL: 9999-12-31T23:59:59.999999999
-  FORMAT: " "
-  LABLAXIS: epoch
-  UNITS: ns
-  VALIDMIN: 2000-12-01T11:58:55.816000000
-  VALIDMAX: 2099-12-31T00:00:00.000000000
-  VAR_TYPE: support_data
-  SCALE_TYP: linear
-  MONOTON: INCREASE
-  TIME_BASE: J2000
-  TIME_SCALE: Terrestrial Time
 
 hi_de_esa_stepping_num:
   <<: *default_uint8

--- a/imap_processing/hi/hi_cdf_attrs.py
+++ b/imap_processing/hi/hi_cdf_attrs.py
@@ -131,7 +131,7 @@ hi_de_l1a_attrs = GlobalDataLevelAttrs(
 
 hi_hk_l1a_attrs = GlobalDataLevelAttrs(
     data_type="L1A_HK>Level-1A Housekeeping",
-    logical_source="imap_hi_l1a_hk",
+    logical_source="imap_hi_l1a_{sensor}-hk",
     logical_source_desc=("IMAP-Hi Instrument Level-1A Housekeeping Data."),
     instrument_base=hi_base,
 )
@@ -148,8 +148,8 @@ hi_hk_l1a_metadata_attrs = ScienceAttrs(
 
 # Histogram attributes
 hi_hist_l1a_global_attrs = GlobalDataLevelAttrs(
-    data_type="L1A_CNT>Level-1A Histogram",
-    logical_source="imap_hi_l1a_hist",
+    data_type="L1A_HIST>Level-1A Histogram",
+    logical_source="imap_hi_l1a_{sensor}-hist",
     logical_source_desc=("IMAP-Hi Instrument Level-1A Histogram Data."),
     instrument_base=hi_base,
 )

--- a/imap_processing/hi/l1a/hi_l1a.py
+++ b/imap_processing/hi/l1a/hi_l1a.py
@@ -58,5 +58,11 @@ def hi_l1a(packet_file_path: Union[str, Path], data_version: str):
 
         # TODO: revisit this
         data.attrs["Data_version"] = data_version
+
+        # set the sensor string in Logical_source
+        sensor_str = HIAPID(apid).sensor
+        data.attrs["Logical_source"] = data.attrs["Logical_source"].format(
+            sensor=sensor_str
+        )
         processed_data.append(data)
     return processed_data

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -52,7 +52,7 @@ def test_app_nhk_decom():
     processed_data = hi_l1a(packet_file_path=bin_data_path, data_version="001")
 
     assert np.unique(processed_data[0]["pkt_apid"].values) == HIAPID.H45_APP_NHK.value
-    assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_hk"
+    assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_45sensor-hk"
     assert processed_data[0].attrs["Data_version"] == "001"
     # TODO: compare with validation data once we have it
 
@@ -61,7 +61,7 @@ def test_app_nhk_decom():
 
     # TODO: ask Vivek about this date mismatch between the file name
     # and the data. May get resolved when we have good sample data.
-    assert cem_raw_cdf_filepath.name == "imap_hi_l1a_hk_20100313_v001.cdf"
+    assert cem_raw_cdf_filepath.name == "imap_hi_l1a_45sensor-hk_20100313_v001.cdf"
 
 
 def test_app_hist_decom():
@@ -70,7 +70,7 @@ def test_app_hist_decom():
     bin_data_path = test_path / "20231030_H45_SCI_CNT.bin"
     processed_data = hi_l1a(packet_file_path=bin_data_path, data_version="001")
 
-    assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_hist"
+    assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_45sensor-hist"
     # TODO: compare with validation data once we have it
     # TODO: Dropping duplicates to ignore ISTP for now. Need to update test data
     processed_data[0] = processed_data[0].sortby("epoch").groupby("epoch").first()
@@ -78,7 +78,7 @@ def test_app_hist_decom():
     # Write CDF
     cem_raw_cdf_filepath = write_cdf(processed_data[0])
 
-    assert cem_raw_cdf_filepath.name.startswith("imap_hi_l1a_hist_")
+    assert cem_raw_cdf_filepath.name.startswith("imap_hi_l1a_45sensor-hist_")
 
 
 def test_allocate_histogram_dataset():
@@ -86,6 +86,7 @@ def test_allocate_histogram_dataset():
     n_packets = 5
     dataset = hist.allocate_histogram_dataset(n_packets)
 
+    assert dataset.attrs["Data_type"] == "L1A_HIST>Level-1A Histogram"
     assert dataset.sizes["epoch"] == n_packets
     assert dataset.sizes["angle"] == 90
     for var_name in (

--- a/imap_processing/tests/hi/test_l1a_sci_de.py
+++ b/imap_processing/tests/hi/test_l1a_sci_de.py
@@ -36,13 +36,13 @@ def test_create_dataset():
     # Test for good data
     list_with_meta_first = [metaevent, directevent_1, directevent_2, directevent_3]
     packet_time = [123] * len(list_with_meta_first)
-    dataset = create_dataset(list_with_meta_first, packet_time, "45sensor")
+    dataset = create_dataset(list_with_meta_first, packet_time)
     assert dataset["epoch"].shape == (3,)
 
     # Test for missing metaevent
     list_with_no_meta = [directevent_1, directevent_2, directevent_3]
     packet_time = [123] * len(list_with_no_meta)
-    dataset = create_dataset(list_with_no_meta, packet_time, "90sensor")
+    dataset = create_dataset(list_with_no_meta, packet_time)
     assert dataset is None
 
     # test for first metaevent missing in the list
@@ -55,7 +55,7 @@ def test_create_dataset():
         directevent_3,
     ]
     packet_time = [123] * len(list_with_meta_middle)
-    dataset = create_dataset(list_with_meta_middle, packet_time, "45sensor")
+    dataset = create_dataset(list_with_meta_middle, packet_time)
     assert dataset["epoch"].shape == (3,)
     np.testing.assert_array_equal(dataset["trigger_id"].data, [1, 2, 3])
 
@@ -68,5 +68,5 @@ def test_create_dataset():
         metaevent,
     ]
     packet_time = [123] * len(list_with_meta_last)
-    dataset = create_dataset(list_with_meta_last, packet_time, "90sensor")
+    dataset = create_dataset(list_with_meta_last, packet_time)
     assert dataset["epoch"].shape == (0,)

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -9,7 +9,7 @@ from imap_processing.hit.l1a import hit_l1a
 from imap_processing.hit.l1b import hit_l1b
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def dependency():
     """Get L1A data from test packet file"""
 


### PR DESCRIPTION
# Change Summary
Final changes to Hi L1 processing needed for SIT-3 🤞 
After reviewing data generated in AWS the following changes were needed:
- hi_hist_l1a_global_attrs["data_type"] should be changed `"L1A_CNT>Level-1A Histogram" -> "L1A_HIST>Level-1A Histogram"`
- Add sensor string to l1a HIST and HK products
- File_naming_convention not found in imap_hi_l1a_45sensor-de_20230927_v001.cdf

closes #630 

## Overview
Minor CDF tweaks prior to SIT-3

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/cdf/config/imap_hi_variable_attrs.yaml
   - Make epoch variable attributes more consistent
- imap_processing/hi/hi_cdf_attrs.py
   - Add sensor fields to l1a hist and hk Logical_source descriptors
- imap_processing/hi/l1a/hi_l1a.py
   - Format Logical_source in common location for any l1a processing
- imap_processing/hi/l1a/science_direct_event.py
   - remove DE specific formatting of Logical_source
- imap_processing/tests/hi/test_l1a.py
   - adjust tests based on update Logical_source values
- imap_processing/tests/hi/test_l1a_sci_de.py
   - adjust tests based on change in where Logical_source values get updated
- imap_processing/tests/hit/test_hit_l1b.py
   - remove scope from dependency fixture to keep file from being written outside tmp_path

## Testing

