### PR TITLE
MNT: Add optional descriptor field to the cli

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -63,6 +63,7 @@ def _parse_args():
     The expected input format is:
     --instrument "mag"
     --data-level "l1a"
+    --descriptor "all"
     --start-date "20231212"
     --version "v001"
     --dependency "[
@@ -85,6 +86,7 @@ def _parse_args():
         "for a specific instrument and data level. Example usage: "
         '"imap_cli --instrument "mag" '
         '--data-level "l1a"'
+        '--descriptor "all"'
         ' --start-date "20231212"'
         '--version "v001"'
         '--dependency "['
@@ -102,6 +104,10 @@ def _parse_args():
     level_help = (
         "The data level to process. Acceptable values are: "
         f"{imap_processing.PROCESSING_LEVELS}"
+    )
+    descriptor_help = (
+        "The descriptor of the product to process. This could be 'all' or a specific "
+        "descriptor like 'sci-1min'. Default is 'all'."
     )
     dependency_help = (
         "Dependency information in str format."
@@ -138,6 +144,11 @@ def _parse_args():
     )
     parser.add_argument("--instrument", type=str, required=True, help=instrument_help)
     parser.add_argument("--data-level", type=str, required=True, help=level_help)
+    # TODO: unused for now, but needed for batch job handling
+    # pass through of status in AWS
+    parser.add_argument(
+        "--descriptor", type=str, required=False, help=descriptor_help, default="all"
+    )
 
     parser.add_argument(
         "--start-date",


### PR DESCRIPTION
# Change Summary

## Overview

This adds the `descriptor` field as an optional command line argument. It is needed for when the indexer lambda tries to update the status table, where the status table has a `descriptor` field. The `descriptor` can be `all` and doesn't get used currently. TBD on whether we want to use it or not.

Worked/debugged with @tech3371 who needed this update for her work in `sds-data-manager`.