### PR TITLE
Document that PSET epoch represents the center time bin in the pointing set

### DIFF
--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -400,6 +400,11 @@ hi_de_nominal_bin:
 
 # ======= L1C PSET Section =======
 
+# Define override values for epoch as defined in imap_constant_attrs.yaml
+hi_pset_epoch:
+  CATDESC: Midpoint time of pointing, number of nanoseconds since J2000 with leap seconds included
+  BIN_LOCATION: 0.5
+
 hi_pset_esa_energy_step:
   <<: *default_esa_energy_step
   LABLAXIS: Energy Step

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -127,11 +127,13 @@ def empty_pset_dataset(n_esa_steps: int, sensor_str: str) -> xr.Dataset:
     # preallocate coordinates xr.DataArrays
     coords = dict()
     # epoch coordinate has only 1 entry for pointing set
+    epoch_attrs = attr_mgr.get_variable_attributes("epoch")
+    epoch_attrs.update(attr_mgr.get_variable_attributes("hi_pset_epoch"))
     coords["epoch"] = xr.DataArray(
         np.empty(1, dtype=np.int64),  # TODO: get dtype from cdf attrs?
         name="epoch",
         dims=["epoch"],
-        attrs=attr_mgr.get_variable_attributes("epoch"),
+        attrs=epoch_attrs,
     )
     attrs = attr_mgr.get_variable_attributes(
         "hi_pset_esa_energy_step", check_schema=False

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -128,7 +128,9 @@ def empty_pset_dataset(n_esa_steps: int, sensor_str: str) -> xr.Dataset:
     coords = dict()
     # epoch coordinate has only 1 entry for pointing set
     epoch_attrs = attr_mgr.get_variable_attributes("epoch")
-    epoch_attrs.update(attr_mgr.get_variable_attributes("hi_pset_epoch"))
+    epoch_attrs.update(
+        attr_mgr.get_variable_attributes("hi_pset_epoch", check_schema=False)
+    )
     coords["epoch"] = xr.DataArray(
         np.empty(1, dtype=np.int64),  # TODO: get dtype from cdf attrs?
         name="epoch",

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -5,6 +5,7 @@ from unittest import mock
 import numpy as np
 import pytest
 
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import load_cdf, write_cdf
 from imap_processing.hi.l1c import hi_l1c
 from imap_processing.hi.utils import HIAPID
@@ -49,6 +50,16 @@ def test_empty_pset_dataset():
     assert dataset.spin_angle_bin.size == 3600
     assert dataset.esa_energy_step.size == n_esa_steps
     assert dataset.calibration_prod.size == n_calibration_prods
+
+    # verify that attrs defined in hi_pset_epoch have overwritten default
+    # epoch attributes
+    attr_mgr = ImapCdfAttributes()
+    attr_mgr.add_instrument_global_attrs("hi")
+    attr_mgr.add_instrument_variable_attrs(instrument="hi", level=None)
+    pset_epoch_attrs = attr_mgr.get_variable_attributes("hi_pset_epoch")
+    for k, v in pset_epoch_attrs.items():
+        assert k in dataset.epoch.attrs
+        assert dataset.epoch.attrs[k] == v
 
 
 @pytest.mark.parametrize("sensor_str", ["90sensor", "45sensor"])

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -56,7 +56,9 @@ def test_empty_pset_dataset():
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs("hi")
     attr_mgr.add_instrument_variable_attrs(instrument="hi", level=None)
-    pset_epoch_attrs = attr_mgr.get_variable_attributes("hi_pset_epoch")
+    pset_epoch_attrs = attr_mgr.get_variable_attributes(
+        "hi_pset_epoch", check_schema=False
+    )
     for k, v in pset_epoch_attrs.items():
         assert k in dataset.epoch.attrs
         assert dataset.epoch.attrs[k] == v


### PR DESCRIPTION
# Change Summary

## Overview
Small PR updating CDF metadata in the Hi L1C PSET to specifically call out that the epoch value is the center of the time covered by the pointing.

## Updated Files
- imap_processing/cdf/config/imap_hi_variable_attrs.yaml
   - Define pset epoch attribute overrides
- imap_processing/hi/l1c/hi_l1c.py
   - Get and apply attribute overrides for pset epoch variable (coordinate)
-  imap_processing/tests/hi/test_hi_l1c.py
   - Add test coverage that checks overrides are applied correctly
 
Closes: #1241