### PR TITLE
ENA Maps: Bin values at indices

### DIFF
--- a/imap_processing/ena_maps/map_utils.py
+++ b/imap_processing/ena_maps/map_utils.py
@@ -47,16 +47,12 @@ def bin_single_array_at_indices(
     num_projection_indices = np.prod(projection_grid_shape)
 
     if value_array.ndim == 1:
-        extra_axis = False
-    elif value_array.ndim == 2:
-        extra_axis = True
-    else:
-        raise NotImplementedError(
-            "Only 1D and 2D arrays are supported for binning. "
-            f"Received array with shape {value_array.shape}."
+        binned_values = np.bincount(
+            projection_indices,
+            weights=value_array[input_indices],
+            minlength=num_projection_indices,
         )
-
-    if extra_axis:
+    elif value_array.ndim == 2:
         # Apply bincount to each row independently
         binned_values = np.apply_along_axis(
             lambda x: np.bincount(
@@ -67,14 +63,11 @@ def bin_single_array_at_indices(
             axis=0,
             arr=value_array,
         )
-
     else:
-        binned_values = np.bincount(
-            projection_indices,
-            weights=value_array[input_indices],
-            minlength=num_projection_indices,
+        raise NotImplementedError(
+            "Only 1D and 2D arrays are supported for binning. "
+            f"Received array with shape {value_array.shape}."
         )
-
     return binned_values
 
 

--- a/imap_processing/ena_maps/map_utils.py
+++ b/imap_processing/ena_maps/map_utils.py
@@ -1,0 +1,89 @@
+"""Utilities for generating ENA maps."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+
+def bin_values_at_indices(
+    input_values_to_bin: dict[str, NDArray],
+    input_indices: NDArray,
+    projection_indices: NDArray,
+    projection_grid_shape: tuple[int, int],
+) -> dict[str, NDArray]:
+    """
+    Project values from input grid to projection grid based on matched indices.
+
+    Parameters
+    ----------
+    input_values_to_bin : dict[str, NDArray]
+        Dict matching variable names to arrays of values to bin.
+    input_indices : NDArray
+        Ordered indices for input grid, corresponding to indices in projection grid.
+        1 dimensional. May be non-unique, depending on the projection method.
+    projection_indices : NDArray
+        Ordered indices for projection grid, corresponding to indices in input grid.
+        1 dimensional. May be non-unique, depending on the projection method.
+    projection_grid_shape : tuple[int, int]
+        The shape of the grid onto which values are projected (rows, columns).
+        This size of the resulting grid (rows * columns) will be the size of the
+        projected values contained in the output dictionary.
+
+    Returns
+    -------
+    dict[str, NDArray]
+        Dict matching the input variable names to the binned values
+        on the projection grid.
+
+    Raises
+    ------
+    ValueError
+        If the input indices are not 1D arrays with the same number of elements.
+    ValueError
+        If the number of i
+    """
+    # Both sets of indices must be 1D with the same number of elements
+    if input_indices.ndim != 1 or projection_indices.ndim != 1:
+        raise ValueError(
+            "Indices must be 1D arrays. "
+            "If using a rectangular grid, the indices must be unwrapped."
+        )
+    if input_indices.size != projection_indices.size:
+        raise ValueError(
+            "The number of input and projection indices must be the same. "
+            f"Received {input_indices.size} input indices and \
+                         {projection_indices.size} projection indices."
+        )
+
+    num_projection_indices = np.multiply(*projection_grid_shape)
+
+    binned_values_dict = {}
+    for value_name, value_array in input_values_to_bin.items():
+        if value_array.size != input_indices.size:
+            # TODO: This assumption doesn't hold for 'Pull' method. Re-evaluate.
+            # If the same size on axis 0, but values has extra axis (e.g. energy bin),
+            # we can carry the extra axis through, adding each bin separately
+            if value_array.shape[0] == input_indices.size:
+                # TODO: Allow for extra axis (e.g. energy bins)
+                # which is summed separately
+                extra_axis = True
+                logger.info(f"Extra axis detected for {value_name}.")
+            else:
+                raise ValueError(
+                    f"Value array for {value_name} "
+                    "must have the same size as the indices."
+                )
+        if extra_axis:
+            # TODO: how can we handle the bincount in case of extra axis?
+            pass
+        binned_values = np.bincount(
+            projection_indices, weights=value_array, minlength=num_projection_indices
+        )
+        binned_values_dict[value_name] = binned_values
+
+    return binned_values_dict

--- a/imap_processing/ena_maps/map_utils.py
+++ b/imap_processing/ena_maps/map_utils.py
@@ -45,11 +45,27 @@ def bin_single_array_at_indices(
 
     Raises
     ------
+    ValueError
+        If the input and projection indices are not 1D arrays
+        with the same number of elements.
     NotImplementedError
-        If the input value_array has more than 2 dimensions.
+        If the input value_array has dimensionality less than 1.
     """
     if input_indices is None:
         input_indices = np.arange(value_array.shape[0])
+
+    # Both sets of indices must be 1D with the same number of elements
+    if input_indices.ndim != 1 or projection_indices.ndim != 1:
+        raise ValueError(
+            "Indices must be 1D arrays. "
+            "If using a rectangular grid, the indices must be unwrapped."
+        )
+    if input_indices.size != projection_indices.size:
+        raise ValueError(
+            "The number of input and projection indices must be the same. \n"
+            f"Received {input_indices.size} input indices and {projection_indices.size}"
+            " projection indices."
+        )
 
     num_projection_indices = np.prod(projection_grid_shape)
 
@@ -116,19 +132,6 @@ def bin_values_at_indices(
         If the input and projection indices are not 1D arrays
         with the same number of elements.
     """
-    # Both sets of indices must be 1D with the same number of elements
-    if input_indices.ndim != 1 or projection_indices.ndim != 1:
-        raise ValueError(
-            "Indices must be 1D arrays. "
-            "If using a rectangular grid, the indices must be unwrapped."
-        )
-    if input_indices.size != projection_indices.size:
-        raise ValueError(
-            "The number of input and projection indices must be the same. \n"
-            f"Received {input_indices.size} input indices and {projection_indices.size}"
-            " projection indices."
-        )
-
     binned_values_dict = {}
     for value_name, value_array in input_values_to_bin.items():
         logger.info(f"Binning {value_name}")

--- a/imap_processing/ena_maps/map_utils.py
+++ b/imap_processing/ena_maps/map_utils.py
@@ -109,7 +109,8 @@ def bin_values_at_indices(
         on the projection grid.
 
     ValueError
-        If the input indices are not 1D arrays with the same number of elements.
+        If the input and projection indices are not 1D arrays
+        with the same number of elements.
     """
     # Both sets of indices must be 1D with the same number of elements
     if input_indices.ndim != 1 or projection_indices.ndim != 1:

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -4,7 +4,57 @@ import pytest
 from imap_processing.ena_maps import map_utils
 
 
-class TestENAMapUtils:
+class TestENAMapMappingUtils:
+    def test_bin_single_array_at_indices(
+        self,
+    ):
+        value_array = np.array([1, 2, 3, 4, 5, 6])
+        input_indices = np.array([0, 1, 2, 2, 1, 0])
+        projection_indices = np.array([1, 2, 3, 1, 2, 3])
+        projection_grid_shape = (5,)
+        expected_projection_values = np.array([0, 4, 4, 4, 0])
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+        )
+        np.testing.assert_equal(projection_values, expected_projection_values)
+
+    def test_bin_single_array_at_indices_extra_axis(
+        self,
+    ):
+        # Binning will occur along axis 0 (combining 1, 2, 3 and 4, 5, 6 separately)
+        value_array = np.array(
+            [
+                [1, 4],
+                [2, 5],
+                [3, 6],
+            ]
+        )
+        input_indices = np.array([0, 1, 2, 2])
+        projection_indices = np.array([1, 0, 1, 6])
+        projection_grid_shape = (7, 1)
+        expected_projection_values = np.array(
+            [
+                [2, 5],
+                [4, 10],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+                [3, 6],
+            ]
+        )
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+        )
+
+        np.testing.assert_equal(projection_values, expected_projection_values)
+
     # Parameterize by the size of the projection grid,
     # which is not necessarily same size as input grid
     @pytest.mark.parametrize("projection_grid_shape", [(1, 1), (10, 10), (360, 720)])
@@ -17,17 +67,17 @@ class TestENAMapUtils:
         ]
         # unwrap to 0,0,0,1,2,3,4,5,6,7,8,9
         unwrapped_input_values = np.ravel(wrapped_input_values, order="C")
-
+        scale_factor = 1.5
         input_values_to_bin = {
             "sum_variable_1": unwrapped_input_values,
-            "sum_variable_2": unwrapped_input_values * 1.5,
+            "sum_variable_2": unwrapped_input_values * scale_factor,
         }
 
         input_indices = np.arange(len(unwrapped_input_values))
         projection_indices = np.zeros_like(input_indices)
         expected_projection_values_1 = np.zeros(projection_grid_shape).ravel()
         expected_projection_values_1[0] = np.sum(unwrapped_input_values)
-        expected_projection_values_2 = expected_projection_values_1 * 1.5
+        expected_projection_values_2 = expected_projection_values_1 * scale_factor
 
         output_dict = map_utils.bin_values_at_indices(
             input_values_to_bin,

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -55,6 +55,37 @@ class TestENAMapMappingUtils:
 
         np.testing.assert_equal(projection_values, expected_projection_values)
 
+    @pytest.mark.parametrize(
+        "projection_grid_shape", [(1, 1), (10, 10), (180, 360), (360, 720), (360, 180)]
+    )
+    @pytest.mark.parametrize(
+        "input_grid_shape", [(1, 1), (10, 10), (180, 360), (360, 720), (360, 180)]
+    )
+    def test_bin_single_array_at_indices_complex(
+        self, projection_grid_shape, input_grid_shape
+    ):
+        np.random.seed(0)
+        extra_axis_size = 11  # Another axis which is not spatially binned, e.g. energy
+        input_grid_size = np.prod(input_grid_shape)
+        projection_grid_size = np.prod(projection_grid_shape)
+        value_array = np.random.rand(input_grid_size, extra_axis_size)
+        input_indices = np.random.randint(0, input_grid_size, size=1000)
+        projection_indices = np.random.randint(0, projection_grid_size, size=1000)
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+        )
+
+        # Create the expected projection values by summing the input values in a loop
+        # This is different from the binning function, which uses np.bincount
+        expected_projection_values = np.zeros((projection_grid_size, extra_axis_size))
+        for ii, ip in zip(input_indices, projection_indices):
+            expected_projection_values[ip, :] += value_array[ii, :]
+
+        np.testing.assert_allclose(projection_values, expected_projection_values)
+
     # Parameterize by the size of the projection grid,
     # which is not necessarily same size as input grid
     @pytest.mark.parametrize("projection_grid_shape", [(1, 1), (10, 10), (360, 720)])
@@ -92,3 +123,60 @@ class TestENAMapMappingUtils:
         np.testing.assert_equal(
             output_dict["sum_variable_2"], expected_projection_values_2
         )
+
+    def test_bin_single_array_at_indices_3d_values_raises(self):
+        value_array = np.ones((2, 2, 2))
+        input_indices = np.array([0, 1])
+        projection_indices = np.array([0, 1])
+        projection_grid_shape = (2,)
+
+        with pytest.raises(
+            NotImplementedError,
+            match=(
+                "Only 1D and 2D arrays are supported for binning. "
+                "Received array with shape"
+            ),
+        ):
+            map_utils.bin_single_array_at_indices(
+                value_array,
+                input_indices=input_indices,
+                projection_indices=projection_indices,
+                projection_grid_shape=projection_grid_shape,
+            )
+
+    def test_bin_values_at_indices_2d_indices_raises(self):
+        input_values = {"test": np.array([1, 2, 3])}
+        input_indices = np.array([[0, 1], [1, 2]])
+        projection_indices = np.array([0, 1, 2])
+        projection_grid_shape = (3,)
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Indices must be 1D arrays. If using a rectangular grid, "
+                "the indices must be unwrapped."
+            ),
+        ):
+            map_utils.bin_values_at_indices(
+                input_values,
+                input_indices=input_indices,
+                projection_indices=projection_indices,
+                projection_grid_shape=projection_grid_shape,
+            )
+
+    def test_bin_values_at_indices_mismatched_sizes_raises(self):
+        input_values = {"test": np.array([1, 2, 3])}
+        input_indices = np.array([0, 1, 0, 1])
+        projection_indices = np.array([0, 1, 2])
+        projection_grid_shape = (3,)
+
+        with pytest.raises(
+            ValueError,
+            match=("The number of input and projection indices must be the same"),
+        ):
+            map_utils.bin_values_at_indices(
+                input_values,
+                input_indices=input_indices,
+                projection_indices=projection_indices,
+                projection_grid_shape=projection_grid_shape,
+            )

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+from imap_processing.ena_maps import map_utils
+
+
+class TestENAMapUtils:
+    # Parameterize by the size of the projection grid,
+    # which is not necessarily same size as input grid
+    @pytest.mark.parametrize("projection_grid_shape", [(1, 1), (10, 10), (360, 720)])
+    def test_bin_values_at_indices_1d_collapse_to_idx_zero(self, projection_grid_shape):
+        wrapped_input_values = [
+            [0, 0, 0],
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ]
+        # unwrap to 0,0,0,1,2,3,4,5,6,7,8,9
+        unwrapped_input_values = np.ravel(wrapped_input_values, order="C")
+
+        input_values_to_bin = {
+            "sum_variable_1": unwrapped_input_values,
+            "sum_variable_2": unwrapped_input_values * 1.5,
+        }
+
+        input_indices = np.arange(len(unwrapped_input_values))
+        projection_indices = np.zeros_like(input_indices)
+        expected_projection_values_1 = np.zeros(projection_grid_shape).ravel()
+        expected_projection_values_1[0] = np.sum(unwrapped_input_values)
+        expected_projection_values_2 = expected_projection_values_1 * 1.5
+
+        output_dict = map_utils.bin_values_at_indices(
+            input_values_to_bin,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+        )
+
+        np.testing.assert_equal(
+            output_dict["sum_variable_1"], expected_projection_values_1
+        )
+        np.testing.assert_equal(
+            output_dict["sum_variable_2"], expected_projection_values_2
+        )

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -65,7 +65,7 @@ class TestENAMapMappingUtils:
     @pytest.mark.parametrize(
         "input_grid_shape", [(1, 1), (10, 10), (180, 360), (360, 720), (360, 180)]
     )
-    def test_bin_single_array_at_indices_complex(
+    def test_bin_single_array_at_indices_complex_2d(
         self, projection_grid_shape, input_grid_shape
     ):
         """Test coverage for bin_single_array_at_indices function w/ complex 2D input,
@@ -103,6 +103,44 @@ class TestENAMapMappingUtils:
 
         np.testing.assert_allclose(projection_values, expected_projection_values)
 
+    @pytest.mark.parametrize("projection_grid_shape", [(1, 1), (10, 10), (180, 360)])
+    @pytest.mark.parametrize("input_grid_shape", [(1, 1), (10, 10), (180, 360)])
+    @pytest.mark.parametrize("num_extra_dims", [1, 2, 3, 5])
+    def test_bin_single_array_at_indices_complex_3d(
+        self, projection_grid_shape, input_grid_shape, num_extra_dims
+    ):
+        """Test coverage for bin_single_array_at_indices function w/ complex N-Dim input
+        Corresponding to 2 extra axes that are not spatially binned.
+        Parameterized across different input and projection grid shapes.
+        """
+        np.random.seed(0)
+        extra_axes_sizes = np.full(num_extra_dims, 3, dtype=int).tolist()
+        input_grid_size = np.prod(input_grid_shape)
+        projection_grid_size = np.prod(projection_grid_shape)
+        value_array = np.random.rand(input_grid_size, *extra_axes_sizes)
+        input_indices = np.random.randint(0, input_grid_size, size=1000)
+        projection_indices = np.random.randint(0, projection_grid_size, size=1000)
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+        )
+
+        # Explicitly check that the shape of the output is the same as projection grid
+        np.testing.assert_equal(
+            projection_values.shape,
+            (projection_grid_size, *extra_axes_sizes),
+        )
+
+        # Create the expected projection values by summing the input values in a loop
+        # This is different from the binning function, which uses np.bincount
+        expected_projection_values = np.zeros((projection_grid_size, *extra_axes_sizes))
+        for ii, ip in zip(input_indices, projection_indices):
+            expected_projection_values[ip, ...] += value_array[ii, ...]
+
+        np.testing.assert_allclose(projection_values, expected_projection_values)
+
     # Parameterize by the size of the projection grid,
     # which is not necessarily same size as input grid
     @pytest.mark.parametrize("projection_grid_shape", [(1, 1), (10, 10), (360, 720)])
@@ -134,7 +172,25 @@ class TestENAMapMappingUtils:
                 [0, 0, 0],
             ]
         )
-        extra_axis_size = input_values_2d.shape[1]
+        extra_axis_size_2d = input_values_2d.shape[1]
+
+        # 3D input values
+        input_values_3d = np.zeros((input_values_2d.shape[0], 3, 3))
+        input_values_3d[:2] = np.array(
+            [
+                [
+                    [1, 2, 3],
+                    [4, 5, 6],
+                    [7, 8, 9],
+                ],
+                [
+                    [10, 11, 12],
+                    [13, 14, 15],
+                    [16, 17, 18],
+                ],
+            ]
+        )
+        extra_axes_size_3d = input_values_3d.shape[1:]
 
         # Set up the expected projection values
         expected_projection_values_1d_1 = np.zeros(projection_grid_shape).ravel()
@@ -143,14 +199,25 @@ class TestENAMapMappingUtils:
             expected_projection_values_1d_1 * scale_factor_1d
         )
         expected_projection_values_2d = np.zeros(
-            (np.prod(projection_grid_shape), extra_axis_size)
+            (np.prod(projection_grid_shape), extra_axis_size_2d)
         )
         expected_projection_values_2d[0, :] = np.array([11.5, 15, 18.5])
+        expected_projection_values_3d = np.zeros(
+            (np.prod(projection_grid_shape), *extra_axes_size_3d)
+        )
+        expected_projection_values_3d[0, :, :] = np.array(
+            [
+                [11, 13, 15],
+                [17, 19, 21],
+                [23, 25, 27],
+            ]
+        )
 
         input_values_to_bin = {
             "sum_variable_1d_1": input_values_1d_1,
             "sum_variable_1d_2": input_values_1d_2,
             "sum_variable_2d": np.array(input_values_2d),
+            "sum_variable_3d": np.array(input_values_3d),
         }
 
         # Set up indices
@@ -158,10 +225,10 @@ class TestENAMapMappingUtils:
         projection_indices = np.zeros_like(input_indices)
 
         output_dict = map_utils.bin_values_at_indices(
-            input_values_to_bin,
-            input_indices=input_indices,
             projection_indices=projection_indices,
             projection_grid_shape=projection_grid_shape,
+            input_values_to_bin=input_values_to_bin,
+            input_indices=input_indices,
         )
 
         np.testing.assert_equal(
@@ -173,28 +240,9 @@ class TestENAMapMappingUtils:
         np.testing.assert_equal(
             output_dict["sum_variable_2d"], expected_projection_values_2d
         )
-
-    def test_bin_single_array_at_indices_3d_values_raises(self):
-        """3D arrays are not currently supported for binning.
-        Test that NotImplementedError is raised."""
-        value_array = np.ones((2, 2, 2))
-        input_indices = np.array([0, 1])
-        projection_indices = np.array([0, 1])
-        projection_grid_shape = (2,)
-
-        with pytest.raises(
-            NotImplementedError,
-            match=(
-                "Only 1D and 2D arrays are supported for binning. "
-                "Received array with shape"
-            ),
-        ):
-            map_utils.bin_single_array_at_indices(
-                value_array,
-                input_indices=input_indices,
-                projection_indices=projection_indices,
-                projection_grid_shape=projection_grid_shape,
-            )
+        np.testing.assert_equal(
+            output_dict["sum_variable_3d"], expected_projection_values_3d
+        )
 
     def test_bin_values_at_indices_2d_indices_raises(self):
         """2D indices are not supported for binning.

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -247,7 +247,7 @@ class TestENAMapMappingUtils:
     def test_bin_values_at_indices_2d_indices_raises(self):
         """2D indices are not supported for binning.
         Test that ValueError is raised."""
-        input_values = {"test": np.array([1, 2, 3])}
+        input_values = np.array([1, 2, 3])
         input_indices = np.array([[0, 1], [1, 2]])
         projection_indices = np.array([0, 1, 2])
         projection_grid_shape = (3,)
@@ -259,7 +259,7 @@ class TestENAMapMappingUtils:
                 "the indices must be unwrapped."
             ),
         ):
-            map_utils.bin_values_at_indices(
+            map_utils.bin_single_array_at_indices(
                 input_values,
                 input_indices=input_indices,
                 projection_indices=projection_indices,
@@ -269,7 +269,7 @@ class TestENAMapMappingUtils:
     def test_bin_values_at_indices_mismatched_sizes_raises(self):
         """Mismatched input and projection indices should raise an error.
         Test that ValueError is raised."""
-        input_values = {"test": np.array([1, 2, 3])}
+        input_values = np.array([1, 2, 3])
         input_indices = np.array([0, 1, 0, 1])
         projection_indices = np.array([0, 1, 2])
         projection_grid_shape = (3,)
@@ -278,7 +278,7 @@ class TestENAMapMappingUtils:
             ValueError,
             match=("The number of input and projection indices must be the same"),
         ):
-            map_utils.bin_values_at_indices(
+            map_utils.bin_single_array_at_indices(
                 input_values,
                 input_indices=input_indices,
                 projection_indices=projection_indices,


### PR DESCRIPTION
# Change Summary

## Overview

Once data value indices have been matched between two frames _(e.g. from an L1C DPS frame to the HAE frame in which the L2 map will be projected)_, a function must "bin" from the first input frame to the second output frame. "Binning" here means taking values from the indices in `frame 1`, and assigning them to the matched index in `frame 2`. 

### Requirements:

- There may be a non- `1:1` correspondence between the indices in frame 1 and the indices in frame 2. That is, multiple indices in one frame may map onto the same index in another frame. 
- Not all possible indices in each frame are guaranteed to be used. This can mean that not all input values are projected into the output frame. It can also mean that not all output frame indices receive any values from the input frame. 
- Values are effectively summed together within a bin. 

Closes #1263 

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- imap_processing/ena_maps/map_utils.py
   - Adds ENA Map util functions for binning values on indices
     - Note this file is also added in #1257 , with other util functions which will create the indices needed for binning. 
- imap_processing/tests/ena_maps/test_map_utils.py
  - Tests of above

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
- 7 New unique unit tests of the binning functionality
  - 33 counting parameterizations
  - Tested against manually generated values and (paper + pencil) and programatically (loop through indices in a more explicit way from how the algorithm uses bincount) calculated values. 