### PR TITLE
MNT: Pass around dataset objects rather than file objects

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -21,6 +21,7 @@ from typing import final
 from urllib.error import HTTPError
 
 import imap_data_access
+import xarray as xr
 
 import imap_processing
 from imap_processing.cdf.utils import load_cdf, write_cdf
@@ -372,19 +373,22 @@ class ProcessInstrument(ABC):
         """
         raise NotImplementedError
 
-    def post_processing(self, products: list[str]):
+    def post_processing(self, datasets: list[xr.Dataset]):
         """
         Complete post-processing.
 
-        Default post-processing consists of uploading newly generated products
-        to the IMAP SDC. Child classes can override this method to customize the
+        Default post-processing consists of writing the datasets to local storage
+        and then uploading those newly generated products to the IMAP SDC.
+        Child classes can override this method to customize the
         post-processing actions.
 
         Parameters
         ----------
-        products : list[str]
-            A list of file paths (products) produced by do_processing method.
+        datasets : list[xarray.Dataset]
+            A list of datasets (products) produced by do_processing method.
         """
+        logger.info("Writing products to local storage")
+        products = [write_cdf(dataset) for dataset in datasets]
         self.upload_products(products)
 
 
@@ -415,8 +419,7 @@ class Codice(ProcessInstrument):
                 )
             # process data
             dataset = codice_l1a.process_codice_l1a(dependencies[0], self.version)
-            cdf_file_path = dataset.attrs["cdf_filename"]
-            return [cdf_file_path]
+            return [dataset]
 
         if self.data_level == "l1b":
             if len(dependencies) > 1:
@@ -425,9 +428,9 @@ class Codice(ProcessInstrument):
                     f"{dependencies}. Expected only one dependency."
                 )
             # process data
-            dataset = codice_l1b.process_codice_l1b(dependencies[0], self.version)
-            cdf_file_path = dataset.attrs["cdf_filename"]
-            return [cdf_file_path]
+            dependency = load_cdf(dependencies[0])
+            dataset = codice_l1b.process_codice_l1b(dependency, self.version)
+            return [dataset]
 
 
 class Glows(ProcessInstrument):
@@ -448,7 +451,6 @@ class Glows(ProcessInstrument):
             List of products.
         """
         print(f"Processing GLOWS {self.data_level}")
-        products = []
         if self.data_level == "l1a":
             if len(dependencies) > 1:
                 raise ValueError(
@@ -456,7 +458,6 @@ class Glows(ProcessInstrument):
                     f"{dependencies}. Expected only one input dependency."
                 )
             datasets = glows_l1a(dependencies[0], self.version)
-            products = [write_cdf(dataset) for dataset in datasets]
 
         if self.data_level == "l1b":
             if len(dependencies) < 1:
@@ -465,10 +466,9 @@ class Glows(ProcessInstrument):
                     f"{dependencies}. Expected at least one input dependency."
                 )
             input_dataset = load_cdf(dependencies[0])
-            dataset = glows_l1b(input_dataset, self.version)
-            products = [write_cdf(dataset)]
+            datasets = [glows_l1b(input_dataset, self.version)]
 
-        return products
+        return datasets
 
 
 class Hi(ProcessInstrument):
@@ -498,18 +498,17 @@ class Hi(ProcessInstrument):
                     f"{dependencies}. Expected only one dependency."
                 )
             datasets = hi_l1a.hi_l1a(dependencies[0], self.version)
-            products = [write_cdf(dataset) for dataset in datasets]
         elif self.data_level == "l1b":
-            dataset = hi_l1b.hi_l1b(dependencies[0], self.version)
-            products = [write_cdf(dataset)]
+            dependencies = [load_cdf(dependency) for dependency in dependencies]
+            datasets = [hi_l1b.hi_l1b(dependencies[0], self.version)]
         elif self.data_level == "l1c":
-            dataset = hi_l1c.hi_l1c(dependencies, self.version)
-            products = [write_cdf(dataset)]
+            dependencies = [load_cdf(dependency) for dependency in dependencies]
+            datasets = [hi_l1c.hi_l1c(dependencies, self.version)]
         else:
             raise NotImplementedError(
                 f"Hi processing not implemented for level {self.data_level}"
             )
-        return products
+        return datasets
 
 
 class Hit(ProcessInstrument):
@@ -580,9 +579,7 @@ class Idex(ProcessInstrument):
                 )
             # read CDF file
             processed_data = PacketParser(dependencies[0], self.version).data
-            cdf_file_path = write_cdf(processed_data)
-            print(f"processed file path: {cdf_file_path}")
-            return [cdf_file_path]
+            return [processed_data]
 
 
 class Lo(ProcessInstrument):
@@ -612,24 +609,24 @@ class Lo(ProcessInstrument):
                     f"Unexpected dependencies found for IMAP-Lo L1A:"
                     f"{dependencies}. Expected only one dependency."
                 )
-            output_files = lo_l1a.lo_l1a(dependencies[0], self.version)
-            return [output_files]
+            dataset = lo_l1a.lo_l1a(dependencies[0], self.version)
+            return [dataset]
 
         elif self.data_level == "l1b":
             data_dict = {}
             for dependency in dependencies:
                 dataset = load_cdf(dependency, to_datetime=True)
                 data_dict[dataset.attrs["Logical_source"]] = dataset
-            output_file = lo_l1b.lo_l1b(data_dict, self.version)
-            return [output_file]
+            dataset = lo_l1b.lo_l1b(data_dict, self.version)
+            return [dataset]
 
         elif self.data_level == "l1c":
             data_dict = {}
             for dependency in dependencies:
                 dataset = load_cdf(dependency, to_datetime=True)
                 data_dict[dataset.attrs["Logical_source"]] = dataset
-            output_file = lo_l1c.lo_l1c(data_dict, self.version)
-            return [output_file]
+            dataset = lo_l1c.lo_l1c(data_dict, self.version)
+            return [dataset]
 
 
 class Mag(ProcessInstrument):
@@ -658,8 +655,8 @@ class Mag(ProcessInstrument):
                     f"Unexpected dependencies found for MAG L1A:"
                     f"{dependencies}. Expected only one dependency."
                 )
-            output_files = mag_l1a(dependencies[0], data_version=self.version)
-            return output_files
+            datasets = mag_l1a(dependencies[0], data_version=self.version)
+            return datasets
 
         if self.data_level == "l1b":
             if len(dependencies) > 1:
@@ -669,8 +666,7 @@ class Mag(ProcessInstrument):
                 )
             input_data = load_cdf(dependencies[0])
             output_dataset = mag_l1b(input_data, self.version)
-            output_files = write_cdf(output_dataset)
-            return [output_files]
+            return [output_dataset]
 
         if self.data_level == "l1c":
             # L1C depends on matching norm/burst files: eg burst-magi and norm-magi or
@@ -684,8 +680,7 @@ class Mag(ProcessInstrument):
             input_data = [load_cdf(dep) for dep in dependencies]
             # Input datasets can be in any order
             output_dataset = mag_l1c(input_data[0], input_data[1], self.version)
-            output_files = write_cdf(output_dataset)
-            return [output_files]
+            return [output_dataset]
 
 
 class Swapi(ProcessInstrument):
@@ -714,10 +709,8 @@ class Swapi(ProcessInstrument):
                     f"{dependencies}. Expected only one dependency."
                 )
             # process data
-            processed_data = swapi_l1(dependencies[0], self.version)
-            # Write all processed data to CDF files
-            products = [write_cdf(dataset) for dataset in processed_data]
-            return products
+            datasets = swapi_l1(dependencies[0], self.version)
+            return datasets
 
 
 class Swe(ProcessInstrument):
@@ -745,12 +738,10 @@ class Swe(ProcessInstrument):
                     f"Unexpected dependencies found for SWE L1A:"
                     f"{dependencies}. Expected only one dependency."
                 )
-            processed_data = swe_l1a(Path(dependencies[0]), data_version=self.version)
+            dataset = swe_l1a(Path(dependencies[0]), data_version=self.version)
             # Right now, we only process science data. Therefore,
             # we expect only one dataset to be returned.
-            cdf_file_path = write_cdf(processed_data)
-            print(f"processed file path: {cdf_file_path}")
-            return [cdf_file_path]
+            return [dataset]
 
         elif self.data_level == "l1b":
             if len(dependencies) > 1:
@@ -760,10 +751,8 @@ class Swe(ProcessInstrument):
                 )
             # read CDF file
             l1a_dataset = load_cdf(dependencies[0])
-            processed_data = swe_l1b(l1a_dataset, data_version=self.version)
-            cdf_file_path = write_cdf(processed_data)
-            print(f"processed file path: {cdf_file_path}")
-            return [cdf_file_path]
+            dataset = swe_l1b(l1a_dataset, data_version=self.version)
+            return [dataset]
         else:
             print("Did not recognize data level. No processing done.")
 
@@ -796,24 +785,21 @@ class Ultra(ProcessInstrument):
                 )
 
             datasets = ultra_l1a.ultra_l1a(dependencies[0], self.version)
-            products = [write_cdf(dataset) for dataset in datasets]
-            return products
+            return datasets
         elif self.data_level == "l1b":
             data_dict = {}
             for dependency in dependencies:
                 dataset = load_cdf(dependency)
                 data_dict[dataset.attrs["Logical_source"]] = dataset
             datasets = ultra_l1b.ultra_l1b(data_dict, self.version)
-            products = [write_cdf(dataset) for dataset in datasets]
-            return products
+            return datasets
         elif self.data_level == "l1c":
             data_dict = {}
             for dependency in dependencies:
                 dataset = load_cdf(dependency)
                 data_dict[dataset.attrs["Logical_source"]] = dataset
             datasets = ultra_l1c.ultra_l1c(data_dict, self.version)
-            products = [write_cdf(dataset) for dataset in datasets]
-            return products
+            return datasets
 
 
 def main():

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -525,8 +525,8 @@ class Hit(ProcessInstrument):
 
         Returns
         -------
-        products : list
-            List of products.
+        datasets : list
+            List of datasets.
         """
         print(f"Processing HIT {self.data_level}")
 
@@ -537,8 +537,8 @@ class Hit(ProcessInstrument):
                     f"{dependencies}. Expected only one dependency."
                 )
             # process data and write all processed data to CDF files
-            products = hit_l1a(dependencies[0], self.version)
-            return products
+            datasets = hit_l1a(dependencies[0], self.version)
+            return datasets
 
         elif self.data_level == "l1b":
             if len(dependencies) > 1:
@@ -548,8 +548,8 @@ class Hit(ProcessInstrument):
                 )
             # process data and write all processed data to CDF files
             l1a_dataset = load_cdf(dependencies[0])
-            products = hit_l1b(l1a_dataset, self.version)
-            return products
+            datasets = hit_l1b(l1a_dataset, self.version)
+            return datasets
 
 
 class Idex(ProcessInstrument):
@@ -578,8 +578,8 @@ class Idex(ProcessInstrument):
                     f"{dependencies}. Expected only one dependency."
                 )
             # read CDF file
-            processed_data = PacketParser(dependencies[0], self.version).data
-            return [processed_data]
+            dataset = PacketParser(dependencies[0], self.version).data
+            return [dataset]
 
 
 class Lo(ProcessInstrument):
@@ -665,8 +665,8 @@ class Mag(ProcessInstrument):
                     f"{dependencies}. Expected only one dependency."
                 )
             input_data = load_cdf(dependencies[0])
-            output_dataset = mag_l1b(input_data, self.version)
-            return [output_dataset]
+            dataset = mag_l1b(input_data, self.version)
+            return [dataset]
 
         if self.data_level == "l1c":
             # L1C depends on matching norm/burst files: eg burst-magi and norm-magi or
@@ -679,8 +679,8 @@ class Mag(ProcessInstrument):
 
             input_data = [load_cdf(dep) for dep in dependencies]
             # Input datasets can be in any order
-            output_dataset = mag_l1c(input_data[0], input_data[1], self.version)
-            return [output_dataset]
+            dataset = mag_l1c(input_data[0], input_data[1], self.version)
+            return [dataset]
 
 
 class Swapi(ProcessInstrument):

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -22,7 +22,7 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.cdf.utils import calc_start_time, write_cdf
+from imap_processing.cdf.utils import calc_start_time
 from imap_processing.codice import constants
 from imap_processing.codice.codice_l0 import decom_packets
 from imap_processing.codice.utils import CODICEAPID, create_hskp_dataset
@@ -429,7 +429,5 @@ def process_codice_l1a(file_path: Path | str, data_version: str) -> xr.Dataset:
 
     # Write dataset to CDF
     logger.info(f"\nFinal data product:\n{dataset}\n")
-    dataset.attrs["cdf_filename"] = write_cdf(dataset)
-    logger.info(f"\tCreated CDF file: {dataset.cdf_filename}")
 
     return dataset

--- a/imap_processing/codice/codice_l1b.py
+++ b/imap_processing/codice/codice_l1b.py
@@ -11,12 +11,10 @@ dataset = process_codice_l1b(l1a_file)
 """
 
 import logging
-from pathlib import Path
 
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.cdf.utils import load_cdf, write_cdf
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -154,14 +152,14 @@ def create_science_dataset(
     return l1b_dataset
 
 
-def process_codice_l1b(file_path: Path, data_version: str) -> xr.Dataset:
+def process_codice_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     """
     Will process CoDICE l1a data to create l1b data products.
 
     Parameters
     ----------
-    file_path : pathlib.Path | str
-        Path to the CoDICE L1a file to process.
+    l1a_dataset : xarray.Dataset
+        CoDICE L1a dataset to process.
     data_version : str
         Version of the data product being created.
 
@@ -170,10 +168,7 @@ def process_codice_l1b(file_path: Path, data_version: str) -> xr.Dataset:
     l1b_dataset : xarray.Dataset
         The``xarray`` dataset containing the science data and supporting metadata.
     """
-    logger.info(f"\nProcessing {file_path.name} file.")
-
-    # Load the L1a CDF
-    l1a_dataset = load_cdf(file_path)
+    logger.info(f"\nProcessing {l1a_dataset.attrs['Logical_source']}.")
 
     # Start constructing l1b dataset
     cdf_attrs = ImapCdfAttributes()
@@ -193,7 +188,5 @@ def process_codice_l1b(file_path: Path, data_version: str) -> xr.Dataset:
 
     # Write the dataset to CDF
     logger.info(f"\nFinal data product:\n{l1b_dataset}\n")
-    l1b_dataset.attrs["cdf_filename"] = write_cdf(l1b_dataset)
-    logger.info(f"\tCreated CDF file: {l1b_dataset.cdf_filename}")
 
     return l1b_dataset

--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -1,14 +1,12 @@
 """IMAP-HI L1B processing module."""
 
 import logging
-from pathlib import Path
 
 import numpy as np
 import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
-from imap_processing.cdf.utils import load_cdf
 from imap_processing.hi.utils import HIAPID
 from imap_processing.utils import convert_raw_to_eu
 
@@ -18,14 +16,14 @@ CDF_MANAGER.load_global_attributes("imap_hi_global_cdf_attrs.yaml")
 CDF_MANAGER.load_variable_attributes("imap_hi_variable_attrs.yaml")
 
 
-def hi_l1b(l1a_cdf_path: Path, data_version: str):
+def hi_l1b(l1a_dataset: xr.Dataset, data_version: str):
     """
     High level IMAP-HI L1B processing function.
 
     Parameters
     ----------
-    l1a_cdf_path : pathlib.Path
-        Path to L1A CDF file.
+    l1a_dataset : xarray.Dataset
+        L1A dataset to process.
     data_version : str
         Version of the data product being created.
 
@@ -34,8 +32,9 @@ def hi_l1b(l1a_cdf_path: Path, data_version: str):
     l1b_dataset : xarray.Dataset
         Processed xarray dataset.
     """
-    logger.info(f"Running Hi L1B processing on file: {l1a_cdf_path.name}")
-    l1a_dataset = load_cdf(l1a_cdf_path)
+    logger.info(
+        f"Running Hi L1B processing on dataset: {l1a_dataset.attrs['Logical_source']}"
+    )
     logical_source_parts = l1a_dataset.attrs["Logical_source"].split("_")
     # TODO: apid is not currently stored in all L1A data but should be.
     #    Use apid to determine what L1B processing function to call

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -9,7 +9,6 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
-from imap_processing.cdf.utils import load_cdf
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +39,8 @@ def hi_l1c(dependencies: list, data_version: str):
     logger.info("Running Hi l1c processing")
 
     # TODO: I am not sure what the input for Goodtimes will be so for now,
-    #    If the input is a CDF, do pset processing
-    if len(dependencies) == 1 and str(dependencies[0]).endswith("cdf"):
+    #    If the input is an xarray Dataset, do pset processing
+    if len(dependencies) == 1 and isinstance(dependencies[0], xr.Dataset):
         l1c_dataset = generate_pset_dataset(dependencies[0])
     else:
         raise NotImplementedError(
@@ -53,21 +52,20 @@ def hi_l1c(dependencies: list, data_version: str):
     return l1c_dataset
 
 
-def generate_pset_dataset(l1b_de_path: Union[Path, str]) -> xr.Dataset:
+def generate_pset_dataset(de_dataset: Union[Path, str]) -> xr.Dataset:
     """
     Will process IMAP-Hi l1b product into a l1c pset xarray dataset.
 
     Parameters
     ----------
-    l1b_de_path : Union[Path, str]
-        Location of IMAP-Hi l1b de product.
+    de_dataset : xarray.Dataset
+        IMAP-Hi l1b de product.
 
     Returns
     -------
     pset_dataset : xarray.Dataset
         Ready to be written to CDF.
     """
-    de_dataset = load_cdf(l1b_de_path)
     sensor_str = de_dataset.attrs["Logical_source"].split("_")[-1].split("-")[0]
     n_esa_step = de_dataset.esa_step.data.size
     pset_dataset = allocate_pset_dataset(n_esa_step, sensor_str)

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -12,7 +12,6 @@ import xarray as xr
 
 from imap_processing import decom, imap_module_directory, utils
 from imap_processing.cdf.global_attrs import ConstantCoordinates
-from imap_processing.cdf.utils import write_cdf
 from imap_processing.hit import hit_cdf_attrs
 from imap_processing.hit.l0.data_classes.housekeeping import Housekeeping
 
@@ -76,16 +75,10 @@ def hit_l1a(packet_file: typing.Union[Path, str], data_version: str):
     ]
     datasets = create_datasets(grouped_data, skip_keys)
 
-    # Create CDF files
-    logger.info("Creating CDF files for HIT L1A data")
-    cdf_filepaths = []
     for dataset in datasets.values():
         # TODO: update to use the add_global_attribute() function
         dataset.attrs["Data_version"] = data_version
-        cdf_file = write_cdf(dataset)
-        cdf_filepaths.append(cdf_file)
-    logger.info(f"L1A CDF files created: {cdf_filepaths}")
-    return cdf_filepaths
+    return list(datasets.values())
 
 
 def decom_packets(packet_file: str):

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -8,7 +8,6 @@ import xarray as xr
 
 from imap_processing import utils
 from imap_processing.cdf.global_attrs import ConstantCoordinates
-from imap_processing.cdf.utils import write_cdf
 from imap_processing.hit import hit_cdf_attrs
 from imap_processing.hit.l0.data_classes.housekeeping import Housekeeping
 
@@ -46,15 +45,9 @@ def hit_l1b(l1a_dataset: xr.Dataset, data_version: str):
         # process science data. placeholder for future code
         pass
 
-    # Create CDF files
-    logger.info("Creating CDF files for HIT L1B data")
-    cdf_filepaths = []
     for dataset in datasets:
         dataset.attrs["Data_version"] = data_version
-        cdf_file = write_cdf(dataset)
-        cdf_filepaths.append(cdf_file)
-    logger.info(f"L1B CDF files created: {cdf_filepaths}")
-    return cdf_filepaths
+    return datasets
 
 
 # TODO: This is going to work differently when we have sample data

--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.cdf.utils import calc_start_time, write_cdf
+from imap_processing.cdf.utils import calc_start_time
 from imap_processing.lo.l0.data_classes.science_direct_events import ScienceDirectEvents
 
 
@@ -70,8 +70,7 @@ def lo_l1a(dependency: Path, data_version: str):
         logical_source = "imap_lo_l1a_spin"
 
     dataset = create_datasets(attr_mgr, logical_source, data_fields)
-    create_file_paths = write_cdf(dataset)
-    return create_file_paths
+    return dataset
 
 
 # TODO: This is going to work differently when I sample data.

--- a/imap_processing/lo/l1a/lo_l1a_write_cdfs.py
+++ b/imap_processing/lo/l1a/lo_l1a_write_cdfs.py
@@ -4,7 +4,6 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.global_attrs import ConstantCoordinates
-from imap_processing.cdf.utils import write_cdf
 from imap_processing.lo.l0.lo_apid import LoAPID
 from imap_processing.lo.l1a import lo_cdf_attrs
 from imap_processing.lo.l1a.lo_data_container import LoContainer
@@ -25,18 +24,17 @@ def write_lo_l1a_cdfs(data: LoContainer):
     created_file_paths : list[Path]
         Location of created CDF files.
     """
-    created_filepaths = []
+    created_datasets = []
 
     # Write Science Direct Events CDF if available
     science_direct_events = data.filter_apid(LoAPID.ILO_SCI_DE.value)
     if science_direct_events:
         scide_dataset = create_lo_scide_dataset(science_direct_events)
-        cdf_file = write_cdf(scide_dataset)
-        created_filepaths.append(cdf_file)
+        created_datasets.append(scide_dataset)
 
     # TODO: Add the rest of the APIDS
 
-    return created_filepaths
+    return created_datasets
 
 
 def create_lo_scide_dataset(sci_de: list):

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.cdf.utils import calc_start_time, write_cdf
+from imap_processing.cdf.utils import calc_start_time
 
 
 def lo_l1b(dependencies: dict, data_version: str):
@@ -53,8 +53,7 @@ def lo_l1b(dependencies: dict, data_version: str):
         ]
 
     dataset = create_datasets(attr_mgr, logical_source, data_fields)
-    create_file_paths = write_cdf(dataset)
-    return create_file_paths
+    return dataset
 
 
 # TODO: This is going to work differently when I sample data.

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.cdf.utils import calc_start_time, write_cdf
+from imap_processing.cdf.utils import calc_start_time
 
 
 def lo_l1c(dependencies: dict, data_version: str):
@@ -54,8 +54,7 @@ def lo_l1c(dependencies: dict, data_version: str):
         ]
 
     dataset = create_datasets(attr_mgr, logical_source, data_fields)
-    create_file_paths = write_cdf(dataset)
-    return create_file_paths
+    return dataset
 
 
 # TODO: This is going to work differently when I sample data.

--- a/imap_processing/mag/l1a/mag_l1a.py
+++ b/imap_processing/mag/l1a/mag_l1a.py
@@ -7,7 +7,7 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.global_attrs import ConstantCoordinates
-from imap_processing.cdf.utils import calc_start_time, write_cdf
+from imap_processing.cdf.utils import calc_start_time
 from imap_processing.mag import mag_cdf_attrs
 from imap_processing.mag.l0 import decom_mag
 from imap_processing.mag.l0.mag_l0_data import MagL0
@@ -95,26 +95,19 @@ def process_and_write_data(
 
     mag_raw = decom_mag.generate_dataset(packet_data, raw_attrs)
 
-    filepath = write_cdf(mag_raw)
-    logger.info(f"Created RAW CDF file at {filepath}")
-
-    generated_files = [filepath]
+    generated_datasets = [mag_raw]
 
     l1a = process_packets(packet_data)
 
     for _, mago in l1a["mago"].items():
         norm_mago_output = generate_dataset(mago, mago_attrs)
-        filepath = write_cdf(norm_mago_output)
-        logger.info(f"Created L1a MAGo CDF file at {filepath}")
-        generated_files.append(filepath)
+        generated_datasets.append(norm_mago_output)
 
     for _, magi in l1a["magi"].items():
         norm_magi_output = generate_dataset(magi, magi_attrs)
-        filepath = write_cdf(norm_magi_output)
-        logger.info(f"Created L1a MAGi CDF file at {filepath}")
-        generated_files.append(filepath)
+        generated_datasets.append(norm_magi_output)
 
-    return generated_files
+    return generated_datasets
 
 
 def process_packets(

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -42,20 +42,20 @@ EXPECTED_ARRAY_SIZES = [
     18,  # lo-sw-species
     10,  # lo-nsw-species
 ]
-EXPECTED_FILENAMES = [
-    "imap_codice_l1a_hskp_20100101_v001.cdf",
-    "imap_codice_l1a_hi-counters-aggregated_20240429_v001.cdf",
-    "imap_codice_l1a_hi-counters-singles_20240429_v001.cdf",
-    "imap_codice_l1a_hi-omni_20240429_v001.cdf",
-    "imap_codice_l1a_hi-sectored_20240429_v001.cdf",
-    "imap_codice_l1a_lo-counters-aggregated_20240429_v001.cdf",
-    "imap_codice_l1a_lo-counters-singles_20240429_v001.cdf",
-    "imap_codice_l1a_lo-sw-angular_20240429_v001.cdf",
-    "imap_codice_l1a_lo-nsw-angular_20240429_v001.cdf",
-    "imap_codice_l1a_lo-sw-priority_20240429_v001.cdf",
-    "imap_codice_l1a_lo-nsw-priority_20240429_v001.cdf",
-    "imap_codice_l1a_lo-sw-species_20240429_v001.cdf",
-    "imap_codice_l1a_lo-nsw-species_20240429_v001.cdf",
+EXPECTED_LOGICAL_SOURCE = [
+    "imap_codice_l1a_hskp",
+    "imap_codice_l1a_hi-counters-aggregated",
+    "imap_codice_l1a_hi-counters-singles",
+    "imap_codice_l1a_hi-omni",
+    "imap_codice_l1a_hi-sectored",
+    "imap_codice_l1a_lo-counters-aggregated",
+    "imap_codice_l1a_lo-counters-singles",
+    "imap_codice_l1a_lo-sw-angular",
+    "imap_codice_l1a_lo-nsw-angular",
+    "imap_codice_l1a_lo-sw-priority",
+    "imap_codice_l1a_lo-nsw-priority",
+    "imap_codice_l1a_lo-sw-species",
+    "imap_codice_l1a_lo-nsw-species",
 ]
 TEST_PACKETS = [
     Path(
@@ -132,24 +132,24 @@ def test_l1a_data(request) -> xr.Dataset:
 
 
 @pytest.mark.parametrize(
-    "test_l1a_data, expected_filename",
-    list(zip(TEST_PACKETS, EXPECTED_FILENAMES)),
+    "test_l1a_data, expected_logical_source",
+    list(zip(TEST_PACKETS, EXPECTED_LOGICAL_SOURCE)),
     indirect=["test_l1a_data"],
 )
-def test_l1a_cdf_filenames(test_l1a_data: xr.Dataset, expected_filename: str):
-    """Tests that the ``process_codice_l1a`` function generates CDF files with
-    expected filenames.
+def test_l1a_cdf_filenames(test_l1a_data: xr.Dataset, expected_logical_source: str):
+    """Tests that the ``process_codice_l1a`` function generates datasets
+    with the expected logical source.
 
     Parameters
     ----------
     test_l1a_data : xarray.Dataset
         A ``xarray`` dataset containing the test data
-    expected_filename : str
+    expected_logical_source : str
         The expected CDF filename
     """
 
     dataset = test_l1a_data
-    assert dataset.cdf_filename.name == expected_filename
+    assert dataset.attrs["Logical_source"] == expected_logical_source
 
 
 @pytest.mark.xfail(

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -6,22 +6,23 @@ import pytest
 import xarray as xr
 
 from imap_processing import imap_module_directory
+from imap_processing.cdf.utils import load_cdf
 from imap_processing.codice.codice_l1b import process_codice_l1b
 
-EXPECTED_FILENAMES = [
-    "imap_codice_l1b_hskp_20100101_v001.cdf",
-    "imap_codice_l1b_hi-counters-aggregated_20240429_v001.cdf",
-    "imap_codice_l1b_hi-counters-singles_20240429_v001.cdf",
-    "imap_codice_l1b_hi-omni_20240429_v001.cdf",
-    "imap_codice_l1b_hi-sectored_20240429_v001.cdf",
-    "imap_codice_l1b_lo-counters-aggregated_20240429_v001.cdf",
-    "imap_codice_l1b_lo-counters-singles_20240429_v001.cdf",
-    "imap_codice_l1b_lo-sw-angular_20240429_v001.cdf",
-    "imap_codice_l1b_lo-nsw-angular_20240429_v001.cdf",
-    "imap_codice_l1b_lo-sw-priority_20240429_v001.cdf",
-    "imap_codice_l1b_lo-nsw-priority_20240429_v001.cdf",
-    "imap_codice_l1b_lo-sw-species_20240429_v001.cdf",
-    "imap_codice_l1b_lo-nsw-species_20240429_v001.cdf",
+EXPECTED_LOGICAL_SOURCE = [
+    "imap_codice_l1b_hskp",
+    "imap_codice_l1b_hi-counters-aggregated",
+    "imap_codice_l1b_hi-counters-singles",
+    "imap_codice_l1b_hi-omni",
+    "imap_codice_l1b_hi-sectored",
+    "imap_codice_l1b_lo-counters-aggregated",
+    "imap_codice_l1b_lo-counters-singles",
+    "imap_codice_l1b_lo-sw-angular",
+    "imap_codice_l1b_lo-nsw-angular",
+    "imap_codice_l1b_lo-sw-priority",
+    "imap_codice_l1b_lo-nsw-priority",
+    "imap_codice_l1b_lo-sw-species",
+    "imap_codice_l1b_lo-nsw-species",
 ]
 TEST_FILES = [
     Path(
@@ -75,19 +76,19 @@ def test_l1b_data(request) -> xr.Dataset:
     dataset : xr.Dataset
         A ``xarray`` dataset containing the test data
     """
-
-    dataset = process_codice_l1b(request.param, data_version="001")
+    input_dataset = load_cdf(request.param)
+    dataset = process_codice_l1b(input_dataset, data_version="001")
     return dataset
 
 
 @pytest.mark.parametrize(
-    "test_l1b_data, expected_filename",
-    list(zip(TEST_FILES, EXPECTED_FILENAMES)),
+    "test_l1b_data, expected_logical_source",
+    list(zip(TEST_FILES, EXPECTED_LOGICAL_SOURCE)),
     indirect=["test_l1b_data"],
 )
-def test_l1b_cdf_filenames(test_l1b_data: xr.Dataset, expected_filename: str):
-    """Tests that the ``process_codice_l1b`` function generates CDF files with
-    expected filenames.
+def test_l1b_cdf_filenames(test_l1b_data: xr.Dataset, expected_logical_source: str):
+    """Tests that the ``process_codice_l1b`` function generates datasets
+    with the expected logical source.
 
     Parameters
     ----------
@@ -98,4 +99,4 @@ def test_l1b_cdf_filenames(test_l1b_data: xr.Dataset, expected_filename: str):
     """
 
     dataset = test_l1b_data
-    assert dataset.cdf_filename.name == expected_filename
+    assert dataset.attrs["Logical_source"] == expected_logical_source

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -1,7 +1,6 @@
 """Test coverage for imap_processing.hi.l1b.hi_l1b.py"""
 
 from imap_processing import imap_module_directory
-from imap_processing.cdf.utils import write_cdf
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.l1b.hi_l1b import hi_l1b
 from imap_processing.hi.utils import HIAPID
@@ -15,9 +14,8 @@ def test_hi_l1b_hk():
     bin_data_path = test_path / "20231030_H45_APP_NHK.bin"
     data_version = "001"
     processed_data = hi_l1a(packet_file_path=bin_data_path, data_version=data_version)
-    l1a_cdf_path = write_cdf(processed_data[0])
 
-    l1b_dataset = hi_l1b(l1a_cdf_path, data_version=data_version)
+    l1b_dataset = hi_l1b(processed_data[0], data_version=data_version)
     assert l1b_dataset.attrs["Logical_source"] == "imap_hi_l1b_45sensor-hk"
 
 
@@ -29,8 +27,7 @@ def test_hi_l1b_de(create_de_data, tmp_path):
     bin_data_path = create_de_data(HIAPID.H45_SCI_DE.value)
     data_version = "001"
     processed_data = hi_l1a(packet_file_path=bin_data_path, data_version=data_version)
-    l1a_cdf_path = write_cdf(processed_data[0])
 
-    l1b_dataset = hi_l1b(l1a_cdf_path, data_version=data_version)
+    l1b_dataset = hi_l1b(processed_data[0], data_version=data_version)
     assert l1b_dataset.attrs["Logical_source"] == "imap_hi_l1b_45sensor-de"
     assert len(l1b_dataset.data_vars) == 14

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -6,7 +6,6 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
-from imap_processing.cdf.utils import write_cdf
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.l1b.hi_l1b import hi_l1b
 from imap_processing.hi.l1c import hi_l1c
@@ -19,11 +18,9 @@ def test_generate_pset_dataset(create_de_data):
     # For now, test using false de data run through l1a and l1b processing
     bin_data_path = create_de_data(HIAPID.H45_SCI_DE.value)
     processed_data = hi_l1a(bin_data_path, "002")
-    l1a_cdf_path = write_cdf(processed_data[0])
-    l1b_dataset = hi_l1b(l1a_cdf_path, "002")
-    l1b_cdf_path = write_cdf(l1b_dataset)
+    l1b_dataset = hi_l1b(processed_data[0], "002")
 
-    l1c_dataset = hi_l1c.generate_pset_dataset(l1b_cdf_path)
+    l1c_dataset = hi_l1c.generate_pset_dataset(l1b_dataset)
 
     assert l1c_dataset.epoch.data[0] == l1b_dataset.epoch.data[0]
 

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -1,5 +1,3 @@
-import pathlib
-
 import pytest
 import xarray as xr
 
@@ -85,10 +83,10 @@ def test_hit_l1a(packet_filepath):
     packet_filepath : str
         Path to ccsds file
     """
-    cdf_filepaths = hit_l1a.hit_l1a(packet_filepath, "001")
-    assert len(cdf_filepaths) == 1
-    assert isinstance(cdf_filepaths[0], pathlib.PurePath)
-    assert cdf_filepaths[0].name == "imap_hit_l1a_hk_20100105_v001.cdf"
+    datasets = hit_l1a.hit_l1a(packet_filepath, "001")
+    assert len(datasets) == 1
+    assert isinstance(datasets[0], xr.Dataset)
+    assert datasets[0].attrs["Logical_source"] == "imap_hit_l1a_hk"
 
 
 def test_total_datasets(unpacked_packets):

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -1,10 +1,7 @@
-import pathlib
-
 import pytest
 import xarray as xr
 
 from imap_processing import imap_module_directory
-from imap_processing.cdf.utils import load_cdf
 from imap_processing.hit.l1a import hit_l1a
 from imap_processing.hit.l1b import hit_l1b
 
@@ -14,7 +11,7 @@ def dependency():
     """Get L1A data from test packet file"""
 
     packet_filepath = imap_module_directory / "tests/hit/test_data/hskp_sample.ccsds"
-    l1a_data = load_cdf(hit_l1a.hit_l1a(packet_filepath, "001")[0])
+    l1a_data = hit_l1a.hit_l1a(packet_filepath, "001")[0]
 
     return l1a_data
 
@@ -40,7 +37,7 @@ def test_hit_l1b(dependency):
     dependency : xr.dataset
         L1A data
     """
-    cdf_filepaths = hit_l1b.hit_l1b(dependency, "001")
-    assert len(cdf_filepaths) == 1
-    assert isinstance(cdf_filepaths[0], pathlib.PurePath)
-    assert cdf_filepaths[0].name == "imap_hit_l1b_hk_20100101_v001.cdf"
+    datasets = hit_l1b.hit_l1b(dependency, "001")
+    assert len(datasets) == 1
+    assert isinstance(datasets[0], xr.Dataset)
+    assert datasets[0].attrs["Logical_source"] == "imap_hit_l1b_hk"

--- a/imap_processing/tests/lo/test_lo_l1a.py
+++ b/imap_processing/tests/lo/test_lo_l1a.py
@@ -6,18 +6,18 @@ from imap_processing.lo.l1a.lo_l1a import lo_l1a
 
 
 @pytest.mark.parametrize(
-    ("dependency", "expected_out"),
+    ("dependency", "expected_logical_source"),
     [
-        (Path("imap_lo_l0_de_20100101_v001.pkts"), "imap_lo_l1a_de_20100101_v001.cdf"),
+        (Path("imap_lo_l0_de_20100101_v001.pkts"), "imap_lo_l1a_de"),
         (
             Path("imap_lo_l0_spin_20100101_v001.pkt"),
-            "imap_lo_l1a_spin_20100101_v001.cdf",
+            "imap_lo_l1a_spin",
         ),
     ],
 )
-def test_lo_l1a(dependency, expected_out):
+def test_lo_l1a(dependency, expected_logical_source):
     # Act
-    output_file = lo_l1a(dependency, "001")
+    output_dataset = lo_l1a(dependency, "001")
 
     # Assert
-    assert expected_out == output_file.name
+    assert expected_logical_source == output_dataset.attrs["Logical_source"]

--- a/imap_processing/tests/lo/test_lo_l1a_write_cdfs.py
+++ b/imap_processing/tests/lo/test_lo_l1a_write_cdfs.py
@@ -85,6 +85,6 @@ def test_write_lo_l1a_cdfs(direct_events):
     lo_data.add(direct_events[0])
     lo_data.add(direct_events[1])
 
-    created_file_paths = write_lo_l1a_cdfs(lo_data)
+    created_datasets = write_lo_l1a_cdfs(lo_data)
 
-    assert created_file_paths[0].name == "imap_lo_l1a_scide_20240410_v001.cdf"
+    assert created_datasets[0].attrs["Logical_source"] == "imap_lo_l1a_scide"

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -19,12 +19,12 @@ def test_lo_l1b():
         dataset = load_cdf(file)
         data[dataset.attrs["Logical_source"]] = dataset
 
-    expected_out = "imap_lo_l1b_de_20100101_v001.cdf"
+    expected_logical_source = "imap_lo_l1b_de"
     # Act
     output_file = lo_l1b(data, "001")
 
     # Assert
-    assert expected_out == output_file.name
+    assert expected_logical_source == output_file.attrs["Logical_source"]
 
 
 def test_create_datasets():

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -17,12 +17,12 @@ def test_lo_l1c():
     dataset = load_cdf(de_file)
     data[dataset.attrs["Logical_source"]] = dataset
 
-    expected_out = "imap_lo_l1c_pset_20100101_v001.cdf"
+    expected_logical_source = "imap_lo_l1c_pset"
     # Act
-    output_file = lo_l1c(data, "001")
+    output_dataset = lo_l1c(data, "001")
 
     # Assert
-    assert expected_out == output_file.name
+    assert expected_logical_source == output_dataset.attrs["Logical_source"]
 
 
 def test_create_dataset():

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -16,12 +16,14 @@ def mock_instrument_dependencies():
         mock.patch("imap_processing.cli.imap_data_access.download") as mock_download,
         mock.patch("imap_processing.cli.imap_data_access.upload") as mock_upload,
         mock.patch("imap_processing.cli.write_cdf") as mock_write_cdf,
+        mock.patch("imap_processing.cli.load_cdf") as mock_load_cdf,
     ):
         mocks = {
             "mock_query": mock_query,
             "mock_download": mock_download,
             "mock_upload": mock_upload,
             "mock_write_cdf": mock_write_cdf,
+            "mock_load_cdf": mock_load_cdf,
         }
         yield mocks
 
@@ -114,6 +116,7 @@ def test_hi_l1(mock_instrument_dependencies, data_level, n_prods):
     mocks["mock_query"].return_value = [{"file_path": "/path/to/file0"}]
     mocks["mock_download"].return_value = "file0"
     mocks["mock_write_cdf"].side_effect = ["/path/to/file0", "/path/to/file1"]
+    mocks["mock_load_cdf"].return_value = xr.Dataset()
 
     # patch autospec=True makes this test confirm that the function call in cli.py
     # matches the mocked function signature.


### PR DESCRIPTION
# Change Summary

## Overview

This is a major update to use datasets as our primary objects that we pass around rather than paths to the datasets on disk. Rather than saving files to disk and writing cdf files in each individual instrument, we can save the CDF files in one common location (CLI) and then pass the datasets around to all of the processing functions.

Many updated files due to the thrashing nature of this change. The tests are now testing against "Logical_source" because we actually don't have the filename in the dataset until the write_cdf() routine. But that is tested already in write_cdf, so not necessary in each individual instrument.