### PR TITLE
SWAPI: Add additional support data to SWAPI L1 and L2

### DIFF
--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -82,6 +82,17 @@ rate_default: &rate_default
   VAR_TYPE: data
   SCALETYP: linear
 
+metadata_default: &metadata_default
+  DEPEND_0: epoch
+  DISPLAY_TYPE: time_series
+  FILLVAL: 4294967295
+  FORMAT: I2
+  UNITS: " "
+  VALIDMIN: 0
+  VALIDMAX: 15
+  VAR_TYPE: support_data
+  SCALETYP: linear
+
 pcem_counts:
   <<: *counts_default
   CATDESC: Primary Channel Electron Multiplier (CEM)  Counts
@@ -135,3 +146,33 @@ coin_rate:
   CATDESC: Coincidence Rates
   FIELDNAM: Coincidence Rates
   LABLAXIS: coin_rate
+
+sweep_table:
+  <<: *metadata_default
+  CATDESC: Sweep table ID.
+  FIELDNAM: Sweep Table
+  LABLAXIS: ID
+
+plan_id:
+  <<: *metadata_default
+  CATDESC: Plan ID.
+  FIELDNAM: Plan ID
+  LABLAXIS: ID
+
+lut_choice:
+  <<: *metadata_default
+  CATDESC: Which LUT is in use.
+  FIELDNAM: LUT Choice
+  LABLAXIS: lut_choice
+
+fpga_type:
+  <<: *metadata_default
+  CATDESC: Type number of the FPGA.
+  FIELDNAM: FPGA Type
+  LABLAXIS: fpga_type
+
+fpga_rev:
+  <<: *metadata_default
+  CATDESC: Revision number of the FPGA.
+  FIELDNAM: FPGA Revision
+  LABLAXIS: fpga_rev

--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -577,8 +577,6 @@ def process_swapi_science(
     # TODO: add others like below once add_global_attribute is fixed
     cdf_manager.add_global_attribute("Data_version", data_version)
     l1_global_attrs = cdf_manager.get_global_attributes("imap_swapi_l1_sci")
-    l1_global_attrs["Sweep_table"] = f"{sci_dataset['sweep_table'].data[0]}"
-    l1_global_attrs["Plan_id"] = f"{sci_dataset['plan_id_science'].data[0]}"
     l1_global_attrs["Apid"] = f"{sci_dataset['pkt_apid'].data[0]}"
 
     dataset = xr.Dataset(
@@ -608,6 +606,43 @@ def process_swapi_science(
 
     # Add quality flags to the dataset
     dataset["swp_l1a_flags"] = swp_flags
+
+    # Add other support data
+    dataset["sweep_table"] = xr.DataArray(
+        good_sweep_sci["sweep_table"].data.reshape(total_full_sweeps, 12)[:, 0],
+        name="sweep_table",
+        dims=["epoch"],
+        attrs=cdf_manager.get_variable_attributes("sweep_table"),
+    )
+    dataset["plan_id"] = xr.DataArray(
+        good_sweep_sci["plan_id_science"].data.reshape(total_full_sweeps, 12)[:, 0],
+        name="plan_id",
+        dims=["epoch"],
+        attrs=cdf_manager.get_variable_attributes("plan_id"),
+    )
+    # Add these additional housekeeping support data
+    #   SWP_HK.LUT_CHOICE - Which LUT is in use
+    #   SWP_HK.FPGA_TYPE - Type number of the FPGA
+    #   SWP_HK.FPGA_REV - Revision number of the FPGA
+    dataset["lut_choice"] = xr.DataArray(
+        good_sweep_hk_data["lut_choice"].data.reshape(total_full_sweeps, 12)[:, 0],
+        name="lut_choice",
+        dims=["epoch"],
+        attrs=cdf_manager.get_variable_attributes("lut_choice"),
+    )
+    dataset["fpga_type"] = xr.DataArray(
+        good_sweep_hk_data["fpga_type"].data.reshape(total_full_sweeps, 12)[:, 0],
+        name="fpga_type",
+        dims=["epoch"],
+        attrs=cdf_manager.get_variable_attributes("fpga_type"),
+    )
+    dataset["fpga_rev"] = xr.DataArray(
+        good_sweep_hk_data["fpga_rev"].data.reshape(total_full_sweeps, 12)[:, 0],
+        name="fpga_rev",
+        dims=["epoch"],
+        attrs=cdf_manager.get_variable_attributes("fpga_rev"),
+    )
+
     # ===================================================================
     # Step 4: Calculate uncertainty
     # ===================================================================

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -51,6 +51,11 @@ def swapi_l2(l1_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         "energy",
         "energy_label",
         "swp_l1a_flags",
+        "sweep_table",
+        "plan_id",
+        "lut_choice",
+        "fpga_type",
+        "fpga_rev",
     ]
     l2_dataset = l1_dataset[l1_data_keys]
 

--- a/imap_processing/tests/swapi/test_swapi_l1.py
+++ b/imap_processing/tests/swapi/test_swapi_l1.py
@@ -179,8 +179,6 @@ def test_swapi_l1_cdf(swapi_l0_test_data_path):
     processed_data = swapi_l1(test_packet_file, data_version="v001")
 
     assert processed_data[0].attrs["Apid"] == f"{SWAPIAPID.SWP_SCI}"
-    assert processed_data[0].attrs["Plan_id"] == "1"
-    assert processed_data[0].attrs["Sweep_table"] == "1"
 
     # Test CDF File
     cdf_filename = "imap_swapi_l1_sci_20240924_v001.cdf"


### PR DESCRIPTION
# Change Summary
close #1033 

## Overview
This adds additional support data to SWAPI L1 and L2 for L3 purposes.

## Updated Files
- imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
   - add CDF attrs
- imap_processing/swapi/l1/swapi_l1.py
   - update to add additional data
- imap_processing/swapi/l2/swapi_l2.py
   - update to retain additional data in L2
## Testing
- imap_processing/tests/swapi/test_swapi_l1.py
