### PR TITLE
913 hi l1a update hi product definition esa step

### DIFF
--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -63,13 +63,13 @@ default_ccsds_met: &hi_ccsds_met
   UNITS: sec
   VAR_TYPE: support_data
 
-hi_esa_stepping_num: &hi_esa_stepping_num
+hi_esa_step: &hi_esa_step
   <<: *default_uint8
   CATDESC: Zero based index indicates which row of onboard stepping table was used
-  FIELDNAM: ESA stepping number
+  FIELDNAM: ESA step
   FILLVAL: 255
   FORMAT: I2
-  LABLAXIS: Stepping Num
+  LABLAXIS: ESA step
   VALIDMIN: 0
   VALIDMAX: 16
   VAR_NOTES: >
@@ -87,8 +87,8 @@ hi_de_de_tag:
   FIELDNAM: Direct Event Time Tag
   LABLAXIS: DE Time Tag
 
-hi_de_esa_stepping_num:
-  <<: *hi_esa_stepping_num
+hi_de_esa_step:
+  <<: *hi_esa_step
 
 hi_de_event_met:
   <<: *default_int64
@@ -174,8 +174,8 @@ hi_hist_angle:
 hi_hist_ccsds_met:
   <<: *hi_ccsds_met
 
-hi_hist_esa_stepping_num:
-  <<: *hi_esa_stepping_num
+hi_hist_esa_step:
+  <<: *hi_esa_step
 
 hi_hist_counters:
   <<: *default_uint16
@@ -201,7 +201,7 @@ hi_de_coincidence_type:
     made up of the ORed quantities: (A hit? 8:0) | (B hit? 4:0)
     | (C1 hit? 2:0) | (C2 hit? 1 : 0)
 
-default_esa_step: &default_esa_step
+default_esa_energy_step: &default_esa_energy_step
   CATDESC: Zero based energy step index
   FIELDNAM: ESA energy step
   FILLVAL: 255
@@ -209,9 +209,9 @@ default_esa_step: &default_esa_step
   VALIDMIN: 0
   VALIDMAX: 12
 
-hi_de_esa_step:
+hi_de_esa_energy_step:
   <<: *default_uint8
-  <<: *default_esa_step
+  <<: *default_esa_energy_step
   LABLAXIS: Energy Step
 
 default_delta_t: &default_delta_t
@@ -254,7 +254,7 @@ hi_de_spin_phase:
 hi_de_hae_latitude:
   <<: *default_float32
   CATDESC: Look direction HAE latitude
-  FIELDNAM: Ecliptic Lattitude
+  FIELDNAM: Ecliptic Latitude
   FORMAT: F5.2
   LABLAXIS: Lat
   VALIDMIN: -180
@@ -294,8 +294,8 @@ hi_de_nominal_bin:
 
 # ======= L1C PSET Section =======
 
-hi_pset_esa_step:
-  <<: *default_esa_step
+hi_pset_esa_energy_step:
+  <<: *default_esa_energy_step
   LABLAXIS: Energy Step
   UNITS: " "
   VALIDMIN: 0
@@ -369,9 +369,9 @@ hi_pset_counts:
   CATDESC: Binned direct events counts during good times
   FIELDNAM: Binned DE counts
   DEPEND_0: epoch
-  DEPEND_1: esa_step
+  DEPEND_1: esa_energy_step
   DEPEND_2: spin_angle_bin
-  LABL_PTR_1: esa_step_label
+  LABL_PTR_1: esa_energy_step_label
   LABL_PTR_2: spin_bin_label
   DISPLAY_TYPE: stack_plot
   FORMAT: I5
@@ -381,9 +381,9 @@ hi_pset_exposure_times:
   CATDESC: Exposure times for each bin during good times
   FIELDNAM: Bin exposure times
   DEPEND_0: epoch
-  DEPEND_1: esa_step
+  DEPEND_1: esa_energy_step
   DEPEND_2: spin_angle_bin
-  LABL_PTR_1: esa_step_label
+  LABL_PTR_1: esa_energy_step_label
   LABL_PTR_2: spin_bin_label
   UNITS: sec
   DISPLAY_TYPE: stack_plot
@@ -394,9 +394,9 @@ hi_pset_background_rates:
   CATDESC: Background count rates
   FIELDNAM: Background count rates
   DEPEND_0: epoch
-  DEPEND_1: esa_step
+  DEPEND_1: esa_energy_step
   DEPEND_2: spin_angle_bin
-  LABL_PTR_1: esa_step_label
+  LABL_PTR_1: esa_energy_step_label
   LABL_PTR_2: spin_bin_label
   UNITS: counts / s
   DISPLAY_TYPE: stack_plot
@@ -407,9 +407,9 @@ hi_pset_background_rates_uncertainty:
   CATDESC: Background count rate uncertainties
   FIELDNAM: Background count rate uncertainties
   DEPEND_0: epoch
-  DEPEND_1: esa_step
+  DEPEND_1: esa_energy_step
   DEPEND_2: spin_angle_bin
-  LABL_PTR_1: esa_step_label
+  LABL_PTR_1: esa_energy_step_label
   LABL_PTR_2: spin_bin_label
   UNITS: counts / s
   DISPLAY_TYPE: stack_plot
@@ -422,7 +422,7 @@ hi_pset_spin_bin_label:
   FORMAT: A4
   VAR_TYPE: metadata
 
-hi_pset_esa_step_label:
+hi_pset_esa_energy_step_label:
   CATDESC: Label esa step
   FIELDNAM: Label esa step
   FORMAT: A4

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -117,7 +117,7 @@ def allocate_histogram_dataset(num_packets: int) -> xr.Dataset:
     data_vars["esa_stepping_num"] = xr.DataArray(
         np.empty(num_packets, dtype=np.uint8),
         dims=["epoch"],
-        attrs=attr_mgr.get_variable_attributes("hi_hist_esa_stepping_num"),
+        attrs=attr_mgr.get_variable_attributes("hi_hist_esa_step"),
     )
 
     # Allocate xarray.DataArray objects for the 24 90-element histogram counters

--- a/imap_processing/hi/l1a/science_direct_event.py
+++ b/imap_processing/hi/l1a/science_direct_event.py
@@ -178,7 +178,7 @@ def create_dataset(de_data_list: list, packet_met_time: list) -> xr.Dataset:
         "event_met": list(),
         "ccsds_met": list(),
         "meta_event_met": list(),
-        "esa_stepping_num": list(),
+        "esa_step": list(),
         "trigger_id": list(),
         "tof_1": list(),
         "tof_2": list(),
@@ -246,7 +246,7 @@ def create_dataset(de_data_list: list, packet_met_time: list) -> xr.Dataset:
         )
         data_dict["event_met"].append(de_met_in_ns)
         data_dict["epoch"].append(met_to_j2000ns(de_met_in_ns / 1e9))
-        data_dict["esa_stepping_num"].append(current_esa_step)
+        data_dict["esa_step"].append(current_esa_step)
         # start_bitmask_data is 1, 2, 3 for detector A, B, C
         # respectively. This is used to identify which detector
         # was hit first for this current direct event.

--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -50,7 +50,7 @@ def hi_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
             l1a_dataset,
             conversion_table_path=conversion_table_path,
             packet_name=packet_enum.name,
-            comment="#",
+            comment="#",  # type: ignore[arg-type]
             # Todo error, Argument "comment" to "convert_raw_to_eu" has incompatible
             # type "str"; expected "dict[Any, Any]"
             converters={"mnemonic": str.lower},

--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -50,7 +50,7 @@ def hi_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
             l1a_dataset,
             conversion_table_path=conversion_table_path,
             packet_name=packet_enum.name,
-            comment="#",  # type: ignore[arg-type]
+            comment="#",
             # Todo error, Argument "comment" to "convert_raw_to_eu" has incompatible
             # type "str"; expected "dict[Any, Any]"
             converters={"mnemonic": str.lower},
@@ -95,7 +95,7 @@ def annotate_direct_events(l1a_dataset: xr.Dataset) -> xr.Dataset:
     new_data_vars = dict()
     for var in [
         "coincidence_type",
-        "esa_step",
+        "esa_energy_step",
         "delta_t_ab",
         "delta_t_ac1",
         "delta_t_bc1",

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -106,13 +106,13 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str) -> xr.Dataset:
         attrs=attr_mgr.get_variable_attributes("epoch"),
     )
     attrs = attr_mgr.get_variable_attributes(
-        "hi_pset_esa_step", check_schema=False
+        "hi_pset_esa_energy_step", check_schema=False
     ).copy()
     dtype = attrs.pop("dtype")
-    coords["esa_step"] = xr.DataArray(
+    coords["esa_energy_step"] = xr.DataArray(
         np.full(n_esa_steps, attrs["FILLVAL"], dtype=dtype),
-        name="esa_step",
-        dims=["esa_step"],
+        name="esa_energy_step",
+        dims=["esa_energy_step"],
         attrs=attrs,
     )
     # spin angle bins are 0.1 degree bins for full 360 degree spin
@@ -149,12 +149,12 @@ def allocate_pset_dataset(n_esa_steps: int, sensor_str: str) -> xr.Dataset:
         )
 
     # Generate label variables
-    data_vars["esa_step_label"] = xr.DataArray(
-        coords["esa_step"].values.astype(str),
-        name="esa_step_label",
-        dims=["esa_step"],
+    data_vars["esa_energy_step_label"] = xr.DataArray(
+        coords["esa_energy_step"].values.astype(str),
+        name="esa_energy_step_label",
+        dims=["esa_energy_step"],
         attrs=attr_mgr.get_variable_attributes(
-            "hi_pset_esa_step_label", check_schema=False
+            "hi_pset_esa_energy_step_label", check_schema=False
         ),
     )
     data_vars["spin_bin_label"] = xr.DataArray(

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -35,7 +35,7 @@ def test_allocate_pset_dataset():
     np.testing.assert_array_equal(dataset.despun_z.data.shape, (1, 3))
     np.testing.assert_array_equal(dataset.hae_latitude.data.shape, (1, 3600))
     np.testing.assert_array_equal(dataset.hae_longitude.data.shape, (1, 3600))
-    n_esa_step = dataset.esa_step.data.size
+    n_esa_step = dataset.esa_energy_step.data.size
     for var in [
         "counts",
         "exposure_times",
@@ -57,7 +57,7 @@ def test_full_dataarray(name, shape, expected_shape):
     """Test coverage for full_dataarray function"""
     coords = {
         "epoch": xr.DataArray(np.array([0])),
-        "esa_step": xr.DataArray(np.arange(10)),
+        "esa_energy_step": xr.DataArray(np.arange(10)),
         "spin_angle_bin": xr.DataArray(np.arange(360)),
     }
     cdf_manager = ImapCdfAttributes()

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -19,7 +19,7 @@ def test_sci_de_decom(create_de_data):
 
     # unique ESA steps should be [1, 2]
     assert np.array_equal(
-        np.sort(np.unique(processed_data[0]["esa_stepping_num"].values)),
+        np.sort(np.unique(processed_data[0]["esa_step"].values)),
         np.array([1, 2]),
     )
     # unique trigger_id should be [1, 2, 3]


### PR DESCRIPTION
# Change Summary
These changes were required to bring Hi product nomenclature in line with other ENA instruments.

This was essentially a search and replace for:
`esa_step` -> `esa_energy_step`
`esa_stepping_num` -> `esa_step`

Closes: #913