### PR TITLE
HIT L0 - data decompression

### DIFF
--- a/imap_processing/hit/l0/constants.py
+++ b/imap_processing/hit/l0/constants.py
@@ -111,3 +111,8 @@ FLAG_PATTERN = np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 # Define size of science frame (num of packets)
 FRAME_SIZE = len(FLAG_PATTERN)
+
+# Define the number of bits in the mantissa and exponent for
+# decompressing data
+MANTISSA_BITS = 12
+EXPONENT_BITS = 4

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -420,11 +420,22 @@ def decompress_rates_16_to_32(packed: int) -> int:
     power = packed >> MANTISSA_BITS
 
     # Decompress the data depending on the value of the exponent
+    # If the exponent (power) extracted from the packed 16-bit integer is greater
+    # than 1, the compressed value needs to be decompressed by reconstructing the
+    # integer using the mantissa and exponent. If the condition is false, the
+    # compressed and uncompressed values are considered the same.
     if power > 1:
-        decompressed_int = (packed & (output_mask >> EXPONENT_BITS)) | (
-            0x0001 << MANTISSA_BITS
-        )
-        decompressed_int = decompressed_int << (power - 1)
+        # Retrieve the "mantissa" portion of the packed value by masking out the
+        # exponent bits
+        mantissa_mask = output_mask >> EXPONENT_BITS
+        mantissa = packed & mantissa_mask
+
+        # Shift the mantissa to the left by 1 to account for the hidden bit
+        # (always set to 1)
+        mantissa_with_hidden_bit = mantissa | (0x0001 << MANTISSA_BITS)
+
+        # Scale the mantissa by the exponent by shifting it to the left by (power - 1)
+        decompressed_int = mantissa_with_hidden_bit << (power - 1)
     else:
         # The compressed and uncompressed values are the same
         decompressed_int = packed

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -424,6 +424,7 @@ def decompress_rates_16_to_32(packed: int) -> int:
     # than 1, the compressed value needs to be decompressed by reconstructing the
     # integer using the mantissa and exponent. If the condition is false, the
     # compressed and uncompressed values are considered the same.
+    decompressed_int: int
     if power > 1:
         # Retrieve the "mantissa" portion of the packed value by masking out the
         # exponent bits
@@ -440,7 +441,7 @@ def decompress_rates_16_to_32(packed: int) -> int:
         # The compressed and uncompressed values are the same
         decompressed_int = packed
 
-    return int(decompressed_int)
+    return decompressed_int
 
 
 def decom_hit(sci_dataset: xr.Dataset) -> xr.Dataset:

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -5,8 +5,10 @@ import xarray as xr
 
 from imap_processing.hit.l0.constants import (
     COUNTS_DATA_STRUCTURE,
+    EXPONENT_BITS,
     FLAG_PATTERN,
     FRAME_SIZE,
+    MANTISSA_BITS,
     MOD_10_MAPPING,
 )
 from imap_processing.utils import convert_to_binary_string
@@ -179,7 +181,7 @@ def parse_count_rates(sci_dataset: xr.Dataset) -> None:
 
         # Decompress data where needed
         if all(x not in field for x in ["hdr", "spare", "pha"]):
-            parsed_data = np.vectorize(decompress_rates)(parsed_data)
+            parsed_data = np.vectorize(decompress_rates_16_to_32)(parsed_data)
 
         # Get dims for data variables (yaml file not created yet)
         if len(field_meta.shape) > 1:
@@ -216,7 +218,7 @@ def is_sequential(counters: np.ndarray) -> np.bool_:
     return np.all(np.diff(counters) == 1)
 
 
-def find_valid_starting_indices(flags: np.ndarray, counters: np.ndarray) -> np.ndarray:
+def get_valid_starting_indices(flags: np.ndarray, counters: np.ndarray) -> np.ndarray:
     """
     Find valid starting indices for science frames.
 
@@ -243,9 +245,6 @@ def find_valid_starting_indices(flags: np.ndarray, counters: np.ndarray) -> np.n
     valid_indices : np.ndarray
         Array of valid indices for science frames.
     """
-    # TODO: consider combining functions to get valid indices to reduce
-    #  code tracing
-
     # Use sliding windows to compare segments of the array (20 packets) with the
     # pattern. This generates an array of overlapping sub-arrays, each of length
     # 20, from the flags array and is used to slide the "window" across the array
@@ -256,38 +255,11 @@ def find_valid_starting_indices(flags: np.ndarray, counters: np.ndarray) -> np.n
     # Get the starting indices of matches
     match_indices = np.where(matches)[0]
     # Filter for only indices from valid science frames with sequential counters
-    valid_indices = get_valid_indices(match_indices, counters, FRAME_SIZE)
+    sequential_check = [
+        is_sequential(counters[idx : idx + FRAME_SIZE]) for idx in match_indices
+    ]
+    valid_indices: np.ndarray = np.array(match_indices[sequential_check], dtype=int)
     return valid_indices
-
-
-def get_valid_indices(
-    indices: np.ndarray, counters: np.ndarray, size: int
-) -> np.ndarray:
-    """
-    Get valid indices for science frames.
-
-    Check if the packet sequence counters for the science frames
-    are sequential. If they are, the science frame is valid and
-    an updated array of valid indices is returned.
-
-    Parameters
-    ----------
-    indices : np.ndarray
-        Array of indices where the packet grouping flags match the pattern.
-    counters : np.ndarray
-        Array of packet sequence counters.
-    size : int
-        Size of science frame. 20 packets per science frame.
-
-    Returns
-    -------
-    valid_indices : np.ndarray
-        Array of valid indices for science frames.
-    """
-    # Check if the packet sequence counters are sequential by getting an array
-    # of boolean values where True indicates the counters are sequential.
-    sequential_check = [is_sequential(counters[idx : idx + size]) for idx in indices]
-    return indices[sequential_check]
 
 
 def update_ccsds_header_dims(sci_dataset: xr.Dataset) -> xr.Dataset:
@@ -370,7 +342,7 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
     total_packets = len(epoch_data)
 
     # Find starting indices for valid science frames
-    starting_indices = find_valid_starting_indices(seq_flgs, seq_ctrs)
+    starting_indices = get_valid_starting_indices(seq_flgs, seq_ctrs)
 
     # Check for extra packets at start and end of file
     # TODO: Will need to handle these extra packets when processing multiple files
@@ -413,47 +385,51 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
     return sci_dataset
 
 
-def decompress_rates(
-    packed: int, num_mantissa_bits: int = 12, num_exponent_bits: int = 4
-) -> int:
+def decompress_rates_16_to_32(packed: int) -> int:
     """
     Will decompress rates data from 16 bits to 32 bits.
 
     This function decompresses the rates data from the binary
-    format to integers. The data is compressed using a fixed
-    point representation with a 4-bit exponent and a 12-bit
-    mantissa. Numbers up to 212 are uncompressed.
+    format to integers. The compressed integer (packed) combines
+    two parts:
+
+    1. Mantissa: Represents the significant digits of the value.
+    2. Exponent: Determines how much to scale the mantissa (using powers of 2).
+
+    These parts are packed together into a single 16-bit integer.
+    Numbers up to 212 are uncompressed.
 
     Parameters
     ----------
     packed : int
-        Compressed integer.
-    num_mantissa_bits : int, optional
-        Number of bits for the mantissa, by default 12.
-    num_exponent_bits : int, optional
-        Number of bits for the exponent, by default 4.
+        Compressed 16-bit integer.
 
     Returns
     -------
-    out : int
+    decompressed_int : int
         Decompressed integer.
     """
-    # Number of bits for the compressed integer is 16
-    output_mask = 0xFFFF  # 0xffff for 16 bit
+    # In compressed formats, the exponent and mantissa are tightly packed together.
+    # The mask ensures you correctly separate the mantissa (useful for reconstructing
+    # the value) from the exponent (used for scaling).
+    # set to 16 bits
+    output_mask = 0xFFFF
 
-    # Right bit shift, packed is the compressed integer
-    power = packed >> num_mantissa_bits
+    # Packed is the compressed integer
+    # Right bit shift to get the exponent
+    power = packed >> MANTISSA_BITS
 
+    # Decompress the data depending on the value of the exponent
     if power > 1:
-        out = (packed & (output_mask >> num_exponent_bits)) | (
-            0x0001 << num_mantissa_bits
+        decompressed_int = (packed & (output_mask >> EXPONENT_BITS)) | (
+            0x0001 << MANTISSA_BITS
         )
-        out = out << (power - 1)
+        decompressed_int = decompressed_int << (power - 1)
     else:
-        # compressed and uncompressed values are the same
-        out = packed
+        # The compressed and uncompressed values are the same
+        decompressed_int = packed
 
-    return out
+    return int(decompressed_int)
 
 
 def decom_hit(sci_dataset: xr.Dataset) -> xr.Dataset:
@@ -512,7 +488,6 @@ def decom_hit(sci_dataset: xr.Dataset) -> xr.Dataset:
     subcom_sectorates(sci_dataset)
 
     # TODO:
-    #  -decompress data
-    #  -clean up dataset - remove raw binary data? Any other fields to remove?
+    #  -clean up dataset - remove raw binary data, raw sectorates? Any other fields?
 
     return sci_dataset

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -177,6 +177,10 @@ def parse_count_rates(sci_dataset: xr.Dataset) -> None:
                 low_gain = data[1::2]  # Items at odd indices 1, 3, 5, etc.
                 parsed_data[i] = [high_gain, low_gain]
 
+        # Decompress data where needed
+        if all(x not in field for x in ["hdr", "spare", "pha"]):
+            parsed_data = np.vectorize(decompress_rates)(parsed_data)
+
         # Get dims for data variables (yaml file not created yet)
         if len(field_meta.shape) > 1:
             if "sectorates" in field:
@@ -407,6 +411,49 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
     )
     sci_dataset["pha_raw"] = xr.DataArray(pha, dims=["epoch"], name="pha_raw")
     return sci_dataset
+
+
+def decompress_rates(
+    packed: int, num_mantissa_bits: int = 12, num_exponent_bits: int = 4
+) -> int:
+    """
+    Will decompress rates data from 16 bits to 32 bits.
+
+    This function decompresses the rates data from the binary
+    format to integers. The data is compressed using a fixed
+    point representation with a 4-bit exponent and a 12-bit
+    mantissa. Numbers up to 212 are uncompressed.
+
+    Parameters
+    ----------
+    packed : int
+        Compressed integer.
+    num_mantissa_bits : int, optional
+        Number of bits for the mantissa, by default 12.
+    num_exponent_bits : int, optional
+        Number of bits for the exponent, by default 4.
+
+    Returns
+    -------
+    out : int
+        Decompressed integer.
+    """
+    # Number of bits for the compressed integer is 16
+    output_mask = 0xFFFF  # 0xffff for 16 bit
+
+    # Right bit shift, packed is the compressed integer
+    power = packed >> num_mantissa_bits
+
+    if power > 1:
+        out = (packed & (output_mask >> num_exponent_bits)) | (
+            0x0001 << num_mantissa_bits
+        )
+        out = out << (power - 1)
+    else:
+        # compressed and uncompressed values are the same
+        out = packed
+
+    return out
 
 
 def decom_hit(sci_dataset: xr.Dataset) -> xr.Dataset:

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -389,15 +389,14 @@ def decompress_rates_16_to_32(packed: int) -> int:
     """
     Will decompress rates data from 16 bits to 32 bits.
 
-    This function decompresses the rates data from the binary
-    format to integers. The compressed integer (packed) combines
+    This function decompresses the rates data from 16-bit integers
+    to 32-bit integers. The compressed integer (packed) combines
     two parts:
 
     1. Mantissa: Represents the significant digits of the value.
     2. Exponent: Determines how much to scale the mantissa (using powers of 2).
 
     These parts are packed together into a single 16-bit integer.
-    Numbers up to 212 are uncompressed.
 
     Parameters
     ----------

--- a/imap_processing/tests/hit/test_decom_hit.py
+++ b/imap_processing/tests/hit/test_decom_hit.py
@@ -10,8 +10,8 @@ from imap_processing.hit.hit_utils import (
 from imap_processing.hit.l0.decom_hit import (
     assemble_science_frames,
     decom_hit,
-    find_valid_starting_indices,
-    get_valid_indices,
+    decompress_rates_16_to_32,
+    get_valid_starting_indices,
     is_sequential,
     parse_count_rates,
     parse_data,
@@ -34,6 +34,7 @@ def sci_dataset():
     datasets_by_apid = packet_file_to_datasets(
         packet_file=packet_file,
         xtce_packet_definition=packet_definition,
+        use_derived_value=False,
     )
 
     science_dataset = datasets_by_apid[HitAPID.HIT_SCIENCE]
@@ -61,8 +62,6 @@ def test_parse_data():
 
 def test_parse_count_rates(sci_dataset):
     """Test the parse_count_rates function."""
-
-    # TODO: complete this test once the function is complete
 
     # Update ccsds header fields to use sc_tick as dimension
     sci_dataset = update_ccsds_header_dims(sci_dataset)
@@ -135,7 +134,7 @@ def test_is_sequential():
         assert True
 
 
-def test_find_valid_starting_indices():
+def test_get_valid_starting_indices():
     """Test the find_valid_starting_indices function."""
     flags = np.array(
         [
@@ -177,33 +176,11 @@ def test_find_valid_starting_indices():
         ]
     )
     counters = np.arange(35)
-    result = find_valid_starting_indices(flags, counters)
+    result = get_valid_starting_indices(flags, counters)
     # The only valid starting index for a science frame
     # in the flags array is 15.
     assert len(result) == 1
     assert result[0] == 15
-
-
-def test_get_valid_indices():
-    """Test the get_valid_indices function."""
-    # Array of starting indices for science frames
-    # in the science data
-    indices = np.array([0, 20, 40])
-    # Array of counters
-    counters = np.arange(60)
-    # Array of valid indices where the packets in the science
-    # frame have corresponding counters in sequential order
-    result = get_valid_indices(indices, counters, 20)
-    # All indices are valid with sequential counters
-    assert len(result) == 3
-
-    # Test array with invalid indices (use smaller sample size)
-    indices = np.array([0, 5, 10])
-    # Array of counters (missing counters 6-8)
-    counters = np.array([0, 1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15, 16, 17])
-    result = get_valid_indices(indices, counters, 5)
-    # Only indices 0 and 10 are valid with sequential counters
-    assert len(result) == 2
 
 
 def test_update_ccsds_header_dims(sci_dataset):
@@ -261,6 +238,24 @@ def test_subcom_sectorates(sci_dataset):
             sci_dataset[f"{species}_energy_max"].shape
             == sci_dataset[f"{species}_energy_min"].shape
         )
+
+
+def test_decompress_rates_16_to_32():
+    """Test the decompress_rates_16_to_32 function.
+
+    This function decompresses a 16-bit packed integer
+    to a 32-bit integer. Used to decompress rates data.
+    """
+    test_cases = [
+        (0, 0),  # Test with zero
+        (15, 15),  # Test with packed integer with no scaling
+        (4096, 4096),  # Test with packed integer with power = 1
+        (64188, 112132096),  # Test with packed integer requiring scaling
+        (65535, 134201344),  # Test with maximum 16-bit value
+        (62218, 79855616),  # Test with arbitrary packed integer
+    ]
+    for packed, expected in test_cases:
+        assert decompress_rates_16_to_32(packed) == expected
 
 
 def test_decom_hit(sci_dataset):

--- a/imap_processing/tests/hit/test_decom_hit.py
+++ b/imap_processing/tests/hit/test_decom_hit.py
@@ -240,22 +240,24 @@ def test_subcom_sectorates(sci_dataset):
         )
 
 
-def test_decompress_rates_16_to_32():
-    """Test the decompress_rates_16_to_32 function.
-
-    This function decompresses a 16-bit packed integer
-    to a 32-bit integer. Used to decompress rates data.
-    """
-    test_cases = [
+@pytest.mark.parametrize(
+    "packed, expected",
+    [
         (0, 0),  # Test with zero
         (15, 15),  # Test with packed integer with no scaling
         (4096, 4096),  # Test with packed integer with power = 1
         (64188, 112132096),  # Test with packed integer requiring scaling
         (65535, 134201344),  # Test with maximum 16-bit value
         (62218, 79855616),  # Test with arbitrary packed integer
-    ]
-    for packed, expected in test_cases:
-        assert decompress_rates_16_to_32(packed) == expected
+    ],
+)
+def test_decompress_rates_16_to_32(packed, expected):
+    """Test the decompress_rates_16_to_32 function.
+
+    This function decompresses a 16-bit packed integer
+    to a 32-bit integer. Used to decompress rates data.
+    """
+    assert decompress_rates_16_to_32(packed) == expected
 
 
 def test_decom_hit(sci_dataset):


### PR DESCRIPTION
This PR adds a function to decom_hit.py to decompress rates data from 16-bit integers to 32-bit integers

## Updated Files
- decom_hit.py
   - new function for decompressing rates data
   - consolidated functions that support finding valid indices for science frames
- constants.py
   - added constants needed for decompressing rates
-test_decom_hit.py
  - add test for decompression function

Closes issue [#1055](https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/1055)
