### PR TITLE
packet_file_to_datasets *NOT* in IDEX

### DIFF
--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -319,6 +319,11 @@ def packet_file_to_datasets(
     packet definition, the ``derived_value`` will be the converted value.
     The dimension of the dataset will be the time field in J2000 nanoseconds.
 
+    Note: While this is a general function intended to work for all
+    instruments, this cannot be used for IDEX due to the complex nature of
+    the xml file. IDEX will continue to use PacketParser and RawDustEvents
+    found in idex_l1.py.
+
     Parameters
     ----------
     packet_file : str

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -319,11 +319,6 @@ def packet_file_to_datasets(
     packet definition, the ``derived_value`` will be the converted value.
     The dimension of the dataset will be the time field in J2000 nanoseconds.
 
-    Note: While this is a general function intended to work for all
-    instruments, this cannot be used for IDEX due to the complex nature of
-    the xml file. IDEX will continue to use PacketParser and RawDustEvents
-    found in idex_l1.py.
-
     Parameters
     ----------
     packet_file : str
@@ -337,6 +332,12 @@ def packet_file_to_datasets(
     -------
     datasets : dict
         Mapping from apid to xarray dataset, one dataset per apid.
+
+    Notes
+    -----
+    This function only handles packet definitions with the same variable structure
+    across all packets with the same ApId. For example, this cannot be used for IDEX
+    due to the conditional XML structure defined for their science packet.
     """
     # Set up containers to store our data
     # We are getting a packet file that may contain multiple apids


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Originally, this PR was intended to switch over IDEX to using the `packet_file_to_datasets` function established in utils.py, however it was decided that this would be more work than it is worth. Due to the nature of the `.xml` file for IDEX, using this function created dimension issues. For now, IDEX will continue to use PacketParser, and RawDustEvents

I added a comment in the doc-string for `packet_file_to_datasets` to explain this.

## New Dependencies
<!--List any new dependencies introduced by these changes-->
None

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
None

## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->
None

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- utils.py
   - Added comment to `packet_file_to_dataset` docstring.

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
None

closes 687 for IDEX only!
