### PR TITLE
Small update CoDICE and IDEX data product naming conventions

### DIFF
--- a/docs/source/development-guide/style-guide/naming-conventions.rst
+++ b/docs/source/development-guide/style-guide/naming-conventions.rst
@@ -21,7 +21,7 @@ The general filename convention is as follows::
   * CoDICE: ``l0``, ``l1a``, ``l1b``, ``l2``, ``l3``
   * GLOWS: ``l0``, ``l1a``, ``l1b``, ``l2``, ``l3a``, ``l3b``, ``l3c``, ``l3d``
   * HIT: ``l0``, ``l1a``, ``l1b``, ``l2``, ``l3``
-  * IDEX: ``l0``, ``l1a``, ``l1b``, ``l2``, ``l3``
+  * IDEX: ``l0``, ``l1a``, ``l1b``, ``l2a``, ``l2b``, ``l3``
   * IMAP-Hi: ``l0``, ``l1a``, ``l1b``, ``l1c``, ``l2``, ``l3``
   * IMAP-Lo: ``l0``, ``l1a``, ``l1b``, ``l1c``, ``l2``
   * IMAP-Ultra: ``l0``, ``l1a``, ``l1b``, ``l1c``, ``l2``, ``l3``
@@ -35,8 +35,9 @@ The general filename convention is as follows::
   descriptors for each instrument:
 
   * CoDICE: ``hskp``, ``lo-counters-aggregated``, ``lo-counters-singles``, ``hi-counters-aggregated``,
-    ``hi-counters-singles``, ``lo-sw-priority``, ``lo-nsw-priority``, ``lo-sw-angular``, ``lo-nsw-angular``, ``lo-pha``,
-    ``hi-pha``, ``lo-sw-species``, ``lo-nsw-species``, ``hi-omni``, ``hi-sectored``, ``lo-ialirt``, ``hi-ialirt``
+    ``hi-counters-singles``, ``hi-priorities``, ``lo-sw-priority``, ``lo-nsw-priority``, ``lo-sw-angular``,
+    ``lo-nsw-angular``, ``lo-pha``, ``hi-pha``, ``lo-sw-species``, ``lo-nsw-species``, ``hi-omni``, ``hi-sectored``,
+    ``lo-ialirt``, ``hi-ialirt``
   * GLOWS: ``histogram``, ``de``
   * HIT: TBD
   * IDEX: ``sci``

--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -25,7 +25,7 @@ PROCESSING_LEVELS = {
     "glows": ["l0", "l1a", "l1b", "l2"],
     "hi": ["l0", "l1a", "l1b", "l1c", "l2"],
     "hit": ["l0", "l1a", "l1b", "l2"],
-    "idex": ["l0", "l1a", "l1b", "l2"],
+    "idex": ["l0", "l1a", "l1b", "l2a", "l2b"],
     "lo": ["l0", "l1a", "l1b", "l1c", "l2"],
     "mag": ["l0", "l1a", "l1b", "l1c", "l2pre", "l2"],
     "swapi": ["l0", "l1", "l2", "l3a", "l3b"],


### PR DESCRIPTION
This PR adds the CoDICE `hi-priorities` data product in the list of valid descriptors and updates the `IDEX` data levels to distinguish between L2A and L2B.

Just noting here that the `VALID_DATALEVELS` list in `imap-data-access` will also need to be updated for IDEX, which will be done in a PR over in that repo (https://github.com/IMAP-Science-Operations-Center/imap-data-access/issues/98)