### PR TITLE
BUG - fix to not write if no science or xr.dataset exists

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -400,6 +400,10 @@ class ProcessInstrument(ABC):
         datasets : list[xarray.Dataset]
             A list of datasets (products) produced by do_processing method.
         """
+        if len(datasets) == 0:
+            logger.info("No products to write to CDF file.")
+            return
+
         logger.info("Writing products to local storage")
         logger.info("Parent files: %s", self._dependency_list)
 
@@ -803,7 +807,7 @@ class Swe(ProcessInstrument):
                     f"Unexpected dependencies found for SWE L1A:"
                     f"{dependencies}. Expected only one dependency."
                 )
-            datasets = [swe_l1a(str(dependencies[0]), data_version=self.version)]
+            datasets = swe_l1a(str(dependencies[0]), data_version=self.version)
             # Right now, we only process science data. Therefore,
             # we expect only one dataset to be returned.
 
@@ -816,7 +820,7 @@ class Swe(ProcessInstrument):
             # read CDF file
             l1a_dataset = load_cdf(dependencies[0])
             # TODO: read lookup table and in-flight calibration data here.
-            datasets = [swe_l1b(l1a_dataset, data_version=self.version)]
+            datasets = swe_l1b(l1a_dataset, data_version=self.version)
         else:
             print("Did not recognize data level. No processing done.")
 

--- a/imap_processing/swe/l1a/swe_l1a.py
+++ b/imap_processing/swe/l1a/swe_l1a.py
@@ -42,7 +42,12 @@ def swe_l1a(packet_file: str, data_version: str) -> xr.Dataset:
         packet_file, xtce_document, use_derived_value=False
     )
 
+    if SWEAPID.SWE_SCIENCE not in datasets_by_apid:
+        logger.info("No science data found in packet file.")
+        return []
     # TODO: figure out how to handle non-science data
-    return swe_science(
-        l0_dataset=datasets_by_apid[SWEAPID.SWE_SCIENCE], data_version=data_version
-    )
+    return [
+        swe_science(
+            l0_dataset=datasets_by_apid[SWEAPID.SWE_SCIENCE], data_version=data_version
+        )
+    ]

--- a/imap_processing/swe/l1b/swe_l1b.py
+++ b/imap_processing/swe/l1b/swe_l1b.py
@@ -46,4 +46,5 @@ def swe_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     data = swe_l1b_science(eu_data, data_version)
     if data is None:
         logger.info("No data to write to CDF")
-    return data
+        return []
+    return [data]

--- a/imap_processing/tests/swe/test_swe_l1a.py
+++ b/imap_processing/tests/swe/test_swe_l1a.py
@@ -7,6 +7,6 @@ def test_cdf_creation():
     test_data_path = "tests/swe/l0_data/2024051010_SWE_SCIENCE_packet.bin"
     processed_data = swe_l1a(imap_module_directory / test_data_path, "001")
 
-    cem_raw_cdf_filepath = write_cdf(processed_data)
+    cem_raw_cdf_filepath = write_cdf(processed_data[0])
 
     assert cem_raw_cdf_filepath.name == "imap_swe_l1a_sci_20240510_v001.cdf"

--- a/imap_processing/tests/swe/test_swe_l1b.py
+++ b/imap_processing/tests/swe/test_swe_l1b.py
@@ -67,9 +67,9 @@ def test_cdf_creation(mock_read_in_flight_cal_data, l1b_validation_df):
     test_data_path = "tests/swe/l0_data/2024051010_SWE_SCIENCE_packet.bin"
     l1a_datasets = swe_l1a(imap_module_directory / test_data_path, "002")
 
-    l1b_dataset = swe_l1b(l1a_datasets, "002")
+    l1b_dataset = swe_l1b(l1a_datasets[0], "002")
 
-    sci_l1b_filepath = write_cdf(l1b_dataset)
+    sci_l1b_filepath = write_cdf(l1b_dataset[0])
 
     assert sci_l1b_filepath.name == "imap_swe_l1b_sci_20240510_v002.cdf"
     # load the CDF file and compare the values

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -133,8 +133,8 @@ def test_swe_l2(mock_read_in_flight_cal_data, use_fake_spin_data_for_time):
     test_data_path = "tests/swe/l0_data/2024051010_SWE_SCIENCE_packet.bin"
     l1a_datasets = swe_l1a(imap_module_directory / test_data_path, "002")
 
-    l1b_dataset = swe_l1b(l1a_datasets, "002")
-    l2_dataset = swe_l2(l1b_dataset, "002")
+    l1b_dataset = swe_l1b(l1a_datasets[0], "002")
+    l2_dataset = swe_l2(l1b_dataset[0], "002")
 
     assert type(l2_dataset) == xr.Dataset
     assert l2_dataset["spin_phase"].shape == (6, 24, 30)

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 import xarray as xr
 
-from imap_processing.cli import Codice, Hi, Hit, Ultra, _validate_args, main
+from imap_processing.cli import Codice, Hi, Hit, Swe, Ultra, _validate_args, main
 
 
 @pytest.fixture()
@@ -233,10 +233,14 @@ def test_hit_l1a(mock_hit_l1a, mock_instrument_dependencies):
     assert mocks["mock_upload"].call_count == 2
 
 
-@mock.patch("imap_processing.cli.hit_l1a")
-def test_post_processing(mock_hit_l1a, mock_instrument_dependencies):
+@mock.patch("imap_processing.cli.swe_l1a")
+def test_post_processing(mock_swe_l1a, mock_instrument_dependencies):
     """Test coverage for post processing"""
     mocks = mock_instrument_dependencies
+    mocks["mock_query"].return_value = [{"file_path": "/path/to/file0"}]
+    mocks["mock_download"].return_value = "dependency0"
+    # Return empty list to simulate no data to write
+    mock_swe_l1a.return_value = []
 
     dependency_str = (
         "[{"
@@ -247,7 +251,11 @@ def test_post_processing(mock_hit_l1a, mock_instrument_dependencies):
         "'start_date': '20100105'"
         "}]"
     )
-    instrument = Hit("l1a", "raw", dependency_str, "20100105", "20100101", "v001", True)
-    post_processing = instrument.post_processing([])
-    assert post_processing is None
+    instrument = Swe("l1a", "raw", dependency_str, "20100105", "20100101", "v001", True)
+
+    # This function calls both the instrument.do_processing() and
+    # instrument.post_processing()
+    instrument.process()
+    assert mock_swe_l1a.call_count == 1
+    # This test is testing that no upload happened
     assert mocks["mock_upload"].call_count == 0

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -231,3 +231,23 @@ def test_hit_l1a(mock_hit_l1a, mock_instrument_dependencies):
     assert mocks["mock_download"].call_count == 1
     assert mock_hit_l1a.call_count == 1
     assert mocks["mock_upload"].call_count == 2
+
+
+@mock.patch("imap_processing.cli.hit_l1a")
+def test_post_processing(mock_hit_l1a, mock_instrument_dependencies):
+    """Test coverage for post processing"""
+    mocks = mock_instrument_dependencies
+
+    dependency_str = (
+        "[{"
+        "'instrument': 'hit',"
+        "'data_level': 'l0',"
+        "'descriptor': 'raw',"
+        "'version': 'v001',"
+        "'start_date': '20100105'"
+        "}]"
+    )
+    instrument = Hit("l1a", "raw", dependency_str, "20100105", "20100101", "v001", True)
+    post_processing = instrument.post_processing([])
+    assert post_processing is None
+    assert mocks["mock_upload"].call_count == 0


### PR DESCRIPTION
# Change Summary
closes #1314 

## Overview
Minor PR to update cli to skip writing if list of data product is empty.

## Updated Files
- imap_processing/cli.py
   - skip writing
- imap_processing/swe/l1a/swe_l1a.py
- imap_processing/swe/l1b/swe_l1b.py
   - update return value

## Testing
imap_processing/tests/swe/test_swe_l1a.py
imap_processing/tests/swe/test_swe_l1b.py
imap_processing/tests/swe/test_swe_l2.py