### PR TITLE
1019 calculate instrument spin phase

### DIFF
--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -270,10 +270,10 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
     """
     Get the spin phase offset from the spacecraft to the instrument.
 
-    The spin phase offset is can be calculated using the instrument frame SPICE
-    kernel and the proper knowledge about which axis of the instrument frame
-    to use (typically the boresight). For now, the offset is a fixed lookup
-    based on Table 1: Nominal Instrument to S/C CS Transformations in 7516-0011_drw.pdf
+    For now, the offset is a fixed lookup based on `Table 1: Nominal Instrument
+    to S/C CS Transformations` in document `7516-0011_drw.pdf`. These fixed
+    values will need to be updated based on calibration data or retrieved using
+    SPICE and the latest IMAP frame kernel.
 
     Parameters
     ----------

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -243,7 +243,7 @@ def get_instrument_spin_phase(
     Get the instrument spin phase for the input query times.
 
     Formula to calculate spin phase:
-        `instrument_spin_phase = (spacecraft_spin_phase + instrument_spin_offset) % 1
+        instrument_spin_phase = (spacecraft_spin_phase + instrument_spin_offset) % 1
 
     Parameters
     ----------

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -143,10 +143,10 @@ def test_get_spin_data():
 )
 def test_get_instrument_spin_phase(instrument, fake_spin_data):
     """Test coverage for get_instrument_spin_phase()"""
-    ets = np.array([7.5, 30, 61, 75, 106, 121, 136])
+    met_times = np.array([7.5, 30, 61, 75, 106, 121, 136])
     expected_nan_mask = np.array([False, False, True, False, True, True, False])
-    inst_phase = get_instrument_spin_phase(ets, instrument)
-    assert inst_phase.shape == ets.shape
+    inst_phase = get_instrument_spin_phase(met_times, instrument)
+    assert inst_phase.shape == met_times.shape
     np.testing.assert_array_equal(np.isnan(inst_phase), expected_nan_mask)
     assert np.logical_and(
         0 <= inst_phase[~expected_nan_mask], inst_phase[~expected_nan_mask] < 1

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -9,8 +9,10 @@ from imap_processing.spice.geometry import (
     SpiceBody,
     SpiceFrame,
     frame_transform,
+    get_instrument_spin_phase,
     get_rotation_matrix,
     get_spacecraft_spin_phase,
+    get_spacecraft_to_instrument_spin_phase_offset,
     get_spin_data,
     imap_state,
     instrument_pointing,
@@ -120,6 +122,55 @@ def test_get_spin_data():
         "thruster_firing",
         "spin_start_time",
     }, "Spin data must have the specified fields."
+
+
+@pytest.mark.usefixtures("_set_spin_data_filepath")
+@pytest.mark.parametrize(
+    "instrument",
+    [
+        SpiceFrame.IMAP_LO,
+        SpiceFrame.IMAP_HI_45,
+        SpiceFrame.IMAP_HI_90,
+        SpiceFrame.IMAP_ULTRA_45,
+        SpiceFrame.IMAP_ULTRA_90,
+        SpiceFrame.IMAP_SWAPI,
+        SpiceFrame.IMAP_IDEX,
+        SpiceFrame.IMAP_CODICE,
+        SpiceFrame.IMAP_HIT,
+        SpiceFrame.IMAP_SWE,
+        SpiceFrame.IMAP_GLOWS,
+        SpiceFrame.IMAP_MAG,
+    ],
+)
+def test_get_instrument_spin_phase(instrument):
+    """Test coverage for get_instrument_spin_phase()"""
+    ets = np.arange(18) + 453051323.0
+    inst_phase = get_instrument_spin_phase(ets, instrument)
+    assert inst_phase.shape == ets.shape
+    assert np.logical_and(0 <= inst_phase, inst_phase < 1).all()
+
+
+@pytest.mark.parametrize(
+    "instrument, expected_offset",
+    [
+        (SpiceFrame.IMAP_LO, 330 / 360),
+        (SpiceFrame.IMAP_HI_45, 255 / 360),
+        (SpiceFrame.IMAP_HI_90, 285 / 360),
+        (SpiceFrame.IMAP_ULTRA_45, 33 / 360),
+        (SpiceFrame.IMAP_ULTRA_90, 210 / 360),
+        (SpiceFrame.IMAP_SWAPI, 168 / 360),
+        (SpiceFrame.IMAP_IDEX, 90 / 360),
+        (SpiceFrame.IMAP_CODICE, 136 / 360),
+        (SpiceFrame.IMAP_HIT, 30 / 360),
+        (SpiceFrame.IMAP_SWE, 153 / 360),
+        (SpiceFrame.IMAP_GLOWS, 127 / 360),
+        (SpiceFrame.IMAP_MAG, 0 / 360),
+    ],
+)
+def test_get_spacecraft_to_instrument_spin_phase_offset(instrument, expected_offset):
+    """Test coverage for get_spacecraft_to_instrument_spin_phase_offset()"""
+    result = get_spacecraft_to_instrument_spin_phase_offset(instrument)
+    assert result == expected_offset
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -124,7 +124,6 @@ def test_get_spin_data():
     }, "Spin data must have the specified fields."
 
 
-@pytest.mark.usefixtures("_set_spin_data_filepath")
 @pytest.mark.parametrize(
     "instrument",
     [
@@ -142,12 +141,16 @@ def test_get_spin_data():
         SpiceFrame.IMAP_MAG,
     ],
 )
-def test_get_instrument_spin_phase(instrument):
+def test_get_instrument_spin_phase(instrument, fake_spin_data):
     """Test coverage for get_instrument_spin_phase()"""
-    ets = np.arange(18) + 453051323.0
+    ets = np.array([7.5, 30, 61, 75, 106, 121, 136])
+    expected_nan_mask = np.array([False, False, True, False, True, True, False])
     inst_phase = get_instrument_spin_phase(ets, instrument)
     assert inst_phase.shape == ets.shape
-    assert np.logical_and(0 <= inst_phase, inst_phase < 1).all()
+    np.testing.assert_array_equal(np.isnan(inst_phase), expected_nan_mask)
+    assert np.logical_and(
+        0 <= inst_phase[~expected_nan_mask], inst_phase[~expected_nan_mask] < 1
+    ).all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Change Summary

## Overview
Adds two functions:
- `get_spacecraft_to_instrument_spin_phase_offset()`
    This function provides the offset to apply to the spacecraft spin phase to get the instrument spin phase. For now, this is a hard coded table. In the future, it will most likely use SPICE to determine the phase offset. 
- `get_instrument_spin_phase()`
   This function just adds the offset to the spacecraft spin phase and does a modulus with 1 to return the phase to the [0, 1) range.

## Updated Files
- imap_processing/spice/geometry.py
- imap_processing/tests/spice/test_geometry.py

Closes: #1019 
