### PR TITLE
Add Hi sensor name to imap_hi_l1b_hk products

### DIFF
--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -26,6 +26,12 @@ imap_hi_l1b_de_attrs:
     Logical_source: imap_hi_l1b_{sensor}-de
     Logical_source_description: IMAP-Hi Instrument Level-1B Direct Event Data.
 
+imap_hi_l1b_hk_attrs:
+    Data_level: 1B
+    Data_type: L1B_HK>Level-1B Housekeeping
+    Logical_source: imap_hi_l1b_{sensor}-hk
+    Logical_source_description: IMAP-Hi Instrument Level-1B Housekeeping Data.
+
 imap_hi_l1c_pset_attrs:
     Data_level: 1C
     Data_type: L1C_PSET>Level-1C Pointing Set

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -2,7 +2,6 @@
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import write_cdf
-from imap_processing.hi.hi_cdf_attrs import hi_hk_l1b_global_attrs
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.l1b.hi_l1b import hi_l1b
 from imap_processing.hi.utils import HIAPID
@@ -19,7 +18,7 @@ def test_hi_l1b_hk():
     l1a_cdf_path = write_cdf(processed_data[0])
 
     l1b_dataset = hi_l1b(l1a_cdf_path, data_version=data_version)
-    assert l1b_dataset.attrs["Logical_source"] == hi_hk_l1b_global_attrs.logical_source
+    assert l1b_dataset.attrs["Logical_source"] == "imap_hi_l1b_45sensor-hk"
 
 
 def test_hi_l1b_de(create_de_data, tmp_path):


### PR DESCRIPTION
# Change Summary
Fixes missing sensor name in Hi l1b housekeeping file

## Overview

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
- imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
   - Add hi_l1b_hk global attributes entry
- imap_processing/hi/l1b/hi_l1b.py
   - Convert l1b hk to use CDF attribute manager
   - Move Logical_source update to common l1b location
- imap_processing/tests/hi/test_hi_l1b.py
   - Update test value for l1b_hk Logical_source

## Testing
Test updated with new Logical_source value

closes #632 