### PR TITLE
REL/CI: Add wheel build to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Build and upload to PyPI
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
@@ -10,12 +11,9 @@ on:
       - published
 
 jobs:
-
-  build_sdist:
-    name: Build source distribution
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
-    outputs:
-      SDIST_NAME: ${{ steps.sdist.outputs.SDIST_NAME }}
 
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +21,7 @@ jobs:
           # We need the full history to generate the proper version number
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.11'
@@ -31,26 +29,23 @@ jobs:
       - name: Install dependencies
         run: python -m pip install build twine
 
-      - name: Build sdist
-        id: sdist
+      - name: Build wheel and source distribution
         run: |
-          python -m build --sdist
-          # Get the name of the build sdist file for later use
-          echo "SDIST_NAME=$(ls -1 dist)" >> $GITHUB_OUTPUT
+          python -m build
 
       - name: Check README rendering for PyPI
         run: twine check dist/*
 
       - name: Upload sdist result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: sdist
-          path: dist/*.tar.gz
+          name: python-package-distributions
+          path: dist/
           if-no-files-found: error
 
   pypi-publish:
     name: Upload release to PyPI
-    needs: build_sdist
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -59,11 +54,10 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-      - name: Download sdist
-        uses: actions/download-artifact@v3
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
         with:
-          name: sdist
-          path: dist
-
-      - name: Publish package distributions to PyPI
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.10


### PR DESCRIPTION
# Change Summary

## Overview
Historically we've only been uploading [source distribution tarballs](https://pypi.org/project/imap-processing/#files), but we should actually be releasing the sdist **and** the wheel. This updates that (by removing the `--sdist` only flag) and updates to the latest packaging recommendation workflow examples here: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/