### PR TITLE
Fix Hi L1b test marked xfail

### DIFF
--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -1,7 +1,5 @@
 """Test coverage for imap_processing.hi.l1b.hi_l1b.py"""
 
-import pytest
-
 from imap_processing import imap_module_directory
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.l1b.hi_l1b import hi_l1b
@@ -21,7 +19,6 @@ def test_hi_l1b_hk():
     assert l1b_dataset.attrs["Logical_source"] == "imap_hi_l1b_45sensor-hk"
 
 
-@pytest.mark.xfail()
 def test_hi_l1b_de(create_de_data, tmp_path):
     """Test coverage for imap_processing.hi.hi_l1b.hi_l1b() with
     direct events L1A as input"""


### PR DESCRIPTION
# Change Summary
Remove xfail on test that isn't failing

## Overview
The test wasn't failing. I just removed the `@pytest.mark.xfail` decorator.

## Updated Files
- imap_processing/tests/hi/test_hi_l1b.py
   - remove xfail decorator from test that passes

Closes #672 