### PR TITLE
Add function to convert j2000ns to j2000s

### DIFF
--- a/imap_processing/spice/time.py
+++ b/imap_processing/spice/time.py
@@ -44,6 +44,26 @@ def met_to_j2000ns(
     return np.asarray(_sct2e_wrapper(sclk_ticks) * 1e9, dtype=np.int64)
 
 
+def j2000ns_to_j2000s(j2000ns: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """
+    Convert the J2000 epoch nanoseconds to J2000 epoch seconds.
+
+    The common CDF coordinate `epoch` stores J2000 nanoseconds. SPICE requires
+    J2000 seconds be used. This is a common function to do that conversion.
+
+    Parameters
+    ----------
+    j2000ns : float, numpy.ndarray
+        Number of nanoseconds since the J2000 epoch.
+
+    Returns
+    -------
+    numpy.ndarray[float]
+        Number of seconds since the J2000 epoch.
+    """
+    return np.asarray(j2000ns, dtype=np.float64) / 1e9
+
+
 @typing.no_type_check
 @ensure_spice
 def _sct2e_wrapper(

--- a/imap_processing/spice/time.py
+++ b/imap_processing/spice/time.py
@@ -44,7 +44,7 @@ def met_to_j2000ns(
     return np.asarray(_sct2e_wrapper(sclk_ticks) * 1e9, dtype=np.int64)
 
 
-def j2000ns_to_j2000s(j2000ns: npt.ArrayLike) -> npt.NDArray[np.float64]:
+def j2000ns_to_j2000s(j2000ns: npt.ArrayLike) -> npt.NDArray[float]:
     """
     Convert the J2000 epoch nanoseconds to J2000 epoch seconds.
 

--- a/imap_processing/tests/spice/test_time.py
+++ b/imap_processing/tests/spice/test_time.py
@@ -5,7 +5,7 @@ import pytest
 import spiceypy as spice
 
 from imap_processing.spice import IMAP_SC_ID
-from imap_processing.spice.time import _sct2e_wrapper, met_to_j2000ns
+from imap_processing.spice.time import _sct2e_wrapper, j2000ns_to_j2000s, met_to_j2000ns
 
 
 def test_met_to_j2000ns(furnish_time_kernels):
@@ -23,6 +23,23 @@ def test_met_to_j2000ns(furnish_time_kernels):
     j2000ns = met_to_j2000ns(met)
     assert j2000ns.dtype == np.int64
     np.testing.assert_array_equal(j2000ns, np.array(et * 1e9))
+
+
+def test_j2000ns_to_j2000s(furnish_time_kernels):
+    """Test coverage for j2000ns_to_j2000s function."""
+    # Use spice to come up with reasonable J2000 values
+    utc = "2025-09-23T00:00:00.000"
+    # Test single value input
+    et = spice.str2et(utc)
+    epoch = int(et * 1e9)
+    j2000s = j2000ns_to_j2000s(epoch)
+    assert j2000s == et
+    # Test array input
+    epoch = (np.arange(et, et + 10000, 100) * 1e9).astype(np.int64)
+    j2000s = j2000ns_to_j2000s(epoch)
+    np.testing.assert_array_equal(
+        j2000s, np.arange(et, et + 10000, 100, dtype=np.float64)
+    )
 
 
 @pytest.mark.parametrize("sclk_ticks", [0.0, np.arange(10)])


### PR DESCRIPTION
# Change Summary

## Overview
Add time conversion function to convert from J2000 nanoseconds to J2000 seconds.

Closes: #1024 