### PR TITLE
Small bug fix - MAG

### DIFF
--- a/imap_processing/mag/l0/decom_mag.py
+++ b/imap_processing/mag/l0/decom_mag.py
@@ -171,4 +171,4 @@ def generate_dataset(
                 attrs=attribute_manager.get_variable_attributes(key),
             )
 
-    return output
+    return output.drop_duplicates("epoch")


### PR DESCRIPTION
# Change Summary
This is a very small bug fix to get rid of L1A processing errors I was having around SHCOARSE not being monotonically increasing (duplicate values).

I have asked MAG what they would like to do about this issue long-term, although I don't anticipate it being a problem in prod. So this might be a temporary fix.

This is only in the mag raw file generation, and this data does not go to the rest of processing. So this data is not removed from the other L1A files (which are not having problems), only from the raw CDF files. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Dropped duplicates from MAG raw CDF file generation.