### PR TITLE
682 imap hi use imapcdfattributes instead of cdfattributemanager

### DIFF
--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -6,14 +6,14 @@ import numpy as np
 import xarray as xr
 
 from imap_processing import imap_module_directory
-from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hi.utils import HIAPID
 from imap_processing.utils import convert_raw_to_eu
 
 logger = logging.getLogger(__name__)
-CDF_MANAGER = CdfAttributeManager(imap_module_directory / "cdf" / "config")
-CDF_MANAGER.load_global_attributes("imap_hi_global_cdf_attrs.yaml")
-CDF_MANAGER.load_variable_attributes("imap_hi_variable_attrs.yaml")
+ATTR_MGR = ImapCdfAttributes()
+ATTR_MGR.add_instrument_global_attrs("hi")
+ATTR_MGR.load_variable_attributes("imap_hi_variable_attrs.yaml")
 
 
 def hi_l1b(l1a_dataset: xr.Dataset, data_version: str):
@@ -54,9 +54,7 @@ def hi_l1b(l1a_dataset: xr.Dataset, data_version: str):
             converters={"mnemonic": str.lower},
         )
 
-        l1b_dataset.attrs.update(
-            CDF_MANAGER.get_global_attributes("imap_hi_l1b_hk_attrs")
-        )
+        l1b_dataset.attrs.update(ATTR_MGR.get_global_attributes("imap_hi_l1b_hk_attrs"))
     elif logical_source_parts[-1].endswith("de"):
         l1b_dataset = annotate_direct_events(l1a_dataset)
     else:
@@ -106,7 +104,7 @@ def annotate_direct_events(l1a_dataset):
         "quality_flag",
         "nominal_bin",
     ]:
-        attrs = CDF_MANAGER.get_variable_attributes(
+        attrs = ATTR_MGR.get_variable_attributes(
             f"hi_de_{var}", check_schema=False
         ).copy()
         dtype = attrs.pop("dtype")
@@ -122,6 +120,6 @@ def annotate_direct_events(l1a_dataset):
         ["tof_1", "tof_2", "tof_3", "de_tag", "ccsds_met", "meta_event_met"]
     )
 
-    de_global_attrs = CDF_MANAGER.get_global_attributes("imap_hi_l1b_de_attrs")
+    de_global_attrs = ATTR_MGR.get_global_attributes("imap_hi_l1b_de_attrs")
     l1b_dataset.attrs.update(**de_global_attrs)
     return l1b_dataset

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -7,8 +7,7 @@ from typing import Union
 import numpy as np
 import xarray as xr
 
-from imap_processing import imap_module_directory
-from imap_processing.cdf.cdf_attribute_manager import CdfAttributeManager
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 
 logger = logging.getLogger(__name__)
 
@@ -93,16 +92,14 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str):
     dataset : xarray.Dataset
         Empty xarray.Dataset ready to be filled with data.
     """
-    cdf_manager = CdfAttributeManager(imap_module_directory / "cdf" / "config")
-    cdf_manager.load_global_attributes("imap_hi_global_cdf_attrs.yaml")
-    cdf_manager.load_variable_attributes("imap_hi_variable_attrs.yaml")
+    attr_mgr = ImapCdfAttributes()
+    attr_mgr.add_instrument_global_attrs("hi")
+    attr_mgr.load_variable_attributes("imap_hi_variable_attrs.yaml")
 
     # preallocate coordinates xr.DataArrays
     coords = dict()
     # epoch coordinate has only 1 entry for pointing set
-    attrs = cdf_manager.get_variable_attributes(
-        "hi_pset_epoch", check_schema=False
-    ).copy()
+    attrs = attr_mgr.get_variable_attributes("hi_pset_epoch", check_schema=False).copy()
     dtype = attrs.pop("dtype")
     coords["epoch"] = xr.DataArray(
         np.empty(1, dtype=dtype),
@@ -110,7 +107,7 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str):
         dims=["epoch"],
         attrs=attrs,
     )
-    attrs = cdf_manager.get_variable_attributes(
+    attrs = attr_mgr.get_variable_attributes(
         "hi_pset_esa_step", check_schema=False
     ).copy()
     dtype = attrs.pop("dtype")
@@ -121,7 +118,7 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str):
         attrs=attrs,
     )
     # spin angle bins are 0.1 degree bins for full 360 degree spin
-    attrs = cdf_manager.get_variable_attributes(
+    attrs = attr_mgr.get_variable_attributes(
         "hi_pset_spin_angle_bin", check_schema=False
     ).copy()
     dtype = attrs.pop("dtype")
@@ -148,9 +145,7 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str):
     ]:
         data_vars[var_name] = full_dataarray(
             var_name,
-            cdf_manager.get_variable_attributes(
-                f"hi_pset_{var_name}", check_schema=False
-            ),
+            attr_mgr.get_variable_attributes(f"hi_pset_{var_name}", check_schema=False),
             coords,
             shape=var_shapes.get(var_name, None),
         )
@@ -160,7 +155,7 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str):
         coords["esa_step"].values.astype(str),
         name="esa_step_label",
         dims=["esa_step"],
-        attrs=cdf_manager.get_variable_attributes(
+        attrs=attr_mgr.get_variable_attributes(
             "hi_pset_esa_step_label", check_schema=False
         ),
     )
@@ -168,7 +163,7 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str):
         coords["spin_angle_bin"].values.astype(str),
         name="spin_bin_label",
         dims=["spin_angle_bin"],
-        attrs=cdf_manager.get_variable_attributes(
+        attrs=attr_mgr.get_variable_attributes(
             "hi_pset_spin_bin_label", check_schema=False
         ),
     )
@@ -176,14 +171,12 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str):
         np.array(["x HAE", "y HAE", "z HAE"], dtype=str),
         name="label_vector_HAE",
         dims=[" "],
-        attrs=cdf_manager.get_variable_attributes(
+        attrs=attr_mgr.get_variable_attributes(
             "hi_pset_label_vector_HAE", check_schema=False
         ),
     )
 
-    pset_global_attrs = cdf_manager.get_global_attributes(
-        "imap_hi_l1c_pset_attrs"
-    ).copy()
+    pset_global_attrs = attr_mgr.get_global_attributes("imap_hi_l1c_pset_attrs").copy()
     pset_global_attrs["Logical_source"] = pset_global_attrs["Logical_source"].format(
         sensor=sensor_str
     )
@@ -196,7 +189,7 @@ def full_dataarray(name, attrs, coords: dict, shape=None):
     Generate an empty xarray.DataArray with appropriate attributes.
 
     Data in DataArray are filled with FILLVAL defined in attributes
-    retrieved from CDF_MANAGER with shape matching coordinates defined by
+    retrieved from ATTR_MGR with shape matching coordinates defined by
     dims or overridden by optional `shape` input.
 
     Parameters


### PR DESCRIPTION
# Change Summary
This is a small change that replaces instances where I was using CdfAttributManager rather than ImapCdfAttributes.

## Updated Files
- imap_processing/hi/l1a/science_direct_event.py
   - Replace CdfAttributeManager with ImapCdfAttributes
- imap_processing/hi/l1b/hi_l1b.py
   - Replace CdfAttributeManager with ImapCdfAttributes
- imap_processing/hi/l1b/hi_l1b.py
   - Replace CdfAttributeManager with ImapCdfAttributes

Closes #682