### PR TITLE
Add some more notes to the release workflow

### DIFF
--- a/docs/source/development-guide/release-workflow.rst
+++ b/docs/source/development-guide/release-workflow.rst
@@ -18,12 +18,13 @@ are described below. It is assumed that steps (1) through (4) in the
 
 The three repositories are expected to be released at different cadences:
 
-- The ``imap_processing`` repository is released on a monthly cadence (typically the last day of the month, but can
+* The ``imap_processing`` repository is released on a monthly cadence (typically the last day of the month, but can
 vary depending on the availability of developers time to make the release.
-- The ``sds_data_manager`` repository is released on a as-needed basis, typically when enough changes have been made
+* The ``sds_data_manager`` repository is released on a as-needed basis, typically when enough changes have been made
 since the last release to justify a new release.
-- The ``imap-data-access`` repository is released whenever a new feature or bug fix is implemented, since this
+* The ``imap-data-access`` repository is released whenever a new feature or bug fix is implemented, since this
 repository acts as a dependency of ``imap_processing`` and is used by external users.
+
 
 *Note: We use the ``imap_processing`` repository as an example in these instructions, but this can be applied to the
 other repositories as well.*

--- a/docs/source/development-guide/release-workflow.rst
+++ b/docs/source/development-guide/release-workflow.rst
@@ -3,8 +3,9 @@
 Release Workflow
 ----------------
 
-This page describes how to make releases of the software within the ``imap_processing`` and ``sds-data-manager``
-repositories, and the steps needed to push said software to the production environment and update the data products.
+This page describes how to make releases of the software within the ``imap_processing``, ``sds-data-manager``, and
+``imap-data-access`` repositories, and the steps needed to push said software to the production environment and update
+the data products.
 
 Software Releases
 ^^^^^^^^^^^^^^^^^
@@ -15,9 +16,17 @@ diagram shown in the :ref:`git & GitHub Workflow <git-and-github-workflow>` page
 are described below. It is assumed that steps (1) through (4) in the
 :ref:`git & GitHub Workflow <git-and-github-workflow>` are already completed.
 
-*Note: We use the ``imap_processing`` repository as an example here, but this can be applied to ``sds-data-manager`` as
-well.*
+The three repositories are expected to be released at different cadences:
 
+- The ``imap_processing`` repository is released on a monthly cadence (typically the last day of the month, but can
+vary depending on the availability of developers time to make the release.
+- The ``sds_data_manager`` repository is released on a as-needed basis, typically when enough changes have been made
+since the last release to justify a new release.
+- The ``imap-data-access`` repository is released whenever a new feature or bug fix is implemented, since this
+repository acts as a dependency of ``imap_processing`` and is used by external users.
+
+*Note: We use the ``imap_processing`` repository as an example in these instructions, but this can be applied to the
+other repositories as well.*
 
 .. _nominal-releases:
 
@@ -27,16 +36,17 @@ Nominal releases
 #. Make sure the ``dev`` branch is up-to-date with any changes you want included in the release (i.e. merge in any
    feature branches using the nominal :ref:`git & GitHub Workflow <git-and-github-workflow>`).
 #. Create a new version branch off of ``dev``.  The name of the branch should match the version number to be used for
-   the release, which should follow the :ref:`software versioning <versioning>` conventions. The patch number should be
-   marked with a ``x``, and the name should be prepended with ``v`` (e.g. ``v0.1.x``).
+   the release, which should follow the :ref:`software versioning <versioning>` conventions. The name should be
+   prepended with ``v`` (e.g. ``v0.1.0``).
 #. Make any release-specific commits to the new version branch using the nominal ``git add``/``git commit`` cycle. This
    may include commits that add release notes, or update version numbers in various configurations.
 #. Push the version branch to the main ``IMAP-Science-Operations-Center`` ``imap_processing`` repo (i.e. ``upstream``).
 #. Create a `new release <https://github.com/IMAP-Science-Operations-Center/imap_processing/releases>`_, using the
    version branch as the ``Target`` branch. Assign a new tag with the specific version number, including the patch
    number (e.g. ``v0.1.0``).
-#. In GitHub, create a pull request that merges the version branch into ``dev``. Proceed with the nominal review & merge
-   process described in steps (10) and (11) in the :ref:`git & GitHub Workflow <git-and-github-workflow>` section.
+#. If there have been release-specific commits, In GitHub, create a pull request that merges the version branch into
+   ``dev``. Proceed with the nominal review & merge process described in steps (10) and (11) in the :ref:`git & GitHub
+   Workflow <git-and-github-workflow>` section.
 
 
 Patches

--- a/docs/source/development-guide/release-workflow.rst
+++ b/docs/source/development-guide/release-workflow.rst
@@ -17,12 +17,13 @@ are described below. It is assumed that steps (1) through (4) in the :ref:`git &
 are already completed.
 
 The three repositories are expected to be released at different cadences:
+
 * The ``imap_processing`` repository is released on a monthly cadence (typically the last day of the month, but can
-vary depending on the availability of developers time to make the release.
+  vary depending on the availability of developers time to make the release.
 * The ``sds_data_manager`` repository is released on a as-needed basis, typically when enough changes have been made
-since the last release to justify a new release.
+  since the last release to justify a new release.
 * The ``imap-data-access`` repository is released whenever a new feature or bug fix is implemented, since this
-repository acts as a dependency of ``imap_processing`` and is used by external users.
+  repository acts as a dependency of ``imap_processing`` and is used by external users.
 
 
 Note: We use the ``imap_processing`` repository as an example in these instructions, but this can be applied to the

--- a/docs/source/development-guide/release-workflow.rst
+++ b/docs/source/development-guide/release-workflow.rst
@@ -13,11 +13,10 @@ Software Releases
 This project uses a workflow in which releases are made off of a 'version branch' (e.g. ``v0.1.x``), as depicted in the
 diagram shown in the :ref:`git & GitHub Workflow <git-and-github-workflow>` page. This includes both 'nominal releases'
 (i.e. new features to be released to the public) and 'patches' (i.e. bug fixes to the version branch). These workflows
-are described below. It is assumed that steps (1) through (4) in the
-:ref:`git & GitHub Workflow <git-and-github-workflow>` are already completed.
+are described below. It is assumed that steps (1) through (4) in the :ref:`git & GitHub Workflow <git-and-github-workflow>`
+are already completed.
 
 The three repositories are expected to be released at different cadences:
-
 * The ``imap_processing`` repository is released on a monthly cadence (typically the last day of the month, but can
 vary depending on the availability of developers time to make the release.
 * The ``sds_data_manager`` repository is released on a as-needed basis, typically when enough changes have been made
@@ -26,8 +25,8 @@ since the last release to justify a new release.
 repository acts as a dependency of ``imap_processing`` and is used by external users.
 
 
-*Note: We use the ``imap_processing`` repository as an example in these instructions, but this can be applied to the
-other repositories as well.*
+Note: We use the ``imap_processing`` repository as an example in these instructions, but this can be applied to the
+other repositories as well.
 
 .. _nominal-releases:
 

--- a/docs/source/development-guide/release-workflow.rst
+++ b/docs/source/development-guide/release-workflow.rst
@@ -42,12 +42,13 @@ Nominal releases
 #. Make any release-specific commits to the new version branch using the nominal ``git add``/``git commit`` cycle. This
    may include commits that add release notes, or update version numbers in various configurations.
 #. Push the version branch to the main ``IMAP-Science-Operations-Center`` ``imap_processing`` repo (i.e. ``upstream``).
-#. Create a `new release <https://github.com/IMAP-Science-Operations-Center/imap_processing/releases>`_, using the
-   version branch as the ``Target`` branch. Assign a new tag with the specific version number, including the patch
-   number (e.g. ``v0.1.0``).
 #. If there have been release-specific commits, In GitHub, create a pull request that merges the version branch into
    ``dev``. Proceed with the nominal review & merge process described in steps (10) and (11) in the :ref:`git & GitHub
    Workflow <git-and-github-workflow>` section.
+#. Create a `new release <https://github.com/IMAP-Science-Operations-Center/imap_processing/releases>`_. Under "Choose a
+   tag", create a new tag with the same name as the version branch (e.g. ``v0.1.0``). For "Release title", also use the
+   name of the version branch (e.g. ``v0.1.0``). In the description box, include appropriate highlights and release
+   notes (you can use a previous release for an example of how this should be formatted).
 
 
 Patches


### PR DESCRIPTION
This PR updates the Release Workflow docs to add some notes on the expected cadences of the releases, as well as make some minor updates based on how we have been making releases.