### PR TITLE
Bring in fixes for geometry modules

### DIFF
--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -522,15 +522,15 @@ def cartesian_to_spherical(
 
         - r : Distance of the point from the origin.
         - azimuth : angle in the xy-plane
-        In degrees if degrees parameter is True (by default):
-        output range=[0, 360],
-        otherwise in radians if degrees parameter is False:
-        output range=[0, 2*pi].
+          In degrees if degrees parameter is True (by default):
+          output range=[0, 360],
+          otherwise in radians if degrees parameter is False:
+          output range=[0, 2*pi].
         - elevation : angle from the z-axis
-        In degrees if degrees parameter is True (by default):
-        output range=[0, 180],
-        otherwise in radians if degrees parameter is False:
-        output range=[-pi/2, pi/2].
+          In degrees if degrees parameter is True (by default):
+          output range=[0, 180],
+          otherwise in radians if degrees parameter is False:
+          output range=[-pi/2, pi/2].
     """
     # Magnitude of the velocity vector
     magnitude_v = np.linalg.norm(v, axis=-1, keepdims=True)

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -522,15 +522,15 @@ def cartesian_to_spherical(
 
         - r : Distance of the point from the origin.
         - azimuth : angle in the xy-plane
-          In degrees if degrees parameter is True (by default):
-            + output range=[0, 360],
-          otherwise in radians if degrees parameter is False:
-            + output range=[0, 2*pi].
+        In degrees if degrees parameter is True (by default):
+        output range=[0, 360],
+        otherwise in radians if degrees parameter is False:
+        output range=[0, 2*pi].
         - elevation : angle from the z-axis
-          In degrees if degrees parameter is True (by default):
-            + output range=[0, 180],
-          otherwise in radians if degrees parameter is False:
-            + output range=[-pi/2, pi/2].
+        In degrees if degrees parameter is True (by default):
+        output range=[0, 180],
+        otherwise in radians if degrees parameter is False:
+        output range=[-pi/2, pi/2].
     """
     # Magnitude of the velocity vector
     magnitude_v = np.linalg.norm(v, axis=-1, keepdims=True)

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -326,8 +326,11 @@ def frame_transform(
         Ephemeris time(s) corresponding to position(s).
     position : np.ndarray
         <x, y, z> vector or array of vectors in reference frame `from_frame`.
-        A single position vector may be provided for multiple `et` query times
-        but only a single position vector can be provided for a single `et`.
+        There are several possible shapes for the input position and et:
+        1. A single position vector may be provided for multiple `et` query times
+        2. A single `et` may be provided for multiple position vectors,
+        3. The same number of `et` and position vectors may be provided.
+        But it is not allowed to have n position vectors and m `et`, where n != m.
     from_frame : SpiceFrame
         Reference frame of input vector(s).
     to_frame : SpiceFrame
@@ -350,11 +353,13 @@ def frame_transform(
                 f"Each input position vector must have 3 elements."
             )
         if not len(position) == np.asarray(et).size:
-            raise ValueError(
-                "Mismatch in number of position vectors and Ephemeris times provided."
-                f"Position has {len(position)} elements and et has "
-                f"{np.asarray(et).size} elements."
-            )
+            if np.asarray(et).size != 1:
+                raise ValueError(
+                    "Mismatch in number of position vectors and "
+                    "Ephemeris times provided."
+                    f"Position has {len(position)} elements and et has "
+                    f"{np.asarray(et).size} elements."
+                )
 
     # rotate will have shape = (3, 3) or (n, 3, 3)
     # position will have shape = (3,) or (n, 3)
@@ -494,6 +499,7 @@ def basis_vectors(
 
 def cartesian_to_spherical(
     v: NDArray,
+    degrees: bool = True,
 ) -> NDArray:
     """
     Convert cartesian coordinates to spherical coordinates.
@@ -504,6 +510,9 @@ def cartesian_to_spherical(
         A NumPy array with shape (n, 3) where each
         row represents a vector
         with x, y, z-components.
+    degrees : bool
+        If True, the azimuth and elevation angles are returned in degrees.
+        Defaults to True.
 
     Returns
     -------
@@ -512,8 +521,12 @@ def cartesian_to_spherical(
         the spherical coordinates (r, azimuth, elevation):
 
         - r : Distance of the point from the origin.
-        - azimuth : angle in the xy-plane in radians [0, 2*pi].
-        - elevation : angle from the z-axis in radians [-pi/2, pi/2].
+        - azimuth : angle in the xy-plane
+          In degrees by default, if degrees parameter is True [0, 360],
+          otherwise in radians if degrees==False [0, 2*pi].
+        - elevation : angle from the z-axis
+          In degrees by default, if degrees parameter is True [0, 360],
+          otherwise in radians if degrees==False [-pi/2, pi/2].
     """
     # Magnitude of the velocity vector
     magnitude_v = np.linalg.norm(v, axis=-1, keepdims=True)
@@ -528,9 +541,12 @@ def cartesian_to_spherical(
 
     # Ensure azimuth is from 0 to 2PI
     az = az % (2 * np.pi)
-    spherical_coords = np.stack(
-        (np.squeeze(magnitude_v), np.degrees(az), np.degrees(el)), axis=-1
-    )
+
+    if degrees:
+        az = np.degrees(az)
+        el = np.degrees(el)
+
+    spherical_coords = np.stack((np.squeeze(magnitude_v), az, el), axis=-1)
 
     return spherical_coords
 

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -522,11 +522,15 @@ def cartesian_to_spherical(
 
         - r : Distance of the point from the origin.
         - azimuth : angle in the xy-plane
-          In degrees by default, if degrees parameter is True [0, 360],
-          otherwise in radians if degrees==False [0, 2*pi].
+          In degrees if degrees parameter is True (by default):
+            + output range=[0, 360],
+          otherwise in radians if degrees parameter is False:
+            + output range=[0, 2*pi].
         - elevation : angle from the z-axis
-          In degrees by default, if degrees parameter is True [0, 360],
-          otherwise in radians if degrees==False [-pi/2, pi/2].
+          In degrees if degrees parameter is True (by default):
+            + output range=[0, 180],
+          otherwise in radians if degrees parameter is False:
+            + output range=[-pi/2, pi/2].
     """
     # Magnitude of the velocity vector
     magnitude_v = np.linalg.norm(v, axis=-1, keepdims=True)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -254,7 +254,7 @@ def test_frame_transform_exceptions():
         match="Mismatch in number of position vectors and Ephemeris times provided.",
     ):
         frame_transform(
-            1,
+            [1, 2],
             np.arange(9).reshape((3, 3)),
             SpiceFrame.ECLIPJ2000,
             SpiceFrame.IMAP_HIT,

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -204,6 +204,19 @@ def test_get_spacecraft_to_instrument_spin_phase_offset(instrument, expected_off
             SpiceFrame.IMAP_SPACECRAFT,
             SpiceFrame.IMAP_DPS,
         ),
+        # single et, multiple position vectors
+        (
+            ["2025-04-30T12:00:00.000"],
+            np.array(
+                [
+                    [1, 0, 0],
+                    [0, 1, 0],
+                    [0, 0, 1],
+                ]
+            ),
+            SpiceFrame.IMAP_SPACECRAFT,
+            SpiceFrame.IMAP_DPS,
+        ),
     ],
 )
 def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_kernels):
@@ -223,11 +236,24 @@ def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_ker
         et = np.array([spice.utc2et(et_str) for et_str in et_strings])
         et_arg = et[0] if len(et) == 1 else et
         result = frame_transform(et_arg, position, from_frame, to_frame)
-        # check the result shape before modifying for value checking
-        assert result.shape == (3,) if len(et) == 1 else (len(et), 3)
-        # compare against pure SPICE calculation
-        position = np.broadcast_to(position, (len(et), 3))
-        result = np.broadcast_to(result, (len(et), 3))
+        # check the result shape before modifying for value checking.
+        # There are 3 cases to consider:
+
+        # 1 event time, multiple position vectors:
+        if len(et) == 1 and position.ndim > 1:
+            assert result.shape == position.shape
+        # multiple event times, single position vector:
+        elif len(et) > 1 and position.ndim == 1:
+            assert result.shape == (len(et), 3)
+        # multiple event times, multiple position vectors (same number of each)
+        elif len(et) > 1 and position.ndim > 1:
+            assert result.shape == (len(et), 3)
+
+        # compare against pure SPICE calculation.
+        # If the result is a single position vector, broadcast it to first.
+        if position.ndim == 1:
+            position = np.broadcast_to(position, (len(et), 3))
+            result = np.broadcast_to(result, (len(et), 3))
         for spice_et, spice_position, test_result in zip(et, position, result):
             rotation_matrix = spice.pxform(from_frame.name, to_frame.name, spice_et)
             spice_result = spice.mxv(rotation_matrix, spice_position)


### PR DESCRIPTION
Closes #1204 

Two small changes, originally made in the much-too-big PR https://github.com/IMAP-Science-Operations-Center/imap_processing/pull/1202 :

1. geometry.frame_transform must be slightly modified to allow multiple position vectors for a single event time
2. geometry.cartesian_to_spherical needed its documentation fixed (had incorrectly specified its return units). Modified it so that it has the same default behavior of returning degrees, but can return radians if needed.

# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->


## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/spice/geometry.py
   - update frame_transform and cartesian_to_spherical functions
   
## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
