### PR TITLE
1255 spice write function to transform azel coordinates between frames

### DIFF
--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -10,9 +10,8 @@ from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.hi.utils import create_dataset_variables, full_dataarray
 from imap_processing.spice.geometry import (
     SpiceFrame,
-    cartesian_to_spherical,
     frame_transform,
-    spherical_to_cartesian,
+    frame_transform_az_el,
 )
 from imap_processing.spice.time import j2000ns_to_j2000s
 
@@ -246,17 +245,13 @@ def pset_geometry(pset_et: float, sensor_str: str) -> dict[str, xr.DataArray]:
     el = 0 if "90" in sensor_str else -45
     dps_az_el = np.array(
         [
-            np.ones(3600),
-            np.deg2rad(np.arange(0.05, 360, 0.1)),
-            np.full(3600, np.deg2rad(el)),
+            np.arange(0.05, 360, 0.1),
+            np.full(3600, el),
         ]
     ).T
-    dps_cartesian = spherical_to_cartesian(dps_az_el)
-    # Transform DPS Cartesian coords into HAE Ecliptic
-    hae_eclip_cartesian = frame_transform(
-        pset_et, dps_cartesian, SpiceFrame.IMAP_DPS, SpiceFrame.ECLIPJ2000
+    hae_az_el = frame_transform_az_el(
+        pset_et, dps_az_el, SpiceFrame.IMAP_DPS, SpiceFrame.ECLIPJ2000, degrees=True
     )
-    hae_az_el = cartesian_to_spherical(hae_eclip_cartesian, degrees=True)
 
     geometry_vars.update(
         create_dataset_variables(
@@ -265,10 +260,10 @@ def pset_geometry(pset_et: float, sensor_str: str) -> dict[str, xr.DataArray]:
             att_manager_lookup_str="hi_pset_{0}",
         )
     )
-    geometry_vars["hae_longitude"].values = hae_az_el[:, 1].astype(np.float32)[
+    geometry_vars["hae_longitude"].values = hae_az_el[:, 0].astype(np.float32)[
         np.newaxis, :
     ]
-    geometry_vars["hae_latitude"].values = hae_az_el[:, 2].astype(np.float32)[
+    geometry_vars["hae_latitude"].values = hae_az_el[:, 1].astype(np.float32)[
         np.newaxis, :
     ]
     return geometry_vars

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -52,11 +52,16 @@ def test_empty_pset_dataset():
 
 
 @pytest.mark.parametrize("sensor_str", ["90sensor", "45sensor"])
+@mock.patch("imap_processing.spice.geometry.frame_transform")
 @mock.patch("imap_processing.hi.l1c.hi_l1c.frame_transform")
-def test_pset_geometry(mock_frame_transform, sensor_str):
+def test_pset_geometry(mock_frame_transform, mock_geom_frame_transform, sensor_str):
     """Test coverage for pset_geometry function"""
-    # Mock frame transform to simply return the input position vectors (no transform)
+    # pset_geometry uses both frame_transform and frame_transform_az_el. By mocking
+    # the frame_transform imported into hi_l1c as well as the geometry.frame_transform
+    # the underlying need for SPICE kernels is remove. Mock them both to just return
+    # the input position vectors.
     mock_frame_transform.side_effect = lambda et, pos, from_frame, to_frame: pos
+    mock_geom_frame_transform.side_effect = lambda et, pos, from_frame, to_frame: pos
 
     geometry_vars = hi_l1c.pset_geometry(0, sensor_str)
 

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -450,12 +450,25 @@ def test_spherical_to_cartesian():
     spherical_points = np.stack(
         (r * np.ones_like(theta).ravel(), theta.ravel(), elev.ravel()), axis=-1
     )
+    spherical_points_degrees = np.stack(
+        (
+            r * np.ones_like(theta).ravel(),
+            np.degrees(theta.ravel()),
+            np.degrees(elev.ravel()),
+        ),
+        axis=-1,
+    )
 
     # Convert elevation to colatitude for SPICE
     colat = np.pi / 2 - spherical_points[:, 2]
+
+    cartesian_from_degrees = spherical_to_cartesian(
+        spherical_points_degrees, degrees=True
+    )
 
     for i in range(len(colat)):
         cartesian_coords = spherical_to_cartesian(np.array([spherical_points[i]]))
         spice_coords = spice.sphrec(r, colat[i], spherical_points[i, 1])
 
         np.testing.assert_allclose(cartesian_coords[0], spice_coords, atol=1e-5)
+        np.testing.assert_allclose(cartesian_from_degrees[i], spice_coords, atol=1e-5)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -1,5 +1,7 @@
 """Tests coverage for imap_processing/spice/geometry.py"""
 
+from unittest import mock
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,6 +13,7 @@ from imap_processing.spice.geometry import (
     basis_vectors,
     cartesian_to_spherical,
     frame_transform,
+    frame_transform_az_el,
     get_instrument_spin_phase,
     get_rotation_matrix,
     get_spacecraft_spin_phase,
@@ -285,6 +288,50 @@ def test_frame_transform_exceptions():
             SpiceFrame.ECLIPJ2000,
             SpiceFrame.IMAP_HIT,
         )
+
+
+@pytest.mark.parametrize(
+    "az_range, el_range",
+    [
+        (
+            np.arange(0, 2 * np.pi, np.pi / 50),
+            np.arange(-np.pi / 2, np.pi / 2, np.pi / 50),
+        ),
+        (np.pi / 2, np.pi / 2),
+    ],
+)
+@mock.patch("imap_processing.spice.geometry.get_rotation_matrix")
+def test_frame_transform_az_el(mock_get_rotation_matrix, az_range, el_range):
+    """Test transforming azimuth and elevation between frames"""
+    et = 0
+    az, el = np.meshgrid(az_range, el_range)
+    az_el = np.squeeze(np.vstack((az.flatten(), el.flatten())).T)
+
+    # Mock get_rotation_matrix to return a 90-degree rotation in xy-plane
+    mock_get_rotation_matrix.side_effect = (
+        lambda t, from_frame, to_frame: np.broadcast_to(
+            [[0, -1, 0], [1, 0, 0], [0, 0, 1]], (3, 3)
+        )
+    )
+
+    to_az_el_radians = frame_transform_az_el(
+        et, az_el, SpiceFrame.IMAP_DPS, SpiceFrame.ECLIPJ2000, degrees=False
+    )
+    to_az_el_degrees = frame_transform_az_el(
+        et, np.degrees(az_el), SpiceFrame.IMAP_DPS, SpiceFrame.ECLIPJ2000, degrees=True
+    )
+
+    expected_az = np.asarray(az_el[..., 0] + np.pi / 2)
+    expected_az[expected_az > 2 * np.pi] -= 2 * np.pi
+    np.testing.assert_allclose(to_az_el_radians[..., 0], expected_az, atol=1e-14)
+    np.testing.assert_allclose(to_az_el_radians[..., 1], az_el[..., 1], atol=1e-14)
+    # Check degrees
+    np.testing.assert_allclose(
+        to_az_el_degrees[..., 0], np.degrees(expected_az), atol=1e-14
+    )
+    np.testing.assert_allclose(
+        to_az_el_degrees[..., 1], np.degrees(az_el[..., 1]), atol=1e-14
+    )
 
 
 def test_get_rotation_matrix(furnish_kernels):


### PR DESCRIPTION
# Change Summary

## Overview
Adds a common geometry function for transforming azimuth/elevation coordinates between reference frames.

## Updated Files
- imap_processing/hi/l1c/hi_l1c.py
   - Replace manual azimuth/elevation frame transform with common function
- imap_processing/spice/geometry.py
   - Add new function `frame_transform_az_el` for doing azimuth/elevation coordinate transforms between reference frames
   - Add optional degrees flag to `spherical_to_cartesian()` function.
- imap_processing/tests/hi/test_hi_l1c.py
   - Fix function mocks for `test_pset_geometry`
- imap_processing/tests/spice/test_geometry.py
   - Add test coverage for new `frame_transform_az_el` funciton
   - Add test coverage for `spherical_to_cartesian` when `degrees=True`

Closes: #1255 
