### PR TITLE
Mag l1a compression fixes

### DIFF
--- a/imap_processing/cdf/config/imap_mag_l1_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l1_variable_attrs.yaml
@@ -1,14 +1,3 @@
-# <=== Label Attributes ===>
-# LABL_PTR_i expects VAR_TYPE of metadata with char data type.
-# We need to define this if we have DEPEND_1 or more.
-# TODO: I am not sure what the FIELDNAM should be.
-# I tried best to match this: https://spdf.gsfc.nasa.gov/istp_guide/variables.html#Metadata_eg1
-direction_label:
-  CATDESC: magnetic field vector data
-  FIELDNAM: Magnetic Field Vector
-  FORMAT: A3
-  VAR_TYPE: metadata
-
 default_attrs: &default
   # Assumed values for all variable attrs unless overwritten
   DEPEND_0: epoch
@@ -46,6 +35,7 @@ vector_attrs:
     LABLAXIS: Magnetic field vector data
     FILLVAL: 9223372036854775807
     FORMAT: I3
+#    LABL_PTR_1: direction_label
 
 mag_support_attrs: &support_default
     <<: *default
@@ -87,7 +77,7 @@ compression_attrs:
   VALIDMIN: 0
   DISPLAY_TYPE: no_plot
 
-compression_flag_attrs:
+compression_flags_attrs:
   <<: *support_default
   CATDESC: Compression information per time stamp, includes a flag and the compression width
   FIELDNAM: Compression information per time stamp
@@ -95,7 +85,8 @@ compression_flag_attrs:
   FORMAT: I2
   VALIDMAX: 21
   VALIDMIN: 0
-
+  LABL_AXIS: compression
+  DISPLAY_TYPE: no_plot
 
 PUS_SPARE1:
     <<: *support_default

--- a/imap_processing/cdf/config/imap_mag_l1_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l1_variable_attrs.yaml
@@ -35,7 +35,6 @@ vector_attrs:
     LABLAXIS: Magnetic field vector data
     FILLVAL: 9223372036854775807
     FORMAT: I3
-#    LABL_PTR_1: direction_label
 
 mag_support_attrs: &support_default
     <<: *default

--- a/imap_processing/cdf/config/imap_mag_l1_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l1_variable_attrs.yaml
@@ -1,3 +1,20 @@
+# <=== Label Attributes ===>
+# LABL_PTR_i expects VAR_TYPE of metadata with char data type.
+# We need to define this if we have DEPEND_1 or more.
+# TODO: I am not sure what the FIELDNAM should be.
+# I tried best to match this: https://spdf.gsfc.nasa.gov/istp_guide/variables.html#Metadata_eg1
+direction_label:
+  CATDESC: magnetic field vector data
+  FIELDNAM: Magnetic Field Vector
+  FORMAT: A3
+  VAR_TYPE: metadata
+
+compression_label:
+  CATDESC: Compression and width
+  FIELDNAM: Compression and width
+  FORMAT: A2
+  VAR_TYPE: metadata
+
 default_attrs: &default
   # Assumed values for all variable attrs unless overwritten
   DEPEND_0: epoch
@@ -22,6 +39,7 @@ default_coords: &default_coords
 raw_vector_attrs:
   <<: *default_coords
   CATDESC: Raw unprocessed magnetic field vector data in bytes
+  DEPEND_0: epoch
   DEPEND_1: direction
   LABL_PTR_1: direction_label
   FIELDNAM: Magnetic Field Vector
@@ -30,9 +48,10 @@ raw_vector_attrs:
 vector_attrs:
     <<: *default_coords
     CATDESC: Magnetic field vector with x y z and sensor range varying by time
+    DEPEND_0: epoch
     DEPEND_1: direction
     FIELDNAM: Magnetic Field Vector
-    LABLAXIS: Magnetic field vector data
+    LABL_PTR_1: direction_label
     FILLVAL: 9223372036854775807
     FORMAT: I3
 
@@ -72,6 +91,7 @@ compression_attrs:
   CATDESC: Flag indicating if the vector is compressed, and the compression width
   FIELDNAM: Compression flag and bit width
   FORMAT: I2
+  VAR_TYPE: support_data
   VALIDMAX: 21
   VALIDMIN: 0
   DISPLAY_TYPE: no_plot
@@ -84,7 +104,7 @@ compression_flags_attrs:
   FORMAT: I2
   VALIDMAX: 21
   VALIDMIN: 0
-  LABL_AXIS: compression
+  LABL_PTR_1: compression_label
   DISPLAY_TYPE: no_plot
 
 PUS_SPARE1:

--- a/imap_processing/cdf/config/imap_mag_l1_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l1_variable_attrs.yaml
@@ -78,6 +78,25 @@ direction_attrs:
     DISPLAY_TYPE: time_series
     LABLAXIS: Magnetic field vector
 
+compression_attrs:
+  <<: *default_coords
+  CATDESC: Flag indicating if the vector is compressed, and the compression width
+  FIELDNAM: Compression flag and bit width
+  FORMAT: I2
+  VALIDMAX: 21
+  VALIDMIN: 0
+  DISPLAY_TYPE: no_plot
+
+compression_flag_attrs:
+  <<: *support_default
+  CATDESC: Compression information per time stamp, includes a flag and the compression width
+  FIELDNAM: Compression information per time stamp
+  DEPEND_1: compression
+  FORMAT: I2
+  VALIDMAX: 21
+  VALIDMIN: 0
+
+
 PUS_SPARE1:
     <<: *support_default
     CATDESC: Spare header from ESA Standard

--- a/imap_processing/mag/l0/decom_mag.py
+++ b/imap_processing/mag/l0/decom_mag.py
@@ -125,6 +125,12 @@ def generate_dataset(
         dims=["direction"],
         attrs=attribute_manager.get_variable_attributes("raw_direction_attrs"),
     )
+    direction_label = xr.DataArray(
+        direction.astype(str),
+        name="direction_label",
+        dims=["direction_label"],
+        attrs=attribute_manager.get_variable_attributes("direction_label"),
+    )
 
     # TODO: Epoch here refers to the start of the sample. Confirm that this is
     # what mag is expecting, and if it is, CATDESC needs to be updated.
@@ -145,7 +151,11 @@ def generate_dataset(
     logical_id = f"imap_mag_l1a_{mode.value.lower()}-raw"
 
     output = xr.Dataset(
-        coords={"epoch": epoch_time, "direction": direction},
+        coords={
+            "epoch": epoch_time,
+            "direction": direction,
+            "direction_label": direction_label,
+        },
         attrs=attribute_manager.get_global_attributes(logical_id),
     )
 

--- a/imap_processing/mag/l0/decom_mag.py
+++ b/imap_processing/mag/l0/decom_mag.py
@@ -125,12 +125,6 @@ def generate_dataset(
         dims=["direction"],
         attrs=attribute_manager.get_variable_attributes("raw_direction_attrs"),
     )
-    direction_label = xr.DataArray(
-        direction.astype(str),
-        name="direction_label",
-        dims=["direction_label"],
-        attrs=attribute_manager.get_variable_attributes("direction_label"),
-    )
 
     # TODO: Epoch here refers to the start of the sample. Confirm that this is
     # what mag is expecting, and if it is, CATDESC needs to be updated.
@@ -151,11 +145,7 @@ def generate_dataset(
     logical_id = f"imap_mag_l1a_{mode.value.lower()}-raw"
 
     output = xr.Dataset(
-        coords={
-            "epoch": epoch_time,
-            "direction": direction,
-            "direction_label": direction_label,
-        },
+        coords={"epoch": epoch_time, "direction": direction},
         attrs=attribute_manager.get_global_attributes(logical_id),
     )
 

--- a/imap_processing/mag/l1a/mag_l1a.py
+++ b/imap_processing/mag/l1a/mag_l1a.py
@@ -159,7 +159,7 @@ def process_packets(
             )
         ).astype("datetime64[D]")
 
-        primary_packet_data = MagL1aPacketProperties(
+        primary_packet_properties = MagL1aPacketProperties(
             mag_l0.SHCOARSE,
             primary_start_time,
             mag_l0.PRI_VECSEC,
@@ -167,28 +167,30 @@ def process_packets(
             mag_l0.ccsds_header.SRC_SEQ_CTR,
             mag_l0.COMPRESSION,
             mago_is_primary,
+            mag_l0.VECTORS[0],
         )
 
         secondary_packet_data = dataclasses.replace(
-            primary_packet_data,
+            primary_packet_properties,
             start_time=secondary_start_time,
             vectors_per_second=mag_l0.SEC_VECSEC,
             pus_ssubtype=mag_l0.PUS_SSUBTYPE,
+            first_byte=mag_l0.VECTORS[0],
         )
         # now we know the number of secs of data in the packet, and the data rates of
         # each sensor, we can calculate how much data is in this packet and where the
         # byte boundaries are.
         primary_vectors, secondary_vectors = MagL1a.process_vector_data(
             mag_l0.VECTORS,  # type: ignore
-            primary_packet_data.total_vectors,
+            primary_packet_properties.total_vectors,
             secondary_packet_data.total_vectors,
             mag_l0.COMPRESSION,
         )
 
         primary_timestamped_vectors = MagL1a.calculate_vector_time(
             primary_vectors,
-            primary_packet_data.vectors_per_second,
-            primary_packet_data.start_time,
+            primary_packet_properties.vectors_per_second,
+            primary_packet_properties.start_time,
         )
         secondary_timestamped_vectors = MagL1a.calculate_vector_time(
             secondary_vectors,
@@ -208,7 +210,7 @@ def process_packets(
                 primary_timestamped_vectors
                 if mago_is_primary
                 else secondary_timestamped_vectors,
-                primary_packet_data if mago_is_primary else secondary_packet_data,
+                primary_packet_properties if mago_is_primary else secondary_packet_data,
             )
         else:
             mago[mago_day].append_vectors(
@@ -217,7 +219,7 @@ def process_packets(
                     if mago_is_primary
                     else secondary_timestamped_vectors
                 ),
-                primary_packet_data if mago_is_primary else secondary_packet_data,
+                primary_packet_properties if mago_is_primary else secondary_packet_data,
             )
 
         if magi_day not in magi:
@@ -228,7 +230,9 @@ def process_packets(
                 primary_timestamped_vectors
                 if not mago_is_primary
                 else secondary_timestamped_vectors,
-                primary_packet_data if not mago_is_primary else secondary_packet_data,
+                primary_packet_properties
+                if not mago_is_primary
+                else secondary_packet_data,
             )
         else:
             magi[magi_day].append_vectors(
@@ -237,7 +241,9 @@ def process_packets(
                     if not mago_is_primary
                     else secondary_timestamped_vectors
                 ),
-                primary_packet_data if not mago_is_primary else secondary_packet_data,
+                primary_packet_properties
+                if not mago_is_primary
+                else secondary_packet_data,
             )
 
     return {"mago": mago, "magi": magi}
@@ -286,7 +292,7 @@ def generate_dataset(
         np.arange(2),
         name="compression",
         dims=["compression"],
-        attrs=attribute_manager.get_variable_attributes("compression_attrs")
+        attrs=attribute_manager.get_variable_attributes("compression_attrs"),
     )
 
     direction = xr.DataArray(
@@ -313,18 +319,23 @@ def generate_dataset(
     )
 
     compression_flags = xr.DataArray(
-        np.zeros((len(time_data), 2)),
+        single_file_l1a.compression_flags,
         name="compression_flags",
         dims=["epoch", "compression"],
         attrs=attribute_manager.get_variable_attributes("compression_flags_attrs"),
     )
 
     output = xr.Dataset(
-        coords={"epoch": epoch_time, "direction": direction},
+        coords={
+            "epoch": epoch_time,
+            "direction": direction,
+            "compression": compression,
+        },
         attrs=attribute_manager.get_global_attributes(logical_file_id),
     )
 
     output["vectors"] = vectors
+    output["compression_flags"] = compression_flags
 
     # TODO: Put is_mago and active in the header
 

--- a/imap_processing/mag/l1a/mag_l1a.py
+++ b/imap_processing/mag/l1a/mag_l1a.py
@@ -167,7 +167,7 @@ def process_packets(
             mag_l0.ccsds_header.SRC_SEQ_CTR,
             mag_l0.COMPRESSION,
             mago_is_primary,
-            mag_l0.VECTORS[0],
+            int(mag_l0.VECTORS[0]),
         )
 
         secondary_packet_data = dataclasses.replace(
@@ -175,7 +175,7 @@ def process_packets(
             start_time=secondary_start_time,
             vectors_per_second=mag_l0.SEC_VECSEC,
             pus_ssubtype=mag_l0.PUS_SSUBTYPE,
-            first_byte=mag_l0.VECTORS[0],
+            first_byte=int(mag_l0.VECTORS[0]),
         )
         # now we know the number of secs of data in the packet, and the data rates of
         # each sensor, we can calculate how much data is in this packet and where the
@@ -325,11 +325,27 @@ def generate_dataset(
         attrs=attribute_manager.get_variable_attributes("compression_flags_attrs"),
     )
 
+    direction_label = xr.DataArray(
+        direction.astype(str),
+        name="direction_label",
+        dims=["direction_label"],
+        attrs=attribute_manager.get_variable_attributes("direction_label"),
+    )
+
+    compression_label = xr.DataArray(
+        compression.astype(str),
+        name="compression_label",
+        dims=["compression_label"],
+        attrs=attribute_manager.get_variable_attributes("compression_label"),
+    )
+
     output = xr.Dataset(
         coords={
             "epoch": epoch_time,
             "direction": direction,
             "compression": compression,
+            "direction_label": direction_label,
+            "compression_label": compression_label,
         },
         attrs=attribute_manager.get_global_attributes(logical_file_id),
     )

--- a/imap_processing/mag/l1a/mag_l1a.py
+++ b/imap_processing/mag/l1a/mag_l1a.py
@@ -282,6 +282,13 @@ def generate_dataset(
         np.dtype("datetime64[ns]"), copy=False
     )
 
+    compression = xr.DataArray(
+        np.arange(2),
+        name="compression",
+        dims=["compression"],
+        attrs=attribute_manager.get_variable_attributes("compression_attrs")
+    )
+
     direction = xr.DataArray(
         np.arange(4),
         name="direction",
@@ -303,6 +310,13 @@ def generate_dataset(
         name="vectors",
         dims=["epoch", "direction"],
         attrs=attribute_manager.get_variable_attributes("vector_attrs"),
+    )
+
+    compression_flags = xr.DataArray(
+        np.zeros((len(time_data), 2)),
+        name="compression_flags",
+        dims=["epoch", "compression"],
+        attrs=attribute_manager.get_variable_attributes("compression_flags_attrs"),
     )
 
     output = xr.Dataset(

--- a/imap_processing/mag/l1a/mag_l1a_data.py
+++ b/imap_processing/mag/l1a/mag_l1a_data.py
@@ -120,6 +120,9 @@ class MagL1aPacketProperties:
     total_vectors : int
         Total number of vectors in this packet - calculated as
         seconds_per_packet * vecsec
+    compression_width : int
+        Value between 0-20 indicating the width of the compressed data. If the packet
+        is uncompressed, this defaults to 0.
     """
 
     shcoarse: int
@@ -129,23 +132,38 @@ class MagL1aPacketProperties:
     src_seq_ctr: int  # From ccsds header
     compression: int
     mago_is_primary: int
+    first_byte: InitVar[int]
     seconds_per_packet: int = field(init=False)
     total_vectors: int = field(init=False)
+    compression_width: int = field(init=False)
 
-    def __post_init__(self, pus_ssubtype: int) -> None:
+    def __post_init__(self, pus_ssubtype: int, first_byte: int) -> None:
         """
-        Calculate seconds_per_packet and total_vectors.
+        Calculate seconds_per_packet, total_vectors, and compression_width.
 
         Parameters
         ----------
         pus_ssubtype : int
             PUS Service Subtype, used to determine the seconds of data in the packet.
+        first_byte : int
+            First byte from the vectors. Needed to compute compression_width, and only
+            really needed if compression == 1. The header is the first byte of the
+            vector data. The compression width is the first 6 bits of that byte.
         """
         # seconds of data in this packet is the SUBTYPE plus 1
         self.seconds_per_packet = pus_ssubtype + 1
 
         # VECSEC is already decoded in mag_l0
         self.total_vectors = self.seconds_per_packet * self.vectors_per_second
+
+        if self.compression == 1:
+            header_bin = bin(first_byte)
+            # first two values in the string are "0b"
+            # going from the end because if the byte starts with zeros, they aren't
+            # included by bin().
+            self.compression_width = int(header_bin[2:-2], 2)
+        else:
+            self.compression_width = 0
 
 
 @dataclass
@@ -217,7 +235,7 @@ class MagL1a:
     most_recent_sequence: int = field(init=False)
     missing_sequences: list[int] = field(default_factory=list)
     start_time: np.datetime64 = field(init=False)
-    compression_flags: np.ndarray = field(init=False)
+    compression_flags: np.ndarray | None = field(init=False, default=None)
 
     def __post_init__(self, starting_packet: MagL1aPacketProperties) -> None:
         """
@@ -236,13 +254,7 @@ class MagL1a:
         # most_recent_sequence is the sequence number of the packet used to initialize
         # the object
         self.most_recent_sequence = starting_packet.src_seq_ctr
-
-        # Initialize the compression flags array with the first packet's compression
-        if not starting_packet.compression:
-            self.compression_flags = np.zeros((self.vectors.shape[0], 2), dtype=np.int8)
-
-        else:
-            self.compression_flags = np.ones((self.vectors.shape[0], 2), dtype=np.int8)
+        self.update_compression_array(starting_packet, self.vectors.shape[0])
 
     def append_vectors(
         self, additional_vectors: np.ndarray, packet_properties: MagL1aPacketProperties
@@ -269,6 +281,34 @@ class MagL1a:
                 range(self.most_recent_sequence + 1, vector_sequence)
             )
         self.most_recent_sequence = vector_sequence
+        self.update_compression_array(packet_properties, additional_vectors.shape[0])
+
+    def update_compression_array(
+        self, packet_properties: MagL1aPacketProperties, length: int
+    ) -> None:
+        """
+        Create or update compression_flags with 1 flag per timestamp.
+
+        If the compression for the packet is true, the second value in the array is the
+        compression width. Otherwise, it is zero.
+
+        Parameters
+        ----------
+        packet_properties : MagL1aPacketProperties
+            Packet properties that define compression flag and compression width.
+        length : int
+            Length of new array to add or append to the compression_flags attribute.
+            This is expected to be the length of the vector array.
+        """
+        new_flags = np.full(
+            (length, 2),
+            [packet_properties.compression, packet_properties.compression_width],
+            dtype=np.int8,
+        )
+        if self.compression_flags is None:
+            self.compression_flags = new_flags
+        else:
+            self.compression_flags = np.concatenate([self.compression_flags, new_flags])
 
     @staticmethod
     def calculate_vector_time(
@@ -350,6 +390,7 @@ class MagL1a:
             return MagL1a.process_compressed_vectors(
                 vector_data.astype(np.uint8), primary_count, secondary_count
             )
+        # first byte is the header containing compression width
 
         # If the vectors are uncompressed, we need them to be int32, as there are
         # bitshifting operations. Either way, the return type should be int32.

--- a/imap_processing/mag/l1a/mag_l1a_data.py
+++ b/imap_processing/mag/l1a/mag_l1a_data.py
@@ -115,6 +115,8 @@ class MagL1aPacketProperties:
         Science Data Compression Flag from level 0
     mago_is_primary : int
         1 if mago is designated the primary sensor, otherwise 0
+    first_byte : int
+        First byte of the vector data. Needed to compute compression_width.
     seconds_per_packet : int
         Number of seconds of data in this packet - calculated as pus_ssubtype + 1
     total_vectors : int
@@ -224,6 +226,7 @@ class MagL1a:
     unpack_one_vector()
     decode_fib_zig_zag()
     twos_complement()
+    update_compression_array()
     """
 
     is_mago: bool

--- a/imap_processing/mag/l1a/mag_l1a_data.py
+++ b/imap_processing/mag/l1a/mag_l1a_data.py
@@ -390,7 +390,6 @@ class MagL1a:
             return MagL1a.process_compressed_vectors(
                 vector_data.astype(np.uint8), primary_count, secondary_count
             )
-        # first byte is the header containing compression width
 
         # If the vectors are uncompressed, we need them to be int32, as there are
         # bitshifting operations. Either way, the return type should be int32.

--- a/imap_processing/mag/l1a/mag_l1a_data.py
+++ b/imap_processing/mag/l1a/mag_l1a_data.py
@@ -187,6 +187,11 @@ class MagL1a:
         List of missing sequence numbers in the day
     start_time : numpy.datetime64
         Start time of the day, in ns since J2000 epoch
+    compression_flags : np.ndarray
+        Array of flags to indication compression and width for all timestamps in the
+        L1A file. Shaped like (n, 2) where n is the number of vectors. First value
+        is a boolean for compressed/uncompressed, second vector is a number between 0-20
+        if the data is compressed, which is the width in bits of the compressed data.
 
     Methods
     -------
@@ -212,6 +217,7 @@ class MagL1a:
     most_recent_sequence: int = field(init=False)
     missing_sequences: list[int] = field(default_factory=list)
     start_time: np.datetime64 = field(init=False)
+    compression_flags: np.ndarray = field(init=False)
 
     def __post_init__(self, starting_packet: MagL1aPacketProperties) -> None:
         """
@@ -230,6 +236,13 @@ class MagL1a:
         # most_recent_sequence is the sequence number of the packet used to initialize
         # the object
         self.most_recent_sequence = starting_packet.src_seq_ctr
+
+        # Initialize the compression flags array with the first packet's compression
+        if not starting_packet.compression:
+            self.compression_flags = np.zeros((self.vectors.shape[0], 2), dtype=np.int8)
+
+        else:
+            self.compression_flags = np.ones((self.vectors.shape[0], 2), dtype=np.int8)
 
     def append_vectors(
         self, additional_vectors: np.ndarray, packet_properties: MagL1aPacketProperties


### PR DESCRIPTION
# Change Summary
This is part one of the fix to #1006 - updating MAG L1A to include the compression flag information and width for the L1B processing step which corrects compressed data.

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
- Some minor updates to CDF files for L1A
- Added compression_width to the packet properties
- Added a step within the L1A data processing to change the compression flag and width to an array which can then be directly written to the CDF
- Updating and creating tests

~I don't think the LABL_PTR_1 attribute is required since it's 2D data - so we can just use LABLAXIS...? Not totally sure about that, would appreciate a look from @tech3371.~
Edit: I figured out why that change is required... as a timeseries it apparently requires it. Not sure if compression flags should just have type no_plot to avoid it, but the vectors need it.

Partly fixes #1006.