### PR TITLE
MNT: Enable numpy 2+ installs

### DIFF
--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -287,7 +287,6 @@ hi_de_nominal_bin:
   <<: *default_uint8
   CATDESC: Corresponding histogram angle bin for this Direct Event
   FIELDNAM: Histogram Bin Number
-  FILLVAL: 511
   FORMAT: I2
   LABLAXIS: Hist Bin \#
   VALIDMIN: 0

--- a/imap_processing/mag/l1a/mag_l1a_data.py
+++ b/imap_processing/mag/l1a/mag_l1a_data.py
@@ -336,6 +336,10 @@ class MagL1a:
         primary_vectors = []
         secondary_vectors = []
 
+        # To avoid overflows, we need to cast the potentially 8 bit signed integers to
+        # int32 before the bitshifting operations below.
+        vector_data = vector_data.astype(np.int32)
+
         # Since the vectors are stored as 50 bit chunks but accessed via hex (4 bit
         # chunks) there is some shifting required for processing the bytes.
         # However, from a bit processing perspective, the first 48 bits of each 50 bit

--- a/poetry.lock
+++ b/poetry.lock
@@ -1747,4 +1747,4 @@ tools = ["openpyxl", "pandas"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "28cbb877e15c362c80541a8cebd35f12575cd86802c902505b4db1f65640d37e"
+content-hash = "f750033025b765826c827adb1142fd59444e13a985755c2a6efc3a207348a959"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ space_packet_parser = ">=4.2.0"
 spiceypy = ">=6.0.0"
 xarray = '>=2023.0.0'
 pyyaml = "^6.0.1"
-numpy = "^1.26.4"
+numpy = "<=3"
 
 # Optional dependencies
 numpydoc = {version="^1.5.0", optional=true}


### PR DESCRIPTION
# Change Summary

## Overview

Numpy 2 is more strict about the overflow math calculations, so we needed to update a few cases to handle that as well.

<!--Add a list or paragraph giving an overview of your changes-->

## New Dependencies

Bumping numpy to allow 2+
