### PR TITLE
Fix data array shapes for CoDICE-Lo products

### DIFF
--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -129,12 +129,12 @@ class CoDICEL1aPipeline:
         for name in self.config["coords"]:
             if name == "epoch":
                 values = self.dataset.epoch.data
+            elif name == "esa_step":
+                values = np.arange(self.config["num_energy_steps"])
             elif name == "inst_az":
                 values = np.arange(self.config["num_positions"])
             elif name == "spin_sector":
                 values = np.arange(self.config["num_spin_sectors"])
-            elif name == "esa_step":
-                values = np.arange(self.config["num_energy_steps"])
             else:
                 # TODO: Need to implement other types of coords
                 continue
@@ -170,8 +170,8 @@ class CoDICEL1aPipeline:
         # Stack the data so that it is easier to reshape and iterate over
         all_data = np.stack(self.data)
 
-        # The dimension of all data is (epoch, num_counters, num_positions,
-        # num_spin_sectors, num_energy_steps) (or may be slightly different
+        # The dimension of all data is (epoch, num_counters, num_energy_steps,
+        # num_positions, num_spin_sectors) (or may be slightly different
         # depending on the data product). In any case, iterate over the
         # num_counters dimension to isolate the data for each counter so
         # that it can be placed in a CDF data variable.
@@ -353,9 +353,9 @@ class CoDICEL1aPipeline:
                     ).reshape(
                         (
                             self.config["num_counters"],
+                            self.config["num_energy_steps"],
                             self.config["num_positions"],
                             self.config["num_spin_sectors"],
-                            self.config["num_energy_steps"],
                         )
                     )
                     self.data.append(reshaped_packet_data)

--- a/imap_processing/codice/constants.py
+++ b/imap_processing/codice/constants.py
@@ -184,7 +184,7 @@ DATA_PRODUCT_CONFIGURATIONS = {
             "energy_label",
         ],  # TODO: These will likely change
         "dataset_name": "imap_codice_l1a_lo-counters-aggregated",
-        "dims": ["epoch", "inst_az", "spin_sector", "esa_step"],
+        "dims": ["epoch", "esa_step", "inst_az", "spin_sector"],
         "instrument": "lo",
         "num_counters": 1,
         "num_energy_steps": 128,
@@ -205,7 +205,7 @@ DATA_PRODUCT_CONFIGURATIONS = {
             "energy_label",
         ],  # TODO: These will likely change
         "dataset_name": "imap_codice_l1a_lo-counters-singles",
-        "dims": ["epoch", "inst_az", "spin_sector", "esa_step"],
+        "dims": ["epoch", "esa_step", "inst_az", "spin_sector"],
         "instrument": "lo",
         "num_counters": 1,
         "num_energy_steps": 128,
@@ -225,9 +225,9 @@ DATA_PRODUCT_CONFIGURATIONS = {
         "variable_names": LO_INST_COUNTS_SINGLES_VARIABLE_NAMES,
     },
     CODICEAPID.COD_LO_SW_ANGULAR_COUNTS: {
-        "coords": ["epoch", "inst_az", "spin_sector", "esa_step", "energy_label"],
+        "coords": ["epoch", "energy_label", "esa_step", "inst_az", "spin_sector"],
         "dataset_name": "imap_codice_l1a_lo-sw-angular",
-        "dims": ["epoch", "inst_az", "spin_sector", "esa_step"],
+        "dims": ["epoch", "esa_step", "inst_az", "spin_sector"],
         "instrument": "lo",
         "num_counters": 4,
         "num_energy_steps": 128,
@@ -248,7 +248,7 @@ DATA_PRODUCT_CONFIGURATIONS = {
     CODICEAPID.COD_LO_NSW_ANGULAR_COUNTS: {
         "coords": ["epoch", "inst_az", "spin_sector", "esa_step", "energy_label"],
         "dataset_name": "imap_codice_l1a_lo-nsw-angular",
-        "dims": ["epoch", "inst_az", "spin_sector", "esa_step"],
+        "dims": ["epoch", "esa_step", "inst_az", "spin_sector"],
         "instrument": "lo",
         "num_counters": 1,
         "num_energy_steps": 128,
@@ -269,7 +269,7 @@ DATA_PRODUCT_CONFIGURATIONS = {
     CODICEAPID.COD_LO_SW_PRIORITY_COUNTS: {
         "coords": ["epoch", "inst_az", "spin_sector", "esa_step", "energy_label"],
         "dataset_name": "imap_codice_l1a_lo-sw-priority",
-        "dims": ["epoch", "inst_az", "spin_sector", "esa_step"],
+        "dims": ["epoch", "esa_step", "inst_az", "spin_sector"],
         "instrument": "lo",
         "num_counters": 5,
         "num_energy_steps": 128,
@@ -290,7 +290,7 @@ DATA_PRODUCT_CONFIGURATIONS = {
     CODICEAPID.COD_LO_NSW_PRIORITY_COUNTS: {
         "coords": ["epoch", "inst_az", "spin_sector", "esa_step", "energy_label"],
         "dataset_name": "imap_codice_l1a_lo-nsw-priority",
-        "dims": ["epoch", "inst_az", "spin_sector", "esa_step"],
+        "dims": ["epoch", "esa_step", "inst_az", "spin_sector"],
         "instrument": "lo",
         "num_counters": 2,
         "num_energy_steps": 128,
@@ -311,7 +311,7 @@ DATA_PRODUCT_CONFIGURATIONS = {
     CODICEAPID.COD_LO_SW_SPECIES_COUNTS: {
         "coords": ["epoch", "inst_az", "spin_sector", "esa_step", "energy_label"],
         "dataset_name": "imap_codice_l1a_lo-sw-species",
-        "dims": ["epoch", "inst_az", "spin_sector", "esa_step"],
+        "dims": ["epoch", "esa_step", "inst_az", "spin_sector"],
         "instrument": "lo",
         "num_counters": 16,
         "num_energy_steps": 128,
@@ -332,7 +332,7 @@ DATA_PRODUCT_CONFIGURATIONS = {
     CODICEAPID.COD_LO_NSW_SPECIES_COUNTS: {
         "coords": ["epoch", "inst_az", "spin_sector", "esa_step", "energy_label"],
         "dataset_name": "imap_codice_l1a_lo-nsw-species",
-        "dims": ["epoch", "inst_az", "spin_sector", "esa_step"],
+        "dims": ["epoch", "esa_step", "inst_az", "spin_sector"],
         "instrument": "lo",
         "num_counters": 8,
         "num_energy_steps": 128,

--- a/imap_processing/codice/decompress.py
+++ b/imap_processing/codice/decompress.py
@@ -50,7 +50,9 @@ def _apply_lossy_a(compressed_bytes: bytes) -> list[int]:
         The 24- or 32-bit decompressed values.
     """
     compressed_values = list(compressed_bytes)
-    decompressed_values = [LOSSY_A_TABLE[item] for item in compressed_values]
+    decompressed_values = [
+        LOSSY_A_TABLE[item - 1] if item > 0 else 0 for item in compressed_values
+    ]
     return decompressed_values
 
 
@@ -71,7 +73,9 @@ def _apply_lossy_b(compressed_bytes: bytes) -> list[int]:
         The 24- or 32-bit decompressed values.
     """
     compressed_values = list(compressed_bytes)
-    decompressed_values = [LOSSY_B_TABLE[item] for item in compressed_values]
+    decompressed_values = [
+        LOSSY_B_TABLE[item - 1] if item > 0 else 0 for item in compressed_values
+    ]
     return decompressed_values
 
 

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -18,14 +18,14 @@ EXPECTED_ARRAY_SHAPES = [
     (),  # hi-ialirt  # TODO: Need to implement
     (),  # lo-ialirt  # TODO: Need to implement
     (31778,),  # hskp
-    (77, 6, 6, 128),  # lo-counters-aggregated
-    (77, 24, 6, 128),  # lo-counters-singles
-    (77, 1, 12, 128),  # lo-sw-priority
-    (77, 1, 12, 128),  # lo-nsw-priority
-    (77, 1, 1, 128),  # lo-sw-species
-    (77, 1, 1, 128),  # lo-nsw-species
-    (77, 5, 12, 128),  # lo-sw-angular
-    (77, 19, 12, 128),  # lo-nsw-angular
+    (77, 128, 6, 6),  # lo-counters-aggregated
+    (77, 128, 24, 6),  # lo-counters-singles
+    (77, 128, 1, 12),  # lo-sw-priority
+    (77, 128, 1, 12),  # lo-nsw-priority
+    (77, 128, 1, 1),  # lo-sw-species
+    (77, 128, 1, 1),  # lo-nsw-species
+    (77, 128, 5, 12),  # lo-sw-angular
+    (77, 128, 19, 12),  # lo-nsw-angular
     (77, 1, 6, 1),  # hi-counters-aggregated
     (77, 1, 12, 1),  # hi-counters-singles
     (77, 15, 4, 1),  # hi-omni

--- a/imap_processing/tests/codice/test_decompress.py
+++ b/imap_processing/tests/codice/test_decompress.py
@@ -13,11 +13,11 @@ lzma_bytes = lzma.compress((234).to_bytes(1, byteorder="big"))
 # LZMA_EXAMPLE = "".join(format(byte, "08b") for byte in lzma_bytes)
 TEST_DATA = [
     (b"\xea", CoDICECompression.NO_COMPRESSION, [234]),
-    (b"\xea", CoDICECompression.LOSSY_A, [221184]),
-    (b"\xea", CoDICECompression.LOSSY_B, [1441792]),
+    (b"\xea", CoDICECompression.LOSSY_A, [212992]),
+    (b"\xea", CoDICECompression.LOSSY_B, [1310720]),
     (lzma_bytes, CoDICECompression.LOSSLESS, [234]),
-    (lzma_bytes, CoDICECompression.LOSSY_A_LOSSLESS, [221184]),
-    (lzma_bytes, CoDICECompression.LOSSY_B_LOSSLESS, [1441792]),
+    (lzma_bytes, CoDICECompression.LOSSY_A_LOSSLESS, [212992]),
+    (lzma_bytes, CoDICECompression.LOSSY_B_LOSSLESS, [1310720]),
 ]
 
 


### PR DESCRIPTION
This PR fixes some issues with how CoDICE-Lo data arrays are shaped, as well as an indexing issue in Lossy A and B table lookup.
