### PR TITLE
FIX: Avoid loss of precision when casting in packet loading

### DIFF
--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -299,10 +299,18 @@ def _create_minimum_dtype_array(values: list, dtype: str) -> npt.NDArray:
     array : np.array
         The array of values.
     """
+    # Create an initial array and then try to safely cast it to the desired dtype
+    x = np.asarray(values)
     try:
-        return np.array(values, dtype=dtype)
+        # ValueError: when trying to cast strings (enum states) to ints
+        y = x.astype(dtype, copy=False)
+        # We need to compare the arrays to see if we trimmed any values by
+        # casting to a smaller datatype (e.g. float64 to uint8, 2.1 to 2)
+        if np.array_equal(x, y):
+            return y
     except ValueError:
-        return np.array(values)
+        pass
+    return x
 
 
 def packet_file_to_datasets(


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

When using derived values there can be situations where a linear conversion factor is applied to a uint8 value to turn a raw measurement into a float temperature value for instance. These are represented as a small uint datatype onboard, but need to be represented as a float or larger integer datatype on the ground so we don't lose precision. Previously we were getting 2.1 cast to 2 after the derived types were attempted to be cast to their onboard types.

closes #780 