### PR TITLE
MNT: Change to a period separator for XTCE definitions

### DIFF
--- a/imap_processing/ccsds/excel_to_xtce.py
+++ b/imap_processing/ccsds/excel_to_xtce.py
@@ -226,7 +226,9 @@ class XTCEGenerator:
                 if pd.isna(row.get("packetName")):
                     # This is a poorly formatted row, skip it
                     continue
-                name = f"{row['packetName']}_{row['mnemonic']}"
+                # separate the packet name and mnemonic with a period
+                # a hyphen is sometimes in the packet name or mnemonic already
+                name = f"{row['packetName']}.{row['mnemonic']}"
                 parameter_ref_entry = Et.SubElement(
                     packet_entry_list, "xtce:ParameterRefEntry"
                 )
@@ -247,7 +249,7 @@ class XTCEGenerator:
         """
         parameter = Et.SubElement(self._parameter_set, "xtce:Parameter")
         # Combine the packet name and mnemonic to create a unique parameter name
-        name = f"{row['packetName']}_{row['mnemonic']}"
+        name = f"{row['packetName']}.{row['mnemonic']}"
         parameter.attrib["name"] = name
         # UINT8, ...
         parameter.attrib["parameterTypeRef"] = name

--- a/imap_processing/tests/ccsds/test_data/expected_output.xml
+++ b/imap_processing/tests/ccsds/test_data/expected_output.xml
@@ -24,10 +24,10 @@
 			<xtce:IntegerParameterType name="PKT_LEN" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="TEST_PACKET_SHCOARSE" signed="false">
+			<xtce:IntegerParameterType name="TEST_PACKET.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="TEST_PACKET_VAR_UINT" signed="false">
+			<xtce:IntegerParameterType name="TEST_PACKET.VAR_UINT" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
@@ -37,13 +37,13 @@
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="TEST_PACKET_VAR_INT" signed="true">
+			<xtce:IntegerParameterType name="TEST_PACKET.VAR_INT" signed="true">
 				<xtce:IntegerDataEncoding sizeInBits="4" encoding="signed" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="TEST_PACKET_VAR_SINT" signed="true">
+			<xtce:IntegerParameterType name="TEST_PACKET.VAR_SINT" signed="true">
 				<xtce:IntegerDataEncoding sizeInBits="5" encoding="signed" />
 			</xtce:IntegerParameterType>
-			<xtce:BinaryParameterType name="TEST_PACKET_VAR_BYTE">
+			<xtce:BinaryParameterType name="TEST_PACKET.VAR_BYTE">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
@@ -53,16 +53,16 @@
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
 			</xtce:BinaryParameterType>
-			<xtce:IntegerParameterType name="TEST_PACKET_VAR_FILL" signed="false">
+			<xtce:IntegerParameterType name="TEST_PACKET.VAR_FILL" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:FloatParameterType name="TEST_PACKET_VAR_FLOAT">
+			<xtce:FloatParameterType name="TEST_PACKET.VAR_FLOAT">
 				<xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754" />
 			</xtce:FloatParameterType>
-			<xtce:IntegerParameterType name="TEST_PACKET2_SHCOARSE" signed="false">
+			<xtce:IntegerParameterType name="TEST_PACKET2.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="TEST_PACKET2_VAR1" signed="false">
+			<xtce:IntegerParameterType name="TEST_PACKET2.VAR1" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 		</xtce:ParameterTypeSet>
@@ -88,31 +88,31 @@
 			<xtce:Parameter name="PKT_LEN" parameterTypeRef="PKT_LEN">
 				<xtce:LongDescription>CCSDS Packet Length (number of bytes after Packet length minus 1)</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET_SHCOARSE" parameterTypeRef="TEST_PACKET_SHCOARSE">
+			<xtce:Parameter name="TEST_PACKET.SHCOARSE" parameterTypeRef="TEST_PACKET.SHCOARSE">
 				<xtce:LongDescription>Mission elapsed time</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET_VAR_UINT" parameterTypeRef="TEST_PACKET_VAR_UINT">
+			<xtce:Parameter name="TEST_PACKET.VAR_UINT" parameterTypeRef="TEST_PACKET.VAR_UINT">
 				<xtce:LongDescription>Unsgned integer data with conversion</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET_VAR_INT" parameterTypeRef="TEST_PACKET_VAR_INT">
+			<xtce:Parameter name="TEST_PACKET.VAR_INT" parameterTypeRef="TEST_PACKET.VAR_INT">
 				<xtce:LongDescription>Integer data</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET_VAR_SINT" parameterTypeRef="TEST_PACKET_VAR_SINT">
+			<xtce:Parameter name="TEST_PACKET.VAR_SINT" parameterTypeRef="TEST_PACKET.VAR_SINT">
 				<xtce:LongDescription>Signed integer data</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET_VAR_BYTE" parameterTypeRef="TEST_PACKET_VAR_BYTE">
+			<xtce:Parameter name="TEST_PACKET.VAR_BYTE" parameterTypeRef="TEST_PACKET.VAR_BYTE">
 				<xtce:LongDescription>Binary data - variable length</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET_VAR_FILL" parameterTypeRef="TEST_PACKET_VAR_FILL">
+			<xtce:Parameter name="TEST_PACKET.VAR_FILL" parameterTypeRef="TEST_PACKET.VAR_FILL">
 				<xtce:LongDescription>Fill data</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET_VAR_FLOAT" parameterTypeRef="TEST_PACKET_VAR_FLOAT">
+			<xtce:Parameter name="TEST_PACKET.VAR_FLOAT" parameterTypeRef="TEST_PACKET.VAR_FLOAT">
 				<xtce:LongDescription>Float data</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET2_SHCOARSE" parameterTypeRef="TEST_PACKET2_SHCOARSE">
+			<xtce:Parameter name="TEST_PACKET2.SHCOARSE" parameterTypeRef="TEST_PACKET2.SHCOARSE">
 				<xtce:LongDescription>Mission elapsed time</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="TEST_PACKET2_VAR1" parameterTypeRef="TEST_PACKET2_VAR1" shortDescription="Variable 1 short desc">
+			<xtce:Parameter name="TEST_PACKET2.VAR1" parameterTypeRef="TEST_PACKET2.VAR1" shortDescription="Variable 1 short desc">
 				<xtce:LongDescription>Variable 1 - long desc</xtce:LongDescription>
 			</xtce:Parameter>
 		</xtce:ParameterSet>
@@ -135,13 +135,13 @@
 					</xtce:RestrictionCriteria>
 				</xtce:BaseContainer>
 				<xtce:EntryList>
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET_SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET_VAR_UINT" />
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET_VAR_INT" />
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET_VAR_SINT" />
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET_VAR_BYTE" />
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET_VAR_FILL" />
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET_VAR_FLOAT" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_UINT" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_INT" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_SINT" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_BYTE" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_FILL" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET.VAR_FLOAT" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
 			<xtce:SequenceContainer name="TEST_PACKET2">
@@ -151,8 +151,8 @@
 					</xtce:RestrictionCriteria>
 				</xtce:BaseContainer>
 				<xtce:EntryList>
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET2_SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="TEST_PACKET2_VAR1" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET2.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="TEST_PACKET2.VAR1" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
 		</xtce:ContainerSet>

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -391,6 +391,18 @@ def packet_file_to_datasets(
         )
         ds = ds.sortby("epoch")
 
+        # Strip any leading characters before "." from the field names which was due
+        # to the packet_name being a part of the variable name in the XTCE definition
+        ds = ds.rename(
+            {
+                # partition splits the string into 3 parts: before ".", ".", after "."
+                # if there was no ".", the second part is an empty string, so we use
+                # the original key in that case
+                key: key.partition(".")[2] or key
+                for key in ds.variables
+            }
+        )
+
         dataset_by_apid[apid] = ds
 
     return dataset_by_apid


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

This updates the XTCE generator to produce a period between the packet name and the mnemonic name, which helps for subsequent parsing.

Additionally, use that helpful fact to strip that leading packet name in the packet_file_to_datasets routine.

## Testing

I did test this out manually by modifying an XTCE file to ensure that the stripping works as expected, but there aren't any other packet definitions with a packet name to make this easily testable yet. Maybe we'll update some of the packet definitions soon to exercise this.