### PR TITLE
Add back Lo Data Version input for lo_l1c in cli.py

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -546,7 +546,7 @@ class Lo(ProcessInstrument):
             for dependency in dependencies:
                 dataset = load_cdf(dependency, to_datetime=True)
                 data_dict[dataset.attrs["Logical_source"]] = dataset
-            output_file = lo_l1c.lo_l1c(data_dict)
+            output_file = lo_l1c.lo_l1c(data_dict, self.version)
             return [output_file]
 
 


### PR DESCRIPTION
# Change Summary

## Overview
Added data version back as an input to lo_l1c

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
- cli.py
   - added data_version back as an input to lo_l1c()

## Testing
Ran unit test and cli
