### PR TITLE
Add function for getting basis vectors from spice

### DIFF
--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -348,10 +348,11 @@ def frame_transform(
                 f"Invalid position shape: {position.shape}. "
                 f"Each input position vector must have 3 elements."
             )
-        if not len(position) == len(et):
+        if not len(position) == np.asarray(et).size:
             raise ValueError(
                 "Mismatch in number of position vectors and Ephemeris times provided."
-                f"Position has {len(position)} elements and et has {len(et)} elements."
+                f"Position has {len(position)} elements and et has "
+                f"{np.asarray(et).size} elements."
             )
 
     # rotate will have shape = (3, 3) or (n, 3, 3)

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -303,8 +303,6 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
     return offset_lookup[instrument]
 
 
-@typing.no_type_check
-@ensure_spice
 def frame_transform(
     et: Union[float, npt.NDArray],
     position: npt.NDArray,
@@ -369,6 +367,8 @@ def frame_transform(
     return result
 
 
+@typing.no_type_check
+@ensure_spice
 def get_rotation_matrix(
     et: Union[float, npt.NDArray],
     from_frame: SpiceFrame,
@@ -443,3 +443,48 @@ def instrument_pointing(
     if isinstance(et, typing.Collection):
         return np.rad2deg([spice.reclat(vec)[1:] for vec in pointing])
     return np.rad2deg(spice.reclat(pointing)[1:])
+
+
+def basis_vectors(
+    et: Union[float, npt.NDArray],
+    from_frame: SpiceFrame,
+    to_frame: SpiceFrame,
+) -> npt.NDArray:
+    """
+    Get the basis vectors of the `from_frame` expressed in the `to_frame`.
+
+    The rotation matrix defining a frame transform are the basis vectors of
+    the `from_frame` expressed in the `to_frame`. This function just transposes
+    each rotation matrix retrieved from the `get_rotation_matrix` function so
+    that basis vectors can be indexed 0 for x, 1 for y, and 2 for z.
+
+    Parameters
+    ----------
+    et : float or np.ndarray
+        Ephemeris time(s) for which to get the rotation matrices.
+    from_frame : SpiceFrame
+        Reference frame to transform from.
+    to_frame : SpiceFrame
+        Reference frame to transform to.
+
+    Returns
+    -------
+    basis_vectors : np.ndarray
+        If `et` is a float, the returned basis vector matrix is of shape `(3, 3)`. If
+        `et` is a np.ndarray, the returned basis vector matrix is of shape `(n, 3, 3)`
+        where `n` matches the number of elements in et and basis vectors are the rows
+        of the 3 by 3 matrices.
+
+    Examples
+    --------
+    >>> from imap_processing.spice.geometry import basis_vectors
+    ... from imap_processing.spice.time import j2000ns_to_j2000s
+    ... et = j2000ns_to_j2000s(dataset.epoch.values)
+    ... basis_vectors = basis_vectors(
+    ...     et, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000
+    ... )
+    ... spacecraft_x = basis_vectors[:, 0]
+    ... spacecraft_y = basis_vectors[:, 1]
+    ... spacecraft_z = basis_vectors[:, 2]
+    """
+    return np.moveaxis(get_rotation_matrix(et, from_frame, to_frame), -1, -2)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -8,6 +8,7 @@ import spiceypy as spice
 from imap_processing.spice.geometry import (
     SpiceBody,
     SpiceFrame,
+    basis_vectors,
     frame_transform,
     get_instrument_spin_phase,
     get_rotation_matrix,
@@ -17,6 +18,7 @@ from imap_processing.spice.geometry import (
     imap_state,
     instrument_pointing,
 )
+from imap_processing.spice.kernels import ensure_spice
 
 
 @pytest.mark.parametrize(
@@ -306,3 +308,20 @@ def test_instrument_pointing(furnish_kernels):
             et, SpiceFrame.IMAP_HI_90, SpiceFrame.ECLIPJ2000, cartesian=True
         )
         assert ins_pointing.shape == (3, 3)
+
+
+@pytest.mark.external_kernel()
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+def test_basis_vectors():
+    """Test coverage for basis_vectors()."""
+    # This call to SPICE needs to be wrapped with `ensure_spice` so that kernels
+    # get furnished automatically
+    et = ensure_spice(spice.utc2et)("2025-09-30T12:00:00.000")
+    # test input of float
+    sc_axes = basis_vectors(et, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.IMAP_SPACECRAFT)
+    np.testing.assert_array_equal(sc_axes, np.eye(3))
+    # test array of et input
+    sc_axes = basis_vectors(
+        np.arange(10) + et, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000
+    )
+    assert sc_axes.shape == (10, 3, 3)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -324,12 +324,14 @@ def test_basis_vectors():
     et_array = np.arange(10) + et
     sc_axes = basis_vectors(et_array, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000)
     assert sc_axes.shape == (10, 3, 3)
-    # Verify that for each time, the basis matrix is the transpose of the
-    # rotation matrix
+    # Verify that for each time, the basis vectors are correct
     for et, basis_matrix in zip(et_array, sc_axes):
         np.testing.assert_array_equal(
             basis_matrix,
-            get_rotation_matrix(
-                et, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000
-            ).T,
+            frame_transform(
+                et * np.ones(3),
+                np.eye(3),
+                SpiceFrame.IMAP_SPACECRAFT,
+                SpiceFrame.ECLIPJ2000,
+            ),
         )

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -252,7 +252,7 @@ def test_frame_transform_exceptions():
         match="Mismatch in number of position vectors and Ephemeris times provided.",
     ):
         frame_transform(
-            np.arange(2),
+            1,
             np.arange(9).reshape((3, 3)),
             SpiceFrame.ECLIPJ2000,
             SpiceFrame.IMAP_HIT,

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -321,7 +321,15 @@ def test_basis_vectors():
     sc_axes = basis_vectors(et, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.IMAP_SPACECRAFT)
     np.testing.assert_array_equal(sc_axes, np.eye(3))
     # test array of et input
-    sc_axes = basis_vectors(
-        np.arange(10) + et, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000
-    )
+    et_array = np.arange(10) + et
+    sc_axes = basis_vectors(et_array, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000)
     assert sc_axes.shape == (10, 3, 3)
+    # Verify that for each time, the basis matrix is the transpose of the
+    # rotation matrix
+    for et, basis_matrix in zip(et_array, sc_axes):
+        np.testing.assert_array_equal(
+            basis_matrix,
+            get_rotation_matrix(
+                et, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000
+            ).T,
+        )


### PR DESCRIPTION
# Change Summary

## Overview
Adds a function for getting basis vectors (for example spacecraft axes) of one frame expressed in another frame.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/spice/geometry.py
   - Fixes a small bug in where the `@ensure_spice` decorator was used. It should be used at the lowest possible level, closest to the `spiceypy` function.
   - Adds function for getting basis vectors
- imap_processing/tests/spice/test_geometry.py
   - Adds test coverage for basis vector function
 
Closes: #794 
