### PR TITLE
Add SPICE data (ephemeris, attitude, and celestial coords) to IDEX l1b CDF

### DIFF
--- a/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
@@ -42,8 +42,15 @@ l1b_target_base: &l1b_target_base
 trigger_base: &trigger_base
   <<: *l1b_data_base
   DISPLAY_TYPE: no_plot
-  CATDESC: ""
   UNITS: " "
+
+spice_base: &spice_base
+  <<: *l1b_data_base
+  VAR_TYPE: data
+  VALIDMIN: -9223372036854775808 # TODO: Find actual validmin
+  VALIDMAX: 9223372036854775807 # TODO: Find actual validmax
+  DISPLAY_TYPE: time_series
+  UNITS: Radians
 
 # <=== Instrument Setting Attributes ===>
 trigger_mode:
@@ -334,3 +341,86 @@ current_neg2p5v_bus:
   CATDESC: Negative current reading on -2.5V bus on LVPS Board (ADC 1 channel 7)
   LABLAXIS: Current
   UNITS: A
+
+# <=== Spice Data Attributes ===>
+ephemeris_position_x:
+  <<: *spice_base
+  FIELDNAM: Position X
+  CATDESC: Cartesian coordinate X positions for the IMAP spacecraft in the ECLIPJ2000 frame.
+  LABLAXIS: Position X
+  UNITS: km
+
+ephemeris_position_y:
+  <<: *spice_base
+  FIELDNAM: Position Y
+  CATDESC: Cartesian coordinate Y positions for the IMAP spacecraft in the ECLIPJ2000 frame.
+  LABLAXIS: Position Y
+  UNITS: km
+
+ephemeris_position_z:
+  <<: *spice_base
+  FIELDNAM: Position Z
+  CATDESC: Cartesian coordinate Z positions for the IMAP spacecraft in the ECLIPJ2000 frame.
+  LABLAXIS: Position Z
+  UNITS: km
+
+ephemeris_velocity_x:
+  <<: *spice_base
+  FIELDNAM: Velocity X
+  CATDESC: Velocity X positions for the IMAP spacecraft in the ECLIPJ2000 frame.
+  LABLAXIS: Velocity X
+  UNITS: km/s
+
+ephemeris_velocity_y:
+  <<: *spice_base
+  FIELDNAM: Velocity Y
+  CATDESC: Velocity Y positions for the IMAP spacecraft in the ECLIPJ2000 frame.
+  LABLAXIS: Velocity Y
+  UNITS: km/s
+
+ephemeris_velocity_z:
+  <<: *spice_base
+  FIELDNAM: Velocity Z
+  CATDESC: Velocity Z positions for the IMAP spacecraft in the ECLIPJ2000 frame.
+  LABLAXIS: Velocity Z
+  UNITS: km/s
+
+right_ascension:
+  <<: *spice_base
+  VALIDMIN: 0
+  VALIDMAX: 6.283185307179586
+  FIELDNAM: Right Ascension
+  CATDESC: Right ascension of the IMAP spacecraft position as observed from Earth in the ECLIPJ2000 reference frame.
+  LABLAXIS: Right Ascension
+
+declination:
+  <<: *spice_base
+  VALIDMIN: -1.5707963267948966
+  VALIDMAX: 1.5707963267948966
+  FIELDNAM: Declination
+  CATDESC: Declination of the IMAP spacecraft position as observed from Earth in the ECLIPJ2000 reference frame.
+  LABLAXIS: Current
+
+attitude_roll:
+  <<: *spice_base
+  VALIDMIN: -3.141592653589793
+  VALIDMAX: 3.141592653589793
+  FIELDNAM: Roll
+  CATDESC: Roll angle (rotation around the X-axis) of the IMAP spacecraft in the ECLIPJ2000 reference frame.
+  LABLAXIS: Roll
+
+attitude_pitch:
+  <<: *spice_base
+  VALIDMIN: -1.5707963267948966
+  VALIDMAX: 3.141592653589793
+  FIELDNAM: Pitch
+  CATDESC: Pitch angle (rotation around the Y-axis) of the IMAP spacecraft in the ECLIPJ2000 reference frame.
+  LABLAXIS: Pitch
+
+attitude_yaw:
+  <<: *spice_base
+  VALIDMIN: -3.141592653589793
+  VALIDMAX: 3.141592653589793
+  FIELDNAM: Yaw
+  CATDESC: Yaw angle (rotation around the Z-axis) of the IMAP spacecraft in the ECLIPJ2000 reference frame.
+  LABLAXIS: Yaw

--- a/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
@@ -47,10 +47,10 @@ trigger_base: &trigger_base
 spice_base: &spice_base
   <<: *l1b_data_base
   VAR_TYPE: data
-  VALIDMIN: -9223372036854775808 # TODO: Find actual validmin
-  VALIDMAX: 9223372036854775807 # TODO: Find actual validmax
+  VALIDMIN: -180
+  VALIDMAX: 360
   DISPLAY_TYPE: time_series
-  UNITS: Radians
+  UNITS: Degrees
 
 # <=== Instrument Setting Attributes ===>
 trigger_mode:
@@ -343,6 +343,7 @@ current_neg2p5v_bus:
   UNITS: A
 
 # <=== Spice Data Attributes ===>
+# TODO: Get actual validmin and vaildmax for ephemeris attrs
 ephemeris_position_x:
   <<: *spice_base
   FIELDNAM: Position X
@@ -388,39 +389,27 @@ ephemeris_velocity_z:
 right_ascension:
   <<: *spice_base
   VALIDMIN: 0
-  VALIDMAX: 6.283185307179586
   FIELDNAM: Right Ascension
   CATDESC: Right ascension of the IMAP spacecraft position as observed from Earth in the ECLIPJ2000 reference frame.
   LABLAXIS: Right Ascension
 
 declination:
   <<: *spice_base
-  VALIDMIN: -1.5707963267948966
-  VALIDMAX: 1.5707963267948966
   FIELDNAM: Declination
   CATDESC: Declination of the IMAP spacecraft position as observed from Earth in the ECLIPJ2000 reference frame.
-  LABLAXIS: Current
+  LABLAXIS: Declination
 
-attitude_roll:
+spin_phase:
   <<: *spice_base
-  VALIDMIN: -3.141592653589793
-  VALIDMAX: 3.141592653589793
-  FIELDNAM: Roll
-  CATDESC: Roll angle (rotation around the X-axis) of the IMAP spacecraft in the ECLIPJ2000 reference frame.
-  LABLAXIS: Roll
+  VALIDMIN: 0
+  FIELDNAM: Spin Phase
+  CATDESC: IMAP Spin Phase
+  LABLAXIS: Spin Phase
 
-attitude_pitch:
+solar_longitude:
   <<: *spice_base
-  VALIDMIN: -1.5707963267948966
-  VALIDMAX: 3.141592653589793
-  FIELDNAM: Pitch
-  CATDESC: Pitch angle (rotation around the Y-axis) of the IMAP spacecraft in the ECLIPJ2000 reference frame.
-  LABLAXIS: Pitch
+  VALIDMAX: 180
+  FIELDNAM: Solar Longitude
+  CATDESC: Solar Longitude of the IMAP spacecraft
+  LABLAXIS: Solar Longitude
 
-attitude_yaw:
-  <<: *spice_base
-  VALIDMIN: -3.141592653589793
-  VALIDMAX: 3.141592653589793
-  FIELDNAM: Yaw
-  CATDESC: Yaw angle (rotation around the Z-axis) of the IMAP spacecraft in the ECLIPJ2000 reference frame.
-  LABLAXIS: Yaw

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -18,7 +18,6 @@ import logging
 from enum import Enum
 from typing import Union
 
-import numpy as np
 import pandas as pd
 import xarray as xr
 
@@ -28,9 +27,10 @@ from imap_processing.spice.geometry import (
     SpiceBody,
     SpiceFrame,
     cartesian_to_spherical,
-    get_rotation_matrix,
+    get_spacecraft_spin_phase,
     imap_state,
-    rotation_matrix_to_euler_angles,
+    instrument_pointing,
+    solar_longitude,
 )
 from imap_processing.spice.time import j2000ns_to_j2000s
 from imap_processing.utils import convert_raw_to_eu
@@ -122,7 +122,7 @@ def idex_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     )
     # Get spice data and save them as xr.DataArrays in the output. Spice data is not
     # used for calculations yet but are saved in the CDF for reference.
-    spice_data = get_spice_data(epoch_da.data, idex_attrs)
+    spice_data = get_spice_data(l1a_dataset, idex_attrs)
 
     trigger_settings = get_trigger_mode_and_level(l1a_dataset)
     if trigger_settings:
@@ -340,15 +340,15 @@ def get_trigger_mode_and_level(
 
 
 def get_spice_data(
-    epoch: np.ndarray, idex_attrs: ImapCdfAttributes
+    l1a_dataset: xr.Dataset, idex_attrs: ImapCdfAttributes
 ) -> dict[str, xr.DataArray]:
     """
     Use spice to query ephemeris, attitude, celestial coordinates for each dust event.
 
     Parameters
     ----------
-    epoch : np.ndarray
-        Dust impact times.
+    l1a_dataset : xarray.Dataset
+        IDEX L1a dataset containing the six waveform arrays and instrument settings.
     idex_attrs : ImapCdfAttributes
         CDF attribute manager object.
 
@@ -358,31 +358,32 @@ def get_spice_data(
         Spice array names and xr.DataArrays.
     """
     # convert 'epoch' from nanoseconds to seconds since j2000
-    et = j2000ns_to_j2000s(epoch)
-    # Get IDEX rotation matrix (matrix to get transformation from the 'ECLIPJ2000'
-    # Reference frame to the IDEX instrument frame)
-    rotation = get_rotation_matrix(et, SpiceFrame.ECLIPJ2000, SpiceFrame.IMAP_IDEX)
-    # In order yaw, pitch, roll in radians
-    euler_angles = rotation_matrix_to_euler_angles(rotation)
-
-    # Get position and velocity of IMAP
+    et = j2000ns_to_j2000s(l1a_dataset["epoch"].data)
+    # Get 'shcoarse' (Mission Elapsed Time)
+    met = l1a_dataset["shcoarse"].data
+    # Get spacecraft spin phase in degrees
+    imap_spin_phase = get_spacecraft_spin_phase(query_met_times=met, degrees=True)
+    # Get position and velocity of IMAP in ecliptic frame
     ephemeris = imap_state(et, observer=SpiceBody.SUN)
-    imap_position = ephemeris[:, :3]
+    # Get Idex pointing in the j200 equatorial frame
+    idex_pointing = instrument_pointing(
+        et, SpiceFrame.IMAP_IDEX, SpiceFrame.J2000, cartesian=True
+    )
+    solar_lon = solar_longitude(et, degrees=True)
 
-    range_ra_and_dec = cartesian_to_spherical(imap_position)
+    range_ra_and_dec = cartesian_to_spherical(idex_pointing)
 
     spice_data = {
-        "ephemeris_position_x": imap_position[:, 0],
-        "ephemeris_position_y": imap_position[:, 1],
-        "ephemeris_position_z": imap_position[:, 2],
+        "ephemeris_position_x": ephemeris[:, 0],
+        "ephemeris_position_y": ephemeris[:, 1],
+        "ephemeris_position_z": ephemeris[:, 2],
         "ephemeris_velocity_x": ephemeris[:, 3],
         "ephemeris_velocity_y": ephemeris[:, 4],
         "ephemeris_velocity_z": ephemeris[:, 5],
         "right_ascension": range_ra_and_dec[:, 1],
         "declination": range_ra_and_dec[:, 2],
-        "attitude_roll": euler_angles[:, 2],
-        "attitude_pitch": euler_angles[:, 1],
-        "attitude_yaw": euler_angles[:, 0],
+        "spin_phase": imap_spin_phase,
+        "solar_longitude": solar_lon,
     }
 
     for name, array in spice_data.items():

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -27,7 +27,8 @@ from imap_processing.spice.geometry import (
     SpiceBody,
     SpiceFrame,
     cartesian_to_spherical,
-    get_spacecraft_spin_phase_angle,
+    get_spacecraft_spin_phase,
+    get_spin_angle,
     imap_state,
     instrument_pointing,
     solar_longitude,
@@ -362,7 +363,8 @@ def get_spice_data(
     # Get 'shcoarse' (Mission Elapsed Time)
     met = l1a_dataset["shcoarse"].data
     # Get spacecraft spin phase in degrees
-    imap_spin_phase = get_spacecraft_spin_phase_angle(query_met_times=met, degrees=True)
+    spin_phase = get_spacecraft_spin_phase(query_met_times=met)
+    imap_spin_phase = get_spin_angle(spin_phase, degrees=True)
     # Get position and velocity of IMAP in ecliptic frame
     ephemeris = imap_state(et, observer=SpiceBody.SUN)
     # Get Idex pointing in the j2000 equatorial frame

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -27,7 +27,7 @@ from imap_processing.spice.geometry import (
     SpiceBody,
     SpiceFrame,
     cartesian_to_spherical,
-    get_spacecraft_spin_phase,
+    get_spacecraft_spin_phase_angle,
     imap_state,
     instrument_pointing,
     solar_longitude,
@@ -362,10 +362,10 @@ def get_spice_data(
     # Get 'shcoarse' (Mission Elapsed Time)
     met = l1a_dataset["shcoarse"].data
     # Get spacecraft spin phase in degrees
-    imap_spin_phase = get_spacecraft_spin_phase(query_met_times=met, degrees=True)
+    imap_spin_phase = get_spacecraft_spin_phase_angle(query_met_times=met, degrees=True)
     # Get position and velocity of IMAP in ecliptic frame
     ephemeris = imap_state(et, observer=SpiceBody.SUN)
-    # Get Idex pointing in the j200 equatorial frame
+    # Get Idex pointing in the j2000 equatorial frame
     idex_pointing = instrument_pointing(
         et, SpiceFrame.IMAP_IDEX, SpiceFrame.J2000, cartesian=True
     )

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -18,11 +18,21 @@ import logging
 from enum import Enum
 from typing import Union
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.spice.geometry import (
+    SpiceBody,
+    SpiceFrame,
+    get_right_ascension_and_declination,
+    get_rotation_matrix,
+    imap_state,
+    rotation_matrix_to_euler_angles,
+)
+from imap_processing.spice.time import j2000ns_to_j2000s
 from imap_processing.utils import convert_raw_to_eu
 
 logger = logging.getLogger(__name__)
@@ -110,6 +120,9 @@ def idex_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         dims=["epoch"],
         attrs=idex_attrs.get_variable_attributes("epoch"),
     )
+    # Get spice data and save them as xr.DataArrays in the output. Spice data is not
+    # used for calculations yet but are saved in the CDF for reference.
+    spice_data = get_spice_data(epoch_da.data, idex_attrs)
 
     trigger_settings = get_trigger_mode_and_level(l1a_dataset)
     if trigger_settings:
@@ -123,7 +136,7 @@ def idex_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # Create l1b Dataset
     l1b_dataset = xr.Dataset(
         coords={"epoch": epoch_da},
-        data_vars=processed_vars | waveforms_converted | trigger_settings,
+        data_vars=processed_vars | waveforms_converted | trigger_settings | spice_data,
         attrs=idex_attrs.get_global_attributes("imap_idex_l1b_sci"),
     )
     # Convert variables
@@ -324,3 +337,62 @@ def get_trigger_mode_and_level(
             f"there is only one valid trigger value per event. This "
             f"caused Merge Error: {e}"
         ) from e
+
+
+def get_spice_data(
+    epoch: np.ndarray, idex_attrs: ImapCdfAttributes
+) -> dict[str, xr.DataArray]:
+    """
+    Use spice to query ephemeris, attitude, celestial coordinates for each dust event.
+
+    Parameters
+    ----------
+    epoch : np.ndarray
+        Dust impact times.
+    idex_attrs : ImapCdfAttributes
+        CDF attribute manager object.
+
+    Returns
+    -------
+    dict
+        Spice array names and xr.DataArrays.
+    """
+    # 'epoch' is in nanoseconds since j2000
+    # convert epoch times to seconds since j2000
+    et = j2000ns_to_j2000s(epoch)
+    # Get IDEX rotation matrix (matrix to get transformation from the 'ECLIPJ2000'
+    # Reference frame to the IDEX instrument frame)
+    rotation = get_rotation_matrix(et, SpiceFrame.ECLIPJ2000, SpiceFrame.IMAP_IDEX)
+    # In order yaw, pitch, roll in radians
+    euler_angles = rotation_matrix_to_euler_angles(rotation)
+
+    # Get position and velocity of IMAP
+    ephemeris = imap_state(et, observer=SpiceBody.SUN)
+    imap_position = ephemeris[:3]
+
+    # get right ascension and declination of the IMAP spacecraft
+    range_ra_and_dec = get_right_ascension_and_declination(imap_position)
+
+    spice_data = {
+        "ephemeris_position_x": imap_position[0],
+        "ephemeris_position_y": imap_position[1],
+        "ephemeris_position_z": imap_position[2],
+        "ephemeris_velocity_x": ephemeris[3],
+        "ephemeris_velocity_y": ephemeris[4],
+        "ephemeris_velocity_z": ephemeris[5],
+        "right_ascension": range_ra_and_dec[1],
+        "declination": range_ra_and_dec[2],
+        "attitude_roll": euler_angles[2],
+        "attitude_pitch": euler_angles[1],
+        "attitude_yaw": euler_angles[0],
+    }
+
+    for name, array in spice_data.items():
+        spice_data[name] = xr.DataArray(
+            name=name,
+            data=array,
+            dims="epoch",
+            attrs=idex_attrs.get_variable_attributes(name),
+        )
+
+    return spice_data

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -27,7 +27,7 @@ from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.spice.geometry import (
     SpiceBody,
     SpiceFrame,
-    get_right_ascension_and_declination,
+    cartesian_to_spherical,
     get_rotation_matrix,
     imap_state,
     rotation_matrix_to_euler_angles,
@@ -357,8 +357,7 @@ def get_spice_data(
     dict
         Spice array names and xr.DataArrays.
     """
-    # 'epoch' is in nanoseconds since j2000
-    # convert epoch times to seconds since j2000
+    # convert 'epoch' from nanoseconds to seconds since j2000
     et = j2000ns_to_j2000s(epoch)
     # Get IDEX rotation matrix (matrix to get transformation from the 'ECLIPJ2000'
     # Reference frame to the IDEX instrument frame)
@@ -368,23 +367,22 @@ def get_spice_data(
 
     # Get position and velocity of IMAP
     ephemeris = imap_state(et, observer=SpiceBody.SUN)
-    imap_position = ephemeris[:3]
+    imap_position = ephemeris[:, :3]
 
-    # get right ascension and declination of the IMAP spacecraft
-    range_ra_and_dec = get_right_ascension_and_declination(imap_position)
+    range_ra_and_dec = cartesian_to_spherical(imap_position)
 
     spice_data = {
-        "ephemeris_position_x": imap_position[0],
-        "ephemeris_position_y": imap_position[1],
-        "ephemeris_position_z": imap_position[2],
-        "ephemeris_velocity_x": ephemeris[3],
-        "ephemeris_velocity_y": ephemeris[4],
-        "ephemeris_velocity_z": ephemeris[5],
-        "right_ascension": range_ra_and_dec[1],
-        "declination": range_ra_and_dec[2],
-        "attitude_roll": euler_angles[2],
-        "attitude_pitch": euler_angles[1],
-        "attitude_yaw": euler_angles[0],
+        "ephemeris_position_x": imap_position[:, 0],
+        "ephemeris_position_y": imap_position[:, 1],
+        "ephemeris_position_z": imap_position[:, 2],
+        "ephemeris_velocity_x": ephemeris[:, 3],
+        "ephemeris_velocity_y": ephemeris[:, 4],
+        "ephemeris_velocity_z": ephemeris[:, 5],
+        "right_ascension": range_ra_and_dec[:, 1],
+        "declination": range_ra_and_dec[:, 2],
+        "attitude_roll": euler_angles[:, 2],
+        "attitude_pitch": euler_angles[:, 1],
+        "attitude_yaw": euler_angles[:, 0],
     }
 
     for name, array in spice_data.items():

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -158,9 +158,37 @@ def get_spin_data() -> pd.DataFrame:
     return spin_df
 
 
-def get_spacecraft_spin_phase(
+def get_spacecraft_spin_phase_angle(
     query_met_times: Union[float, npt.NDArray],
     degrees: bool = False,
+) -> Union[float, npt.NDArray]:
+    """
+    Get the spacecraft spin phase angle for the input query times.
+
+    Parameters
+    ----------
+    query_met_times : float or np.ndarray
+        Query times in Mission Elapsed Time (MET).
+    degrees : bool
+        If degrees parameter is True, return angle in degrees otherwise return angle in
+        radians. Default is False.
+
+    Returns
+    -------
+    spin_phase : float or np.ndarray
+        Spin phase angle in degrees or radians for the input query times.
+    """
+    spin_phase = get_spacecraft_spin_phase(query_met_times)
+    if degrees:
+        # Convert to degrees
+        return spin_phase * 360
+    else:
+        # Convert to radians
+        return spin_phase * 2 * np.pi
+
+
+def get_spacecraft_spin_phase(
+    query_met_times: Union[float, npt.NDArray],
 ) -> Union[float, npt.NDArray]:
     """
     Get the spacecraft spin phase for the input query times.
@@ -172,14 +200,11 @@ def get_spacecraft_spin_phase(
     ----------
     query_met_times : float or np.ndarray
         Query times in Mission Elapsed Time (MET).
-    degrees : bool
-        If True, spin phase output will be in degrees.
 
     Returns
     -------
     spin_phase : float or np.ndarray
-        Spin phase for the input query times. If 'degrees' is True, spin phase is a
-        floating point number in the range [0, 360) degrees.
+        Spin phase for the input query times.
     """
     spin_df = get_spin_data()
 
@@ -236,9 +261,6 @@ def get_spacecraft_spin_phase(
     )
     bad_spin_phases = invalid_spin_phase_range | invalid_spins
     spin_phases[bad_spin_phases] = np.nan
-
-    if degrees:
-        spin_phases *= 360
 
     if is_scalar:
         return spin_phases[0]

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -158,33 +158,39 @@ def get_spin_data() -> pd.DataFrame:
     return spin_df
 
 
-def get_spacecraft_spin_phase_angle(
-    query_met_times: Union[float, npt.NDArray],
+def get_spin_angle(
+    spin_phases: Union[float, npt.NDArray],
     degrees: bool = False,
 ) -> Union[float, npt.NDArray]:
     """
-    Get the spacecraft spin phase angle for the input query times.
+    Convert spin_phases to radians or degrees.
 
     Parameters
     ----------
-    query_met_times : float or np.ndarray
-        Query times in Mission Elapsed Time (MET).
+    spin_phases : float or np.ndarray
+        Instrument or spacecraft spin phases. Spin phase is a
+        floating point number in the range [0, 1) corresponding to the
+        spin angle / 360.
     degrees : bool
         If degrees parameter is True, return angle in degrees otherwise return angle in
         radians. Default is False.
 
     Returns
     -------
-    spin_phase : float or np.ndarray
-        Spin phase angle in degrees or radians for the input query times.
+    spin_phases : float or np.ndarray
+        Spin angle in degrees or radians for the input query times.
     """
-    spin_phase = get_spacecraft_spin_phase(query_met_times)
+    if np.any(spin_phases < 0) or np.any(spin_phases > 1):
+        raise ValueError(
+            f"Spin phases, {spin_phases} are outside of the expected spin phase range, "
+            f"[0, 1) "
+        )
     if degrees:
         # Convert to degrees
-        return spin_phase * 360
+        return spin_phases * 360
     else:
         # Convert to radians
-        return spin_phase * 2 * np.pi
+        return spin_phases * 2 * np.pi
 
 
 def get_spacecraft_spin_phase(

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -160,6 +160,7 @@ def get_spin_data() -> pd.DataFrame:
 
 def get_spacecraft_spin_phase(
     query_met_times: Union[float, npt.NDArray],
+    degrees: bool = False,
 ) -> Union[float, npt.NDArray]:
     """
     Get the spacecraft spin phase for the input query times.
@@ -171,11 +172,14 @@ def get_spacecraft_spin_phase(
     ----------
     query_met_times : float or np.ndarray
         Query times in Mission Elapsed Time (MET).
+    degrees : bool
+        If True, spin phase output will be in degrees.
 
     Returns
     -------
     spin_phase : float or np.ndarray
-        Spin phase for the input query times.
+        Spin phase for the input query times. If 'degrees' is True, spin phase is a
+        floating point number in the range [0, 360) degrees.
     """
     spin_df = get_spin_data()
 
@@ -233,14 +237,16 @@ def get_spacecraft_spin_phase(
     bad_spin_phases = invalid_spin_phase_range | invalid_spins
     spin_phases[bad_spin_phases] = np.nan
 
+    if degrees:
+        spin_phases *= 360
+
     if is_scalar:
         return spin_phases[0]
     return spin_phases
 
 
 def get_instrument_spin_phase(
-    query_met_times: Union[float, npt.NDArray],
-    instrument: SpiceFrame,
+    query_met_times: Union[float, npt.NDArray], instrument: SpiceFrame
 ) -> Union[float, npt.NDArray]:
     """
     Get the instrument spin phase for the input query times.
@@ -466,48 +472,6 @@ def get_rotation_matrix(
     return vec_pxform(from_frame.name, to_frame.name, et)
 
 
-def rotation_matrix_to_euler_angles(
-    rotation_matrix: npt.NDArray, axes: Union[list, None] = None
-) -> npt.NDArray:
-    """
-    Get the Euler angles from a rotation matrix.
-
-    This is a vectorized wrapper around `spiceypy.m2eul`
-    "Factor a rotation matrix as a product of three rotations about specified coordinate
-    axes."
-    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/m2eul.html
-
-    Parameters
-    ----------
-    rotation_matrix : np.ndarray
-        Either single 2d rotation matrix of shape, `(3,3)` or 3d array
-        of rotation matrices of shape `(n, 3, 3)`.
-    axes : list, optional
-        Indices of third, second, and first rotation axes.
-        Default is [3, 2, 1]. They must be in the set of values: [1, 2, 3].
-
-    Returns
-    -------
-    euler_angles: np.ndarray
-        If `rotation_matrix` is a 2d array, the euler angles are of shape `(3)`
-        and if `rotation_matrix` is a 3d np.ndarray,
-        the returned euler angles are of shape `(n,3)`
-        where `n` matches the number of matrices in rotation_matrix.
-    """
-    if not axes:
-        axes = [3, 2, 1]
-    elif any(axis not in [1, 2, 3] for axis in axes):
-        raise ValueError("Axes must be in [1, 2, or 3].")
-
-    # If rotation_matrix is 2d, add another dimension
-    while rotation_matrix.ndim < 3:
-        rotation_matrix = np.expand_dims(rotation_matrix, axis=0)
-
-    euler_angles = np.array([spice.m2eul(m, *axes) for m in rotation_matrix])
-    # Return array of euler angles and remove the first dimension if it is 1.
-    return np.squeeze(euler_angles)
-
-
 def instrument_pointing(
     et: Union[float, npt.NDArray],
     instrument: SpiceFrame,
@@ -686,3 +650,64 @@ def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = False) -> 
     cartesian_coords = np.stack((x, y, z), axis=-1)
 
     return cartesian_coords
+
+
+def cartesian_to_latitudinal(coords: NDArray, degrees: bool = False) -> NDArray:
+    """
+    Convert cartesian coordinates to latitudinal coordinates in radians.
+
+    This is a vectorized wrapper around `spiceypy.reclat`
+    "Convert from rectangular coordinates to latitudinal coordinates."
+    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/reclat_c.html
+
+    Parameters
+    ----------
+    coords : np.ndarray
+        Either shape (n, 3) or (3) where the last dimension represents a vector
+        with x, y, z-components.
+    degrees : bool
+        If True, the longitude and latitude coords are returned in degrees.
+        Defaults to False.
+
+    Returns
+    -------
+    np.ndarray
+        A NumPy array with shape (n, 3) or (3), where the last dimension contains
+        the latitudinal coordinates (radius, longitude, latitude).
+    """
+    # If coords is 1d, add another dimension
+    while coords.ndim < 2:
+        coords = np.expand_dims(coords, axis=0)
+    latitudinal_coords = np.array([spice.reclat(vec) for vec in coords])
+
+    if degrees:
+        latitudinal_coords[..., 1:] = np.degrees(latitudinal_coords[..., 1:])
+    # Return array of latitudinal and remove the first dimension if it is 1.
+    return np.squeeze(latitudinal_coords)
+
+
+def solar_longitude(
+    et: Union[np.ndarray, float],
+    degrees: bool = False,
+) -> Union[float, npt.NDArray]:
+    """
+    Compute the solar longitude of the Imap Spacecraft.
+
+    Parameters
+    ----------
+    et : float or np.ndarray
+        Ephemeris time(s) to at which to compute solar longitude.
+    degrees : bool
+        If True, the longitude is returned in degrees.
+        Defaults to False.
+
+    Returns
+    -------
+    float or np.ndarray
+        The solar longitude at the specified times.
+    """
+    # Get position of IMAP in ecliptic frame
+    imap_pos = imap_state(et, observer=SpiceBody.SUN)[..., 0:3]
+    lat_coords = cartesian_to_latitudinal(imap_pos, degrees=degrees)[..., 1]
+
+    return float(lat_coords) if lat_coords.size == 1 else lat_coords

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -466,6 +466,46 @@ def get_rotation_matrix(
     return vec_pxform(from_frame.name, to_frame.name, et)
 
 
+def rotation_matrix_to_euler_angles(
+    rotation_matrix: npt.NDArray, axes: Union[list | None] = None
+) -> npt.NDArray:
+    """
+    Get the Euler angles from a rotation matrix.
+
+    This is a vectorized wrapper around `spiceypy.m2eul`
+    "Factor a rotation matrix as a product of three rotations about
+        specified coordinate axes."
+    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/m2eul.html
+
+    Parameters
+    ----------
+    rotation_matrix : np.ndarray
+        Either single 2d rotation matrix of shape, `(3,3)` or 3d array
+        of rotation matrices of shape `(n, 3, 3)`.
+    axes : SpiceFrame
+        Indices of third, second, and first rotation axes.
+        Default is [3, 2, 1].
+
+    Returns
+    -------
+    euler_angles: np.ndarray
+        If `rotation_matrix` is a 2d array, the euler angles are of shape `(3)`
+        and if `rotation_matrix` is a 3d np.ndarray,
+        the returned euler angles are of shape `(n,3)`
+        where `n` matches the number of matrices in rotation_matrix.
+    """
+    if not axes:
+        axes = [3, 2, 1]
+
+    # If rotation_matrix is 2d, add another dimension
+    while rotation_matrix.ndim < 3:
+        rotation_matrix = np.expand_dims(rotation_matrix, axis=0)
+
+    euler_angles = np.array([spice.m2eul(m, *axes) for m in rotation_matrix])
+    # Return array of euler angles and remove the first dimension if it is 1.
+    return np.squeeze(euler_angles)
+
+
 def instrument_pointing(
     et: Union[float, npt.NDArray],
     instrument: SpiceFrame,
@@ -644,3 +684,32 @@ def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = False) -> 
     cartesian_coords = np.stack((x, y, z), axis=-1)
 
     return cartesian_coords
+
+
+def get_right_ascension_and_declination(coords: npt.NDArray) -> npt.NDArray:
+    """
+    Convert rectangular coordinates to range, right ascension, and declination.
+
+    This is a vectorized wrapper around `spiceypy.recrad`
+    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recrad_c.html
+
+    Parameters
+    ----------
+    coords : npt.NDArray
+        Cartesian (rectangular) coordinates with shape `(n, 3)`,
+        where each row contains [x, y, z].
+
+    Returns
+    -------
+     npt.NDArray
+        Returns np.ndarray containing range, right ascension and declination values.
+        If the input coords are shape `(3)`, the output array is of shape `(3)` and
+        if the input coords are shape `(n, 3)`,
+        the output array is of shape `(n, 3)` where n matches the number sets in coords.
+    """
+    # If coords is 1d, add another dimension
+    while coords.ndim < 2:
+        coords = np.expand_dims(coords, axis=0)
+
+    array = np.array([np.array(spice.recrad(coords)) for coords in coords])
+    return np.squeeze(array)

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -473,8 +473,8 @@ def rotation_matrix_to_euler_angles(
     Get the Euler angles from a rotation matrix.
 
     This is a vectorized wrapper around `spiceypy.m2eul`
-    "Factor a rotation matrix as a product of three rotations about
-        specified coordinate axes."
+    "Factor a rotation matrix as a product of three rotations about specified coordinate
+    axes."
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/m2eul.html
 
     Parameters

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -482,9 +482,9 @@ def rotation_matrix_to_euler_angles(
     rotation_matrix : np.ndarray
         Either single 2d rotation matrix of shape, `(3,3)` or 3d array
         of rotation matrices of shape `(n, 3, 3)`.
-    axes : SpiceFrame
+    axes : list, optional
         Indices of third, second, and first rotation axes.
-        Default is [3, 2, 1].
+        Default is [3, 2, 1]. They must be in the set of values: [1, 2, 3].
 
     Returns
     -------
@@ -496,6 +496,8 @@ def rotation_matrix_to_euler_angles(
     """
     if not axes:
         axes = [3, 2, 1]
+    elif any(axis not in [1, 2, 3] for axis in axes):
+        raise ValueError("Axes must be in [1, 2, or 3].")
 
     # If rotation_matrix is 2d, add another dimension
     while rotation_matrix.ndim < 3:
@@ -684,32 +686,3 @@ def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = False) -> 
     cartesian_coords = np.stack((x, y, z), axis=-1)
 
     return cartesian_coords
-
-
-def get_right_ascension_and_declination(coords: npt.NDArray) -> npt.NDArray:
-    """
-    Convert rectangular coordinates to range, right ascension, and declination.
-
-    This is a vectorized wrapper around `spiceypy.recrad`
-    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recrad_c.html
-
-    Parameters
-    ----------
-    coords : np.ndarray
-        Cartesian (rectangular) coordinates with shape `(3)` or `(n, 3)`,
-        where each row contains [x, y, z].
-
-    Returns
-    -------
-     np.ndarray
-        Returns np.ndarray containing range, right ascension and declination values.
-        If the input coords are shape `(3)`, the output array is of shape `(3)` and
-        if the input coords are shape `(n, 3)`,
-        the output array is of shape `(n, 3)` where n matches the number sets in coords.
-    """
-    # If coords is 1d, add another dimension
-    while coords.ndim < 2:
-        coords = np.expand_dims(coords, axis=0)
-
-    array = np.array([np.array(spice.recrad(coords)) for coords in coords])
-    return np.squeeze(array)

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -695,13 +695,13 @@ def get_right_ascension_and_declination(coords: npt.NDArray) -> npt.NDArray:
 
     Parameters
     ----------
-    coords : npt.NDArray
-        Cartesian (rectangular) coordinates with shape `(n, 3)`,
+    coords : np.ndarray
+        Cartesian (rectangular) coordinates with shape `(3)` or `(n, 3)`,
         where each row contains [x, y, z].
 
     Returns
     -------
-     npt.NDArray
+     np.ndarray
         Returns np.ndarray containing range, right ascension and declination values.
         If the input coords are shape `(3)`, the output array is of shape `(3)` and
         if the input coords are shape `(n, 3)`,

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -467,7 +467,7 @@ def get_rotation_matrix(
 
 
 def rotation_matrix_to_euler_angles(
-    rotation_matrix: npt.NDArray, axes: Union[list | None] = None
+    rotation_matrix: npt.NDArray, axes: Union[list, None] = None
 ) -> npt.NDArray:
     """
     Get the Euler angles from a rotation matrix.

--- a/imap_processing/tests/idex/conftest.py
+++ b/imap_processing/tests/idex/conftest.py
@@ -16,9 +16,8 @@ SPICE_ARRAYS = [
     "ephemeris_velocity_z",
     "right_ascension",
     "declination",
-    "attitude_roll",
-    "attitude_pitch",
-    "attitude_yaw",
+    "solar_longitude",
+    "spin_phase",
 ]
 
 
@@ -37,13 +36,13 @@ def decom_test_data() -> xr.Dataset:
     return PacketParser(test_file, "001").data
 
 
-def get_spice_data_side_effect_func(epoch, idex_attrs):
+def get_spice_data_side_effect_func(l1a_ds, idex_attrs):
     # Create a mock dictionary of spice arrays
 
     return {
         name: xr.DataArray(
             name=name,
-            data=np.ones(len(epoch)),
+            data=np.ones(len(l1a_ds["epoch"])),
             dims="epoch",
             attrs=idex_attrs.get_variable_attributes(name),
         )

--- a/imap_processing/tests/idex/conftest.py
+++ b/imap_processing/tests/idex/conftest.py
@@ -1,10 +1,25 @@
 from pathlib import Path
 
+import numpy as np
 import pytest
 import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.idex.idex_l1a import PacketParser
+
+SPICE_ARRAYS = [
+    "ephemeris_position_x",
+    "ephemeris_position_y",
+    "ephemeris_position_z",
+    "ephemeris_velocity_x",
+    "ephemeris_velocity_y",
+    "ephemeris_velocity_z",
+    "right_ascension",
+    "declination",
+    "attitude_roll",
+    "attitude_pitch",
+    "attitude_yaw",
+]
 
 
 @pytest.fixture(scope="module")
@@ -20,3 +35,17 @@ def decom_test_data() -> xr.Dataset:
         f"{imap_module_directory}/tests/idex/imap_idex_l0_raw_20231214_v001.pkts"
     )
     return PacketParser(test_file, "001").data
+
+
+def get_spice_data_side_effect_func(epoch, idex_attrs):
+    # Create a mock dictionary of spice arrays
+
+    return {
+        name: xr.DataArray(
+            name=name,
+            data=np.ones(len(epoch)),
+            dims="epoch",
+            attrs=idex_attrs.get_variable_attributes(name),
+        )
+        for name in SPICE_ARRAYS
+    }

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -15,10 +15,13 @@ from imap_processing.idex.idex_l1b import (
     idex_l1b,
     unpack_instrument_settings,
 )
+from imap_processing.tests.idex import conftest
+from imap_processing.tests.idex.conftest import get_spice_data_side_effect_func
 
 
 @pytest.fixture(scope="module")
-def l1b_dataset(decom_test_data: xr.Dataset) -> xr.Dataset:
+@mock.patch("imap_processing.idex.idex_l1b.get_spice_data")
+def l1b_dataset(mock_get_spice_data, decom_test_data: xr.Dataset) -> xr.Dataset:
     """Return a ``xarray`` dataset containing test data.
 
     Returns
@@ -26,6 +29,9 @@ def l1b_dataset(decom_test_data: xr.Dataset) -> xr.Dataset:
     dataset : xr.Dataset
         A ``xarray`` dataset containing the test data
     """
+
+    mock_get_spice_data.side_effect = get_spice_data_side_effect_func
+
     dataset = idex_l1b(decom_test_data, data_version="001")
     return dataset
 
@@ -185,3 +191,18 @@ def test_get_trigger_settings_failure(decom_test_data):
 
     with pytest.raises(ValueError, match=error_ms):
         get_trigger_mode_and_level(decom_test_data)
+
+
+def test_spice_data(l1b_dataset):
+    """
+    Check that the expected spice arrays are in the output l1b cdf
+
+    Parameters
+    ----------
+    l1b_dataset : xarray.Dataset
+        L1b dataset
+    """
+
+    for array in conftest.SPICE_ARRAYS:
+        assert array in l1b_dataset
+        assert len(l1b_dataset[array]) == len(l1b_dataset["epoch"])

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -37,6 +37,25 @@ def l1b_dataset(mock_get_spice_data, decom_test_data: xr.Dataset) -> xr.Dataset:
     return dataset
 
 
+@pytest.fixture()
+def mock_spice_functions():
+    """Mock spice functions to avoid loading kernels."""
+    with (
+        mock.patch("imap_processing.idex.idex_l1b.imap_state") as mock_state,
+        mock.patch(
+            "imap_processing.idex.idex_l1b.instrument_pointing"
+        ) as mock_pointing,
+        mock.patch("imap_processing.idex.idex_l1b.solar_longitude") as mock_lon,
+    ):
+        mock_state.side_effect = lambda t, observer: np.ones((len(t), 6))
+        mock_pointing.side_effect = lambda t, instrument, to_frame, cartesian: np.ones(
+            (len(t), 3)
+        )
+        mock_lon.side_effect = lambda t, degrees: np.ones(len(t))
+
+        yield mock_state, mock_pointing, mock_lon
+
+
 def test_l1b_cdf_filenames(l1b_dataset: xr.Dataset):
     """Tests that the ``idex_l1b`` function generates datasets
     with the expected logical source.
@@ -194,9 +213,13 @@ def test_get_trigger_settings_failure(decom_test_data):
         get_trigger_mode_and_level(decom_test_data)
 
 
-@mock.patch("imap_processing.idex.idex_l1b.get_rotation_matrix")
-@mock.patch("imap_processing.idex.idex_l1b.imap_state")
-def test_get_spice_data(mock_state, mock_matrix, decom_test_data, furnish_kernels):
+@pytest.mark.usefixtures("use_fake_spin_data_for_time")
+def test_get_spice_data(
+    mock_spice_functions,
+    use_fake_spin_data_for_time,
+    decom_test_data,
+    furnish_kernels,
+):
     """
     Test the get_spice_data() function.
 
@@ -206,14 +229,8 @@ def test_get_spice_data(mock_state, mock_matrix, decom_test_data, furnish_kernel
         L1a dataset
     """
     kernels = ["naif0012.tls"]
-    # example rotation matrix
-    rotation = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
-    # Mock rotation matrix for each time (n, 3, 3)
-    mock_matrix.side_effect = lambda t, from_frame, to_frame: np.tile(
-        rotation, (len(t), 1, 1)
-    )
-    # Returns position and velocity values for each time (n,6)
-    mock_state.side_effect = lambda t, observer,: np.ones((len(t), 6))
+    times = decom_test_data["shcoarse"].data
+    use_fake_spin_data_for_time(np.min(times), np.max(times))
 
     # Mock attribute manager variable attrs
     idex_attrs = ImapCdfAttributes()
@@ -223,9 +240,8 @@ def test_get_spice_data(mock_state, mock_matrix, decom_test_data, furnish_kernel
         mock.patch.object(idex_attrs, "get_variable_attributes") as mock_attrs,
     ):
         mock_attrs.return_value = {"CATDESC": "Test var"}
-        et = decom_test_data["epoch"].data
 
-        spice_data = get_spice_data(et, idex_attrs)
+        spice_data = get_spice_data(decom_test_data, idex_attrs)
 
     for array in conftest.SPICE_ARRAYS:
         assert array in spice_data

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -11,6 +11,7 @@ from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import write_cdf
 from imap_processing.idex.idex_l1b import (
+    get_spice_data,
     get_trigger_mode_and_level,
     idex_l1b,
     unpack_instrument_settings,
@@ -193,16 +194,39 @@ def test_get_trigger_settings_failure(decom_test_data):
         get_trigger_mode_and_level(decom_test_data)
 
 
-def test_spice_data(l1b_dataset):
+@mock.patch("imap_processing.idex.idex_l1b.get_rotation_matrix")
+@mock.patch("imap_processing.idex.idex_l1b.imap_state")
+def test_get_spice_data(mock_state, mock_matrix, decom_test_data, furnish_kernels):
     """
-    Check that the expected spice arrays are in the output l1b cdf
+    Test the get_spice_data() function.
 
     Parameters
     ----------
-    l1b_dataset : xarray.Dataset
-        L1b dataset
+    decom_test_data : xarray.Dataset
+        L1a dataset
     """
+    kernels = ["naif0012.tls"]
+    # example rotation matrix
+    rotation = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+    # Mock rotation matrix for each time (n, 3, 3)
+    mock_matrix.side_effect = lambda t, from_frame, to_frame: np.tile(
+        rotation, (len(t), 1, 1)
+    )
+    # Returns position and velocity values for each time (n,6)
+    mock_state.side_effect = lambda t, observer,: np.ones((len(t), 6))
+
+    # Mock attribute manager variable attrs
+    idex_attrs = ImapCdfAttributes()
+
+    with (
+        furnish_kernels(kernels),
+        mock.patch.object(idex_attrs, "get_variable_attributes") as mock_attrs,
+    ):
+        mock_attrs.return_value = {"CATDESC": "Test var"}
+        et = decom_test_data["epoch"].data
+
+        spice_data = get_spice_data(et, idex_attrs)
 
     for array in conftest.SPICE_ARRAYS:
-        assert array in l1b_dataset
-        assert len(l1b_dataset[array]) == len(l1b_dataset["epoch"])
+        assert array in spice_data
+        assert len(spice_data[array]) == len(decom_test_data["epoch"])

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -18,6 +18,7 @@ from imap_processing.spice.geometry import (
     get_instrument_spin_phase,
     get_rotation_matrix,
     get_spacecraft_spin_phase,
+    get_spacecraft_spin_phase_angle,
     get_spacecraft_to_instrument_spin_phase_offset,
     get_spin_data,
     imap_state,
@@ -60,6 +61,22 @@ def fake_spin_data(monkeypatch, spice_test_data_path):
     return fake_spin_path
 
 
+@mock.patch("imap_processing.spice.geometry.get_spacecraft_spin_phase")
+def test_get_spacecraft_spin_phase_angle(mock_spin_phase):
+    """Test get_spacecraft_spin_phase_angle() with mocked spin data."""
+    test_met_times = np.ones(5)
+    mock_spin_phase.side_effect = lambda qt: np.ones(len(test_met_times)) * 0.5
+    # Expected values for spin phase in degrees and radians if spin phase is 0.5
+    expected_deg = 180
+    expected_rad = np.pi
+    # Get spin phase angles in degrees and radians
+    spin_phases_deg = get_spacecraft_spin_phase_angle(test_met_times, degrees=True)
+    spin_phases_rad = get_spacecraft_spin_phase_angle(test_met_times, degrees=False)
+    # Test conversions
+    assert np.all(spin_phases_deg == expected_deg)
+    assert np.all(spin_phases_rad == expected_rad)
+
+
 @pytest.mark.parametrize(
     "query_met_times, expected",
     [
@@ -99,11 +116,6 @@ def test_get_spacecraft_spin_phase(query_met_times, expected, fake_spin_data):
         assert spin_phases.shape == expected.shape
     # Test the value
     np.testing.assert_array_almost_equal(spin_phases, expected)
-    # Test get spin phase in degrees
-    spin_phases_deg = get_spacecraft_spin_phase(
-        query_met_times=query_met_times, degrees=True
-    )
-    np.testing.assert_array_almost_equal(spin_phases, spin_phases_deg / 360)
 
 
 @pytest.mark.parametrize("query_met_times", [-1, 165])

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -11,6 +11,7 @@ from imap_processing.spice.geometry import (
     SpiceBody,
     SpiceFrame,
     basis_vectors,
+    cartesian_to_latitudinal,
     cartesian_to_spherical,
     frame_transform,
     frame_transform_az_el,
@@ -21,7 +22,7 @@ from imap_processing.spice.geometry import (
     get_spin_data,
     imap_state,
     instrument_pointing,
-    rotation_matrix_to_euler_angles,
+    solar_longitude,
     spherical_to_cartesian,
 )
 from imap_processing.spice.kernels import ensure_spice
@@ -98,6 +99,11 @@ def test_get_spacecraft_spin_phase(query_met_times, expected, fake_spin_data):
         assert spin_phases.shape == expected.shape
     # Test the value
     np.testing.assert_array_almost_equal(spin_phases, expected)
+    # Test get spin phase in degrees
+    spin_phases_deg = get_spacecraft_spin_phase(
+        query_met_times=query_met_times, degrees=True
+    )
+    np.testing.assert_array_almost_equal(spin_phases, spin_phases_deg / 360)
 
 
 @pytest.mark.parametrize("query_met_times", [-1, 165])
@@ -358,20 +364,6 @@ def test_get_rotation_matrix(furnish_kernels):
         assert rotation.shape == (10, 3, 3)
 
 
-def test_rotation_matrix_to_euler_angles():
-    """Test rotation_matrix_to_euler_angles()."""
-    # example rotation matrix
-    rotation = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
-
-    # test with one rotation matrix
-    euler_angles = rotation_matrix_to_euler_angles(rotation, axes=[3, 2, 1])
-    assert euler_angles.shape == (3,)
-    # Test with multiple rotation matrices
-    rotation = np.tile(rotation, (10, 1, 1))
-    euler_angles = rotation_matrix_to_euler_angles(rotation, axes=[3, 2, 1])
-    assert euler_angles.shape == (10, 3)
-
-
 def test_instrument_pointing(furnish_kernels):
     kernels = [
         "naif0012.tls",
@@ -480,3 +472,40 @@ def test_spherical_to_cartesian():
 
         np.testing.assert_allclose(cartesian_coords[0], spice_coords, atol=1e-5)
         np.testing.assert_allclose(cartesian_from_degrees[i], spice_coords, atol=1e-5)
+
+
+def test_cartesian_to_latitudinal():
+    """Test cartesian_to_latitudinal()."""
+    # example cartesian coords
+    coords = np.ones(3)
+
+    # test with one coord vector
+    lat_coords = cartesian_to_latitudinal(coords, degrees=True)
+    assert lat_coords.shape == (3,)
+    assert lat_coords[1] == 45
+    assert lat_coords[2] == 35.264389682754654
+
+    # Test with multiple coord vectors
+    coords = np.tile(coords, (10, 1))
+    lat_coords = cartesian_to_latitudinal(coords, degrees=True)
+    assert lat_coords.shape == (10, 3)
+
+
+@mock.patch("imap_processing.spice.geometry.imap_state")
+def test_solar_longitude(mock_state):
+    """Test solar_longitude()."""
+
+    mock_state.side_effect = (
+        lambda t, observer: np.ones(6) if (isinstance(t, int)) else np.ones((len(t), 6))
+    )
+    # example et time
+    et = 798033670
+
+    # test for one time interval
+    lon = solar_longitude(et, degrees=True)
+    assert lon == 45
+
+    # Test with multiple time intervals
+    et = np.tile(et, (10, 1))
+    lon = solar_longitude(et, degrees=True)
+    assert lon.shape == (10,)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -351,7 +351,6 @@ def test_get_rotation_matrix(furnish_kernels):
         rotation = get_rotation_matrix(
             et, SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT
         )
-
         assert rotation.shape == (3, 3)
         # test array of et input
         rotation = get_rotation_matrix(

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -15,12 +15,14 @@ from imap_processing.spice.geometry import (
     frame_transform,
     frame_transform_az_el,
     get_instrument_spin_phase,
+    get_right_ascension_and_declination,
     get_rotation_matrix,
     get_spacecraft_spin_phase,
     get_spacecraft_to_instrument_spin_phase_offset,
     get_spin_data,
     imap_state,
     instrument_pointing,
+    rotation_matrix_to_euler_angles,
     spherical_to_cartesian,
 )
 from imap_processing.spice.kernels import ensure_spice
@@ -349,12 +351,35 @@ def test_get_rotation_matrix(furnish_kernels):
         rotation = get_rotation_matrix(
             et, SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT
         )
+
         assert rotation.shape == (3, 3)
         # test array of et input
         rotation = get_rotation_matrix(
             np.arange(10) + et, SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT
         )
         assert rotation.shape == (10, 3, 3)
+
+
+def test_rotation_matrix_to_euler_angles(furnish_kernels):
+    """rotation_matrix_to_euler_angles()."""
+    kernels = [
+        "naif0012.tls",
+        "imap_wkcp.tf",
+        "imap_science_0001.tf",
+        "sim_1yr_imap_attitude.bc",
+        "sim_1yr_imap_pointing_frame.bc",
+    ]
+    # example rotation matrix
+    rotation = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+
+    with furnish_kernels(kernels):
+        # test with one rotation matrix
+        euler_angles = rotation_matrix_to_euler_angles(rotation, axes=[3, 2, 1])
+        assert euler_angles.shape == (3,)
+        # Test with multiple rotation matrices
+        rotation = np.tile(rotation, (10, 1, 1))
+        euler_angles = rotation_matrix_to_euler_angles(rotation, axes=[3, 2, 1])
+        assert euler_angles.shape == (10, 3)
 
 
 def test_instrument_pointing(furnish_kernels):
@@ -472,3 +497,17 @@ def test_spherical_to_cartesian():
 
         np.testing.assert_allclose(cartesian_coords[0], spice_coords, atol=1e-5)
         np.testing.assert_allclose(cartesian_from_degrees[i], spice_coords, atol=1e-5)
+
+
+def test_get_right_ascension_and_declination():
+    """Tests get_right_ascension_and_declination()."""
+    # example coordinates
+    coords = np.linspace(0, 1, 3)
+
+    # test with one rotation matrix
+    ra_and_dec = get_right_ascension_and_declination(coords)
+    assert ra_and_dec.shape == (3,)
+    # Test with multiple sets of coords
+    coords = np.tile(coords, (10, 1))
+    euler_angles = get_right_ascension_and_declination(coords)
+    assert euler_angles.shape == (10, 3)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -15,7 +15,6 @@ from imap_processing.spice.geometry import (
     frame_transform,
     frame_transform_az_el,
     get_instrument_spin_phase,
-    get_right_ascension_and_declination,
     get_rotation_matrix,
     get_spacecraft_spin_phase,
     get_spacecraft_to_instrument_spin_phase_offset,
@@ -359,26 +358,18 @@ def test_get_rotation_matrix(furnish_kernels):
         assert rotation.shape == (10, 3, 3)
 
 
-def test_rotation_matrix_to_euler_angles(furnish_kernels):
-    """rotation_matrix_to_euler_angles()."""
-    kernels = [
-        "naif0012.tls",
-        "imap_wkcp.tf",
-        "imap_science_0001.tf",
-        "sim_1yr_imap_attitude.bc",
-        "sim_1yr_imap_pointing_frame.bc",
-    ]
+def test_rotation_matrix_to_euler_angles():
+    """Test rotation_matrix_to_euler_angles()."""
     # example rotation matrix
     rotation = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
 
-    with furnish_kernels(kernels):
-        # test with one rotation matrix
-        euler_angles = rotation_matrix_to_euler_angles(rotation, axes=[3, 2, 1])
-        assert euler_angles.shape == (3,)
-        # Test with multiple rotation matrices
-        rotation = np.tile(rotation, (10, 1, 1))
-        euler_angles = rotation_matrix_to_euler_angles(rotation, axes=[3, 2, 1])
-        assert euler_angles.shape == (10, 3)
+    # test with one rotation matrix
+    euler_angles = rotation_matrix_to_euler_angles(rotation, axes=[3, 2, 1])
+    assert euler_angles.shape == (3,)
+    # Test with multiple rotation matrices
+    rotation = np.tile(rotation, (10, 1, 1))
+    euler_angles = rotation_matrix_to_euler_angles(rotation, axes=[3, 2, 1])
+    assert euler_angles.shape == (10, 3)
 
 
 def test_instrument_pointing(furnish_kernels):
@@ -449,18 +440,11 @@ def test_cartesian_to_spherical():
 
     for point in cartesian_points:
         r, az, el = cartesian_to_spherical(point)
-        r_spice, colat_spice, slong_spice = spice.recsph(point)
+        range, ra, dec = spice.recrad(point)
 
-        # Convert SPICE co-latitude to elevation
-        el_spice = 90 - np.degrees(colat_spice)
-        az_spice = np.degrees(slong_spice)
-
-        # Normalize azimuth to [0, 360]
-        az_spice = az_spice % 360
-
-        np.testing.assert_allclose(r, r_spice, atol=1e-5)
-        np.testing.assert_allclose(az, az_spice, atol=1e-5)
-        np.testing.assert_allclose(el, el_spice, atol=1e-5)
+        np.testing.assert_allclose(r, range, atol=1e-5)
+        np.testing.assert_allclose(az, np.degrees(ra), atol=1e-5)
+        np.testing.assert_allclose(el, np.degrees(dec), atol=1e-5)
 
 
 def test_spherical_to_cartesian():
@@ -496,17 +480,3 @@ def test_spherical_to_cartesian():
 
         np.testing.assert_allclose(cartesian_coords[0], spice_coords, atol=1e-5)
         np.testing.assert_allclose(cartesian_from_degrees[i], spice_coords, atol=1e-5)
-
-
-def test_get_right_ascension_and_declination():
-    """Tests get_right_ascension_and_declination()."""
-    # example coordinates
-    coords = np.linspace(0, 1, 3)
-
-    # test with one rotation matrix
-    ra_and_dec = get_right_ascension_and_declination(coords)
-    assert ra_and_dec.shape == (3,)
-    # Test with multiple sets of coords
-    coords = np.tile(coords, (10, 1))
-    euler_angles = get_right_ascension_and_declination(coords)
-    assert euler_angles.shape == (10, 3)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -18,8 +18,8 @@ from imap_processing.spice.geometry import (
     get_instrument_spin_phase,
     get_rotation_matrix,
     get_spacecraft_spin_phase,
-    get_spacecraft_spin_phase_angle,
     get_spacecraft_to_instrument_spin_phase_offset,
+    get_spin_angle,
     get_spin_data,
     imap_state,
     instrument_pointing,
@@ -61,22 +61,6 @@ def fake_spin_data(monkeypatch, spice_test_data_path):
     return fake_spin_path
 
 
-@mock.patch("imap_processing.spice.geometry.get_spacecraft_spin_phase")
-def test_get_spacecraft_spin_phase_angle(mock_spin_phase):
-    """Test get_spacecraft_spin_phase_angle() with mocked spin data."""
-    test_met_times = np.ones(5)
-    mock_spin_phase.side_effect = lambda qt: np.ones(len(test_met_times)) * 0.5
-    # Expected values for spin phase in degrees and radians if spin phase is 0.5
-    expected_deg = 180
-    expected_rad = np.pi
-    # Get spin phase angles in degrees and radians
-    spin_phases_deg = get_spacecraft_spin_phase_angle(test_met_times, degrees=True)
-    spin_phases_rad = get_spacecraft_spin_phase_angle(test_met_times, degrees=False)
-    # Test conversions
-    assert np.all(spin_phases_deg == expected_deg)
-    assert np.all(spin_phases_rad == expected_rad)
-
-
 @pytest.mark.parametrize(
     "query_met_times, expected",
     [
@@ -116,6 +100,20 @@ def test_get_spacecraft_spin_phase(query_met_times, expected, fake_spin_data):
         assert spin_phases.shape == expected.shape
     # Test the value
     np.testing.assert_array_almost_equal(spin_phases, expected)
+
+
+def test_get_spin_angle():
+    """Test get_spin_angle() with fake spin phases."""
+    test_spin_phases = np.ones(10) * 0.5
+    # Expected values for spin angles in degrees and radians if spin phase is 0.5
+    expected_deg = 180
+    expected_rad = np.pi
+    # Get spin angles in degrees and radians
+    spin_phases_deg = get_spin_angle(test_spin_phases, degrees=True)
+    spin_phases_rad = get_spin_angle(test_spin_phases, degrees=False)
+    # Test conversions
+    assert np.all(spin_phases_deg == expected_deg)
+    assert np.all(spin_phases_rad == expected_rad)
 
 
 @pytest.mark.parametrize("query_met_times", [-1, 165])


### PR DESCRIPTION
# Change Summary

closes #1282
closes #1306

## Overview
Add SPICE data (ephemeris, attitude, and celestial coords) to IDEX l1b CDF using code defined in imap_processing/spice/geometry.py. (Thank you to whomever wrote very readable code!) 


## Updated Files
- imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
   - Add attributes for the new spice arrays. Will need to go back and get expected valid ranges for some of the arrays.
- imap_processing/idex/idex_l1b.py
   - Add function to query all the necessary spice data using functions from imap_processing/spice/geometry.py
   - Create xr.DataArrays for the spice data and add to the output cdf.
- imap_processing/spice/geometry.py
   - Add wrapper function for m2eul https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/m2eul.html
   - Add wrapper function for https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recrad_c.html
- imap_processing/tests/idex/conftest.py
   - Created a pytest 'side_effect' function to enable l1b testing without furnishing kernels.
- imap_processing/tests/idex/test_idex_l1b.py
   - Test idex l1b without having to furnish kernels 
- imap_processing/tests/spice/test_geometry.py
   - Add tests for new spice functions (for vectorized or not) 

