### PR TITLE
Update Lo DE Case Decoder for 4, 1 TOF2

### DIFF
--- a/imap_processing/lo/l0/decompression_tables/decompression_tables.py
+++ b/imap_processing/lo/l0/decompression_tables/decompression_tables.py
@@ -63,7 +63,7 @@ CASE_DECODER = {
     (1, 0): VariableFields(True, True, True, False, False, False),
     (2, 0): VariableFields(True, True, False, False, False, True),
     (3, 0): VariableFields(True, False, False, False, False, False),
-    (4, 1): VariableFields(True, False, False, False, False, True),
+    (4, 1): VariableFields(True, False, True, False, False, True),
     (4, 0): VariableFields(True, False, False, True, False, False),
     (5, 0): VariableFields(True, False, True, False, False, False),
     (6, 1): VariableFields(True, False, False, False, False, True),


### PR DESCRIPTION
# Change Summary

The Lo Direct Event case decoder for case 4, mode 1 TOF 2 was updated from False to True. This issue was found during validation testing which will be added in a follow-up PR.

Closes #1165 