### PR TITLE
Fixed Lo DE unpacking scheme 

### DIFF
--- a/imap_processing/lo/l0/decompression_tables/decompression_tables.py
+++ b/imap_processing/lo/l0/decompression_tables/decompression_tables.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 # must be shifted by 1 bit to the left
 DE_BIT_SHIFT = 1
 
-# This named tupled will be used to store the bit length
+# This named tuple will be used to store the bit length
 # of each TOF field. This length will be used for unpacking
 # the TOF data.
 DataFields = namedtuple(
@@ -24,7 +24,7 @@ DataFields = namedtuple(
     ],
 )
 # the bit length for each field
-DATA_BITS = DataFields(12, 3, 1, 10, 9, 9, 6, 3, 1)
+DATA_BITS = DataFields(12, 3, 1, 10, 9, 9, 6, 4, 2)
 
 # This named tuple will be used to store which
 # TOF fields are transmitted for each case / mode.
@@ -61,7 +61,7 @@ CASE_DECODER = {
     (4, 1): TOFFields(True, False, False, False, False, True),
     (4, 0): TOFFields(True, False, False, True, False, False),
     (5, 0): TOFFields(True, False, True, False, False, False),
-    (6, 1): TOFFields(True, False, False, True, False, False),
+    (6, 1): TOFFields(True, False, False, False, False, True),
     (6, 0): TOFFields(True, False, False, True, False, False),
     (7, 0): TOFFields(True, False, False, False, False, False),
     (8, 0): TOFFields(False, True, True, False, False, True),

--- a/imap_processing/tests/lo/test_science_direct_events.py
+++ b/imap_processing/tests/lo/test_science_direct_events.py
@@ -153,7 +153,7 @@ def test_decompress_data_multi_de(multi_de):
     # TOF1 not transmitted
     tof2_1 = "000000010"  # 2
     tof3_1 = "000011"  # 3
-    cksm_1 = "000"  # 0
+    cksm_1 = "0000"  # 0
     # POS not transmitted
 
     # DE Two


### PR DESCRIPTION
# Change Summary

## Overview
Found issues with the Lo unpacking scheme defined in decompression_tables.py

- For coincidence type 6, mode 1: TOF3 is not transmitted, but Position is
- The checksum is now 4 bits instead of 3 bits
- Fixed mistake with the position bits saying 1 instead of 2

Closes #900