### PR TITLE
Ultra l1b - Extendedspin First Pass

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -92,6 +92,13 @@ x_coin:
   LABLAXIS: x coincidence position
   UNITS: mm / 100
 
+event_times:
+  <<: *default_float32
+  CATDESC: time of event as calculated using aux and de l1a packets
+  FIELDNAM: event_times
+  LABLAXIS: event times
+  UNITS: seconds
+
 tof_start_stop:
   <<: *default_float32
   CATDESC: Particle time of flight from start to stop

--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -37,6 +37,16 @@ class ENAFlags(FlagNameMixin):
     BADSPIN = 2**2  # bit 2, Bad spin
 
 
+class ImapAttitudeUltraFlags(FlagNameMixin):
+    """IMAP Ultra flags."""
+
+    NONE = CommonFlags.NONE
+    INF = CommonFlags.INF  # bit 0
+    NEG = CommonFlags.NEG  # bit 1
+    BADSPIN = ENAFlags.BADSPIN  # bit 2
+    FLAG1 = 2**3  # bit 3
+
+
 class ImapHkUltraFlags(FlagNameMixin):
     """IMAP Ultra HK flags."""
 

--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -44,7 +44,7 @@ class ImapUltraFlags(FlagNameMixin):
     INF = CommonFlags.INF  # bit 0
     NEG = CommonFlags.NEG  # bit 1
     BADSPIN = ENAFlags.BADSPIN  # bit 2
-    FLAG1 = 2**3  # bit 2
+    HIGHCOUNTS = 2**3  # bit 3
 
 
 class ImapLoFlags(FlagNameMixin):
@@ -54,7 +54,7 @@ class ImapLoFlags(FlagNameMixin):
     INF = CommonFlags.INF  # bit 0
     NEG = CommonFlags.NEG  # bit 1
     BADSPIN = ENAFlags.BADSPIN  # bit 2
-    FLAG2 = 2**3  # bit 2
+    FLAG2 = 2**3  # bit 3
 
 
 class HitFlags(

--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -37,14 +37,11 @@ class ENAFlags(FlagNameMixin):
     BADSPIN = 2**2  # bit 2, Bad spin
 
 
-class ImapUltraFlags(FlagNameMixin):
-    """IMAP Ultra flags."""
+class ImapHkUltraFlags(FlagNameMixin):
+    """IMAP Ultra HK flags."""
 
     NONE = CommonFlags.NONE
-    INF = CommonFlags.INF  # bit 0
-    NEG = CommonFlags.NEG  # bit 1
-    BADSPIN = ENAFlags.BADSPIN  # bit 2
-    HIGHCOUNTS = 2**3  # bit 3
+    HIGHCOUNTS = 2**0  # bit 0
 
 
 class ImapLoFlags(FlagNameMixin):

--- a/imap_processing/tests/test_quality_flags.py
+++ b/imap_processing/tests/test_quality_flags.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from imap_processing.quality_flags import HitFlags, ImapLoFlags, ImapUltraFlags
+from imap_processing.quality_flags import HitFlags, ImapAttitudeUltraFlags, ImapLoFlags
 
 
 def test_quality_flags():
@@ -10,31 +10,31 @@ def test_quality_flags():
 
     # Test individual flags
     assert HitFlags.NONE == 0x0
-    assert ImapUltraFlags.NONE == 0x0
+    assert ImapAttitudeUltraFlags.NONE == 0x0
     assert ImapLoFlags.NONE == 0x0
     assert HitFlags.INF == 2**0
-    assert ImapUltraFlags.INF == 2**0
+    assert ImapAttitudeUltraFlags.INF == 2**0
     assert ImapLoFlags.INF == 2**0
     assert HitFlags.NEG == 2**1
-    assert ImapUltraFlags.NEG == 2**1
+    assert ImapAttitudeUltraFlags.NEG == 2**1
     assert ImapLoFlags.NEG == 2**1
-    assert ImapUltraFlags.BADSPIN == 2**2
+    assert ImapAttitudeUltraFlags.BADSPIN == 2**2
     assert ImapLoFlags.BADSPIN == 2**2
-    assert ImapUltraFlags.HIGHCOUNTS == 2**3
+    assert ImapAttitudeUltraFlags.FLAG1 == 2**3
     assert ImapLoFlags.FLAG2 == 2**3
     assert HitFlags.FLAG3 == 2**2
 
     # Test combined flags for Ultra
     flag = (
-        ImapUltraFlags.INF
-        | ImapUltraFlags.NEG
-        | ImapUltraFlags.BADSPIN
-        | ImapUltraFlags.HIGHCOUNTS
+        ImapAttitudeUltraFlags.INF
+        | ImapAttitudeUltraFlags.NEG
+        | ImapAttitudeUltraFlags.BADSPIN
+        | ImapAttitudeUltraFlags.FLAG1
     )
-    assert flag & ImapUltraFlags.INF
-    assert flag & ImapUltraFlags.BADSPIN
-    assert flag & ImapUltraFlags.HIGHCOUNTS
-    assert flag.name == "INF|NEG|BADSPIN|HIGHCOUNTS"
+    assert flag & ImapAttitudeUltraFlags.INF
+    assert flag & ImapAttitudeUltraFlags.BADSPIN
+    assert flag & ImapAttitudeUltraFlags.FLAG1
+    assert flag.name == "INF|NEG|BADSPIN|FLAG1"
     assert flag.value == 15
 
     # Test combined flags for Lo
@@ -56,16 +56,16 @@ def test_quality_flags():
     data = np.array([-6, np.inf, 2, 3])
     quality = np.array(
         [
-            ImapUltraFlags.INF | ImapUltraFlags.NEG,
-            ImapUltraFlags.INF,
-            ImapUltraFlags.NONE,
-            ImapUltraFlags.NONE,
+            ImapAttitudeUltraFlags.INF | ImapAttitudeUltraFlags.NEG,
+            ImapAttitudeUltraFlags.INF,
+            ImapAttitudeUltraFlags.NONE,
+            ImapAttitudeUltraFlags.NONE,
         ]
     )
     # Select data without INF flags
-    non_inf_mask = (quality & ImapUltraFlags.INF.value) == 0
+    non_inf_mask = (quality & ImapAttitudeUltraFlags.INF.value) == 0
     np.array_equal(data[non_inf_mask], np.array([-6, 2, 3]))
 
     # Select data without NEG or INF flags
-    non_neg_mask = (quality & ImapUltraFlags.NEG.value) == 0
+    non_neg_mask = (quality & ImapAttitudeUltraFlags.NEG.value) == 0
     np.array_equal(data[non_inf_mask & non_neg_mask], np.array([2, 3]))

--- a/imap_processing/tests/test_quality_flags.py
+++ b/imap_processing/tests/test_quality_flags.py
@@ -20,7 +20,7 @@ def test_quality_flags():
     assert ImapLoFlags.NEG == 2**1
     assert ImapUltraFlags.BADSPIN == 2**2
     assert ImapLoFlags.BADSPIN == 2**2
-    assert ImapUltraFlags.FLAG1 == 2**3
+    assert ImapUltraFlags.HIGHCOUNTS == 2**3
     assert ImapLoFlags.FLAG2 == 2**3
     assert HitFlags.FLAG3 == 2**2
 
@@ -29,12 +29,12 @@ def test_quality_flags():
         ImapUltraFlags.INF
         | ImapUltraFlags.NEG
         | ImapUltraFlags.BADSPIN
-        | ImapUltraFlags.FLAG1
+        | ImapUltraFlags.HIGHCOUNTS
     )
     assert flag & ImapUltraFlags.INF
     assert flag & ImapUltraFlags.BADSPIN
-    assert flag & ImapUltraFlags.FLAG1
-    assert flag.name == "INF|NEG|BADSPIN|FLAG1"
+    assert flag & ImapUltraFlags.HIGHCOUNTS
+    assert flag.name == "INF|NEG|BADSPIN|HIGHCOUNTS"
     assert flag.value == 15
 
     # Test combined flags for Lo

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -1,13 +1,10 @@
 """Tests Extended Raw Events for ULTRA L1b."""
 
-from unittest import mock
-
 import numpy as np
 import pandas as pd
 import pytest
 
 from imap_processing.ultra.constants import UltraConstants
-from imap_processing.ultra.l1b.de import calculate_de
 
 
 @pytest.fixture()
@@ -20,105 +17,97 @@ def df_filt(de_dataset, events_fsw_comparison_theta_0):
     return df_filt
 
 
-@mock.patch("imap_processing.ultra.l1b.de.get_annotated_particle_velocity")
-def test_calculate_de(mock_get_annotated_particle_velocity, de_dataset, df_filt):
+def test_calculate_de(l1b_de_dataset, df_filt):
     """Tests calculate_de function."""
 
-    # Mock get_annotated_particle_velocity to avoid needing kernels
-    def side_effect_func(event_times, position, ultra_frame, dps_frame, sc_frame):
-        """
-        Mock behavior of get_annotated_particle_velocity.
-
-        Returns NaN-filled arrays matching the expected output shape.
-        """
-        num_events = event_times.size
-        return (
-            np.full((num_events, 3), np.nan),  # sc_velocity
-            np.full((num_events, 3), np.nan),  # sc_dps_velocity
-            np.full((num_events, 3), np.nan),  # helio_velocity
-        )
-
-    mock_get_annotated_particle_velocity.side_effect = side_effect_func
-
-    dataset = calculate_de(de_dataset, "imap_ultra_l1b_45sensor-de")
-
     # Front and back positions
-    assert np.allclose(dataset["x_front"].data, df_filt["Xf"].astype("float"))
-    assert np.allclose(dataset["y_front"], df_filt["Yf"].astype("float"))
-    assert np.allclose(dataset["x_back"], df_filt["Xb"].astype("float"))
-    assert np.allclose(dataset["y_back"], df_filt["Yb"].astype("float"))
+    assert np.allclose(l1b_de_dataset["x_front"].data, df_filt["Xf"].astype("float"))
+    assert np.allclose(l1b_de_dataset["y_front"], df_filt["Yf"].astype("float"))
+    assert np.allclose(l1b_de_dataset["x_back"], df_filt["Xb"].astype("float"))
+    assert np.allclose(l1b_de_dataset["y_back"], df_filt["Yb"].astype("float"))
 
     # Coincidence positions
-    assert np.allclose(dataset["x_coin"], df_filt["Xc"].astype("float"))
+    assert np.allclose(l1b_de_dataset["x_coin"], df_filt["Xc"].astype("float"))
 
     # Time of flight
-    assert np.allclose(dataset["tof_start_stop"], df_filt["TOF"].astype("float"))
-    assert np.allclose(dataset["tof_stop_coin"], df_filt["eTOF"].astype("float"))
-    assert np.allclose(dataset["tof_corrected"], df_filt["cTOF"].astype("float"))
+    assert np.allclose(l1b_de_dataset["tof_start_stop"], df_filt["TOF"].astype("float"))
+    assert np.allclose(l1b_de_dataset["tof_stop_coin"], df_filt["eTOF"].astype("float"))
+    assert np.allclose(l1b_de_dataset["tof_corrected"], df_filt["cTOF"].astype("float"))
 
     # Distances and path lengths
-    assert np.allclose(dataset["front_back_distance"], df_filt["d"].astype("float"))
-    assert np.allclose(dataset["path_length"], df_filt["r"].astype("float"))
+    assert np.allclose(
+        l1b_de_dataset["front_back_distance"], df_filt["d"].astype("float")
+    )
+    assert np.allclose(l1b_de_dataset["path_length"], df_filt["r"].astype("float"))
 
     # Coincidence, start, and event types
-    assert np.allclose(dataset["coincidence_type"], df_filt["CoinType"].astype("float"))
-    assert np.allclose(dataset["start_type"], df_filt["StartType"].astype("float"))
-    assert np.allclose(dataset["event_type"], df_filt["StopType"].astype("float"))
+    assert np.allclose(
+        l1b_de_dataset["coincidence_type"], df_filt["CoinType"].astype("float")
+    )
+    assert np.allclose(
+        l1b_de_dataset["start_type"], df_filt["StartType"].astype("float")
+    )
+    assert np.allclose(
+        l1b_de_dataset["event_type"], df_filt["StopType"].astype("float")
+    )
 
     # Energies and species
-    assert np.allclose(dataset["energy"], df_filt["Energy"].astype("float"))
-    species_array = dataset["species"][
+    assert np.allclose(l1b_de_dataset["energy"], df_filt["Energy"].astype("float"))
+    species_array = l1b_de_dataset["species"][
         np.where(
-            (dataset["tof_corrected"] > UltraConstants.CTOF_SPECIES_MIN)
-            & (dataset["tof_corrected"] < UltraConstants.CTOF_SPECIES_MAX)
+            (l1b_de_dataset["tof_corrected"] > UltraConstants.CTOF_SPECIES_MIN)
+            & (l1b_de_dataset["tof_corrected"] < UltraConstants.CTOF_SPECIES_MAX)
         )[0]
     ]
     assert np.all(species_array == "H")
 
     # Velocities in various frames
-    test_tof = dataset["tof_start_stop"]
-    test_ph = dataset["event_type"]
-    test_species = dataset["species"]
+    test_tof = l1b_de_dataset["tof_start_stop"]
+    test_ph = l1b_de_dataset["event_type"]
+    test_species = l1b_de_dataset["species"]
     condition = (test_tof > 0) & (test_ph < 8)
     assert np.allclose(
-        dataset["direct_event_velocity"][:, 0].values[condition],
+        l1b_de_dataset["direct_event_velocity"][:, 0].values[condition],
         df_filt["vx"].astype("float").values[condition],
         rtol=1e-2,
     )
     assert np.allclose(
-        dataset["direct_event_velocity"][:, 1].values[condition],
+        l1b_de_dataset["direct_event_velocity"][:, 1].values[condition],
         df_filt["vy"].astype("float").values[condition],
         rtol=1e-2,
     )
     assert np.allclose(
-        dataset["direct_event_velocity"][:, 2].values[condition],
+        l1b_de_dataset["direct_event_velocity"][:, 2].values[condition],
         df_filt["vz"].astype("float").values[condition],
         rtol=1e-2,
     )
     assert np.allclose(
-        dataset["velocity_magnitude"].values[condition],
+        l1b_de_dataset["velocity_magnitude"].values[condition],
         df_filt["vmag"].astype("float").values[condition],
         rtol=1e-2,
     )
     condition = (test_tof > 0) & (test_ph < 8) & (test_species == "H")
     assert np.allclose(
-        dataset["tof_energy"].values[condition],
+        l1b_de_dataset["tof_energy"].values[condition],
         df_filt["energy_revised"].astype("float").values[condition],
         rtol=1e-2,
     )
     assert np.allclose(
-        dataset["azimuth"].values[condition],
+        l1b_de_dataset["azimuth"].values[condition],
         df_filt["event_phi"].astype("float").values[condition] % (2 * np.pi),
         rtol=1e-2,
     )
 
-    assert dataset["velocity_sc"].shape == (len(de_dataset["epoch"]), 3)
-    assert dataset["velocity_dps_sc"].shape == (len(de_dataset["epoch"]), 3)
-    assert dataset["velocity_dps_helio"].shape == (len(de_dataset["epoch"]), 3)
+    assert l1b_de_dataset["velocity_sc"].shape == (len(l1b_de_dataset["epoch"]), 3)
+    assert l1b_de_dataset["velocity_dps_sc"].shape == (len(l1b_de_dataset["epoch"]), 3)
+    assert l1b_de_dataset["velocity_dps_helio"].shape == (
+        len(l1b_de_dataset["epoch"]),
+        3,
+    )
 
     # Event efficiency
     assert np.allclose(
-        dataset["event_efficiency"],
-        np.full(len(de_dataset["epoch"]), np.nan),
+        l1b_de_dataset["event_efficiency"],
+        np.full(len(l1b_de_dataset["epoch"]), np.nan),
         equal_nan=True,
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -1,0 +1,50 @@
+"""Tests Culling for ULTRA L1b."""
+
+from imap_processing.ultra.l1b.ultra_l1b_culling import get_spin
+
+# @pytest.fixture()
+# def pointing_frame_kernels(spice_test_data_path):
+#     """List SPICE kernels."""
+#     required_kernels = [
+#         "imap_wkcp.tf",
+#         "imap_sclk_0000.tsc",
+#         "naif0012.tls",
+#     ]
+#     kernels = [str(spice_test_data_path / kernel) for kernel in required_kernels]
+#     return kernels
+
+# @pytest.mark.usefixtures("use_fake_spin_data_for_time")
+# def test_cull_something(use_fake_spin_data_for_time, l1c_culling_test_data,
+#                         pointing_frame_kernels):
+#
+#     df = pd.read_csv(l1c_culling_test_data, delim_whitespace=True,
+#                      comment='#', header=0)
+#
+#     spice.furnsh(pointing_frame_kernels)
+#     # Get IDs.
+#     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.gipool
+#     id_imap_sclk = spice.gipool("CK_-43000_SCLK", 0, 1)
+#     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.sce2c
+#     # Convert start and end times to SCLK.
+#     sclk_begtim = spice.sce2c(int(id_imap_sclk), df['tdb'].min())
+#     met_begtime = sclkticks_to_met(sclk_begtim)
+#
+#     # Do one pointing at a time
+#     use_fake_spin_data_for_time(met_begtime)
+
+
+def test_de_dataset(use_fake_spin_data_for_time, l1b_de_dataset):
+    l1b_de_dataset["de_event_met"]
+    spin_number = l1b_de_dataset["SPINNUMBER"].values
+
+    # Create fake universal spin table
+    use_fake_spin_data_for_time(
+        l1b_de_dataset["de_event_met"][0], l1b_de_dataset["de_event_met"][-1]
+    )
+    # From universal spin table
+    # From l1b de dataset
+    energy = de_dataset["ENERGY_PH"].values
+    # 0-10, 10-20, above 20 keV
+
+    get_spin(l1b_de_dataset["de_event_met"], l1b_de_dataset["energy"])
+    print("hi")

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -14,24 +14,24 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
 def test_get_spin(use_fake_spin_data_for_time, l1b_de_dataset):
     """Tests get_spin function."""
     use_fake_spin_data_for_time(
-        l1b_de_dataset["de_event_met"][0], l1b_de_dataset["de_event_met"][-1]
+        l1b_de_dataset["event_times"][0], l1b_de_dataset["event_times"][-1]
     )
     spin_number, spin_start_time, spin_duration = get_spin(
-        l1b_de_dataset["de_event_met"]
+        l1b_de_dataset["event_times"]
     )
 
     assert len(np.unique(spin_number)) == len(np.unique(spin_start_time))
-    assert np.all(l1b_de_dataset["de_event_met"].values >= spin_start_time)
+    assert np.all(l1b_de_dataset["event_times"].values >= spin_start_time)
 
 
 def test_get_energy_histogram(use_fake_spin_data_for_time, l1b_de_dataset):
     """Tests get_energy_histogram function."""
 
     use_fake_spin_data_for_time(
-        l1b_de_dataset["de_event_met"][0], l1b_de_dataset["de_event_met"][-1]
+        l1b_de_dataset["event_times"][0], l1b_de_dataset["event_times"][-1]
     )
 
-    spin_number, _, _ = get_spin(l1b_de_dataset["de_event_met"])
+    spin_number, _, _ = get_spin(l1b_de_dataset["event_times"])
     hist, _ = get_energy_histogram(spin_number, l1b_de_dataset["energy"].values)
 
     assert hist.shape == (4, 15)
@@ -79,24 +79,23 @@ def test_flag_spin(use_fake_spin_data_for_time, l1b_de_dataset):
     """Tests flag_spin function."""
 
     use_fake_spin_data_for_time(
-        l1b_de_dataset["de_event_met"][0], l1b_de_dataset["de_event_met"][-1]
+        l1b_de_dataset["event_times"][0], l1b_de_dataset["event_times"][-1]
     )
 
-    spin_number, _, _ = get_spin(l1b_de_dataset["de_event_met"])
+    spin_number, _, _ = get_spin(l1b_de_dataset["event_times"])
     energy = l1b_de_dataset["energy"].values
     hist, spin_edges = get_energy_histogram(spin_number, energy)
 
-    quality_flags_data = flag_spin(l1b_de_dataset["de_event_met"], energy)
-    assert np.all(
-        quality_flags_data[energy < 0] & ImapUltraFlags.NEG.value
-        == ImapUltraFlags.NEG.value
-    )
+    quality_flags, spin, energy = flag_spin(l1b_de_dataset["event_times"], energy)
 
-    flag = ImapUltraFlags(quality_flags_data[0])
+    flag = ImapUltraFlags(quality_flags[0])
     assert flag.name == "HIGHCOUNTS"
+
+    spin_1 = quality_flags[spin == 1]
+
     components = []
     for flag in ImapUltraFlags:
-        if quality_flags_data[np.where(quality_flags_data == 10)][0] & flag.value:
+        if quality_flags[np.where(quality_flags == 10)][0] & flag.value:
             components.append(flag.name)
     assert components == ["NEG", "HIGHCOUNTS"]
 
@@ -109,6 +108,6 @@ def test_flag_spin(use_fake_spin_data_for_time, l1b_de_dataset):
         if hist[energy_idx][spin_idx] > UltraConstants.COUNTS_THRESHOLDS[energy_idx]:
             mask = (energy_bin_idx == energy_idx) & (spin_bin_idx == spin_idx)
             assert np.all(
-                (quality_flags_data[mask] & ImapUltraFlags.HIGHCOUNTS.value)
+                (quality_flags[mask] & ImapUltraFlags.HIGHCOUNTS.value)
                 == ImapUltraFlags.HIGHCOUNTS.value
             )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -91,23 +91,10 @@ def test_flag_spin(use_fake_spin_data_for_time, l1b_de_dataset):
     flag = ImapUltraFlags(quality_flags[0])
     assert flag.name == "HIGHCOUNTS"
 
-    spin_1 = quality_flags[spin == 1]
+    flagged_indices = np.unique(spin)[hist[0, :] > 0]
+    unflagged_indices = np.setdiff1d(np.unique(spin), flagged_indices)
+    assert np.all(quality_flags[flagged_indices] == ImapUltraFlags.HIGHCOUNTS.value)
+    assert np.all(quality_flags[unflagged_indices] == ImapUltraFlags.NONE.value)
 
-    components = []
-    for flag in ImapUltraFlags:
-        if quality_flags[np.where(quality_flags == 10)][0] & flag.value:
-            components.append(flag.name)
-    assert components == ["NEG", "HIGHCOUNTS"]
-
-    energy_bin_idx = (
-        np.digitize(energy, bins=UltraConstants.CULLING_ENERGY_BIN_EDGES) - 1
-    )
-    spin_bin_idx = np.digitize(spin_number, bins=spin_edges) - 1
-
-    for energy_idx, spin_idx in np.ndindex(hist.shape):
-        if hist[energy_idx][spin_idx] > UltraConstants.COUNTS_THRESHOLDS[energy_idx]:
-            mask = (energy_bin_idx == energy_idx) & (spin_bin_idx == spin_idx)
-            assert np.all(
-                (quality_flags[mask] & ImapUltraFlags.HIGHCOUNTS.value)
-                == ImapUltraFlags.HIGHCOUNTS.value
-            )
+    # Only HIGHCOUNT bits were set
+    assert np.all(quality_flags == quality_flags & ImapUltraFlags.HIGHCOUNTS)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -1,8 +1,9 @@
 """Tests Culling for ULTRA L1b."""
 
 import numpy as np
+import pytest
 
-from imap_processing.quality_flags import ImapUltraFlags
+from imap_processing.quality_flags import ImapHkUltraFlags
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_spin,
@@ -11,90 +12,72 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
 )
 
 
+@pytest.fixture()
+def test_data(use_fake_spin_data_for_time):
+    """Fixture to compute and return test data."""
+    time = np.arange(0, 32, 2)
+    spin_number = np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2])
+    energy = np.array([5, 5, 5, 5, 5, 5, 5, 5, 5, 15, 15, 25, -2, -2, -2, 2])
+
+    use_fake_spin_data_for_time(time[0], time[-1])
+
+    energy_edges = UltraConstants.CULLING_ENERGY_BIN_EDGES
+    unique_spins = np.unique(spin_number)
+    expected_counts = np.zeros((len(energy_edges) - 1, len(unique_spins)))
+
+    for spin_idx, spin in enumerate(unique_spins):
+        for energy_idx in range(len(energy_edges) - 1):
+            count = np.sum(
+                (spin_number == spin)
+                & (energy >= energy_edges[energy_idx])
+                & (energy < energy_edges[energy_idx + 1])
+            )
+            expected_counts[energy_idx, spin_idx] = count
+
+    return time, spin_number, energy, expected_counts
+
+
 def test_get_spin(use_fake_spin_data_for_time, l1b_de_dataset):
     """Tests get_spin function."""
     use_fake_spin_data_for_time(
         l1b_de_dataset["event_times"][0], l1b_de_dataset["event_times"][-1]
     )
-    spin_number, spin_start_time, spin_duration = get_spin(
-        l1b_de_dataset["event_times"]
+    spin_number = get_spin(l1b_de_dataset["event_times"])
+
+    assert len(spin_number) == len(l1b_de_dataset["event_times"])
+    expected_num_spins = np.ceil(
+        (
+            l1b_de_dataset["event_times"].values[-1]
+            - l1b_de_dataset["event_times"].values[0]
+        )
+        / 15
     )
-
-    assert len(np.unique(spin_number)) == len(np.unique(spin_start_time))
-    assert np.all(l1b_de_dataset["event_times"].values >= spin_start_time)
+    assert np.array_equal(len(np.unique(spin_number)), expected_num_spins)
 
 
-def test_get_energy_histogram(use_fake_spin_data_for_time, l1b_de_dataset):
+def test_get_energy_histogram(test_data):
     """Tests get_energy_histogram function."""
 
-    use_fake_spin_data_for_time(
-        l1b_de_dataset["event_times"][0], l1b_de_dataset["event_times"][-1]
-    )
+    _, spin_number, energy, expected_counts = test_data
 
-    spin_number, _, _ = get_spin(l1b_de_dataset["event_times"])
-    hist, _ = get_energy_histogram(spin_number, l1b_de_dataset["energy"].values)
+    hist, _ = get_energy_histogram(spin_number, energy)
 
-    assert hist.shape == (4, 15)
-
-    energies_spin_0 = l1b_de_dataset["energy"].values[spin_number == 0]
-    assert (
-        len(
-            energies_spin_0[
-                energies_spin_0 >= UltraConstants.CULLING_ENERGY_BIN_EDGES[3]
-            ]
-        )
-        == hist[3][0]
-    )
-    assert (
-        len(
-            energies_spin_0[
-                (energies_spin_0 < UltraConstants.CULLING_ENERGY_BIN_EDGES[3])
-                & (energies_spin_0 >= UltraConstants.CULLING_ENERGY_BIN_EDGES[2])
-            ]
-        )
-        == hist[2][0]
-    )
-
-    energies_spin_14 = l1b_de_dataset["energy"].values[spin_number == 14]
-    assert (
-        len(
-            energies_spin_14[
-                energies_spin_14 >= UltraConstants.CULLING_ENERGY_BIN_EDGES[3]
-            ]
-        )
-        == hist[3][14]
-    )
-    assert (
-        len(
-            energies_spin_14[
-                (energies_spin_14 < UltraConstants.CULLING_ENERGY_BIN_EDGES[3])
-                & (energies_spin_14 >= UltraConstants.CULLING_ENERGY_BIN_EDGES[2])
-            ]
-        )
-        == hist[2][14]
-    )
+    assert np.all(hist == expected_counts / 15)
 
 
-def test_flag_spin(use_fake_spin_data_for_time, l1b_de_dataset):
+def test_flag_spin(test_data):
     """Tests flag_spin function."""
 
-    use_fake_spin_data_for_time(
-        l1b_de_dataset["event_times"][0], l1b_de_dataset["event_times"][-1]
-    )
+    time, _, energy, expected_counts = test_data
+    quality_flags, spin, energy = flag_spin(time, energy)
 
-    spin_number, _, _ = get_spin(l1b_de_dataset["event_times"])
-    energy = l1b_de_dataset["energy"].values
-    hist, spin_edges = get_energy_histogram(spin_number, energy)
-
-    quality_flags, spin, energy = flag_spin(l1b_de_dataset["event_times"], energy)
-
-    flag = ImapUltraFlags(quality_flags[0])
+    flag = ImapHkUltraFlags(quality_flags[1])
     assert flag.name == "HIGHCOUNTS"
 
-    flagged_indices = np.unique(spin)[hist[0, :] > 0]
+    flagged_indices = np.unique(spin)[expected_counts[0, :] / 15 > 0]
     unflagged_indices = np.setdiff1d(np.unique(spin), flagged_indices)
-    assert np.all(quality_flags[flagged_indices] == ImapUltraFlags.HIGHCOUNTS.value)
-    assert np.all(quality_flags[unflagged_indices] == ImapUltraFlags.NONE.value)
+    assert np.all(quality_flags[flagged_indices] == ImapHkUltraFlags.HIGHCOUNTS.value)
+    assert np.all(quality_flags[unflagged_indices] == ImapHkUltraFlags.NONE.value)
 
     # Only HIGHCOUNT bits were set
-    assert np.all(quality_flags == quality_flags & ImapUltraFlags.HIGHCOUNTS)
+    assert np.all(quality_flags == quality_flags & ImapHkUltraFlags.HIGHCOUNTS)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -1,50 +1,114 @@
 """Tests Culling for ULTRA L1b."""
 
-from imap_processing.ultra.l1b.ultra_l1b_culling import get_spin
+import numpy as np
 
-# @pytest.fixture()
-# def pointing_frame_kernels(spice_test_data_path):
-#     """List SPICE kernels."""
-#     required_kernels = [
-#         "imap_wkcp.tf",
-#         "imap_sclk_0000.tsc",
-#         "naif0012.tls",
-#     ]
-#     kernels = [str(spice_test_data_path / kernel) for kernel in required_kernels]
-#     return kernels
-
-# @pytest.mark.usefixtures("use_fake_spin_data_for_time")
-# def test_cull_something(use_fake_spin_data_for_time, l1c_culling_test_data,
-#                         pointing_frame_kernels):
-#
-#     df = pd.read_csv(l1c_culling_test_data, delim_whitespace=True,
-#                      comment='#', header=0)
-#
-#     spice.furnsh(pointing_frame_kernels)
-#     # Get IDs.
-#     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.gipool
-#     id_imap_sclk = spice.gipool("CK_-43000_SCLK", 0, 1)
-#     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.sce2c
-#     # Convert start and end times to SCLK.
-#     sclk_begtim = spice.sce2c(int(id_imap_sclk), df['tdb'].min())
-#     met_begtime = sclkticks_to_met(sclk_begtim)
-#
-#     # Do one pointing at a time
-#     use_fake_spin_data_for_time(met_begtime)
+from imap_processing.quality_flags import ImapUltraFlags
+from imap_processing.ultra.constants import UltraConstants
+from imap_processing.ultra.l1b.ultra_l1b_culling import (
+    flag_spin,
+    get_energy_histogram,
+    get_spin,
+)
 
 
-def test_de_dataset(use_fake_spin_data_for_time, l1b_de_dataset):
-    l1b_de_dataset["de_event_met"]
-    spin_number = l1b_de_dataset["SPINNUMBER"].values
-
-    # Create fake universal spin table
+def test_get_spin(use_fake_spin_data_for_time, l1b_de_dataset):
+    """Tests get_spin function."""
     use_fake_spin_data_for_time(
         l1b_de_dataset["de_event_met"][0], l1b_de_dataset["de_event_met"][-1]
     )
-    # From universal spin table
-    # From l1b de dataset
-    energy = de_dataset["ENERGY_PH"].values
-    # 0-10, 10-20, above 20 keV
+    spin_number, spin_start_time, spin_duration = get_spin(
+        l1b_de_dataset["de_event_met"]
+    )
 
-    get_spin(l1b_de_dataset["de_event_met"], l1b_de_dataset["energy"])
-    print("hi")
+    assert len(np.unique(spin_number)) == len(np.unique(spin_start_time))
+    assert np.all(l1b_de_dataset["de_event_met"].values >= spin_start_time)
+
+
+def test_get_energy_histogram(use_fake_spin_data_for_time, l1b_de_dataset):
+    """Tests get_energy_histogram function."""
+
+    use_fake_spin_data_for_time(
+        l1b_de_dataset["de_event_met"][0], l1b_de_dataset["de_event_met"][-1]
+    )
+
+    spin_number, _, _ = get_spin(l1b_de_dataset["de_event_met"])
+    hist, _ = get_energy_histogram(spin_number, l1b_de_dataset["energy"].values)
+
+    assert hist.shape == (4, 15)
+
+    energies_spin_0 = l1b_de_dataset["energy"].values[spin_number == 0]
+    assert (
+        len(
+            energies_spin_0[
+                energies_spin_0 >= UltraConstants.CULLING_ENERGY_BIN_EDGES[3]
+            ]
+        )
+        == hist[3][0]
+    )
+    assert (
+        len(
+            energies_spin_0[
+                (energies_spin_0 < UltraConstants.CULLING_ENERGY_BIN_EDGES[3])
+                & (energies_spin_0 >= UltraConstants.CULLING_ENERGY_BIN_EDGES[2])
+            ]
+        )
+        == hist[2][0]
+    )
+
+    energies_spin_14 = l1b_de_dataset["energy"].values[spin_number == 14]
+    assert (
+        len(
+            energies_spin_14[
+                energies_spin_14 >= UltraConstants.CULLING_ENERGY_BIN_EDGES[3]
+            ]
+        )
+        == hist[3][14]
+    )
+    assert (
+        len(
+            energies_spin_14[
+                (energies_spin_14 < UltraConstants.CULLING_ENERGY_BIN_EDGES[3])
+                & (energies_spin_14 >= UltraConstants.CULLING_ENERGY_BIN_EDGES[2])
+            ]
+        )
+        == hist[2][14]
+    )
+
+
+def test_flag_spin(use_fake_spin_data_for_time, l1b_de_dataset):
+    """Tests flag_spin function."""
+
+    use_fake_spin_data_for_time(
+        l1b_de_dataset["de_event_met"][0], l1b_de_dataset["de_event_met"][-1]
+    )
+
+    spin_number, _, _ = get_spin(l1b_de_dataset["de_event_met"])
+    energy = l1b_de_dataset["energy"].values
+    hist, spin_edges = get_energy_histogram(spin_number, energy)
+
+    quality_flags_data = flag_spin(l1b_de_dataset["de_event_met"], energy)
+    assert np.all(
+        quality_flags_data[energy < 0] & ImapUltraFlags.NEG.value
+        == ImapUltraFlags.NEG.value
+    )
+
+    flag = ImapUltraFlags(quality_flags_data[0])
+    assert flag.name == "HIGHCOUNTS"
+    components = []
+    for flag in ImapUltraFlags:
+        if quality_flags_data[np.where(quality_flags_data == 10)][0] & flag.value:
+            components.append(flag.name)
+    assert components == ["NEG", "HIGHCOUNTS"]
+
+    energy_bin_idx = (
+        np.digitize(energy, bins=UltraConstants.CULLING_ENERGY_BIN_EDGES) - 1
+    )
+    spin_bin_idx = np.digitize(spin_number, bins=spin_edges) - 1
+
+    for energy_idx, spin_idx in np.ndindex(hist.shape):
+        if hist[energy_idx][spin_idx] > UltraConstants.COUNTS_THRESHOLDS[energy_idx]:
+            mask = (energy_bin_idx == energy_idx) & (spin_bin_idx == spin_idx)
+            assert np.all(
+                (quality_flags_data[mask] & ImapUltraFlags.HIGHCOUNTS.value)
+                == ImapUltraFlags.HIGHCOUNTS.value
+            )

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -1,6 +1,7 @@
 """Module for constants and useful shared classes used in Ultra."""
 
 from dataclasses import dataclass
+from typing import ClassVar
 
 
 @dataclass(frozen=True)
@@ -75,7 +76,5 @@ class UltraConstants:
 
     # TODO: this is a temporary place for this.
     # Thresholds for culling based on counts.
-    COUNTS_THRESHOLD_0_10_KEV = 100
-    COUNTS_THRESHOLD_10_20_KEV = 100
-    COUNTS_THRESHOLD_GE_20_KEV = 100
-    CULLING_ENERGY_BINS = [0, 10, 20, 1e5]
+    CULLING_ENERGY_BIN_EDGES: ClassVar[list] = [-1e5, 0, 10, 20, 1e5]
+    COUNTS_THRESHOLDS: ClassVar[list] = [0, 100, 100, 100]

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -75,6 +75,7 @@ class UltraConstants:
 
     # TODO: this is a temporary place for this.
     # Thresholds for culling based on counts.
-    CULLING_THRESHOLD_0_10_KEV = 100
-    CULLING_THRESHOLD_10_20_KEV = 100
-    CULLING_THRESHOLD_GE_20_KEV = 100
+    COUNTS_THRESHOLD_0_10_KEV = 100
+    COUNTS_THRESHOLD_10_20_KEV = 100
+    COUNTS_THRESHOLD_GE_20_KEV = 100
+    CULLING_ENERGY_BINS = [0, 10, 20, 1e5]

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -72,3 +72,9 @@ class UltraConstants:
     # Constants for species determination based on ctof range.
     CTOF_SPECIES_MIN = 50
     CTOF_SPECIES_MAX = 200
+
+    # TODO: this is a temporary place for this.
+    # Thresholds for culling based on counts.
+    CULLING_THRESHOLD_0_10_KEV = 100
+    CULLING_THRESHOLD_10_20_KEV = 100
+    CULLING_THRESHOLD_GE_20_KEV = 100

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -77,4 +77,4 @@ class UltraConstants:
     # TODO: this is a temporary place for this.
     # Thresholds for culling based on counts.
     CULLING_ENERGY_BIN_EDGES: ClassVar[list] = [-1e5, 0, 10, 20, 1e5]
-    COUNTS_THRESHOLDS: ClassVar[list] = [0, 100, 100, 100]
+    COUNT_RATES_THRESHOLDS: ClassVar[list] = [0, 100, 100, 100]

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -144,8 +144,10 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
         "start_type",
         "event_type",
         "de_event_met",
+        "event_times",
     ]
-    dataset_keys = ["COIN_TYPE", "START_TYPE", "STOP_TYPE", "SHCOARSE"]
+    dataset_keys = ["COIN_TYPE", "START_TYPE", "STOP_TYPE", "SHCOARSE",
+                    "EVENTTIMES"]
 
     de_dict.update(
         {key: de_dataset[dataset_key] for key, dataset_key in zip(keys, dataset_keys)}

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -146,8 +146,7 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
         "de_event_met",
         "event_times",
     ]
-    dataset_keys = ["COIN_TYPE", "START_TYPE", "STOP_TYPE", "SHCOARSE",
-                    "EVENTTIMES"]
+    dataset_keys = ["COIN_TYPE", "START_TYPE", "STOP_TYPE", "SHCOARSE", "EVENTTIMES"]
 
     de_dict.update(
         {key: de_dataset[dataset_key] for key, dataset_key in zip(keys, dataset_keys)}

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -11,14 +11,14 @@ from imap_processing.spice.geometry import get_spin_data
 from imap_processing.ultra.constants import UltraConstants
 
 
-def get_spin(met: NDArray) -> tuple[NDArray, NDArray, NDArray]:
+def get_spin(eventtimes_met: NDArray) -> tuple[NDArray, NDArray, NDArray]:
     """
     Get spin parameters for each event.
 
     Parameters
     ----------
-    met : NDArray
-        Mission Elaspsed Time.
+    eventtimes_met : NDArray
+        Event Times in Mission Elapsed Time.
 
     Returns
     -------
@@ -32,7 +32,7 @@ def get_spin(met: NDArray) -> tuple[NDArray, NDArray, NDArray]:
     spin_df = get_spin_data()
 
     last_spin_indices = (
-        np.searchsorted(spin_df["spin_start_time"], met, side="right") - 1
+        np.searchsorted(spin_df["spin_start_time"], eventtimes_met, side="right") - 1
     )
     spin_number = spin_df["spin_number"].values[last_spin_indices]
     spin_start_time = spin_df["spin_start_time"].values[last_spin_indices]
@@ -73,39 +73,46 @@ def get_energy_histogram(
     return hist, spin_edges
 
 
-def flag_spin(met: NDArray, energy: NDArray) -> NDArray:
+def flag_spin(eventtimes_met: NDArray, energy: NDArray) -> NDArray:
     """
     Flag data based on counts and negative energies.
 
     Parameters
     ----------
-    met : NDArray
-        Mission Elapsed Time.
+    eventtimes_met : NDArray
+        Event Times in Mission Elapsed Time.
     energy : NDArray
         Energy data.
 
     Returns
     -------
-    quality_flags_data : NDArray
+    quality_flags : NDArray
         Quality flags.
     """
-    quality_flags_data = np.full(len(met), ImapUltraFlags.NONE.value, dtype=np.uint16)
-
-    # Flag negative energies.
-    quality_flags_data[energy < 0] |= ImapUltraFlags.NEG.value
-
-    spin, _, _ = get_spin(met)
+    spin, _, _ = get_spin(eventtimes_met)
     hist, spin_edges = get_energy_histogram(spin, energy)
-
-    # Map data points to bins
-    energy_bin_idx = (
-        np.digitize(energy, bins=UltraConstants.CULLING_ENERGY_BIN_EDGES) - 1
+    quality_flags = np.full(
+        hist.shape[0] * hist.shape[1], ImapUltraFlags.NONE.value, dtype=np.uint16
     )
-    spin_bin_idx = np.digitize(spin, bins=spin_edges) - 1
 
-    for energy_idx, spin_idx in np.ndindex(hist.shape):
-        if hist[energy_idx][spin_idx] > UltraConstants.COUNTS_THRESHOLDS[energy_idx]:
-            mask = (energy_bin_idx == energy_idx) & (spin_bin_idx == spin_idx)
-            quality_flags_data[mask] |= ImapUltraFlags.HIGHCOUNTS.value
+    appended_spin = []
+    appended_energy = []
 
-    return quality_flags_data
+    for energy_idx in range(hist.shape[0]):
+        # Counts for each spin at this energy
+        spin_counts = hist[energy_idx][:]
+        # Indices where the counts exceed the threshold
+        indices = np.nonzero(spin_counts > UltraConstants.COUNTS_THRESHOLDS[energy_idx])
+        flattened_indices = energy_idx * hist.shape[1] + indices[0]
+        quality_flags[flattened_indices] |= ImapUltraFlags.HIGHCOUNTS.value
+
+        # Calculate the energy midpoint for each bin
+        energy_midpoint = (
+            UltraConstants.CULLING_ENERGY_BIN_EDGES[energy_idx]
+            + UltraConstants.CULLING_ENERGY_BIN_EDGES[energy_idx + 1]
+        ) / 2
+
+        appended_spin.extend(np.unique(spin).tolist())
+        appended_energy.extend([energy_midpoint] * len(np.unique(spin)))
+
+    return quality_flags, appended_spin, appended_energy

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -73,7 +73,9 @@ def get_energy_histogram(
     return hist, spin_edges
 
 
-def flag_spin(eventtimes_met: NDArray, energy: NDArray) -> NDArray:
+def flag_spin(
+    eventtimes_met: NDArray, energy: NDArray
+) -> tuple[NDArray, NDArray, NDArray]:
     """
     Flag data based on counts and negative energies.
 
@@ -88,6 +90,10 @@ def flag_spin(eventtimes_met: NDArray, energy: NDArray) -> NDArray:
     -------
     quality_flags : NDArray
         Quality flags.
+    appended_spin : NDArray
+        Spin data.
+    appended_energy : NDArray
+        Energy midpoint data.
     """
     spin, _, _ = get_spin(eventtimes_met)
     hist, spin_edges = get_energy_histogram(spin, energy)
@@ -95,8 +101,8 @@ def flag_spin(eventtimes_met: NDArray, energy: NDArray) -> NDArray:
         hist.shape[0] * hist.shape[1], ImapUltraFlags.NONE.value, dtype=np.uint16
     )
 
-    appended_spin = []
-    appended_energy = []
+    appended_spin = np.empty(0, dtype=np.uint16)
+    appended_energy = np.empty(0, dtype=np.float64)
 
     for energy_idx in range(hist.shape[0]):
         # Counts for each spin at this energy
@@ -112,7 +118,9 @@ def flag_spin(eventtimes_met: NDArray, energy: NDArray) -> NDArray:
             + UltraConstants.CULLING_ENERGY_BIN_EDGES[energy_idx + 1]
         ) / 2
 
-        appended_spin.extend(np.unique(spin).tolist())
-        appended_energy.extend([energy_midpoint] * len(np.unique(spin)))
+        appended_spin = np.concatenate((appended_spin, np.unique(spin)))
+        appended_energy = np.concatenate(
+            (appended_energy, np.full(len(np.unique(spin)), energy_midpoint))
+        )
 
     return quality_flags, appended_spin, appended_energy

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -1,72 +1,113 @@
+"""Culls Events for ULTRA L1b."""
+
 import numpy as np
+from numpy.typing import NDArray
+import xarray
 
-# from imap_processing.ultra.l1b.ultra_l1b_extended import the energy equation here
-from imap_processing.spice.geometry import get_spacecraft_spin_phase, get_spin_data
+from imap_processing.spice.geometry import get_spin_data
 from imap_processing.quality_flags import ImapUltraFlags
+from imap_processing.ultra.constants import UltraConstants
 
 
-def get_spin(met) -> list:
+def get_spin(met: NDArray) -> tuple[NDArray, NDArray, NDArray]:
+    """
+    Get spin parameters for each event.
 
-    # TODO: error handling for out of range spins
+    Parameters
+    ----------
+    met : NDArray
+        Mission Elaspsed Time.
+
+    Returns
+    -------
+    spin_number : NDArray
+        Spin number from Universal Spin Table.
+    spin_start_time : NDArray
+        Spin start time from Universal Spin Table.
+    spin_duration : NDArray
+        Spin duration from Universal Spin Table.
+    """
     spin_df = get_spin_data()
 
     last_spin_indices = (
         np.searchsorted(spin_df["spin_start_time"], met, side="right") - 1
     )
-    spin = spin_df["spin_number"].values[last_spin_indices]
+    spin_number = spin_df["spin_number"].values[last_spin_indices]
     spin_start_time = spin_df["spin_start_time"].values[last_spin_indices]
     spin_duration = spin_df["spin_period_sec"].values[last_spin_indices]
 
-    return spin# TODO, spin_start_time, spin_duration
+    return spin_number, spin_start_time, spin_duration
 
 
-def get_energy_histogram(spin, energy):
+def get_energy_histogram(spin_number: NDArray,
+                         energy: NDArray) -> tuple[NDArray, NDArray]:
     """
-    Compute a 3D histogram of the particle data.
+    Compute a 2D histogram of the counts.
 
     Parameters
     ----------
-    v : tuple[np.ndarray, np.ndarray, np.ndarray]
-        The x,y,z-components of the velocity vector.
-    energy : np.ndarray
+    spin_number : NDArray
+        Spin number.
+    energy : NDArray
         The particle energy.
-    az_bin_edges : np.ndarray
-        Array of azimuth bin boundary values.
-    el_bin_edges : np.ndarray
-        Array of elevation bin boundary values.
-    energy_bin_edges : np.ndarray
-        Array of energy bin edges.
 
     Returns
     -------
-    hist : np.ndarray
-        A 3D histogram array.
+    hist : NDArray
+        A 2D histogram array.
+    spin_edges : NDArray
+        Edges of the spin number bins.
     """
-
-    spin_edges = np.unique(spin)
+    spin_edges = np.unique(spin_number)
     spin_edges = np.append(spin_edges, spin_edges[-1] + 1)
-    energy_bin_edges = [-1e5, 0, 10, 20, 1e5]
 
     # 2D binning.
-    hist, _ = np.histogramdd(sample=(energy, spin),
-                          bins=[energy_bin_edges, spin_edges])
+    hist, _ = np.histogramdd(sample=(energy, spin_number),
+                             bins=[UltraConstants.CULLING_ENERGY_BINS,
+                                   spin_edges])
 
-    return hist, spin_edges, energy_bin_edges
+    return hist, spin_edges
 
 
-def flag_spin(l1b_de_dataset):
+def flag_spin(met: NDArray, energy: NDArray)-> NDArray:
+    """
+    Flags data based on counts and negative energies.
 
-    quality_flags_data = np.zeros(len(l1b_de_dataset["de_event_met"]), np.uint16)
-    quality_flags_data[l1b_de_dataset["energy"] < 0] |= ImapUltraFlags.NEG.value
+    Parameters
+    ----------
+    l1b_de_dataset : xarray.Dataset
+        Data in xarray format.
 
-    spin = get_spin(l1b_de_dataset["de_event_met"])
-    hist, spin_edges, energy_bin_edges = get_energy_histogram(spin, l1b_de_dataset["energy"])
+    Returns
+    -------
+    quality_flags_data : NDArray
+        Quality flags.
+    """
+    quality_flags_data = np.zeros(len(met), np.uint16)
 
-    energy_bin_idx = np.digitize(l1b_de_dataset["energy"], bins=energy_bin_edges) - 1
+    # Flag negative energies.
+    quality_flags_data[energy < 0] |= ImapUltraFlags.NEG.value
+
+    spin = get_spin(met)
+    hist, spin_edges, energy_bin_edges = get_energy_histogram(spin, energy)
+
+    # Map data points to bins
+    energy_bin_idx = np.digitize(energy, bins=energy_bin_edges) - 1
     spin_bin_idx = np.digitize(spin, bins=spin_edges) - 1
 
-    for spin_idx, energy_idx in np.ndindex(hist.shape):
-        if hist[energy_idx, spin_idx] > 100:  # Threshold for quality flag
-            # Find all data points corresponding to this bin
+    # Define thresholds for each energy bin
+    thresholds = [
+        UltraConstants.COUNTS_THRESHOLD_0_10_KEV,  # For energy range -1e5 to 0-10 keV
+        UltraConstants.COUNTS_THRESHOLD_10_20_KEV,  # For energy range 10-20 keV
+        UltraConstants.COUNTS_THRESHOLD_GE_20_KEV,  # For energy range >=20 keV
+    ]
+
+    # Iterate through non-empty bins
+    for energy_idx, spin_idx in np.argwhere(hist > 0):
+        threshold = thresholds[min(energy_idx, len(thresholds) - 1)]
+        if hist[energy_idx, spin_idx] > threshold:
+            # Create a mask for data points in the current high-count bin
             mask = (energy_bin_idx == energy_idx) & (spin_bin_idx == spin_idx)
             quality_flags_data[mask] |= ImapUltraFlags.BADSPIN.value
+
+    return quality_flags_data

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -1,4 +1,8 @@
 """Culls Events for ULTRA L1b."""
+# TODO: Add "bad attitude times" to the culling process.
+# TODO: Implement threshold calculations.
+# TODO: Add rates data.
+# TODO:
 
 import numpy as np
 from numpy.typing import NDArray
@@ -86,7 +90,7 @@ def flag_spin(met: NDArray, energy: NDArray) -> NDArray:
     quality_flags_data : NDArray
         Quality flags.
     """
-    quality_flags_data = np.zeros(len(met), np.uint16)
+    quality_flags_data = np.full(len(met), ImapUltraFlags.NONE.value, dtype=np.uint16)
 
     # Flag negative energies.
     quality_flags_data[energy < 0] |= ImapUltraFlags.NEG.value
@@ -102,7 +106,6 @@ def flag_spin(met: NDArray, energy: NDArray) -> NDArray:
 
     for energy_idx, spin_idx in np.ndindex(hist.shape):
         if hist[energy_idx][spin_idx] > UltraConstants.COUNTS_THRESHOLDS[energy_idx]:
-            # Create a mask for data points in the current high-count bin
             mask = (energy_bin_idx == energy_idx) & (spin_bin_idx == spin_idx)
             quality_flags_data[mask] |= ImapUltraFlags.HIGHCOUNTS.value
 

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -2,10 +2,9 @@
 
 import numpy as np
 from numpy.typing import NDArray
-import xarray
 
-from imap_processing.spice.geometry import get_spin_data
 from imap_processing.quality_flags import ImapUltraFlags
+from imap_processing.spice.geometry import get_spin_data
 from imap_processing.ultra.constants import UltraConstants
 
 
@@ -39,8 +38,9 @@ def get_spin(met: NDArray) -> tuple[NDArray, NDArray, NDArray]:
     return spin_number, spin_start_time, spin_duration
 
 
-def get_energy_histogram(spin_number: NDArray,
-                         energy: NDArray) -> tuple[NDArray, NDArray]:
+def get_energy_histogram(
+    spin_number: NDArray, energy: NDArray
+) -> tuple[NDArray, NDArray]:
     """
     Compute a 2D histogram of the counts.
 
@@ -62,21 +62,24 @@ def get_energy_histogram(spin_number: NDArray,
     spin_edges = np.append(spin_edges, spin_edges[-1] + 1)
 
     # 2D binning.
-    hist, _ = np.histogramdd(sample=(energy, spin_number),
-                             bins=[UltraConstants.CULLING_ENERGY_BINS,
-                                   spin_edges])
+    hist, _ = np.histogramdd(
+        sample=(energy, spin_number),
+        bins=[UltraConstants.CULLING_ENERGY_BIN_EDGES, spin_edges],
+    )
 
     return hist, spin_edges
 
 
-def flag_spin(met: NDArray, energy: NDArray)-> NDArray:
+def flag_spin(met: NDArray, energy: NDArray) -> NDArray:
     """
-    Flags data based on counts and negative energies.
+    Flag data based on counts and negative energies.
 
     Parameters
     ----------
-    l1b_de_dataset : xarray.Dataset
-        Data in xarray format.
+    met : NDArray
+        Mission Elapsed Time.
+    energy : NDArray
+        Energy data.
 
     Returns
     -------
@@ -88,26 +91,19 @@ def flag_spin(met: NDArray, energy: NDArray)-> NDArray:
     # Flag negative energies.
     quality_flags_data[energy < 0] |= ImapUltraFlags.NEG.value
 
-    spin = get_spin(met)
-    hist, spin_edges, energy_bin_edges = get_energy_histogram(spin, energy)
+    spin, _, _ = get_spin(met)
+    hist, spin_edges = get_energy_histogram(spin, energy)
 
     # Map data points to bins
-    energy_bin_idx = np.digitize(energy, bins=energy_bin_edges) - 1
+    energy_bin_idx = (
+        np.digitize(energy, bins=UltraConstants.CULLING_ENERGY_BIN_EDGES) - 1
+    )
     spin_bin_idx = np.digitize(spin, bins=spin_edges) - 1
 
-    # Define thresholds for each energy bin
-    thresholds = [
-        UltraConstants.COUNTS_THRESHOLD_0_10_KEV,  # For energy range -1e5 to 0-10 keV
-        UltraConstants.COUNTS_THRESHOLD_10_20_KEV,  # For energy range 10-20 keV
-        UltraConstants.COUNTS_THRESHOLD_GE_20_KEV,  # For energy range >=20 keV
-    ]
-
-    # Iterate through non-empty bins
-    for energy_idx, spin_idx in np.argwhere(hist > 0):
-        threshold = thresholds[min(energy_idx, len(thresholds) - 1)]
-        if hist[energy_idx, spin_idx] > threshold:
+    for energy_idx, spin_idx in np.ndindex(hist.shape):
+        if hist[energy_idx][spin_idx] > UltraConstants.COUNTS_THRESHOLDS[energy_idx]:
             # Create a mask for data points in the current high-count bin
             mask = (energy_bin_idx == energy_idx) & (spin_bin_idx == spin_idx)
-            quality_flags_data[mask] |= ImapUltraFlags.BADSPIN.value
+            quality_flags_data[mask] |= ImapUltraFlags.HIGHCOUNTS.value
 
     return quality_flags_data

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+# from imap_processing.ultra.l1b.ultra_l1b_extended import the energy equation here
+
+
+def get_spin(met, energy) -> list:
+    for time in met:
+        # Get the nearest spin start and duration prior to the event
+        spin_start = aux_spin_starts[aux_spin_starts <= time][-1]
+        duration = np.array(decom_aux["DURATION"])[aux_spin_starts <= time][-1]
+
+        # Find the events
+        event_indices = np.where(np.array(decom_events["SHCOARSE"]) == time)
+
+        for event_index in event_indices[0]:
+            phase_angle = decom_events["PHASE_ANGLE"][event_index]
+
+            durations.append(duration)
+            spin_starts.append(spin_start)
+
+            # If there were no events, the time is set to 'SHCOARSE'
+            if decom_events["COUNT"][event_index] == 0:
+                event_times.append(decom_events["SHCOARSE"][event_index])
+            else:
+                event_times.append(spin_start + (duration / 1000) * (phase_angle / 720))
+
+    decom_events["DURATION"] = durations
+    decom_events["TIMESPINSTART"] = spin_starts
+    decom_events["EVENTTIMES"] = event_times
+
+    return (
+        energy,
+        counts,
+    )
+
+
+def get_energy_histogram(
+    energy: np.ndarray,
+) -> NDArray:
+    """
+    Compute a 3D histogram of the particle data.
+
+    Parameters
+    ----------
+    v : tuple[np.ndarray, np.ndarray, np.ndarray]
+        The x,y,z-components of the velocity vector.
+    energy : np.ndarray
+        The particle energy.
+    az_bin_edges : np.ndarray
+        Array of azimuth bin boundary values.
+    el_bin_edges : np.ndarray
+        Array of elevation bin boundary values.
+    energy_bin_edges : np.ndarray
+        Array of energy bin edges.
+
+    Returns
+    -------
+    hist : np.ndarray
+        A 3D histogram array.
+    """
+    energy_bin_edges = [0, 10, 20]
+    spin_times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    # 2D binning.
+    hist, _ = np.histogramdd(sample=(energy), bins=[energy_bin_edges])
+
+    return hist

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -1,42 +1,26 @@
 import numpy as np
 
 # from imap_processing.ultra.l1b.ultra_l1b_extended import the energy equation here
+from imap_processing.spice.geometry import get_spacecraft_spin_phase, get_spin_data
+from imap_processing.quality_flags import ImapUltraFlags
 
 
-def get_spin(met, energy) -> list:
-    for time in met:
-        # Get the nearest spin start and duration prior to the event
-        spin_start = aux_spin_starts[aux_spin_starts <= time][-1]
-        duration = np.array(decom_aux["DURATION"])[aux_spin_starts <= time][-1]
+def get_spin(met) -> list:
 
-        # Find the events
-        event_indices = np.where(np.array(decom_events["SHCOARSE"]) == time)
+    # TODO: error handling for out of range spins
+    spin_df = get_spin_data()
 
-        for event_index in event_indices[0]:
-            phase_angle = decom_events["PHASE_ANGLE"][event_index]
-
-            durations.append(duration)
-            spin_starts.append(spin_start)
-
-            # If there were no events, the time is set to 'SHCOARSE'
-            if decom_events["COUNT"][event_index] == 0:
-                event_times.append(decom_events["SHCOARSE"][event_index])
-            else:
-                event_times.append(spin_start + (duration / 1000) * (phase_angle / 720))
-
-    decom_events["DURATION"] = durations
-    decom_events["TIMESPINSTART"] = spin_starts
-    decom_events["EVENTTIMES"] = event_times
-
-    return (
-        energy,
-        counts,
+    last_spin_indices = (
+        np.searchsorted(spin_df["spin_start_time"], met, side="right") - 1
     )
+    spin = spin_df["spin_number"].values[last_spin_indices]
+    spin_start_time = spin_df["spin_start_time"].values[last_spin_indices]
+    spin_duration = spin_df["spin_period_sec"].values[last_spin_indices]
+
+    return spin# TODO, spin_start_time, spin_duration
 
 
-def get_energy_histogram(
-    energy: np.ndarray,
-) -> NDArray:
+def get_energy_histogram(spin, energy):
     """
     Compute a 3D histogram of the particle data.
 
@@ -58,10 +42,31 @@ def get_energy_histogram(
     hist : np.ndarray
         A 3D histogram array.
     """
-    energy_bin_edges = [0, 10, 20]
-    spin_times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    spin_edges = np.unique(spin)
+    spin_edges = np.append(spin_edges, spin_edges[-1] + 1)
+    energy_bin_edges = [-1e5, 0, 10, 20, 1e5]
 
     # 2D binning.
-    hist, _ = np.histogramdd(sample=(energy), bins=[energy_bin_edges])
+    hist, _ = np.histogramdd(sample=(energy, spin),
+                          bins=[energy_bin_edges, spin_edges])
 
-    return hist
+    return hist, spin_edges, energy_bin_edges
+
+
+def flag_spin(l1b_de_dataset):
+
+    quality_flags_data = np.zeros(len(l1b_de_dataset["de_event_met"]), np.uint16)
+    quality_flags_data[l1b_de_dataset["energy"] < 0] |= ImapUltraFlags.NEG.value
+
+    spin = get_spin(l1b_de_dataset["de_event_met"])
+    hist, spin_edges, energy_bin_edges = get_energy_histogram(spin, l1b_de_dataset["energy"])
+
+    energy_bin_idx = np.digitize(l1b_de_dataset["energy"], bins=energy_bin_edges) - 1
+    spin_bin_idx = np.digitize(spin, bins=spin_edges) - 1
+
+    for spin_idx, energy_idx in np.ndindex(hist.shape):
+        if hist[energy_idx, spin_idx] > 100:  # Threshold for quality flag
+            # Find all data points corresponding to this bin
+            mask = (energy_bin_idx == energy_idx) & (spin_bin_idx == spin_idx)
+            quality_flags_data[mask] |= ImapUltraFlags.BADSPIN.value

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -2,7 +2,6 @@
 # TODO: Add "bad attitude times" to the culling process.
 # TODO: Implement threshold calculations.
 # TODO: Add rates data.
-# TODO:
 
 import numpy as np
 from numpy.typing import NDArray

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -6,14 +6,14 @@
 import numpy as np
 from numpy.typing import NDArray
 
-from imap_processing.quality_flags import ImapUltraFlags
+from imap_processing.quality_flags import ImapHkUltraFlags
 from imap_processing.spice.geometry import get_spin_data
 from imap_processing.ultra.constants import UltraConstants
 
 
-def get_spin(eventtimes_met: NDArray) -> tuple[NDArray, NDArray, NDArray]:
+def get_spin(eventtimes_met: NDArray) -> NDArray:
     """
-    Get spin parameters for each event.
+    Get spin number for each event.
 
     Parameters
     ----------
@@ -23,11 +23,7 @@ def get_spin(eventtimes_met: NDArray) -> tuple[NDArray, NDArray, NDArray]:
     Returns
     -------
     spin_number : NDArray
-        Spin number from Universal Spin Table.
-    spin_start_time : NDArray
-        Spin start time from Universal Spin Table.
-    spin_duration : NDArray
-        Spin duration from Universal Spin Table.
+        Spin number at each event derived the from Universal Spin Table.
     """
     spin_df = get_spin_data()
 
@@ -35,17 +31,15 @@ def get_spin(eventtimes_met: NDArray) -> tuple[NDArray, NDArray, NDArray]:
         np.searchsorted(spin_df["spin_start_time"], eventtimes_met, side="right") - 1
     )
     spin_number = spin_df["spin_number"].values[last_spin_indices]
-    spin_start_time = spin_df["spin_start_time"].values[last_spin_indices]
-    spin_duration = spin_df["spin_period_sec"].values[last_spin_indices]
 
-    return spin_number, spin_start_time, spin_duration
+    return spin_number
 
 
 def get_energy_histogram(
     spin_number: NDArray, energy: NDArray
 ) -> tuple[NDArray, NDArray]:
     """
-    Compute a 2D histogram of the counts.
+    Compute a 2D histogram of the counts binned by energy and spin number.
 
     Parameters
     ----------
@@ -57,18 +51,26 @@ def get_energy_histogram(
     Returns
     -------
     hist : NDArray
-        A 2D histogram array.
+        A 2D histogram array containing the
+        count rate per spin at each energy bin.
     spin_edges : NDArray
         Edges of the spin number bins.
     """
-    spin_edges = np.unique(spin_number)
-    spin_edges = np.append(spin_edges, spin_edges[-1] + 1)
+    spin_df = get_spin_data()
 
-    # 2D binning.
+    spin_edges = np.unique(spin_number)
+    spin_edges = np.append(spin_edges, spin_edges.max() + 1)
+
+    # Counts per spin at each energy bin.
     hist, _ = np.histogramdd(
         sample=(energy, spin_number),
         bins=[UltraConstants.CULLING_ENERGY_BIN_EDGES, spin_edges],
     )
+
+    # Count rate per spin at each energy bin.
+    for i in range(hist.shape[1]):
+        spin_duration = spin_df.spin_period_sec[spin_df.spin_number == i]
+        hist[:, i] /= spin_duration.values[0]
 
     return hist, spin_edges
 
@@ -95,22 +97,24 @@ def flag_spin(
     appended_energy : NDArray
         Energy midpoint data.
     """
-    spin, _, _ = get_spin(eventtimes_met)
+    spin = get_spin(eventtimes_met)
     hist, spin_edges = get_energy_histogram(spin, energy)
     quality_flags = np.full(
-        hist.shape[0] * hist.shape[1], ImapUltraFlags.NONE.value, dtype=np.uint16
+        hist.shape[0] * hist.shape[1], ImapHkUltraFlags.NONE.value, dtype=np.uint16
     )
 
     appended_spin = np.empty(0, dtype=np.uint16)
     appended_energy = np.empty(0, dtype=np.float64)
 
     for energy_idx in range(hist.shape[0]):
-        # Counts for each spin at this energy
-        spin_counts = hist[energy_idx][:]
+        # Count rates for each spin at this energy
+        spin_count_rates = hist[energy_idx][:]
         # Indices where the counts exceed the threshold
-        indices = np.nonzero(spin_counts > UltraConstants.COUNTS_THRESHOLDS[energy_idx])
+        indices = np.nonzero(
+            spin_count_rates > UltraConstants.COUNT_RATES_THRESHOLDS[energy_idx]
+        )
         flattened_indices = energy_idx * hist.shape[1] + indices[0]
-        quality_flags[flattened_indices] |= ImapUltraFlags.HIGHCOUNTS.value
+        quality_flags[flattened_indices] |= ImapHkUltraFlags.HIGHCOUNTS.value
 
         # Calculate the energy midpoint for each bin
         energy_midpoint = (


### PR DESCRIPTION
# Change Summary

## Overview
What you will want to focus on is ultra_l1b_culling.py and test_ultra_l1b_culling.py. Everything else is just modified to get those programs working.

## New Files
- ultra_l1b_culling.py
   - Gets spin_number, spin_start_time, spin_duration based off of mission elapsed time (met) and Universal Spin Table
   - Bins based on spin number and energy level
   - Creates a quality flag for counts that exceed a given threshold at each energy level for each spin

## Updated Files
- conftest.py
   - moved the creation of l1b de dataset here
- quality_flags.py
   - defined a new "HIGHCOUNTS" flag for Ultra
- imap_ultra_l1b_variable_attrs.yaml
   - added event_times attribute
- de.py
   - added event_times to dataset
- constants.py
   - added thresholds for counts based on each energy level
   
## Testing
- test_quality_flags.py
- test_ultra_l1b_culling.py
- test_de.py

## TODO
Todos are listed at the top of ultra_l1b_culling.py. I also need to confirm if we want an entire spin discarded or only the spins discarded at each energy level.