### PR TITLE
Refactor parse_direct_events to remove for loop

### DIFF
--- a/imap_processing/hi/l1a/science_direct_event.py
+++ b/imap_processing/hi/l1a/science_direct_event.py
@@ -77,7 +77,7 @@ def parse_direct_events(de_data: bytes) -> dict[str, npt.ArrayLike]:
     # Each DE consists of 6-bytes. Considering the data as 3 2-byte words,
     # each word contains the following:
     # word_0: 2-bits of Trigger ID, upper 14-bits of de_tag
-    # word_1: lower 2-bits of de_tag, upper 10-bits tof_1, upper 4-bits of tof_2
+    # word_1: lower 2-bits of de_tag, 10-bits tof_1, upper 4-bits of tof_2
     # word_3: lower 6-bits of tof_2, 10-bits of tof_3
     # Interpret binary blob as uint16 array and reshape to (3, n)
     data_uint16 = np.reshape(

--- a/imap_processing/hi/l1a/science_direct_event.py
+++ b/imap_processing/hi/l1a/science_direct_event.py
@@ -8,7 +8,6 @@ import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.spice.time import met_to_j2000ns
-from imap_processing.utils import convert_to_binary_string
 
 # TODO: read LOOKED_UP_DURATION_OF_TICK from
 # instrument status summary later. This value
@@ -22,7 +21,7 @@ MILLISECOND_TO_NS = 1e6
 MICROSECOND_TO_NS = 1e3
 
 
-def parse_direct_events(de_data: bytes) -> dict[str, list]:
+def parse_direct_events(de_data: bytes) -> dict[str, npt.ArrayLike]:
     """
     Parse event data from a binary blob.
 
@@ -75,40 +74,26 @@ def parse_direct_events(de_data: bytes) -> dict[str, list]:
     Dict[str, list]
         Parsed event data.
     """
-    de_dict = defaultdict(list)
-    binary_str_val = convert_to_binary_string(de_data)
-    for event_data in break_into_bits_size(binary_str_val):
-        # parse direct event
-        de_dict["trigger_id"].append(int(event_data[:2], 2))
-        de_dict["de_tag"].append(int(event_data[2:18], 2))
-        de_dict["tof_1"].append(int(event_data[18:28], 2))
-        de_dict["tof_2"].append(int(event_data[28:38], 2))
-        de_dict["tof_3"].append(int(event_data[38:48], 2))
+    # Each DE consists of 6-bytes. Considering the data as 3 2-byte words,
+    # each word contains the following:
+    # word_0: 2-bits of Trigger ID, upper 14-bits of de_tag
+    # word_1: lower 2-bits of de_tag, upper 10-bits tof_1, upper 4-bits of tof_2
+    # word_3: lower 6-bits of tof_2, 10-bits of tof_3
+    # Interpret binary blob as uint16 array and reshape to (3, n)
+    data_uint16 = np.reshape(
+        np.frombuffer(de_data, dtype=">u2"), (3, -1), order="F"
+    ).astype(np.uint16)
+
+    de_dict = dict()
+    de_dict["trigger_id"] = (data_uint16[0] >> (6 + 8)).astype(np.uint8)
+    de_dict["de_tag"] = (data_uint16[0] << 2) + (data_uint16[1] >> (6 + 8))
+    de_dict["tof_1"] = (data_uint16[1] & int(b"00111111_11110000", 2)) >> 4
+    de_dict["tof_2"] = ((data_uint16[1] & int(b"00000000_00001111", 2)) << 6) + (
+        data_uint16[2] >> (2 + 8)
+    )
+    de_dict["tof_3"] = data_uint16[2] & int(b"00000011_11111111", 2)
 
     return de_dict
-
-
-def break_into_bits_size(binary_data: str) -> list:
-    """
-    Break binary stream data into 48-bits.
-
-    Parameters
-    ----------
-    binary_data : str
-        Binary data.
-
-    Returns
-    -------
-    list
-        List of 48-bits.
-    """
-    # TODO: ask Paul what to do if the length of
-    # binary_data is not a multiple of 48
-    field_bit_length = 48
-    return [
-        binary_data[i : i + field_bit_length]
-        for i in range(0, len(binary_data), field_bit_length)
-    ]
 
 
 def create_dataset(de_data_dict: dict[str, npt.ArrayLike]) -> xr.Dataset:

--- a/imap_processing/hi/l1a/science_direct_event.py
+++ b/imap_processing/hi/l1a/science_direct_event.py
@@ -48,21 +48,6 @@ def parse_direct_events(de_data: bytes) -> dict[str, npt.ArrayLike]:
     If there is no event record for certain ESA step, then both packets will
     contain 0-bits in DE_TOF.
 
-    In direct event data, if no hit is registered, the tof_x field in
-    the DE to a value of negative one. However, since the field is described as a
-    "10-bit unsigned counter," it cannot actually store negative numbers.
-    Instead, the value negative is represented by the maximum value that can
-    be stored in a 10-bit unsigned integer, which is 0x3FF (in hexadecimal)
-    or 1023 in decimal. This value is used as a special marker to
-    indicate that no hit was registered. Ideally, the system should
-    not be able to register a hit with a value of 1023 for all
-    tof_1, tof_2, tof_3, because this is in case of an error. But,
-    IMAP-Hi like to process it still to investigate the data.
-    Example of what it will look like if no hit was registered.
-
-    |        (start_bitmask_data, de_tag, 1023, 1023, 1023)
-    |        start_bitmask_data will be 1 or 2 or 3.
-
     Parameters
     ----------
     de_data : bytes
@@ -74,22 +59,27 @@ def parse_direct_events(de_data: bytes) -> dict[str, npt.ArrayLike]:
     Dict[str, list]
         Parsed event data.
     """
-    # Each DE consists of 6-bytes. Considering the data as 3 2-byte words,
+    # The de_data is a binary blob with Nx6 bytes of data where N = number of
+    # direct events encoded into the binary blob. Interpreting the data as
+    # big-endian uint16 data and reshaping into a (3, -1) ndarray results
+    # in an array with shape (3, N). Indexing the first axis of that array
+    # (e.g. data_uint16[i]) gives the ith 2-bytes of data for each of the N
+    # direct events.
+    # Considering the 6-bytes of data for each DE as 3 2-byte words,
     # each word contains the following:
     # word_0: 2-bits of Trigger ID, upper 14-bits of de_tag
     # word_1: lower 2-bits of de_tag, 10-bits tof_1, upper 4-bits of tof_2
-    # word_3: lower 6-bits of tof_2, 10-bits of tof_3
-    # Interpret binary blob as uint16 array and reshape to (3, n)
+    # word_2: lower 6-bits of tof_2, 10-bits of tof_3
     data_uint16 = np.reshape(
         np.frombuffer(de_data, dtype=">u2"), (3, -1), order="F"
     ).astype(np.uint16)
 
     de_dict = dict()
-    de_dict["trigger_id"] = (data_uint16[0] >> (6 + 8)).astype(np.uint8)
-    de_dict["de_tag"] = (data_uint16[0] << 2) + (data_uint16[1] >> (6 + 8))
+    de_dict["trigger_id"] = (data_uint16[0] >> 14).astype(np.uint8)
+    de_dict["de_tag"] = (data_uint16[0] << 2) + (data_uint16[1] >> 14)
     de_dict["tof_1"] = (data_uint16[1] & int(b"00111111_11110000", 2)) >> 4
     de_dict["tof_2"] = ((data_uint16[1] & int(b"00000000_00001111", 2)) << 6) + (
-        data_uint16[2] >> (2 + 8)
+        data_uint16[2] >> 10
     )
     de_dict["tof_3"] = data_uint16[2] & int(b"00000011_11111111", 2)
 

--- a/imap_processing/tests/hi/test_science_direct_event.py
+++ b/imap_processing/tests/hi/test_science_direct_event.py
@@ -21,11 +21,11 @@ def test_parse_direct_events():
     # Encode the random events data into a bit-string
     bin_str = ""
     for i in range(n_events):
-        bin_str += f"{exp_dict["trigger_id"][i]:02b}"  # 2-bits for trigger_id
-        bin_str += f"{exp_dict["de_tag"][i]:016b}"  # 16-bits for de_tag
-        bin_str += f"{exp_dict["tof_1"][i]:010b}"  # 10-bits for tof_1
-        bin_str += f"{exp_dict["tof_2"][i]:010b}"  # 10-bits for tof_2
-        bin_str += f"{exp_dict["tof_3"][i]:010b}"  # 10-bits for tof_3
+        bin_str += f"{exp_dict['trigger_id'][i]:02b}"  # 2-bits for trigger_id
+        bin_str += f"{exp_dict['de_tag'][i]:016b}"  # 16-bits for de_tag
+        bin_str += f"{exp_dict['tof_1'][i]:010b}"  # 10-bits for tof_1
+        bin_str += f"{exp_dict['tof_2'][i]:010b}"  # 10-bits for tof_2
+        bin_str += f"{exp_dict['tof_3'][i]:010b}"  # 10-bits for tof_3
     # Convert the bit-string into a bytes object
     bytes_obj = bytes([int(bin_str[i : i + 8], 2) for i in range(0, len(bin_str), 8)])
     # Parse the fake events and check values

--- a/imap_processing/tests/hi/test_science_direct_event.py
+++ b/imap_processing/tests/hi/test_science_direct_event.py
@@ -1,4 +1,36 @@
-from imap_processing.hi.l1a.science_direct_event import create_dataset
+import numpy as np
+
+from imap_processing.hi.l1a.science_direct_event import (
+    create_dataset,
+    parse_direct_events,
+)
+
+
+def test_parse_direct_events():
+    """Test coverage for parse_direct_events function."""
+    # Generate fake, binary blob using random numbers
+    np.random.seed(2)
+    n_events = 10_000
+    exp_dict = dict()
+    exp_dict["trigger_id"] = np.random.randint(1, 4, size=n_events, dtype=np.uint8)
+    exp_dict["de_tag"] = np.random.randint(0, 2**16, size=n_events, dtype=np.uint16)
+    exp_dict["tof_1"] = np.random.randint(0, 2**10, size=n_events, dtype=np.uint16)
+    exp_dict["tof_2"] = np.random.randint(0, 2**10, size=n_events, dtype=np.uint16)
+    exp_dict["tof_3"] = np.random.randint(0, 2**10, size=n_events, dtype=np.uint16)
+
+    bin_str = ""
+    for i in range(n_events):
+        bin_str += f"{exp_dict["trigger_id"][i]:02b}"
+        bin_str += f"{exp_dict["de_tag"][i]:016b}"
+        bin_str += f"{exp_dict["tof_1"][i]:010b}"
+        bin_str += f"{exp_dict["tof_2"][i]:010b}"
+        bin_str += f"{exp_dict["tof_3"][i]:010b}"
+
+    bytes_obj = bytes([int(bin_str[i : i + 8], 2) for i in range(0, len(bin_str), 8)])
+    de_dict = parse_direct_events(bytes_obj)
+
+    for key in exp_dict.keys():
+        np.testing.assert_array_equal(de_dict[key], exp_dict[key])
 
 
 def test_create_dataset():

--- a/imap_processing/tests/hi/test_science_direct_event.py
+++ b/imap_processing/tests/hi/test_science_direct_event.py
@@ -18,17 +18,18 @@ def test_parse_direct_events():
     exp_dict["tof_2"] = np.random.randint(0, 2**10, size=n_events, dtype=np.uint16)
     exp_dict["tof_3"] = np.random.randint(0, 2**10, size=n_events, dtype=np.uint16)
 
+    # Encode the random events data into a bit-string
     bin_str = ""
     for i in range(n_events):
-        bin_str += f"{exp_dict["trigger_id"][i]:02b}"
-        bin_str += f"{exp_dict["de_tag"][i]:016b}"
-        bin_str += f"{exp_dict["tof_1"][i]:010b}"
-        bin_str += f"{exp_dict["tof_2"][i]:010b}"
-        bin_str += f"{exp_dict["tof_3"][i]:010b}"
-
+        bin_str += f"{exp_dict["trigger_id"][i]:02b}"  # 2-bits for trigger_id
+        bin_str += f"{exp_dict["de_tag"][i]:016b}"  # 16-bits for de_tag
+        bin_str += f"{exp_dict["tof_1"][i]:010b}"  # 10-bits for tof_1
+        bin_str += f"{exp_dict["tof_2"][i]:010b}"  # 10-bits for tof_2
+        bin_str += f"{exp_dict["tof_3"][i]:010b}"  # 10-bits for tof_3
+    # Convert the bit-string into a bytes object
     bytes_obj = bytes([int(bin_str[i : i + 8], 2) for i in range(0, len(bin_str), 8)])
+    # Parse the fake events and check values
     de_dict = parse_direct_events(bytes_obj)
-
     for key in exp_dict.keys():
         np.testing.assert_array_equal(de_dict[key], exp_dict[key])
 


### PR DESCRIPTION
Add test coverage for parse_direct_events

# Change Summary
This PR changes how the direct events are parsed from the binary blob in Hi SCI_DE packets. It interprets the bytes data as 16-bit unsigned integers and then reshapes them into a 3xN ndarray. This is done to take advantage of numpy broadcasting. Bit-shifting and bitwise_and with bitmasks are used to extract the unsigned integer values from the 16-bit integers.

## Updated Files
- imap_processing/hi/l1a/science_direct_event.py
   - Interpret bytes as uint16 array and use numpy bit-shifts and bitwise_and to extract list of direct events.
- imap_processing/tests/hi/test_science_direct_event.py
   - Add specific test coverage for the `parse_direct_events` function.

Closes: #1217 
