### PR TITLE
Update Management of HIT CDF Attributes to use YAMLs

### DIFF
--- a/docs/source/code-documentation/cdf.rst
+++ b/docs/source/code-documentation/cdf.rst
@@ -1,0 +1,18 @@
+.. _cdf:
+
+CDF
+======
+
+.. currentmodule:: imap_processing.cdf
+
+This is the CDF module, which contains the code for creating CDF files.
+
+The code to manage CDF attributes for all instruments can be found below:
+
+.. autosummary::
+    :toctree: generated/
+    :template: autosummary.rst
+    :recursive:
+
+    cdf_attribute_manager
+    imap_cdf_manager

--- a/docs/source/code-documentation/cdf.rst
+++ b/docs/source/code-documentation/cdf.rst
@@ -9,10 +9,6 @@ This is the CDF module, which contains the code for creating CDF files.
 
 The code to manage CDF attributes for all instruments can be found below:
 
-.. autosummary::
-    :toctree: generated/
-    :template: autosummary.rst
-    :recursive:
-
-    cdf_attribute_manager
-    imap_cdf_manager
+.. automodule:: imap_processing.cdf.imap_cdf_manager
+    :members:
+    :undoc-members:

--- a/docs/source/code-documentation/index.rst
+++ b/docs/source/code-documentation/index.rst
@@ -25,6 +25,7 @@ Instruments
    swapi
    swe
    ultra
+   cdf
 
 Utility functions can be found in modules within the top package level.
 

--- a/imap_processing/cdf/cdf_attribute_manager.py
+++ b/imap_processing/cdf/cdf_attribute_manager.py
@@ -26,12 +26,12 @@ class CdfAttributeManager:
 
     To use, you can load one or many global and variable attribute files:
 
-    ```
-    cdf_attr_manager = CdfAttributeManager(data_dir)
-    cdf_attr_manager.load_global_attributes("global_attrs.yaml")
-    cdf_attr_manager.load_global_attributes("instrument_global_attrs.yaml")
-    cdf_attr_manager.load_variable_attributes("variable_attrs.yaml")
-    ```
+    .. code::
+
+        cdf_attr_manager = CdfAttributeManager(data_dir)
+        cdf_attr_manager.load_global_attributes("global_attrs.yaml")
+        cdf_attr_manager.load_global_attributes("instrument_global_attrs.yaml")
+        cdf_attr_manager.load_variable_attributes("variable_attrs.yaml")
 
     Later files will overwrite earlier files if the same attribute is defined.
 
@@ -41,23 +41,23 @@ class CdfAttributeManager:
     instrument_id. If this is not included, then only the attributes defined in the top
     level of the file are used.
 
-    ```
-    # Instrument ID is optional for refining the attributes used from the file
-    global_attrs = cdf_attr_manager.get_global_attributes(instrument_id)
-    variable_attrs = cdf_attr_manager.get_variable_attributes(variable_name)
-    ```
+    .. code::
+
+        # Instrument ID is optional for refining the attributes used from the file
+        global_attrs = cdf_attr_manager.get_global_attributes(instrument_id)
+        variable_attrs = cdf_attr_manager.get_variable_attributes(variable_name)
 
     The variable and global attributes are validated against the schemas upon calling
-    `get_global_attributes` and `get_variable_attributes`.
+    ``get_global_attributes`` and ``get_variable_attributes``.
 
     Parameters
     ----------
-    data_dir : Path
+    data_dir : pathlib.Path
         The directory containing the schema and variable files (nominally config/).
 
     Attributes
     ----------
-    source_dir : Path
+    source_dir : pathlib.Path
         The directory containing the schema and variable files - nominally config/
     """
 

--- a/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
@@ -1,0 +1,27 @@
+instrument_base: &instrument_base
+  Descriptor: &desc
+    HIT>IMAP High-energy Ion Telescope
+  TEXT: &txt >
+    The High-energy Ion Telescope (HIT) measures the elemental composition, energy spectra,
+    angle distributions, and arrival times of high-energy ions. HIT delivers full-sky
+    coverage from a wide instrument field-of-view (FOV) to enable a high resolution of ion
+    measurements, such as observing shock-accelerated ions, determining the origin of the
+    solar energetic particles (SEPs) spectra, and resolving particle transport in the
+    heliosphere. See https://imap.princeton.edu/instruments/hit for more details.
+  Instrument_type: Particles (space)
+
+  # L1a
+imap_hit_l1a_hk:
+    <<: *instrument_base
+    Data_level: 1A
+    Data_type: L1A_HK>Level-1A Housekeeping
+    Logical_source: imap_hit_l1a_hk
+    Logical_source_description: IMAP Mission HIT Instrument Level-1A Housekeeping Data.
+
+  # L1b
+imap_hit_l1b_hk:
+    <<: *instrument_base
+    Data_level: 1B
+    Data_type: L1B_HK>Level-1B Housekeeping
+    Logical_source: imap_hit_l1b_hk
+    Logical_source_description: IMAP Mission HIT Instrument Level-1B Housekeeping Data.

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -1,0 +1,494 @@
+# <=== Defaults ===>
+# Assumed values for all variable attrs unless overwritten
+default_attrs: &default
+  DEPEND_0: epoch
+  DISPLAY_TYPE: time_series
+  FILLVAL: -9223372036854775808
+  FORMAT: I12
+  VALIDMIN: 0
+  VALIDMAX: 9223372036854775807
+  VAR_TYPE: data
+  UNITS: ' '
+  SCALETYP: linear
+
+hk_support_attrs: &support_default
+  <<: *default
+  DISPLAY_TYPE: no_plot
+  VAR_TYPE: ignore_data
+
+# <=== Coordinates ===>
+epoch:
+  CATDESC: Time, number of nanoseconds since J2000 with leap seconds included
+  FIELDNAM: epoch
+  LABLAXIS: epoch
+  FILLVAL: -9223372036854775808
+  FORMAT: " " # Supposedly not required, fails in xarray_to_cdf
+  VALIDMIN: -9223372036854775808
+  VALIDMAX: 9223372036854775807
+  UNITS: ns
+  VAR_TYPE: support_data
+  SCALETYP: linear
+  MONOTON: INCREASE
+  TIME_BASE: J2000
+  TIME_SCALE: Terrestrial Time
+  REFERENCE_POSITION: Rotating Earth Geoid
+
+adc_channels:   # adc_channels is a dependency for leak_i data variable
+  <<: *support_default
+  VALIDMIN: 0
+  VALIDMAX: 63
+  VAR_TYPE: metadata
+  CATDESC: ADC Channel
+  FIELDNAM: ADC Channel
+  LABLAXIS: Channel
+  FORMAT: I2
+
+
+# <=== Data Variable Attributes ===>
+#TODO is DEPEND_0 needed for no_plot variables in housekeeping?
+
+fsw_version_a:
+  <<: *support_default
+  VALIDMAX: 3
+  CATDESC: Flight Software Version Number (A.B.C bits)
+  FIELDNAM: Flight Software Version Number A
+  LABLAXIS: FSW A
+  FORMAT: I1
+
+fsw_version_b:
+  <<: *support_default
+  VALIDMAX: 15
+  CATDESC: Flight Software Version Number (A.B.C bits)
+  FIELDNAM: Flight Software Version Number B
+  FLABLAXIS: FSW B
+  FORMAT: I2
+
+fsw_version_c:
+  <<: *support_default
+  VALIDMAX: 63
+  CATDESC: Flight Software Version Number (A.B.C bits)
+  FIELDNAM: Flight Software Version Number C
+  FLABLAXIS: FSW C
+  FORMAT: I2
+
+num_good_cmds:
+  <<: *support_default
+  VALIDMAX: 255
+  CATDESC: Number of Good Commands
+  FIELDNAM: Number of Good Commands
+  FLABLAXIS: Counts
+  FORMAT: I3
+
+last_good_cmd:
+  <<: *support_default
+  VALIDMAX: 255
+  CATDESC: Last Good Command
+  FIELDNAM: Last Good Command
+  FLABLAXIS: Last cmd
+  FORMAT: I3
+
+last_good_seq_num:
+  <<: *support_default
+  VALIDMAX: 255
+  CATDESC: Last Good Sequence Number
+  FIELDNAM: Last Good Sequence Number
+  FLABLAXIS: Last num
+  FORMAT: I3
+
+num_bad_cmds:
+  <<: *support_default
+  VALIDMAX: 255
+  CATDESC: Number of Bad Commands
+  FIELDNAM: Number of Bad Commands
+  FLABLAXIS: Counts
+  FORMAT: I3
+
+last_bad_cmd:
+  <<: *support_default
+  VALIDMAX: 255
+  CATDESC: Last Bad Command
+  FIELDNAM: Last Bad Command
+  FLABLAXIS: Last cmd
+  FORMAT: I3
+
+last_bad_seq_num:
+  <<: *support_default
+  VALIDMAX: 255
+  CATDESC: Last Bad Sequence Number
+  FIELDNAM: Last Bad Sequence Number
+  FLABLAXIS: Last num
+  FORMAT: I3
+
+fee_running:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - FEE Running (1) or Reset (0)
+  FIELDNAM: FEE Running (1) or Reset (0)
+  FLABLAXIS: State
+  FORMAT: I1
+
+mram_disabled:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - MRAM Disabled (1) or Enabled (0)
+  FIELDNAM: MRAM Disabled (1) or Enabled (0)
+  FLABLAXIS: State
+  FORMAT: I1
+
+enable_50khz:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - 50kHz Enabled (1) or Disabled (0)
+  FIELDNAM: 50kHz Enabled (1) or Disabled (0)
+  FLABLAXIS: State
+  FORMAT: I1
+
+enable_hvps:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - HVPS Enabled (1) or Disabled (0)
+  FIELDNAM: HVPS Enabled (1) or Disabled (0)
+  FLABLAXIS: State
+  FORMAT: I1
+
+table_status:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - Table Status OK (1) or Error (0)
+  FIELDNAM: Table Status OK (1) or Error (0)
+  FLABLAXIS: Status
+  FORMAT: I1
+
+heater_control:
+  <<: *support_default
+  VALIDMAX: 2
+  CATDESC: State - Heater Control (0=None, 1=Pri, 2=Sec)
+  FIELDNAM: Heater Control (0=None, 1=Pri, 2=Sec)
+  FLABLAXIS: State
+  FORMAT: I1
+
+adc_mode:
+  <<: *support_default
+  VALIDMAX: 3
+  CATDESC: State - ADC Mode (0=quiet, 1=normal, 2=adcstim, 3=adcThreshold
+  FIELDNAM: ADC Mode (0=quiet, 1=normal, 2=adcstim, 3=adcThreshold)
+  FLABLAXIS: ADC mode
+  FORMAT: I1
+
+mode:
+  <<: *support_default
+  VALIDMAX: 3
+  CATDESC: State - Mode (0=Boot, 1=Maintenance, 2=Standby, 3=Science)
+  FIELDNAM: Mode (0=Boot, 1=Maintenance, 2=Standby, 3=Science)
+  FLABLAXIS: Mode
+  FORMAT: I1
+
+dyn_thresh_lvl:
+  <<: *support_default
+  VALIDMAX: 3
+  CATDESC: Dynamic Threshold Level (0-3)
+  FIELDNAM: Dynamic Threshold Level (0-3)
+  FLABLAXIS: Level
+  FORMAT: I1
+
+num_evnt_last_hk:
+  <<: *support_default
+  VALIDMAX: 262143
+  CATDESC: Number of Events Since Last HK Update
+  FIELDNAM: Number of Events Since Last HK Update
+  FLABLAXIS: Num events
+  FORMAT: I6
+
+num_errors:
+  <<: *support_default
+  VALIDMAX: 255
+  CATDESC: Number of Errors
+  FIELDNAM: Number of Errors
+  FLABLAXIS: Num errors
+  FORMAT: I3
+
+last_error_num:
+  <<: *support_default
+  VALIDMAX: 255
+  CATDESC: State - Last Error Number
+  FIELDNAM: Last Error Number
+  FLABLAXIS: Error num
+  FORMAT: I3
+
+code_checksum:
+  <<: *support_default
+  VALIDMAX: 65535
+  CATDESC: Code Checksum
+  FIELDNAM: Code Checksum
+  FLABLAXIS: Checksum
+  FORMAT: I5
+
+spin_period_short:
+  <<: *support_default
+  VALIDMAX: 65535
+  CATDESC: Spin Period Short at T=0
+  FIELDNAM: Spin Period Short at T=0
+  FLABLAXIS: Spin period short
+  FORMAT: I5
+
+spin_period_long:
+  <<: *support_default
+  VALIDMAX: 65535
+  CATDESC: Spin Period Long at T=0
+  FIELDNAM: Spin Period Long at T=0
+  FLABLAXIS: Spin period long
+  FORMAT: I5
+
+leak_i:
+  <<: *support_default
+  depend_1: adc_channels
+  CATDESC: Leakage Current [I]
+  FIELDNAM: Leakage Current [I]
+  FLABLAXIS: Current I
+  labl_ptr: adc_channels
+  FORMAT: I19",
+
+phasic_stat:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - Phasic Status
+  FIELDNAM: Phasic Status
+  FLABLAXIS: Status
+  FORMAT: I1
+
+active_heater:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - Active Heater
+  FIELDNAM: Active Heater
+  FLABLAXIS: State
+  FORMAT: I1
+
+heater_on:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - Heater On/Off
+  FIELDNAM: Heater On/Off
+  FLABLAXIS: State
+  FORMAT: I1
+
+test_pulser_on:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - Test Pulser On/Off
+  FIELDNAM: Test Pulser On/Off
+  FLABLAXIS: State
+  FORMAT: I1
+
+dac0_enable:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - DAC 0 Enable
+  FIELDNAM: DAC 0 Enable
+  FLABLAXIS: State
+  FORMAT: I1
+
+dac1_enable:
+  <<: *support_default
+  VALIDMAX: 1
+  CATDESC: State - DAC 1 Enable
+  FIELDNAM: DAC 1 Enable
+  FLABLAXIS: State
+  FORMAT: I1
+
+
+# TODO consider making another default entry for the following variables since they
+#  all have the same max and format. Need more info from Eric
+
+preamp_l234a":
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Preamp L234A
+  FIELDNAM: Preamp L234A
+  FLABLAXIS: Preamp L234A
+  FORMAT: I4
+
+preamp_l1a:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Preamp L1A
+  FIELDNAM: Preamp L1A
+  FLABLAXIS: Preamp L1A
+  FORMAT: I4
+
+preamp_l1b:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Preamp L1B
+  FIELDNAM: Preamp L1B
+  FLABLAXIS: Preamp L1B
+  FORMAT: I4
+
+preamp_l234b:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Preamp L234B
+  FIELDNAM: Preamp L234B
+  FLABLAXIS: Preamp L234B
+  FORMAT: I4
+
+temp0:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: FEE LDO Regulator Mounted on the Board Next to the Low-dropout Regulator
+  FIELDNAM: FEE LDO Regulator
+  FLABLAXIS: Temp0
+  FORMAT: I4
+
+temp1:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Primary Heater Mounted on the Board Next to the Primary Heater Circuit
+  FIELDNAM: Primary Heater
+  FLABLAXIS: Temp1
+  FORMAT: I4
+
+temp2:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: FEE FPGA Mounted on the Board Next to the FPGA
+  FIELDNAM: FEE FPGA
+  FLABLAXIS: Temp2
+  FORMAT: I4
+
+temp3:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Secondary Heater
+  FIELDNAM: Secondary Heater
+  FLABLAXIS: Temp3
+  FORMAT: I4
+
+analog_temp:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Chassis Temp Mounted on the Analog Board Close to Thermostats, Heaters, and Chassis
+  FIELDNAM: Analog Temp
+  FLABLAXIS: Analog temp
+  FORMAT: I4
+
+hvps_temp:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Board Temp Mounted Inside Faraday Cage in Middle of Board Near Connector Side
+  FIELDNAM: Board Temp
+  FLABLAXIS: HVPS temp
+  FORMAT: I4
+
+idpu_temp:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: LDO Temp Mounted on Top of the Low-dropout Regulator
+  FIELDNAM: LDO Temp
+  FLABLAXIS: IDPU temp
+  FORMAT: I4
+
+lvps_temp:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: Board Temp Mounted in the Middle of Board on Opposite Side of Hottest Component
+  FIELDNAM: Board Temp
+  FLABLAXIS: LVPS temp
+  FORMAT: I4
+
+ebox_3d4vd:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: 3.4VD Ebox (Digital)
+  FIELDNAM: 3.4VD Ebox (Digital)
+  FLABLAXIS: 3.4VD Ebox
+  FORMAT: I4
+
+ebox_5d1vd:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: 5.1VD Ebox (Digital)
+  FIELDNAM: 5.1VD Ebox (Digital)
+  FLABLAXIS: 5.1VD Ebox
+  FORMAT: I4
+
+ebox_p12va:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: +12VA Ebox (Analog)
+  FIELDNAM: +12VA Ebox (Analog)
+  FLABLAXIS: +12VA Ebox
+  FORMAT: I4
+
+ebox_m12va:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: -12VA Ebox (Analog)
+  FIELDNAM: -12VA Ebox (Analog)
+  FLABLAXIS: -12VA Ebox
+  FORMAT: I4
+
+ebox_p5d7va:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: +5.7VA Ebox (Analog)
+  FIELDNAM: +5.7VA Ebox (Analog)
+  FLABLAXIS: +5.7VA Ebox
+  FORMAT: I4
+
+ebox_m5d7va:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: -5.7VA Ebox (Analog)
+  FIELDNAM: -5.7VA Ebox (Analog)
+  FLABLAXIS: -5.7VA Ebox
+  FORMAT: I4
+
+ref_p5v:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: +5V ref
+  FIELDNAM: +5V ref
+  FLABLAXIS: +5V ref
+  FORMAT: I4
+
+l1ab_bias:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: L1A/B Bias
+  FIELDNAM: L1A/B Bias
+  FLABLAXIS: L1A/B Bias
+  FORMAT: I4
+
+l2ab_bias:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: L2A/B Bias
+  FIELDNAM: L2A/B Bias
+  FLABLAXIS: L2A/B Bias
+  FORMAT: I4
+
+l34a_bias:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: L3/4A Bias
+  FIELDNAM: L3/4A Bias
+  FLABLAXIS: L3/4A Bias
+  FORMAT: I4
+
+l34b_bias:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: L3/4B Bias
+  FIELDNAM: L3/4B Bias
+  FLABLAXIS: L3/4B Bias
+  FORMAT: I4
+
+ebox_p2d0vd:
+  <<: *default
+  VALIDMAX: 4095
+  CATDESC: +2.0VD Ebox (Digital)
+  FIELDNAM: +2.0VD Ebox (Digital)
+  FLABLAXIS: +2.0VD Ebox
+  FORMAT: I4
+

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -49,6 +49,15 @@ adc_channels:   # adc_channels is a dependency for leak_i data variable
   LABLAXIS: Channel
   FORMAT: I2
 
+# <=== Label Attributes ===>
+# LABL_PTR_i expects VAR_TYPE of metadata with char data type
+
+adc_channels_label:
+  CATDESC: Analog Digital Converter Channels
+  FIELDNAM: ADC Channels
+  FORMAT: A2
+  VAR_TYPE: metadata
+
 
 # <=== Data Variable Attributes ===>
 #TODO is DEPEND_0 needed for no_plot variables in housekeeping?
@@ -251,7 +260,7 @@ leak_i:
   CATDESC: Leakage Current [I]
   FIELDNAM: Leakage Current [I]
   LABLAXIS: Current I
-  labl_ptr: adc_channels
+  LABEL_PTR_1: adc_channels_label
   FORMAT: I19
 
 phasic_stat:

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -37,7 +37,10 @@ epoch:
   REFERENCE_POSITION: Rotating Earth Geoid
 
 adc_channels:   # adc_channels is a dependency for leak_i data variable
-  <<: *support_default
+  DISPLAY_TYPE: no_plot
+  FILLVAL: -9223372036854775808
+  UNITS: ' '
+  SCALETYP: linear
   VALIDMIN: 0
   VALIDMAX: 63
   VAR_TYPE: metadata
@@ -244,12 +247,12 @@ spin_period_long:
 
 leak_i:
   <<: *support_default
-  depend_1: adc_channels
+  DEPEND_1: adc_channels
   CATDESC: Leakage Current [I]
   FIELDNAM: Leakage Current [I]
   LABLAXIS: Current I
   labl_ptr: adc_channels
-  FORMAT: I19",
+  FORMAT: I19
 
 phasic_stat:
   <<: *support_default
@@ -303,7 +306,7 @@ dac1_enable:
 # TODO consider making another default entry for the following variables since they
 #  all have the same max and format. Need more info from Eric
 
-preamp_l234a":
+preamp_l234a:
   <<: *default
   VALIDMAX: 4095
   CATDESC: Preamp L234A

--- a/imap_processing/cdf/config/imap_hit_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1b_variable_attrs.yaml
@@ -37,7 +37,10 @@ epoch:
   REFERENCE_POSITION: Rotating Earth Geoid
 
 adc_channels:   # adc_channels is a dependency for leak_i data variable
-  <<: *support_default
+  DISPLAY_TYPE: no_plot
+  FILLVAL: -9223372036854775808
+  UNITS: ' '
+  SCALETYP: linear
   VALIDMIN: 0
   VALIDMAX: 63
   VAR_TYPE: metadata
@@ -244,12 +247,12 @@ spin_period_long:
 
 leak_i:
   <<: *support_default
-  depend_1: adc_channels
+  DEPEND_1: adc_channels
   CATDESC: Leakage Current [I]
   FIELDNAM: Leakage Current [I]
   LABLAXIS: Current I
   labl_ptr: adc_channels
-  FORMAT: I19",
+  FORMAT: I19
 
 phasic_stat:
   <<: *support_default
@@ -302,7 +305,7 @@ dac1_enable:
 
 # TODO Update data formats. Should be float values. Need more info from instrument team
 
-preamp_l234a":
+preamp_l234a:
   <<: *default
   VALIDMAX: 4095  # Need more info from instr. team
   CATDESC: Preamp L234A Voltage
@@ -338,7 +341,7 @@ preamp_l234b:
   CATDESC: Preamp L234B Voltage
   FIELDNAM: Preamp L234B Voltage
   LABLAXIS: Voltage
-  FORMAT: I4
+  FORMAT: I2
   UNITS: V
   FILLVAL: -1.0000000E+31
 

--- a/imap_processing/cdf/config/imap_hit_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1b_variable_attrs.yaml
@@ -300,198 +300,278 @@ dac1_enable:
   FORMAT: I1
 
 
-# TODO consider making another default entry for the following variables since they
-#  all have the same max and format. Need more info from Eric
+# TODO Update data formats. Should be float values. Need more info from instrument team
 
 preamp_l234a":
   <<: *default
-  VALIDMAX: 4095
-  CATDESC: Preamp L234A
-  FIELDNAM: Preamp L234A
-  LABLAXIS: Preamp L234A
+  VALIDMAX: 4095  # Need more info from instr. team
+  CATDESC: Preamp L234A Voltage
+  FIELDNAM: Preamp L234A Voltage
+  LABLAXIS: Voltage
   FORMAT: I4
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 preamp_l1a:
   <<: *default
-  VALIDMAX: 4095
-  CATDESC: Preamp L1A
-  FIELDNAM: Preamp L1A
-  LABLAXIS: Preamp L1A
+  VALIDMAX: 4095  # Need more info from instr. team
+  CATDESC: Preamp L1A Voltage
+  FIELDNAM: Preamp L1A Voltage
+  LABLAXIS: Voltage
   FORMAT: I4
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 preamp_l1b:
   <<: *default
-  VALIDMAX: 4095
-  CATDESC: Preamp L1B
-  FIELDNAM: Preamp L1B
-  LABLAXIS: Preamp L1B
+  VALIDMAX: 4095  # Need more info from instr. team
+  CATDESC: Preamp L1B Voltage
+  FIELDNAM: Preamp L1B Voltage
+  LABLAXIS: Voltage
   FORMAT: I4
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 preamp_l234b:
   <<: *default
-  VALIDMAX: 4095
-  CATDESC: Preamp L234B
-  FIELDNAM: Preamp L234B
-  LABLAXIS: Preamp L234B
+  VALIDMAX: 4095 # Need more info from instr. team
+  CATDESC: Preamp L234B Voltage
+  FIELDNAM: Preamp L234B Voltage
+  LABLAXIS: Voltage
   FORMAT: I4
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 temp0:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: -25
+  VALIDMAX: 57
   CATDESC: FEE LDO Regulator Mounted on the Board Next to the Low-dropout Regulator
   FIELDNAM: FEE LDO Regulator
-  LABLAXIS: Temp0
-  FORMAT: I4
+  LABLAXIS: Temperature
+  FORMAT: I2
+  UNITS: C
+  FILLVAL: -1.0000000E+31
 
 temp1:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: -25
+  VALIDMAX: 50
   CATDESC: Primary Heater Mounted on the Board Next to the Primary Heater Circuit
   FIELDNAM: Primary Heater
-  LABLAXIS: Temp1
-  FORMAT: I4
+  LABLAXIS: Temperature
+  FORMAT: I2
+  UNITS: C
+  FILLVAL: -1.0000000E+31
 
 temp2:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: -25
+  VALIDMAX: 50
   CATDESC: FEE FPGA Mounted on the Board Next to the FPGA
   FIELDNAM: FEE FPGA
-  LABLAXIS: Temp2
-  FORMAT: I4
+  LABLAXIS: Temperature
+  FORMAT: I2
+  UNITS: C
+  FILLVAL: -1.0000000E+31
 
 temp3:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: -25
+  VALIDMAX: 50
   CATDESC: Secondary Heater
   FIELDNAM: Secondary Heater
-  LABLAXIS: Temp3
-  FORMAT: I4
+  LABLAXIS: Temperature
+  FORMAT: I2
+  UNITS: C
+  FILLVAL: -1.0000000E+31
 
 analog_temp:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: -25
+  VALIDMAX: 50
   CATDESC: Chassis Temp Mounted on the Analog Board Close to Thermostats, Heaters, and Chassis
   FIELDNAM: Analog Temp
-  LABLAXIS: Analog temp
-  FORMAT: I4
+  LABLAXIS: Temperature
+  FORMAT: I2
+  UNITS: C
+  FILLVAL: -1.0000000E+31
 
 hvps_temp:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: -25
+  VALIDMAX: 50
   CATDESC: Board Temp Mounted Inside Faraday Cage in Middle of Board Near Connector Side
   FIELDNAM: Board Temp
-  LABLAXIS: HVPS temp
-  FORMAT: I4
+  LABLAXIS: Temperature
+  FORMAT: I2
+  UNITS: C
+  FILLVAL: -1.0000000E+31
 
 idpu_temp:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: -25
+  VALIDMAX: 65
   CATDESC: LDO Temp Mounted on Top of the Low-dropout Regulator
   FIELDNAM: LDO Temp
-  LABLAXIS: IDPU temp
-  FORMAT: I4
+  LABLAXIS: Temperature
+  FORMAT: I2
+  UNITS: C
+  FILLVAL: -1.0000000E+31
 
 lvps_temp:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: -25
+  VALIDMAX: 80
   CATDESC: Board Temp Mounted in the Middle of Board on Opposite Side of Hottest Component
   FIELDNAM: Board Temp
-  LABLAXIS: LVPS temp
-  FORMAT: I4
+  LABLAXIS: Temperature
+  FORMAT: I2
+  UNITS: C
+  FILLVAL: -1.0000000E+31
 
 ebox_3d4vd:
   <<: *default
-  VALIDMAX: 4095
+  # doc says min 3.1
+  # doc says max 3.6
+  VALIDMIN: 3
+  VALIDMAX: 4
   CATDESC: 3.4VD Ebox (Digital)
   FIELDNAM: 3.4VD Ebox (Digital)
-  LABLAXIS: 3.4VD Ebox
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: F2.1
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 ebox_5d1vd:
   <<: *default
-  VALIDMAX: 4095
+  # doc says min 4.85
+  # doc says max 5.45
+  VALIDMIN: 4
+  VALIDMAX: 6
   CATDESC: 5.1VD Ebox (Digital)
   FIELDNAM: 5.1VD Ebox (Digital)
-  LABLAXIS: 5.1VD Ebox
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: F3.2
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 ebox_p12va:
   <<: *default
-  VALIDMAX: 4095
+  # doc says min 11.2
+  # doc says max 13.1
+  VALIDMIN: 11
+  VALIDMAX: 14
   CATDESC: +12VA Ebox (Analog)
   FIELDNAM: +12VA Ebox (Analog)
-  LABLAXIS: +12VA Ebox
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: F3.1
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 ebox_m12va:
   <<: *default
-  VALIDMAX: 4095
+  # doc says min -13.1
+  # doc says max -11.2
+  VALIDMIN: -14
+  VALIDMAX: -12
   CATDESC: -12VA Ebox (Analog)
   FIELDNAM: -12VA Ebox (Analog)
-  LABLAXIS: -12VA Ebox
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: F3.1
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 ebox_p5d7va:
   <<: *default
-  VALIDMAX: 4095
+  # doc says min 5.3
+  # doc says max 6.3
+  VALIDMIN: 5
+  VALIDMAX: 7
   CATDESC: +5.7VA Ebox (Analog)
   FIELDNAM: +5.7VA Ebox (Analog)
-  LABLAXIS: +5.7VA Ebox
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: F2.1
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 ebox_m5d7va:
   <<: *default
-  VALIDMAX: 4095
+  # doc says min -6.4125
+  # doc says max -5.25
+  VALIDMIN: -7
+  VALIDMAX: -5
   CATDESC: -5.7VA Ebox (Analog)
   FIELDNAM: -5.7VA Ebox (Analog)
-  LABLAXIS: -5.7VA Ebox
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: F5.4
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 ref_p5v:
+  #Need more info from instrument team on min and max values
   <<: *default
-  VALIDMAX: 4095
   CATDESC: +5V ref
   FIELDNAM: +5V ref
-  LABLAXIS: +5V ref
+  LABLAXIS: Voltage
   FORMAT: I4
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 l1ab_bias:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: 0
+  VALIDMAX: 15
   CATDESC: L1A/B Bias
   FIELDNAM: L1A/B Bias
-  LABLAXIS: L1A/B Bias
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: I2
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 l2ab_bias:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: 0
+  VALIDMAX: 25
   CATDESC: L2A/B Bias
   FIELDNAM: L2A/B Bias
-  LABLAXIS: L2A/B Bias
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: I2
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 l34a_bias:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: 0
+  VALIDMAX: 255
   CATDESC: L3/4A Bias
   FIELDNAM: L3/4A Bias
-  LABLAXIS: L3/4A Bias
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: I3
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 l34b_bias:
   <<: *default
-  VALIDMAX: 4095
+  VALIDMIN: 0
+  VALIDMAX: 225
   CATDESC: L3/4B Bias
   FIELDNAM: L3/4B Bias
-  LABLAXIS: L3/4B Bias
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: I3
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 
 ebox_p2d0vd:
   <<: *default
-  VALIDMAX: 4095
+  # doc says min 1.79
+  # doc says max 2.5
+  VALIDMIN: 1
+  VALIDMAX: 3
   CATDESC: +2.0VD Ebox (Digital)
   FIELDNAM: +2.0VD Ebox (Digital)
-  LABLAXIS: +2.0VD Ebox
-  FORMAT: I4
+  LABLAXIS: Voltage
+  FORMAT: F3.2
+  UNITS: V
+  FILLVAL: -1.0000000E+31
 

--- a/imap_processing/cdf/imap_cdf_manager.py
+++ b/imap_processing/cdf/imap_cdf_manager.py
@@ -16,7 +16,7 @@ class ImapCdfAttributes(CdfAttributeManager):
 
     Parameters
     ----------
-    source_dir : Path or None
+    source_dir : pathlib.Path or None
         Source directory.
     """
 
@@ -26,7 +26,7 @@ class ImapCdfAttributes(CdfAttributeManager):
 
         Parameters
         ----------
-        source_dir : Path or None
+        source_dir : pathlib.Path or None
             Source directory.
         """
         if source_dir is None:

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -125,7 +125,7 @@ def group_data(unpacked_data: list):
     return grouped_data
 
 
-def create_datasets(data: dict, attr_mgr):
+def create_datasets(data: dict, attr_mgr: ImapCdfAttributes):
     """
     Create a dataset for each APID in the data.
 

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -143,6 +143,15 @@ def create_datasets(data: dict, attr_mgr: ImapCdfAttributes):
         dictionary will be converted to a CDF.
     """
     logger.info("Creating datasets for HIT L1A data")
+
+    skip_keys = [
+        "shcoarse",
+        "ground_sw_version",
+        "packet_file_name",
+        "ccsds_header",
+        "leak_i_raw",
+    ]
+
     processed_data = {}
     for apid, data_packets in data.items():
         if apid == HitAPID.HIT_HSKP:
@@ -152,13 +161,6 @@ def create_datasets(data: dict, attr_mgr: ImapCdfAttributes):
             #  leak_i_raw can be handled in the housekeeping class as an
             #  InitVar so that it doesn't show up when you extract the object's
             #  field names.
-            skip_keys = [
-                "shcoarse",
-                "ground_sw_version",
-                "packet_file_name",
-                "ccsds_header",
-                "leak_i_raw",
-            ]
         elif apid == HitAPID.HIT_SCIENCE:
             logical_source = "imap_hit_l1a_sci-counts"
             # TODO what about pulse height? It has the same apid.
@@ -193,9 +195,21 @@ def create_datasets(data: dict, attr_mgr: ImapCdfAttributes):
             attrs=attr_mgr.get_variable_attributes("adc_channels"),
         )
 
+        # NOTE: LABL_PTR_1 should be CDF_CHAR.
+        adc_channels_label = xr.DataArray(
+            adc_channels.values.astype(str),
+            name="adc_channels_label",
+            dims=["adc_channels_label"],
+            attrs=attr_mgr.get_variable_attributes("adc_channels_label"),
+        )
+
         # Create xarray dataset
         dataset = xr.Dataset(
-            coords={"epoch": epoch_time, "adc_channels": adc_channels},
+            coords={
+                "epoch": epoch_time,
+                "adc_channels": adc_channels,
+                "adc_channels_label": adc_channels_label,
+            },
             attrs=attr_mgr.get_global_attributes(logical_source),
         )
 

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -59,6 +59,12 @@ def hit_l1a(packet_file: typing.Union[Path, str], data_version: str):
     sorted_packets = utils.sort_by_time(packets, "SHCOARSE")
     grouped_data = group_data(sorted_packets)
 
+    # create the attribute manager for this data level
+    attr_mgr = ImapCdfAttributes()
+    attr_mgr.add_instrument_global_attrs(instrument="hit")
+    attr_mgr.add_instrument_variable_attrs(instrument="hit", level="l1a")
+    attr_mgr.add_global_attribute("Data_version", data_version)
+
     # Create datasets
     # TODO define keys to skip for each apid. Currently just have
     #  a list for housekeeping. Some of these may change later.
@@ -72,7 +78,7 @@ def hit_l1a(packet_file: typing.Union[Path, str], data_version: str):
         "ccsds_header",
         "leak_i_raw",
     ]
-    datasets = create_datasets(grouped_data, data_version, skip_keys)
+    datasets = create_datasets(grouped_data, attr_mgr, skip_keys)
 
     return list(datasets.values())
 
@@ -131,7 +137,7 @@ def group_data(unpacked_data: list):
     return grouped_data
 
 
-def create_datasets(data: dict, data_version, skip_keys=None):
+def create_datasets(data: dict, attr_mgr, skip_keys=None):
     """
     Create a dataset for each APID in the data.
 
@@ -139,10 +145,10 @@ def create_datasets(data: dict, data_version, skip_keys=None):
     ----------
     data : dict
         A single dictionary containing data for all instances of an APID.
-    data_version : str
-        Version of the data product being created.
-    skip_keys : list, Optional
-        Keys to skip in the metadata.
+    attr_mgr : ImapCdfAttributes
+        attribute manager used to get the data product field's attributes
+    skip_keys: list, Optional
+        Keys to skip in the metadata
 
     Returns
     -------
@@ -150,12 +156,6 @@ def create_datasets(data: dict, data_version, skip_keys=None):
         A dictionary containing xarray.Dataset for each APID. Each dataset in the
         dictionary will be converted to a CDF.
     """
-    # create the attribute manager for this data level
-    attr_mgr = ImapCdfAttributes()
-    attr_mgr.add_instrument_global_attrs(instrument="hit")
-    attr_mgr.add_instrument_variable_attrs(instrument="hit", level="l1a")
-    attr_mgr.add_global_attribute("Data_version", data_version)
-
     logger.info("Creating datasets for HIT L1A data")
     processed_data = {}
     for apid, data_packets in data.items():
@@ -227,4 +227,3 @@ def create_datasets(data: dict, data_version, skip_keys=None):
         processed_data[apid] = dataset
     logger.info("HIT L1A datasets created")
     return processed_data
-

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -66,19 +66,7 @@ def hit_l1a(packet_file: typing.Union[Path, str], data_version: str):
     attr_mgr.add_global_attribute("Data_version", data_version)
 
     # Create datasets
-    # TODO define keys to skip for each apid. Currently just have
-    #  a list for housekeeping. Some of these may change later.
-    #  leak_i_raw can be handled in the housekeeping class as an
-    #  InitVar so that it doesn't show up when you extract the object's
-    #  field names.
-    skip_keys = [
-        "shcoarse",
-        "ground_sw_version",
-        "packet_file_name",
-        "ccsds_header",
-        "leak_i_raw",
-    ]
-    datasets = create_datasets(grouped_data, attr_mgr, skip_keys)
+    datasets = create_datasets(grouped_data, attr_mgr)
 
     return list(datasets.values())
 
@@ -137,7 +125,7 @@ def group_data(unpacked_data: list):
     return grouped_data
 
 
-def create_datasets(data: dict, attr_mgr, skip_keys=None):
+def create_datasets(data: dict, attr_mgr):
     """
     Create a dataset for each APID in the data.
 
@@ -146,9 +134,7 @@ def create_datasets(data: dict, attr_mgr, skip_keys=None):
     data : dict
         A single dictionary containing data for all instances of an APID.
     attr_mgr : ImapCdfAttributes
-        attribute manager used to get the data product field's attributes
-    skip_keys: list, Optional
-        Keys to skip in the metadata
+        Attribute manager used to get the data product field's attributes.
 
     Returns
     -------
@@ -161,6 +147,18 @@ def create_datasets(data: dict, attr_mgr, skip_keys=None):
     for apid, data_packets in data.items():
         if apid == HitAPID.HIT_HSKP:
             logical_source = "imap_hit_l1a_hk"
+            # TODO define keys to skip for each apid. Currently just have
+            #  a list for housekeeping. Some of these may change later.
+            #  leak_i_raw can be handled in the housekeeping class as an
+            #  InitVar so that it doesn't show up when you extract the object's
+            #  field names.
+            skip_keys = [
+                "shcoarse",
+                "ground_sw_version",
+                "packet_file_name",
+                "ccsds_header",
+                "leak_i_raw",
+            ]
         elif apid == HitAPID.HIT_SCIENCE:
             logical_source = "imap_hit_l1a_sci-counts"
             # TODO what about pulse height? It has the same apid.

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -202,21 +202,29 @@ def create_datasets(data: dict, data_version, skip_keys=None):
         )
 
         # Create xarray data array for each metadata field
-        for key, value in metadata_arrays.items():
-            if key not in skip_keys:
-                if key == "leak_i":
+        for field, data in metadata_arrays.items():
+            if field not in skip_keys:
+                # Create a list of all the dimensions using the DEPEND_I keys in the
+                # attributes
+                dims = [
+                    value
+                    for key, value in attr_mgr.get_variable_attributes(field).items()
+                    if "DEPEND" in key
+                ]
+                if field == "leak_i":
                     # 2D array - needs two dims
-                    dataset[key] = xr.DataArray(
-                        value,
-                        dims=["epoch", "adc_channels"],
-                        attrs=attr_mgr.get_variable_attributes(key),
+                    dataset[field] = xr.DataArray(
+                        data,
+                        dims=dims,
+                        attrs=attr_mgr.get_variable_attributes(field),
                     )
                 else:
-                    dataset[key] = xr.DataArray(
-                        value,
-                        dims=["epoch"],
-                        attrs=attr_mgr.get_variable_attributes(key),
+                    dataset[field] = xr.DataArray(
+                        data,
+                        dims=dims,
+                        attrs=attr_mgr.get_variable_attributes(field),
                     )
         processed_data[apid] = dataset
     logger.info("HIT L1A datasets created")
     return processed_data
+

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -55,12 +55,13 @@ def hit_l1b(l1a_dataset: xr.Dataset, data_version: str):
 
 # TODO: This is going to work differently when we have sample data
 def create_hk_dataset(attr_mgr):
-    """Create a housekeeping dataset.
+    """
+    Create a housekeeping dataset.
 
     Parameters
     ----------
     attr_mgr : ImapCdfAttributes
-        attribute manager used to get the data product field's attributes
+        Attribute manager used to get the data product field's attributes.
 
     Returns
     -------

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -7,8 +7,7 @@ import numpy as np
 import xarray as xr
 
 from imap_processing import utils
-from imap_processing.cdf.global_attrs import ConstantCoordinates
-from imap_processing.hit import hit_cdf_attrs
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hit.l0.data_classes.housekeeping import Housekeeping
 
 logger = logging.getLogger(__name__)
@@ -39,21 +38,24 @@ def hit_l1b(l1a_dataset: xr.Dataset, data_version: str):
     # Create datasets
     datasets = []
     if "_hk" in logical_source:
-        dataset = create_hk_dataset()
+        dataset = create_hk_dataset(data_version)
         datasets.append(dataset)
     elif "_sci" in logical_source:
         # process science data. placeholder for future code
         pass
 
-    for dataset in datasets:
-        dataset.attrs["Data_version"] = data_version
     return datasets
 
 
 # TODO: This is going to work differently when we have sample data
-def create_hk_dataset():
+def create_hk_dataset(data_version):
     """
     Create a housekeeping dataset.
+
+    Parameters
+    ----------
+    data_version : str
+        Version of the data product being created.
 
     Returns
     -------
@@ -76,6 +78,14 @@ def create_hk_dataset():
         "leak_i_raw",
     ]
 
+    # create the attribute manager for this data level
+    attr_mgr = ImapCdfAttributes()
+    attr_mgr.add_instrument_global_attrs(instrument="hit")
+    attr_mgr.add_instrument_variable_attrs(instrument="hit", level="l1b")
+    attr_mgr.add_global_attribute("Data_version", data_version)
+
+    logical_source = "imap_hit_l1b_hk"
+
     # Create fake data for now
 
     # Convert integers into datetime64[s]
@@ -90,20 +100,20 @@ def create_hk_dataset():
         data=epoch_converted_time,
         name="epoch",
         dims=["epoch"],
-        attrs=ConstantCoordinates.EPOCH,
+        attrs=attr_mgr.get_variable_attributes("epoch"),
     )
 
     adc_channels = xr.DataArray(
         np.arange(n_channels, dtype=np.uint16),
         name="adc_channels",
         dims=["adc_channels"],
-        attrs=hit_cdf_attrs.l1b_hk_attrs["adc_channels"].output(),
+        attrs=attr_mgr.get_variable_attributes("adc_channels"),
     )
 
     # Create xarray dataset
     hk_dataset = xr.Dataset(
         coords={"epoch": epoch_time, "adc_channels": adc_channels},
-        attrs=hit_cdf_attrs.hit_hk_l1b_attrs.output(),
+        attrs=attr_mgr.get_global_attributes(logical_source),
     )
 
     # Create xarray data array for each data field
@@ -114,7 +124,7 @@ def create_hk_dataset():
             # attributes
             dims = [
                 value
-                for key, value in hit_cdf_attrs.l1b_hk_attrs[field].output().items()
+                for key, value in attr_mgr.get_variable_attributes(field).items()
                 if "DEPEND" in key
             ]
 
@@ -125,7 +135,7 @@ def create_hk_dataset():
                 hk_dataset[field] = xr.DataArray(
                     np.ones((n_epoch, n_channels), dtype=np.uint16),
                     dims=dims,
-                    attrs=hit_cdf_attrs.l1b_hk_attrs[field].output(),
+                    attrs=attr_mgr.get_variable_attributes(field),
                 )
             elif field in [
                 "preamp_l234a",
@@ -156,13 +166,13 @@ def create_hk_dataset():
                 hk_dataset[field] = xr.DataArray(
                     np.ones(3, dtype=np.float16),
                     dims=dims,
-                    attrs=hit_cdf_attrs.l1b_hk_attrs[field].output(),
+                    attrs=attr_mgr.get_variable_attributes(field),
                 )
             else:
                 hk_dataset[field] = xr.DataArray(
                     [1, 1, 1],
                     dims=dims,
-                    attrs=hit_cdf_attrs.l1b_hk_attrs[field].output(),
+                    attrs=attr_mgr.get_variable_attributes(field),
                 )
 
     logger.info("HIT L1B datasets created")

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -31,6 +31,12 @@ def hit_l1b(l1a_dataset: xr.Dataset, data_version: str):
     cdf_filepaths : xarray.Dataset
         L1B processed data.
     """
+    # create the attribute manager for this data level
+    attr_mgr = ImapCdfAttributes()
+    attr_mgr.add_instrument_global_attrs(instrument="hit")
+    attr_mgr.add_instrument_variable_attrs(instrument="hit", level="l1b")
+    attr_mgr.add_global_attribute("Data_version", data_version)
+
     # TODO: Check for type of L1A dataset and determine what L1B products to make
     #   Need more info from instrument teams. Work with housekeeping data for now
     logical_source = "imap_hit_l1b_hk"
@@ -38,7 +44,7 @@ def hit_l1b(l1a_dataset: xr.Dataset, data_version: str):
     # Create datasets
     datasets = []
     if "_hk" in logical_source:
-        dataset = create_hk_dataset(data_version)
+        dataset = create_hk_dataset(attr_mgr)
         datasets.append(dataset)
     elif "_sci" in logical_source:
         # process science data. placeholder for future code
@@ -48,14 +54,13 @@ def hit_l1b(l1a_dataset: xr.Dataset, data_version: str):
 
 
 # TODO: This is going to work differently when we have sample data
-def create_hk_dataset(data_version):
-    """
-    Create a housekeeping dataset.
+def create_hk_dataset(attr_mgr):
+    """Create a housekeeping dataset.
 
     Parameters
     ----------
-    data_version : str
-        Version of the data product being created.
+    attr_mgr : ImapCdfAttributes
+        attribute manager used to get the data product field's attributes
 
     Returns
     -------
@@ -77,12 +82,6 @@ def create_hk_dataset(data_version):
         "ccsds_header",
         "leak_i_raw",
     ]
-
-    # create the attribute manager for this data level
-    attr_mgr = ImapCdfAttributes()
-    attr_mgr.add_instrument_global_attrs(instrument="hit")
-    attr_mgr.add_instrument_variable_attrs(instrument="hit", level="l1b")
-    attr_mgr.add_global_attribute("Data_version", data_version)
 
     logical_source = "imap_hit_l1b_hk"
 

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -1,7 +1,10 @@
+import pathlib
+
 import pytest
 import xarray as xr
 
 from imap_processing import imap_module_directory, utils
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hit.l0.data_classes.housekeeping import Housekeeping
 from imap_processing.hit.l1a import hit_l1a
 
@@ -67,7 +70,15 @@ def test_create_datasets(unpacked_packets):
         "ccsds_header",
         "leak_i_raw",
     ]
-    datasets_by_apid = hit_l1a.create_datasets(grouped_data, "001", skip_keys=skip_keys)
+
+    attr_mgr = ImapCdfAttributes()
+    attr_mgr.add_instrument_global_attrs(instrument="hit")
+    attr_mgr.add_instrument_variable_attrs(instrument="hit", level="l1a")
+    attr_mgr.add_global_attribute("Data_version", "001")
+
+    datasets_by_apid = hit_l1a.create_datasets(
+        grouped_data, attr_mgr, skip_keys=skip_keys
+    )
     assert len(datasets_by_apid.keys()) == 1
     assert isinstance(datasets_by_apid[hit_l1a.HitAPID.HIT_HSKP], xr.Dataset)
 

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -1,5 +1,3 @@
-import pathlib
-
 import pytest
 import xarray as xr
 
@@ -63,22 +61,13 @@ def test_create_datasets(unpacked_packets):
         A sorted list of decommutated packets
     """
     grouped_data = hit_l1a.group_data(unpacked_packets)
-    skip_keys = [
-        "shcoarse",
-        "ground_sw_version",
-        "packet_file_name",
-        "ccsds_header",
-        "leak_i_raw",
-    ]
 
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="hit")
     attr_mgr.add_instrument_variable_attrs(instrument="hit", level="l1a")
     attr_mgr.add_global_attribute("Data_version", "001")
 
-    datasets_by_apid = hit_l1a.create_datasets(
-        grouped_data, attr_mgr, skip_keys=skip_keys
-    )
+    datasets_by_apid = hit_l1a.create_datasets(grouped_data, attr_mgr)
     assert len(datasets_by_apid.keys()) == 1
     assert isinstance(datasets_by_apid[hit_l1a.HitAPID.HIT_HSKP], xr.Dataset)
 

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -67,16 +67,15 @@ def test_create_datasets(unpacked_packets):
         "ccsds_header",
         "leak_i_raw",
     ]
-    datasets_by_apid = hit_l1a.create_datasets(grouped_data, skip_keys=skip_keys)
+    datasets_by_apid = hit_l1a.create_datasets(grouped_data, "001", skip_keys=skip_keys)
     assert len(datasets_by_apid.keys()) == 1
     assert isinstance(datasets_by_apid[hit_l1a.HitAPID.HIT_HSKP], xr.Dataset)
 
 
 def test_hit_l1a(packet_filepath):
-    """Create L1A CDF files
+    """Create L1A datasets
 
-    Creates a CDF file for each apid dataset and stores all
-    cdf file paths in a list
+    Creates xarray datasets from a packet.
 
     Parameters
     ----------

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -1,7 +1,11 @@
+import pathlib
+
 import pytest
 import xarray as xr
 
 from imap_processing import imap_module_directory
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.cdf.utils import load_cdf
 from imap_processing.hit.l1a import hit_l1a
 from imap_processing.hit.l1b import hit_l1b
 
@@ -22,7 +26,13 @@ def test_create_hk_dataset():
     Creates a xarray dataset for housekeeping data
     """
 
-    l1b_hk_dataset = hit_l1b.create_hk_dataset("001")
+    # create the attribute manager for this data level
+    attr_mgr = ImapCdfAttributes()
+    attr_mgr.add_instrument_global_attrs(instrument="hit")
+    attr_mgr.add_instrument_variable_attrs(instrument="hit", level="l1b")
+    attr_mgr.add_global_attribute("Data_version", "001")
+
+    l1b_hk_dataset = hit_l1b.create_hk_dataset(attr_mgr)
     assert isinstance(l1b_hk_dataset, xr.Dataset)
 
 

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -22,7 +22,7 @@ def test_create_hk_dataset():
     Creates a xarray dataset for housekeeping data
     """
 
-    l1b_hk_dataset = hit_l1b.create_hk_dataset()
+    l1b_hk_dataset = hit_l1b.create_hk_dataset("001")
     assert isinstance(l1b_hk_dataset, xr.Dataset)
 
 

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -1,11 +1,8 @@
-import pathlib
-
 import pytest
 import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.cdf.utils import load_cdf
 from imap_processing.hit.l1a import hit_l1a
 from imap_processing.hit.l1b import hit_l1b
 


### PR DESCRIPTION
# Change Summary

## Overview
Update HIT to use yaml files and cdf attribute manager. Added yaml files and updated l1a and l1b
processing code to use the new process for handling cdf attributes

## New Dependencies
None

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- imap_hit_global_cdf_attrs.yaml
   - defines global attributes for hit
- imap_hit_l1a_variable_attrs.yaml
  - defines l1a variable attributes for hit
- imap_hit_l1b_variable_attrs.yaml
  - defines l1b variable attributes for hit

## Deleted Files
None

## Updated Files
- hit_l1a.py
   - Added cdf attribute manager
   - Added loop to create a list of dims for variables based on their DEPEND_i attribute fields. L1b processing code already had this, so now both are consistent
- hit_l1b.py
   - Added cdf attribute manager

## Testing
Updated hit l1a and l1b unit tests to reflect changes described above.
