### PR TITLE
FIX: Handle wrap-around in is_sequential check

### DIFF
--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -129,7 +129,7 @@ def is_sequential(counters: np.ndarray) -> np.bool_:
     bool
         True if the sequence counters are sequential, False otherwise.
     """
-    return np.all(np.diff(counters) == 1)
+    return np.all((np.diff(counters) % 16384) == 1)
 
 
 def get_valid_starting_indices(flags: np.ndarray, counters: np.ndarray) -> np.ndarray:

--- a/imap_processing/tests/hit/test_decom_hit.py
+++ b/imap_processing/tests/hit/test_decom_hit.py
@@ -125,12 +125,10 @@ def test_parse_count_rates(sci_dataset):
 
 def test_is_sequential():
     """Test the is_sequential function."""
-    counters = np.array([0, 1, 2, 3, 4])
-    if is_sequential(counters):
-        assert True
-    counters = np.array([0, 2, 3, 4, 5])
-    if not is_sequential(counters):
-        assert True
+    assert is_sequential(np.array([0, 1, 2, 3, 4]))
+    assert not is_sequential(np.array([0, 2, 3, 4, 5]))
+    # Wrap-around case
+    assert is_sequential(np.array([16382, 16383, 0, 1, 2]))
 
 
 def test_get_valid_starting_indices():


### PR DESCRIPTION
# Change Summary

## Overview

Sequence counters have a wrap-around at 16383 due to the limited number of bits allocated to that slot. This handles the ring math to account for sequential packets across the wrap.
closes #1304
