### PR TITLE
Lo - Create L1A Direct Event CDFs 

### DIFF
--- a/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
@@ -127,6 +127,7 @@ direct_events:
   CATDESC: Index of number of direct events for pointing
   FIELDNAM: direct_events
   LABLAXIS: DE
+  LABL_PTR_1: direct_events_label
 
 ## Fields
 de_time:
@@ -146,7 +147,7 @@ esa_step:
   VALIDMAX: 7
   FORMAT: I1
   CATDESC: Energy Step
-  DEPEND_1: esa_step
+  DEPEND_1: direct_events
   FIELDNAM: Energy Step
   LABLAXIS: ESA
 

--- a/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
@@ -51,6 +51,7 @@ de_default_attrs: &de_default
   <<: *default
   VAR_TYPE: support_data
   DEPEND_1: direct_events
+  LABL_PTR_1: direct_events_label
 
 hist_az_60_default: &hist_az_60_default
   <<: *default_uint32
@@ -127,7 +128,6 @@ direct_events:
   CATDESC: Index of number of direct events for pointing
   FIELDNAM: direct_events
   LABLAXIS: DE
-  LABL_PTR_1: direct_events_label
 
 ## Fields
 de_time:
@@ -147,7 +147,6 @@ esa_step:
   VALIDMAX: 7
   FORMAT: I1
   CATDESC: Energy Step
-  DEPEND_1: direct_events
   FIELDNAM: Energy Step
   LABLAXIS: ESA
 

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -239,6 +239,7 @@ def parse_events(dataset: xr.Dataset, attr_mgr: ImapCdfAttributes) -> xr.Dataset
 
             pointing_de += 1
 
+    del dataset.attrs["bit_pos"]
     logger.info("\n Returning Lo L1A Direct Events Dataset")
     return dataset
 

--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -9,8 +9,12 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.lo.l0.lo_apid import LoAPID
-from imap_processing.lo.l0.lo_science import parse_histogram
-from imap_processing.utils import packet_file_to_datasets
+from imap_processing.lo.l0.lo_science import (
+    combine_segmented_packets,
+    parse_events,
+    parse_histogram,
+)
+from imap_processing.utils import convert_to_binary_string, packet_file_to_datasets
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -60,8 +64,29 @@ def lo_l1a(dependency: Path, data_version: str) -> list[xr.Dataset]:
         datasets_by_apid[LoAPID.ILO_SCI_CNT] = add_dataset_attrs(
             datasets_by_apid[LoAPID.ILO_SCI_CNT], attr_mgr, logical_source
         )
+    if LoAPID.ILO_SCI_DE in datasets_by_apid:
+        logical_source = "imap_lo_l1a_de"
+        datasets_by_apid[LoAPID.ILO_SCI_DE]["data"] = xr.DataArray(
+            [
+                convert_to_binary_string(data)
+                for data in datasets_by_apid[LoAPID.ILO_SCI_DE]["data"].values
+            ],
+            dims=datasets_by_apid[LoAPID.ILO_SCI_DE]["data"].dims,
+            attrs=datasets_by_apid[LoAPID.ILO_SCI_DE]["data"].attrs,
+        )
 
-    good_apids = [LoAPID.ILO_SCI_CNT]
+        datasets_by_apid[LoAPID.ILO_SCI_DE] = combine_segmented_packets(
+            datasets_by_apid[LoAPID.ILO_SCI_DE]
+        )
+
+        datasets_by_apid[LoAPID.ILO_SCI_DE] = parse_events(
+            datasets_by_apid[LoAPID.ILO_SCI_DE], attr_mgr
+        )
+        datasets_by_apid[LoAPID.ILO_SCI_DE] = add_dataset_attrs(
+            datasets_by_apid[LoAPID.ILO_SCI_DE], attr_mgr, logical_source
+        )
+
+    good_apids = [LoAPID.ILO_SCI_CNT, LoAPID.ILO_SCI_DE]
     logger.info(f"\nReturning datasets: {[LoAPID(apid) for apid in good_apids]}")
     return [datasets_by_apid[good_apid] for good_apid in good_apids]
 
@@ -151,6 +176,43 @@ def add_dataset_attrs(
                 "seq_flgs",
                 "src_seq_ctr",
                 "pkt_len",
+            ]
+        )
+    elif logical_source == "imap_lo_l1a_de":
+        direct_events = xr.DataArray(
+            data=np.arange(sum(dataset["de_count"].values), dtype=np.uint16),
+            name="direct_events",
+            dims=["direct_events"],
+            attrs=attr_mgr.get_variable_attributes("direct_events"),
+        )
+
+        direct_events_label = xr.DataArray(
+            direct_events.values.astype(str),
+            name="direct_events_label",
+            dims=["direct_events_label"],
+            attrs=attr_mgr.get_variable_attributes("direct_events_label"),
+        )
+
+        dataset = dataset.assign_coords(
+            direct_events=direct_events,
+            direct_events_label=direct_events_label,
+        )
+
+        # dataset.shcoarse.attrs.update(attr_mgr.get_variable_attributes("shcoarse"))
+        dataset.epoch.attrs.update(attr_mgr.get_variable_attributes("epoch"))
+        dataset.attrs.update(attr_mgr.get_global_attributes(logical_source))
+        dataset = dataset.drop_vars(
+            [
+                "version",
+                "type",
+                "sec_hdr_flg",
+                "pkt_apid",
+                "seq_flgs",
+                "src_seq_ctr",
+                "pkt_len",
+                "shcoarse",
+                "data",
+                "events",
             ]
         )
 

--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -52,11 +52,11 @@ def lo_l1a(dependency: Path, data_version: str) -> list[xr.Dataset]:
     attr_mgr.add_instrument_variable_attrs(instrument="lo", level="l1a")
     attr_mgr.add_global_attribute("Data_version", data_version)
 
-    logger.info(
-        f"\nProcessing {LoAPID(LoAPID.ILO_SCI_CNT).name} "
-        f"packet (APID: {LoAPID.ILO_SCI_CNT.value})"
-    )
     if LoAPID.ILO_SCI_CNT in datasets_by_apid:
+        logger.info(
+            f"\nProcessing {LoAPID(LoAPID.ILO_SCI_CNT).name} "
+            f"packet (APID: {LoAPID.ILO_SCI_CNT.value})"
+        )
         logical_source = "imap_lo_l1a_histogram"
         datasets_by_apid[LoAPID.ILO_SCI_CNT] = parse_histogram(
             datasets_by_apid[LoAPID.ILO_SCI_CNT], attr_mgr
@@ -65,6 +65,10 @@ def lo_l1a(dependency: Path, data_version: str) -> list[xr.Dataset]:
             datasets_by_apid[LoAPID.ILO_SCI_CNT], attr_mgr, logical_source
         )
     if LoAPID.ILO_SCI_DE in datasets_by_apid:
+        logger.info(
+            f"\nProcessing {LoAPID(LoAPID.ILO_SCI_DE).name} "
+            f"packet (APID: {LoAPID.ILO_SCI_DE.value})"
+        )
         logical_source = "imap_lo_l1a_de"
         datasets_by_apid[LoAPID.ILO_SCI_DE]["data"] = xr.DataArray(
             [
@@ -114,6 +118,7 @@ def add_dataset_attrs(
     # TODO: may want up split up these if statements into their
     # own functions
     if logical_source == "imap_lo_l1a_histogram":
+        # Create coordinates for the dataset
         azimuth_60 = xr.DataArray(
             data=np.arange(0, 6, dtype=np.uint8),
             name="azimuth_60",
@@ -152,6 +157,7 @@ def add_dataset_attrs(
             attrs=attr_mgr.get_variable_attributes("esa_step_label"),
         )
 
+        # Get attributes for shcoarse and epoch
         dataset.shcoarse.attrs.update(attr_mgr.get_variable_attributes("shcoarse"))
         dataset.epoch.attrs.update(attr_mgr.get_variable_attributes("epoch"))
 
@@ -179,6 +185,7 @@ def add_dataset_attrs(
             ]
         )
     elif logical_source == "imap_lo_l1a_de":
+        # Create the coordinates for the dataset
         direct_events = xr.DataArray(
             data=np.arange(sum(dataset["de_count"].values), dtype=np.uint16),
             name="direct_events",
@@ -197,8 +204,7 @@ def add_dataset_attrs(
             direct_events=direct_events,
             direct_events_label=direct_events_label,
         )
-
-        # dataset.shcoarse.attrs.update(attr_mgr.get_variable_attributes("shcoarse"))
+        # add the epoch and global attributes
         dataset.epoch.attrs.update(attr_mgr.get_variable_attributes("epoch"))
         dataset.attrs.update(attr_mgr.get_global_attributes(logical_source))
         dataset = dataset.drop_vars(

--- a/imap_processing/tests/lo/test_lo_l1a.py
+++ b/imap_processing/tests/lo/test_lo_l1a.py
@@ -1,29 +1,20 @@
-from pathlib import Path
-
 import numpy as np
-import pytest
 
 from imap_processing import imap_module_directory
 from imap_processing.lo.l1a.lo_l1a import lo_l1a
 
 
-@pytest.mark.skip(reason="not implemented")
-@pytest.mark.parametrize(
-    ("dependency", "expected_logical_source"),
-    [
-        (Path("imap_lo_l0_de_20100101_v001.pkts"), "imap_lo_l1a_de"),
-        (
-            Path("imap_lo_l0_spin_20100101_v001.pkt"),
-            "imap_lo_l1a_spin",
-        ),
-    ],
-)
-def test_lo_l1a(dependency, expected_logical_source):
+def test_lo_l1a():
     # Act
+    dependency = (
+        imap_module_directory / "tests/lo/test_pkts/imap_lo_l0_raw_20240803_v002.pkts"
+    )
+    expected_logical_source = ["imap_lo_l1a_histogram", "imap_lo_l1a_de"]
     output_dataset = lo_l1a(dependency, "001")
 
     # Assert
-    assert expected_logical_source == output_dataset.attrs["Logical_source"]
+    for dataset, logical_source in zip(output_dataset, expected_logical_source):
+        assert logical_source == dataset.attrs["Logical_source"]
 
 
 def test_lo_l1a_dataset():


### PR DESCRIPTION
# Change Summary

## Overview
Adds the DE processing code to the pipeline and adds L1A Direct Event Attributes to the processed dataset

## Updated Files
- imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
   - minor fixes to attribute fields
- imap_processing/lo/l0/lo_science.py
   - removed bit_pos from attributes (used for tracking bit position of direct event data)
- imap_processing/lo/l1a/lo_l1a.py
   - Added DE processing to file
   - Added DE attribute setting

## Testing
Added check for L1A dataset logical source results for each product being created in the pipeline. Planning to add further attribute testing in the future

Closes #1013
Closes #1014 
