### PR TITLE
FIX: CLI help needs to be strings not tuples

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -91,11 +91,11 @@ def _parse_args():
         '--version "v001"'
         '--dependency "['
         '   {"instrument": "mag",'
-        '   "data_level": "l0"',
-        '   "descriptor": "sci"',
-        '   "version": "v001"',
-        '   "start_date": "20231212"',
-        '}]" --upload-to-sdc"',
+        '   "data_level": "l0",'
+        '   "descriptor": "sci",'
+        '   "version": "v001",'
+        '   "start_date": "20231212"'
+        '}]" --upload-to-sdc"'
     )
     instrument_help = (
         "The instrument to process. Acceptable values are: "


### PR DESCRIPTION

# Change Summary

## Overview
The commas need to be inside the strings not outside for the help text to render in the CLI.

Before the cli would crash when calling the help, now it prints out the help message.
```bash
imap_cli -h
```