### PR TITLE
SWAPI: rename CDF variable names to match algorithm document

### DIFF
--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -607,7 +607,7 @@ def process_swapi_science(
     )
 
     # Add quality flags to the dataset
-    dataset["swp_flags"] = swp_flags
+    dataset["swp_l1a_flags"] = swp_flags
     # ===================================================================
     # Step 4: Calculate uncertainty
     # ===================================================================
@@ -619,32 +619,32 @@ def process_swapi_science(
     # Above uncertaintly formula will change in the future.
     # Replace it with actual formula once SWAPI provides it.
     # Right now, we are using sqrt(count) as a placeholder
-    dataset["swp_pcem_err_plus"] = xr.DataArray(
+    dataset["swp_pcem_counts_err_plus"] = xr.DataArray(
         np.sqrt(swp_pcem_counts),
         dims=["epoch", "energy"],
         attrs=cdf_manager.get_variable_attributes("pcem_uncertainty"),
     )
-    dataset["swp_pcem_err_minus"] = xr.DataArray(
+    dataset["swp_pcem_counts_err_minus"] = xr.DataArray(
         np.sqrt(swp_pcem_counts),
         dims=["epoch", "energy"],
         attrs=cdf_manager.get_variable_attributes("pcem_uncertainty"),
     )
-    dataset["swp_scem_err_plus"] = xr.DataArray(
+    dataset["swp_scem_counts_err_plus"] = xr.DataArray(
         np.sqrt(swp_scem_counts),
         dims=["epoch", "energy"],
         attrs=cdf_manager.get_variable_attributes("scem_uncertainty"),
     )
-    dataset["swp_scem_err_minus"] = xr.DataArray(
+    dataset["swp_scem_counts_err_minus"] = xr.DataArray(
         np.sqrt(swp_scem_counts),
         dims=["epoch", "energy"],
         attrs=cdf_manager.get_variable_attributes("scem_uncertainty"),
     )
-    dataset["swp_coin_err_plus"] = xr.DataArray(
+    dataset["swp_coin_counts_err_plus"] = xr.DataArray(
         np.sqrt(swp_coin_counts),
         dims=["epoch", "energy"],
         attrs=cdf_manager.get_variable_attributes("coin_uncertainty"),
     )
-    dataset["swp_coin_err_minus"] = xr.DataArray(
+    dataset["swp_coin_counts_err_minus"] = xr.DataArray(
         np.sqrt(swp_coin_counts),
         dims=["epoch", "energy"],
         attrs=cdf_manager.get_variable_attributes("coin_uncertainty"),

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -50,7 +50,7 @@ def swapi_l2(l1_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         "epoch",
         "energy",
         "energy_label",
-        "swp_flags",
+        "swp_l1a_flags",
     ]
     l2_dataset = l1_dataset[l1_data_keys]
 
@@ -74,29 +74,41 @@ def swapi_l2(l1_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     l2_dataset["swp_coin_rate"].attrs = cdf_manager.get_variable_attributes("coin_rate")
 
     # update uncertainty
-    l2_dataset["swp_pcem_unc_plus"] = l1_dataset["swp_pcem_err_plus"] / TIME_PER_BIN
-    l2_dataset["swp_pcem_unc_minus"] = l1_dataset["swp_pcem_err_minus"] / TIME_PER_BIN
-    l2_dataset["swp_scem_unc_plus"] = l1_dataset["swp_scem_err_plus"] / TIME_PER_BIN
-    l2_dataset["swp_scem_unc_minus"] = l1_dataset["swp_scem_err_minus"] / TIME_PER_BIN
-    l2_dataset["swp_coin_unc_plus"] = l1_dataset["swp_coin_err_plus"] / TIME_PER_BIN
-    l2_dataset["swp_coin_unc_minus"] = l1_dataset["swp_coin_err_minus"] / TIME_PER_BIN
+    l2_dataset["swp_pcem_rate_err_plus"] = (
+        l1_dataset["swp_pcem_counts_err_plus"] / TIME_PER_BIN
+    )
+    l2_dataset["swp_pcem_rate_err_minus"] = (
+        l1_dataset["swp_pcem_counts_err_minus"] / TIME_PER_BIN
+    )
+    l2_dataset["swp_scem_rate_err_plus"] = (
+        l1_dataset["swp_scem_counts_err_plus"] / TIME_PER_BIN
+    )
+    l2_dataset["swp_scem_rate_err_minus"] = (
+        l1_dataset["swp_scem_counts_err_minus"] / TIME_PER_BIN
+    )
+    l2_dataset["swp_coin_rate_err_plus"] = (
+        l1_dataset["swp_coin_counts_err_plus"] / TIME_PER_BIN
+    )
+    l2_dataset["swp_coin_rate_err_minus"] = (
+        l1_dataset["swp_coin_counts_err_minus"] / TIME_PER_BIN
+    )
     # update attrs
-    l2_dataset["swp_pcem_unc_plus"].attrs = cdf_manager.get_variable_attributes(
+    l2_dataset["swp_pcem_rate_err_plus"].attrs = cdf_manager.get_variable_attributes(
         "pcem_uncertainty"
     )
-    l2_dataset["swp_pcem_unc_minus"].attrs = cdf_manager.get_variable_attributes(
+    l2_dataset["swp_pcem_rate_err_minus"].attrs = cdf_manager.get_variable_attributes(
         "pcem_uncertainty"
     )
-    l2_dataset["swp_scem_unc_plus"].attrs = cdf_manager.get_variable_attributes(
+    l2_dataset["swp_scem_rate_err_plus"].attrs = cdf_manager.get_variable_attributes(
         "scem_uncertainty"
     )
-    l2_dataset["swp_scem_unc_minus"].attrs = cdf_manager.get_variable_attributes(
+    l2_dataset["swp_scem_rate_err_minus"].attrs = cdf_manager.get_variable_attributes(
         "scem_uncertainty"
     )
-    l2_dataset["swp_coin_unc_plus"].attrs = cdf_manager.get_variable_attributes(
+    l2_dataset["swp_coin_rate_err_plus"].attrs = cdf_manager.get_variable_attributes(
         "coin_uncertainty"
     )
-    l2_dataset["swp_coin_unc_minus"].attrs = cdf_manager.get_variable_attributes(
+    l2_dataset["swp_coin_rate_err_minus"].attrs = cdf_manager.get_variable_attributes(
         "coin_uncertainty"
     )
 

--- a/imap_processing/tests/swapi/test_swapi_l1.py
+++ b/imap_processing/tests/swapi/test_swapi_l1.py
@@ -153,7 +153,7 @@ def test_process_swapi_science(decom_test_data):
     # Test that we calculated uncertainty correctly
     np.testing.assert_allclose(
         np.sqrt(processed_data["swp_pcem_counts"][0]),
-        processed_data["swp_pcem_err_plus"][0],
+        processed_data["swp_pcem_counts_err_plus"][0],
     )
 
     # make PLAN_ID data incorrect. Now processed data should have less sweeps

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -17,5 +17,6 @@ def test_swapi_l2_cdf(swapi_l0_test_data_path):
 
     # Test uncertainty variables are as expected
     np.testing.assert_array_equal(
-        l2_dataset["swp_pcem_unc_plus"], l1_dataset["swp_pcem_err_plus"] / TIME_PER_BIN
+        l2_dataset["swp_pcem_rate_err_plus"],
+        l1_dataset["swp_pcem_counts_err_plus"] / TIME_PER_BIN,
     )


### PR DESCRIPTION
# Change Summary
closes #1034 
## Overview
This is a small PR that renames variable names to match what's in algorithm document as requested by SWAPI team.

## Updated Files
- imap_processing/swapi/l1/swapi_l1.py
   - update variable names
- imap_processing/swapi/l2/swapi_l2.py
   - update variable names

## Testing
- imap_processing/tests/swapi/test_swapi_l1.py
- imap_processing/tests/swapi/test_swapi_l2.py