### PR TITLE
MNT: Rename spice -> spiceypy

### DIFF
--- a/imap_processing/ialirt/process_ephemeris.py
+++ b/imap_processing/ialirt/process_ephemeris.py
@@ -11,7 +11,7 @@ import typing
 from typing import Union
 
 import numpy as np
-import spiceypy as spice
+import spiceypy
 from numpy import ndarray
 
 from imap_processing.spice.geometry import SpiceBody, SpiceFrame, imap_state
@@ -53,14 +53,14 @@ def latitude_longitude_to_ecef(
     # Retrieve Earth's radii from SPICE
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.bod
     # (url cont.) vrd
-    radii = spice.bodvrd("EARTH", "RADII", 3)[1]
+    radii = spiceypy.bodvrd("EARTH", "RADII", 3)[1]
     equatorial_radius = radii[0]  # Equatorial radius in km
     polar_radius = radii[2]  # Polar radius in km
     flattening = (equatorial_radius - polar_radius) / equatorial_radius
 
     # Convert geodetic coordinates to rectangular coordinates
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.georec
-    rect_coords = spice.georec(
+    rect_coords = spiceypy.georec(
         longitude_radians, latitude_radians, altitude, equatorial_radius, flattening
     )
 
@@ -114,7 +114,7 @@ def calculate_azimuth_and_elevation(
 
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.azlcpo
     for timestamp in observation_time:
-        azel_results = spice.azlcpo(
+        azel_results = spiceypy.azlcpo(
             method="Ellipsoid",  # Only method supported
             target=target,  # target ephemeris object
             et=timestamp,  # time of observation

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -352,7 +352,7 @@ def frame_transform(
     This function is a vectorized equivalent to performing the following SPICE
     calls for each input time and position vector to perform the transform.
     The matrix multiplication step is done using `numpy.matmul` rather than
-    `spice.mxv`.
+    `spiceypy.mxv`.
     >>> rotation_matrix = spiceypy.pxform(from_frame, to_frame, et)
     ... result = spiceypy.mxv(rotation_matrix, position)
 

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -1,5 +1,5 @@
 """
-Functions for computing geometry, many of which use SPICE.
+Functions for computing geometry, many of which use SPICEYPY.
 
 Paradigms for developing this module:
 
@@ -18,7 +18,7 @@ from typing import Union
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-import spiceypy as spice
+import spiceypy
 from numpy.typing import NDArray
 
 from imap_processing.spice.kernels import ensure_spice
@@ -33,17 +33,17 @@ class SpiceBody(IntEnum):
     # IMAP Pointing Frame (Despun) as defined in imap_science_0001.tf
     IMAP_DPS = -43901
     # Standard NAIF bodies
-    SOLAR_SYSTEM_BARYCENTER = spice.bodn2c("SOLAR_SYSTEM_BARYCENTER")
-    SUN = spice.bodn2c("SUN")
-    EARTH = spice.bodn2c("EARTH")
+    SOLAR_SYSTEM_BARYCENTER = spiceypy.bodn2c("SOLAR_SYSTEM_BARYCENTER")
+    SUN = spiceypy.bodn2c("SUN")
+    EARTH = spiceypy.bodn2c("EARTH")
 
 
 class SpiceFrame(IntEnum):
     """Enum containing SPICE IDs for reference frames, defined in imap_wkcp.tf."""
 
     # Standard SPICE Frames
-    J2000 = spice.irfnum("J2000")
-    ECLIPJ2000 = spice.irfnum("ECLIPJ2000")
+    J2000 = spiceypy.irfnum("J2000")
+    ECLIPJ2000 = spiceypy.irfnum("ECLIPJ2000")
     ITRF93 = 13000
     # IMAP Pointing Frame (Despun) as defined in imap_science_0001.tf
     IMAP_DPS = -43901
@@ -112,7 +112,7 @@ def imap_state(
      The Cartesian state vector representing the position and velocity of the
      IMAP spacecraft.
     """
-    state, _ = spice.spkezr(
+    state, _ = spiceypy.spkezr(
         SpiceBody.IMAP.name, et, ref_frame.name, abcorr, observer.name
     )
     return np.asarray(state)
@@ -353,8 +353,8 @@ def frame_transform(
     calls for each input time and position vector to perform the transform.
     The matrix multiplication step is done using `numpy.matmul` rather than
     `spice.mxv`.
-    >>> rotation_matrix = spice.pxform(from_frame, to_frame, et)
-    ... result = spice.mxv(rotation_matrix, position)
+    >>> rotation_matrix = spiceypy.pxform(from_frame, to_frame, et)
+    ... result = spiceypy.mxv(rotation_matrix, position)
 
     Parameters
     ----------
@@ -492,7 +492,7 @@ def get_rotation_matrix(
         where `n` matches the number of elements in et.
     """
     vec_pxform = np.vectorize(
-        spice.pxform,
+        spiceypy.pxform,
         excluded=["fromstr", "tostr"],
         signature="(),(),()->(3,3)",
         otypes=[np.float64],
@@ -534,8 +534,8 @@ def instrument_pointing(
     if cartesian:
         return pointing
     if isinstance(et, typing.Collection):
-        return np.rad2deg([spice.reclat(vec)[1:] for vec in pointing])
-    return np.rad2deg(spice.reclat(pointing)[1:])
+        return np.rad2deg([spiceypy.reclat(vec)[1:] for vec in pointing])
+    return np.rad2deg(spiceypy.reclat(pointing)[1:])
 
 
 def basis_vectors(
@@ -706,7 +706,7 @@ def cartesian_to_latitudinal(coords: NDArray, degrees: bool = False) -> NDArray:
     # If coords is 1d, add another dimension
     while coords.ndim < 2:
         coords = np.expand_dims(coords, axis=0)
-    latitudinal_coords = np.array([spice.reclat(vec) for vec in coords])
+    latitudinal_coords = np.array([spiceypy.reclat(vec) for vec in coords])
 
     if degrees:
         latitudinal_coords[..., 1:] = np.degrees(latitudinal_coords[..., 1:])

--- a/imap_processing/spice/time.py
+++ b/imap_processing/spice/time.py
@@ -1,4 +1,4 @@
-"""Time conversion functions that rely on SPICE."""
+"""Time conversion functions that rely on SPICEYPY."""
 
 import typing
 from collections.abc import Collection, Iterable
@@ -6,7 +6,7 @@ from typing import Union
 
 import numpy as np
 import numpy.typing as npt
-import spiceypy as spice
+import spiceypy
 
 from imap_processing.spice import IMAP_SC_ID
 from imap_processing.spice.kernels import ensure_spice
@@ -94,7 +94,7 @@ def ttj2000ns_to_et(tt_ns: npt.ArrayLike) -> npt.NDArray[float]:
     """
     tt_seconds = np.asarray(tt_ns, dtype=np.float64) / 1e9
     vectorized_unitim = np.vectorize(
-        spice.unitim, [float], excluded=["insys", "outsys"]
+        spiceypy.unitim, [float], excluded=["insys", "outsys"]
     )
     return vectorized_unitim(tt_seconds, "TT", "ET")
 
@@ -122,7 +122,7 @@ def met_to_utc(met: npt.ArrayLike, precision: int = 9) -> npt.NDArray[str]:
     """
     sclk_ticks = met_to_sclkticks(met)
     et = _sct2e_wrapper(sclk_ticks)
-    return spice.et2utc(et, "ISOC", prec=precision)
+    return spiceypy.et2utc(et, "ISOC", prec=precision)
 
 
 def met_to_datetime64(
@@ -169,9 +169,9 @@ def _sct2e_wrapper(
         Ephemeris time, seconds past J2000.
     """
     if isinstance(sclk_ticks, Collection):
-        return np.array([spice.sct2e(IMAP_SC_ID, s) for s in sclk_ticks])
+        return np.array([spiceypy.sct2e(IMAP_SC_ID, s) for s in sclk_ticks])
     else:
-        return spice.sct2e(IMAP_SC_ID, sclk_ticks)
+        return spiceypy.sct2e(IMAP_SC_ID, sclk_ticks)
 
 
 @typing.no_type_check
@@ -200,10 +200,13 @@ def sct_to_ttj2000s(
     """
     if isinstance(sclk_ticks, Collection):
         return np.array(
-            [spice.unitim(spice.sct2e(IMAP_SC_ID, s), "ET", "TT") for s in sclk_ticks]
+            [
+                spiceypy.unitim(spiceypy.sct2e(IMAP_SC_ID, s), "ET", "TT")
+                for s in sclk_ticks
+            ]
         )
     else:
-        return spice.unitim(spice.sct2e(IMAP_SC_ID, sclk_ticks), "ET", "TT")
+        return spiceypy.unitim(spiceypy.sct2e(IMAP_SC_ID, sclk_ticks), "ET", "TT")
 
 
 @typing.no_type_check
@@ -229,9 +232,9 @@ def str_to_et(
         Ephemeris time, seconds past J2000.
     """
     if isinstance(time_str, str):
-        return spice.str2et(time_str)
+        return spiceypy.str2et(time_str)
     else:
-        return np.array([spice.str2et(t) for t in time_str])
+        return np.array([spiceypy.str2et(t) for t in time_str])
 
 
 @typing.no_type_check
@@ -272,4 +275,4 @@ def et_to_utc(
     utc_time : str or np.ndarray
         UTC time(s).
     """
-    return spice.et2utc(et, format_str, precision, utclen)
+    return spiceypy.et2utc(et, format_str, precision, utclen)

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests
-import spiceypy as spice
+import spiceypy
 
 from imap_processing import imap_module_directory
 from imap_processing.spice.time import met_to_ttj2000ns
@@ -42,7 +42,7 @@ def _autoclear_spice():
     prevent the kernel pool from interfering with future tests. Option autouse
     ensures this is run after every test."""
     yield
-    spice.kclear()
+    spiceypy.kclear()
 
 
 @pytest.fixture(scope="session")
@@ -125,22 +125,22 @@ def spice_test_data_path(imap_tests_path):
 @pytest.fixture()
 def furnish_time_kernels(spice_test_data_path):
     """Furnishes (temporarily) the testing LSK and SCLK"""
-    spice.kclear()
+    spiceypy.kclear()
     test_lsk = spice_test_data_path / "naif0012.tls"
     test_sclk = spice_test_data_path / "imap_sclk_0000.tsc"
-    spice.furnsh(str(test_lsk))
-    spice.furnsh(str(test_sclk))
+    spiceypy.furnsh(str(test_lsk))
+    spiceypy.furnsh(str(test_sclk))
     yield test_lsk, test_sclk
-    spice.kclear()
+    spiceypy.kclear()
 
 
 @pytest.fixture()
 def furnish_sclk(spice_test_data_path):
     """Furnishes (temporarily) the SCLK for JPSS stored in the package data directory"""
     test_sclk = spice_test_data_path / "imap_sclk_0000.tsc"
-    spice.furnsh(str(test_sclk))
+    spiceypy.furnsh(str(test_sclk))
     yield test_sclk
-    spice.kclear()
+    spiceypy.kclear()
 
 
 @pytest.fixture()
@@ -149,7 +149,9 @@ def furnish_kernels(spice_test_data_path):
 
     @contextmanager
     def furnish_kernels(kernels: list[Path]):
-        with spice.KernelPool([str(spice_test_data_path / k) for k in kernels]) as pool:
+        with spiceypy.KernelPool(
+            [str(spice_test_data_path / k) for k in kernels]
+        ) as pool:
             yield pool
 
     return furnish_kernels
@@ -228,7 +230,7 @@ def session_test_metakernel(monkeypatch_session, tmpdir_factory, spice_test_data
     -----
     - This fixture needs to `scope=session` so that the SPICE_METAKERNEL
     environment variable is available for other fixtures that require time
-    conversions using spice.
+    conversions using spiceypy.
     - No furnishing of kernels occur as part of this fixture. This allows other
     fixtures with lesser scope or individual tests to override the environment
     variable as needed. Use the `metakernel_path_not_set` fixture in tests that
@@ -240,7 +242,7 @@ def session_test_metakernel(monkeypatch_session, tmpdir_factory, spice_test_data
     make_metakernel_from_kernels(metakernel_path, kernels_to_load)
     monkeypatch_session.setenv("SPICE_METAKERNEL", str(metakernel_path))
     yield str(metakernel_path)
-    spice.kclear()
+    spiceypy.kclear()
 
 
 @pytest.fixture()
@@ -290,7 +292,7 @@ def use_test_metakernel(
         make_metakernel_from_kernels(metakernel_path, kernels_to_load)
         monkeypatch.setenv("SPICE_METAKERNEL", str(metakernel_path))
         yield str(metakernel_path)
-    spice.kclear()
+    spiceypy.kclear()
 
 
 @pytest.fixture()

--- a/imap_processing/tests/spice/test_kernels.py
+++ b/imap_processing/tests/spice/test_kernels.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-import spiceypy as spice
+import spiceypy
 from spiceypy.utils.exceptions import SpiceyError
 
 from imap_processing.spice.kernels import (
@@ -45,11 +45,11 @@ def multiple_pointing_kernels(spice_test_data_path):
 @pytest.fixture()
 def et_times(pointing_frame_kernels):
     """Tests get_et_times function."""
-    spice.furnsh(pointing_frame_kernels)
+    spiceypy.furnsh(pointing_frame_kernels)
 
-    ck_kernel, _, _, _ = spice.kdata(0, "ck")
-    ck_cover = spice.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
-    et_start, et_end = spice.wnfetd(ck_cover, 0)
+    ck_kernel, _, _, _ = spiceypy.kdata(0, "ck")
+    ck_cover = spiceypy.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
+    et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
     et_times = _get_et_times(et_start, et_end)
 
     return et_times
@@ -58,7 +58,7 @@ def et_times(pointing_frame_kernels):
 @ensure_spice
 def single_wrap_et2utc(et, fmt, prec):
     """Directly decorate a spice function with ensure_spice for use in tests"""
-    return spice.et2utc(et, fmt, prec)
+    return spiceypy.et2utc(et, fmt, prec)
 
 
 @ensure_spice
@@ -72,7 +72,7 @@ def double_wrap_et2utc(et, fmt, prec):
 @ensure_spice(time_kernels_only=True)
 def single_wrap_et2utc_tk_only(et, fmt, prec):
     """Directly wrap a spice function with optional time_kernels_only set True"""
-    return spice.et2utc(et, fmt, prec)
+    return spiceypy.et2utc(et, fmt, prec)
 
 
 @ensure_spice(time_kernels_only=True)
@@ -101,7 +101,7 @@ def test_ensure_spice_emus_mk_path(func, use_test_metakernel):
 @pytest.mark.usefixtures("_unset_metakernel_path")
 def test_ensure_spice_time_kernels():
     """Test functionality of ensure spice with timekernels set"""
-    wrapped = ensure_spice(spice.et2utc, time_kernels_only=True)
+    wrapped = ensure_spice(spiceypy.et2utc, time_kernels_only=True)
     # TODO: Update/remove this test when a decision has been made about
     #   whether IMAP will use the time_kernels_only functionality and the
     #   ensure_spice decorator has been update.
@@ -113,7 +113,7 @@ def test_ensure_spice_time_kernels():
 @pytest.mark.usefixtures("_unset_metakernel_path")
 def test_ensure_spice_key_error():
     """Test functionality of ensure spice when all branches fail"""
-    wrapped = ensure_spice(spice.et2utc)
+    wrapped = ensure_spice(spiceypy.et2utc)
     # The ensure_spice decorator should raise a SpiceyError when all attempts to
     # furnish a set of kernels with sufficient coverage for the spiceypy
     # functions that it decorates.
@@ -123,7 +123,7 @@ def test_ensure_spice_key_error():
 
 def test_average_quaternions(et_times, pointing_frame_kernels):
     """Tests average_quaternions function."""
-    spice.furnsh(pointing_frame_kernels)
+    spiceypy.furnsh(pointing_frame_kernels)
     q_avg = _average_quaternions(et_times)
 
     # Generated from MATLAB code results
@@ -133,10 +133,10 @@ def test_average_quaternions(et_times, pointing_frame_kernels):
 
 def test_create_rotation_matrix(et_times, pointing_frame_kernels):
     """Tests create_rotation_matrix function."""
-    spice.furnsh(pointing_frame_kernels)
+    spiceypy.furnsh(pointing_frame_kernels)
     rotation_matrix = _create_rotation_matrix(et_times)
     q_avg = _average_quaternions(et_times)
-    z_avg = spice.q2m(list(q_avg))[:, 2]
+    z_avg = spiceypy.q2m(list(q_avg))[:, 2]
 
     rotation_matrix_expected = np.array(
         [[0.0000, 0.0000, 1.0000], [0.9104, -0.4136, 0.0000], [0.4136, 0.9104, 0.0000]]
@@ -151,8 +151,8 @@ def test_create_pointing_frame(
     spice_test_data_path, pointing_frame_kernels, tmp_path, et_times
 ):
     """Tests create_pointing_frame function."""
-    spice.kclear()
-    spice.furnsh(pointing_frame_kernels)
+    spiceypy.kclear()
+    spiceypy.furnsh(pointing_frame_kernels)
     create_pointing_frame(
         pointing_frame_path=tmp_path / "imap_dps.bc",
         ck_path=spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
@@ -161,9 +161,9 @@ def test_create_pointing_frame(
     # After imap_dps.bc has been created.
     dps_kernel = str(tmp_path / "imap_dps.bc")
 
-    spice.furnsh(dps_kernel)
-    rotation_matrix_1 = spice.pxform("ECLIPJ2000", "IMAP_DPS", et_times[0] + 100)
-    rotation_matrix_2 = spice.pxform("ECLIPJ2000", "IMAP_DPS", et_times[0] + 1000)
+    spiceypy.furnsh(dps_kernel)
+    rotation_matrix_1 = spiceypy.pxform("ECLIPJ2000", "IMAP_DPS", et_times[0] + 100)
+    rotation_matrix_2 = spiceypy.pxform("ECLIPJ2000", "IMAP_DPS", et_times[0] + 1000)
 
     # All the rotation matrices should be the same.
     assert np.array_equal(rotation_matrix_1, rotation_matrix_2)
@@ -178,7 +178,7 @@ def test_create_pointing_frame(
     assert (tmp_path / "imap_dps.bc").exists()
 
     # Tests error handling when incorrect kernel is loaded.
-    spice.furnsh(pointing_frame_kernels)
+    spiceypy.furnsh(pointing_frame_kernels)
     with pytest.raises(
         ValueError, match="Error: Expected CK kernel badname_kernel.bc"
     ):  # Replace match string with expected error message
@@ -189,11 +189,11 @@ def test_create_pointing_frame(
 
 def test_et_times(pointing_frame_kernels):
     """Tests get_et_times function."""
-    spice.furnsh(pointing_frame_kernels)
+    spiceypy.furnsh(pointing_frame_kernels)
 
-    ck_kernel, _, _, _ = spice.kdata(0, "ck")
-    ck_cover = spice.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
-    et_start, et_end = spice.wnfetd(ck_cover, 0)
+    ck_kernel, _, _, _ = spiceypy.kdata(0, "ck")
+    ck_cover = spiceypy.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
+    et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
     et_times = _get_et_times(et_start, et_end)
 
     assert et_times[0] == et_start
@@ -204,7 +204,7 @@ def test_et_times(pointing_frame_kernels):
 
 def test_multiple_attempts(pointing_frame_kernels, tmp_path, spice_test_data_path):
     """Tests create_pointing_frame function with multiple pointing kernels."""
-    spice.furnsh(pointing_frame_kernels)
+    spiceypy.furnsh(pointing_frame_kernels)
 
     # Check that a single segment is added regardless of how many times
     # create_pointing_frame is called.
@@ -212,32 +212,32 @@ def test_multiple_attempts(pointing_frame_kernels, tmp_path, spice_test_data_pat
         pointing_frame_path=tmp_path / "imap_dps.bc",
         ck_path=spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
     )
-    ck_cover = spice.ckcov(
+    ck_cover = spiceypy.ckcov(
         str(tmp_path / "imap_dps.bc"), -43901, True, "INTERVAL", 0, "TDB"
     )
-    num_intervals = spice.wncard(ck_cover)
+    num_intervals = spiceypy.wncard(ck_cover)
     assert num_intervals == 1
 
     create_pointing_frame(
         pointing_frame_path=tmp_path / "imap_dps.bc",
         ck_path=spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
     )
-    ck_cover = spice.ckcov(
+    ck_cover = spiceypy.ckcov(
         str(tmp_path / "imap_dps.bc"), -43901, True, "INTERVAL", 0, "TDB"
     )
-    num_intervals = spice.wncard(ck_cover)
+    num_intervals = spiceypy.wncard(ck_cover)
     assert num_intervals == 1
 
 
 def test_multiple_pointings(pointing_frame_kernels, spice_test_data_path, tmp_path):
     """Tests create_pointing_frame function with multiple pointing kernels."""
-    spice.furnsh(pointing_frame_kernels)
+    spiceypy.furnsh(pointing_frame_kernels)
 
     create_pointing_frame(
         pointing_frame_path=tmp_path / "imap_pointing_frame.bc",
         ck_path=spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
     )
-    ck_cover_pointing = spice.ckcov(
+    ck_cover_pointing = spiceypy.ckcov(
         str(tmp_path / "imap_pointing_frame.bc"),
         -43901,
         True,
@@ -245,10 +245,10 @@ def test_multiple_pointings(pointing_frame_kernels, spice_test_data_path, tmp_pa
         0,
         "TDB",
     )
-    num_intervals = spice.wncard(ck_cover_pointing)
-    et_start_pointing, et_end_pointing = spice.wnfetd(ck_cover_pointing, 0)
+    num_intervals = spiceypy.wncard(ck_cover_pointing)
+    et_start_pointing, et_end_pointing = spiceypy.wnfetd(ck_cover_pointing, 0)
 
-    ck_cover = spice.ckcov(
+    ck_cover = spiceypy.ckcov(
         str(spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc"),
         -43000,
         True,
@@ -256,8 +256,8 @@ def test_multiple_pointings(pointing_frame_kernels, spice_test_data_path, tmp_pa
         0,
         "TDB",
     )
-    num_intervals_expected = spice.wncard(ck_cover)
-    et_start_expected, et_end_expected = spice.wnfetd(ck_cover, 0)
+    num_intervals_expected = spiceypy.wncard(ck_cover)
+    et_start_expected, et_end_expected = spiceypy.wnfetd(ck_cover, 0)
 
     assert num_intervals == num_intervals_expected
     assert et_start_pointing == et_start_expected
@@ -265,8 +265,8 @@ def test_multiple_pointings(pointing_frame_kernels, spice_test_data_path, tmp_pa
 
     et_times = _get_et_times(et_start_pointing, et_end_pointing)
 
-    spice.furnsh(str(tmp_path / "imap_pointing_frame.bc"))
-    rotation_matrix_1 = spice.pxform("ECLIPJ2000", "IMAP_DPS", et_times[100])
-    rotation_matrix_2 = spice.pxform("ECLIPJ2000", "IMAP_DPS", et_times[1000])
+    spiceypy.furnsh(str(tmp_path / "imap_pointing_frame.bc"))
+    rotation_matrix_1 = spiceypy.pxform("ECLIPJ2000", "IMAP_DPS", et_times[100])
+    rotation_matrix_2 = spiceypy.pxform("ECLIPJ2000", "IMAP_DPS", et_times[1000])
 
     assert np.array_equal(rotation_matrix_1, rotation_matrix_2)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-import spiceypy as spice
+import spiceypy
 
 from imap_processing.spice.geometry import SpiceFrame
 from imap_processing.ultra.l1b.ultra_l1b_annotated import (
@@ -31,9 +31,9 @@ def kernels(spice_test_data_path):
 @pytest.mark.external_kernel()
 def test_get_particle_velocity(spice_test_data_path, kernels):
     """Tests get_particle_velocity function."""
-    spice.furnsh(kernels)
+    spiceypy.furnsh(kernels)
 
-    pointing_cover = spice.ckcov(
+    pointing_cover = spiceypy.ckcov(
         str(spice_test_data_path / "sim_1yr_imap_pointing_frame.bc"),
         SpiceFrame.IMAP_DPS.value,
         True,
@@ -42,7 +42,7 @@ def test_get_particle_velocity(spice_test_data_path, kernels):
         "TDB",
     )
     # Get start and end time of first interval
-    start, _ = spice.wnfetd(pointing_cover, 0)
+    start, _ = spiceypy.wnfetd(pointing_cover, 0)
 
     times = np.array([start])
     instrument_velocity = np.array([[41.18609, -471.24467, -832.8784]])
@@ -71,7 +71,7 @@ def test_get_particle_velocity(spice_test_data_path, kernels):
     magnitude_sc_90 = np.linalg.norm(sc_velocity_90)
     magnitude_dps_45 = np.linalg.norm(sc_dps_velocity_45)
     magnitude_dps_90 = np.linalg.norm(sc_dps_velocity_90)
-    state, lt = spice.spkezr("IMAP", times, "IMAP_DPS", "NONE", "SUN")
+    state, lt = spiceypy.spkezr("IMAP", times, "IMAP_DPS", "NONE", "SUN")
 
     assert np.allclose(magnitude_sc_45, magnitude_sc_90, atol=1e-6)
     assert np.allclose(magnitude_dps_45, magnitude_dps_90, atol=1e-6)

--- a/tools/spice/spice_examples.py
+++ b/tools/spice/spice_examples.py
@@ -9,7 +9,7 @@ https://spiceypy.readthedocs.io/en/main/documentation.html.
 import logging
 
 import numpy.typing as npt
-import spiceypy as spice
+import spiceypy
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -42,22 +42,22 @@ def get_attitude_timerange(ck_kernel: str, id: int) -> tuple:
 
     # Get the coverage window
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.ckcov
-    cover = spice.ckcov(ck_path, int(id), True, "SEGMENT", 0, "TDB")
+    cover = spiceypy.ckcov(ck_path, int(id), True, "SEGMENT", 0, "TDB")
 
     # TODO: Deal with gaps in coverage. For now, we use one interval.
     # How we interpolate may change when using type 2 kernels.
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.wncard
-    spice.wncard(cover)
+    spiceypy.wncard(cover)
 
     # Retrieve the start and end times of the coverage interval
     interval = 0
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.wnfetd
-    start, end = spice.wnfetd(cover, interval)
+    start, end = spiceypy.wnfetd(cover, interval)
 
     # Convert start and end times from ET to UTC for human readability
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.et2utc
-    start_utc = spice.et2utc(start, "C", 0)
-    end_utc = spice.et2utc(end, "C", 0)
+    start_utc = spiceypy.et2utc(start, "C", 0)
+    end_utc = spiceypy.et2utc(end, "C", 0)
 
     logger.info(f"Coverage Interval for ID {id}:")
     logger.info(f"Start Time (UTC): {start_utc}")
@@ -94,13 +94,13 @@ def _get_particle_velocity(
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.mxv
     # https://spiceypy.readthedocs.io/en/main/
     # documentation.html#spiceypy.spiceypy.pxform
-    dps_velocity = spice.mxv(
-        spice.pxform("IMAP_ULTRA_45", "IMAP_DPS", time), ultra_velocity
+    dps_velocity = spiceypy.mxv(
+        spiceypy.pxform("IMAP_ULTRA_45", "IMAP_DPS", time), ultra_velocity
     )
 
     # Spacecraft velocity in the DPS frame wrt the heliosphere
     # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.spkezr
-    state, lt = spice.spkezr("IMAP", time, "IMAP_DPS", "NONE", "SUN")
+    state, lt = spiceypy.spkezr("IMAP", time, "IMAP_DPS", "NONE", "SUN")
 
     # Extract the velocity part of the state vector
     imap_dps_velocity = state[3:6]
@@ -122,7 +122,7 @@ def build_annotated_events(direct_events: dict, kernels: list) -> None:
     kernels : list
         List of kernels to be loaded.
     """
-    with spice.KernelPool(kernels):
+    with spiceypy.KernelPool(kernels):
         # Hack: create time for IMAP_DPS frame
         # dps = despun reference frame.
         # TODO: compute the mean z-axis for a given pointing and
@@ -134,10 +134,10 @@ def build_annotated_events(direct_events: dict, kernels: list) -> None:
         # together a memo on how this will work.
 
         # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.pdpool
-        spice.pdpool("FRAME_-43906_FREEZE_EPOCH", [802094471.0])
+        spiceypy.pdpool("FRAME_-43906_FREEZE_EPOCH", [802094471.0])
 
         # https://spiceypy.readthedocs.io/en/main/documentation.html#spiceypy.spiceypy.et2utc
-        time_event = spice.et2utc(direct_events["tdb"], "C", 0)
+        time_event = spiceypy.et2utc(direct_events["tdb"], "C", 0)
 
         logger.info(f"Time (UTC): {time_event}")
 

--- a/tools/spice/spice_utils.py
+++ b/tools/spice/spice_utils.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Optional
 
-import spiceypy as spice
+import spiceypy
 
 logger = logging.getLogger(__name__)
 
@@ -58,11 +58,11 @@ def list_loaded_kernels(extensions: Optional[list[str]] = None) -> list:
     result : list
         A list of kernel filenames.
     """
-    count = spice.ktotal("ALL")
+    count = spiceypy.ktotal("ALL")
     result = []
 
     for i in range(count):
-        file, _, _, _ = spice.kdata(i, "ALL")
+        file, _, _, _ = spiceypy.kdata(i, "ALL")
         # Append the file if no specific extensions are provided
         if extensions is None:
             result.append(file)
@@ -88,18 +88,18 @@ def list_all_constants() -> dict:
     # start = 0, Which component to start retrieving for `name'.
     # room = 1000, The largest number of values to return.
     # n = 81, Number of values returned for `name'.
-    kernel_vars = spice.gnpool("*", 0, 1000, 81)
+    kernel_vars = spiceypy.gnpool("*", 0, 1000, 81)
 
     result = {}
     for kernel_var in sorted(kernel_vars):
         # retrieve data about a kernel variable
-        n, kernel_type = spice.dtpool(kernel_var)
+        n, kernel_type = spiceypy.dtpool(kernel_var)
         # numerical data type
         if kernel_type == "N":
-            values = spice.gdpool(kernel_var, 0, n)
+            values = spiceypy.gdpool(kernel_var, 0, n)
             result[kernel_var] = values
         # character data type
         elif kernel_type == "C":
-            values = spice.gcpool(kernel_var, 0, n, 81)
+            values = spiceypy.gcpool(kernel_var, 0, n, 81)
             result[kernel_var] = values
     return result

--- a/tools/tests/unit/test_spice_examples.py
+++ b/tools/tests/unit/test_spice_examples.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import spiceypy as spice
+import spiceypy
 
 from imap_processing import imap_module_directory
 from tools.spice.spice_examples import (
@@ -63,7 +63,7 @@ def direct_events():
 def test_get_attitude_timerange(kernels, kernel_directory):
     """Tests get_attitude_timerange function."""
 
-    with spice.KernelPool(kernels):
+    with spiceypy.KernelPool(kernels):
         ck_kernel = list_files_with_extensions(kernel_directory, [".ck"])
         start, end = get_attitude_timerange(ck_kernel, -43000)
 
@@ -74,14 +74,14 @@ def test_get_attitude_timerange(kernels, kernel_directory):
 def test_get_particle_velocity(direct_events, kernels, kernel_directory):
     """Tests the get_particle_velocity function."""
 
-    with spice.KernelPool(kernels):
+    with spiceypy.KernelPool(kernels):
         _get_particle_velocity(direct_events)
 
 
 @pytest.mark.xfail(reason="Download NAIF kernels")
 def test_build_annotated_events(direct_events, kernels, kernel_directory):
     """Tests the build_annotated_events function."""
-    spice.kclear()
+    spiceypy.kclear()
     kernels = list_files_with_extensions(
         kernel_directory, [".tsc", ".tls", ".tf", ".bsp", ".ck"]
     )

--- a/tools/tests/unit/test_spice_utils.py
+++ b/tools/tests/unit/test_spice_utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-import spiceypy as spice
+import spiceypy
 
 from tools.spice.spice_utils import (
     list_all_constants,
@@ -47,7 +47,7 @@ def test_list_loaded_kernels(kernels):
     """Tests the ``list_loaded_kernels`` function"""
     directory = Path(__file__).parent.parent / "test_data" / "spice"
 
-    with spice.KernelPool(kernels):
+    with spiceypy.KernelPool(kernels):
         result = list_loaded_kernels()
 
     expected = [
@@ -68,7 +68,7 @@ def test_list_all_constants():
     directory = Path(__file__).parent.parent / "test_data" / "spice"
     kernels = list_files_with_extensions(directory, [".tsc"])
 
-    with spice.KernelPool(kernels):
+    with spiceypy.KernelPool(kernels):
         result = list_all_constants()
 
     # Expected keys


### PR DESCRIPTION
# Change Summary

## Overview

The spiceypy package import can be left alone to avoid conflicts with our internal spice module name.

closes #1209
