### PR TITLE
Lo - Update XTCE to fix HK enum state issue

### DIFF
--- a/imap_processing/lo/packet_definitions/lo_xtce.xml
+++ b/imap_processing/lo/packet_definitions/lo_xtce.xml
@@ -24,6 +24,2555 @@
 			<xtce:IntegerParameterType name="PKT_LEN" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
 			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.BOARD_TYPE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="EM" />
+					<xtce:Enumeration value="1" label="FM" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.RESET_REASON_SOFT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.RESET_REASON_FPGA_WDOG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.RESET_REASON_CPU_WDOG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.RESET_REASON_PFO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.RESET_REASON_POR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.CPU_WDOG_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.FPGA_WDOG_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.WDOG_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.INSTR_ID" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="1" label="ILO" />
+					<xtce:Enumeration value="2" label="H45" />
+					<xtce:Enumeration value="3" label="COD" />
+					<xtce:Enumeration value="4" label="SWE" />
+					<xtce:Enumeration value="5" label="ICE" />
+					<xtce:Enumeration value="6" label="H90" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.CDH_FPGA_VERSION" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.IFB_FPGA_VERSION" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.BULK_HVPS_VERSION" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.FSW_VERSION" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_SHK.SELECTED_IMG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="PRI" />
+					<xtce:Enumeration value="1" label="SEC" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:BinaryParameterType name="ILO_APP_SHK.FSW_VERSION_STR">
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
+							<xtce:LinearAdjustment slope="8" intercept="-1016" />
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+			<xtce:BinaryParameterType name="ILO_APP_SHK.ENG_LUT_VERSION_STR">
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
+							<xtce:LinearAdjustment slope="8" intercept="-936" />
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+			<xtce:BinaryParameterType name="ILO_APP_SHK.SCI_LUT_VERSION_STR">
+				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
+					<xtce:SizeInBits>
+						<xtce:DynamicValue>
+							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
+							<xtce:LinearAdjustment slope="8" intercept="-936" />
+						</xtce:DynamicValue>
+					</xtce:SizeInBits>
+				</xtce:BinaryDataEncoding>
+			</xtce:BinaryParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.SCRATCH_BUFFER_ADDR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.SPARE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_SHK.CHKSUM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.OP_MODE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="SAFE" />
+					<xtce:Enumeration value="1" label="LVENG" />
+					<xtce:Enumeration value="2" label="LVSCI" />
+					<xtce:Enumeration value="3" label="HVENG" />
+					<xtce:Enumeration value="4" label="HVSCI" />
+					<xtce:Enumeration value="5" label="HVSTANDBY" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CMD_EXE_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CMD_REJ_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.CMD_LAST_OPCODE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="4096" label="ILO_NOOP" />
+					<xtce:Enumeration value="4097" label="ILO_RESET" />
+					<xtce:Enumeration value="4098" label="ILO_SHUTDOWN" />
+					<xtce:Enumeration value="4099" label="ILO_MODE_SET" />
+					<xtce:Enumeration value="4100" label="ILO_PARAM_SET" />
+					<xtce:Enumeration value="4101" label="ILO_PARAM_LOAD" />
+					<xtce:Enumeration value="4102" label="ILO_HEAT_CNFG" />
+					<xtce:Enumeration value="4103" label="ILO_HEAT_CTRL" />
+					<xtce:Enumeration value="4352" label="ILO_TLM_RATE" />
+					<xtce:Enumeration value="4353" label="ILO_LATCHED_CLR" />
+					<xtce:Enumeration value="4354" label="ILO_EVENT_CTRL" />
+					<xtce:Enumeration value="4355" label="ILO_MARKER_SET" />
+					<xtce:Enumeration value="4608" label="ILO_FDR_CNFG" />
+					<xtce:Enumeration value="4609" label="ILO_SAFE" />
+					<xtce:Enumeration value="4610" label="ILO_SAFE_CLR" />
+					<xtce:Enumeration value="4864" label="ILO_RTS_START" />
+					<xtce:Enumeration value="4865" label="ILO_RTS_STOP" />
+					<xtce:Enumeration value="4866" label="ILO_RTS_COND_WAIT" />
+					<xtce:Enumeration value="5120" label="ILO_MEM_PEEK" />
+					<xtce:Enumeration value="5121" label="ILO_MEM_POKE" />
+					<xtce:Enumeration value="5122" label="ILO_MEM_DUMP" />
+					<xtce:Enumeration value="5123" label="ILO_MRAM_WP" />
+					<xtce:Enumeration value="5124" label="ILO_MEM_LOAD" />
+					<xtce:Enumeration value="5125" label="ILO_MEM_COPY" />
+					<xtce:Enumeration value="5126" label="ILO_MEM_CHKSUM" />
+					<xtce:Enumeration value="5127" label="ILO_EDAC_TEST" />
+					<xtce:Enumeration value="5376" label="ILO_SENSOR_PWR" />
+					<xtce:Enumeration value="5377" label="ILO_SCI_CNFG" />
+					<xtce:Enumeration value="5378" label="ILO_SCI_INJ_EVENTS" />
+					<xtce:Enumeration value="5632" label="ILO_REG_PEEK" />
+					<xtce:Enumeration value="5633" label="ILO_REG_POKE" />
+					<xtce:Enumeration value="5634" label="ILO_IFB_CTRL" />
+					<xtce:Enumeration value="5635" label="ILO_IFB_DATA_INT" />
+					<xtce:Enumeration value="5636" label="ILO_IFB_STAR_ADJ" />
+					<xtce:Enumeration value="5637" label="ILO_IFB_OSCOPE" />
+					<xtce:Enumeration value="5895" label="ILO_TOF_BD_CTRL" />
+					<xtce:Enumeration value="5896" label="ILO_TOF_THRESH" />
+					<xtce:Enumeration value="5897" label="ILO_TOF_STIM_CTRL" />
+					<xtce:Enumeration value="5898" label="ILO_TOF_STIM_CNFG" />
+					<xtce:Enumeration value="5899" label="ILO_TOF_DATA_REQ" />
+					<xtce:Enumeration value="5900" label="ILO_TOF_FAST_DATA_REQ" />
+					<xtce:Enumeration value="5901" label="ILO_TOF_VETO" />
+					<xtce:Enumeration value="6144" label="ILO_TOF_HVPS_CTRL" />
+					<xtce:Enumeration value="6145" label="ILO_PAC_OCP" />
+					<xtce:Enumeration value="6146" label="ILO_PAC_RMP" />
+					<xtce:Enumeration value="6147" label="ILO_PAC_RMP_RAW" />
+					<xtce:Enumeration value="6148" label="ILO_PAC_RMP_REL" />
+					<xtce:Enumeration value="6149" label="ILO_MCP_OCP" />
+					<xtce:Enumeration value="6150" label="ILO_MCP_RMP" />
+					<xtce:Enumeration value="6151" label="ILO_MCP_RMP_RAW" />
+					<xtce:Enumeration value="6152" label="ILO_MCP_RMP_REL" />
+					<xtce:Enumeration value="6400" label="ILO_PIVOT_STEP" />
+					<xtce:Enumeration value="6401" label="ILO_PIVOT_STEP_CUMUL_CNT" />
+					<xtce:Enumeration value="6402" label="ILO_PIVOT_STEP_CANCEL" />
+					<xtce:Enumeration value="6403" label="ILO_PIVOT_POW_IDLE_EN" />
+					<xtce:Enumeration value="6404" label="ILO_PIVOT_POW_IDLE_EX" />
+					<xtce:Enumeration value="6405" label="ILO_PIVOT_ACCEL" />
+					<xtce:Enumeration value="6406" label="ILO_PIVOT_MICRO_STEP" />
+					<xtce:Enumeration value="6407" label="ILO_PIVOT_CURR_CTRL" />
+					<xtce:Enumeration value="6408" label="ILO_PPM_MOVE" />
+					<xtce:Enumeration value="6409" label="ILO_PPM_ENTER_DIAG_MODE" />
+					<xtce:Enumeration value="6410" label="ILO_PPM_EXIT_DIAG_MODE" />
+					<xtce:Enumeration value="6411" label="ILO_PPM_LATCHED_CLR" />
+					<xtce:Enumeration value="6412" label="ILO_PPM_RESTORE" />
+					<xtce:Enumeration value="6413" label="ILO_PPM_MOTOR_SET" />
+					<xtce:Enumeration value="6414" label="ILO_PPM_STOP" />
+					<xtce:Enumeration value="6415" label="ILO_PPM_MICROSTEP_SET" />
+					<xtce:Enumeration value="6656" label="ILO_HVPS_MST" />
+					<xtce:Enumeration value="6657" label="ILO_HVPS_RAW_CMD" />
+					<xtce:Enumeration value="6658" label="ILO_HVPS_ADC_CTRL" />
+					<xtce:Enumeration value="6659" label="ILO_HVPS_EN" />
+					<xtce:Enumeration value="6660" label="ILO_HVPS_DS" />
+					<xtce:Enumeration value="6661" label="ILO_ESA_N_RMP" />
+					<xtce:Enumeration value="6662" label="ILO_ESA_N_RMP_REL" />
+					<xtce:Enumeration value="6663" label="ILO_ESA_N_RMP_RAW" />
+					<xtce:Enumeration value="6664" label="ILO_ESA_P_RMP" />
+					<xtce:Enumeration value="6665" label="ILO_ESA_P_RMP_REL" />
+					<xtce:Enumeration value="6666" label="ILO_ESA_P_RMP_RAW" />
+					<xtce:Enumeration value="6667" label="ILO_DEF_N_RMP" />
+					<xtce:Enumeration value="6668" label="ILO_DEF_N_RMP_REL" />
+					<xtce:Enumeration value="6669" label="ILO_DEF_N_RMP_RAW" />
+					<xtce:Enumeration value="6670" label="ILO_DEF_P_RMP" />
+					<xtce:Enumeration value="6671" label="ILO_DEF_P_RMP_REL" />
+					<xtce:Enumeration value="6672" label="ILO_DEF_P_RMP_RAW" />
+					<xtce:Enumeration value="6673" label="ILO_PMT_RMP" />
+					<xtce:Enumeration value="6674" label="ILO_PMT_RMP_REL" />
+					<xtce:Enumeration value="6675" label="ILO_PMT_RMP_RAW" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.ITF_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.WATCHDOG_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TEMP1_311P18_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IMAPLO_ICE_TOF_TEMP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-848.0" exponent="0" />
+							<xtce:Term coefficient="1.488529" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TEMP3_311P18_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LO_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.SPARE_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_12V_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-268.22373246839686" exponent="0" />
+							<xtce:Term coefficient="0.14103584591030507" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_5V_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-268.73559622290213" exponent="0" />
+							<xtce:Term coefficient="0.14164365828789297" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_3P3V_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-267.8401530306961" exponent="0" />
+							<xtce:Term coefficient="0.14124348472252374" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_3P3V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001611" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002441" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_N5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.002441" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.005859" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_N12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.005859" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_3P3V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="13.441939999999999" exponent="0" />
+							<xtce:Term coefficient="0.92158" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_5V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-1.7082810000000002" exponent="0" />
+							<xtce:Term coefficient="0.488167" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_N5V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.46099999999999997" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_12V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3.005379" exponent="0" />
+							<xtce:Term coefficient="0.701694" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LVPS_N12V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-47.530631" exponent="0" />
+							<xtce:Term coefficient="0.14082999999999998" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_1P5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001221" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_1P8V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001221" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_3P3V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001221" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.005897" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_N12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.005841" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002441" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_5V_ADC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002441" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_PROCESSOR_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_1P8V_LDO_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_1P5V_LDO_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAD_28" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CDH_SDRAM_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="7" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_CMD_TIMEOUT_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_DAC_UPDATE_ACK_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_READ_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_TLM_TIMEOUT_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_WRITE_ACK_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_CMD_PARITY_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_CMD_FRAME_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_TLM_PARITY_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_TLM_FRAME_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_TIMEOUT_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_CNT_ERR_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_STAT_CMD_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_STAT_MST_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_HV_PLUG_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="EN" />
+					<xtce:Enumeration value="1" label="LIM" />
+					<xtce:Enumeration value="2" label="DS" />
+					<xtce:Enumeration value="3" label="DS" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_STAT_POR_RST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_STAT_PFO_RST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_STAT_SOFT_RST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_BULK_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_ESA_POS_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_ESA_NEG_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DAC_PAD0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_ESA_NEG_DAC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DAC_PAD1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_ESA_POS_DAC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DAC_PAD2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DEF_NEG_DAC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.48889" exponent="0" />
+							<xtce:Term coefficient="0.97806" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DAC_PAD3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DEF_POS_DAC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="5.0253" exponent="0" />
+							<xtce:Term coefficient="1.2213" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DAC_PAD4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PMT_DAC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.99418" exponent="0" />
+							<xtce:Term coefficient="0.24414" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_ADC1_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_ADC1_MODE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="SCI" />
+					<xtce:Enumeration value="1" label="ENG" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_ADC1_CH_SEL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="BULK_V" />
+					<xtce:Enumeration value="1" label="ESA_NEG_V" />
+					<xtce:Enumeration value="2" label="ESA_POS_V" />
+					<xtce:Enumeration value="3" label="DEF_NEG_V" />
+					<xtce:Enumeration value="4" label="DEF_POS_V" />
+					<xtce:Enumeration value="5" label="PMT_V" />
+					<xtce:Enumeration value="6" label="PMT_I" />
+					<xtce:Enumeration value="7" label="BULK_U" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_ADC2_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_ADC2_MODE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="SCI" />
+					<xtce:Enumeration value="1" label="ENG" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.BHV_ADC2_CH_SEL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DEF_NEG_I" />
+					<xtce:Enumeration value="1" label="DEF_POS_I" />
+					<xtce:Enumeration value="2" label="ADC_REF1_V" />
+					<xtce:Enumeration value="3" label="ADC_REF2_V" />
+					<xtce:Enumeration value="4" label="P12P0_V" />
+					<xtce:Enumeration value="5" label="N12P0_V" />
+					<xtce:Enumeration value="6" label="P3P3_V" />
+					<xtce:Enumeration value="7" label="P1P5_V" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="5" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_ADC1_WAIT_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_ADC2_WAIT_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_BULK_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1.5214501510574" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_ESA_NEG_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-12.338" exponent="0" />
+							<xtce:Term coefficient="0.5216" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_ESA_POS_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="3.8245" exponent="0" />
+							<xtce:Term coefficient="1.0605" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DEF_NEG_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2375" exponent="0" />
+							<xtce:Term coefficient="1.2292" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DEF_POS_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="3.7393" exponent="0" />
+							<xtce:Term coefficient="1.5376" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PMT_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.46017" exponent="0" />
+							<xtce:Term coefficient="0.30798" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PMT_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.295301441" exponent="0" />
+							<xtce:Term coefficient="0.00561741144" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_BULK_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.030517578125" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DEF_NEG_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.0817617106" exponent="0" />
+							<xtce:Term coefficient="0.00573128038" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_DEF_POS_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.272811891" exponent="0" />
+							<xtce:Term coefficient="0.00578272729" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_ADC_REF1_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002440214738897023" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_ADC_REF2_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0024386907669760624" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_12P0_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.006122833814913541" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_N12P0_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-17.267" exponent="0" />
+							<xtce:Term coefficient="0.0054229" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_3P3_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0012259383128948346" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_PAD17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_1P5_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0012097902097902098" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.MEM_OP_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="IDLE" />
+					<xtce:Enumeration value="1" label="CHECKINGFAIL" />
+					<xtce:Enumeration value="2" label="COPYINGFAIL" />
+					<xtce:Enumeration value="3" label="VERIFYINGFAIL" />
+					<xtce:Enumeration value="4" label="SUCCESS" />
+					<xtce:Enumeration value="5" label="CHECKSUMMING" />
+					<xtce:Enumeration value="6" label="CHECKING" />
+					<xtce:Enumeration value="7" label="COPYING" />
+					<xtce:Enumeration value="8" label="VERIFYING" />
+					<xtce:Enumeration value="9" label="INVALID" />
+					<xtce:Enumeration value="10" label="INVALID" />
+					<xtce:Enumeration value="11" label="INVALID" />
+					<xtce:Enumeration value="12" label="INVALID" />
+					<xtce:Enumeration value="13" label="INVALID" />
+					<xtce:Enumeration value="14" label="INVALID" />
+					<xtce:Enumeration value="15" label="INVALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.MEM_DUMP_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="IDLE" />
+					<xtce:Enumeration value="1" label="BUSY" />
+					<xtce:Enumeration value="2" label="INVALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.SPIN_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.MISSED_PPS_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CPU_IDLE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.256" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.SPIN_BIN_IDX" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.SPIN_PERIOD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.00032" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.CDH_HEATER_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.CDH_HEATER_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.INSTR_PWR_12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.INSTR_PWR_ANALOG_5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.INSTR_PWR_DIGITAL_5V_3P3V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_CMD_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_INTERFACE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_ADC_TLM_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_ADC_TLM_TIMEOUT_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_ADC_TLM_ID_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_ADC_TLM_FRAME_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_TLM_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_TLM_TIMEOUT_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_TLM_ID_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_TLM_FRAME_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_TLM_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_ADC_TLM_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_REG_TLM_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_CNT_TLM_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_DE_TLM_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_TLM_TIMEOUT_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_TLM_ID_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_TLM_FRAME_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.DIRECT_EVENT_TIME_TAG_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.DIRECT_EVENT_FIFO_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_INTERFACE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPC_TLM_TIMEOUT_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPC_TLM_PARITY_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPC_TLM_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_HV_PLUG_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="DS" />
+					<xtce:Enumeration value="2" label="LIM" />
+					<xtce:Enumeration value="3" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_CMD_COUNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_CTRL_INT_MUX" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="NORMAL_ADC" />
+					<xtce:Enumeration value="1" label="IFB_5V" />
+					<xtce:Enumeration value="2" label="IFB_2P5V" />
+					<xtce:Enumeration value="3" label="STAR_OFFSET" />
+					<xtce:Enumeration value="4" label="PAC_VSET" />
+					<xtce:Enumeration value="5" label="PAC_OCP" />
+					<xtce:Enumeration value="6" label="MCP_VSET" />
+					<xtce:Enumeration value="7" label="MCP_OCP" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_CTRL_ADC_CLK_DS" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_CTRL_OSCOPE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_CTRL_STAR_SYNC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_CTRL_DATA" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_DATA_INTERVAL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="13.3344" exponent="0" />
+							<xtce:Term coefficient="0.06945" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_HVPS_CTRL_SYNC_CLK" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="EN" />
+					<xtce:Enumeration value="1" label="DS" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_HVPS_CTRL_PAC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_HVPS_CTRL_MCP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_HVPS_CTRL_LV" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAC_VSET" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-17.348051" exponent="0" />
+							<xtce:Term coefficient="97.307885" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAC_OCP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.01933594" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.MCP_VSET" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="438.995359" exponent="0" />
+							<xtce:Term coefficient="35.590409" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.MCP_OCP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.01933594" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.STAR_OFFSET_ADJUST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-1.0" exponent="0" />
+							<xtce:Term coefficient="0.01933594" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_OSCOPE_CH1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="IFB_TEMP1" />
+					<xtce:Enumeration value="2" label="IFB_TEMP0" />
+					<xtce:Enumeration value="3" label="IFB_5V" />
+					<xtce:Enumeration value="4" label="IFB_3P3V" />
+					<xtce:Enumeration value="5" label="IFB_12VP" />
+					<xtce:Enumeration value="6" label="IFB_12VN" />
+					<xtce:Enumeration value="7" label="LV_CM" />
+					<xtce:Enumeration value="8" label="LV_VM" />
+					<xtce:Enumeration value="9" label="LV_TEMP" />
+					<xtce:Enumeration value="10" label="MCP_CM" />
+					<xtce:Enumeration value="11" label="MCP_VM" />
+					<xtce:Enumeration value="12" label="MCP_TEMP" />
+					<xtce:Enumeration value="13" label="PAC_CM" />
+					<xtce:Enumeration value="14" label="PAC_VM" />
+					<xtce:Enumeration value="15" label="PAC_TEMP" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.IFB_OSCOPE_CH0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="IFB_TEMP1" />
+					<xtce:Enumeration value="2" label="IFB_TEMP0" />
+					<xtce:Enumeration value="3" label="IFB_5V" />
+					<xtce:Enumeration value="4" label="IFB_3P3V" />
+					<xtce:Enumeration value="5" label="IFB_12VP" />
+					<xtce:Enumeration value="6" label="IFB_12VN" />
+					<xtce:Enumeration value="7" label="LV_CM" />
+					<xtce:Enumeration value="8" label="LV_VM" />
+					<xtce:Enumeration value="9" label="LV_TEMP" />
+					<xtce:Enumeration value="10" label="MCP_CM" />
+					<xtce:Enumeration value="11" label="MCP_VM" />
+					<xtce:Enumeration value="12" label="MCP_TEMP" />
+					<xtce:Enumeration value="13" label="PAC_CM" />
+					<xtce:Enumeration value="14" label="PAC_VM" />
+					<xtce:Enumeration value="15" label="PAC_TEMP" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_HOT_SPOT_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-277.407" exponent="0" />
+							<xtce:Term coefficient="0.123407" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_COLD_SPOT_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-274.285" exponent="0" />
+							<xtce:Term coefficient="0.121487" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_5P0_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002416992" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_3P3_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001208496" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_12P0_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.007250977" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_N12P0_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-16.434" exponent="0" />
+							<xtce:Term coefficient="0.005220703" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LV_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.2337" exponent="0" />
+							<xtce:Term coefficient="0.1361" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LV_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0043746" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.LV_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-277.53" exponent="0" />
+							<xtce:Term coefficient="0.246813" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.MCP_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.1548" exponent="0" />
+							<xtce:Term coefficient="0.043607" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.MCP_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-475.860941" exponent="0" />
+							<xtce:Term coefficient="9.46897" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.MCP_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-276.278" exponent="0" />
+							<xtce:Term coefficient="0.245421" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAC_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.1874" exponent="0" />
+							<xtce:Term coefficient="0.056193" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAC_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-23.226667" exponent="0" />
+							<xtce:Term coefficient="12.384764" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.IFB_PAD14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PAC_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-280.701" exponent="0" />
+							<xtce:Term coefficient="0.248983" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_CMD_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PAD0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_CFD_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.00991867816091954" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PAD1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PRE_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-267.76137705513673" exponent="0" />
+							<xtce:Term coefficient="0.5663548006176765" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PAD2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_REG_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-266.92886348747373" exponent="0" />
+							<xtce:Term coefficient="0.5648677344297106" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PAD3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_MCP_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.3033433595481494" exponent="0" />
+							<xtce:Term coefficient="0.02445388053548595" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PAD4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_MCP_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="4.505" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PAD5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_BD_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.525483578148183" exponent="0" />
+							<xtce:Term coefficient="0.3050864416570392" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PAD6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_BD_P5_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.009937854710556186" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_PAD7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF_BD_P6_V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.027111787964010148" exponent="0" />
+							<xtce:Term coefficient="0.009926214962484822" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.AN_A_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.AN_B0_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.AN_B3_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.AN_C_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_CTRL_TLM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_CTRL_DE_TLM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_CTRL_TOF3_REQ" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_CTRL_TOF2_REQ" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_CTRL_TOF1_REQ" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF_BD_CTRL_TOF0_REQ" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.STIM_CTRL_AN_C_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.STIM_CTRL_AN_C_SRC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STOP" />
+					<xtce:Enumeration value="1" label="START" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.STIM_CTRL_AN_B3_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.STIM_CTRL_AN_B3_SRC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STOP" />
+					<xtce:Enumeration value="1" label="START" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.STIM_CTRL_AN_B0_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.STIM_CTRL_AN_B0_SRC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STOP" />
+					<xtce:Enumeration value="1" label="START" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.STIM_CTRL_AN_A_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.STIM_CTRL_AN_A_SRC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STOP" />
+					<xtce:Enumeration value="1" label="START" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.STIM_CNFG_FREQ" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1.0" exponent="0" />
+							<xtce:Term coefficient="1.0" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.STIM_CNFG_DELAY" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="20.833333333333336" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF3_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.46726299520543435" exponent="0" />
+							<xtce:Term coefficient="1.3715585136889914" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF2_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.3744222712503813" exponent="0" />
+							<xtce:Term coefficient="1.3312687906975365" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF1_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.7201813051183734" exponent="0" />
+							<xtce:Term coefficient="1.3209957435920419" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.TOF0_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.5525235549626046" exponent="0" />
+							<xtce:Term coefficient="1.3469946516059763" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF3_VETO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF2_VETO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF1_VETO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.TOF0_VETO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.BHV_SPARE14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_PAD0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_COARSE_POT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-25.6" exponent="0" />
+							<xtce:Term coefficient="0.085828" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_PAD1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_FINE_POT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0001406" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_PAD2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_COARSE_POT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-5.1" exponent="0" />
+							<xtce:Term coefficient="0.085891" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_PAD3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_FINE_POT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0001406" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_PAD4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_ACTUATOR_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-511.151" exponent="0" />
+							<xtce:Term coefficient="0.500052" exponent="1" />
+							<xtce:Term coefficient="-0.000245442" exponent="2" />
+							<xtce:Term coefficient="6.01427e-08" exponent="3" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_PAD5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_BOARD_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-19075.98733563" exponent="0" />
+							<xtce:Term coefficient="36.88265703859" exponent="1" />
+							<xtce:Term coefficient="-0.02952704275942" exponent="2" />
+							<xtce:Term coefficient="1.258716630941e-05" exponent="3" />
+							<xtce:Term coefficient="-3.016728267882e-09" exponent="4" />
+							<xtce:Term coefficient="3.855586503305e-13" exponent="5" />
+							<xtce:Term coefficient="-2.054430438544e-17" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_PAD6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_MOTOR_CURRENT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.57" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_PAD7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_MOTOR_CURRENT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.57" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_CUMULATIVE_CNT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="180.0624" exponent="0" />
+							<xtce:Term coefficient="-0.00246027" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="43" label="POSITIVE" />
+					<xtce:Enumeration value="45" label="NEGATIVE" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="180.0624" exponent="0" />
+							<xtce:Term coefficient="-0.00246027" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="43" label="POSITIVE" />
+					<xtce:Enumeration value="45" label="NEGATIVE" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_CURRENT_STEP_CNT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.00246027" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PCC_CURRENT_STEP_CNT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.00246027" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_CURRENT_SETPT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="49" label="PRI_500_MA" />
+					<xtce:Enumeration value="50" label="PRI_600_MA" />
+					<xtce:Enumeration value="51" label="PRI_700_MA" />
+					<xtce:Enumeration value="52" label="PRI_800_MA" />
+					<xtce:Enumeration value="53" label="PRI_700_MA" />
+					<xtce:Enumeration value="54" label="PRI_700_MA" />
+					<xtce:Enumeration value="55" label="PRI_700_MA" />
+					<xtce:Enumeration value="56" label="PRI_700_MA" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_CURRENT_SETPT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="49" label="SEC_500_MA" />
+					<xtce:Enumeration value="50" label="SEC_600_MA" />
+					<xtce:Enumeration value="51" label="SEC_700_MA" />
+					<xtce:Enumeration value="52" label="SEC_800_MA" />
+					<xtce:Enumeration value="53" label="SEC_700_MA" />
+					<xtce:Enumeration value="54" label="SEC_700_MA" />
+					<xtce:Enumeration value="55" label="SEC_700_MA" />
+					<xtce:Enumeration value="56" label="SEC_700_MA" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_PRI_ACTIVE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_PRI_POWERED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_PRI_USTEP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_PRI_ACCEL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_SEC_ACTIVE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_SEC_POWERED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_SEC_USTEP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PCC_SEC_ACCEL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.RTS_ID" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.RTS_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.RTS_NUM_CMDS" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.RTS_NUM_CMDS_EXE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.RTS_INDEX" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.RTS_NEXT_OPCODE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="4096" label="ILO_NOOP" />
+					<xtce:Enumeration value="4097" label="ILO_RESET" />
+					<xtce:Enumeration value="4098" label="ILO_SHUTDOWN" />
+					<xtce:Enumeration value="4099" label="ILO_MODE_SET" />
+					<xtce:Enumeration value="4100" label="ILO_PARAM_SET" />
+					<xtce:Enumeration value="4101" label="ILO_PARAM_LOAD" />
+					<xtce:Enumeration value="4102" label="ILO_HEAT_CNFG" />
+					<xtce:Enumeration value="4103" label="ILO_HEAT_CTRL" />
+					<xtce:Enumeration value="4352" label="ILO_TLM_RATE" />
+					<xtce:Enumeration value="4353" label="ILO_LATCHED_CLR" />
+					<xtce:Enumeration value="4354" label="ILO_EVENT_CTRL" />
+					<xtce:Enumeration value="4355" label="ILO_MARKER_SET" />
+					<xtce:Enumeration value="4608" label="ILO_FDR_CNFG" />
+					<xtce:Enumeration value="4609" label="ILO_SAFE" />
+					<xtce:Enumeration value="4610" label="ILO_SAFE_CLR" />
+					<xtce:Enumeration value="4864" label="ILO_RTS_START" />
+					<xtce:Enumeration value="4865" label="ILO_RTS_STOP" />
+					<xtce:Enumeration value="4866" label="ILO_RTS_COND_WAIT" />
+					<xtce:Enumeration value="5120" label="ILO_MEM_PEEK" />
+					<xtce:Enumeration value="5121" label="ILO_MEM_POKE" />
+					<xtce:Enumeration value="5122" label="ILO_MEM_DUMP" />
+					<xtce:Enumeration value="5123" label="ILO_MRAM_WP" />
+					<xtce:Enumeration value="5124" label="ILO_MEM_LOAD" />
+					<xtce:Enumeration value="5125" label="ILO_MEM_COPY" />
+					<xtce:Enumeration value="5126" label="ILO_MEM_CHKSUM" />
+					<xtce:Enumeration value="5127" label="ILO_EDAC_TEST" />
+					<xtce:Enumeration value="5376" label="ILO_SENSOR_PWR" />
+					<xtce:Enumeration value="5377" label="ILO_SCI_CNFG" />
+					<xtce:Enumeration value="5378" label="ILO_SCI_INJ_EVENTS" />
+					<xtce:Enumeration value="5632" label="ILO_REG_PEEK" />
+					<xtce:Enumeration value="5633" label="ILO_REG_POKE" />
+					<xtce:Enumeration value="5634" label="ILO_IFB_CTRL" />
+					<xtce:Enumeration value="5635" label="ILO_IFB_DATA_INT" />
+					<xtce:Enumeration value="5636" label="ILO_IFB_STAR_ADJ" />
+					<xtce:Enumeration value="5637" label="ILO_IFB_OSCOPE" />
+					<xtce:Enumeration value="5895" label="ILO_TOF_BD_CTRL" />
+					<xtce:Enumeration value="5896" label="ILO_TOF_THRESH" />
+					<xtce:Enumeration value="5897" label="ILO_TOF_STIM_CTRL" />
+					<xtce:Enumeration value="5898" label="ILO_TOF_STIM_CNFG" />
+					<xtce:Enumeration value="5899" label="ILO_TOF_DATA_REQ" />
+					<xtce:Enumeration value="5900" label="ILO_TOF_FAST_DATA_REQ" />
+					<xtce:Enumeration value="5901" label="ILO_TOF_VETO" />
+					<xtce:Enumeration value="6144" label="ILO_TOF_HVPS_CTRL" />
+					<xtce:Enumeration value="6145" label="ILO_PAC_OCP" />
+					<xtce:Enumeration value="6146" label="ILO_PAC_RMP" />
+					<xtce:Enumeration value="6147" label="ILO_PAC_RMP_RAW" />
+					<xtce:Enumeration value="6148" label="ILO_PAC_RMP_REL" />
+					<xtce:Enumeration value="6149" label="ILO_MCP_OCP" />
+					<xtce:Enumeration value="6150" label="ILO_MCP_RMP" />
+					<xtce:Enumeration value="6151" label="ILO_MCP_RMP_RAW" />
+					<xtce:Enumeration value="6152" label="ILO_MCP_RMP_REL" />
+					<xtce:Enumeration value="6400" label="ILO_PIVOT_STEP" />
+					<xtce:Enumeration value="6401" label="ILO_PIVOT_STEP_CUMUL_CNT" />
+					<xtce:Enumeration value="6402" label="ILO_PIVOT_STEP_CANCEL" />
+					<xtce:Enumeration value="6403" label="ILO_PIVOT_POW_IDLE_EN" />
+					<xtce:Enumeration value="6404" label="ILO_PIVOT_POW_IDLE_EX" />
+					<xtce:Enumeration value="6405" label="ILO_PIVOT_ACCEL" />
+					<xtce:Enumeration value="6406" label="ILO_PIVOT_MICRO_STEP" />
+					<xtce:Enumeration value="6407" label="ILO_PIVOT_CURR_CTRL" />
+					<xtce:Enumeration value="6408" label="ILO_PPM_MOVE" />
+					<xtce:Enumeration value="6409" label="ILO_PPM_ENTER_DIAG_MODE" />
+					<xtce:Enumeration value="6410" label="ILO_PPM_EXIT_DIAG_MODE" />
+					<xtce:Enumeration value="6411" label="ILO_PPM_LATCHED_CLR" />
+					<xtce:Enumeration value="6412" label="ILO_PPM_RESTORE" />
+					<xtce:Enumeration value="6413" label="ILO_PPM_MOTOR_SET" />
+					<xtce:Enumeration value="6414" label="ILO_PPM_STOP" />
+					<xtce:Enumeration value="6415" label="ILO_PPM_MICROSTEP_SET" />
+					<xtce:Enumeration value="6656" label="ILO_HVPS_MST" />
+					<xtce:Enumeration value="6657" label="ILO_HVPS_RAW_CMD" />
+					<xtce:Enumeration value="6658" label="ILO_HVPS_ADC_CTRL" />
+					<xtce:Enumeration value="6659" label="ILO_HVPS_EN" />
+					<xtce:Enumeration value="6660" label="ILO_HVPS_DS" />
+					<xtce:Enumeration value="6661" label="ILO_ESA_N_RMP" />
+					<xtce:Enumeration value="6662" label="ILO_ESA_N_RMP_REL" />
+					<xtce:Enumeration value="6663" label="ILO_ESA_N_RMP_RAW" />
+					<xtce:Enumeration value="6664" label="ILO_ESA_P_RMP" />
+					<xtce:Enumeration value="6665" label="ILO_ESA_P_RMP_REL" />
+					<xtce:Enumeration value="6666" label="ILO_ESA_P_RMP_RAW" />
+					<xtce:Enumeration value="6667" label="ILO_DEF_N_RMP" />
+					<xtce:Enumeration value="6668" label="ILO_DEF_N_RMP_REL" />
+					<xtce:Enumeration value="6669" label="ILO_DEF_N_RMP_RAW" />
+					<xtce:Enumeration value="6670" label="ILO_DEF_P_RMP" />
+					<xtce:Enumeration value="6671" label="ILO_DEF_P_RMP_REL" />
+					<xtce:Enumeration value="6672" label="ILO_DEF_P_RMP_RAW" />
+					<xtce:Enumeration value="6673" label="ILO_PMT_RMP" />
+					<xtce:Enumeration value="6674" label="ILO_PMT_RMP_REL" />
+					<xtce:Enumeration value="6675" label="ILO_PMT_RMP_RAW" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.RTS_TIME_REMAINING" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.OP_HTR_SELECT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="PRI" />
+					<xtce:Enumeration value="1" label="SEC" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.OP_HTR_MODE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="MANUAL" />
+					<xtce:Enumeration value="1" label="BLIND" />
+					<xtce:Enumeration value="2" label="AUTO" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.OP_HTR_CYCLE_TIME" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.OP_HTR_PAD0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.OP_HTR_LO_SETPOINT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.OP_HTR_PAD1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.OP_HTR_HI_SETPOINT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.CDH_HV_PLUG_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="LIM" />
+					<xtce:Enumeration value="2" label="DS" />
+					<xtce:Enumeration value="3" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.SPARE16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.SCI_CYCLE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="READY" />
+					<xtce:Enumeration value="1" label="START_ACQ" />
+					<xtce:Enumeration value="2" label="WAIT_FIRST_SPIN" />
+					<xtce:Enumeration value="3" label="WAIT_SPIN" />
+					<xtce:Enumeration value="4" label="WAIT_BIN" />
+					<xtce:Enumeration value="5" label="COLLECT" />
+					<xtce:Enumeration value="6" label="TLM" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPM_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INIT" />
+					<xtce:Enumeration value="1" label="READY" />
+					<xtce:Enumeration value="2" label="CHECKING_POWER" />
+					<xtce:Enumeration value="3" label="MOVING" />
+					<xtce:Enumeration value="4" label="DIAG_READY" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPM_MOTOR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="87" label="PRI" />
+					<xtce:Enumeration value="86" label="SEC" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPM_DIRECTION" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="43" label="CW" />
+					<xtce:Enumeration value="45" label="CCW" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PPM_STEP_PERIOD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="200.0" exponent="0" />
+							<xtce:Term coefficient="-40.0" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPM_MICROSTEP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="110" label="DS" />
+					<xtce:Enumeration value="115" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PPM_CURRENT_THRESHOLD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-22.0" exponent="0" />
+							<xtce:Term coefficient="0.5" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PPM_STALL_THRESHOLD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PPM_STALL_PERIOD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PPM_PAD0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PPM_LOWER_BOUND" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PPM_PAD1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.PPM_UPPER_BOUND" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPM_USE_CONFLICT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPM_STALLED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPM_OUT_OF_RANGE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_APP_NHK.PPM_POWER_PROBLEM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.MARKER" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.SPARE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_APP_NHK.CHKSUM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="ILO_SCI_CNT.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
@@ -43,7 +2592,7 @@
 			<xtce:IntegerParameterType name="ILO_SCI_DE.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:BinaryParameterType name="ILO_SCI_DE.DATA">
+			<xtce:BinaryParameterType name="ILO_SCI_DE.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
@@ -82,25 +2631,3720 @@
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="ILO_SPIN.ACQ_START_SUBSEC" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="ILO_SPIN.ACQ_END_SEC" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="ILO_SPIN.ACQ_END_SUBSEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_1" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:BinaryParameterType name="ILO_SPIN.SPIN_DATA">
-				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
-					<xtce:SizeInBits>
-						<xtce:DynamicValue>
-							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-184" />
-						</xtce:DynamicValue>
-					</xtce:SizeInBits>
-				</xtce:BinaryDataEncoding>
-			</xtce:BinaryParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SEC_SPIN_28" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.START_SUBSEC_SPIN_28" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1e-06" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_NEG_DAC_SPIN_28" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_SPIN.ESA_POS_DAC_SPIN_28" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_STATE_SPIN_28" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PHASE_STATE_SPIN_28" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="INVALID" />
+					<xtce:Enumeration value="1" label="VALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_SPIN.PERIOD_SOURCE_SPIN_28" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="SUN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
 			<xtce:IntegerParameterType name="ILO_SPIN.CHKSUM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.JUMPER_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.RESET_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.WATCHDOG_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CTRL_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SCRATCHPAD_1_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SCRATCHPAD_2_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CPU_UART_CLOCK_BAUD_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.TICK_TIMER_CTRL_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.TICK_TIMER_RELOAD_COUNT_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.TICK_TIMER_COUNTER_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.MET_CTRL_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.MET_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.MET_COARSE_COUNTER_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.MET_FINE_COUNTER_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.MDM25P_14_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.TOF_TEMP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-848.0" exponent="0" />
+							<xtce:Term coefficient="1.488529" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.MDM25P_16_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LO_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_12V_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-268.22373246839686" exponent="0" />
+							<xtce:Term coefficient="0.14103584591030507" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_5V_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-268.73559622290213" exponent="0" />
+							<xtce:Term coefficient="0.14164365828789297" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_3P3V_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-267.8401530306961" exponent="0" />
+							<xtce:Term coefficient="0.14124348472252374" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_3P3V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001611" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002441" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_N5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.002441" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.005859" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_N12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.005859" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_3P3V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="13.441939999999999" exponent="0" />
+							<xtce:Term coefficient="0.92158" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_5V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-1.7082810000000002" exponent="0" />
+							<xtce:Term coefficient="0.488167" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_N5V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.46099999999999997" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_12V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3.005379" exponent="0" />
+							<xtce:Term coefficient="0.701694" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LVPS_N12V_I" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-47.530631" exponent="0" />
+							<xtce:Term coefficient="0.14082999999999998" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_1P5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001221" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_1P8V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001221" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_3P3V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001221" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.005897" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_21" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_N12V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.005841" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_22" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_5V" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002441" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_23" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_5V_ADC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002441" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_24" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_PROCESSOR_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_25" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_1P8V_LDO_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_26" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_1P5V_LDO_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PAD_27" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CDH_SDRAM_T" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-3437.954" exponent="0" />
+							<xtce:Term coefficient="28.11013" exponent="1" />
+							<xtce:Term coefficient="-0.09663306" exponent="2" />
+							<xtce:Term coefficient="0.0001770658" exponent="3" />
+							<xtce:Term coefficient="-1.813383e-07" exponent="4" />
+							<xtce:Term coefficient="9.822223e-11" exponent="5" />
+							<xtce:Term coefficient="-2.196408e-14" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.ADC_CTRL_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SC_CMD_FIFO_CTRL_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SC_TLM_FIFO_CTRL_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.INTERRUPT_LEVEL_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.INTERRUPT_PENDING_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.INTERRUPT_ENABLE_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_ENABLE_AND_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_BIN_PERIOD_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_BIN_INDEX_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_PERIOD_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_PERIOD_TIMER_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_PERIOD_TIMER_AT_NXT_PPS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_TIME_STAMP_SECONDS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_TIME_STAMP_SUBSECONDS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LOOPBACK_CTRL_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LOOPBACK_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LOOPBACK_TX_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.LOOPBACK_RX_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.DISCRETE_IO_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.HEATER_CTRL_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.HEATER_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.INSTR_PWR_CTRL_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.INSTR_PWR_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.IFB_INTERFACE_CTRL_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.IFB_INTERFACE_CMD_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.IFB_ADC_TLM_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.IFB_REG_TLM_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.TOF_INTERFACE_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.DE_TIME_TAG_RESOLUTION_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.DE_TIME_TAG_CTRL_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.DE_FIFO_CTRL_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.FEE_RESET_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.FEE_RESET_CMD_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.FEE_RESET_DURATION_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.SPIN_PULSE_DURATION_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.HVPS_CTRL_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.HVPS_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.HVPS_CMD_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PIVOT_INTERFACE_CTRL_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PIVOT_INTERFACE_STATUS_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PIVOT_CMD_DATA_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.PIVOT_CMD_OPCODE_REG" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_CDH.CHKSUM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IF_CONTROL_SPARE1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="7" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.IF_CONTROL_CMD_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="NONE" />
+					<xtce:Enumeration value="1" label="ERROR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IF_CONTROL_SPARE2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="23" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.IF_CONTROL_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.REG_IF_SPARE1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.REG_IF_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.REG_IF_SPARE2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.REG_IF_TO_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.REG_IF_ID_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.REG_IF_FRM_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_UN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_OV" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_FF" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_HF" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_FE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_TO_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_ID_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_IF_STATUS_FRM_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.FPGA_VERSION" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.SPARE1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.HV_PLUG_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="DS" />
+					<xtce:Enumeration value="2" label="LIM" />
+					<xtce:Enumeration value="3" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.BOARD_ID" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="1" label="EM" />
+					<xtce:Enumeration value="9" label="FM" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.CMD_COUNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.SPARE2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_AUX_MUX" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="NORMAL" />
+					<xtce:Enumeration value="1" label="IFB_5V_VM" />
+					<xtce:Enumeration value="2" label="IFB_2P5V_VM" />
+					<xtce:Enumeration value="3" label="STAR_OFF_DAC" />
+					<xtce:Enumeration value="4" label="PAC_VSET_DAC" />
+					<xtce:Enumeration value="5" label="PAC_OCP_DAC" />
+					<xtce:Enumeration value="6" label="MCP_VSET_DAC" />
+					<xtce:Enumeration value="7" label="MCP_OCP_DAC" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.ADC_CLK_DIS" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.OSCOPE_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="NORMAL" />
+					<xtce:Enumeration value="1" label="OSCOPE" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.STAR_SYNC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="SPIN_IGNORE" />
+					<xtce:Enumeration value="1" label="SPIN_SYNCED" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.IFB_DATA_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IFB_DATA_INTERVAL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="13.3344" exponent="0" />
+							<xtce:Term coefficient="0.06945" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.SYNC_CLK_MSB" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="EN" />
+					<xtce:Enumeration value="1" label="DS" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.PAC_EN_MSB" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.MCP_EN_MSB" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.LV_EN_MSB" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.SYNC_CLK_LSB" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="EN" />
+					<xtce:Enumeration value="1" label="DS" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.PAC_EN_LSB" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.MCP_EN_LSB" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.LV_EN_LSB" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAC_VSET" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-17.348051" exponent="0" />
+							<xtce:Term coefficient="97.307885" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAC_OCP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.01933594" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.MCP_VSET" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="438.995359" exponent="0" />
+							<xtce:Term coefficient="35.590409" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.MCP_OCP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.01933594" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.STAR_OFFSET_ADJUST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-1.0" exponent="0" />
+							<xtce:Term coefficient="0.01933594" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.OSCOPE_CHANNEL_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="IFB_TEMP1" />
+					<xtce:Enumeration value="2" label="IFB_TEMP0" />
+					<xtce:Enumeration value="3" label="IFB_5V" />
+					<xtce:Enumeration value="4" label="IFB_3P3V" />
+					<xtce:Enumeration value="5" label="IFB_12VP" />
+					<xtce:Enumeration value="6" label="IFB_12VN" />
+					<xtce:Enumeration value="7" label="LV_CM" />
+					<xtce:Enumeration value="8" label="LV_VM" />
+					<xtce:Enumeration value="9" label="LV_TEMP" />
+					<xtce:Enumeration value="10" label="MCP_CM" />
+					<xtce:Enumeration value="11" label="MCP_VM" />
+					<xtce:Enumeration value="12" label="MCP_TEMP" />
+					<xtce:Enumeration value="13" label="PAC_CM" />
+					<xtce:Enumeration value="14" label="PAC_VM" />
+					<xtce:Enumeration value="15" label="PAC_TEMP" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_IFB.OSCOPE_CHANNEL_0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STAR" />
+					<xtce:Enumeration value="1" label="IFB_TEMP1" />
+					<xtce:Enumeration value="2" label="IFB_TEMP0" />
+					<xtce:Enumeration value="3" label="IFB_5V" />
+					<xtce:Enumeration value="4" label="IFB_3P3V" />
+					<xtce:Enumeration value="5" label="IFB_12VP" />
+					<xtce:Enumeration value="6" label="IFB_12VN" />
+					<xtce:Enumeration value="7" label="LV_CM" />
+					<xtce:Enumeration value="8" label="LV_VM" />
+					<xtce:Enumeration value="9" label="LV_TEMP" />
+					<xtce:Enumeration value="10" label="MCP_CM" />
+					<xtce:Enumeration value="11" label="MCP_VM" />
+					<xtce:Enumeration value="12" label="MCP_TEMP" />
+					<xtce:Enumeration value="13" label="PAC_CM" />
+					<xtce:Enumeration value="14" label="PAC_VM" />
+					<xtce:Enumeration value="15" label="PAC_TEMP" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.STAR_BRIGHT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001208496" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IFB_TEMP1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-277.407" exponent="0" />
+							<xtce:Term coefficient="0.123407" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IFB_TEMP0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-274.285" exponent="0" />
+							<xtce:Term coefficient="0.121487" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IFB_V5P0_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002416992" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IFB_V3P3_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.001208496" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IFB_V12P0_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.007250977" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.IFB_V12N0_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-16.434" exponent="0" />
+							<xtce:Term coefficient="0.005220703" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.LV_CM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.2337" exponent="0" />
+							<xtce:Term coefficient="0.1361" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.LV_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0043746" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.LV_TEMP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-277.53" exponent="0" />
+							<xtce:Term coefficient="0.246813" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.MCP_CM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.1548" exponent="0" />
+							<xtce:Term coefficient="0.043607" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.MCP_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-475.860941" exponent="0" />
+							<xtce:Term coefficient="9.46897" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.MCP_TEMP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-276.278" exponent="0" />
+							<xtce:Term coefficient="0.245421" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAC_CM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.1874" exponent="0" />
+							<xtce:Term coefficient="0.056193" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAC_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-23.226667" exponent="0" />
+							<xtce:Term coefficient="12.384764" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAD_15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.PAC_TEMP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-280.701" exponent="0" />
+							<xtce:Term coefficient="0.248983" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.SPARE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_IFB.CHKSUM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_SPARE1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="7" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_PKT_RCVD" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_ADC_PKT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_REG_PKT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_CNT_PKT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_DE_PKT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_SPARE2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_TO_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_ID_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.IF_STATUS_FRM_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="OK" />
+					<xtce:Enumeration value="1" label="ERR" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.CMD_ERROR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.CFD_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.00991867816091954" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PRE_TM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-267.76137705513673" exponent="0" />
+							<xtce:Term coefficient="0.5663548006176765" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.REG_TM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-266.92886348747373" exponent="0" />
+							<xtce:Term coefficient="0.5648677344297106" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.MCP_CM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.3033433595481494" exponent="0" />
+							<xtce:Term coefficient="0.02445388053548595" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.MCP_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="4.505" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.CM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.525483578148183" exponent="0" />
+							<xtce:Term coefficient="0.3050864416570392" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.P5_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.009937854710556186" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.P6_VM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="10" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.027111787964010148" exponent="0" />
+							<xtce:Term coefficient="0.009926214962484822" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.AN_A_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.AN_B0_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.AN_B3_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.PAD_10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.AN_C_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="6" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF_BD_TLM_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.DIRECT_EVENT_TLM_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.SPARE1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF3_REQUIRED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF2_REQUIRED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF1_REQUIRED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF0_REQUIRED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.STIM_ANODE_C_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.STIM_ANODE_C_SRC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STOP" />
+					<xtce:Enumeration value="1" label="START" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.STIM_ANODE_B3_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.STIM_ANODE_B3_SRC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STOP" />
+					<xtce:Enumeration value="1" label="START" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.STIM_ANODE_B0_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.STIM_ANODE_B0_SRC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STOP" />
+					<xtce:Enumeration value="1" label="START" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.STIM_ANODE_A_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.STIM_ANODE_A_SRC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="STOP" />
+					<xtce:Enumeration value="1" label="START" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.STIM_FREQ" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1.0" exponent="0" />
+							<xtce:Term coefficient="1.0" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.STIM_DELAY" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="20.833333333333336" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.TOF3_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.46726299520543435" exponent="0" />
+							<xtce:Term coefficient="1.3715585136889914" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.TOF2_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.3744222712503813" exponent="0" />
+							<xtce:Term coefficient="1.3312687906975365" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.TOF1_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.7201813051183734" exponent="0" />
+							<xtce:Term coefficient="1.3209957435920419" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.TOF0_THR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.5525235549626046" exponent="0" />
+							<xtce:Term coefficient="1.3469946516059763" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.SPARE2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF3_VETO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF2_VETO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF1_VETO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_TOF_BD.TOF0_VETO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_TOF_BD.CHKSUM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.HVPS_VERSION" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.RESERVED_1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.MASTER_EN_TO" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.SOFT_RST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.PFO_RST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.POR_RST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.RESERVED_2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.CMD_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ARM_ERR" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ARM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="CLR" />
+					<xtce:Enumeration value="1" label="SET" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.RESERVED_3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.HV_PLUG_STATE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="EN" />
+					<xtce:Enumeration value="1" label="LIM" />
+					<xtce:Enumeration value="2" label="DS" />
+					<xtce:Enumeration value="3" label="DS" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.MSTR_EN" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.RESERVED_4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="13" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ESA_NEG_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ESA_POS_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.BULK_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DAC0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2667" exponent="0" />
+							<xtce:Term coefficient="0.41509" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DAC1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="6.1821" exponent="0" />
+							<xtce:Term coefficient="0.84395" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DAC2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.48889" exponent="0" />
+							<xtce:Term coefficient="0.97806" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DAC3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="5.0253" exponent="0" />
+							<xtce:Term coefficient="1.2213" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DAC4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.99418" exponent="0" />
+							<xtce:Term coefficient="0.24414" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.RESERVED_5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ADC2_CH_SEL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DEF_NEG_I" />
+					<xtce:Enumeration value="1" label="DEF_POS_I" />
+					<xtce:Enumeration value="2" label="ADC_REF1_V" />
+					<xtce:Enumeration value="3" label="ADC_REF2_V" />
+					<xtce:Enumeration value="4" label="P12P0_V" />
+					<xtce:Enumeration value="5" label="N12P0_V" />
+					<xtce:Enumeration value="6" label="P3P3_V" />
+					<xtce:Enumeration value="7" label="P1P5_V" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.RESERVED_6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ADC2_RDY" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ADC2_MODE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="SCI" />
+					<xtce:Enumeration value="1" label="ENG" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ADC2_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.RESERVED_7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ADC1_CH_SEL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="BULK_V" />
+					<xtce:Enumeration value="1" label="ESA_NEG_V" />
+					<xtce:Enumeration value="2" label="ESA_POS_V" />
+					<xtce:Enumeration value="3" label="DEF_NEG_V" />
+					<xtce:Enumeration value="4" label="DEF_POS_V" />
+					<xtce:Enumeration value="5" label="PMT_V" />
+					<xtce:Enumeration value="6" label="PMT_I" />
+					<xtce:Enumeration value="7" label="BULK_U" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.RESERVED_8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ADC1_RDY" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ADC1_MODE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="SCI" />
+					<xtce:Enumeration value="1" label="ENG" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_BULK_HVPS.ADC1_CTRL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="DS" />
+					<xtce:Enumeration value="1" label="EN" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.ADC1_WAIT_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0002" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.ADC2_WAIT_CNT" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0002" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.HVPS_BULK_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="1.5214501510574" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.U_NEG_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-12.338" exponent="0" />
+							<xtce:Term coefficient="0.5216" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.U_POS_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="3.8245" exponent="0" />
+							<xtce:Term coefficient="1.0605" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD8" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DEF_NEG_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="2.2375" exponent="0" />
+							<xtce:Term coefficient="1.2292" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD9" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DEF_POS_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="3.7393" exponent="0" />
+							<xtce:Term coefficient="1.5376" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD10" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PMT_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.46017" exponent="0" />
+							<xtce:Term coefficient="0.30798" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD11" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PMT_IMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.295301441" exponent="0" />
+							<xtce:Term coefficient="0.00561741144" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD12" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.BULK_IMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.030517578125" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD13" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DEF_NEG_IMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-0.0817617106" exponent="0" />
+							<xtce:Term coefficient="0.00573128038" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD14" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.DEF_POS_IMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.272811891" exponent="0" />
+							<xtce:Term coefficient="0.00578272729" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD15" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.ADC_REF1_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.002440214738897023" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD16" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.ADC_REF2_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0024386907669760624" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD17" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.P12P0_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.006122833814913541" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD18" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.N12P0_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-17.267" exponent="0" />
+							<xtce:Term coefficient="0.0054229" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD19" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.P3P3_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0012259383128948346" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.PAD20" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.P1P5_VMON" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0012097902097902098" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_BULK_HVPS.CHKSUM" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.SHCOARSE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PAD0" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.COARSE_POT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-25.6" exponent="0" />
+							<xtce:Term coefficient="0.085828" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PAD1" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.FINE_POT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0001406" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PAD2" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.COARSE_POT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-5.1" exponent="0" />
+							<xtce:Term coefficient="0.085891" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PAD3" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.FINE_POT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.0001406" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PAD4" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.ACTUATOR_TEMP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-511.151" exponent="0" />
+							<xtce:Term coefficient="0.500052" exponent="1" />
+							<xtce:Term coefficient="-0.000245442" exponent="2" />
+							<xtce:Term coefficient="6.01427e-08" exponent="3" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PAD5" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PCC_BOARD_TEMP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="-19075.98733563" exponent="0" />
+							<xtce:Term coefficient="36.88265703859" exponent="1" />
+							<xtce:Term coefficient="-0.02952704275942" exponent="2" />
+							<xtce:Term coefficient="1.258716630941e-05" exponent="3" />
+							<xtce:Term coefficient="-3.016728267882e-09" exponent="4" />
+							<xtce:Term coefficient="3.855586503305e-13" exponent="5" />
+							<xtce:Term coefficient="-2.054430438544e-17" exponent="6" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PAD6" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.MOTOR_CURRENT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.57" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.PAD7" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.MOTOR_CURRENT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.57" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.CUMULATIVE_CNT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="180.0624" exponent="0" />
+							<xtce:Term coefficient="-0.00246027" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.CUMULATIVE_CNT_SGN_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="43" label="POSITIVE" />
+					<xtce:Enumeration value="45" label="NEGATIVE" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.CUMULATIVE_CNT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="180.0624" exponent="0" />
+							<xtce:Term coefficient="-0.00246027" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.CUMULATIVE_CNT_SGN_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="43" label="POSITIVE" />
+					<xtce:Enumeration value="45" label="NEGATIVE" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.CURRENT_STEP_CNT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.00246027" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.CURRENT_STEP_CNT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
+					<xtce:DefaultCalibrator>
+						<xtce:PolynomialCalibrator>
+							<xtce:Term coefficient="0.00246027" exponent="1" />
+						</xtce:PolynomialCalibrator>
+					</xtce:DefaultCalibrator>
+				</xtce:IntegerDataEncoding>
+			</xtce:IntegerParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.CURRENT_SETPT_PRI" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="49" label="PRI_500_MA" />
+					<xtce:Enumeration value="50" label="PRI_600_MA" />
+					<xtce:Enumeration value="51" label="PRI_700_MA" />
+					<xtce:Enumeration value="52" label="PRI_800_MA" />
+					<xtce:Enumeration value="53" label="PRI_700_MA" />
+					<xtce:Enumeration value="54" label="PRI_700_MA" />
+					<xtce:Enumeration value="55" label="PRI_700_MA" />
+					<xtce:Enumeration value="56" label="PRI_700_MA" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.CURRENT_SETPT_SEC" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="UNKNOWN" />
+					<xtce:Enumeration value="49" label="SEC_500_MA" />
+					<xtce:Enumeration value="50" label="SEC_600_MA" />
+					<xtce:Enumeration value="51" label="SEC_700_MA" />
+					<xtce:Enumeration value="52" label="SEC_800_MA" />
+					<xtce:Enumeration value="53" label="SEC_700_MA" />
+					<xtce:Enumeration value="54" label="SEC_700_MA" />
+					<xtce:Enumeration value="55" label="SEC_700_MA" />
+					<xtce:Enumeration value="56" label="SEC_700_MA" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.PRI_ACTIVE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.PRI_POWERED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.PRI_USTEP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.PRI_ACCEL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.SEC_ACTIVE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.SEC_POWERED" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.SEC_USTEP" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="ILO_DIAG_PCC.SEC_ACCEL" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="N" />
+					<xtce:Enumeration value="1" label="Y" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.SPARE" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="ILO_DIAG_PCC.CHKSUM" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 		</xtce:ParameterTypeSet>
@@ -126,6 +6370,1040 @@
 			<xtce:Parameter name="PKT_LEN" parameterTypeRef="PKT_LEN">
 				<xtce:LongDescription>CCSDS Packet Length (number of bytes after Packet length minus 1)</xtce:LongDescription>
 			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.SHCOARSE" parameterTypeRef="ILO_APP_SHK.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.BOARD_TYPE" parameterTypeRef="ILO_APP_SHK.BOARD_TYPE" shortDescription="ILO_APP_SHK.BOARD_TYPE">
+				<xtce:LongDescription>ILO_APP_SHK.CDH_JUMPER_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.RESET_REASON_SOFT" parameterTypeRef="ILO_APP_SHK.RESET_REASON_SOFT" shortDescription="ILO_APP_SHK.RESET_REASON_SOFT">
+				<xtce:LongDescription>ILO_APP_SHK.RESET_REASON_SOFT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.RESET_REASON_FPGA_WDOG" parameterTypeRef="ILO_APP_SHK.RESET_REASON_FPGA_WDOG" shortDescription="ILO_APP_SHK.RESET_REASON_FPGA_WDOG">
+				<xtce:LongDescription>ILO_APP_SHK.RESET_REASON_FPGA_WDOG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.RESET_REASON_CPU_WDOG" parameterTypeRef="ILO_APP_SHK.RESET_REASON_CPU_WDOG" shortDescription="ILO_APP_SHK.RESET_REASON_CPU_WDOG">
+				<xtce:LongDescription>ILO_APP_SHK.RESET_REASON_CPU_WDOG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.RESET_REASON_PFO" parameterTypeRef="ILO_APP_SHK.RESET_REASON_PFO" shortDescription="ILO_APP_SHK.RESET_REASON_PFO">
+				<xtce:LongDescription>ILO_APP_SHK.RESET_REASON_PFO</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.RESET_REASON_POR" parameterTypeRef="ILO_APP_SHK.RESET_REASON_POR" shortDescription="ILO_APP_SHK.RESET_REASON_PFO">
+				<xtce:LongDescription>ILO_APP_SHK.RESET_REASON_PFO</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.CPU_WDOG_STATE" parameterTypeRef="ILO_APP_SHK.CPU_WDOG_STATE" shortDescription="ILO_APP_SHK.CPU_WDOG_STATE">
+				<xtce:LongDescription>ILO_APP_SHK.CPU_WDOG_STATE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.FPGA_WDOG_STATE" parameterTypeRef="ILO_APP_SHK.FPGA_WDOG_STATE" shortDescription="ILO_APP_SHK.FPGA_WDOG_STATE">
+				<xtce:LongDescription>ILO_APP_SHK.FPGA_WDOG_STATE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.WDOG_CNT" parameterTypeRef="ILO_APP_SHK.WDOG_CNT" shortDescription="ILO_APP_SHK.WDOG_CNT">
+				<xtce:LongDescription>ILO_APP_SHK.WDOG_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.INSTR_ID" parameterTypeRef="ILO_APP_SHK.INSTR_ID" shortDescription="ILO_APP_SHK.INSTR_ID">
+				<xtce:LongDescription>ILO_APP_SHK.INSTR_ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.CDH_FPGA_VERSION" parameterTypeRef="ILO_APP_SHK.CDH_FPGA_VERSION" shortDescription="ILO_APP_SHK.CDH_FPGA_VERSION">
+				<xtce:LongDescription>ILO_APP_SHK.CDH_FPGA_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.IFB_FPGA_VERSION" parameterTypeRef="ILO_APP_SHK.IFB_FPGA_VERSION" shortDescription="ILO_APP_SHK.IFB_FPGA_VERSION">
+				<xtce:LongDescription>ILO_APP_SHK.IFB_FPGA_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.BULK_HVPS_VERSION" parameterTypeRef="ILO_APP_SHK.BULK_HVPS_VERSION" shortDescription="ILO_APP_SHK.BULK_HVPS_VERSION">
+				<xtce:LongDescription>ILO_APP_SHK.BULK_HVPS_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.FSW_VERSION" parameterTypeRef="ILO_APP_SHK.FSW_VERSION" shortDescription="ILO_APP_SHK.FSW_VERSION">
+				<xtce:LongDescription>ILO_APP_SHK.FSW_VERSION</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.SELECTED_IMG" parameterTypeRef="ILO_APP_SHK.SELECTED_IMG" shortDescription="ILO_APP_SHK.SELECTED_IMG">
+				<xtce:LongDescription>ILO_APP_SHK.SELECTED_IMG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.FSW_VERSION_STR" parameterTypeRef="ILO_APP_SHK.FSW_VERSION_STR" shortDescription="ILO_APP_SHK.FSW_VERSION_STR">
+				<xtce:LongDescription>ILO_APP_SHK.FSW_VERSION_STR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.ENG_LUT_VERSION_STR" parameterTypeRef="ILO_APP_SHK.ENG_LUT_VERSION_STR" shortDescription="ILO_APP_SHK.ENG_LUT_VERSION_STR">
+				<xtce:LongDescription>ILO_APP_SHK.ENG_LUT_VERSION_STR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.SCI_LUT_VERSION_STR" parameterTypeRef="ILO_APP_SHK.SCI_LUT_VERSION_STR" shortDescription="ILO_APP_SHK.SCI_LUT_VERSION_STR">
+				<xtce:LongDescription>ILO_APP_SHK.SCI_LUT_VERSION_STR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.SCRATCH_BUFFER_ADDR" parameterTypeRef="ILO_APP_SHK.SCRATCH_BUFFER_ADDR" shortDescription="SDRAM address of scratch buffer address">
+				<xtce:LongDescription>SDRAM address of scratch buffer address</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.SPARE" parameterTypeRef="ILO_APP_SHK.SPARE" shortDescription="ILO_APP_SHK.SPARE">
+				<xtce:LongDescription>ILO_APP_SHK.SPARE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_SHK.CHKSUM" parameterTypeRef="ILO_APP_SHK.CHKSUM" shortDescription="ILO_APP_SHK.CHKSUM">
+				<xtce:LongDescription>ILO_APP_SHK.CHKSUM</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.SHCOARSE" parameterTypeRef="ILO_APP_NHK.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.OP_MODE" parameterTypeRef="ILO_APP_NHK.OP_MODE" shortDescription="Current operating mode">
+				<xtce:LongDescription>Current operating mode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.CMD_EXE_CNT" parameterTypeRef="ILO_APP_NHK.CMD_EXE_CNT" shortDescription="Accepted commands count">
+				<xtce:LongDescription>Accepted commands count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.CMD_REJ_CNT" parameterTypeRef="ILO_APP_NHK.CMD_REJ_CNT" shortDescription="Rejected commands count">
+				<xtce:LongDescription>Rejected commands count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.CMD_LAST_OPCODE" parameterTypeRef="ILO_APP_NHK.CMD_LAST_OPCODE" shortDescription="Last accepted command opcode">
+				<xtce:LongDescription>Last accepted command opcode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.ITF_ERR_CNT" parameterTypeRef="ILO_APP_NHK.ITF_ERR_CNT" shortDescription="ITF Error count">
+				<xtce:LongDescription>ITF Error count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.WATCHDOG_CNT" parameterTypeRef="ILO_APP_NHK.WATCHDOG_CNT" shortDescription="Watchdog reset count">
+				<xtce:LongDescription>Watchdog reset count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_0" parameterTypeRef="ILO_APP_NHK.PAD_0" />
+			<xtce:Parameter name="ILO_APP_NHK.TEMP1_311P18_T" parameterTypeRef="ILO_APP_NHK.TEMP1_311P18_T" shortDescription="NOT USED, KEEPING IN CASE REPURPOSED">
+				<xtce:LongDescription>NOT USED, KEEPING IN CASE REPURPOSED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_1" parameterTypeRef="ILO_APP_NHK.PAD_1" />
+			<xtce:Parameter name="ILO_APP_NHK.IMAPLO_ICE_TOF_TEMP" parameterTypeRef="ILO_APP_NHK.IMAPLO_ICE_TOF_TEMP" shortDescription="SYSTEM TEMPERATURE 2: MDM25P – 15 TEMPERATURE">
+				<xtce:LongDescription>SYSTEM TEMPERATURE 2: MDM25P – 15 TEMPERATURE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_2" parameterTypeRef="ILO_APP_NHK.PAD_2" />
+			<xtce:Parameter name="ILO_APP_NHK.TEMP3_311P18_T" parameterTypeRef="ILO_APP_NHK.TEMP3_311P18_T" shortDescription="NOT USED, KEEPING IN CASE REPURPOSED">
+				<xtce:LongDescription>NOT USED, KEEPING IN CASE REPURPOSED</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_3" parameterTypeRef="ILO_APP_NHK.PAD_3" />
+			<xtce:Parameter name="ILO_APP_NHK.LO_T" parameterTypeRef="ILO_APP_NHK.LO_T" shortDescription="LO OPERATIONAL HEATER TEMPERATURE MONITOR">
+				<xtce:LongDescription>LO OPERATIONAL HEATER TEMPERATURE MONITOR</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_4" parameterTypeRef="ILO_APP_NHK.PAD_4" />
+			<xtce:Parameter name="ILO_APP_NHK.SPARE_T" parameterTypeRef="ILO_APP_NHK.SPARE_T" shortDescription="NOT USED, KEEPING IN CASE REPURPOSED, USED TO BE HVPS_T">
+				<xtce:LongDescription>NOT USED, KEEPING IN CASE REPURPOSED, USED TO BE HVPS_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_5" parameterTypeRef="ILO_APP_NHK.PAD_5" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_12V_T" parameterTypeRef="ILO_APP_NHK.LVPS_12V_T" shortDescription="LVPS Temperature 1: LVPS – 12V Temperature">
+				<xtce:LongDescription>LVPS Temperature 1: LVPS – 12V Temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_6" parameterTypeRef="ILO_APP_NHK.PAD_6" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_5V_T" parameterTypeRef="ILO_APP_NHK.LVPS_5V_T" shortDescription="LVPS Temperature 2: LVPS – 5V Temperature">
+				<xtce:LongDescription>LVPS Temperature 2: LVPS – 5V Temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_7" parameterTypeRef="ILO_APP_NHK.PAD_7" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_3P3V_T" parameterTypeRef="ILO_APP_NHK.LVPS_3P3V_T" shortDescription="LVPS Temperature 3: LVPS – +3.3V Temperature">
+				<xtce:LongDescription>LVPS Temperature 3: LVPS – +3.3V Temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_8" parameterTypeRef="ILO_APP_NHK.PAD_8" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_3P3V" parameterTypeRef="ILO_APP_NHK.LVPS_3P3V" shortDescription="LVPS – Digital V1: LVPS – +3.3V">
+				<xtce:LongDescription>LVPS – Digital V1: LVPS – +3.3V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_9" parameterTypeRef="ILO_APP_NHK.PAD_9" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_5V" parameterTypeRef="ILO_APP_NHK.LVPS_5V" shortDescription="LVPS – Digital V2: LVPS – +5V">
+				<xtce:LongDescription>LVPS – Digital V2: LVPS – +5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_10" parameterTypeRef="ILO_APP_NHK.PAD_10" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_N5V" parameterTypeRef="ILO_APP_NHK.LVPS_N5V" shortDescription="LVPS – Digital V3: LVPS – -5V">
+				<xtce:LongDescription>LVPS – Digital V3: LVPS – -5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_11" parameterTypeRef="ILO_APP_NHK.PAD_11" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_12V" parameterTypeRef="ILO_APP_NHK.LVPS_12V" shortDescription="LVPS – Digital V4: LVPS – +12V">
+				<xtce:LongDescription>LVPS – Digital V4: LVPS – +12V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_12" parameterTypeRef="ILO_APP_NHK.PAD_12" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_N12V" parameterTypeRef="ILO_APP_NHK.LVPS_N12V" shortDescription="LVPS – Digital V5: LVPS – -12V">
+				<xtce:LongDescription>LVPS – Digital V5: LVPS – -12V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_13" parameterTypeRef="ILO_APP_NHK.PAD_13" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_3P3V_I" parameterTypeRef="ILO_APP_NHK.LVPS_3P3V_I" shortDescription="LVPS – Digital I1: LVPS – +3.3V Current">
+				<xtce:LongDescription>LVPS – Digital I1: LVPS – +3.3V Current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_14" parameterTypeRef="ILO_APP_NHK.PAD_14" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_5V_I" parameterTypeRef="ILO_APP_NHK.LVPS_5V_I" shortDescription="LVPS – Digital I2: LVPS – +5V Current">
+				<xtce:LongDescription>LVPS – Digital I2: LVPS – +5V Current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_15" parameterTypeRef="ILO_APP_NHK.PAD_15" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_N5V_I" parameterTypeRef="ILO_APP_NHK.LVPS_N5V_I" shortDescription="LVPS – Digital I3: LVPS – -5V Current">
+				<xtce:LongDescription>LVPS – Digital I3: LVPS – -5V Current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_16" parameterTypeRef="ILO_APP_NHK.PAD_16" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_12V_I" parameterTypeRef="ILO_APP_NHK.LVPS_12V_I" shortDescription="LVPS – Digital I4: LVPS – +12V Current">
+				<xtce:LongDescription>LVPS – Digital I4: LVPS – +12V Current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_17" parameterTypeRef="ILO_APP_NHK.PAD_17" />
+			<xtce:Parameter name="ILO_APP_NHK.LVPS_N12V_I" parameterTypeRef="ILO_APP_NHK.LVPS_N12V_I" shortDescription="LVPS – Digital I5: LVPS – -12V Current">
+				<xtce:LongDescription>LVPS – Digital I5: LVPS – -12V Current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_18" parameterTypeRef="ILO_APP_NHK.PAD_18" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_1P5V" parameterTypeRef="ILO_APP_NHK.CDH_1P5V" shortDescription="CDH – + 1.5V">
+				<xtce:LongDescription>CDH – + 1.5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_19" parameterTypeRef="ILO_APP_NHK.PAD_19" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_1P8V" parameterTypeRef="ILO_APP_NHK.CDH_1P8V" shortDescription="CDH – +1.8V">
+				<xtce:LongDescription>CDH – +1.8V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_20" parameterTypeRef="ILO_APP_NHK.PAD_20" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_3P3V" parameterTypeRef="ILO_APP_NHK.CDH_3P3V" shortDescription="CDH – +3.3V">
+				<xtce:LongDescription>CDH – +3.3V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_21" parameterTypeRef="ILO_APP_NHK.PAD_21" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_12V" parameterTypeRef="ILO_APP_NHK.CDH_12V" shortDescription="CDH – +12V">
+				<xtce:LongDescription>CDH – +12V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_22" parameterTypeRef="ILO_APP_NHK.PAD_22" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_N12V" parameterTypeRef="ILO_APP_NHK.CDH_N12V" shortDescription="CDH – -12V">
+				<xtce:LongDescription>CDH – -12V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_23" parameterTypeRef="ILO_APP_NHK.PAD_23" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_5V" parameterTypeRef="ILO_APP_NHK.CDH_5V" shortDescription="CDH – +5V">
+				<xtce:LongDescription>CDH – +5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_24" parameterTypeRef="ILO_APP_NHK.PAD_24" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_5V_ADC" parameterTypeRef="ILO_APP_NHK.CDH_5V_ADC" shortDescription="CDH – Analog Ref: CDH – +5V ADC">
+				<xtce:LongDescription>CDH – Analog Ref: CDH – +5V ADC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_25" parameterTypeRef="ILO_APP_NHK.PAD_25" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_PROCESSOR_T" parameterTypeRef="ILO_APP_NHK.CDH_PROCESSOR_T" shortDescription="CDH temperature 1 monitor">
+				<xtce:LongDescription>CDH temperature 1 monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_26" parameterTypeRef="ILO_APP_NHK.PAD_26" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_1P8V_LDO_T" parameterTypeRef="ILO_APP_NHK.CDH_1P8V_LDO_T" shortDescription="CDH temperature 2 monitor">
+				<xtce:LongDescription>CDH temperature 2 monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_27" parameterTypeRef="ILO_APP_NHK.PAD_27" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_1P5V_LDO_T" parameterTypeRef="ILO_APP_NHK.CDH_1P5V_LDO_T" shortDescription="CDH temperature 3 monitor">
+				<xtce:LongDescription>CDH temperature 3 monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAD_28" parameterTypeRef="ILO_APP_NHK.PAD_28" />
+			<xtce:Parameter name="ILO_APP_NHK.CDH_SDRAM_T" parameterTypeRef="ILO_APP_NHK.CDH_SDRAM_T" shortDescription="CDH temperature 4 monitor">
+				<xtce:LongDescription>CDH temperature 4 monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_CTRL" parameterTypeRef="ILO_APP_NHK.BHV_CTRL" shortDescription="Bulk HVPS Control Enable status">
+				<xtce:LongDescription>Bulk HVPS Control Enable status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE15" parameterTypeRef="ILO_APP_NHK.BHV_SPARE15" />
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_CMD_TIMEOUT_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_CMD_TIMEOUT_ERR_CNT" shortDescription="BHV_STATUS_CMD_TIMEOUT_ERR_CNT">
+				<xtce:LongDescription>BHV_STATUS_CMD_TIMEOUT_ERR_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_DAC_UPDATE_ACK_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_DAC_UPDATE_ACK_ERR_CNT" shortDescription="BHV_STATUS_DAC_UPDATE_ACK_ERR_CNT">
+				<xtce:LongDescription>BHV_STATUS_DAC_UPDATE_ACK_ERR_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_READ_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_READ_ERR_CNT" shortDescription="BHV_STATUS_READ_ERR_CNT">
+				<xtce:LongDescription>BHV_STATUS_READ_ERR_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_TLM_TIMEOUT_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_TLM_TIMEOUT_ERR_CNT" shortDescription="BHV_STATUS_TLM_TIMEOUT_ERR_CNT">
+				<xtce:LongDescription>BHV_STATUS_TLM_TIMEOUT_ERR_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_WRITE_ACK_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_WRITE_ACK_ERR_CNT" shortDescription="BHV_STATUS_WRITE_ACK_ERR_CNT">
+				<xtce:LongDescription>BHV_STATUS_WRITE_ACK_ERR_CNT</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_CMD_PARITY_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_CMD_PARITY_ERR_CNT" shortDescription="Bulk HVPS Status command parity error status">
+				<xtce:LongDescription>Bulk HVPS Status command parity error status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_CMD_FRAME_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_CMD_FRAME_ERR_CNT" shortDescription="Bulk HVPS Status command frame error status">
+				<xtce:LongDescription>Bulk HVPS Status command frame error status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_TLM_PARITY_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_TLM_PARITY_ERR_CNT" shortDescription="Bulk HVPS Status telemetry parity error status">
+				<xtce:LongDescription>Bulk HVPS Status telemetry parity error status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_TLM_FRAME_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_TLM_FRAME_ERR_CNT" shortDescription="Bulk HVPS Status telemetry frame error status">
+				<xtce:LongDescription>Bulk HVPS Status telemetry frame error status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_TIMEOUT_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_TIMEOUT_ERR_CNT" shortDescription="Bulk HVPS Status timeout error status">
+				<xtce:LongDescription>Bulk HVPS Status timeout error status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_CNT_ERR_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_CNT_ERR_CNT" shortDescription="Bulk HVPS Status count error status">
+				<xtce:LongDescription>Bulk HVPS Status count error status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_CMD_CNT" parameterTypeRef="ILO_APP_NHK.BHV_STAT_CMD_CNT" shortDescription="Bulk HVPS Status command count">
+				<xtce:LongDescription>Bulk HVPS Status command count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_MST_EN" parameterTypeRef="ILO_APP_NHK.BHV_STAT_MST_EN" shortDescription="Bulk HVPS Status master enable status">
+				<xtce:LongDescription>Bulk HVPS Status master enable status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_HV_PLUG_STATE" parameterTypeRef="ILO_APP_NHK.BHV_HV_PLUG_STATE" shortDescription="Bulk High Voltage plug status">
+				<xtce:LongDescription>Bulk High Voltage plug status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_POR_RST" parameterTypeRef="ILO_APP_NHK.BHV_STAT_POR_RST" shortDescription="Bulk HVPS Status Power On Reset status">
+				<xtce:LongDescription>Bulk HVPS Status Power On Reset status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_PFO_RST" parameterTypeRef="ILO_APP_NHK.BHV_STAT_PFO_RST" shortDescription="Bulk HVPS Status Power Failure Reset status">
+				<xtce:LongDescription>Bulk HVPS Status Power Failure Reset status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_STAT_SOFT_RST" parameterTypeRef="ILO_APP_NHK.BHV_STAT_SOFT_RST" shortDescription="Bulk HVPS Status Software Reset status">
+				<xtce:LongDescription>Bulk HVPS Status Software Reset status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_BULK_CTRL" parameterTypeRef="ILO_APP_NHK.BHV_BULK_CTRL" shortDescription="Bulk HVPS Bulk enable status, includes DEF_NEG, DEF_POS, and PMT_BIAS">
+				<xtce:LongDescription>Bulk HVPS Bulk enable status, includes DEF_NEG, DEF_POS, and PMT_BIAS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ESA_POS_CTRL" parameterTypeRef="ILO_APP_NHK.BHV_ESA_POS_CTRL" shortDescription="Bulk HVPS ESA_POS enable status">
+				<xtce:LongDescription>Bulk HVPS ESA_POS enable status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ESA_NEG_CTRL" parameterTypeRef="ILO_APP_NHK.BHV_ESA_NEG_CTRL" shortDescription="Bulk HVPS ESA_NEG disable status">
+				<xtce:LongDescription>Bulk HVPS ESA_NEG disable status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE1" parameterTypeRef="ILO_APP_NHK.BHV_SPARE1" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DAC_PAD0" parameterTypeRef="ILO_APP_NHK.BHV_DAC_PAD0" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ESA_NEG_DAC" parameterTypeRef="ILO_APP_NHK.BHV_ESA_NEG_DAC" shortDescription="Bulk HVPS raw DAC value, ESA_NEG">
+				<xtce:LongDescription>Bulk HVPS raw DAC value, ESA_NEG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DAC_PAD1" parameterTypeRef="ILO_APP_NHK.BHV_DAC_PAD1" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ESA_POS_DAC" parameterTypeRef="ILO_APP_NHK.BHV_ESA_POS_DAC" shortDescription="Bulk HVPS raw DAC value, ESA_POS">
+				<xtce:LongDescription>Bulk HVPS raw DAC value, ESA_POS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DAC_PAD2" parameterTypeRef="ILO_APP_NHK.BHV_DAC_PAD2" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DEF_NEG_DAC" parameterTypeRef="ILO_APP_NHK.BHV_DEF_NEG_DAC" shortDescription="Bulk HVPS raw DAC value, DEF_NEG">
+				<xtce:LongDescription>Bulk HVPS raw DAC value, DEF_NEG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DAC_PAD3" parameterTypeRef="ILO_APP_NHK.BHV_DAC_PAD3" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DEF_POS_DAC" parameterTypeRef="ILO_APP_NHK.BHV_DEF_POS_DAC" shortDescription="Bulk HVPS raw DAC value, DEF_POS">
+				<xtce:LongDescription>Bulk HVPS raw DAC value, DEF_POS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DAC_PAD4" parameterTypeRef="ILO_APP_NHK.BHV_DAC_PAD4" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PMT_DAC" parameterTypeRef="ILO_APP_NHK.BHV_PMT_DAC" shortDescription="Bulk HVPS raw DAC value, PMT_BIAS">
+				<xtce:LongDescription>Bulk HVPS raw DAC value, PMT_BIAS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC1_CTRL" parameterTypeRef="ILO_APP_NHK.BHV_ADC1_CTRL" shortDescription="Bulk HVPS ADC1 enable status">
+				<xtce:LongDescription>Bulk HVPS ADC1 enable status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC1_MODE" parameterTypeRef="ILO_APP_NHK.BHV_ADC1_MODE" shortDescription="Bulk HVPS ADC1 mode">
+				<xtce:LongDescription>Bulk HVPS ADC1 mode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC1_CH_SEL" parameterTypeRef="ILO_APP_NHK.BHV_ADC1_CH_SEL" shortDescription="Bulk HVPS ADC1 channel select">
+				<xtce:LongDescription>Bulk HVPS ADC1 channel select</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC2_CTRL" parameterTypeRef="ILO_APP_NHK.BHV_ADC2_CTRL" shortDescription="Bulk HVPS ADC2 enable status">
+				<xtce:LongDescription>Bulk HVPS ADC2 enable status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC2_MODE" parameterTypeRef="ILO_APP_NHK.BHV_ADC2_MODE" shortDescription="Bulk HVPS ADC2 mode">
+				<xtce:LongDescription>Bulk HVPS ADC2 mode</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE2" parameterTypeRef="ILO_APP_NHK.BHV_SPARE2" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC2_CH_SEL" parameterTypeRef="ILO_APP_NHK.BHV_ADC2_CH_SEL" shortDescription="Bulk HVPS ADC2 channel select">
+				<xtce:LongDescription>Bulk HVPS ADC2 channel select</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE3" parameterTypeRef="ILO_APP_NHK.BHV_SPARE3" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC1_WAIT_CNT" parameterTypeRef="ILO_APP_NHK.BHV_ADC1_WAIT_CNT" shortDescription="Bulk HVPS ADC1 wait count">
+				<xtce:LongDescription>Bulk HVPS ADC1 wait count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC2_WAIT_CNT" parameterTypeRef="ILO_APP_NHK.BHV_ADC2_WAIT_CNT" shortDescription="Bulk HVPS ADC2 wait count">
+				<xtce:LongDescription>Bulk HVPS ADC2 wait count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD2" parameterTypeRef="ILO_APP_NHK.BHV_PAD2" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_BULK_V" parameterTypeRef="ILO_APP_NHK.BHV_BULK_V" shortDescription="Bulk HVPS Bulk voltage">
+				<xtce:LongDescription>Bulk HVPS Bulk voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD3" parameterTypeRef="ILO_APP_NHK.BHV_PAD3" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ESA_NEG_V" parameterTypeRef="ILO_APP_NHK.BHV_ESA_NEG_V" shortDescription="Bulk HVPS ESA_NEG voltage">
+				<xtce:LongDescription>Bulk HVPS ESA_NEG voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD4" parameterTypeRef="ILO_APP_NHK.BHV_PAD4" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ESA_POS_V" parameterTypeRef="ILO_APP_NHK.BHV_ESA_POS_V" shortDescription="Bulk HVPS ESA_POS voltage">
+				<xtce:LongDescription>Bulk HVPS ESA_POS voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD5" parameterTypeRef="ILO_APP_NHK.BHV_PAD5" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DEF_NEG_V" parameterTypeRef="ILO_APP_NHK.BHV_DEF_NEG_V" shortDescription="Bulk HVPS DEF_NEG voltage">
+				<xtce:LongDescription>Bulk HVPS DEF_NEG voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD6" parameterTypeRef="ILO_APP_NHK.BHV_PAD6" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DEF_POS_V" parameterTypeRef="ILO_APP_NHK.BHV_DEF_POS_V" shortDescription="Bulk HVPS DEF_POS voltage">
+				<xtce:LongDescription>Bulk HVPS DEF_POS voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD7" parameterTypeRef="ILO_APP_NHK.BHV_PAD7" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PMT_V" parameterTypeRef="ILO_APP_NHK.BHV_PMT_V" shortDescription="Bulk HVPS PMT voltage">
+				<xtce:LongDescription>Bulk HVPS PMT voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD8" parameterTypeRef="ILO_APP_NHK.BHV_PAD8" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PMT_I" parameterTypeRef="ILO_APP_NHK.BHV_PMT_I" shortDescription="Bulk HVPS PMT current">
+				<xtce:LongDescription>Bulk HVPS PMT current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD9" parameterTypeRef="ILO_APP_NHK.BHV_PAD9" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_BULK_I" parameterTypeRef="ILO_APP_NHK.BHV_BULK_I" shortDescription="Bulk HVPS Bulk current">
+				<xtce:LongDescription>Bulk HVPS Bulk current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD10" parameterTypeRef="ILO_APP_NHK.BHV_PAD10" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DEF_NEG_I" parameterTypeRef="ILO_APP_NHK.BHV_DEF_NEG_I" shortDescription="Bulk HVPS DEF_NEG current">
+				<xtce:LongDescription>Bulk HVPS DEF_NEG current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD11" parameterTypeRef="ILO_APP_NHK.BHV_PAD11" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_DEF_POS_I" parameterTypeRef="ILO_APP_NHK.BHV_DEF_POS_I" shortDescription="Bulk HVPS DEF_POS current">
+				<xtce:LongDescription>Bulk HVPS DEF_POS current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD12" parameterTypeRef="ILO_APP_NHK.BHV_PAD12" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC_REF1_V" parameterTypeRef="ILO_APP_NHK.BHV_ADC_REF1_V" shortDescription="Bulk HVPS ADC Reference 1 voltage">
+				<xtce:LongDescription>Bulk HVPS ADC Reference 1 voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD13" parameterTypeRef="ILO_APP_NHK.BHV_PAD13" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_ADC_REF2_V" parameterTypeRef="ILO_APP_NHK.BHV_ADC_REF2_V" shortDescription="Bulk HVPS ADC Reference 2 voltage">
+				<xtce:LongDescription>Bulk HVPS ADC Reference 2 voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD14" parameterTypeRef="ILO_APP_NHK.BHV_PAD14" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_12P0_V" parameterTypeRef="ILO_APP_NHK.BHV_12P0_V" shortDescription="Bulk HVPS positive 12V rail voltage">
+				<xtce:LongDescription>Bulk HVPS positive 12V rail voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD15" parameterTypeRef="ILO_APP_NHK.BHV_PAD15" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_N12P0_V" parameterTypeRef="ILO_APP_NHK.BHV_N12P0_V" shortDescription="Bulk HVPS negative 12V rail voltage">
+				<xtce:LongDescription>Bulk HVPS negative 12V rail voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD16" parameterTypeRef="ILO_APP_NHK.BHV_PAD16" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_3P3_V" parameterTypeRef="ILO_APP_NHK.BHV_3P3_V" shortDescription="Bulk HVPS 3p3 rail voltage">
+				<xtce:LongDescription>Bulk HVPS 3p3 rail voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_PAD17" parameterTypeRef="ILO_APP_NHK.BHV_PAD17" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_1P5_V" parameterTypeRef="ILO_APP_NHK.BHV_1P5_V" shortDescription="Bulk HVPS 1p5 rail voltage">
+				<xtce:LongDescription>Bulk HVPS 1p5 rail voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE4" parameterTypeRef="ILO_APP_NHK.BHV_SPARE4" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MEM_OP_STATE" parameterTypeRef="ILO_APP_NHK.MEM_OP_STATE" shortDescription="Memory operation state">
+				<xtce:LongDescription>Memory operation state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MEM_DUMP_STATE" parameterTypeRef="ILO_APP_NHK.MEM_DUMP_STATE" shortDescription="Memory dump state">
+				<xtce:LongDescription>Memory dump state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.SPIN_CNT" parameterTypeRef="ILO_APP_NHK.SPIN_CNT" shortDescription="Spin count">
+				<xtce:LongDescription>Spin count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MISSED_PPS_CNT" parameterTypeRef="ILO_APP_NHK.MISSED_PPS_CNT" shortDescription="Missed PPS from Spacecraft count">
+				<xtce:LongDescription>Missed PPS from Spacecraft count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.CPU_IDLE" parameterTypeRef="ILO_APP_NHK.CPU_IDLE" shortDescription="CPU idle percentage">
+				<xtce:LongDescription>CPU idle percentage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE5" parameterTypeRef="ILO_APP_NHK.BHV_SPARE5" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.SPIN_BIN_IDX" parameterTypeRef="ILO_APP_NHK.SPIN_BIN_IDX" shortDescription="Spin bin index">
+				<xtce:LongDescription>Spin bin index</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.SPIN_PERIOD" parameterTypeRef="ILO_APP_NHK.SPIN_PERIOD" shortDescription="Spin period">
+				<xtce:LongDescription>Spin period times 320 us</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.CDH_HEATER_1" parameterTypeRef="ILO_APP_NHK.CDH_HEATER_1" shortDescription="Heater 1 status">
+				<xtce:LongDescription>Heater 1 status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.CDH_HEATER_2" parameterTypeRef="ILO_APP_NHK.CDH_HEATER_2" shortDescription="Heater 2 status">
+				<xtce:LongDescription>Heater 2 status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.INSTR_PWR_12V" parameterTypeRef="ILO_APP_NHK.INSTR_PWR_12V" shortDescription="Instrument switched power output +/- 12V status">
+				<xtce:LongDescription>Instrument switched power output +/- 12V status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.INSTR_PWR_ANALOG_5V" parameterTypeRef="ILO_APP_NHK.INSTR_PWR_ANALOG_5V" shortDescription="Instrument switched power output analog 5V status">
+				<xtce:LongDescription>Instrument switched power output analog 5V status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.INSTR_PWR_DIGITAL_5V_3P3V" parameterTypeRef="ILO_APP_NHK.INSTR_PWR_DIGITAL_5V_3P3V" shortDescription="Instrument switched power output digital 5V and 3P3V status">
+				<xtce:LongDescription>Instrument switched power output digital 5V and 3P3V status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_CMD_ERROR" parameterTypeRef="ILO_APP_NHK.IFB_CMD_ERROR" shortDescription="Error status if an IFB an attempt to write a command before interface was ready">
+				<xtce:LongDescription>Error status if an IFB an attempt to write a command before interface was ready</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_INTERFACE" parameterTypeRef="ILO_APP_NHK.IFB_INTERFACE" shortDescription="CDH IFB interface status">
+				<xtce:LongDescription>CDH IFB interface status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_ADC_TLM_PKT_RCVD" parameterTypeRef="ILO_APP_NHK.IFB_ADC_TLM_PKT_RCVD" shortDescription="Star sensor FIFO underflow">
+				<xtce:LongDescription>Star sensor FIFO underflow</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_ADC_TLM_TIMEOUT_ERROR" parameterTypeRef="ILO_APP_NHK.IFB_ADC_TLM_TIMEOUT_ERROR" shortDescription="Star sensor FIFO overflow">
+				<xtce:LongDescription>Star sensor FIFO overflow</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_ADC_TLM_ID_ERROR" parameterTypeRef="ILO_APP_NHK.IFB_ADC_TLM_ID_ERROR" shortDescription="Star sensor FIFO full">
+				<xtce:LongDescription>Star sensor FIFO full</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_ADC_TLM_FRAME_ERROR" parameterTypeRef="ILO_APP_NHK.IFB_ADC_TLM_FRAME_ERROR" shortDescription="Star sensor FIFO half full">
+				<xtce:LongDescription>Star sensor FIFO half full</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_TLM_PKT_RCVD" parameterTypeRef="ILO_APP_NHK.IFB_TLM_PKT_RCVD" shortDescription="Star sensor FIFO empty">
+				<xtce:LongDescription>Star sensor FIFO empty</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_TLM_TIMEOUT_ERROR" parameterTypeRef="ILO_APP_NHK.IFB_TLM_TIMEOUT_ERROR" shortDescription="IFB ADC telemetry packet received">
+				<xtce:LongDescription>IFB ADC telemetry packet received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_TLM_ID_ERROR" parameterTypeRef="ILO_APP_NHK.IFB_TLM_ID_ERROR" shortDescription="IFB ADC telemetry timeout error">
+				<xtce:LongDescription>IFB ADC telemetry timeout error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_TLM_FRAME_ERROR" parameterTypeRef="ILO_APP_NHK.IFB_TLM_FRAME_ERROR" shortDescription="IFB ADC telemetry ID error">
+				<xtce:LongDescription>IFB ADC telemetry ID error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_TLM_PKT_RCVD" parameterTypeRef="ILO_APP_NHK.TOF_BD_TLM_PKT_RCVD" shortDescription="IFB ADC telemetry frame error">
+				<xtce:LongDescription>IFB ADC telemetry frame error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_ADC_TLM_PKT_RCVD" parameterTypeRef="ILO_APP_NHK.TOF_BD_ADC_TLM_PKT_RCVD" shortDescription="IFB telemetry packet received">
+				<xtce:LongDescription>IFB telemetry packet received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_REG_TLM_PKT_RCVD" parameterTypeRef="ILO_APP_NHK.TOF_BD_REG_TLM_PKT_RCVD" shortDescription="IFB telemetry timeout error">
+				<xtce:LongDescription>IFB telemetry timeout error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_CNT_TLM_PKT_RCVD" parameterTypeRef="ILO_APP_NHK.TOF_BD_CNT_TLM_PKT_RCVD" shortDescription="IFB telemetry ID error">
+				<xtce:LongDescription>IFB telemetry ID error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_DE_TLM_PKT_RCVD" parameterTypeRef="ILO_APP_NHK.TOF_BD_DE_TLM_PKT_RCVD" shortDescription="IFB telemetry frame error">
+				<xtce:LongDescription>IFB telemetry frame error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_TLM_TIMEOUT_ERROR" parameterTypeRef="ILO_APP_NHK.TOF_BD_TLM_TIMEOUT_ERROR" shortDescription="Any TOF Board telemetry packet received">
+				<xtce:LongDescription>Any TOF Board telemetry packet received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_TLM_ID_ERROR" parameterTypeRef="ILO_APP_NHK.TOF_BD_TLM_ID_ERROR" shortDescription="TOF Board ADC telemetry packet recevied">
+				<xtce:LongDescription>TOF Board ADC telemetry packet recevied</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_TLM_FRAME_ERROR" parameterTypeRef="ILO_APP_NHK.TOF_BD_TLM_FRAME_ERROR" shortDescription="TOF Board register telemetry packet recevied">
+				<xtce:LongDescription>TOF Board register telemetry packet recevied</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE7" parameterTypeRef="ILO_APP_NHK.BHV_SPARE7" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.DIRECT_EVENT_TIME_TAG_CNT" parameterTypeRef="ILO_APP_NHK.DIRECT_EVENT_TIME_TAG_CNT" shortDescription="Direct event time tag counter">
+				<xtce:LongDescription>Direct event time tag counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.DIRECT_EVENT_FIFO_CNT" parameterTypeRef="ILO_APP_NHK.DIRECT_EVENT_FIFO_CNT" shortDescription="Direct event FIFO count">
+				<xtce:LongDescription>Direct event FIFO count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_INTERFACE" parameterTypeRef="ILO_APP_NHK.PCC_INTERFACE" shortDescription="Pivot platform interface status">
+				<xtce:LongDescription>Pivot platform interface status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPC_TLM_TIMEOUT_ERROR" parameterTypeRef="ILO_APP_NHK.PPC_TLM_TIMEOUT_ERROR" shortDescription="Pivot platform interface telemetry timeout error">
+				<xtce:LongDescription>Pivot platform interface telemetry timeout error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPC_TLM_PARITY_ERROR" parameterTypeRef="ILO_APP_NHK.PPC_TLM_PARITY_ERROR" shortDescription="Pivot platform interface telemetry parity error">
+				<xtce:LongDescription>Pivot platform interface telemetry parity error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPC_TLM_PKT_RCVD" parameterTypeRef="ILO_APP_NHK.PPC_TLM_PKT_RCVD" shortDescription="Pivot platform interface telemetry packet received">
+				<xtce:LongDescription>Pivot platform interface telemetry packet received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_HV_PLUG_STATE" parameterTypeRef="ILO_APP_NHK.IFB_HV_PLUG_STATE" shortDescription="IFB High Voltage plug status">
+				<xtce:LongDescription>IFB High Voltage plug status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE10" parameterTypeRef="ILO_APP_NHK.BHV_SPARE10" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_CMD_COUNT" parameterTypeRef="ILO_APP_NHK.IFB_CMD_COUNT" shortDescription="IFB command counter">
+				<xtce:LongDescription>IFB command counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_CTRL_INT_MUX" parameterTypeRef="ILO_APP_NHK.IFB_CTRL_INT_MUX" shortDescription="IFB internal mux selection">
+				<xtce:LongDescription>IFB internal mux selection</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_CTRL_ADC_CLK_DS" parameterTypeRef="ILO_APP_NHK.IFB_CTRL_ADC_CLK_DS" shortDescription="IFB AC clock de-assert status">
+				<xtce:LongDescription>IFB AC clock de-assert status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_CTRL_OSCOPE" parameterTypeRef="ILO_APP_NHK.IFB_CTRL_OSCOPE" shortDescription="IFB oscope mode status">
+				<xtce:LongDescription>IFB oscope mode status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_CTRL_STAR_SYNC" parameterTypeRef="ILO_APP_NHK.IFB_CTRL_STAR_SYNC" shortDescription="IFB star sync status">
+				<xtce:LongDescription>IFB star sync status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_CTRL_DATA" parameterTypeRef="ILO_APP_NHK.IFB_CTRL_DATA" shortDescription="IFB telmetry state">
+				<xtce:LongDescription>IFB telmetry state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE11" parameterTypeRef="ILO_APP_NHK.BHV_SPARE11" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_DATA_INTERVAL" parameterTypeRef="ILO_APP_NHK.IFB_DATA_INTERVAL" shortDescription="IFB Data Interval">
+				<xtce:LongDescription>IFB Data Interval</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_HVPS_CTRL_SYNC_CLK" parameterTypeRef="ILO_APP_NHK.TOF_HVPS_CTRL_SYNC_CLK" shortDescription="TOF HVPS sync clock state">
+				<xtce:LongDescription>TOF HVPS sync clock state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_HVPS_CTRL_PAC" parameterTypeRef="ILO_APP_NHK.TOF_HVPS_CTRL_PAC" shortDescription="TOF HVPS PAC state">
+				<xtce:LongDescription>TOF HVPS PAC state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_HVPS_CTRL_MCP" parameterTypeRef="ILO_APP_NHK.TOF_HVPS_CTRL_MCP" shortDescription="TOF HVPS MCP state">
+				<xtce:LongDescription>TOF HVPS MCP state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_HVPS_CTRL_LV" parameterTypeRef="ILO_APP_NHK.TOF_HVPS_CTRL_LV" shortDescription="TOF Board LV state">
+				<xtce:LongDescription>TOF Board LV state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE12" parameterTypeRef="ILO_APP_NHK.BHV_SPARE12" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAC_VSET" parameterTypeRef="ILO_APP_NHK.PAC_VSET" shortDescription="TOF HVPS PAC VSET DAC">
+				<xtce:LongDescription>TOF HVPS PAC VSET DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAC_OCP" parameterTypeRef="ILO_APP_NHK.PAC_OCP" shortDescription="TOF HVPS PAC overcurrent protection">
+				<xtce:LongDescription>TOF HVPS PAC overcurrent protection</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MCP_VSET" parameterTypeRef="ILO_APP_NHK.MCP_VSET" shortDescription="TOF HVPS MCP VSET DAC">
+				<xtce:LongDescription>TOF HVPS MCP VSET DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MCP_OCP" parameterTypeRef="ILO_APP_NHK.MCP_OCP" shortDescription="TOF HVPS MCP overcurrent protection">
+				<xtce:LongDescription>TOF HVPS MCP overcurrent protection</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STAR_OFFSET_ADJUST" parameterTypeRef="ILO_APP_NHK.STAR_OFFSET_ADJUST" shortDescription="Star sensor offset adjust">
+				<xtce:LongDescription>Star sensor offset adjust</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_OSCOPE_CH1" parameterTypeRef="ILO_APP_NHK.IFB_OSCOPE_CH1" shortDescription="IFB oscope channel 1 selection">
+				<xtce:LongDescription>IFB oscope channel 1 selection</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_OSCOPE_CH0" parameterTypeRef="ILO_APP_NHK.IFB_OSCOPE_CH0" shortDescription="IFB oscope channel 0 selection">
+				<xtce:LongDescription>IFB oscope channel 0 selection</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD0" parameterTypeRef="ILO_APP_NHK.IFB_PAD0" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_HOT_SPOT_T" parameterTypeRef="ILO_APP_NHK.IFB_HOT_SPOT_T" shortDescription="IFB temperature hot spot between FPGA and 2P5V regulator">
+				<xtce:LongDescription>IFB temperature hot spot between FPGA and 2P5V regulator</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD1" parameterTypeRef="ILO_APP_NHK.IFB_PAD1" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_COLD_SPOT_T" parameterTypeRef="ILO_APP_NHK.IFB_COLD_SPOT_T" shortDescription="IFB temperature cold spot at board corner between J1 and J2">
+				<xtce:LongDescription>IFB temperature cold spot at board corner between J1 and J2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD2" parameterTypeRef="ILO_APP_NHK.IFB_PAD2" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_5P0_V" parameterTypeRef="ILO_APP_NHK.IFB_5P0_V" shortDescription="IFB 5V voltage">
+				<xtce:LongDescription>IFB 5V voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD3" parameterTypeRef="ILO_APP_NHK.IFB_PAD3" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_3P3_V" parameterTypeRef="ILO_APP_NHK.IFB_3P3_V" shortDescription="IFB 3P3V voltage">
+				<xtce:LongDescription>IFB 3P3V voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD4" parameterTypeRef="ILO_APP_NHK.IFB_PAD4" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_12P0_V" parameterTypeRef="ILO_APP_NHK.IFB_12P0_V" shortDescription="IFB +12V voltage">
+				<xtce:LongDescription>IFB +12V voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD5" parameterTypeRef="ILO_APP_NHK.IFB_PAD5" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_N12P0_V" parameterTypeRef="ILO_APP_NHK.IFB_N12P0_V" shortDescription="IFB -12V voltage">
+				<xtce:LongDescription>IFB -12V voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD6" parameterTypeRef="ILO_APP_NHK.IFB_PAD6" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.LV_I" parameterTypeRef="ILO_APP_NHK.LV_I" shortDescription="TOF Board LV current">
+				<xtce:LongDescription>TOF Board LV current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD7" parameterTypeRef="ILO_APP_NHK.IFB_PAD7" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.LV_V" parameterTypeRef="ILO_APP_NHK.LV_V" shortDescription="TOF Board LV voltage">
+				<xtce:LongDescription>TOF Board LV voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD8" parameterTypeRef="ILO_APP_NHK.IFB_PAD8" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.LV_T" parameterTypeRef="ILO_APP_NHK.LV_T" shortDescription="TOF Board LV temperature">
+				<xtce:LongDescription>TOF Board LV temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD9" parameterTypeRef="ILO_APP_NHK.IFB_PAD9" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MCP_I" parameterTypeRef="ILO_APP_NHK.MCP_I" shortDescription="MCP current">
+				<xtce:LongDescription>MCP current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD10" parameterTypeRef="ILO_APP_NHK.IFB_PAD10" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MCP_V" parameterTypeRef="ILO_APP_NHK.MCP_V" shortDescription="MCP voltage">
+				<xtce:LongDescription>MCP voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD11" parameterTypeRef="ILO_APP_NHK.IFB_PAD11" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MCP_T" parameterTypeRef="ILO_APP_NHK.MCP_T" shortDescription="MCP temperature">
+				<xtce:LongDescription>MCP temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD12" parameterTypeRef="ILO_APP_NHK.IFB_PAD12" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAC_I" parameterTypeRef="ILO_APP_NHK.PAC_I" shortDescription="PAC current">
+				<xtce:LongDescription>PAC current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD13" parameterTypeRef="ILO_APP_NHK.IFB_PAD13" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAC_V" parameterTypeRef="ILO_APP_NHK.PAC_V" shortDescription="PAC voltage">
+				<xtce:LongDescription>PAC voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.IFB_PAD14" parameterTypeRef="ILO_APP_NHK.IFB_PAD14" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PAC_T" parameterTypeRef="ILO_APP_NHK.PAC_T" shortDescription="PAC temperature">
+				<xtce:LongDescription>PAC temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_CMD_ERROR" parameterTypeRef="ILO_APP_NHK.TOF_CMD_ERROR" shortDescription="TOF Board command error counter">
+				<xtce:LongDescription>TOF Board command error counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PAD0" parameterTypeRef="ILO_APP_NHK.TOF_PAD0" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_CFD_V" parameterTypeRef="ILO_APP_NHK.TOF_CFD_V" shortDescription="TOF Board CFD voltage">
+				<xtce:LongDescription>TOF Board CFD voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PAD1" parameterTypeRef="ILO_APP_NHK.TOF_PAD1" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PRE_T" parameterTypeRef="ILO_APP_NHK.TOF_PRE_T" shortDescription="TOF Board preamp temperature">
+				<xtce:LongDescription>TOF Board preamp temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PAD2" parameterTypeRef="ILO_APP_NHK.TOF_PAD2" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_REG_T" parameterTypeRef="ILO_APP_NHK.TOF_REG_T" shortDescription="TOF Board regulator temperature">
+				<xtce:LongDescription>TOF Board regulator temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PAD3" parameterTypeRef="ILO_APP_NHK.TOF_PAD3" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_MCP_I" parameterTypeRef="ILO_APP_NHK.TOF_MCP_I" shortDescription="MCP current">
+				<xtce:LongDescription>MCP current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PAD4" parameterTypeRef="ILO_APP_NHK.TOF_PAD4" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_MCP_V" parameterTypeRef="ILO_APP_NHK.TOF_MCP_V" shortDescription="MCP voltage">
+				<xtce:LongDescription>MCP voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PAD5" parameterTypeRef="ILO_APP_NHK.TOF_PAD5" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_I" parameterTypeRef="ILO_APP_NHK.TOF_BD_I" shortDescription="TOF Board current">
+				<xtce:LongDescription>TOF Board current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PAD6" parameterTypeRef="ILO_APP_NHK.TOF_PAD6" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_P5_V" parameterTypeRef="ILO_APP_NHK.TOF_BD_P5_V" shortDescription="TOF Board +5V voltage">
+				<xtce:LongDescription>TOF Board +5V voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_PAD7" parameterTypeRef="ILO_APP_NHK.TOF_PAD7" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_P6_V" parameterTypeRef="ILO_APP_NHK.TOF_BD_P6_V" shortDescription="TOF Board +6V Voltage">
+				<xtce:LongDescription>TOF Board +6V Voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.AN_A_THR" parameterTypeRef="ILO_APP_NHK.AN_A_THR" shortDescription="Anode A threshold">
+				<xtce:LongDescription>Anode A threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.AN_B0_THR" parameterTypeRef="ILO_APP_NHK.AN_B0_THR" shortDescription="Anode B0 threshold">
+				<xtce:LongDescription>Anode B0 threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.AN_B3_THR" parameterTypeRef="ILO_APP_NHK.AN_B3_THR" shortDescription="Anode B3 threshold">
+				<xtce:LongDescription>Anode B3 threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.AN_C_THR" parameterTypeRef="ILO_APP_NHK.AN_C_THR" shortDescription="Anode C threshold">
+				<xtce:LongDescription>Anode C threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_CTRL_TLM" parameterTypeRef="ILO_APP_NHK.TOF_BD_CTRL_TLM" shortDescription="TOF Board Control telemetry state">
+				<xtce:LongDescription>TOF Board Control telemetry state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_CTRL_DE_TLM" parameterTypeRef="ILO_APP_NHK.TOF_BD_CTRL_DE_TLM" shortDescription="TOF Board Control direct event telemetry state">
+				<xtce:LongDescription>TOF Board Control direct event telemetry state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_CTRL_TOF3_REQ" parameterTypeRef="ILO_APP_NHK.TOF_BD_CTRL_TOF3_REQ" shortDescription="TOF Board Control valid TOF3 required">
+				<xtce:LongDescription>TOF Board Control valid TOF3 required</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_CTRL_TOF2_REQ" parameterTypeRef="ILO_APP_NHK.TOF_BD_CTRL_TOF2_REQ" shortDescription="TOF Board Control valid TOF2 required">
+				<xtce:LongDescription>TOF Board Control valid TOF2 required</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_CTRL_TOF1_REQ" parameterTypeRef="ILO_APP_NHK.TOF_BD_CTRL_TOF1_REQ" shortDescription="TOF Board Control valid TOF1 required">
+				<xtce:LongDescription>TOF Board Control valid TOF1 required</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF_BD_CTRL_TOF0_REQ" parameterTypeRef="ILO_APP_NHK.TOF_BD_CTRL_TOF0_REQ" shortDescription="TOF Board Control valid TOF0 required">
+				<xtce:LongDescription>TOF Board Control valid TOF0 required</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CTRL_AN_C_STATE" parameterTypeRef="ILO_APP_NHK.STIM_CTRL_AN_C_STATE" shortDescription="TOF Board Stimulus Control Anode C state">
+				<xtce:LongDescription>TOF Board Stimulus Control Anode C state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CTRL_AN_C_SRC" parameterTypeRef="ILO_APP_NHK.STIM_CTRL_AN_C_SRC" shortDescription="TOF Board Stimulus Control Anode C pulse state">
+				<xtce:LongDescription>TOF Board Stimulus Control Anode C pulse state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CTRL_AN_B3_STATE" parameterTypeRef="ILO_APP_NHK.STIM_CTRL_AN_B3_STATE" shortDescription="TOF Board Stimulus Control Anode B3 state">
+				<xtce:LongDescription>TOF Board Stimulus Control Anode B3 state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CTRL_AN_B3_SRC" parameterTypeRef="ILO_APP_NHK.STIM_CTRL_AN_B3_SRC" shortDescription="TOF Board Stimulus Control Anode B3 pulse state">
+				<xtce:LongDescription>TOF Board Stimulus Control Anode B3 pulse state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CTRL_AN_B0_STATE" parameterTypeRef="ILO_APP_NHK.STIM_CTRL_AN_B0_STATE" shortDescription="TOF Board Stimulus Control Anode B0 state">
+				<xtce:LongDescription>TOF Board Stimulus Control Anode B0 state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CTRL_AN_B0_SRC" parameterTypeRef="ILO_APP_NHK.STIM_CTRL_AN_B0_SRC" shortDescription="TOF Board Stimulus Control Anode B0 pulse state">
+				<xtce:LongDescription>TOF Board Stimulus Control Anode B0 pulse state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CTRL_AN_A_STATE" parameterTypeRef="ILO_APP_NHK.STIM_CTRL_AN_A_STATE" shortDescription="TOF Board Stimulus Control Anode A state">
+				<xtce:LongDescription>TOF Board Stimulus Control Anode A state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CTRL_AN_A_SRC" parameterTypeRef="ILO_APP_NHK.STIM_CTRL_AN_A_SRC" shortDescription="TOF Board Stimulus Control Anode A pulse state">
+				<xtce:LongDescription>TOF Board Stimulus Control Anode A pulse state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE13" parameterTypeRef="ILO_APP_NHK.BHV_SPARE13" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CNFG_FREQ" parameterTypeRef="ILO_APP_NHK.STIM_CNFG_FREQ" shortDescription="TOF Board Stimulus Config frequency">
+				<xtce:LongDescription>TOF Board Stimulus Config frequency</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.STIM_CNFG_DELAY" parameterTypeRef="ILO_APP_NHK.STIM_CNFG_DELAY" shortDescription="TOF Board Stimulus Config delay">
+				<xtce:LongDescription>TOF Board Stimulus Config delay</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF3_THR" parameterTypeRef="ILO_APP_NHK.TOF3_THR" shortDescription="TOF Board TOF3 threshold">
+				<xtce:LongDescription>TOF Board TOF3 threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF2_THR" parameterTypeRef="ILO_APP_NHK.TOF2_THR" shortDescription="TOF Board TOF2 threshold">
+				<xtce:LongDescription>TOF Board TOF2 threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF1_THR" parameterTypeRef="ILO_APP_NHK.TOF1_THR" shortDescription="TOF Board TOF1 threshold">
+				<xtce:LongDescription>TOF Board TOF1 threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF0_THR" parameterTypeRef="ILO_APP_NHK.TOF0_THR" shortDescription="TOF Board TOF0 threshold">
+				<xtce:LongDescription>TOF Board TOF0 threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF3_VETO" parameterTypeRef="ILO_APP_NHK.TOF3_VETO" shortDescription="TOF3 veto">
+				<xtce:LongDescription>TOF3 veto</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF2_VETO" parameterTypeRef="ILO_APP_NHK.TOF2_VETO" shortDescription="TOF2 veto">
+				<xtce:LongDescription>TOF2 veto</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF1_VETO" parameterTypeRef="ILO_APP_NHK.TOF1_VETO" shortDescription="TOF1 veto">
+				<xtce:LongDescription>TOF1 veto</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.TOF0_VETO" parameterTypeRef="ILO_APP_NHK.TOF0_VETO" shortDescription="TOF0 veto">
+				<xtce:LongDescription>TOF0 veto</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.BHV_SPARE14" parameterTypeRef="ILO_APP_NHK.BHV_SPARE14" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PAD0" parameterTypeRef="ILO_APP_NHK.PCC_PAD0" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_COARSE_POT_PRI" parameterTypeRef="ILO_APP_NHK.PCC_COARSE_POT_PRI" shortDescription="Pivot platform ADC primary coarse pot degrees">
+				<xtce:LongDescription>Pivot platform ADC primary coarse pot degrees</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PAD1" parameterTypeRef="ILO_APP_NHK.PCC_PAD1" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_FINE_POT_PRI" parameterTypeRef="ILO_APP_NHK.PCC_FINE_POT_PRI" shortDescription="Pivot platform ADC primary fine pot degrees">
+				<xtce:LongDescription>Pivot platform ADC primary fine pot degrees</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PAD2" parameterTypeRef="ILO_APP_NHK.PCC_PAD2" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_COARSE_POT_SEC" parameterTypeRef="ILO_APP_NHK.PCC_COARSE_POT_SEC" shortDescription="Pivot platform ADC secondary coarse pot degrees">
+				<xtce:LongDescription>Pivot platform ADC secondary coarse pot degrees</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PAD3" parameterTypeRef="ILO_APP_NHK.PCC_PAD3" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_FINE_POT_SEC" parameterTypeRef="ILO_APP_NHK.PCC_FINE_POT_SEC" shortDescription="Pivot platform ADC secondary fine pot degrees">
+				<xtce:LongDescription>Pivot platform ADC secondary fine pot degrees</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PAD4" parameterTypeRef="ILO_APP_NHK.PCC_PAD4" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_ACTUATOR_T" parameterTypeRef="ILO_APP_NHK.PCC_ACTUATOR_T" shortDescription="Pivot platform ADC actuator temperature">
+				<xtce:LongDescription>Pivot platform ADC actuator temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PAD5" parameterTypeRef="ILO_APP_NHK.PCC_PAD5" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_BOARD_T" parameterTypeRef="ILO_APP_NHK.PCC_BOARD_T" shortDescription="Pivot platform ADC board temperature">
+				<xtce:LongDescription>Pivot platform ADC board temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PAD6" parameterTypeRef="ILO_APP_NHK.PCC_PAD6" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_MOTOR_CURRENT_PRI" parameterTypeRef="ILO_APP_NHK.PCC_MOTOR_CURRENT_PRI" shortDescription="Pivot platform ADC primary motor current">
+				<xtce:LongDescription>Pivot platform ADC primary motor current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PAD7" parameterTypeRef="ILO_APP_NHK.PCC_PAD7" shortDescription="pad for alignment">
+				<xtce:LongDescription>pad for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_MOTOR_CURRENT_SEC" parameterTypeRef="ILO_APP_NHK.PCC_MOTOR_CURRENT_SEC" shortDescription="Pivot platform ADC secondary motor current">
+				<xtce:LongDescription>Pivot platform ADC secondary motor current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_CUMULATIVE_CNT_PRI" parameterTypeRef="ILO_APP_NHK.PCC_CUMULATIVE_CNT_PRI" shortDescription="Pivot platform primary cumulative count">
+				<xtce:LongDescription>Pivot platform primary cumulative count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_PRI" parameterTypeRef="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_PRI" shortDescription="Pivot platform primary cumulative count sign">
+				<xtce:LongDescription>Pivot platform primary cumulative count sign</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SEC" parameterTypeRef="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SEC" shortDescription="Pivot platform secondary cumulative count">
+				<xtce:LongDescription>Pivot platform secondary cumulative count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_SEC" parameterTypeRef="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_SEC" shortDescription="Pivot platform secondary cumulative count sign">
+				<xtce:LongDescription>Pivot platform secondary cumulative count sign</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_CURRENT_STEP_CNT_PRI" parameterTypeRef="ILO_APP_NHK.PCC_CURRENT_STEP_CNT_PRI" shortDescription="Pivot platform primary current step count">
+				<xtce:LongDescription>Pivot platform primary current step count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_CURRENT_STEP_CNT_SEC" parameterTypeRef="ILO_APP_NHK.PCC_CURRENT_STEP_CNT_SEC" shortDescription="Pivot platform secondary current step count">
+				<xtce:LongDescription>Pivot platform secondary current step count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_CURRENT_SETPT_PRI" parameterTypeRef="ILO_APP_NHK.PCC_CURRENT_SETPT_PRI" shortDescription="Pivot platform primary current setpoint">
+				<xtce:LongDescription>Pivot platform primary current setpoint</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_CURRENT_SETPT_SEC" parameterTypeRef="ILO_APP_NHK.PCC_CURRENT_SETPT_SEC" shortDescription="Pivot platform secondary current setpoint">
+				<xtce:LongDescription>Pivot platform secondary current setpoint</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PRI_ACTIVE" parameterTypeRef="ILO_APP_NHK.PCC_PRI_ACTIVE" shortDescription="Pivot platform primary port active - motion in progress status">
+				<xtce:LongDescription>Pivot platform primary port active - motion in progress status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PRI_POWERED" parameterTypeRef="ILO_APP_NHK.PCC_PRI_POWERED" shortDescription="Pivot platform primary port powered - powered idle state">
+				<xtce:LongDescription>Pivot platform primary port powered - powered idle state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PRI_USTEP" parameterTypeRef="ILO_APP_NHK.PCC_PRI_USTEP" shortDescription="Pivot platform primary port micro-stepping status">
+				<xtce:LongDescription>Pivot platform primary port micro-stepping status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_PRI_ACCEL" parameterTypeRef="ILO_APP_NHK.PCC_PRI_ACCEL" shortDescription="Pivot platform primary acceleration profiling status">
+				<xtce:LongDescription>Pivot platform primary acceleration profiling status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_SEC_ACTIVE" parameterTypeRef="ILO_APP_NHK.PCC_SEC_ACTIVE" shortDescription="Pivot platform secondary port active - motion in progress status">
+				<xtce:LongDescription>Pivot platform secondary port active - motion in progress status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_SEC_POWERED" parameterTypeRef="ILO_APP_NHK.PCC_SEC_POWERED" shortDescription="Pivot platform secondary port powered - powered idle state">
+				<xtce:LongDescription>Pivot platform secondary port powered - powered idle state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_SEC_USTEP" parameterTypeRef="ILO_APP_NHK.PCC_SEC_USTEP" shortDescription="Pivot platform secondary port micro-stepping status">
+				<xtce:LongDescription>Pivot platform secondary port micro-stepping status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PCC_SEC_ACCEL" parameterTypeRef="ILO_APP_NHK.PCC_SEC_ACCEL" shortDescription="Pivot platform secondary acceleration profiling status">
+				<xtce:LongDescription>Pivot platform secondary acceleration profiling status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.RTS_ID" parameterTypeRef="ILO_APP_NHK.RTS_ID" shortDescription="Currently running macro ID">
+				<xtce:LongDescription>Currently running macro ID</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.RTS_STATE" parameterTypeRef="ILO_APP_NHK.RTS_STATE" shortDescription="Currently running macro state">
+				<xtce:LongDescription>Currently running macro state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.RTS_NUM_CMDS" parameterTypeRef="ILO_APP_NHK.RTS_NUM_CMDS" shortDescription="Currently running macro number of commands">
+				<xtce:LongDescription>Currently running macro number of commands</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.RTS_NUM_CMDS_EXE" parameterTypeRef="ILO_APP_NHK.RTS_NUM_CMDS_EXE" shortDescription="Currently running macro number of commands executed so far">
+				<xtce:LongDescription>Currently running macro number of commands executed so far</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.RTS_INDEX" parameterTypeRef="ILO_APP_NHK.RTS_INDEX" shortDescription="Currently running macro command index">
+				<xtce:LongDescription>Currently running macro command index</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.RTS_NEXT_OPCODE" parameterTypeRef="ILO_APP_NHK.RTS_NEXT_OPCODE" shortDescription="Currently running macro next opcode to be executed">
+				<xtce:LongDescription>Currently running macro next opcode to be executed</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.RTS_TIME_REMAINING" parameterTypeRef="ILO_APP_NHK.RTS_TIME_REMAINING" shortDescription="Currently running macro time until next command">
+				<xtce:LongDescription>Currently running macro time until next command</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.OP_HTR_SELECT" parameterTypeRef="ILO_APP_NHK.OP_HTR_SELECT" shortDescription="Current selected heater that will operate under configured modes">
+				<xtce:LongDescription>Current selected heater that will operate under configured modes. Effectively last active heater.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.OP_HTR_MODE" parameterTypeRef="ILO_APP_NHK.OP_HTR_MODE" shortDescription="Heater mode, MANUAL, BLIND, or AUTO.">
+				<xtce:LongDescription>Heater mode, MANUAL, BLIND, or AUTO.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.OP_HTR_CYCLE_TIME" parameterTypeRef="ILO_APP_NHK.OP_HTR_CYCLE_TIME" shortDescription="BLIND mode cycle time in seconds (on for # seconds, off for # seconds)">
+				<xtce:LongDescription>BLIND mode cycle time in seconds (on for # seconds, off for # seconds)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.OP_HTR_PAD0" parameterTypeRef="ILO_APP_NHK.OP_HTR_PAD0" />
+			<xtce:Parameter name="ILO_APP_NHK.OP_HTR_LO_SETPOINT" parameterTypeRef="ILO_APP_NHK.OP_HTR_LO_SETPOINT" shortDescription="AUTO mode lower setpoint, heater will turn on when this is reached.">
+				<xtce:LongDescription>AUTO mode lower setpoint, heater will turn on when this is reached.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.OP_HTR_PAD1" parameterTypeRef="ILO_APP_NHK.OP_HTR_PAD1" />
+			<xtce:Parameter name="ILO_APP_NHK.OP_HTR_HI_SETPOINT" parameterTypeRef="ILO_APP_NHK.OP_HTR_HI_SETPOINT" shortDescription="AUTO mode upper setpoint, heater will turn off when this is reached.">
+				<xtce:LongDescription>AUTO mode upper setpoint, heater will turn off when this is reached.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.CDH_HV_PLUG_STATE" parameterTypeRef="ILO_APP_NHK.CDH_HV_PLUG_STATE" shortDescription="HV limit plug status from CDH board">
+				<xtce:LongDescription>HV limit plug status from CDH board</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.SPARE16" parameterTypeRef="ILO_APP_NHK.SPARE16" />
+			<xtce:Parameter name="ILO_APP_NHK.SCI_CYCLE" parameterTypeRef="ILO_APP_NHK.SCI_CYCLE" shortDescription="Current state of science cycle">
+				<xtce:LongDescription>Current state of science cycle</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_STATE" parameterTypeRef="ILO_APP_NHK.PPM_STATE" shortDescription="Current state of PPM state machine">
+				<xtce:LongDescription>Current state of PPM state machine</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_MOTOR" parameterTypeRef="ILO_APP_NHK.PPM_MOTOR" shortDescription="Selected motor channel for motion">
+				<xtce:LongDescription>Selected motor channel for motion</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_DIRECTION" parameterTypeRef="ILO_APP_NHK.PPM_DIRECTION" shortDescription="Selected direction for motion">
+				<xtce:LongDescription>Selected direction for motion</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_STEP_PERIOD" parameterTypeRef="ILO_APP_NHK.PPM_STEP_PERIOD" shortDescription="Step  period divisor (converts to steps per second)">
+				<xtce:LongDescription>Step  period divisor (converts to steps per second)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_MICROSTEP" parameterTypeRef="ILO_APP_NHK.PPM_MICROSTEP" shortDescription="Microstepping state">
+				<xtce:LongDescription>Microstepping state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_CURRENT_THRESHOLD" parameterTypeRef="ILO_APP_NHK.PPM_CURRENT_THRESHOLD" shortDescription="The minimum motor current to determine if a motor is powered">
+				<xtce:LongDescription>The minimum motor current to determine if a motor is powered</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_STALL_THRESHOLD" parameterTypeRef="ILO_APP_NHK.PPM_STALL_THRESHOLD" shortDescription="The minimum number of coarse potentiometer counts over the stall period">
+				<xtce:LongDescription>The minimum number of coarse potentiometer counts over the stall period to detect stall</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_STALL_PERIOD" parameterTypeRef="ILO_APP_NHK.PPM_STALL_PERIOD" shortDescription="The time period the stall threshold is integrated over, in seconds">
+				<xtce:LongDescription>The time period the stall threshold is integrated over to detect stall, in seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_PAD0" parameterTypeRef="ILO_APP_NHK.PPM_PAD0" />
+			<xtce:Parameter name="ILO_APP_NHK.PPM_LOWER_BOUND" parameterTypeRef="ILO_APP_NHK.PPM_LOWER_BOUND" shortDescription="Primary Coarse Lower bound of coarse potentiometer for out of range check">
+				<xtce:LongDescription>Primary CoarseLower bound of coarse potentiometer for out of range check</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_PAD1" parameterTypeRef="ILO_APP_NHK.PPM_PAD1" />
+			<xtce:Parameter name="ILO_APP_NHK.PPM_UPPER_BOUND" parameterTypeRef="ILO_APP_NHK.PPM_UPPER_BOUND" shortDescription="Primary CoarseUpper bound of coarse potentiometer for out of range check">
+				<xtce:LongDescription>Primary CoarseUpper bound of coarse potentiometer for out of range check</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_USE_CONFLICT" parameterTypeRef="ILO_APP_NHK.PPM_USE_CONFLICT" shortDescription="If a motor is already active when attempting to command new motion">
+				<xtce:LongDescription>If a motor is already active when attempting to command new motion</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_STALLED" parameterTypeRef="ILO_APP_NHK.PPM_STALLED" shortDescription="Motor stall detected">
+				<xtce:LongDescription>Motor stall detected</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_OUT_OF_RANGE" parameterTypeRef="ILO_APP_NHK.PPM_OUT_OF_RANGE" shortDescription="Motor went out of range of allowed coarse potentiomenter boundaries">
+				<xtce:LongDescription>Motor went out of range of allowed coarse potentiomenter boundaries</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.PPM_POWER_PROBLEM" parameterTypeRef="ILO_APP_NHK.PPM_POWER_PROBLEM" shortDescription="Motor Power problem detected">
+				<xtce:LongDescription>Power problem detected, either no power when expected, or power when not expected.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.MARKER" parameterTypeRef="ILO_APP_NHK.MARKER" shortDescription="Echo value from MARKER command">
+				<xtce:LongDescription>Echo value from MARKER command</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.SPARE" parameterTypeRef="ILO_APP_NHK.SPARE" shortDescription="Spare for alignment">
+				<xtce:LongDescription>Spare for alignment</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_APP_NHK.CHKSUM" parameterTypeRef="ILO_APP_NHK.CHKSUM" shortDescription="CRC-16 Checksum">
+				<xtce:LongDescription>CRC-16 Checksum</xtce:LongDescription>
+			</xtce:Parameter>
 			<xtce:Parameter name="ILO_SCI_CNT.SHCOARSE" parameterTypeRef="ILO_SCI_CNT.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
 				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
 			</xtce:Parameter>
@@ -136,8 +7414,8 @@
 			<xtce:Parameter name="ILO_SCI_DE.SHCOARSE" parameterTypeRef="ILO_SCI_DE.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
 				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="ILO_SCI_DE.DATA" parameterTypeRef="ILO_SCI_DE.DATA" shortDescription="TOF Direct Event Time Tagged data">
-				<xtce:LongDescription>See table 7 of Section 4.2.1 for sizing and see Table 8 and table 9 in section 4.2.1.2 (PHA Event Compression and Packing by ICE) of IMAP-Lo Data Flow document</xtce:LongDescription>
+			<xtce:Parameter name="ILO_SCI_DE.PACKETDATA" parameterTypeRef="ILO_SCI_DE.PACKETDATA" shortDescription="DE Packet Data">
+				<xtce:LongDescription>DE Packet Data</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="ILO_STAR.SHCOARSE" parameterTypeRef="ILO_STAR.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
 				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
@@ -160,7 +7438,7 @@
 			<xtce:Parameter name="ILO_SPIN.ACQ_START_SEC" parameterTypeRef="ILO_SPIN.ACQ_START_SEC" shortDescription="Acquisition start whole seconds">
 				<xtce:LongDescription>Acquisition start whole seconds</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="ILO_SPIN.ACQ_START_SUBSEC" parameterTypeRef="ILO_SPIN.ACQ_START_SUBSEC" shortDescription="Acquisition start subseconds">
+			<xtce:Parameter name="ILO_SPIN.ACQ_START_SUBSEC" parameterTypeRef="ILO_SPIN.ACQ_START_SUBSEC" shortDescription="Acquisition start subseconds (microseconds)">
 				<xtce:LongDescription>Acquisition start subseconds</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="ILO_SPIN.ACQ_END_SEC" parameterTypeRef="ILO_SPIN.ACQ_END_SEC" shortDescription="Acquisition end whole seconds">
@@ -169,11 +7447,1527 @@
 			<xtce:Parameter name="ILO_SPIN.ACQ_END_SUBSEC" parameterTypeRef="ILO_SPIN.ACQ_END_SUBSEC" shortDescription="Acquisition end subseconds">
 				<xtce:LongDescription>Acquisition end subseconds</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="ILO_SPIN.SPIN_DATA" parameterTypeRef="ILO_SPIN.SPIN_DATA" shortDescription="Binary Spin data">
-				<xtce:LongDescription>Binary Spin data</xtce:LongDescription>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_1" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_1" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_1" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_1" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_1" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_1" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_1" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_1" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_1" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_1" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_1" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_1" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_1" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_1" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_2" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_2" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_2" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_2" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_2" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_2" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_2" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_2" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_2" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_2" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_2" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_2" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_2" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_2" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_3" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_3" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_3" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_3" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_3" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_3" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_3" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_3" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_3" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_3" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_3" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_3" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_3" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_3" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_4" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_4" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_4" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_4" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_4" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_4" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_4" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_4" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_4" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_4" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_4" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_4" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_4" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_4" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_5" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_5" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_5" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_5" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_5" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_5" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_5" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_5" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_5" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_5" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_5" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_5" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_5" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_5" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_6" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_6" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_6" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_6" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_6" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_6" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_6" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_6" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_6" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_6" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_6" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_6" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_6" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_6" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_7" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_7" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_7" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_7" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_7" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_7" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_7" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_7" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_7" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_7" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_7" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_7" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_7" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_7" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_8" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_8" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_8" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_8" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_8" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_8" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_8" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_8" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_8" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_8" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_8" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_8" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_8" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_8" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_9" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_9" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_9" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_9" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_9" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_9" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_9" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_9" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_9" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_9" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_9" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_9" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_9" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_9" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_10" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_10" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_10" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_10" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_10" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_10" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_10" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_10" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_10" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_10" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_10" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_10" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_10" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_10" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_11" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_11" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_11" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_11" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_11" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_11" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_11" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_11" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_11" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_11" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_11" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_11" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_11" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_11" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_12" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_12" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_12" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_12" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_12" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_12" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_12" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_12" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_12" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_12" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_12" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_12" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_12" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_12" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_13" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_13" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_13" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_13" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_13" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_13" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_13" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_13" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_13" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_13" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_13" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_13" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_13" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_13" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_14" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_14" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_14" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_14" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_14" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_14" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_14" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_14" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_14" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_14" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_14" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_14" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_14" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_14" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_15" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_15" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_15" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_15" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_15" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_15" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_15" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_15" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_15" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_15" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_15" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_15" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_15" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_15" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_16" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_16" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_16" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_16" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_16" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_16" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_16" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_16" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_16" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_16" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_16" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_16" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_16" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_16" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_17" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_17" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_17" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_17" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_17" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_17" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_17" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_17" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_17" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_17" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_17" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_17" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_17" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_17" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_18" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_18" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_18" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_18" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_18" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_18" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_18" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_18" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_18" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_18" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_18" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_18" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_18" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_18" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_19" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_19" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_19" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_19" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_19" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_19" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_19" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_19" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_19" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_19" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_19" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_19" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_19" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_19" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_20" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_20" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_20" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_20" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_20" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_20" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_20" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_20" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_20" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_20" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_20" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_20" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_20" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_20" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_21" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_21" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_21" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_21" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_21" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_21" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_21" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_21" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_21" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_21" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_21" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_21" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_21" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_21" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_22" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_22" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_22" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_22" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_22" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_22" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_22" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_22" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_22" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_22" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_22" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_22" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_22" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_22" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_23" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_23" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_23" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_23" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_23" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_23" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_23" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_23" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_23" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_23" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_23" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_23" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_23" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_23" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_24" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_24" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_24" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_24" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_24" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_24" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_24" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_24" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_24" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_24" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_24" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_24" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_24" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_24" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_25" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_25" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_25" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_25" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_25" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_25" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_25" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_25" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_25" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_25" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_25" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_25" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_25" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_25" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_26" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_26" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_26" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_26" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_26" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_26" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_26" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_26" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_26" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_26" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_26" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_26" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_26" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_26" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_27" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_27" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_27" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_27" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_27" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_27" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_27" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_27" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_27" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_27" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_27" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_27" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_27" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_27" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SEC_SPIN_28" parameterTypeRef="ILO_SPIN.START_SEC_SPIN_28" shortDescription="Spin start time, seconds">
+				<xtce:LongDescription>Spin start time, seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.START_SUBSEC_SPIN_28" parameterTypeRef="ILO_SPIN.START_SUBSEC_SPIN_28" shortDescription="Spin start time, subseconds">
+				<xtce:LongDescription>Spin start time, subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_NEG_DAC_SPIN_28" parameterTypeRef="ILO_SPIN.ESA_NEG_DAC_SPIN_28" shortDescription="Spin ESA Negative DAC">
+				<xtce:LongDescription>Spin ESA Negative DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.ESA_POS_DAC_SPIN_28" parameterTypeRef="ILO_SPIN.ESA_POS_DAC_SPIN_28" shortDescription="Spin ESA Positive DAC">
+				<xtce:LongDescription>Spin ESA Positive DAC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_STATE_SPIN_28" parameterTypeRef="ILO_SPIN.PERIOD_STATE_SPIN_28" shortDescription="Spin period validity">
+				<xtce:LongDescription>Spin period validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PHASE_STATE_SPIN_28" parameterTypeRef="ILO_SPIN.PHASE_STATE_SPIN_28" shortDescription="Spin phase validity">
+				<xtce:LongDescription>Spin phase validity</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_SPIN.PERIOD_SOURCE_SPIN_28" parameterTypeRef="ILO_SPIN.PERIOD_SOURCE_SPIN_28" shortDescription="Spin period source">
+				<xtce:LongDescription>Spin period source</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="ILO_SPIN.CHKSUM" parameterTypeRef="ILO_SPIN.CHKSUM" shortDescription="16 bit CRC checksum">
 				<xtce:LongDescription>16 bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SHCOARSE" parameterTypeRef="ILO_DIAG_CDH.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.JUMPER_REG" parameterTypeRef="ILO_DIAG_CDH.JUMPER_REG" shortDescription="CDH Control registers - Jumper">
+				<xtce:LongDescription>CDH Control registers - Jumper</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.RESET_REG" parameterTypeRef="ILO_DIAG_CDH.RESET_REG" shortDescription="CDH Control registers - Reset">
+				<xtce:LongDescription>CDH Control registers - Reset</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.WATCHDOG_REG" parameterTypeRef="ILO_DIAG_CDH.WATCHDOG_REG" shortDescription="CDH Control registers - Watchdog">
+				<xtce:LongDescription>CDH Control registers - Watchdog</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.CTRL_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.CTRL_STATUS_REG" shortDescription="CDH Control registers - Control and Status (lower two bytes)">
+				<xtce:LongDescription>CDH Control registers - Control and Status (lower two bytes)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SCRATCHPAD_1_REG" parameterTypeRef="ILO_DIAG_CDH.SCRATCHPAD_1_REG" shortDescription="CDH Scratchpad registers - 1">
+				<xtce:LongDescription>CDH Scratchpad registers - 1</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SCRATCHPAD_2_REG" parameterTypeRef="ILO_DIAG_CDH.SCRATCHPAD_2_REG" shortDescription="CDH Scratchpad registers - 2">
+				<xtce:LongDescription>CDH Scratchpad registers - 2</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.CPU_UART_CLOCK_BAUD_REG" parameterTypeRef="ILO_DIAG_CDH.CPU_UART_CLOCK_BAUD_REG" shortDescription="CDH CPU UART Clock Buad">
+				<xtce:LongDescription>CDH CPU UART Clock Buad</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.TICK_TIMER_CTRL_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.TICK_TIMER_CTRL_STATUS_REG" shortDescription="CDH Tick Timers - Tick Timers Control and Status">
+				<xtce:LongDescription>CDH Tick Timers - Tick Timers Control and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.TICK_TIMER_RELOAD_COUNT_REG" parameterTypeRef="ILO_DIAG_CDH.TICK_TIMER_RELOAD_COUNT_REG" shortDescription="CDH Tick Timers - Tick Timer n Reload Count">
+				<xtce:LongDescription>CDH Tick Timers - Tick Timer n Reload Count</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.TICK_TIMER_COUNTER_REG" parameterTypeRef="ILO_DIAG_CDH.TICK_TIMER_COUNTER_REG" shortDescription="CDH Tick Timers - Tick Timer n Counter">
+				<xtce:LongDescription>CDH Tick Timers - Tick Timer n Counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.MET_CTRL_REG" parameterTypeRef="ILO_DIAG_CDH.MET_CTRL_REG" shortDescription="CDH MET Control - MET Control">
+				<xtce:LongDescription>CDH MET Control - MET Control</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.MET_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.MET_STATUS_REG" shortDescription="CDH MET Control - MET Status">
+				<xtce:LongDescription>CDH MET Control - MET Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.MET_COARSE_COUNTER_REG" parameterTypeRef="ILO_DIAG_CDH.MET_COARSE_COUNTER_REG" shortDescription="CDH MET Control - MET Coarse Counter">
+				<xtce:LongDescription>CDH MET Control - MET Coarse Counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.MET_FINE_COUNTER_REG" parameterTypeRef="ILO_DIAG_CDH.MET_FINE_COUNTER_REG" shortDescription="CDH MET Control - MET Fine Counter">
+				<xtce:LongDescription>CDH MET Control - MET Fine Counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_0" parameterTypeRef="ILO_DIAG_CDH.PAD_0" />
+			<xtce:Parameter name="ILO_DIAG_CDH.MDM25P_14_T" parameterTypeRef="ILO_DIAG_CDH.MDM25P_14_T" shortDescription="MDM25P_14_T">
+				<xtce:LongDescription>MDM25P_14_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_1" parameterTypeRef="ILO_DIAG_CDH.PAD_1" />
+			<xtce:Parameter name="ILO_DIAG_CDH.TOF_TEMP" parameterTypeRef="ILO_DIAG_CDH.TOF_TEMP" shortDescription="TOF_TEMP">
+				<xtce:LongDescription>TOF_TEMP</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_2" parameterTypeRef="ILO_DIAG_CDH.PAD_2" />
+			<xtce:Parameter name="ILO_DIAG_CDH.MDM25P_16_T" parameterTypeRef="ILO_DIAG_CDH.MDM25P_16_T" shortDescription="MDM25P_16_T">
+				<xtce:LongDescription>MDM25P_16_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_3" parameterTypeRef="ILO_DIAG_CDH.PAD_3" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LO_T" parameterTypeRef="ILO_DIAG_CDH.LO_T" shortDescription="LO_T">
+				<xtce:LongDescription>LO_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_4" parameterTypeRef="ILO_DIAG_CDH.PAD_4" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_12V_T" parameterTypeRef="ILO_DIAG_CDH.LVPS_12V_T" shortDescription="LVPS_12V_T">
+				<xtce:LongDescription>LVPS_12V_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_5" parameterTypeRef="ILO_DIAG_CDH.PAD_5" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_5V_T" parameterTypeRef="ILO_DIAG_CDH.LVPS_5V_T" shortDescription="LVPS_5V_T">
+				<xtce:LongDescription>LVPS_5V_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_6" parameterTypeRef="ILO_DIAG_CDH.PAD_6" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_3P3V_T" parameterTypeRef="ILO_DIAG_CDH.LVPS_3P3V_T" shortDescription="LVPS_3P3V_T">
+				<xtce:LongDescription>LVPS_3P3V_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_7" parameterTypeRef="ILO_DIAG_CDH.PAD_7" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_3P3V" parameterTypeRef="ILO_DIAG_CDH.LVPS_3P3V" shortDescription="LVPS_3P3V">
+				<xtce:LongDescription>LVPS_3P3V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_8" parameterTypeRef="ILO_DIAG_CDH.PAD_8" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_5V" parameterTypeRef="ILO_DIAG_CDH.LVPS_5V" shortDescription="LVPS_5V">
+				<xtce:LongDescription>LVPS_5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_9" parameterTypeRef="ILO_DIAG_CDH.PAD_9" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_N5V" parameterTypeRef="ILO_DIAG_CDH.LVPS_N5V" shortDescription="LVPS_N5V">
+				<xtce:LongDescription>LVPS_N5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_10" parameterTypeRef="ILO_DIAG_CDH.PAD_10" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_12V" parameterTypeRef="ILO_DIAG_CDH.LVPS_12V" shortDescription="LVPS_12V">
+				<xtce:LongDescription>LVPS_12V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_11" parameterTypeRef="ILO_DIAG_CDH.PAD_11" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_N12V" parameterTypeRef="ILO_DIAG_CDH.LVPS_N12V" shortDescription="LVPS_N12V">
+				<xtce:LongDescription>LVPS_N12V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_12" parameterTypeRef="ILO_DIAG_CDH.PAD_12" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_3P3V_I" parameterTypeRef="ILO_DIAG_CDH.LVPS_3P3V_I" shortDescription="LVPS_3P3V_I">
+				<xtce:LongDescription>LVPS_3P3V_I</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_13" parameterTypeRef="ILO_DIAG_CDH.PAD_13" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_5V_I" parameterTypeRef="ILO_DIAG_CDH.LVPS_5V_I" shortDescription="LVPS_5V_I">
+				<xtce:LongDescription>LVPS_5V_I</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_14" parameterTypeRef="ILO_DIAG_CDH.PAD_14" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_N5V_I" parameterTypeRef="ILO_DIAG_CDH.LVPS_N5V_I" shortDescription="LVPS_N5V_I">
+				<xtce:LongDescription>LVPS_N5V_I</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_15" parameterTypeRef="ILO_DIAG_CDH.PAD_15" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_12V_I" parameterTypeRef="ILO_DIAG_CDH.LVPS_12V_I" shortDescription="LVPS_12V_I">
+				<xtce:LongDescription>LVPS_12V_I</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_16" parameterTypeRef="ILO_DIAG_CDH.PAD_16" />
+			<xtce:Parameter name="ILO_DIAG_CDH.LVPS_N12V_I" parameterTypeRef="ILO_DIAG_CDH.LVPS_N12V_I" shortDescription="LVPS_N12V_I">
+				<xtce:LongDescription>LVPS_N12V_I</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_17" parameterTypeRef="ILO_DIAG_CDH.PAD_17" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_1P5V" parameterTypeRef="ILO_DIAG_CDH.CDH_1P5V" shortDescription="CDH_1P5V">
+				<xtce:LongDescription>CDH_1P5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_18" parameterTypeRef="ILO_DIAG_CDH.PAD_18" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_1P8V" parameterTypeRef="ILO_DIAG_CDH.CDH_1P8V" shortDescription="CDH_1P8V">
+				<xtce:LongDescription>CDH_1P8V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_19" parameterTypeRef="ILO_DIAG_CDH.PAD_19" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_3P3V" parameterTypeRef="ILO_DIAG_CDH.CDH_3P3V" shortDescription="CDH_3P3V">
+				<xtce:LongDescription>CDH_3P3V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_20" parameterTypeRef="ILO_DIAG_CDH.PAD_20" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_12V" parameterTypeRef="ILO_DIAG_CDH.CDH_12V" shortDescription="CDH_12V">
+				<xtce:LongDescription>CDH_12V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_21" parameterTypeRef="ILO_DIAG_CDH.PAD_21" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_N12V" parameterTypeRef="ILO_DIAG_CDH.CDH_N12V" shortDescription="CDH_N12V">
+				<xtce:LongDescription>CDH_N12V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_22" parameterTypeRef="ILO_DIAG_CDH.PAD_22" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_5V" parameterTypeRef="ILO_DIAG_CDH.CDH_5V" shortDescription="CDH_5V">
+				<xtce:LongDescription>CDH_5V</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_23" parameterTypeRef="ILO_DIAG_CDH.PAD_23" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_5V_ADC" parameterTypeRef="ILO_DIAG_CDH.CDH_5V_ADC" shortDescription="CDH_5V_ADC">
+				<xtce:LongDescription>CDH_5V_ADC</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_24" parameterTypeRef="ILO_DIAG_CDH.PAD_24" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_PROCESSOR_T" parameterTypeRef="ILO_DIAG_CDH.CDH_PROCESSOR_T" shortDescription="CDH_PROCESSOR_T">
+				<xtce:LongDescription>CDH_PROCESSOR_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_25" parameterTypeRef="ILO_DIAG_CDH.PAD_25" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_1P8V_LDO_T" parameterTypeRef="ILO_DIAG_CDH.CDH_1P8V_LDO_T" shortDescription="CDH_1P8V_LDO_T">
+				<xtce:LongDescription>CDH_1P8V_LDO_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_26" parameterTypeRef="ILO_DIAG_CDH.PAD_26" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_1P5V_LDO_T" parameterTypeRef="ILO_DIAG_CDH.CDH_1P5V_LDO_T" shortDescription="CDH_1P5V_LDO_T">
+				<xtce:LongDescription>CDH_1P5V_LDO_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PAD_27" parameterTypeRef="ILO_DIAG_CDH.PAD_27" />
+			<xtce:Parameter name="ILO_DIAG_CDH.CDH_SDRAM_T" parameterTypeRef="ILO_DIAG_CDH.CDH_SDRAM_T" shortDescription="CDH_SDRAM_T">
+				<xtce:LongDescription>CDH_SDRAM_T</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.ADC_CTRL_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.ADC_CTRL_STATUS_REG" shortDescription="CDH ADC Control and Status">
+				<xtce:LongDescription>CDH ADC Control and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SC_CMD_FIFO_CTRL_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.SC_CMD_FIFO_CTRL_STATUS_REG" shortDescription="CDH Spacecraft Data Interface - Spacecraft Command FIFO Control and Status">
+				<xtce:LongDescription>CDH Spacecraft Data Interface - Spacecraft Command FIFO Control and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SC_TLM_FIFO_CTRL_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.SC_TLM_FIFO_CTRL_STATUS_REG" shortDescription="CDH Spacecraft Data Interface - Spacecraft Telemetry FIFO Control and Status">
+				<xtce:LongDescription>CDH Spacecraft Data Interface - Spacecraft Telemetry FIFO Control and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.INTERRUPT_LEVEL_REG" parameterTypeRef="ILO_DIAG_CDH.INTERRUPT_LEVEL_REG" shortDescription="CDH Interrupts - Interrupt Level">
+				<xtce:LongDescription>CDH Interrupts - Interrupt Level</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.INTERRUPT_PENDING_REG" parameterTypeRef="ILO_DIAG_CDH.INTERRUPT_PENDING_REG" shortDescription="CDH Interrupts - Interrupt Pending">
+				<xtce:LongDescription>CDH Interrupts - Interrupt Pending</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.INTERRUPT_ENABLE_REG" parameterTypeRef="ILO_DIAG_CDH.INTERRUPT_ENABLE_REG" shortDescription="CDH Interrupts - Interrupt Enable">
+				<xtce:LongDescription>CDH Interrupts - Interrupt Enable</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_ENABLE_AND_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_ENABLE_AND_STATUS_REG" shortDescription="CDH Spin - Spin Enable and Status">
+				<xtce:LongDescription>CDH Spin - Spin Enable and Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_BIN_PERIOD_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_BIN_PERIOD_REG" shortDescription="CDH Spin - Spin Bin Period">
+				<xtce:LongDescription>CDH Spin - Spin Bin Period</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_BIN_INDEX_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_BIN_INDEX_REG" shortDescription="CDH Spin - Spin Bin Index">
+				<xtce:LongDescription>CDH Spin - Spin Bin Index</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_PERIOD_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_PERIOD_REG" shortDescription="CDH Spin - Spin Period">
+				<xtce:LongDescription>CDH Spin - Spin Period</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_PERIOD_TIMER_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_PERIOD_TIMER_REG" shortDescription="CDH Spin - Spin Period Timer">
+				<xtce:LongDescription>CDH Spin - Spin Period Timer</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_PERIOD_TIMER_AT_NXT_PPS_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_PERIOD_TIMER_AT_NXT_PPS_REG" shortDescription="CDH Spin - Spin Period Timer at Next 1PPS">
+				<xtce:LongDescription>CDH Spin - Spin Period Timer at Next 1PPS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_TIME_STAMP_SECONDS_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_TIME_STAMP_SECONDS_REG" shortDescription="CDH Spin - Spin Time Stamp Seconds">
+				<xtce:LongDescription>CDH Spin - Spin Time Stamp Seconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_TIME_STAMP_SUBSECONDS_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_TIME_STAMP_SUBSECONDS_REG" shortDescription="CDH Spin - Spin Time Stamp Subseconds">
+				<xtce:LongDescription>CDH Spin - Spin Time Stamp Subseconds</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.LOOPBACK_CTRL_REG" parameterTypeRef="ILO_DIAG_CDH.LOOPBACK_CTRL_REG" shortDescription="CDH External Loopback - Loopback Control">
+				<xtce:LongDescription>CDH External Loopback - Loopback Control</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.LOOPBACK_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.LOOPBACK_STATUS_REG" shortDescription="CDH External Loopback - Loopback Status">
+				<xtce:LongDescription>CDH External Loopback - Loopback Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.LOOPBACK_TX_REG" parameterTypeRef="ILO_DIAG_CDH.LOOPBACK_TX_REG" shortDescription="CDH External Loopback - Loopback Transmit">
+				<xtce:LongDescription>CDH External Loopback - Loopback Transmit</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.LOOPBACK_RX_REG" parameterTypeRef="ILO_DIAG_CDH.LOOPBACK_RX_REG" shortDescription="CDH External Loopback - Loopback Receive">
+				<xtce:LongDescription>CDH External Loopback - Loopback Receive</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.DISCRETE_IO_REG" parameterTypeRef="ILO_DIAG_CDH.DISCRETE_IO_REG" shortDescription="CDH Discrete IO">
+				<xtce:LongDescription>CDH Discrete IO</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.HEATER_CTRL_REG" parameterTypeRef="ILO_DIAG_CDH.HEATER_CTRL_REG" shortDescription="CDH Heater Control - Heater Control">
+				<xtce:LongDescription>CDH Heater Control - Heater Control</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.HEATER_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.HEATER_STATUS_REG" shortDescription="CDH Heater Control - Heater Status">
+				<xtce:LongDescription>CDH Heater Control - Heater Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.INSTR_PWR_CTRL_REG" parameterTypeRef="ILO_DIAG_CDH.INSTR_PWR_CTRL_REG" shortDescription="CDH Instrument Power Control - Instrument Power Control">
+				<xtce:LongDescription>CDH Instrument Power Control - Instrument Power Control</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.INSTR_PWR_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.INSTR_PWR_STATUS_REG" shortDescription="CDH Instrument Power Control - Instrument Power Status">
+				<xtce:LongDescription>CDH Instrument Power Control - Instrument Power Status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.IFB_INTERFACE_CTRL_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.IFB_INTERFACE_CTRL_STATUS_REG" shortDescription="ILO_DIAG_CDH.IFB_INTERFACE_CTRL_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.IFB_INTERFACE_CTRL_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.IFB_INTERFACE_CMD_REG" parameterTypeRef="ILO_DIAG_CDH.IFB_INTERFACE_CMD_REG" shortDescription="ILO_DIAG_CDH.IFB_INTERFACE_CMD_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.IFB_INTERFACE_CMD_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.IFB_ADC_TLM_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.IFB_ADC_TLM_STATUS_REG" shortDescription="ILO_DIAG_CDH.IFB_ADC_TLM_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.IFB_ADC_TLM_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.IFB_REG_TLM_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.IFB_REG_TLM_STATUS_REG" shortDescription="ILO_DIAG_CDH.IFB_REG_TLM_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.IFB_REG_TLM_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.TOF_INTERFACE_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.TOF_INTERFACE_STATUS_REG" shortDescription="ILO_DIAG_CDH.TOF_INTERFACE_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.TOF_INTERFACE_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.DE_TIME_TAG_RESOLUTION_REG" parameterTypeRef="ILO_DIAG_CDH.DE_TIME_TAG_RESOLUTION_REG" shortDescription="ILO_DIAG_CDH.DE_TIME_TAG_RESOLUTION_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.DE_TIME_TAG_RESOLUTION_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.DE_TIME_TAG_CTRL_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.DE_TIME_TAG_CTRL_STATUS_REG" shortDescription="ILO_DIAG_CDH.DE_TIME_TAG_CTRL_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.DE_TIME_TAG_CTRL_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.DE_FIFO_CTRL_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.DE_FIFO_CTRL_STATUS_REG" shortDescription="ILO_DIAG_CDH.DE_FIFO_CTRL_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.DE_FIFO_CTRL_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.FEE_RESET_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.FEE_RESET_STATUS_REG" shortDescription="ILO_DIAG_CDH.FEE_RESET_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.FEE_RESET_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.FEE_RESET_CMD_REG" parameterTypeRef="ILO_DIAG_CDH.FEE_RESET_CMD_REG" shortDescription="ILO_DIAG_CDH.FEE_RESET_CMD_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.FEE_RESET_CMD_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.FEE_RESET_DURATION_REG" parameterTypeRef="ILO_DIAG_CDH.FEE_RESET_DURATION_REG" shortDescription="ILO_DIAG_CDH.FEE_RESET_DURATION_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.FEE_RESET_DURATION_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.SPIN_PULSE_DURATION_REG" parameterTypeRef="ILO_DIAG_CDH.SPIN_PULSE_DURATION_REG" shortDescription="ILO_DIAG_CDH.SPIN_PULSE_DURATION_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.SPIN_PULSE_DURATION_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.HVPS_CTRL_REG" parameterTypeRef="ILO_DIAG_CDH.HVPS_CTRL_REG" shortDescription="ILO_DIAG_CDH.HVPS_CTRL_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.HVPS_CTRL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.HVPS_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.HVPS_STATUS_REG" shortDescription="ILO_DIAG_CDH.HVPS_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.HVPS_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.HVPS_CMD_REG" parameterTypeRef="ILO_DIAG_CDH.HVPS_CMD_REG" shortDescription="ILO_DIAG_CDH.HVPS_CMD_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.HVPS_CMD_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PIVOT_INTERFACE_CTRL_REG" parameterTypeRef="ILO_DIAG_CDH.PIVOT_INTERFACE_CTRL_REG" shortDescription="ILO_DIAG_CDH.PIVOT_INTERFACE_CTRL_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.PIVOT_INTERFACE_CTRL_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PIVOT_INTERFACE_STATUS_REG" parameterTypeRef="ILO_DIAG_CDH.PIVOT_INTERFACE_STATUS_REG" shortDescription="ILO_DIAG_CDH.PIVOT_INTERFACE_STATUS_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.PIVOT_INTERFACE_STATUS_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PIVOT_CMD_DATA_REG" parameterTypeRef="ILO_DIAG_CDH.PIVOT_CMD_DATA_REG" shortDescription="ILO_DIAG_CDH.PIVOT_CMD_DATA_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.PIVOT_CMD_DATA_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.PIVOT_CMD_OPCODE_REG" parameterTypeRef="ILO_DIAG_CDH.PIVOT_CMD_OPCODE_REG" shortDescription="ILO_DIAG_CDH.PIVOT_CMD_OPCODE_REG">
+				<xtce:LongDescription>ILO_DIAG_CDH.PIVOT_CMD_OPCODE_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_CDH.CHKSUM" parameterTypeRef="ILO_DIAG_CDH.CHKSUM" shortDescription="16-bit CRC checksum">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.SHCOARSE" parameterTypeRef="ILO_DIAG_IFB.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.IF_CONTROL_SPARE1" parameterTypeRef="ILO_DIAG_IFB.IF_CONTROL_SPARE1" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.IF_CONTROL_CMD_ERR" parameterTypeRef="ILO_DIAG_IFB.IF_CONTROL_CMD_ERR" shortDescription="IFB Command register write error">
+				<xtce:LongDescription>A set bit indicates that an attempt was made to write to the IFB Command register when the
+interface was not ready to accept new commands. The bit is cleared by a write of ‘1’ to the bit
+location. An attempted write may compromise previously written command.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.IF_CONTROL_SPARE2" parameterTypeRef="ILO_DIAG_IFB.IF_CONTROL_SPARE2" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.IF_CONTROL_EN" parameterTypeRef="ILO_DIAG_IFB.IF_CONTROL_EN" shortDescription="ILO Interface is enabled">
+				<xtce:LongDescription>A set bit indicates that the LO Interface is enabled. A clear bit puts the interface in the reset
+state and could be used as a soft reset for the interface logic.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.REG_IF_SPARE1" parameterTypeRef="ILO_DIAG_IFB.REG_IF_SPARE1" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.REG_IF_PKT_RCVD" parameterTypeRef="ILO_DIAG_IFB.REG_IF_PKT_RCVD" shortDescription="IFB register data interface status packet received">
+				<xtce:LongDescription>IFB register data interface status packet received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.REG_IF_SPARE2" parameterTypeRef="ILO_DIAG_IFB.REG_IF_SPARE2" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.REG_IF_TO_ERR" parameterTypeRef="ILO_DIAG_IFB.REG_IF_TO_ERR" shortDescription="IFB register data interface status time out error">
+				<xtce:LongDescription>IFB register data interface status time out error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.REG_IF_ID_ERR" parameterTypeRef="ILO_DIAG_IFB.REG_IF_ID_ERR" shortDescription="IFB register data interface status ID error">
+				<xtce:LongDescription>IFB register data interface status ID error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.REG_IF_FRM_ERR" parameterTypeRef="ILO_DIAG_IFB.REG_IF_FRM_ERR" shortDescription="IFB register data interface status framing error">
+				<xtce:LongDescription>IFB register data interface status framing error</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE1" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE1" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_UN" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_UN" shortDescription="Star sensor FIFOunderflow flag">
+				<xtce:LongDescription>Star sensor FIFOunderflow flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_OV" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_OV" shortDescription="Star sensor FIFO overflow flag">
+				<xtce:LongDescription>Star sensor FIFO overflow flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_FF" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_FF" shortDescription="Star sensor FIFO full flag">
+				<xtce:LongDescription>Star sensor FIFO full flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_HF" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_HF" shortDescription="Star sensor FIFO half-full flag">
+				<xtce:LongDescription>Star sensor FIFO half-full flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_SS_FE" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_FE" shortDescription="Star sensor FIFO emplty flag">
+				<xtce:LongDescription>Star sensor FIFO emplty flag</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE2" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE2" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_PKT_RCVD" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_PKT_RCVD" shortDescription="Valid packet received">
+				<xtce:LongDescription>Valid packet received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE3" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE3" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_TO_ERR" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_TO_ERR" shortDescription="Entire packet has not been received within a 1 ms window">
+				<xtce:LongDescription>Entire packet has not been received within a 1 ms window</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_ID_ERR" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_ID_ERR" shortDescription="Packet with an incorrect ID has been received">
+				<xtce:LongDescription>Packet with an incorrect ID has been received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_IF_STATUS_FRM_ERR" parameterTypeRef="ILO_DIAG_IFB.ADC_IF_STATUS_FRM_ERR" shortDescription="Framing error detected">
+				<xtce:LongDescription>Framing error detected</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.FPGA_VERSION" parameterTypeRef="ILO_DIAG_IFB.FPGA_VERSION" shortDescription="FPGA version (hard-coded constant)">
+				<xtce:LongDescription>FPGA version (hard-coded constant)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.SPARE1" parameterTypeRef="ILO_DIAG_IFB.SPARE1" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.HV_PLUG_STATE" parameterTypeRef="ILO_DIAG_IFB.HV_PLUG_STATE" shortDescription="Status of HV plug">
+				<xtce:LongDescription>Status of HV plug</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.BOARD_ID" parameterTypeRef="ILO_DIAG_IFB.BOARD_ID" shortDescription="Status of IFB jumper field">
+				<xtce:LongDescription>Status of IFB jumper field</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.CMD_COUNT" parameterTypeRef="ILO_DIAG_IFB.CMD_COUNT" shortDescription="Roll over counter of every command received">
+				<xtce:LongDescription>Roll over counter of every command received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.SPARE2" parameterTypeRef="ILO_DIAG_IFB.SPARE2" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_AUX_MUX" parameterTypeRef="ILO_DIAG_IFB.ADC_AUX_MUX" shortDescription="Selects the auxiliary ADC internal 8-channel mux input">
+				<xtce:LongDescription>Selects the auxiliary ADC internal 8-channel mux input</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.ADC_CLK_DIS" parameterTypeRef="ILO_DIAG_IFB.ADC_CLK_DIS" shortDescription="1' to deassert adc_sclk and adc_cs_n signals. '0' for normal ADC operation">
+				<xtce:LongDescription>'1' to deassert adc_sclk and adc_cs_n signals. '0' for normal ADC operation.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.OSCOPE_EN" parameterTypeRef="ILO_DIAG_IFB.OSCOPE_EN" shortDescription="'1' to select oscope mode. '0' for normal operation.">
+				<xtce:LongDescription>'1' to select oscope mode. '0' for normal operation.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.STAR_SYNC" parameterTypeRef="ILO_DIAG_IFB.STAR_SYNC" shortDescription="Spin_pulse synchronization from ICE">
+				<xtce:LongDescription>1' to synchronize IFB ADC Telemetry to spin_pulse from ICE. '0' to ignore state of spin_pulse.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.IFB_DATA_EN" parameterTypeRef="ILO_DIAG_IFB.IFB_DATA_EN" shortDescription="IFB ADC and REG Telemetry to ICE enable">
+				<xtce:LongDescription>'1' to enable IFB ADC and REG Telemetry to ICE. '0' to disable IFB ADC and REG Telemetry to ICE.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.IFB_DATA_INTERVAL" parameterTypeRef="ILO_DIAG_IFB.IFB_DATA_INTERVAL" shortDescription="Sets the IFB ADC telemetry primary cadence interval">
+				<xtce:LongDescription>Sets the IFB ADC telemetry primary cadence interval</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.SYNC_CLK_MSB" parameterTypeRef="ILO_DIAG_IFB.SYNC_CLK_MSB" shortDescription="11' to disable TOF HVPS sync clock">
+				<xtce:LongDescription>11' to disable TOF HVPS sync clock</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAC_EN_MSB" parameterTypeRef="ILO_DIAG_IFB.PAC_EN_MSB" shortDescription="11' to enable PAC HV Supply">
+				<xtce:LongDescription>11' to enable PAC HV Supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.MCP_EN_MSB" parameterTypeRef="ILO_DIAG_IFB.MCP_EN_MSB" shortDescription="11' to enable MCP HV Supply">
+				<xtce:LongDescription>11' to enable MCP HV Supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.LV_EN_MSB" parameterTypeRef="ILO_DIAG_IFB.LV_EN_MSB" shortDescription="11' to enable TOF Board LV Supply">
+				<xtce:LongDescription>11' to enable TOF Board LV Supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.SYNC_CLK_LSB" parameterTypeRef="ILO_DIAG_IFB.SYNC_CLK_LSB" shortDescription="11' to disable TOF HVPS sync clock">
+				<xtce:LongDescription>11' to disable TOF HVPS sync clock</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAC_EN_LSB" parameterTypeRef="ILO_DIAG_IFB.PAC_EN_LSB" shortDescription="11' to enable PAC HV Supply">
+				<xtce:LongDescription>11' to enable PAC HV Supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.MCP_EN_LSB" parameterTypeRef="ILO_DIAG_IFB.MCP_EN_LSB" shortDescription="11' to enable MCP HV Supply">
+				<xtce:LongDescription>11' to enable MCP HV Supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.LV_EN_LSB" parameterTypeRef="ILO_DIAG_IFB.LV_EN_LSB" shortDescription="11' to enable TOF Board LV Supply">
+				<xtce:LongDescription>11' to enable TOF Board LV Supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAC_VSET" parameterTypeRef="ILO_DIAG_IFB.PAC_VSET" shortDescription="Enables 5V reference to PAC HV supply">
+				<xtce:LongDescription>Enables 5V reference to PAC HV supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAC_OCP" parameterTypeRef="ILO_DIAG_IFB.PAC_OCP" shortDescription="Enables 5V reference to PAC HV supply">
+				<xtce:LongDescription>Enables 5V reference to PAC HV supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.MCP_VSET" parameterTypeRef="ILO_DIAG_IFB.MCP_VSET" shortDescription="Enables 5V reference to MCP HV supply">
+				<xtce:LongDescription>Enables 5V reference to MCP HV supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.MCP_OCP" parameterTypeRef="ILO_DIAG_IFB.MCP_OCP" shortDescription="Enables 5V reference to MCP HV supply">
+				<xtce:LongDescription>Enables 5V reference to MCP HV supply</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.STAR_OFFSET_ADJUST" parameterTypeRef="ILO_DIAG_IFB.STAR_OFFSET_ADJUST" shortDescription="Star sensor offset adjust">
+				<xtce:LongDescription>Star sensor offset adjust</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.OSCOPE_CHANNEL_1" parameterTypeRef="ILO_DIAG_IFB.OSCOPE_CHANNEL_1" shortDescription="Oscope channel 1 ADC channel select">
+				<xtce:LongDescription>Oscope channel 1 ADC channel select</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.OSCOPE_CHANNEL_0" parameterTypeRef="ILO_DIAG_IFB.OSCOPE_CHANNEL_0" shortDescription="Oscope channel 0 ADC channel select">
+				<xtce:LongDescription>Oscope channel 0 ADC channel select</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_0" parameterTypeRef="ILO_DIAG_IFB.PAD_0" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.STAR_BRIGHT" parameterTypeRef="ILO_DIAG_IFB.STAR_BRIGHT" />
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_1" parameterTypeRef="ILO_DIAG_IFB.PAD_1" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.IFB_TEMP1" parameterTypeRef="ILO_DIAG_IFB.IFB_TEMP1" shortDescription="IFB temperature (hot spot between FPGA and 2.5V regulator)">
+				<xtce:LongDescription>IFB temperature (hot spot between FPGA and 2.5V regulator)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_2" parameterTypeRef="ILO_DIAG_IFB.PAD_2" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.IFB_TEMP0" parameterTypeRef="ILO_DIAG_IFB.IFB_TEMP0" shortDescription="IFB temperature (cold spot at board corner between J1 and J2)">
+				<xtce:LongDescription>IFB temperature (cold spot at board corner between J1 and J2)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_3" parameterTypeRef="ILO_DIAG_IFB.PAD_3" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.IFB_V5P0_VM" parameterTypeRef="ILO_DIAG_IFB.IFB_V5P0_VM" shortDescription="IFB +5V voltage monitor">
+				<xtce:LongDescription>IFB +5V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_4" parameterTypeRef="ILO_DIAG_IFB.PAD_4" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.IFB_V3P3_VM" parameterTypeRef="ILO_DIAG_IFB.IFB_V3P3_VM" shortDescription="IFB +3.3V voltage monitor">
+				<xtce:LongDescription>IFB +3.3V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_5" parameterTypeRef="ILO_DIAG_IFB.PAD_5" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.IFB_V12P0_VM" parameterTypeRef="ILO_DIAG_IFB.IFB_V12P0_VM" shortDescription="IFB +12V voltage monitor">
+				<xtce:LongDescription>IFB +12V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_6" parameterTypeRef="ILO_DIAG_IFB.PAD_6" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.IFB_V12N0_VM" parameterTypeRef="ILO_DIAG_IFB.IFB_V12N0_VM" shortDescription="IFB -12V voltage monitor">
+				<xtce:LongDescription>IFB -12V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_7" parameterTypeRef="ILO_DIAG_IFB.PAD_7" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.LV_CM" parameterTypeRef="ILO_DIAG_IFB.LV_CM" shortDescription="LV supply primary side current">
+				<xtce:LongDescription>LV supply primary side current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_8" parameterTypeRef="ILO_DIAG_IFB.PAD_8" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.LV_VM" parameterTypeRef="ILO_DIAG_IFB.LV_VM" shortDescription="LV supply primary side voltage">
+				<xtce:LongDescription>LV supply primary side voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_9" parameterTypeRef="ILO_DIAG_IFB.PAD_9" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.LV_TEMP" parameterTypeRef="ILO_DIAG_IFB.LV_TEMP" shortDescription="LV temperature">
+				<xtce:LongDescription>LV temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_10" parameterTypeRef="ILO_DIAG_IFB.PAD_10" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.MCP_CM" parameterTypeRef="ILO_DIAG_IFB.MCP_CM" shortDescription="MCP primary side current">
+				<xtce:LongDescription>MCP primary side current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_11" parameterTypeRef="ILO_DIAG_IFB.PAD_11" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.MCP_VM" parameterTypeRef="ILO_DIAG_IFB.MCP_VM" shortDescription="MCP primary side voltage">
+				<xtce:LongDescription>MCP primary side voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_12" parameterTypeRef="ILO_DIAG_IFB.PAD_12" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.MCP_TEMP" parameterTypeRef="ILO_DIAG_IFB.MCP_TEMP" shortDescription="MCP temperature">
+				<xtce:LongDescription>MCP temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_13" parameterTypeRef="ILO_DIAG_IFB.PAD_13" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.PAC_CM" parameterTypeRef="ILO_DIAG_IFB.PAC_CM" shortDescription="PAC primary side current">
+				<xtce:LongDescription>PAC primary side current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_14" parameterTypeRef="ILO_DIAG_IFB.PAD_14" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.PAC_VM" parameterTypeRef="ILO_DIAG_IFB.PAC_VM" shortDescription="PAC primary side voltage">
+				<xtce:LongDescription>PAC primary side voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.PAD_15" parameterTypeRef="ILO_DIAG_IFB.PAD_15" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_IFB.PAC_TEMP" parameterTypeRef="ILO_DIAG_IFB.PAC_TEMP" shortDescription="PAC temperature">
+				<xtce:LongDescription>PAC temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.SPARE" parameterTypeRef="ILO_DIAG_IFB.SPARE" shortDescription="spare">
+				<xtce:LongDescription>spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_IFB.CHKSUM" parameterTypeRef="ILO_DIAG_IFB.CHKSUM" shortDescription="packet checksum">
+				<xtce:LongDescription>packet checksum</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.SHCOARSE" parameterTypeRef="ILO_DIAG_TOF_BD.SHCOARSE" shortDescription="CCSDS Secondary Header MET" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_SPARE1" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_SPARE1" shortDescription="Spare">
+				<xtce:LongDescription>Spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_PKT_RCVD" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_PKT_RCVD" shortDescription="A set bit indicates that a packet has been received over the TOF interface">
+				<xtce:LongDescription>A set bit indicates that a packet has been received over the TOF interface</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_ADC_PKT" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_ADC_PKT" shortDescription="A set bit indicates that a valid TOF ADC data packet has been received">
+				<xtce:LongDescription>A set bit indicates that a valid TOF packet containing ADC data has been received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_REG_PKT" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_REG_PKT" shortDescription="A set bit indicates that a valid TOF register packet has been received">
+				<xtce:LongDescription>A set bit indicates that a valid TOF register packet has been received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_CNT_PKT" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_CNT_PKT" shortDescription="A set bit indicates that a valid TOF rate count packet has been received">
+				<xtce:LongDescription>A set bit indicates that a valid TOF rate count packet has been received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_DE_PKT" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_DE_PKT" shortDescription="A set bit indicates that a valid TOF direct event packet has been received">
+				<xtce:LongDescription>A set bit indicates that a valid TOF direct event packet has been received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_SPARE2" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_SPARE2" shortDescription="Spare">
+				<xtce:LongDescription>Spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_TO_ERR" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_TO_ERR" shortDescription="A set bit indicates that a packet has not been received within a 1 ms window">
+				<xtce:LongDescription>A set bit indicates that entire packet has not been received within a 1 ms window</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_ID_ERR" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_ID_ERR" shortDescription="A set bit indicates that a packet with an incorrect ID has been received">
+				<xtce:LongDescription>A set bit indicates that a packet with an incorrect ID has been received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.IF_STATUS_FRM_ERR" parameterTypeRef="ILO_DIAG_TOF_BD.IF_STATUS_FRM_ERR" shortDescription="A set bit indicates that a framing error has been detected">
+				<xtce:LongDescription>Sets anonde threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.CMD_ERROR" parameterTypeRef="ILO_DIAG_TOF_BD.CMD_ERROR" shortDescription="A TOF Board command error counter">
+				<xtce:LongDescription>A TOF Board 6-bit cmd_error counter resides in the TOF Board FPGA and is incremented with the
+occurrence of a greater than 1ms timeout between a potential address/data pair. The counter rolls-over
+and is only reset at power up. The counter resides in the tof_id 0x80 TOF Board Telemetry packet.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.CFD_VM" parameterTypeRef="ILO_DIAG_TOF_BD.CFD_VM" shortDescription="TOF Board Constant Fraction Discriminator monitor">
+				<xtce:LongDescription>TOF Board Constant Fraction Discriminator monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_0" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_0" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PRE_TM" parameterTypeRef="ILO_DIAG_TOF_BD.PRE_TM" shortDescription="TOF Board preamp temperature">
+				<xtce:LongDescription>TOF Board preamp temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_1" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_1" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.REG_TM" parameterTypeRef="ILO_DIAG_TOF_BD.REG_TM" shortDescription="TOF Board regulator temperature">
+				<xtce:LongDescription>TOF Board regulator temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_2" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_2" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.MCP_CM" parameterTypeRef="ILO_DIAG_TOF_BD.MCP_CM" shortDescription="TOF Board monitor of MCP Current">
+				<xtce:LongDescription>TOF Board monitor of MCP Current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_3" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_3" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.MCP_VM" parameterTypeRef="ILO_DIAG_TOF_BD.MCP_VM" shortDescription="TOF Board monitor of MCP Voltage">
+				<xtce:LongDescription>TOF Board monitor of MCP Voltage</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_4" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_4" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.CM" parameterTypeRef="ILO_DIAG_TOF_BD.CM" shortDescription="TOF Board current monitor">
+				<xtce:LongDescription>TOF Board current monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_5" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_5" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.P5_VM" parameterTypeRef="ILO_DIAG_TOF_BD.P5_VM" shortDescription="TOF Board +5V voltage monitor">
+				<xtce:LongDescription>TOF Board +5V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_6" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_6" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.P6_VM" parameterTypeRef="ILO_DIAG_TOF_BD.P6_VM" shortDescription="TOF Board +6V voltage monitor">
+				<xtce:LongDescription>TOF Board +6V voltage monitor</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_7" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_7" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.AN_A_THR" parameterTypeRef="ILO_DIAG_TOF_BD.AN_A_THR" shortDescription="Sets anode A threshold">
+				<xtce:LongDescription>Sets anonde threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_8" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_8" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.AN_B0_THR" parameterTypeRef="ILO_DIAG_TOF_BD.AN_B0_THR" shortDescription="Sets anode B0 threshold">
+				<xtce:LongDescription>Sets anonde threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_9" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_9" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.AN_B3_THR" parameterTypeRef="ILO_DIAG_TOF_BD.AN_B3_THR" shortDescription="Sets anode B3 threshold">
+				<xtce:LongDescription>Sets anonde threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.PAD_10" parameterTypeRef="ILO_DIAG_TOF_BD.PAD_10" />
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.AN_C_THR" parameterTypeRef="ILO_DIAG_TOF_BD.AN_C_THR" shortDescription="Sets anode C threshold">
+				<xtce:LongDescription>Sets anonde threshold</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF_BD_TLM_EN" parameterTypeRef="ILO_DIAG_TOF_BD.TOF_BD_TLM_EN" shortDescription="1 enables TOF Board Telemetry to ICE. 0 disables all TOF Board Telemetry to ICE">
+				<xtce:LongDescription>1' to enable TOF Board Telemetry to ICE. '0' to disable all TOF Board Telemetry to ICE.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.DIRECT_EVENT_TLM_EN" parameterTypeRef="ILO_DIAG_TOF_BD.DIRECT_EVENT_TLM_EN" shortDescription="1 enables TOF Board DE Tlm to ICE. 0 disables all TOF Board DE Tlm to ICE">
+				<xtce:LongDescription>1' to enable TOF Board Direct Event Telemetry to ICE. '0' to disable all TOF Board Direct Event Telemetry to ICE</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.SPARE1" parameterTypeRef="ILO_DIAG_TOF_BD.SPARE1" shortDescription="Spare">
+				<xtce:LongDescription>Spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF3_REQUIRED" parameterTypeRef="ILO_DIAG_TOF_BD.TOF3_REQUIRED" shortDescription="TOF3 required valid TOF measurement for a DE to be produced">
+				<xtce:LongDescription>If tof_reqd bit = '1' then the tof chip must have valid time-of-flight for a Direct Event to be processed</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF2_REQUIRED" parameterTypeRef="ILO_DIAG_TOF_BD.TOF2_REQUIRED" shortDescription="TOF2 required valid TOF measurement for a DE to be produced">
+				<xtce:LongDescription>If tof_reqd bit = '1' then the tof chip must have valid time-of-flight for a Direct Event to be processed</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF1_REQUIRED" parameterTypeRef="ILO_DIAG_TOF_BD.TOF1_REQUIRED" shortDescription="TOF1 required valid TOF measurement for a DE to be produced">
+				<xtce:LongDescription>If tof_reqd bit = '1' then the tof chip must have valid time-of-flight for a Direct Event to be processed</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF0_REQUIRED" parameterTypeRef="ILO_DIAG_TOF_BD.TOF0_REQUIRED" shortDescription="TOF0 required valid TOF measurement for a DE to be produced">
+				<xtce:LongDescription>If tof_reqd bit = '1' then the tof chip must have valid time-of-flight for a Direct Event to be processed</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_ANODE_C_EN" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_ANODE_C_EN" shortDescription="1' to enable anode C stimulation">
+				<xtce:LongDescription>'1' to enable anode stimulation</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_ANODE_C_SRC" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_ANODE_C_SRC" shortDescription="'1&quot; to generate a &quot;start&quot; pulse. '0' to generate a &quot;stop&quot; pulse.">
+				<xtce:LongDescription>'1" to generate a "start" pulse. '0' to generate a "stop" pulse.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_ANODE_B3_EN" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_ANODE_B3_EN" shortDescription="1' to enable anode B3 stimulation">
+				<xtce:LongDescription>'1' to enable anode stimulation</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_ANODE_B3_SRC" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_ANODE_B3_SRC" shortDescription="'1&quot; to generate a &quot;start&quot; pulse. '0' to generate a &quot;stop&quot; pulse.">
+				<xtce:LongDescription>'1" to generate a "start" pulse. '0' to generate a "stop" pulse.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_ANODE_B0_EN" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_ANODE_B0_EN" shortDescription="1' to enable anode B0 stimulation">
+				<xtce:LongDescription>'1' to enable anode stimulation</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_ANODE_B0_SRC" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_ANODE_B0_SRC" shortDescription="'1&quot; to generate a &quot;start&quot; pulse. '0' to generate a &quot;stop&quot; pulse.">
+				<xtce:LongDescription>'1" to generate a "start" pulse. '0' to generate a "stop" pulse.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_ANODE_A_EN" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_ANODE_A_EN" shortDescription="1' to enable anode A stimulation">
+				<xtce:LongDescription>'1' to enable anode stimulation</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_ANODE_A_SRC" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_ANODE_A_SRC" shortDescription="'1&quot; to generate a &quot;start&quot; pulse. '0' to generate a &quot;stop&quot; pulse.">
+				<xtce:LongDescription>'1" to generate a "start" pulse. '0' to generate a "stop" pulse.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_FREQ" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_FREQ" shortDescription="Sets stimulation frequency">
+				<xtce:LongDescription>Sets stimulation frequency
+stim freq [events/s] = stim_freq reg value + 1 0x0 = 1event/s 0x8 = 9events/s 0xF = 16events/s</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.STIM_DELAY" parameterTypeRef="ILO_DIAG_TOF_BD.STIM_DELAY" shortDescription="Sets time-of-flight">
+				<xtce:LongDescription>Sets time-of-flight
+stim delay [ns] = stim_delay reg value * 20.8ns 0x0 = 0ns 0x8 = 166.4ns 0xF = 312ns</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF3_THR" parameterTypeRef="ILO_DIAG_TOF_BD.TOF3_THR" shortDescription="TOF3 values exceeding this setting are suppressed from further processing">
+				<xtce:LongDescription>TOF3 values greater than the registered value are suppressed from further processing</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF2_THR" parameterTypeRef="ILO_DIAG_TOF_BD.TOF2_THR" shortDescription="TOF2 values below this setting are suppressed from further processing">
+				<xtce:LongDescription>TOF2 values greater than the registered value are suppressed from further processing</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF1_THR" parameterTypeRef="ILO_DIAG_TOF_BD.TOF1_THR" shortDescription="TOF1 values below this setting are suppressed from further processing">
+				<xtce:LongDescription>TOF1 values greater than the registered value are suppressed from further processing</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF0_THR" parameterTypeRef="ILO_DIAG_TOF_BD.TOF0_THR" shortDescription="TOF0 values below this setting are suppressed from further processing">
+				<xtce:LongDescription>TOF0 values greater than the registered value are suppressed from further processing</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.SPARE2" parameterTypeRef="ILO_DIAG_TOF_BD.SPARE2" shortDescription="Spare">
+				<xtce:LongDescription>Spare</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF3_VETO" parameterTypeRef="ILO_DIAG_TOF_BD.TOF3_VETO" shortDescription="TOF3 alone vetoed when enabled">
+				<xtce:LongDescription>TOF3 alone vetoed when enabled</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF2_VETO" parameterTypeRef="ILO_DIAG_TOF_BD.TOF2_VETO" shortDescription="TOF2 alone vetoed when enabled">
+				<xtce:LongDescription>TOF2 alone vetoed when enabled</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF1_VETO" parameterTypeRef="ILO_DIAG_TOF_BD.TOF1_VETO" shortDescription="TOF1 alone vetoed when enabled">
+				<xtce:LongDescription>TOF1 alone vetoed when enabled</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.TOF0_VETO" parameterTypeRef="ILO_DIAG_TOF_BD.TOF0_VETO" shortDescription="TOF0 alone vetoed when enabled">
+				<xtce:LongDescription>TOF0 alone vetoed when enabled</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_TOF_BD.CHKSUM" parameterTypeRef="ILO_DIAG_TOF_BD.CHKSUM" shortDescription="Checksum">
+				<xtce:LongDescription>Checksum</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.SHCOARSE" parameterTypeRef="ILO_DIAG_BULK_HVPS.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.HVPS_VERSION" parameterTypeRef="ILO_DIAG_BULK_HVPS.HVPS_VERSION" shortDescription="Version number">
+				<xtce:LongDescription>Version number</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.RESERVED_1" parameterTypeRef="ILO_DIAG_BULK_HVPS.RESERVED_1" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.MASTER_EN_TO" parameterTypeRef="ILO_DIAG_BULK_HVPS.MASTER_EN_TO" shortDescription="Master Enable Time-Out">
+				<xtce:LongDescription>A set bit indicates that the second command to alter the state of the Master Enable bit has not been received within a 2 second time-out window.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.SOFT_RST" parameterTypeRef="ILO_DIAG_BULK_HVPS.SOFT_RST" shortDescription="Soft Reset">
+				<xtce:LongDescription>A set bit indicates that the soft reset command was received.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PFO_RST" parameterTypeRef="ILO_DIAG_BULK_HVPS.PFO_RST" shortDescription="Power Failure Reset">
+				<xtce:LongDescription>A set bit indicates the FPGA was reset due to the assertion of the PFO# signal.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.POR_RST" parameterTypeRef="ILO_DIAG_BULK_HVPS.POR_RST" shortDescription="Power On Reset">
+				<xtce:LongDescription>A set bit indicates that the FPGA was reset when the SYS_RESET# has been asserted.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.RESERVED_2" parameterTypeRef="ILO_DIAG_BULK_HVPS.RESERVED_2" shortDescription="Execute Command Error">
+				<xtce:LongDescription>A set bit indicates that an incorrect command was received after the Master Enable interface was armed</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.CMD_ERR" parameterTypeRef="ILO_DIAG_BULK_HVPS.CMD_ERR" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ARM_ERR" parameterTypeRef="ILO_DIAG_BULK_HVPS.ARM_ERR" shortDescription="Arm Command Error">
+				<xtce:LongDescription>A set bit indicates that an incorrect Arm command has been received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ARM" parameterTypeRef="ILO_DIAG_BULK_HVPS.ARM" shortDescription="Arm Command">
+				<xtce:LongDescription>A set bit indicates that a valid ARM command has been received. The bit is automatically cleared when either a valid Master Enable or Master Disable command is received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.RESERVED_3" parameterTypeRef="ILO_DIAG_BULK_HVPS.RESERVED_3" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.HV_PLUG_STATE" parameterTypeRef="ILO_DIAG_BULK_HVPS.HV_PLUG_STATE" shortDescription="HV Limit">
+				<xtce:LongDescription>‘1’ – Plug inserted</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.MSTR_EN" parameterTypeRef="ILO_DIAG_BULK_HVPS.MSTR_EN" shortDescription="Master Enable">
+				<xtce:LongDescription>A set bit indicates that a valid sequence of the ARM command followed by the ENABLE command has been received. The bit is cleared when the ARM command followed by the DISABLE command have been received</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.RESERVED_4" parameterTypeRef="ILO_DIAG_BULK_HVPS.RESERVED_4" shortDescription="ILO_DIAG_BULK_HVPS.GPO_REG">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.GPO_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ESA_NEG_CTRL" parameterTypeRef="ILO_DIAG_BULK_HVPS.ESA_NEG_CTRL" shortDescription="U- Enable">
+				<xtce:LongDescription>U- Enable</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ESA_POS_CTRL" parameterTypeRef="ILO_DIAG_BULK_HVPS.ESA_POS_CTRL" shortDescription="U+ Enable">
+				<xtce:LongDescription>U+ Enable</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.BULK_CTRL" parameterTypeRef="ILO_DIAG_BULK_HVPS.BULK_CTRL" shortDescription="Bulk Enable">
+				<xtce:LongDescription>Bulk Enable</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD0" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD0" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DAC0" parameterTypeRef="ILO_DIAG_BULK_HVPS.DAC0" shortDescription="ILO_DIAG_BULK_HVPS.DAC0_REG">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC0_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD1" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD1" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DAC1" parameterTypeRef="ILO_DIAG_BULK_HVPS.DAC1" shortDescription="ILO_DIAG_BULK_HVPS.DAC1_REG">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC1_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD2" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD2" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DAC2" parameterTypeRef="ILO_DIAG_BULK_HVPS.DAC2" shortDescription="ILO_DIAG_BULK_HVPS.DAC2_REG">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC2_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD3" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD3" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DAC3" parameterTypeRef="ILO_DIAG_BULK_HVPS.DAC3" shortDescription="ILO_DIAG_BULK_HVPS.DAC3_REG">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC3_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD4" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD4" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DAC4" parameterTypeRef="ILO_DIAG_BULK_HVPS.DAC4" shortDescription="ILO_DIAG_BULK_HVPS.DAC4_REG">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DAC4_REG</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.RESERVED_5" parameterTypeRef="ILO_DIAG_BULK_HVPS.RESERVED_5" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC2_CH_SEL" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC2_CH_SEL" shortDescription="ADC2 Channel Select">
+				<xtce:LongDescription>When the ADC2 interface is set to the Engineering mode this field can be used to select which ADC2 channel is to be sampled constantly; otherwise, in the Science mode, this field indicates the channel that is currently being sampled</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.RESERVED_6" parameterTypeRef="ILO_DIAG_BULK_HVPS.RESERVED_6" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC2_RDY" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC2_RDY" shortDescription="ADC2 Data Ready">
+				<xtce:LongDescription>A set bit indicates that the ADC2 has completed the sampling process and data is available for the readout. Bit is cleared by writing a ‘1’ to the bit location</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC2_MODE" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC2_MODE" shortDescription="ADC2 Engineering Mode">
+				<xtce:LongDescription>A set bit indicates that the ADC2 is configured in the Engineering mode, where only the channel indicated by the ADC2 Channel Select field is constantly sampled.  A cleared bit indicates the Science mode, where all channels are sampled in a round robin manner.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC2_CTRL" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC2_CTRL" shortDescription="ADC2 Enable">
+				<xtce:LongDescription>A set bit enables data acquisition through the ADC2 interface.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.RESERVED_7" parameterTypeRef="ILO_DIAG_BULK_HVPS.RESERVED_7" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC1_CH_SEL" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC1_CH_SEL" shortDescription="ADC1 Channel Select">
+				<xtce:LongDescription>When the ADC1 interface is set to the Engineering mode this field can be used to select which ADC1 channel is to be sampled constantly; otherwise, in the Science mode, this field indicates the channel that is currently being sampled</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.RESERVED_8" parameterTypeRef="ILO_DIAG_BULK_HVPS.RESERVED_8" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC1_RDY" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC1_RDY" shortDescription="ADC1 Data Ready">
+				<xtce:LongDescription>A set bit indicates that the ADC1 has completed the sampling process and data is available for the readout. Bit is cleared by writing a ‘1’ to the bit location</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC1_MODE" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC1_MODE" shortDescription="ADC1 Engineering Mode">
+				<xtce:LongDescription>A set bit indicates that the ADC1 is configured in the Engineering mode, where only the channel indicated by the ADC1 Channel Select field is constantly sampled.  A cleared bit indicates the Science mode, where all channels are sampled in a round robin manner.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC1_CTRL" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC1_CTRL" shortDescription="ADC1 Enable">
+				<xtce:LongDescription>A set bit enables data acquisition through the ADC1 interface.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC1_WAIT_CNT" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC1_WAIT_CNT" shortDescription="ADC1 Wait Count Register">
+				<xtce:LongDescription>The ADC1 Wait Count Register specifies the number of 5MHz clock cycles (200 ns period) between ADC1 conversions.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC2_WAIT_CNT" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC2_WAIT_CNT" shortDescription="ADC2 Wait Count Register">
+				<xtce:LongDescription>The ADC2 Wait Count Register specifies the number of 5MHz clock cycles (200 ns period) between ADC2 conversions.</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD5" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD5" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.HVPS_BULK_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.HVPS_BULK_VMON" shortDescription="ILO_DIAG_BULK_HVPS.HVPS_BULK_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.HVPS_BULK_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD6" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD6" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.U_NEG_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.U_NEG_VMON" shortDescription="ILO_DIAG_BULK_HVPS.U_NEG_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.U_NEG_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD7" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD7" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.U_POS_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.U_POS_VMON" shortDescription="ILO_DIAG_BULK_HVPS.U_POS_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.U_POS_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD8" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD8" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DEF_NEG_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.DEF_NEG_VMON" shortDescription="ILO_DIAG_BULK_HVPS.DEF_NEG_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DEF_NEG_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD9" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD9" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DEF_POS_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.DEF_POS_VMON" shortDescription="ILO_DIAG_BULK_HVPS.DEF_POS_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DEF_POS_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD10" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD10" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PMT_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.PMT_VMON" shortDescription="ILO_DIAG_BULK_HVPS.PMT_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.PMT_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD11" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD11" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PMT_IMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.PMT_IMON" shortDescription="ILO_DIAG_BULK_HVPS.PMT_IMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.PMT_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD12" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD12" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.BULK_IMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.BULK_IMON" shortDescription="ILO_DIAG_BULK_HVPS.BULK_IMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.BULK_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD13" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD13" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DEF_NEG_IMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.DEF_NEG_IMON" shortDescription="ILO_DIAG_BULK_HVPS.DEF_NEG_IMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DEF_NEG_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD14" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD14" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.DEF_POS_IMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.DEF_POS_IMON" shortDescription="ILO_DIAG_BULK_HVPS.DEF_POS_IMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.DEF_POS_IMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD15" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD15" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC_REF1_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC_REF1_VMON" shortDescription="ILO_DIAG_BULK_HVPS.REF1_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.REF1_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD16" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD16" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.ADC_REF2_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.ADC_REF2_VMON" shortDescription="ILO_DIAG_BULK_HVPS.REF2_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.REF2_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD17" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD17" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.P12P0_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.P12P0_VMON" shortDescription="ILO_DIAG_BULK_HVPS.P12P0_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.P12P0_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD18" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD18" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.N12P0_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.N12P0_VMON" shortDescription="ILO_DIAG_BULK_HVPS.N12P0_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.N12P0_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD19" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD19" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.P3P3_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.P3P3_VMON" shortDescription="ILO_DIAG_BULK_HVPS.P3P3_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.P3P3_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.PAD20" parameterTypeRef="ILO_DIAG_BULK_HVPS.PAD20" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.P1P5_VMON" parameterTypeRef="ILO_DIAG_BULK_HVPS.P1P5_VMON" shortDescription="ILO_DIAG_BULK_HVPS.P1P5_VMON">
+				<xtce:LongDescription>ILO_DIAG_BULK_HVPS.P1P5_VMON</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_BULK_HVPS.CHKSUM" parameterTypeRef="ILO_DIAG_BULK_HVPS.CHKSUM" shortDescription="16-bit CRC checksum">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.SHCOARSE" parameterTypeRef="ILO_DIAG_PCC.SHCOARSE" shortDescription="CCSDS Secondary Header MET">
+				<xtce:LongDescription>CCSDS Secondary Header MET</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PAD0" parameterTypeRef="ILO_DIAG_PCC.PAD0" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_PCC.COARSE_POT_PRI" parameterTypeRef="ILO_DIAG_PCC.COARSE_POT_PRI" shortDescription="Primary motor coarse pot">
+				<xtce:LongDescription>Primary motor coarse pot</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PAD1" parameterTypeRef="ILO_DIAG_PCC.PAD1" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_PCC.FINE_POT_PRI" parameterTypeRef="ILO_DIAG_PCC.FINE_POT_PRI" shortDescription="Primary motor fine pot">
+				<xtce:LongDescription>Primary motor fine pot</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PAD2" parameterTypeRef="ILO_DIAG_PCC.PAD2" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_PCC.COARSE_POT_SEC" parameterTypeRef="ILO_DIAG_PCC.COARSE_POT_SEC" shortDescription="Secondary motor coarse pot">
+				<xtce:LongDescription>Secondary motor coarse pot</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PAD3" parameterTypeRef="ILO_DIAG_PCC.PAD3" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_PCC.FINE_POT_SEC" parameterTypeRef="ILO_DIAG_PCC.FINE_POT_SEC" shortDescription="Secondary motor fine pot">
+				<xtce:LongDescription>Secondary motor fine pot</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PAD4" parameterTypeRef="ILO_DIAG_PCC.PAD4" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_PCC.ACTUATOR_TEMP" parameterTypeRef="ILO_DIAG_PCC.ACTUATOR_TEMP" shortDescription="Actuator temperature">
+				<xtce:LongDescription>Actuator temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PAD5" parameterTypeRef="ILO_DIAG_PCC.PAD5" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_PCC.PCC_BOARD_TEMP" parameterTypeRef="ILO_DIAG_PCC.PCC_BOARD_TEMP" shortDescription="PCC Board temperature">
+				<xtce:LongDescription>PCC Board temperature</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PAD6" parameterTypeRef="ILO_DIAG_PCC.PAD6" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_PCC.MOTOR_CURRENT_PRI" parameterTypeRef="ILO_DIAG_PCC.MOTOR_CURRENT_PRI" shortDescription="Primary motor current">
+				<xtce:LongDescription>Primary motor current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PAD7" parameterTypeRef="ILO_DIAG_PCC.PAD7" shortDescription="pad" />
+			<xtce:Parameter name="ILO_DIAG_PCC.MOTOR_CURRENT_SEC" parameterTypeRef="ILO_DIAG_PCC.MOTOR_CURRENT_SEC" shortDescription="Secondary motor current">
+				<xtce:LongDescription>Secondary motor current</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.CUMULATIVE_CNT_PRI" parameterTypeRef="ILO_DIAG_PCC.CUMULATIVE_CNT_PRI" shortDescription="Cummulative step count">
+				<xtce:LongDescription>Cumulative Step Count (Primary)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.CUMULATIVE_CNT_SGN_PRI" parameterTypeRef="ILO_DIAG_PCC.CUMULATIVE_CNT_SGN_PRI" shortDescription="Cumulative step count sign enumeration">
+				<xtce:LongDescription>0x2B = Positive
+0x2D = Negative</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.CUMULATIVE_CNT_SEC" parameterTypeRef="ILO_DIAG_PCC.CUMULATIVE_CNT_SEC" shortDescription="Cummulative step count">
+				<xtce:LongDescription>Cumulative Step Count (Secondary)</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.CUMULATIVE_CNT_SGN_SEC" parameterTypeRef="ILO_DIAG_PCC.CUMULATIVE_CNT_SGN_SEC" shortDescription="Cumulative step count sign enumeration">
+				<xtce:LongDescription>0x2B = Positive
+0x2D = Negative</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.CURRENT_STEP_CNT_PRI" parameterTypeRef="ILO_DIAG_PCC.CURRENT_STEP_CNT_PRI" shortDescription="Primary motor axis countdown counter">
+				<xtce:LongDescription>Primary motor axis countdown counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.CURRENT_STEP_CNT_SEC" parameterTypeRef="ILO_DIAG_PCC.CURRENT_STEP_CNT_SEC" shortDescription="Secondary motor axis countdown counter">
+				<xtce:LongDescription>Secondary motor axis countdown counter</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.CURRENT_SETPT_PRI" parameterTypeRef="ILO_DIAG_PCC.CURRENT_SETPT_PRI" shortDescription="Current setpoint value">
+				<xtce:LongDescription>0x31 = 500ma, 0x32 = 600ma, 0x33 = 700ma, 0x34 = 800ma, 0x35 = 700ma, 0x36 = 700ma, 0x37 = 700ma, 0x38 = 700ma</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.CURRENT_SETPT_SEC" parameterTypeRef="ILO_DIAG_PCC.CURRENT_SETPT_SEC" shortDescription="Current setpoint value">
+				<xtce:LongDescription>0x31 = 500ma, 0x32 = 600ma, 0x33 = 700ma, 0x34 = 800ma, 0x35 = 700ma, 0x36 = 700ma, 0x37 = 700ma, 0x38 = 700ma</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PRI_ACTIVE" parameterTypeRef="ILO_DIAG_PCC.PRI_ACTIVE" shortDescription="Pivot platform primary port active - motion in progress status">
+				<xtce:LongDescription>Pivot platform primary port active - motion in progress status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PRI_POWERED" parameterTypeRef="ILO_DIAG_PCC.PRI_POWERED" shortDescription="Pivot platform primary port powered - powered idle state">
+				<xtce:LongDescription>Pivot platform primary port powered - powered idle state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PRI_USTEP" parameterTypeRef="ILO_DIAG_PCC.PRI_USTEP" shortDescription="Pivot platform primary port micro-stepping status">
+				<xtce:LongDescription>Pivot platform primary port micro-stepping status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.PRI_ACCEL" parameterTypeRef="ILO_DIAG_PCC.PRI_ACCEL" shortDescription="Pivot platform primary acceleration profiling status">
+				<xtce:LongDescription>Pivot platform primary acceleration profiling status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.SEC_ACTIVE" parameterTypeRef="ILO_DIAG_PCC.SEC_ACTIVE" shortDescription="Pivot platform secondary port active - motion in progress status">
+				<xtce:LongDescription>Pivot platform secondary port active - motion in progress status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.SEC_POWERED" parameterTypeRef="ILO_DIAG_PCC.SEC_POWERED" shortDescription="Pivot platform secondary port powered - powered idle state">
+				<xtce:LongDescription>Pivot platform secondary port powered - powered idle state</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.SEC_USTEP" parameterTypeRef="ILO_DIAG_PCC.SEC_USTEP" shortDescription="Pivot platform secondary port micro-stepping status">
+				<xtce:LongDescription>Pivot platform secondary port micro-stepping status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.SEC_ACCEL" parameterTypeRef="ILO_DIAG_PCC.SEC_ACCEL" shortDescription="Pivot platform secondary acceleration profiling status">
+				<xtce:LongDescription>Pivot platform secondary acceleration profiling status</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="ILO_DIAG_PCC.SPARE" parameterTypeRef="ILO_DIAG_PCC.SPARE" shortDescription="spare" />
+			<xtce:Parameter name="ILO_DIAG_PCC.CHKSUM" parameterTypeRef="ILO_DIAG_PCC.CHKSUM" shortDescription="16-bit CRC checksum">
+				<xtce:LongDescription>16-bit CRC checksum</xtce:LongDescription>
 			</xtce:Parameter>
 		</xtce:ParameterSet>
 		<xtce:ContainerSet>
@@ -186,6 +8980,392 @@
 					<xtce:ParameterRefEntry parameterRef="SEQ_FLGS" />
 					<xtce:ParameterRefEntry parameterRef="SRC_SEQ_CTR" />
 					<xtce:ParameterRefEntry parameterRef="PKT_LEN" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="ILO_APP_SHK">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="676" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.BOARD_TYPE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.RESET_REASON_SOFT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.RESET_REASON_FPGA_WDOG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.RESET_REASON_CPU_WDOG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.RESET_REASON_PFO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.RESET_REASON_POR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.CPU_WDOG_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.FPGA_WDOG_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.WDOG_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.INSTR_ID" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.CDH_FPGA_VERSION" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.IFB_FPGA_VERSION" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.BULK_HVPS_VERSION" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.FSW_VERSION" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.SELECTED_IMG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.FSW_VERSION_STR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.ENG_LUT_VERSION_STR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.SCI_LUT_VERSION_STR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.SCRATCH_BUFFER_ADDR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.SPARE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_SHK.CHKSUM" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="ILO_APP_NHK">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="677" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.OP_MODE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CMD_EXE_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CMD_REJ_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CMD_LAST_OPCODE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.ITF_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.WATCHDOG_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TEMP1_311P18_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IMAPLO_ICE_TOF_TEMP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TEMP3_311P18_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LO_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.SPARE_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_12V_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_5V_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_3P3V_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_3P3V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_N5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_N12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_3P3V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_5V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_N5V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_12V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LVPS_N12V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_1P5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_1P8V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_3P3V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_N12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_5V_ADC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_PROCESSOR_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_1P8V_LDO_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_1P5V_LDO_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAD_28" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_SDRAM_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_CMD_TIMEOUT_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_DAC_UPDATE_ACK_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_READ_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_TLM_TIMEOUT_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_WRITE_ACK_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_CMD_PARITY_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_CMD_FRAME_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_TLM_PARITY_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_TLM_FRAME_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_TIMEOUT_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_CNT_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_CMD_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_MST_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_HV_PLUG_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_POR_RST" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_PFO_RST" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_STAT_SOFT_RST" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_BULK_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ESA_POS_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ESA_NEG_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DAC_PAD0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ESA_NEG_DAC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DAC_PAD1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ESA_POS_DAC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DAC_PAD2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DEF_NEG_DAC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DAC_PAD3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DEF_POS_DAC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DAC_PAD4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PMT_DAC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC1_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC1_MODE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC1_CH_SEL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC2_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC2_MODE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC2_CH_SEL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC1_WAIT_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC2_WAIT_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_BULK_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ESA_NEG_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ESA_POS_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DEF_NEG_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DEF_POS_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PMT_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PMT_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_BULK_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DEF_NEG_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_DEF_POS_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC_REF1_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_ADC_REF2_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_12P0_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_N12P0_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_3P3_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_PAD17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_1P5_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MEM_OP_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MEM_DUMP_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.SPIN_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MISSED_PPS_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CPU_IDLE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.SPIN_BIN_IDX" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.SPIN_PERIOD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_HEATER_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_HEATER_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.INSTR_PWR_12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.INSTR_PWR_ANALOG_5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.INSTR_PWR_DIGITAL_5V_3P3V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_CMD_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_INTERFACE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_ADC_TLM_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_ADC_TLM_TIMEOUT_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_ADC_TLM_ID_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_ADC_TLM_FRAME_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_TLM_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_TLM_TIMEOUT_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_TLM_ID_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_TLM_FRAME_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_TLM_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_ADC_TLM_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_REG_TLM_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_CNT_TLM_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_DE_TLM_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_TLM_TIMEOUT_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_TLM_ID_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_TLM_FRAME_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.DIRECT_EVENT_TIME_TAG_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.DIRECT_EVENT_FIFO_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_INTERFACE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPC_TLM_TIMEOUT_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPC_TLM_PARITY_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPC_TLM_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_HV_PLUG_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_CMD_COUNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_CTRL_INT_MUX" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_CTRL_ADC_CLK_DS" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_CTRL_OSCOPE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_CTRL_STAR_SYNC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_CTRL_DATA" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_DATA_INTERVAL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_HVPS_CTRL_SYNC_CLK" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_HVPS_CTRL_PAC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_HVPS_CTRL_MCP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_HVPS_CTRL_LV" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAC_VSET" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAC_OCP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MCP_VSET" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MCP_OCP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STAR_OFFSET_ADJUST" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_OSCOPE_CH1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_OSCOPE_CH0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_HOT_SPOT_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_COLD_SPOT_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_5P0_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_3P3_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_12P0_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_N12P0_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LV_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LV_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.LV_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MCP_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MCP_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MCP_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAC_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAC_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.IFB_PAD14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PAC_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_CMD_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PAD0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_CFD_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PAD1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PRE_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PAD2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_REG_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PAD3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_MCP_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PAD4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_MCP_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PAD5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PAD6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_P5_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_PAD7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_P6_V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.AN_A_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.AN_B0_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.AN_B3_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.AN_C_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_CTRL_TLM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_CTRL_DE_TLM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_CTRL_TOF3_REQ" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_CTRL_TOF2_REQ" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_CTRL_TOF1_REQ" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF_BD_CTRL_TOF0_REQ" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CTRL_AN_C_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CTRL_AN_C_SRC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CTRL_AN_B3_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CTRL_AN_B3_SRC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CTRL_AN_B0_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CTRL_AN_B0_SRC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CTRL_AN_A_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CTRL_AN_A_SRC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CNFG_FREQ" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.STIM_CNFG_DELAY" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF3_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF2_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF1_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF0_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF3_VETO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF2_VETO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF1_VETO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.TOF0_VETO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.BHV_SPARE14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PAD0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_COARSE_POT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PAD1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_FINE_POT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PAD2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_COARSE_POT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PAD3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_FINE_POT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PAD4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_ACTUATOR_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PAD5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_BOARD_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PAD6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_MOTOR_CURRENT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PAD7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_MOTOR_CURRENT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_CUMULATIVE_CNT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_CUMULATIVE_CNT_SGN_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_CURRENT_STEP_CNT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_CURRENT_STEP_CNT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_CURRENT_SETPT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_CURRENT_SETPT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PRI_ACTIVE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PRI_POWERED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PRI_USTEP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_PRI_ACCEL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_SEC_ACTIVE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_SEC_POWERED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_SEC_USTEP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PCC_SEC_ACCEL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.RTS_ID" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.RTS_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.RTS_NUM_CMDS" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.RTS_NUM_CMDS_EXE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.RTS_INDEX" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.RTS_NEXT_OPCODE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.RTS_TIME_REMAINING" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.OP_HTR_SELECT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.OP_HTR_MODE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.OP_HTR_CYCLE_TIME" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.OP_HTR_PAD0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.OP_HTR_LO_SETPOINT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.OP_HTR_PAD1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.OP_HTR_HI_SETPOINT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CDH_HV_PLUG_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.SPARE16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.SCI_CYCLE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_MOTOR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_DIRECTION" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_STEP_PERIOD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_MICROSTEP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_CURRENT_THRESHOLD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_STALL_THRESHOLD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_STALL_PERIOD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_PAD0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_LOWER_BOUND" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_PAD1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_UPPER_BOUND" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_USE_CONFLICT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_STALLED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_OUT_OF_RANGE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.PPM_POWER_PROBLEM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.MARKER" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.SPARE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_APP_NHK.CHKSUM" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
 			<xtce:SequenceContainer name="ILO_SCI_CNT">
@@ -208,7 +9388,7 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="ILO_SCI_DE.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="ILO_SCI_DE.DATA" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SCI_DE.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
 			<xtce:SequenceContainer name="ILO_STAR">
@@ -237,8 +9417,618 @@
 					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ACQ_START_SUBSEC" />
 					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ACQ_END_SEC" />
 					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ACQ_END_SUBSEC" />
-					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.SPIN_DATA" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SEC_SPIN_28" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.START_SUBSEC_SPIN_28" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_NEG_DAC_SPIN_28" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.ESA_POS_DAC_SPIN_28" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_STATE_SPIN_28" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PHASE_STATE_SPIN_28" />
+					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.PERIOD_SOURCE_SPIN_28" />
 					<xtce:ParameterRefEntry parameterRef="ILO_SPIN.CHKSUM" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="ILO_DIAG_CDH">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="721" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.JUMPER_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.RESET_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.WATCHDOG_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CTRL_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SCRATCHPAD_1_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SCRATCHPAD_2_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CPU_UART_CLOCK_BAUD_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.TICK_TIMER_CTRL_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.TICK_TIMER_RELOAD_COUNT_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.TICK_TIMER_COUNTER_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.MET_CTRL_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.MET_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.MET_COARSE_COUNTER_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.MET_FINE_COUNTER_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.MDM25P_14_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.TOF_TEMP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.MDM25P_16_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LO_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_12V_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_5V_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_3P3V_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_3P3V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_N5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_N12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_3P3V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_5V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_N5V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_12V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LVPS_N12V_I" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_1P5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_1P8V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_3P3V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_21" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_N12V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_22" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_5V" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_23" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_5V_ADC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_24" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_PROCESSOR_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_25" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_1P8V_LDO_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_26" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_1P5V_LDO_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PAD_27" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CDH_SDRAM_T" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.ADC_CTRL_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SC_CMD_FIFO_CTRL_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SC_TLM_FIFO_CTRL_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.INTERRUPT_LEVEL_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.INTERRUPT_PENDING_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.INTERRUPT_ENABLE_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_ENABLE_AND_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_BIN_PERIOD_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_BIN_INDEX_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_PERIOD_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_PERIOD_TIMER_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_PERIOD_TIMER_AT_NXT_PPS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_TIME_STAMP_SECONDS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_TIME_STAMP_SUBSECONDS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LOOPBACK_CTRL_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LOOPBACK_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LOOPBACK_TX_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.LOOPBACK_RX_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.DISCRETE_IO_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.HEATER_CTRL_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.HEATER_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.INSTR_PWR_CTRL_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.INSTR_PWR_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.IFB_INTERFACE_CTRL_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.IFB_INTERFACE_CMD_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.IFB_ADC_TLM_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.IFB_REG_TLM_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.TOF_INTERFACE_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.DE_TIME_TAG_RESOLUTION_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.DE_TIME_TAG_CTRL_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.DE_FIFO_CTRL_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.FEE_RESET_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.FEE_RESET_CMD_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.FEE_RESET_DURATION_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.SPIN_PULSE_DURATION_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.HVPS_CTRL_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.HVPS_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.HVPS_CMD_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PIVOT_INTERFACE_CTRL_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PIVOT_INTERFACE_STATUS_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PIVOT_CMD_DATA_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.PIVOT_CMD_OPCODE_REG" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_CDH.CHKSUM" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="ILO_DIAG_IFB">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="722" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IF_CONTROL_SPARE1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IF_CONTROL_CMD_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IF_CONTROL_SPARE2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IF_CONTROL_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.REG_IF_SPARE1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.REG_IF_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.REG_IF_SPARE2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.REG_IF_TO_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.REG_IF_ID_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.REG_IF_FRM_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_UN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_OV" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_FF" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_HF" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_SS_FE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_SPARE3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_TO_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_ID_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_IF_STATUS_FRM_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.FPGA_VERSION" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.SPARE1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.HV_PLUG_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.BOARD_ID" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.CMD_COUNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.SPARE2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_AUX_MUX" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.ADC_CLK_DIS" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.OSCOPE_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.STAR_SYNC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IFB_DATA_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IFB_DATA_INTERVAL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.SYNC_CLK_MSB" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAC_EN_MSB" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.MCP_EN_MSB" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.LV_EN_MSB" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.SYNC_CLK_LSB" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAC_EN_LSB" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.MCP_EN_LSB" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.LV_EN_LSB" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAC_VSET" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAC_OCP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.MCP_VSET" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.MCP_OCP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.STAR_OFFSET_ADJUST" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.OSCOPE_CHANNEL_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.OSCOPE_CHANNEL_0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.STAR_BRIGHT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IFB_TEMP1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IFB_TEMP0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IFB_V5P0_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IFB_V3P3_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IFB_V12P0_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.IFB_V12N0_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.LV_CM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.LV_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.LV_TEMP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.MCP_CM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.MCP_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.MCP_TEMP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAC_CM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAC_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAD_15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.PAC_TEMP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.SPARE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_IFB.CHKSUM" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="ILO_DIAG_TOF_BD">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="723" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_SPARE1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_PKT_RCVD" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_ADC_PKT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_REG_PKT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_CNT_PKT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_DE_PKT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_SPARE2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_TO_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_ID_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.IF_STATUS_FRM_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.CMD_ERROR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.CFD_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PRE_TM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.REG_TM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.MCP_CM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.MCP_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.CM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.P5_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.P6_VM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.AN_A_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.AN_B0_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.AN_B3_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.PAD_10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.AN_C_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF_BD_TLM_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.DIRECT_EVENT_TLM_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.SPARE1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF3_REQUIRED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF2_REQUIRED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF1_REQUIRED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF0_REQUIRED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_ANODE_C_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_ANODE_C_SRC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_ANODE_B3_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_ANODE_B3_SRC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_ANODE_B0_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_ANODE_B0_SRC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_ANODE_A_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_ANODE_A_SRC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_FREQ" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.STIM_DELAY" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF3_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF2_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF1_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF0_THR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.SPARE2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF3_VETO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF2_VETO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF1_VETO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.TOF0_VETO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_TOF_BD.CHKSUM" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="ILO_DIAG_BULK_HVPS">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="724" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.HVPS_VERSION" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.RESERVED_1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.MASTER_EN_TO" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.SOFT_RST" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PFO_RST" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.POR_RST" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.RESERVED_2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.CMD_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ARM_ERR" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ARM" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.RESERVED_3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.HV_PLUG_STATE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.MSTR_EN" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.RESERVED_4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ESA_NEG_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ESA_POS_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.BULK_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DAC0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DAC1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DAC2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DAC3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DAC4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.RESERVED_5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC2_CH_SEL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.RESERVED_6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC2_RDY" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC2_MODE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC2_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.RESERVED_7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC1_CH_SEL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.RESERVED_8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC1_RDY" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC1_MODE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC1_CTRL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC1_WAIT_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC2_WAIT_CNT" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.HVPS_BULK_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.U_NEG_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.U_POS_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD8" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DEF_NEG_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD9" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DEF_POS_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD10" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PMT_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD11" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PMT_IMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD12" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.BULK_IMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD13" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DEF_NEG_IMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD14" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.DEF_POS_IMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD15" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC_REF1_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD16" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.ADC_REF2_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD17" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.P12P0_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD18" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.N12P0_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD19" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.P3P3_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.PAD20" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.P1P5_VMON" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_BULK_HVPS.CHKSUM" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+			<xtce:SequenceContainer name="ILO_DIAG_PCC">
+				<xtce:BaseContainer containerRef="CCSDSPacket">
+					<xtce:RestrictionCriteria>
+						<xtce:Comparison parameterRef="PKT_APID" value="725" useCalibratedValue="false" />
+					</xtce:RestrictionCriteria>
+				</xtce:BaseContainer>
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.SHCOARSE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PAD0" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.COARSE_POT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PAD1" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.FINE_POT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PAD2" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.COARSE_POT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PAD3" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.FINE_POT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PAD4" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.ACTUATOR_TEMP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PAD5" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PCC_BOARD_TEMP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PAD6" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.MOTOR_CURRENT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PAD7" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.MOTOR_CURRENT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CUMULATIVE_CNT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CUMULATIVE_CNT_SGN_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CUMULATIVE_CNT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CUMULATIVE_CNT_SGN_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CURRENT_STEP_CNT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CURRENT_STEP_CNT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CURRENT_SETPT_PRI" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CURRENT_SETPT_SEC" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PRI_ACTIVE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PRI_POWERED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PRI_USTEP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.PRI_ACCEL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.SEC_ACTIVE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.SEC_POWERED" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.SEC_USTEP" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.SEC_ACCEL" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.SPARE" />
+					<xtce:ParameterRefEntry parameterRef="ILO_DIAG_PCC.CHKSUM" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
 		</xtce:ContainerSet>


### PR DESCRIPTION
# Change Summary

## Overview

The Lo telemetry sheet did HK state enums did not cover the full set of possible values resulting in errors from space packet parser when decommutating sample data. A new telemetry sheet has been delivered resolving this error.

Closes #1197