### PR TITLE
662 migrate remaining hi products to use cdfattributemanager

### DIFF
--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -20,6 +20,18 @@ imap_hi_l1a_de_attrs:
     Logical_source: imap_hi_l1a_{sensor}-de
     Logical_source_description: IMAP-Hi Instrument Level-1A Direct Event Data.
 
+imap_hi_l1a_hist_attrs:
+    Data_level: 1A
+    Data_type: L1A_HIST>Level-1A Histogram
+    Logical_source: imap_hi_l1a_{sensor}-hist
+    Logical_source_description: IMAP-Hi Instrument Level-1A Histogram Data.
+
+imap_hi_l1a_hk_attrs:
+    Data_level: 1A
+    Data_type: L1A_HK>Level-1A Housekeeping
+    Logical_source: imap_hi_l1a_{sensor}-hk
+    Logical_source_description: IMAP-Hi Instrument Level-1A Housekeeping Data.
+
 imap_hi_l1b_de_attrs:
     Data_level: 1B
     Data_type: L1B_DE>Level-1B Direct Event

--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -26,12 +26,6 @@ imap_hi_l1a_hist_attrs:
     Logical_source: imap_hi_l1a_{sensor}-hist
     Logical_source_description: IMAP-Hi Instrument Level-1A Histogram Data.
 
-imap_hi_l1a_hk_attrs:
-    Data_level: 1A
-    Data_type: L1A_HK>Level-1A Housekeeping
-    Logical_source: imap_hi_l1a_{sensor}-hk
-    Logical_source_description: IMAP-Hi Instrument Level-1A Housekeeping Data.
-
 imap_hi_l1b_de_attrs:
     Data_level: 1B
     Data_type: L1B_DE>Level-1B Direct Event

--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -72,14 +72,31 @@ default_epoch: &default_epoch
   REFERENCE_POSITION: Rotating Earth Geoid
   dtype: int64
 
-# ------- L1A DE Section -------
-hi_de_ccsds_met:
+default_ccsds_met: &hi_ccsds_met
   <<: *default_uint32
   CATDESC: CCSDS mission elapsed time (MET). 32-bit integer value that represents the MET in seconds.
   FIELDNAM: Mission Elapsed Time(MET)
   LABLAXIS: CCSDS MET
   UNITS: sec
   VAR_TYPE: support_data
+
+hi_esa_stepping_num: &hi_esa_stepping_num
+  <<: *default_uint8
+  CATDESC: Zero based index indicates which row of onboard stepping table was used
+  FIELDNAM: ESA stepping number
+  FILLVAL: 255
+  FORMAT: I2
+  LABLAXIS: Stepping Num
+  VALIDMIN: 0
+  VALIDMAX: 16
+  VAR_NOTES: >
+    ESA (electrostatic analyzer) stepping number is 4-bit integer value that indicates
+    which row of the onboard stepping table was used to set voltages of the inner and
+    outer ESA surfaces.
+
+# ======= L1A DE Section =======
+hi_de_ccsds_met:
+  <<: *hi_ccsds_met
 
 hi_de_de_tag:
   <<: *default_uint16
@@ -92,18 +109,7 @@ hi_de_epoch:
   CATDESC: Direct Event time, number of nanoseconds since J2000 with leap seconds included
 
 hi_de_esa_stepping_num:
-  <<: *default_uint8
-  CATDESC: Zero based index indicates which row of onboard stepping table was used
-  FIELDNAM: ESA stepping number
-  FILLVAL: 255
-  FORMAT: I2
-  LABLAXIS: Stepping Num
-  VALIDMIN: 0
-  VALIDMAX: 16
-  VAR_NOTES: >
-    ESA (electrostatic analyzer) stepping number is 4-bit integer value that indicates
-    which row of the onboard stepping table was used to set voltages of the inner and
-    outter ESA surfaces.
+  <<: *hi_esa_stepping_num
 
 hi_de_event_met:
   <<: *default_uint64
@@ -171,7 +177,39 @@ hi_de_tof_3:
     Time of flight is 10-bit integer value that represents the time of flight of
     the direct event. 1023 is the value used to indicate no event was registered.
 
-# ------- L1B DE Section -------
+# ======= L1A HIST Section =======
+hi_hist_epoch:
+  <<: *default_epoch
+
+hi_hist_angle:
+  SCALE_TYPE: linear
+  CATDESC: Angle bin centers for histogram data.
+  FIELDNAM: ANGLE
+  FILLVAL: 65535
+  VALIDMIN: 0
+  VALIDMAX: 360
+  FORMAT: I3
+  UNITS: deg
+  LABLAXIS: ANGLE
+  VAR_TYPE: support_data
+  dtype: uint16
+
+hi_hist_ccsds_met:
+  <<: *hi_ccsds_met
+
+hi_hist_esa_stepping_num:
+  <<: *hi_esa_stepping_num
+
+hi_hist_counters:
+  <<: *default_uint16
+  CATDESC: Angular histogram of {counter_name} type events
+  FIELDNAM: "{counter_name} histogram"
+  VALIDMAX: 4095
+  DEPEND_1: angle
+  FORMAT: I4
+  LABLAXIS: "{counter_name}"
+
+# ======= L1B DE Section =======
 hi_de_coincidence_type:
   <<: *default_uint8
   CATDESC: Bitmap of detectors hit for Direct Event
@@ -278,7 +316,7 @@ hi_de_nominal_bin:
   VALIDMIN: 0
   VALIDMAX: 89
 
-# ------- L1C PSET Section -------
+# ======= L1C PSET Section =======
 hi_pset_epoch:
   <<: *default_epoch
 

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -4,9 +4,9 @@ import numpy as np
 import xarray as xr
 from space_packet_parser.parser import Packet
 
-from imap_processing.cdf.utils import met_to_j2000ns
 from imap_processing import imap_module_directory
 from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
+from imap_processing.cdf.utils import met_to_j2000ns
 
 # TODO: Verify that these names are OK for counter variables in the CDF
 # define the names of the 24 counter arrays

--- a/imap_processing/hi/l1a/science_direct_event.py
+++ b/imap_processing/hi/l1a/science_direct_event.py
@@ -6,7 +6,6 @@ from space_packet_parser.parser import Packet
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
-from imap_processing.cdf.global_attrs import ConstantCoordinates
 from imap_processing.cdf.utils import met_to_j2000ns
 
 # TODO: read LOOKED_UP_DURATION_OF_TICK from
@@ -274,7 +273,7 @@ def create_dataset(de_data_list: list, packet_met_time: list) -> xr.Dataset:
         data_dict.pop("epoch"),
         name="epoch",
         dims=["epoch"],
-        attrs=ConstantCoordinates.EPOCH,
+        attrs=cdf_manager.get_variable_attributes("hi_de_epoch"),
     )
 
     de_global_attrs = cdf_manager.get_global_attributes("imap_hi_l1a_de_attrs")

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -91,7 +91,7 @@ def test_allocate_histogram_dataset():
     assert dataset.sizes["angle"] == 90
     for var_name in (
         "ccsds_met",
-        "esa_step",
+        "esa_stepping_num",
         *hist.QUALIFIED_COUNTERS,
         *hist.LONG_COUNTERS,
         *hist.TOTAL_COUNTERS,


### PR DESCRIPTION
# Change Summary
Migration of Hi L1A hist and de processing to use CdfAttributeManager.
- hist needed total migration including variable attributes and global attributes
- de only needed to migrate the epoch attributes

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
- imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
   - add global attributes for hi_l1a_hist products
- imap_processing/cdf/config/imap_hi_variable_attrs.yaml
   - Add hi_l1a_hist variable attributes
   - Reorganize common variable attribute definition for `ccsds_met` and`esa_stepping_num`
- imap_processing/hi/l1a/histogram.py
   - Change from using hi_cdf_attrs to CdfAttributeManager
   - Modify how counter name is injected into counter variable attributes
- imap_processing/hi/l1a/science_direct_event.py
   - Use CdfAttributeManager for epoch attributes
- imap_processing/tests/hi/test_l1a.py
   - Update variable name from `esa_step` to `esa_stepping_num`. 

## Testing
The only testing change was to match the renaming of `esa_step` to `esa_stepping_num`

closes 662