### PR TITLE
Ultra l1b - extendedspin data structure

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -313,16 +313,17 @@ rate_rejected_events:
   # TODO: come back to format
   UNITS: 1/s
 
-quality_hk:
-  <<: *default
-  CATDESC: Spin filter derived from Ultra housekeeping. Bitwise flagging used to filter the spin.
-  FIELDNAM: quality_hk
-  LABLAXIS: quality hk
-  # TODO: come back to format
+quality_ena_rates:
+  <<: *default_uint16
+  CATDESC: Spin filter derived from Ultra ena rates. Bitwise flagging used to filter the spin.
+  FIELDNAM: quality_ena_rates
+  LABLAXIS: quality_ena_rates
+  DEPEND_0: spin_number
+  DEPEND_1: median_rate_energy
   UNITS: " "
 
 quality_attitude:
-  <<: *default
+  <<: *default_uint16
   CATDESC: Spin filter derived from IMAP attitude. Bitwise flagging used to filter the spin.
   FIELDNAM: quality_attitude
   LABLAXIS: quality attitude
@@ -330,7 +331,7 @@ quality_attitude:
   UNITS: " "
 
 quality_instruments:
-  <<: *default
+  <<: *default_uint16
   CATDESC: Spin filter derived from instruments other than Ultra. Bitwise flagging used to filter the spin.
   FIELDNAM: quality_instruments
   LABLAXIS: quality instruments

--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -47,8 +47,8 @@ class ImapAttitudeUltraFlags(FlagNameMixin):
     FLAG1 = 2**3  # bit 3
 
 
-class ImapHkUltraFlags(FlagNameMixin):
-    """IMAP Ultra HK flags."""
+class ImapRatesUltraFlags(FlagNameMixin):
+    """IMAP Ultra Rates flags."""
 
     NONE = CommonFlags.NONE
     HIGHCOUNTS = 2**0  # bit 0

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -195,12 +195,12 @@ def aux_dataset(ccsds_path_theta_0, xtce_path):
     decom_ultra_aux = process_ultra_apids(
         grouped_data[ULTRA_AUX.apid[0]], ULTRA_AUX.apid[0]
     )
-    l1a_rates_dataset = ultra_l1a.create_dataset(
+    l1a_aux_dataset = ultra_l1a.create_dataset(
         {
             ULTRA_AUX.apid[0]: decom_ultra_aux,
         }
     )
-    return l1a_rates_dataset
+    return l1a_aux_dataset
 
 
 @pytest.fixture()
@@ -212,7 +212,8 @@ def l1b_datasets(
 
     data_dict = {}
     data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
-    data_dict["imap_ultra_l1a_45sensor-aux"] = aux_dataset
+    # TODO: this is a placeholder for the hk dataset.
+    data_dict["imap_ultra_l1a_45sensor-hk"] = aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
     use_fake_spin_data_for_time(
         de_dataset["EVENTTIMES"][0], de_dataset["EVENTTIMES"][-1]

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -10,9 +10,10 @@ from imap_processing.ultra.l0.decom_ultra import process_ultra_apids
 from imap_processing.ultra.l0.ultra_utils import (
     ULTRA_AUX,
     ULTRA_EVENTS,
+    ULTRA_RATES,
 )
 from imap_processing.ultra.l1a import ultra_l1a
-from imap_processing.ultra.l1b.de import calculate_de
+from imap_processing.ultra.l1b.ultra_l1b import ultra_l1b
 from imap_processing.utils import group_by_apid
 
 
@@ -171,9 +172,51 @@ def de_dataset(ccsds_path_theta_0, xtce_path):
 
 
 @pytest.fixture()
+def rates_dataset(ccsds_path_theta_0, xtce_path):
+    """L1A test data"""
+    packets = decom.decom_packets(ccsds_path_theta_0, xtce_path)
+    grouped_data = group_by_apid(packets)
+    decom_ultra_rates = process_ultra_apids(
+        grouped_data[ULTRA_RATES.apid[0]], ULTRA_RATES.apid[0]
+    )
+    l1a_rates_dataset = ultra_l1a.create_dataset(
+        {
+            ULTRA_RATES.apid[0]: decom_ultra_rates,
+        }
+    )
+    return l1a_rates_dataset
+
+
+@pytest.fixture()
+def aux_dataset(ccsds_path_theta_0, xtce_path):
+    """L1A test data"""
+    packets = decom.decom_packets(ccsds_path_theta_0, xtce_path)
+    grouped_data = group_by_apid(packets)
+    decom_ultra_aux = process_ultra_apids(
+        grouped_data[ULTRA_AUX.apid[0]], ULTRA_AUX.apid[0]
+    )
+    l1a_rates_dataset = ultra_l1a.create_dataset(
+        {
+            ULTRA_AUX.apid[0]: decom_ultra_aux,
+        }
+    )
+    return l1a_rates_dataset
+
+
+@pytest.fixture()
 @mock.patch("imap_processing.ultra.l1b.de.get_annotated_particle_velocity")
-def l1b_de_dataset(mock_get_annotated_particle_velocity, de_dataset):
+def l1b_datasets(
+    mock_get_annotated_particle_velocity, de_dataset, use_fake_spin_data_for_time
+):
     """L1B test data"""
+
+    data_dict = {}
+    data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
+    data_dict["imap_ultra_l1a_45sensor-aux"] = aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+    use_fake_spin_data_for_time(
+        de_dataset["EVENTTIMES"][0], de_dataset["EVENTTIMES"][-1]
+    )
 
     # Mock get_annotated_particle_velocity to avoid needing kernels
     def side_effect_func(event_times, position, ultra_frame, dps_frame, sc_frame):
@@ -191,6 +234,6 @@ def l1b_de_dataset(mock_get_annotated_particle_velocity, de_dataset):
 
     mock_get_annotated_particle_velocity.side_effect = side_effect_func
 
-    dataset = calculate_de(de_dataset, "imap_ultra_l1b_45sensor-de")
+    output_datasets = ultra_l1b(data_dict, data_version="001")
 
-    return dataset
+    return output_datasets

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -17,9 +17,10 @@ def df_filt(de_dataset, events_fsw_comparison_theta_0):
     return df_filt
 
 
-def test_calculate_de(l1b_de_dataset, df_filt):
+def test_calculate_de(l1b_datasets, df_filt):
     """Tests calculate_de function."""
 
+    l1b_de_dataset = l1b_datasets["imap_ultra_l1b_45sensor-de"]
     # Front and back positions
     assert np.allclose(l1b_de_dataset["x_front"].data, df_filt["Xf"].astype("float"))
     assert np.allclose(l1b_de_dataset["y_front"], df_filt["Yf"].astype("float"))

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -20,7 +20,7 @@ def df_filt(de_dataset, events_fsw_comparison_theta_0):
 def test_calculate_de(l1b_datasets, df_filt):
     """Tests calculate_de function."""
 
-    l1b_de_dataset = l1b_datasets["imap_ultra_l1b_45sensor-de"]
+    l1b_de_dataset = l1b_datasets[0]
     # Front and back positions
     assert np.allclose(l1b_de_dataset["x_front"].data, df_filt["Xf"].astype("float"))
     assert np.allclose(l1b_de_dataset["y_front"], df_filt["Yf"].astype("float"))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -32,35 +30,7 @@ def mock_data_l1a_rates_dict():
 
 
 @pytest.fixture()
-def mock_data_l1a_de_aux_rates_dict():
-    # Create sample data for the xarray Dataset
-    epoch = np.arange(
-        "2024-02-07T15:28:37", "2024-02-07T15:28:42", dtype="datetime64[s]"
-    ).astype("datetime64[ns]")
-
-    data_vars = {
-        "var": ("epoch", np.zeros(5)),
-    }
-
-    attrs = {
-        "Logical_source": "imap_ultra_l1a_45sensor-name",
-        "Logical_source_description": "IMAP Mission ULTRA Instrument "
-        "Level-1A Single-Sensor Data",
-    }
-
-    dataset = xr.Dataset(data_vars, coords={"epoch": epoch}, attrs=attrs)
-
-    data_dict = {
-        "imap_ultra_l1a_45sensor-de": dataset,
-        "imap_ultra_l1a_45sensor-aux": dataset,
-        "imap_ultra_l1a_45sensor-rates": dataset,
-    }
-
-    return data_dict
-
-
-@pytest.fixture()
-def mock_data_l1b_dict():
+def mock_data_l1b_de_dict():
     epoch = np.array(
         [760591786368000000, 760591787368000000, 760591788368000000],
         dtype="datetime64[ns]",
@@ -69,9 +39,44 @@ def mock_data_l1b_dict():
     return data_dict
 
 
-def test_create_dataset(mock_data_l1b_dict):
+@pytest.fixture()
+def mock_data_l1b_extendedspin_dict():
+    spin = np.array(
+        [0, 1, 2],
+        dtype="uint32",
+    )
+    energy = np.array(
+        [0, 1],
+        dtype="int32",
+    )
+    quality = np.zeros((2, 3), dtype="uint16")
+    data_dict = {
+        "spin_number": spin,
+        "median_rate_energy": energy,
+        "quality_ena_rates": quality,
+    }
+    return data_dict
+
+
+def test_create_extendedspin_dataset(mock_data_l1b_extendedspin_dict):
     """Tests that dataset is created as expected."""
-    dataset = create_dataset(mock_data_l1b_dict, "imap_ultra_l1b_45sensor-de", "l1b")
+    dataset = create_dataset(
+        mock_data_l1b_extendedspin_dict, "imap_ultra_l1b_45sensor-extendedspin", "l1b"
+    )
+
+    assert "spin_number" in dataset.coords
+    assert "median_rate_energy" in dataset.coords
+    assert dataset.coords["spin_number"].dtype == "uint32"
+    assert dataset.attrs["Logical_source"] == "imap_ultra_l1b_45sensor-extendedspin"
+    assert dataset["quality_ena_rates"].attrs["UNITS"] == " "
+    np.testing.assert_array_equal(
+        dataset["quality_ena_rates"], np.zeros((3, 2), dtype="uint16")
+    )
+
+
+def test_create_de_dataset(mock_data_l1b_de_dict):
+    """Tests that dataset is created as expected."""
+    dataset = create_dataset(mock_data_l1b_de_dict, "imap_ultra_l1b_45sensor-de", "l1b")
 
     assert "epoch" in dataset.coords
     assert dataset.coords["epoch"].dtype == "datetime64[ns]"
@@ -80,64 +85,29 @@ def test_create_dataset(mock_data_l1b_dict):
     np.testing.assert_array_equal(dataset["x_front"], np.zeros(3))
 
 
-def test_ultra_l1b_rates(mock_data_l1a_de_aux_rates_dict):
+def test_ultra_l1b_de(l1b_datasets):
     """Tests that L1b data is created."""
-    output_datasets = ultra_l1b(mock_data_l1a_de_aux_rates_dict, data_version="001")
 
-    assert len(output_datasets) == 3
-    assert (
-        output_datasets[0].attrs["Logical_source"]
-        == "imap_ultra_l1b_45sensor-extendedspin"
-    )
-    assert (
-        output_datasets[1].attrs["Logical_source"]
-        == "imap_ultra_l1b_45sensor-cullingmask"
-    )
-    assert (
-        output_datasets[2].attrs["Logical_source"] == "imap_ultra_l1b_45sensor-badtimes"
-    )
-    assert (
-        output_datasets[0].attrs["Logical_source_description"]
-        == "IMAP-Ultra Instrument Level-1B Extended Spin Data."
-    )
+    assert len(l1b_datasets) == 4
 
+    # Define the suffixes and prefix
+    prefix = "imap_ultra_l1b_45sensor"
+    suffixes = ["de", "extendedspin", "cullingmask", "badtimes"]
 
-@pytest.mark.external_kernel()
-@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-@mock.patch("imap_processing.ultra.l1b.de.get_annotated_particle_velocity")
-def test_ultra_l1b_de(mock_get_annotated_particle_velocity, de_dataset):
-    """Tests that L1b data is created."""
-    data_dict = {}
-    data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
-    data_dict["imap_ultra_l1a_45sensor-aux"] = de_dataset
-    data_dict["imap_ultra_l1a_45sensor-rates"] = de_dataset
-
-    # Mock get_annotated_particle_velocity to avoid needing kernels
-    def side_effect_func(event_times, position, ultra_frame, dps_frame, sc_frame):
-        """
-        Mock behavior of get_annotated_particle_velocity.
-
-        Returns NaN-filled arrays matching the expected output shape.
-        """
-        num_events = event_times.size
-        return (
-            np.full((num_events, 3), np.nan),  # sc_velocity
-            np.full((num_events, 3), np.nan),  # sc_dps_velocity
-            np.full((num_events, 3), np.nan),  # helio_velocity
+    for suffix in enumerate(suffixes):
+        expected_logical_source = f"{prefix}-{suffix}"
+        assert (
+            l1b_datasets[expected_logical_source].attrs["Logical_source"]
+            == expected_logical_source
         )
 
-    mock_get_annotated_particle_velocity.side_effect = side_effect_func
-    output_datasets = ultra_l1b(data_dict, data_version="001")
-
-    assert len(output_datasets) == 1
-    assert output_datasets[0].attrs["Logical_source"] == "imap_ultra_l1b_45sensor-de"
     assert (
-        output_datasets[0].attrs["Logical_source_description"]
+        l1b_datasets["imap_ultra_l1b_45sensor-de"].attrs["Logical_source_description"]
         == "IMAP-Ultra Instrument Level-1B Direct Event Data."
     )
 
 
-def test_ultra_l1b_error(mock_data_l1a_de_aux_rates_dict):
+def test_ultra_l1b_error(mock_data_l1a_rates_dict):
     """Tests that L1a data throws an error."""
     mock_data_l1a_rates_dict["bad_key"] = mock_data_l1a_rates_dict.pop(
         "imap_ultra_l1a_45sensor-rates"

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -61,7 +61,10 @@ def mock_data_l1b_extendedspin_dict():
 def test_create_extendedspin_dataset(mock_data_l1b_extendedspin_dict):
     """Tests that dataset is created as expected."""
     dataset = create_dataset(
-        mock_data_l1b_extendedspin_dict, "imap_ultra_l1b_45sensor-extendedspin", "l1b"
+        mock_data_l1b_extendedspin_dict,
+        "imap_ultra_l1b_45sensor-extendedspin",
+        "l1b",
+        "001",
     )
 
     assert "spin_number" in dataset.coords
@@ -70,13 +73,15 @@ def test_create_extendedspin_dataset(mock_data_l1b_extendedspin_dict):
     assert dataset.attrs["Logical_source"] == "imap_ultra_l1b_45sensor-extendedspin"
     assert dataset["quality_ena_rates"].attrs["UNITS"] == " "
     np.testing.assert_array_equal(
-        dataset["quality_ena_rates"], np.zeros((3, 2), dtype="uint16")
+        dataset["quality_ena_rates"], np.zeros((2, 3), dtype="uint16")
     )
 
 
 def test_create_de_dataset(mock_data_l1b_de_dict):
     """Tests that dataset is created as expected."""
-    dataset = create_dataset(mock_data_l1b_de_dict, "imap_ultra_l1b_45sensor-de", "l1b")
+    dataset = create_dataset(
+        mock_data_l1b_de_dict, "imap_ultra_l1b_45sensor-de", "l1b", "001"
+    )
 
     assert "epoch" in dataset.coords
     assert dataset.coords["epoch"].dtype == "datetime64[ns]"
@@ -94,7 +99,7 @@ def test_ultra_l1b_de(l1b_datasets):
     prefix = "imap_ultra_l1b_45sensor"
     suffixes = ["de", "extendedspin", "cullingmask", "badtimes"]
 
-    for suffix in enumerate(suffixes):
+    for suffix in suffixes:
         expected_logical_source = f"{prefix}-{suffix}"
         assert (
             l1b_datasets[expected_logical_source].attrs["Logical_source"]

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -32,7 +32,7 @@ def mock_data_l1a_rates_dict():
 
 
 @pytest.fixture()
-def mock_data_l1a_de_aux_dict():
+def mock_data_l1a_de_aux_rates_dict():
     # Create sample data for the xarray Dataset
     epoch = np.arange(
         "2024-02-07T15:28:37", "2024-02-07T15:28:42", dtype="datetime64[s]"
@@ -53,6 +53,7 @@ def mock_data_l1a_de_aux_dict():
     data_dict = {
         "imap_ultra_l1a_45sensor-de": dataset,
         "imap_ultra_l1a_45sensor-aux": dataset,
+        "imap_ultra_l1a_45sensor-rates": dataset,
     }
 
     return data_dict
@@ -79,9 +80,9 @@ def test_create_dataset(mock_data_l1b_dict):
     np.testing.assert_array_equal(dataset["x_front"], np.zeros(3))
 
 
-def test_ultra_l1b_rates(mock_data_l1a_rates_dict):
+def test_ultra_l1b_rates(mock_data_l1a_de_aux_rates_dict):
     """Tests that L1b data is created."""
-    output_datasets = ultra_l1b(mock_data_l1a_rates_dict, data_version="001")
+    output_datasets = ultra_l1b(mock_data_l1a_de_aux_rates_dict, data_version="001")
 
     assert len(output_datasets) == 3
     assert (
@@ -109,6 +110,7 @@ def test_ultra_l1b_de(mock_get_annotated_particle_velocity, de_dataset):
     data_dict = {}
     data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
     data_dict["imap_ultra_l1a_45sensor-aux"] = de_dataset
+    data_dict["imap_ultra_l1a_45sensor-rates"] = de_dataset
 
     # Mock get_annotated_particle_velocity to avoid needing kernels
     def side_effect_func(event_times, position, ultra_frame, dps_frame, sc_frame):
@@ -135,7 +137,7 @@ def test_ultra_l1b_de(mock_get_annotated_particle_velocity, de_dataset):
     )
 
 
-def test_ultra_l1b_error(mock_data_l1a_rates_dict):
+def test_ultra_l1b_error(mock_data_l1a_de_aux_rates_dict):
     """Tests that L1a data throws an error."""
     mock_data_l1a_rates_dict["bad_key"] = mock_data_l1a_rates_dict.pop(
         "imap_ultra_l1a_45sensor-rates"

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -99,15 +99,12 @@ def test_ultra_l1b_de(l1b_datasets):
     prefix = "imap_ultra_l1b_45sensor"
     suffixes = ["de", "extendedspin", "cullingmask", "badtimes"]
 
-    for suffix in suffixes:
-        expected_logical_source = f"{prefix}-{suffix}"
-        assert (
-            l1b_datasets[expected_logical_source].attrs["Logical_source"]
-            == expected_logical_source
-        )
+    for i in range(len(suffixes)):
+        expected_logical_source = f"{prefix}-{suffixes[i]}"
+        assert l1b_datasets[i].attrs["Logical_source"] == expected_logical_source
 
     assert (
-        l1b_datasets["imap_ultra_l1b_45sensor-de"].attrs["Logical_source_description"]
+        l1b_datasets[0].attrs["Logical_source_description"]
         == "IMAP-Ultra Instrument Level-1B Direct Event Data."
     )
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from imap_processing.quality_flags import ImapHkUltraFlags
+from imap_processing.quality_flags import ImapRatesUltraFlags
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_spin,
@@ -37,19 +37,17 @@ def test_data(use_fake_spin_data_for_time):
     return time, spin_number, energy, expected_counts
 
 
-def test_get_spin(use_fake_spin_data_for_time, l1b_de_dataset):
+def test_get_spin(use_fake_spin_data_for_time, l1b_datasets):
     """Tests get_spin function."""
+    de_dataset = l1b_datasets["imap_ultra_l1b_45sensor-de"]
     use_fake_spin_data_for_time(
-        l1b_de_dataset["event_times"][0], l1b_de_dataset["event_times"][-1]
+        de_dataset["event_times"][0], de_dataset["event_times"][-1]
     )
-    spin_number = get_spin(l1b_de_dataset["event_times"])
+    spin_number = get_spin(de_dataset["event_times"])
 
-    assert len(spin_number) == len(l1b_de_dataset["event_times"])
+    assert len(spin_number) == len(de_dataset["event_times"])
     expected_num_spins = np.ceil(
-        (
-            l1b_de_dataset["event_times"].values[-1]
-            - l1b_de_dataset["event_times"].values[0]
-        )
+        (de_dataset["event_times"].values[-1] - de_dataset["event_times"].values[0])
         / 15
     )
     assert np.array_equal(len(np.unique(spin_number)), expected_num_spins)
@@ -71,13 +69,14 @@ def test_flag_spin(test_data):
     time, _, energy, expected_counts = test_data
     quality_flags, spin, energy = flag_spin(time, energy)
 
-    flag = ImapHkUltraFlags(quality_flags[1])
+    flag = ImapRatesUltraFlags(quality_flags[0, :][expected_counts[0, :] / 15 > 0])
     assert flag.name == "HIGHCOUNTS"
 
-    flagged_indices = np.unique(spin)[expected_counts[0, :] / 15 > 0]
-    unflagged_indices = np.setdiff1d(np.unique(spin), flagged_indices)
-    assert np.all(quality_flags[flagged_indices] == ImapHkUltraFlags.HIGHCOUNTS.value)
-    assert np.all(quality_flags[unflagged_indices] == ImapHkUltraFlags.NONE.value)
+    assert np.all(flag == ImapRatesUltraFlags.HIGHCOUNTS.value)
+    assert np.all(
+        quality_flags[0, :][expected_counts[0, :] / 15 <= 0]
+        == ImapRatesUltraFlags.NONE.value
+    )
 
     # Only HIGHCOUNT bits were set
-    assert np.all(quality_flags == quality_flags & ImapHkUltraFlags.HIGHCOUNTS)
+    assert np.all(quality_flags == quality_flags & ImapRatesUltraFlags.HIGHCOUNTS)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -39,7 +39,7 @@ def test_data(use_fake_spin_data_for_time):
 
 def test_get_spin(use_fake_spin_data_for_time, l1b_datasets):
     """Tests get_spin function."""
-    de_dataset = l1b_datasets["imap_ultra_l1b_45sensor-de"]
+    de_dataset = l1b_datasets[0]
     use_fake_spin_data_for_time(
         de_dataset["event_times"][0], de_dataset["event_times"][-1]
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -68,7 +68,7 @@ def mock_data_l1c_dict():
 def test_create_dataset(mock_data_l1c_dict):
     """Tests that dataset is created as expected."""
     dataset = create_dataset(
-        mock_data_l1c_dict, "imap_ultra_l1c_45sensor-histogram", "l1c"
+        mock_data_l1c_dict, "imap_ultra_l1c_45sensor-histogram", "l1c", "001"
     )
 
     assert "epoch" in dataset.coords

--- a/imap_processing/ultra/l1b/badtimes.py
+++ b/imap_processing/ultra/l1b/badtimes.py
@@ -5,14 +5,14 @@ import xarray as xr
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_badtimes(extended_spin_dict: dict, name: str) -> xr.Dataset:
+def calculate_badtimes(extended_spin_dict: xr.Dataset, name: str) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Badtimes Data.
 
     Parameters
     ----------
-    extended_spin_dict : dict
-        L1b data dictionary.
+    extendedspin_dataset : xarray.Dataset
+        Dataset containing the data.
     name : str
         Name of the dataset.
 

--- a/imap_processing/ultra/l1b/badtimes.py
+++ b/imap_processing/ultra/l1b/badtimes.py
@@ -5,7 +5,9 @@ import xarray as xr
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_badtimes(extended_spin_dict: xr.Dataset, name: str) -> xr.Dataset:
+def calculate_badtimes(
+    extendedspin_dataset: xr.Dataset, name: str, data_version: str
+) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Badtimes Data.
 
@@ -15,12 +17,20 @@ def calculate_badtimes(extended_spin_dict: xr.Dataset, name: str) -> xr.Dataset:
         Dataset containing the data.
     name : str
         Name of the dataset.
+    data_version : str
+        Version of the data.
 
     Returns
     -------
     badtimes_dataset : xarray.Dataset
         Dataset containing the data.
     """
-    badtimes_dataset = create_dataset(extended_spin_dict, name, "l1b")
+    badtimes_dict = {}
+    badtimes_dict["spin_number"] = extendedspin_dataset["spin_number"]
+    badtimes_dict["median_rate_energy"] = extendedspin_dataset["median_rate_energy"]
+
+    # TODO: add more data to badtimes_dict.
+
+    badtimes_dataset = create_dataset(badtimes_dict, name, "l1b", data_version)
 
     return badtimes_dataset

--- a/imap_processing/ultra/l1b/cullingmask.py
+++ b/imap_processing/ultra/l1b/cullingmask.py
@@ -5,7 +5,9 @@ import xarray as xr
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_cullingmask(extended_spin_dict: xr.Dataset, name: str) -> xr.Dataset:
+def calculate_cullingmask(
+    extendedspin_dataset: xr.Dataset, name: str, data_version: str
+) -> xr.Dataset:
     """
     Create dataset with defined datatype for Culling Mask Data.
 
@@ -15,12 +17,20 @@ def calculate_cullingmask(extended_spin_dict: xr.Dataset, name: str) -> xr.Datas
         Dataset containing the data.
     name : str
         Name of the dataset.
+    data_version : str
+        Version of the data.
 
     Returns
     -------
     cullingmask_dataset : xarray.Dataset
         Dataset containing the data.
     """
-    cullingmask_dataset = create_dataset(extended_spin_dict, name, "l1b")
+    cullingmask_dict = {}
+    cullingmask_dict["spin_number"] = extendedspin_dataset["spin_number"]
+    cullingmask_dict["median_rate_energy"] = extendedspin_dataset["median_rate_energy"]
+
+    # TODO: add more data to cullingmask_dict.
+
+    cullingmask_dataset = create_dataset(cullingmask_dict, name, "l1b", data_version)
 
     return cullingmask_dataset

--- a/imap_processing/ultra/l1b/cullingmask.py
+++ b/imap_processing/ultra/l1b/cullingmask.py
@@ -5,14 +5,14 @@ import xarray as xr
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_cullingmask(extended_spin_dict: dict, name: str) -> xr.Dataset:
+def calculate_cullingmask(extended_spin_dict: xr.Dataset, name: str) -> xr.Dataset:
     """
     Create dataset with defined datatype for Culling Mask Data.
 
     Parameters
     ----------
-    extended_spin_dict : dict
-        L1b data dictionary.
+    extendedspin_dataset : xarray.Dataset
+        Dataset containing the data.
     name : str
         Name of the dataset.
 

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -28,7 +28,7 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
+def calculate_de(de_dataset: xr.Dataset, name: str, data_version: str) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Direct Event Data.
 
@@ -38,6 +38,8 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
         L1a dataset containing direct event data.
     name : str
         Name of the l1a dataset.
+    data_version : str
+        Version of the data.
 
     Returns
     -------
@@ -184,6 +186,6 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
         len(de_dataset["epoch"]), np.nan, dtype=np.float32
     )
 
-    dataset = create_dataset(de_dict, name, "l1b")
+    dataset = create_dataset(de_dict, name, "l1b", data_version)
 
     return dataset

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -7,19 +7,27 @@ from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
 def calculate_extendedspin(
-    rates_dataset: xr.Dataset, de_dataset: xr.Dataset, name: str
+    aux_dataset: xr.Dataset,
+    rates_dataset: xr.Dataset,
+    de_dataset: xr.Dataset,
+    name: str,
+    data_version: str,
 ) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Extended Spin Data.
 
     Parameters
     ----------
+    aux_dataset : xarray.Dataset
+        Dataset containing l1a aux data.
     rates_dataset : xarray.Dataset
         Dataset containing l1a rates data.
     de_dataset : xarray.Dataset
-        Dataset containing l1b de data
+        Dataset containing l1b de data.
     name : str
         Name of the dataset.
+    data_version : str
+        Version of the data.
 
     Returns
     -------
@@ -28,29 +36,26 @@ def calculate_extendedspin(
     """
     extendedspin_dict = {}
     quality_flags, spin, energy = flag_spin(
-        de_dataset["event_times"],
-        de_dataset["energy"],
+        de_dataset["event_times"].values,
+        de_dataset["energy"].values,
     )
 
     # These will be the coordinates.
     extendedspin_dict["spin_number"] = spin
-    extendedspin_dict["energy"] = energy
+    extendedspin_dict["median_rate_energy"] = energy
 
     # TODO
     # extendedspin_dict["ena_rates"]
     # extendedspin_dict["ena_rates_threshold"]
     # extendedspin_dict["spin_start_time"]
     # extendedspin_dict["avg_spin_period"]
-    # extendedspin_dict["rate_start_pulses"]
-    # extendedspin_dict["rate_stop_pulses"]
-    # extendedspin_dict["rate_coin_pulses"]
-    # extendedspin_dict["rate_processed_events"]
-    # extendedspin_dict["rate_rejected_events"]
+    # extendedspin_dict["spin_rate"]
     # extendedspin_dict["quality_attitude"]
     # extendedspin_dict["quality_instruments"]
+    # extendedspin_dict["quality_hk"]
 
     extendedspin_dict["quality_ena_rates"] = quality_flags
 
-    extendedspin_dataset = create_dataset(extendedspin_dict, name, "l1b")
+    extendedspin_dataset = create_dataset(extendedspin_dict, name, "l1b", data_version)
 
     return extendedspin_dataset

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -1,19 +1,23 @@
 """Calculate Extended Spin."""
 
-import numpy as np
 import xarray as xr
 
+from imap_processing.ultra.l1b.ultra_l1b_culling import flag_spin
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_extendedspin(rates_dataset: xr.Dataset, name: str) -> xr.Dataset:
+def calculate_extendedspin(
+    rates_dataset: xr.Dataset, de_dataset: xr.Dataset, name: str
+) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Extended Spin Data.
 
     Parameters
     ----------
     rates_dataset : xarray.Dataset
-        Dataset containing rates data.
+        Dataset containing l1a rates data.
+    de_dataset : xarray.Dataset
+        Dataset containing l1b de data
     name : str
         Name of the dataset.
 
@@ -23,22 +27,29 @@ def calculate_extendedspin(rates_dataset: xr.Dataset, name: str) -> xr.Dataset:
         Dataset containing the data.
     """
     extendedspin_dict = {}
+    quality_flags, spin, energy = flag_spin(
+        de_dataset["event_times"],
+        de_dataset["energy"],
+    )
 
-    epoch = rates_dataset.coords["epoch"].values
+    # These will be the coordinates.
+    extendedspin_dict["spin_number"] = spin
+    extendedspin_dict["energy"] = energy
 
-    # Placeholder for calculations
-    extendedspin_dict["epoch"] = epoch
-    extendedspin_dict["spin_number"] = np.zeros(len(epoch), dtype=np.uint64)
-    extendedspin_dict["spin_start_time"] = np.zeros(len(epoch), dtype=np.float64)
-    extendedspin_dict["avg_spin_period"] = np.zeros(len(epoch), dtype=np.float64)
-    extendedspin_dict["rate_start_pulses"] = np.zeros(len(epoch), dtype=np.float64)
-    extendedspin_dict["rate_stop_pulses"] = np.zeros(len(epoch), dtype=np.float64)
-    extendedspin_dict["rate_coin_pulses"] = np.zeros(len(epoch), dtype=np.float64)
-    extendedspin_dict["rate_processed_events"] = np.zeros(len(epoch), dtype=np.float64)
-    extendedspin_dict["rate_rejected_events"] = np.zeros(len(epoch), dtype=np.float64)
-    extendedspin_dict["quality_hk"] = np.zeros(len(epoch), dtype=np.uint16)
-    extendedspin_dict["quality_attitude"] = np.zeros(len(epoch), dtype=np.uint16)
-    extendedspin_dict["quality_instruments"] = np.zeros(len(epoch), dtype=np.uint16)
+    # TODO
+    # extendedspin_dict["ena_rates"]
+    # extendedspin_dict["ena_rates_threshold"]
+    # extendedspin_dict["spin_start_time"]
+    # extendedspin_dict["avg_spin_period"]
+    # extendedspin_dict["rate_start_pulses"]
+    # extendedspin_dict["rate_stop_pulses"]
+    # extendedspin_dict["rate_coin_pulses"]
+    # extendedspin_dict["rate_processed_events"]
+    # extendedspin_dict["rate_rejected_events"]
+    # extendedspin_dict["quality_attitude"]
+    # extendedspin_dict["quality_instruments"]
+
+    extendedspin_dict["quality_ena_rates"] = quality_flags
 
     extendedspin_dataset = create_dataset(extendedspin_dict, name, "l1b")
 

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -7,7 +7,7 @@ from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
 def calculate_extendedspin(
-    aux_dataset: xr.Dataset,
+    hk_dataset: xr.Dataset,
     rates_dataset: xr.Dataset,
     de_dataset: xr.Dataset,
     name: str,
@@ -18,8 +18,8 @@ def calculate_extendedspin(
 
     Parameters
     ----------
-    aux_dataset : xarray.Dataset
-        Dataset containing l1a aux data.
+    hk_dataset : xarray.Dataset
+        Dataset containing l1a hk data.
     rates_dataset : xarray.Dataset
         Dataset containing l1a rates data.
     de_dataset : xarray.Dataset

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -28,7 +28,7 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
     instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90
 
     if (
-        f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
+        f"imap_ultra_l1a_{instrument_id}sensor-hk" in data_dict
         and f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict
         and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
     ):
@@ -38,7 +38,7 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
             data_version,
         )
         extendedspin_dataset = calculate_extendedspin(
-            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
+            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-hk"],
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
             de_dataset,
             f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -8,7 +8,7 @@ from imap_processing.ultra.l1b.de import calculate_de
 from imap_processing.ultra.l1b.extendedspin import calculate_extendedspin
 
 
-def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
+def ultra_l1b(data_dict: dict, data_version: str) -> dict[str, xr.Dataset]:
     """
     Will process ULTRA L1A data into L1B CDF files at output_filepath.
 
@@ -21,10 +21,9 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
 
     Returns
     -------
-    output_datasets : list[xarray.Dataset]
-        List of xarray.Dataset.
+    output_datasets : dict
+        Dict of xarray.Dataset.
     """
-    output_datasets = []
     instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90
 
     if (
@@ -35,32 +34,33 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
         de_dataset = calculate_de(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
             f"imap_ultra_l1b_{instrument_id}sensor-de",
+            data_version,
         )
-        # TODO: move these to use ImapCdfAttributes().add_global_attribute()
-        de_dataset.attrs["Data_version"] = data_version
-
         extendedspin_dataset = calculate_extendedspin(
+            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
             de_dataset,
             f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
+            data_version,
         )
-        # TODO: move these to use ImapCdfAttributes().add_global_attribute()
-        extendedspin_dataset.attrs["Data_version"] = data_version
-
         cullingmask_dataset = calculate_cullingmask(
-            extendedspin_dataset, f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"
+            extendedspin_dataset,
+            f"imap_ultra_l1b_{instrument_id}sensor-cullingmask",
+            data_version,
         )
-        cullingmask_dataset.attrs["Data_version"] = data_version
-
         badtimes_dataset = calculate_badtimes(
-            extendedspin_dataset, f"imap_ultra_l1b_{instrument_id}sensor-badtimes"
-        )
-        badtimes_dataset.attrs["Data_version"] = data_version
-
-        output_datasets.extend(
-            [de_dataset, extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
+            extendedspin_dataset,
+            f"imap_ultra_l1b_{instrument_id}sensor-badtimes",
+            data_version,
         )
     else:
         raise ValueError("Data dictionary does not contain the expected keys.")
+
+    output_datasets = {
+        f"imap_ultra_l1b_{instrument_id}sensor-de": de_dataset,
+        f"imap_ultra_l1b_{instrument_id}sensor-extendedspin": extendedspin_dataset,
+        f"imap_ultra_l1b_{instrument_id}sensor-badtimes": badtimes_dataset,
+        f"imap_ultra_l1b_{instrument_id}sensor-cullingmask": cullingmask_dataset,
+    }
 
     return output_datasets

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -27,9 +27,21 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
     output_datasets = []
     instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90
 
-    if f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict:
+    if (
+        f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
+        and f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict
+        and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
+    ):
+        de_dataset = calculate_de(
+            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
+            f"imap_ultra_l1b_{instrument_id}sensor-de",
+        )
+        # TODO: move these to use ImapCdfAttributes().add_global_attribute()
+        de_dataset.attrs["Data_version"] = data_version
+
         extendedspin_dataset = calculate_extendedspin(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
+            de_dataset,
             f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
         )
         # TODO: move these to use ImapCdfAttributes().add_global_attribute()
@@ -46,19 +58,8 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
         badtimes_dataset.attrs["Data_version"] = data_version
 
         output_datasets.extend(
-            [extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
+            [de_dataset, extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
         )
-    elif (
-        f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
-        and f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict
-    ):
-        de_dataset = calculate_de(
-            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
-            f"imap_ultra_l1b_{instrument_id}sensor-de",
-        )
-        de_dataset.attrs["Data_version"] = data_version
-
-        output_datasets.append(de_dataset)
     else:
         raise ValueError("Data dictionary does not contain the expected keys.")
 

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -8,7 +8,7 @@ from imap_processing.ultra.l1b.de import calculate_de
 from imap_processing.ultra.l1b.extendedspin import calculate_extendedspin
 
 
-def ultra_l1b(data_dict: dict, data_version: str) -> dict[str, xr.Dataset]:
+def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A data into L1B CDF files at output_filepath.
 
@@ -21,9 +21,10 @@ def ultra_l1b(data_dict: dict, data_version: str) -> dict[str, xr.Dataset]:
 
     Returns
     -------
-    output_datasets : dict
-        Dict of xarray.Dataset.
+    output_datasets : list[xarray.Dataset]
+        List of xarray.Dataset.
     """
+    output_datasets = []
     instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90
 
     if (
@@ -53,14 +54,10 @@ def ultra_l1b(data_dict: dict, data_version: str) -> dict[str, xr.Dataset]:
             f"imap_ultra_l1b_{instrument_id}sensor-badtimes",
             data_version,
         )
+        output_datasets.extend(
+            [de_dataset, extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
+        )
     else:
         raise ValueError("Data dictionary does not contain the expected keys.")
-
-    output_datasets = {
-        f"imap_ultra_l1b_{instrument_id}sensor-de": de_dataset,
-        f"imap_ultra_l1b_{instrument_id}sensor-extendedspin": extendedspin_dataset,
-        f"imap_ultra_l1b_{instrument_id}sensor-badtimes": badtimes_dataset,
-        f"imap_ultra_l1b_{instrument_id}sensor-cullingmask": cullingmask_dataset,
-    }
 
     return output_datasets

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -105,11 +105,8 @@ def flag_spin(
     energy_midpoints = (bin_edges[:-1] + bin_edges[1:]) / 2
     spin = np.unique(spin)
 
-    for energy_idx in range(hist.shape[0]):
-        # Count rates for each spin at this energy
-        spin_count_rates = hist[energy_idx][:]
-        # Indices where the counts exceed the threshold
-        indices = spin_count_rates > UltraConstants.COUNT_RATES_THRESHOLDS[energy_idx]
-        quality_flags[energy_idx, indices] |= ImapRatesUltraFlags.HIGHCOUNTS.value
+    # Indices where the counts exceed the threshold
+    indices = hist > np.array(UltraConstants.COUNT_RATES_THRESHOLDS)[:, np.newaxis]
+    quality_flags[indices] |= ImapRatesUltraFlags.HIGHCOUNTS.value
 
     return quality_flags, spin, energy_midpoints

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -6,7 +6,7 @@
 import numpy as np
 from numpy.typing import NDArray
 
-from imap_processing.quality_flags import ImapHkUltraFlags
+from imap_processing.quality_flags import ImapRatesUltraFlags
 from imap_processing.spice.geometry import get_spin_data
 from imap_processing.ultra.constants import UltraConstants
 
@@ -99,32 +99,17 @@ def flag_spin(
     """
     spin = get_spin(eventtimes_met)
     hist, spin_edges = get_energy_histogram(spin, energy)
-    quality_flags = np.full(
-        hist.shape[0] * hist.shape[1], ImapHkUltraFlags.NONE.value, dtype=np.uint16
-    )
+    quality_flags = np.full(hist.shape, ImapRatesUltraFlags.NONE.value, dtype=np.uint16)
 
-    appended_spin = np.empty(0, dtype=np.uint16)
-    appended_energy = np.empty(0, dtype=np.float64)
+    bin_edges = np.array(UltraConstants.CULLING_ENERGY_BIN_EDGES)
+    energy_midpoints = (bin_edges[:-1] + bin_edges[1:]) / 2
+    spin = np.unique(spin)
 
     for energy_idx in range(hist.shape[0]):
         # Count rates for each spin at this energy
         spin_count_rates = hist[energy_idx][:]
         # Indices where the counts exceed the threshold
-        indices = np.nonzero(
-            spin_count_rates > UltraConstants.COUNT_RATES_THRESHOLDS[energy_idx]
-        )
-        flattened_indices = energy_idx * hist.shape[1] + indices[0]
-        quality_flags[flattened_indices] |= ImapHkUltraFlags.HIGHCOUNTS.value
+        indices = spin_count_rates > UltraConstants.COUNT_RATES_THRESHOLDS[energy_idx]
+        quality_flags[energy_idx, indices] |= ImapRatesUltraFlags.HIGHCOUNTS.value
 
-        # Calculate the energy midpoint for each bin
-        energy_midpoint = (
-            UltraConstants.CULLING_ENERGY_BIN_EDGES[energy_idx]
-            + UltraConstants.CULLING_ENERGY_BIN_EDGES[energy_idx + 1]
-        ) / 2
-
-        appended_spin = np.concatenate((appended_spin, np.unique(spin)))
-        appended_energy = np.concatenate(
-            (appended_energy, np.full(len(np.unique(spin)), energy_midpoint))
-        )
-
-    return quality_flags, appended_spin, appended_energy
+    return quality_flags, spin, energy_midpoints

--- a/imap_processing/ultra/l1c/histogram.py
+++ b/imap_processing/ultra/l1c/histogram.py
@@ -6,7 +6,9 @@ import xarray as xr
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_histogram(histogram_dataset: xr.Dataset, name: str) -> xr.Dataset:
+def calculate_histogram(
+    histogram_dataset: xr.Dataset, name: str, data_version: str
+) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Histogram Data.
 
@@ -16,6 +18,8 @@ def calculate_histogram(histogram_dataset: xr.Dataset, name: str) -> xr.Dataset:
         Dataset containing histogram data.
     name : str
         Name of dataset.
+    data_version : str
+        Version of the data.
 
     Returns
     -------
@@ -31,6 +35,6 @@ def calculate_histogram(histogram_dataset: xr.Dataset, name: str) -> xr.Dataset:
     histogram_dict["epoch"] = epoch
     histogram_dict["sid"] = np.zeros(len(epoch), dtype=np.uint8)
 
-    dataset = create_dataset(histogram_dict, name, "l1c")
+    dataset = create_dataset(histogram_dict, name, "l1c", data_version)
 
     return dataset

--- a/imap_processing/ultra/l1c/pset.py
+++ b/imap_processing/ultra/l1c/pset.py
@@ -6,7 +6,9 @@ import xarray as xr
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_pset(pset_dataset: xr.Dataset, name: str) -> xr.Dataset:
+def calculate_pset(
+    pset_dataset: xr.Dataset, name: str, data_version: str
+) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
 
@@ -16,6 +18,8 @@ def calculate_pset(pset_dataset: xr.Dataset, name: str) -> xr.Dataset:
         Dataset containing histogram data.
     name : str
         Name of the dataset.
+    data_version : str
+        Version of the data.
 
     Returns
     -------
@@ -31,6 +35,6 @@ def calculate_pset(pset_dataset: xr.Dataset, name: str) -> xr.Dataset:
     pset_dict["epoch"] = epoch
     pset_dict["esa_step"] = np.zeros(len(epoch), dtype=np.uint8)
 
-    dataset = create_dataset(pset_dict, name, "l1c")
+    dataset = create_dataset(pset_dict, name, "l1c", data_version)
 
     return dataset

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -31,9 +31,8 @@ def ultra_l1c(data_dict: dict, data_version: str) -> list[xr.Dataset]:
         histogram_dataset = calculate_histogram(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-histogram"],
             f"imap_ultra_l1c_{instrument_id}sensor-histogram",
+            data_version,
         )
-        # TODO: move these to use ImapCdfAttributes().add_global_attribute()
-        histogram_dataset.attrs["Data_version"] = data_version
         output_datasets = [histogram_dataset]
     elif (
         f"imap_ultra_l1b_{instrument_id}sensor-cullingmask" in data_dict
@@ -43,8 +42,8 @@ def ultra_l1c(data_dict: dict, data_version: str) -> list[xr.Dataset]:
         pset_dataset = calculate_pset(
             data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
             f"imap_ultra_l1c_{instrument_id}sensor-pset",
+            data_version,
         )
-        pset_dataset.attrs["Data_version"] = data_version
         output_datasets = [pset_dataset]
     else:
         raise ValueError("Data dictionary does not contain the expected keys.")

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -46,7 +46,7 @@ def create_dataset(
             dims=["epoch"],
             attrs=cdf_manager.get_variable_attributes("epoch"),
         )
-        if name in {f"imap_ultra_l1b_{x}sensor-de" for x in [45, 90]}:
+        if "sensor-de" in name:
             coords = {"epoch": epoch_time, "component": ["vx", "vy", "vz"]}
         else:
             coords = {"epoch": epoch_time}

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -5,7 +5,9 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 
 
-def create_dataset(data_dict: dict, name: str, level: str) -> xr.Dataset:
+def create_dataset(
+    data_dict: dict, name: str, level: str, data_version: str
+) -> xr.Dataset:
     """
     Create xarray for L1b data.
 
@@ -17,6 +19,8 @@ def create_dataset(data_dict: dict, name: str, level: str) -> xr.Dataset:
         Name of the dataset.
     level : str
         Level of the dataset.
+    data_version : str
+        Version of the data.
 
     Returns
     -------
@@ -26,36 +30,60 @@ def create_dataset(data_dict: dict, name: str, level: str) -> xr.Dataset:
     cdf_manager = ImapCdfAttributes()
     cdf_manager.add_instrument_global_attrs("ultra")
     cdf_manager.add_instrument_variable_attrs("ultra", level)
-    epoch_time = xr.DataArray(
-        data_dict["epoch"],
-        name="epoch",
-        dims=["epoch"],
-        attrs=cdf_manager.get_variable_attributes("epoch"),
-    )
+    cdf_manager.add_global_attribute("Data_version", data_version)
+
+    if name in {f"imap_ultra_l1b_{x}sensor-de" for x in [45, 90]}:
+        epoch_time = xr.DataArray(
+            data_dict["epoch"],
+            name="epoch",
+            dims=["epoch"],
+            attrs=cdf_manager.get_variable_attributes("epoch"),
+        )
+        coords = {"epoch": epoch_time, "component": ["vx", "vy", "vz"]}
+        default_dimension = "epoch"
+    else:
+        coords = {
+            "spin_number": data_dict["spin_number"],
+            "median_rate_energy": data_dict["median_rate_energy"],
+        }
+        default_dimension = "spin_number"
 
     dataset = xr.Dataset(
-        coords={"epoch": epoch_time, "component": ["vx", "vy", "vz"]},
+        coords=coords,
         attrs=cdf_manager.get_global_attributes(name),
     )
 
+    velocity_keys = {
+        "direct_event_velocity",
+        "velocity_sc",
+        "velocity_dps_sc",
+        "velocity_dps_helio",
+    }
+    rates_keys = {
+        "ena_rates",
+        "ena_rates_threshold",
+        "quality_ena_rates",
+    }
+
     for key in data_dict.keys():
-        if key == "epoch":
+        if key in ["epoch", "spin_number", "median_rate_energy"]:
             continue
-        elif key in [
-            "direct_event_velocity",
-            "velocity_sc",
-            "velocity_dps_sc",
-            "velocity_dps_helio",
-        ]:
+        elif key in velocity_keys:
             dataset[key] = xr.DataArray(
                 data_dict[key],
                 dims=["epoch", "component"],
                 attrs=cdf_manager.get_variable_attributes(key),
             )
+        elif key in rates_keys:
+            dataset[key] = xr.DataArray(
+                data_dict[key],
+                dims=["median_rate_energy", "spin_number"],
+                attrs=cdf_manager.get_variable_attributes(key),
+            )
         else:
             dataset[key] = xr.DataArray(
                 data_dict[key],
-                dims=["epoch"],
+                dims=[default_dimension],
                 attrs=cdf_manager.get_variable_attributes(key),
             )
 

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -32,21 +32,25 @@ def create_dataset(
     cdf_manager.add_instrument_variable_attrs("ultra", level)
     cdf_manager.add_global_attribute("Data_version", data_version)
 
-    if name in {f"imap_ultra_l1b_{x}sensor-de" for x in [45, 90]}:
+    if "spin_number" in data_dict.keys():
+        coords = {
+            "spin_number": data_dict["spin_number"],
+            "median_rate_energy": data_dict["median_rate_energy"],
+        }
+        default_dimension = "spin_number"
+
+    else:
         epoch_time = xr.DataArray(
             data_dict["epoch"],
             name="epoch",
             dims=["epoch"],
             attrs=cdf_manager.get_variable_attributes("epoch"),
         )
-        coords = {"epoch": epoch_time, "component": ["vx", "vy", "vz"]}
+        if name in {f"imap_ultra_l1b_{x}sensor-de" for x in [45, 90]}:
+            coords = {"epoch": epoch_time, "component": ["vx", "vy", "vz"]}
+        else:
+            coords = {"epoch": epoch_time}
         default_dimension = "epoch"
-    else:
-        coords = {
-            "spin_number": data_dict["spin_number"],
-            "median_rate_energy": data_dict["median_rate_energy"],
-        }
-        default_dimension = "spin_number"
 
     dataset = xr.Dataset(
         coords=coords,


### PR DESCRIPTION
# Change Summary

## Overview
This updates the structure of the ultra l1b extended spin table. However, one small change would propagate other changes in other files. Any major changes in files are listed as "Focus on these" and those are the ones you should focus on.

## Updated Files
**Focus on these**
- extended_spin.py
   - Added structure of what is expected for this data product. 
- ultra_l1b.py
   - The extended_spin data product is dependent on the de data product. And the culling and badtimes data products are both dependent on the extended_spin data product. So I changed the logical involved here.
- ultra_l1b_culling.py
   - I had to change the structure of quality flags for creating an xarray with two coordinates (spin and energy)
- ultra_l1_utils.py
   - Change the logic for creating the dataset based on which data product is being created.

**Not on these**
- quality_flags.py
   - Name change of the flag
- imap_ultra_l1b_variable_attrs.yaml
   - Define quality_ena_rates attributes
- badtimes.py and cullingmask.py
   - Changed the data type for the input. Added data version as an input. 
- calculate_de.py, histogram.py, pset.py, ultra_l1c.py
   - added data_version as an input.
- conftest.py
   - added test data
  
## Testing
- test_de.py
- test_ultra_l1b.py
- test_ultra_l1b_culling.py
- test_ultra_l1c.py