### PR TITLE
700 refactor hi l1a histogram

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,7 +115,7 @@ nitpick_ignore_regex = [
     (r"py:.*", r".*InitVar*"),
     (r"py:.*", r".*.glows.utils.constants.TimeTuple.*"),
     (r"py:.*", r".*glows.utils.constants.DirectEvent.*"),
-    (r"py:.*", r".*numpy.int.*"),
+    (r"py:.*", r".*numpy.u?int\d+*"),
     (r"py:.*", r".*np.ndarray.*"),
     (r"py:.*", r".*numpy._typing._array_like._ScalarType_co.*"),
     (r"py:.*", r".*idex.l1a.TRIGGER_DESCRIPTION.*"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,13 +115,14 @@ nitpick_ignore_regex = [
     (r"py:.*", r".*InitVar*"),
     (r"py:.*", r".*.glows.utils.constants.TimeTuple.*"),
     (r"py:.*", r".*glows.utils.constants.DirectEvent.*"),
-    (r"py:.*", r".*numpy.u?int\d+*"),
+    (r"py:.*", r".*numpy.int.*"),
     (r"py:.*", r".*np.ndarray.*"),
     (r"py:.*", r".*numpy._typing._array_like._ScalarType_co.*"),
     (r"py:.*", r".*idex.l1a.TRIGGER_DESCRIPTION.*"),
     (r"py:.*", r".*.spice.geometry.SpiceBody.*"),
     (r"py:.*", r".*.spice.geometry.SpiceFrame.*"),
     (r"py:class", r"numpy._typing.*"),
+    (r"py:class", r"^numpy\.(u?int(?:8|16|32|64))$"),
 ]
 
 # Ignore the inherited members from the <instrument>APID IntEnum class

--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -55,6 +55,54 @@ default_float32_attrs: &default_float32
   VALIDMAX: 3.4028235e+38
   dtype: float32
 
+default_ccsds_version: &default_ccsds_version
+  <<: *default_uint8
+  CATDESC: CCSDS packet version number
+  FIELDNAM: CCSDS version
+  VAR_TYPE: support_data
+
+default_ccsds_type: &default_ccsds_type
+  <<: *default_uint8
+  CATDESC: CCSDS packet type
+  FIELDNAM: CCSDS type
+  VAR_TYPE: support_data
+
+default_ccsds_sec_hdr_flg: &default_ccsds_sec_hdr_flg
+  <<: *default_uint8
+  CATDESC: CCSDS secondary header flag
+  FIELDNAM: CCSDS secondary header flag
+  VAR_TYPE: support_data
+
+default_ccsds_pkt_apid: &default_ccsds_pkt_apid
+  <<: *default_uint16
+  CATDESC: CCSDS application process ID
+  FIELDNAM: CCSDS APID
+  VAR_TYPE: support_data
+
+default_ccsds_seq_flgs: &default_ccsds_seq_flgs
+  <<: *default_uint8
+  CATDESC: CCSDS sequence flags
+  FIELDNAM: CCSDS sequence flags
+  VAR_TYPE: support_data
+
+default_ccsds_src_seq_ctr: &default_ccsds_src_seq_ctr
+  <<: *default_uint16
+  CATDESC: CCSDS source sequence counter
+  FIELDNAM: CCSDS sequence counter
+  VAR_TYPE: support_data
+
+default_ccsds_pkt_len: &default_ccsds_pkt_len
+  <<: *default_uint16
+  CATDESC: CCSDS packet length
+  FIELDNAM: CCSDS packet length
+  VAR_TYPE: support_data
+
+default_ccsds_cksum: &default_ccsds_cksum
+  <<: *default_uint16
+  CATDESC: CCSDS packet checksum
+  FIELDNAM: CCSDS packet checksum
+  VAR_TYPE: support_data
+
 default_ccsds_met: &hi_ccsds_met
   <<: *default_uint32
   CATDESC: CCSDS mission elapsed time (MET). 32-bit integer value that represents the MET in seconds.
@@ -178,6 +226,27 @@ hi_hist_angle:
   VAR_TYPE: support_data
   dtype: uint16
 
+hi_hist_version:
+  <<: *default_ccsds_version
+
+hi_hist_type:
+  <<: *default_ccsds_type
+
+hi_hist_sec_hdr_flg:
+  <<: *default_ccsds_sec_hdr_flg
+
+hi_hist_pkt_apid:
+  <<: *default_ccsds_pkt_apid
+
+hi_hist_seq_flgs:
+  <<: *default_ccsds_seq_flgs
+
+hi_hist_src_seq_ctr:
+  <<: *default_ccsds_src_seq_ctr
+
+hi_hist_pkt_len:
+  <<: *default_ccsds_pkt_len
+
 hi_hist_ccsds_met:
   <<: *hi_ccsds_met
 
@@ -198,6 +267,9 @@ hi_hist_counters:
   DEPEND_1: angle
   LABL_PTR_1: angle_label
   FORMAT: I4
+
+hi_hist_cksum:
+  <<: *default_ccsds_cksum
 
 # ======= L1B DE Section =======
 hi_de_coincidence_type:

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -132,7 +132,7 @@ def unpack_hist_counter(counter_bytes: bytes) -> NDArray[np.uint16]:
 
     Returns
     -------
-    output_array : numpy.ndarray[np.uint16]
+    output_array : numpy.ndarray[numpy.unit16]
         The unpacked 12-bit unsigned integers for the input bytes. The
         output array has a shape of (n, 90) where n is the number of SCI_CNT
         packets in the input dataset.

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -132,7 +132,7 @@ def unpack_hist_counter(counter_bytes: bytes) -> NDArray[np.uint16]:
 
     Returns
     -------
-    output_array : numpy.ndarray[numpy.unit16]
+    output_array : numpy.ndarray[numpy.uint16]
         The unpacked 12-bit unsigned integers for the input bytes. The
         output array has a shape of (n, 90) where n is the number of SCI_CNT
         packets in the input dataset.

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -40,20 +40,15 @@ def create_dataset(input_ds: xr.Dataset) -> xr.Dataset:
     Parameters
     ----------
     input_ds : xarray.Dataset
-        Dataset of packets.
+        Dataset of packets generated using the
+        `imap_processing.utils.packet_file_to_datasets` function.
 
     Returns
     -------
     dataset : xarray.Dataset
         Dataset with all metadata field data in xr.DataArray.
     """
-    dataset = allocate_histogram_dataset(len(input_ds.epoch))
-
-    # TODO: Move into the allocate dataset function. Ticket: #700
-    dataset["epoch"].data[:] = input_ds["epoch"].data
-    dataset["ccsds_met"].data = input_ds["shcoarse"].data
-    dataset["esa_stepping_num"].data = input_ds["esa_step"].data
-    dataset["num_of_spins"].data = input_ds["num_of_spins"].data
+    dataset = update_packet_dataset(input_ds)
 
     # unpack the counter binary blobs into the Dataset
     for counter in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
@@ -77,84 +72,87 @@ def create_dataset(input_ds: xr.Dataset) -> xr.Dataset:
     return dataset
 
 
-def allocate_histogram_dataset(num_packets: int) -> xr.Dataset:
+def update_packet_dataset(dataset: xr.Dataset) -> xr.Dataset:
     """
-    Allocate empty xarray.Dataset for specified number of Hi Histogram packets.
+    Update dataset generated from ccsds to match L1A CDF definition.
 
     Parameters
     ----------
-    num_packets : int
-        The number of Hi Histogram packets to allocate space for
-        in the xarray.Dataset.
+    dataset : xarray.Dataset
+        Dataset read in from IMAP-Hi histogram CCSDS data.
 
     Returns
     -------
     dataset : xarray.Dataset
-        Empty xarray.Dataset ready to be filled with packet data.
+        Updated xarray.Dataset ready to be filled with histogram counter data.
     """
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="hi")
     attr_mgr.add_instrument_variable_attrs(instrument="hi", level=None)
-    # preallocate the xr.DataArrays for all CDF attributes based on number of packets
-    coords = dict()
-    coords["epoch"] = xr.DataArray(
-        np.empty(num_packets, dtype="datetime64[ns]"),
-        name="epoch",
-        dims=["epoch"],
-        attrs=attr_mgr.get_variable_attributes("epoch"),
-    )
-    # Histogram data is binned in 90, 4-degree bins
-    coords["angle"] = xr.DataArray(
-        np.arange(2, 360, 4),
-        name="angle",
-        dims=["angle"],
-        attrs=attr_mgr.get_variable_attributes("hi_hist_angle"),
-    )
 
-    data_vars = dict()
-    # Generate label variables
-    data_vars["angle_label"] = xr.DataArray(
-        coords["angle"].values.astype(str),
+    dataset.epoch.attrs.update(
+        attr_mgr.get_variable_attributes("epoch"),
+    )
+    # Add the hist_angle coordinate
+    # Histogram data is binned in 90, 4-degree bins
+    attrs = attr_mgr.get_variable_attributes("hi_hist_angle")
+    dataset.coords.update(
+        {
+            "angle": xr.DataArray(
+                np.arange(2, 360, 4),
+                name="angle",
+                dims=["angle"],
+                attrs=attrs,
+            )
+        }
+    )
+    # Rename shcoarse variable
+    dataset = dataset.rename_vars({"shcoarse": "ccsds_met"})
+    # Update existing variable attributes
+    for var_name in [
+        "version",
+        "type",
+        "sec_hdr_flg",
+        "pkt_apid",
+        "seq_flgs",
+        "src_seq_ctr",
+        "pkt_len",
+        "ccsds_met",
+        "esa_step",
+        "num_of_spins",
+        "cksum",
+    ]:
+        attrs = attr_mgr.get_variable_attributes(f"hi_hist_{var_name}")
+        dataset.data_vars[var_name].attrs.update(attrs)
+
+    new_vars = dict()
+    # Allocate xarray.DataArray objects for the 90-element histogram counters
+    default_counter_attrs = attr_mgr.get_variable_attributes(
+        "hi_hist_counters", check_schema=False
+    )
+    for counter_name in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
+        # Inject counter name into generic counter attributes
+        counter_attrs = default_counter_attrs.copy()
+        dtype = counter_attrs.pop("dtype")
+        for key, val in counter_attrs.items():
+            if isinstance(val, str) and "{counter_name}" in val:
+                counter_attrs[key] = val.format(counter_name=counter_name)
+        new_vars[counter_name] = xr.DataArray(
+            data=np.empty((dataset.epoch.size, dataset.angle.size), dtype=dtype),
+            dims=["epoch", "angle"],
+            attrs=counter_attrs,
+        )
+
+    # Generate label variable for angle coordinate
+    new_vars["angle_label"] = xr.DataArray(
+        dataset.coords["angle"].values.astype(str),
         name="angle_label",
         dims=["angle"],
         attrs=attr_mgr.get_variable_attributes(
             "hi_hist_angle_label", check_schema=False
         ),
     )
-    # Other data variables
-    data_vars["ccsds_met"] = xr.DataArray(
-        np.empty(num_packets, dtype=np.uint32),
-        dims=["epoch"],
-        attrs=attr_mgr.get_variable_attributes("hi_hist_ccsds_met"),
-    )
-    data_vars["esa_stepping_num"] = xr.DataArray(
-        np.empty(num_packets, dtype=np.uint8),
-        dims=["epoch"],
-        attrs=attr_mgr.get_variable_attributes("hi_hist_esa_step"),
-    )
-    data_vars["num_of_spins"] = xr.DataArray(
-        np.empty(num_packets, dtype=np.uint8),
-        dims=["epoch"],
-        attrs=attr_mgr.get_variable_attributes("hi_hist_esa_step"),
-    )
 
-    # Allocate xarray.DataArray objects for the 24 90-element histogram counters
-    default_counter_attrs = attr_mgr.get_variable_attributes("hi_hist_counters")
-    for counter_name in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
-        # Inject counter name into generic counter attributes
-        counter_attrs = default_counter_attrs.copy()
-        for key, val in counter_attrs.items():
-            if isinstance(val, str) and "{counter_name}" in val:
-                counter_attrs[key] = val.format(counter_name=counter_name)
-        data_vars[counter_name] = xr.DataArray(
-            data=np.empty((num_packets, len(coords["angle"])), np.uint16),
-            dims=["epoch", "angle"],
-            attrs=counter_attrs,
-        )
-
-    dataset = xr.Dataset(
-        data_vars=data_vars,
-        coords=coords,
-        attrs=attr_mgr.get_global_attributes("imap_hi_l1a_hist_attrs"),
-    )
+    dataset.update(new_vars)
+    dataset.attrs.update(attr_mgr.get_global_attributes("imap_hi_l1a_hist_attrs"))
     return dataset

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import xarray as xr
+from numpy._typing import NDArray
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 
@@ -48,47 +49,12 @@ def create_dataset(input_ds: xr.Dataset) -> xr.Dataset:
     dataset : xarray.Dataset
         Dataset with all metadata field data in xr.DataArray.
     """
-    dataset = update_packet_dataset(input_ds)
-
-    # unpack the counter binary blobs into the Dataset
-    for counter in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
-        # Interpret bytestrings for all epochs of current counter as uint8 array
-        counter_uint8 = np.frombuffer(input_ds[counter].data.sum(), dtype=np.uint8)
-        # Split into triplets of upper-byte, split-byte and lower-byte arrays
-        upper_uint8, split_unit8, lower_uint8 = np.reshape(
-            counter_uint8, (3, -1), order="F"
-        ).astype(np.uint16)
-        # Compute even indexed uint12 values from upper-byte and first 4-bits of
-        # split-byte
-        even_uint12 = (upper_uint8 << 4) + (split_unit8 >> 4)
-        # Compute odd indexed uint12 values from lower 4-bits of split-byte and
-        # lower-byte
-        odd_uint12 = ((split_unit8 & (2**4 - 1)) << 8) + lower_uint8
-        combined = np.reshape(np.column_stack((even_uint12, odd_uint12)), (-1, 90))
-        # Assign dataset counter data
-        dataset[counter].data = combined
-        pass
-
-    return dataset
-
-
-def update_packet_dataset(dataset: xr.Dataset) -> xr.Dataset:
-    """
-    Update dataset generated from ccsds to match L1A CDF definition.
-
-    Parameters
-    ----------
-    dataset : xarray.Dataset
-        Dataset read in from IMAP-Hi histogram CCSDS data.
-
-    Returns
-    -------
-    dataset : xarray.Dataset
-        Updated xarray.Dataset ready to be filled with histogram counter data.
-    """
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="hi")
     attr_mgr.add_instrument_variable_attrs(instrument="hi", level=None)
+
+    # Rename shcoarse variable (do this first since it copies the input_ds)
+    dataset = input_ds.rename_vars({"shcoarse": "ccsds_met"})
 
     dataset.epoch.attrs.update(
         attr_mgr.get_variable_attributes("epoch"),
@@ -106,8 +72,6 @@ def update_packet_dataset(dataset: xr.Dataset) -> xr.Dataset:
             )
         }
     )
-    # Rename shcoarse variable
-    dataset = dataset.rename_vars({"shcoarse": "ccsds_met"})
     # Update existing variable attributes
     for var_name in [
         "version",
@@ -126,19 +90,17 @@ def update_packet_dataset(dataset: xr.Dataset) -> xr.Dataset:
         dataset.data_vars[var_name].attrs.update(attrs)
 
     new_vars = dict()
-    # Allocate xarray.DataArray objects for the 90-element histogram counters
-    default_counter_attrs = attr_mgr.get_variable_attributes(
-        "hi_hist_counters", check_schema=False
-    )
+    # Populate 90-element histogram counters
+    default_counter_attrs = attr_mgr.get_variable_attributes("hi_hist_counters")
     for counter_name in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
         # Inject counter name into generic counter attributes
         counter_attrs = default_counter_attrs.copy()
-        dtype = counter_attrs.pop("dtype")
         for key, val in counter_attrs.items():
             if isinstance(val, str) and "{counter_name}" in val:
                 counter_attrs[key] = val.format(counter_name=counter_name)
+        # Instantiate the counter DataArray
         new_vars[counter_name] = xr.DataArray(
-            data=np.empty((dataset.epoch.size, dataset.angle.size), dtype=dtype),
+            data=unpack_hist_counter(input_ds[counter_name].data.sum()),
             dims=["epoch", "angle"],
             attrs=counter_attrs,
         )
@@ -155,4 +117,37 @@ def update_packet_dataset(dataset: xr.Dataset) -> xr.Dataset:
 
     dataset.update(new_vars)
     dataset.attrs.update(attr_mgr.get_global_attributes("imap_hi_l1a_hist_attrs"))
+
     return dataset
+
+
+def unpack_hist_counter(counter_bytes: bytes) -> NDArray[np.uint16]:
+    """
+    Unpack Hi SCI_CNT counter data for a single counter.
+
+    Parameters
+    ----------
+    counter_bytes : bytes
+        Sum individual bytes for all epochs of a Hi SCI_CNT counter.
+
+    Returns
+    -------
+    output_array : numpy.ndarray[np.uint16]
+        The unpacked 12-bit unsigned integers for the input bytes. The
+        output array has a shape of (n, 90) where n is the number of SCI_CNT
+        packets in the input dataset.
+    """
+    # Interpret bytes for all epochs of current counter as uint8 array
+    counter_uint8 = np.frombuffer(counter_bytes, dtype=np.uint8)
+    # Split into triplets of upper-byte, split-byte and lower-byte arrays
+    upper_uint8, split_unit8, lower_uint8 = np.reshape(
+        counter_uint8, (3, -1), order="F"
+    ).astype(np.uint16)
+    # Compute even indexed uint12 values from upper-byte and first 4-bits of
+    # split-byte
+    even_uint12 = (upper_uint8 << 4) + (split_unit8 >> 4)
+    # Compute odd indexed uint12 values from lower 4-bits of split-byte and
+    # lower-byte
+    odd_uint12 = ((split_unit8 & (2**4 - 1)) << 8) + lower_uint8
+    output_array = np.column_stack((even_uint12, odd_uint12)).reshape(-1, 90)
+    return output_array

--- a/imap_processing/hi/l1a/histogram.py
+++ b/imap_processing/hi/l1a/histogram.py
@@ -4,7 +4,6 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.utils import convert_to_binary_string
 
 # define the names of the 24 counter arrays
 # contained in the histogram packet
@@ -57,17 +56,23 @@ def create_dataset(input_ds: xr.Dataset) -> xr.Dataset:
     dataset["num_of_spins"].data = input_ds["num_of_spins"].data
 
     # unpack the counter binary blobs into the Dataset
-    # TODO: Look into avoiding the for-loops below
-    #       It seems like we could try to reshape the arrays and do some numpy
-    #       broadcasting rather than for-loops directly here. Ticket: #700
-    for i_epoch in range(input_ds["epoch"].size):
-        for counter in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
-            binary_str_val = convert_to_binary_string(input_ds[counter].data[i_epoch])
-            # unpack array of 90 12-bit unsigned integers
-            counter_ints = [
-                int(binary_str_val[i * 12 : (i + 1) * 12], 2) for i in range(90)
-            ]
-            dataset[counter][i_epoch] = counter_ints
+    for counter in (*QUALIFIED_COUNTERS, *LONG_COUNTERS, *TOTAL_COUNTERS):
+        # Interpret bytestrings for all epochs of current counter as uint8 array
+        counter_uint8 = np.frombuffer(input_ds[counter].data.sum(), dtype=np.uint8)
+        # Split into triplets of upper-byte, split-byte and lower-byte arrays
+        upper_uint8, split_unit8, lower_uint8 = np.reshape(
+            counter_uint8, (3, -1), order="F"
+        ).astype(np.uint16)
+        # Compute even indexed uint12 values from upper-byte and first 4-bits of
+        # split-byte
+        even_uint12 = (upper_uint8 << 4) + (split_unit8 >> 4)
+        # Compute odd indexed uint12 values from lower 4-bits of split-byte and
+        # lower-byte
+        odd_uint12 = ((split_unit8 & (2**4 - 1)) << 8) + lower_uint8
+        combined = np.reshape(np.column_stack((even_uint12, odd_uint12)), (-1, 90))
+        # Assign dataset counter data
+        dataset[counter].data = combined
+        pass
 
     return dataset
 


### PR DESCRIPTION
# Change Summary

## Overview
This is a major overhaul of the Hi L1A hist processing. It was partially necessitated by an update to the SCI_CNT packet definition. The other changes were driven by the implementation of the `packet_file_to_datasets` function which was written after this code was first implemented.

## Updated Files
- imap_processing/cdf/config/imap_hi_variable_attrs.yaml
   - Added default entries for CCSDS header entries that were previously not decoded from the packets.
   - Added CCSDS header entries to the HIST CDF variable attributes.
- imap_processing/hi/l1a/histogram.py
   - No longer allocate Dataset from scratch. Instead, the L1A CDF is derived from the packet Dataset that is passed in.
   - Update attributes for variables already in the input dataset.
   - Only add data variables that are not already present in the input dataset.
   - Extract method for decoding the 90 element 12-bit counter arrays.
- imap_processing/tests/hi/test_l1a.py
   - Remove test for removed function: `allocate_histogram_dataset`
   - Add test coverage for new function: `unpack_hist_counter`


Closes: #700 
