### PR TITLE
update link on documentation

### DIFF
--- a/docs/source/development-guide/getting-started.rst
+++ b/docs/source/development-guide/getting-started.rst
@@ -29,6 +29,6 @@ Our tests are run using pytest:
     pytest
 
 Related Information
------------------
+-------------------
 
 For more information relating to infrastructure, see `sds-data-manager <https://sds-data-manager.readthedocs.io/en/latest/>`_.

--- a/docs/source/development-guide/getting-started.rst
+++ b/docs/source/development-guide/getting-started.rst
@@ -28,8 +28,7 @@ Our tests are run using pytest:
     poetry shell
     pytest
 
-Other Information
+Related Information
 -----------------
 
-Another source of useful links is the `internal IMAP help page <https://lasp.colorado.edu/galaxy/pages/viewpage.action?pageId=193401231>`_, or the
-`infrastructure documentation <https://sds-data-manager.readthedocs.io/en/latest/>`_.
+For more information relating to infrastructure, see `sds-data-manager <https://sds-data-manager.readthedocs.io/en/latest/>`_.


### PR DESCRIPTION
# Change Summary

closes #1134

## Overview
Update the "other" documentation in the getting started page. 

## Updated Files
- docs/source/development-guide/getting-started.rst
   - Removed the link to the galaxy help page
   - Updated wording to be more clear. 

