### PR TITLE
ENH: Add "Parents" global attribute to datasets

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -133,7 +133,7 @@ def write_cdf(
         # Include the current files if there are any and include just the filename
         # [file1.txt, file2.cdf, ...]
         dataset.attrs["Parents"] = dataset.attrs.get("Parents", []) + [
-            p.name for p in parent_files
+            parent_file.name for parent_file in parent_files
         ]
 
     # Convert the xarray object to a CDF

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from pathlib import Path
+from typing import Optional
 
 import imap_data_access
 import numpy as np
@@ -62,7 +63,9 @@ def load_cdf(
     return dataset
 
 
-def write_cdf(dataset: xr.Dataset, **extra_cdf_kwargs: dict) -> Path:
+def write_cdf(
+    dataset: xr.Dataset, parent_files: Optional[list] = None, **extra_cdf_kwargs: dict
+) -> Path:
     """
     Write the contents of "data" to a CDF file using cdflib.xarray_to_cdf.
 
@@ -77,6 +80,10 @@ def write_cdf(dataset: xr.Dataset, **extra_cdf_kwargs: dict) -> Path:
     ----------
     dataset : xarray.Dataset
         The dataset object to convert to a CDF.
+    parent_files : list of Path, optional
+        List of parent files that were used to make this file. These get added to
+        the ``Parents`` global attribute:
+        https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html.
     **extra_cdf_kwargs : dict
         Additional keyword arguments to pass to the ``xarray_to_cdf`` function.
 
@@ -121,6 +128,13 @@ def write_cdf(dataset: xr.Dataset, **extra_cdf_kwargs: dict) -> Path:
     dataset.attrs["Logical_file_id"] = file_path.stem
     # Add the processing version to the dataset attributes
     dataset.attrs["ground_software_version"] = imap_processing._version.__version__
+    # Add any parent files to the dataset attributes
+    if parent_files:
+        # Include the current files if there are any and include just the filename
+        # [file1.txt, file2.cdf, ...]
+        dataset.attrs["Parents"] = dataset.attrs.get("Parents", []) + [
+            p.name for p in parent_files
+        ]
 
     # Convert the xarray object to a CDF
     xarray_to_cdf(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -257,6 +257,7 @@ class ProcessInstrument(ABC):
 
         # Convert string into a dictionary
         self.dependencies = loads(dependency_str.replace("'", '"'))
+        self._dependency_list: list = []
 
         self.start_date = start_date
         self.end_date = end_date
@@ -356,7 +357,8 @@ class ProcessInstrument(ABC):
         list[Path]
             List of dependencies downloaded from the IMAP SDC.
         """
-        return self.download_dependencies()
+        self._dependency_list = self.download_dependencies()
+        return self._dependency_list
 
     @abstractmethod
     def do_processing(self, dependencies: list) -> list[xr.Dataset]:
@@ -393,7 +395,10 @@ class ProcessInstrument(ABC):
             A list of datasets (products) produced by do_processing method.
         """
         logger.info("Writing products to local storage")
-        products = [write_cdf(dataset) for dataset in datasets]
+        products = [
+            write_cdf(dataset, parent_files=self._dependency_list)
+            for dataset in datasets
+        ]
         self.upload_products(products)
 
 

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for the ``cdf.utils`` module."""
 
+from pathlib import Path
+
 import imap_data_access
 import numpy as np
 import pytest
@@ -92,3 +94,16 @@ def test_written_and_loaded_dataset(test_dataset):
 
     new_dataset = load_cdf(write_cdf(test_dataset))
     assert str(test_dataset) == str(new_dataset)
+
+
+def test_parents_injection(test_dataset):
+    """Tests the ``write_cdf`` function for Parents attribute injection.
+
+    Parameters
+    ----------
+    test_dataset : xarray.Dataset
+        An ``xarray`` dataset object to test with
+    """
+    parent_paths = [Path("test_parent1.cdf"), Path("/abc/test_parent2.cdf")]
+    new_dataset = load_cdf(write_cdf(test_dataset, parent_files=parent_paths))
+    assert new_dataset.attrs["Parents"] == [p.name for p in parent_paths]


### PR DESCRIPTION
# Change Summary

## Overview

This injects the Parent files used to create this data product when writing the CDF file. This takes all of the dependencies input during the processing run and saves them to the processing runner class. Then adds a new path to the `write_cdf()` routine to inject the parents attribute when writing the dataset, similar to how we are adding other global attributes like logical file id.

Note that we can add other dependencies like calibration files and the like in the processing routines directly if we want to do that too.

closes https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/849