### PR TITLE
Add Hexadecimal state handling to excel_to_xtce

### DIFF
--- a/imap_processing/ccsds/excel_to_xtce.py
+++ b/imap_processing/ccsds/excel_to_xtce.py
@@ -415,12 +415,12 @@ class XTCEGenerator:
             The dictionary for the state.
         """
         value = state["value"]
-        # convert hex string to int
-        if isinstance(value, str) and value.startswith("0x"):
-            state["value"] = int(value, 16)
-            return state
         # return if already an int
-        elif isinstance(value, int):
+        if isinstance(value, int):
+            return state
+        # convert hex string to int
+        elif isinstance(value, str) and value.startswith("0x"):
+            state["value"] = int(value, 16)
             return state
         # raise error if value is neither a hex string or integer
         else:

--- a/imap_processing/ccsds/excel_to_xtce.py
+++ b/imap_processing/ccsds/excel_to_xtce.py
@@ -391,17 +391,18 @@ class XTCEGenerator:
         ]
         for _, state_row in state_sheet.iterrows():
             enumeration = Et.SubElement(enumeration_list, "xtce:Enumeration")
-            converted_state = self._convert_state_to_int(state_row)
-            enumeration.attrib["value"] = str(converted_state["value"])
-            enumeration.attrib["label"] = str(converted_state["state"])
+            valid_state = self._ensure_state_value_is_int(state_row)
+            enumeration.attrib["value"] = str(valid_state["value"])
+            enumeration.attrib["label"] = str(valid_state["state"])
 
-    def _convert_state_to_int(self, state: dict) -> dict:
+    def _ensure_state_value_is_int(self, state: dict) -> dict:
         """
-        Convert a telemetry state value to an integer if it's a hexadecimal string.
+        Ensure the telemetry state value is an integer.
 
         Some telemetry state values are documented as a hex string,
         which space packet parser cannot handle. If the value of a
-        state is a hex string, convert it to an integer.
+        state is a hex string rather than an int, convert it to an integer.
+        If the value is neither a hex string or an integer, raise an error.
 
         Parameters
         ----------

--- a/imap_processing/ccsds/excel_to_xtce.py
+++ b/imap_processing/ccsds/excel_to_xtce.py
@@ -391,8 +391,39 @@ class XTCEGenerator:
         ]
         for _, state_row in state_sheet.iterrows():
             enumeration = Et.SubElement(enumeration_list, "xtce:Enumeration")
-            enumeration.attrib["value"] = str(state_row["value"])
-            enumeration.attrib["label"] = str(state_row["state"])
+            converted_state = self._convert_state_to_int(state_row)
+            enumeration.attrib["value"] = str(converted_state["value"])
+            enumeration.attrib["label"] = str(converted_state["state"])
+
+    def _convert_state_to_int(self, state: dict) -> dict:
+        """
+        Convert a telemetry state value to an integer if it's a hexadecimal string.
+
+        Some telemetry state values are documented as a hex string,
+        which space packet parser cannot handle. If the value of a
+        state is a hex string, convert it to an integer.
+
+        Parameters
+        ----------
+        state : dict
+            Dictionary with telemetry state and value.
+
+        Returns
+        -------
+        dict
+            The dictionary for the state.
+        """
+        value = state["value"]
+        # convert hex string to int
+        if isinstance(value, str) and value.startswith("0x"):
+            state["value"] = int(value, 16)
+            return state
+        # return if already an int
+        elif isinstance(value, int):
+            return state
+        # raise error if value is neither a hex string or integer
+        else:
+            raise ValueError(f"Invalid value of {value} for state {state['state']}")
 
     def to_xml(self, output_xml_path: Path) -> None:
         """

--- a/imap_processing/tests/ccsds/test_data/expected_output.xml
+++ b/imap_processing/tests/ccsds/test_data/expected_output.xml
@@ -64,6 +64,7 @@
 				<xtce:EnumerationList>
 					<xtce:Enumeration value="0" label="OFF" />
 					<xtce:Enumeration value="1" label="ON" />
+					<xtce:Enumeration value="2" label="NONE" />
 				</xtce:EnumerationList>
 			</xtce:EnumeratedParameterType>
 			<xtce:IntegerParameterType name="TEST_PACKET2.SHCOARSE" signed="false">

--- a/imap_processing/tests/ccsds/test_excel_to_xtce.py
+++ b/imap_processing/tests/ccsds/test_excel_to_xtce.py
@@ -195,10 +195,10 @@ def xtce_excel_file(tmp_path):
     }
 
     states = {
-        "packetName": ["TEST_PACKET"] * 2,
-        "mnemonic": ["VAR_STATE"] * 2,
-        "value": [0, "0x1"],
-        "state": ["OFF", "ON"],
+        "packetName": ["TEST_PACKET"] * 3,
+        "mnemonic": ["VAR_STATE"] * 3,
+        "value": [0, 1, "0x2"],
+        "state": ["OFF", "ON", "NONE"],
     }
 
     # Write the DataFrame to an excel file

--- a/imap_processing/tests/ccsds/test_excel_to_xtce.py
+++ b/imap_processing/tests/ccsds/test_excel_to_xtce.py
@@ -197,7 +197,7 @@ def xtce_excel_file(tmp_path):
     states = {
         "packetName": ["TEST_PACKET"] * 2,
         "mnemonic": ["VAR_STATE"] * 2,
-        "value": [0, 1],
+        "value": [0, "0x1"],
         "state": ["OFF", "ON"],
     }
 


### PR DESCRIPTION
# Change Summary

## Overview
Some telemetry definition housekeeping state values are listed in hexadecimal form. `space-packet-parser` requires states to be in decimal form. This PR adds a function to ensure that the state value is an integer or a hexadecimal string is converted to an integer.

Closes #1158