### PR TITLE
859 spice frame transform function

### DIFF
--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -58,6 +58,8 @@ class SpiceFrame(IntEnum):
     IMAP_HIT = -43500
     IMAP_IDEX = -43700
     IMAP_GLOWS = -43750
+    # IMAP Pointing Frame (Despun) as defined in iamp_science_0001.tf
+    IMAP_DPS = -43901
 
 
 @typing.no_type_check
@@ -253,10 +255,14 @@ def frame_transform(
             )
     elif position.ndim == 2:
         if not position.shape[1] == 3:
-            raise ValueError("Each input position vector must have 3 elements.")
+            raise ValueError(
+                f"Invalid position shape: {position.shape}. "
+                f"Each input position vector must have 3 elements."
+            )
         if not len(position) == len(et):
             raise ValueError(
                 "Mismatch in number of position vectors and Ephemeris times provided."
+                f"Position has {len(position)} elements and et has {len(et)} elements."
             )
 
     vec_pxform = get_vec_pxform()

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -265,17 +265,14 @@ def frame_transform(
                 f"Position has {len(position)} elements and et has {len(et)} elements."
             )
 
+    # rotate will have shape = (3, 3) or (n, 3, 3)
+    # position will have shape = (3,) or (n, 3)
     rotate = get_rotation_matrix(from_frame, to_frame, et)
-
-    if hasattr(rotate[0][0], "__len__"):
-        result = np.array(
-            [
-                np.matmul(rotate, pos).astype(np.float64)
-                for rotate, pos in zip(rotate, position)
-            ]
-        )
-    else:
-        result = np.matmul(rotate, position).astype(np.float64)
+    # adding a dimension to position results in the following input and output
+    # shapes from matrix multiplication
+    # Single et/position:      (3, 3),(3, 1) -> (3, 1)
+    # Multiple et/positions :  (n, 3, 3),(n, 3, 1) -> (n, 3, 1)
+    result = np.squeeze(rotate @ position[..., np.newaxis])
 
     return result
 

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -28,7 +28,7 @@ class SpiceBody(IntEnum):
     # A subset of IMAP Specific bodies as defined in imap_wkcp.tf
     IMAP = -43
     IMAP_SPACECRAFT = -43000
-    # IMAP Pointing Frame (Despun) as defined in iamp_science_0001.tf
+    # IMAP Pointing Frame (Despun) as defined in imap_science_0001.tf
     IMAP_DPS = -43901
     # Standard NAIF bodies
     SOLAR_SYSTEM_BARYCENTER = spice.bodn2c("SOLAR_SYSTEM_BARYCENTER")
@@ -227,6 +227,13 @@ def frame_transform(
 ) -> npt.NDArray:
     """
     Transform an <x, y, z> vector between reference frames (rotation only).
+
+    This function is a vectorized equivalent to performing the following SPICE
+    calls for each input time and position vector to perform the transform.
+    The matrix multiplication step is done using `numpy.matmul` rather than
+    `spice.mxv`.
+    >>> rotation_matrix = spice.pxform(from_frame, to_frame, et)
+    ... result = spice.mxv(rotation_matrix, position)
 
     Parameters
     ----------

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -220,24 +220,24 @@ def get_spacecraft_spin_phase(
 @typing.no_type_check
 @ensure_spice
 def frame_transform(
-    from_frame: SpiceFrame,
-    to_frame: SpiceFrame,
     et: Union[float, npt.NDArray],
     position: npt.NDArray,
+    from_frame: SpiceFrame,
+    to_frame: SpiceFrame,
 ) -> npt.NDArray:
     """
     Transform an <x, y, z> vector between reference frames (rotation only).
 
     Parameters
     ----------
-    from_frame : SpiceFrame
-        Reference frame of input vector(s).
-    to_frame : SpiceFrame
-        Reference frame of output vector(s).
     et : float or npt.NDArray
         Ephemeris time(s) corresponding to position(s).
     position : npt.NDArray
         <x, y, z> vector or array of vectors in reference frame `from_frame`.
+    from_frame : SpiceFrame
+        Reference frame of input vector(s).
+    to_frame : SpiceFrame
+        Reference frame of output vector(s).
 
     Returns
     -------
@@ -267,7 +267,7 @@ def frame_transform(
 
     # rotate will have shape = (3, 3) or (n, 3, 3)
     # position will have shape = (3,) or (n, 3)
-    rotate = get_rotation_matrix(from_frame, to_frame, et)
+    rotate = get_rotation_matrix(et, from_frame, to_frame)
     # adding a dimension to position results in the following input and output
     # shapes from matrix multiplication
     # Single et/position:      (3, 3),(3, 1) -> (3, 1)
@@ -278,7 +278,9 @@ def frame_transform(
 
 
 def get_rotation_matrix(
-    from_frame: SpiceFrame, to_frame: SpiceFrame, et: Union[float, npt.NDArray]
+    et: Union[float, npt.NDArray],
+    from_frame: SpiceFrame,
+    to_frame: SpiceFrame,
 ) -> npt.NDArray:
     """
     Get the rotation matrix/matrices that can be used to transform between frames.
@@ -290,12 +292,12 @@ def get_rotation_matrix(
 
     Parameters
     ----------
+    et : float or npt.NDArray
+        Ephemeris time(s) for which to get the rotation matrices.
     from_frame : SpiceFrame
         Reference frame to transform from.
     to_frame : SpiceFrame
         Reference frame to transform to.
-    et : float or npt.NDArray
-        Ephemeris time(s) for which to get the rotation matrices.
 
     Returns
     -------

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -4,6 +4,8 @@ import logging
 import os
 import re
 import time
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Optional
 
 import cdflib
@@ -121,6 +123,18 @@ def furnish_sclk(spice_test_data_path):
     spice.furnsh(str(test_sclk))
     yield test_sclk
     spice.kclear()
+
+
+@pytest.fixture()
+def furnish_kernels(spice_test_data_path):
+    """Return a function that will furnish an arbitrary list of kernels."""
+
+    @contextmanager
+    def furnish_kernels(kernels: list[Path]):
+        with spice.KernelPool([str(spice_test_data_path / k) for k in kernels]) as pool:
+            yield pool
+
+    return furnish_kernels
 
 
 @pytest.fixture(scope="session")

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -128,7 +128,7 @@ def test_frame_transform(furnish_kernels):
         et_0 = spice.utc2et("2025-04-30T12:00:00.000")
         position = np.arange(3) + 1
         result_0 = frame_transform(
-            SpiceFrame.IMAP_ULTRA_45, SpiceFrame.IMAP_DPS, et_0, position
+            et_0, position, SpiceFrame.IMAP_ULTRA_45, SpiceFrame.IMAP_DPS
         )
         # compare against pure SPICE calculation
         rotation_matrix = spice.pxform(
@@ -141,10 +141,7 @@ def test_frame_transform(furnish_kernels):
         ets = np.array([et_0, et_0 + 10])
         positions = np.array([[1, 1, 1], [1, 2, 3]])
         vec_result = frame_transform(
-            SpiceFrame.IMAP_HI_90,
-            SpiceFrame.IMAP_DPS,
-            ets,
-            positions,
+            ets, positions, SpiceFrame.IMAP_HI_90, SpiceFrame.IMAP_DPS
         )
 
         assert vec_result.shape == (2, 3)
@@ -163,34 +160,34 @@ def test_frame_transform_exceptions():
         ValueError, match="Position vectors with one dimension must have 3 elements."
     ):
         frame_transform(
-            SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.IMAP_CODICE, 0, np.arange(4)
+            0, np.arange(4), SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.IMAP_CODICE
         )
     with pytest.raises(
         ValueError,
         match="Ephemeris time must be float when single position vector is provided.",
     ):
         frame_transform(
-            SpiceFrame.ECLIPJ2000,
-            SpiceFrame.IMAP_HIT,
             np.asarray(0),
             np.array([1, 0, 0]),
+            SpiceFrame.ECLIPJ2000,
+            SpiceFrame.IMAP_HIT,
         )
     with pytest.raises(ValueError, match="Invalid position shape: "):
         frame_transform(
-            SpiceFrame.ECLIPJ2000,
-            SpiceFrame.IMAP_HIT,
             np.arange(2),
             np.arange(4).reshape((2, 2)),
+            SpiceFrame.ECLIPJ2000,
+            SpiceFrame.IMAP_HIT,
         )
     with pytest.raises(
         ValueError,
         match="Mismatch in number of position vectors and Ephemeris times provided.",
     ):
         frame_transform(
-            SpiceFrame.ECLIPJ2000,
-            SpiceFrame.IMAP_HIT,
             np.arange(2),
             np.arange(9).reshape((3, 3)),
+            SpiceFrame.ECLIPJ2000,
+            SpiceFrame.IMAP_HIT,
         )
 
 
@@ -207,11 +204,11 @@ def test_get_rotation_matrix(furnish_kernels):
         et = spice.utc2et("2025-09-30T12:00:00.000")
         # test input of float
         rotation = get_rotation_matrix(
-            SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT, et
+            et, SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT
         )
         assert rotation.shape == (3, 3)
         # test array of et input
         rotation = get_rotation_matrix(
-            SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT, np.arange(10) + et
+            np.arange(10) + et, SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT
         )
         assert rotation.shape == (10, 3, 3)


### PR DESCRIPTION
# Change Summary

## Overview
Add SPICE functions for transforming positions from one reference frame to another. This is useful for things like transforming particle velocity vectors.

## Updated Files
- imap_processing/spice/geometry.py
   - Added function: `frame_transform`
   - Added function: `get_rotation_matrix`
- imap_processing/tests/spice/test_geometry.py
   - Added test coverage for new geometry functions
- imap_processing/tests/conftest.py
   - Added general fixture/context manager for furnishing a list of kernels.
 
closes #859 
