### PR TITLE
Download CoDICE L0 test file from AWS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           if [ "$RUN_EXTERNAL_KERNEL_MARK" = "true" ] || [ "$RUN_DOWNLOAD_TEST_DATA" = "true" ]; then
             poetry run pytest --color=yes --cov --cov-report=xml
           else
-            poetry run pytest --color=yes --cov --cov-report=xml -m "not external_kernel"
+            poetry run pytest --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"
           fi
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,10 @@ jobs:
       - name: Testing
         id: test
         env:
-          RUN_EXTERNAL_KERNEL_MARK: ${{ contains(matrix.os, 'ubuntu') && matrix.python-version == '3.9' }}
-          RUN_DOWNLOAD_TEST_DATA: ${{ contains(matrix.os, 'ubuntu') && matrix.python-version == '3.9' }}
+          USE_EXTERNAL_DATA: ${{ contains(matrix.os, 'ubuntu') && matrix.python-version == '3.9' }}
         run: |
           # Ignore the network marks from the remote test environment
-          if [ "$RUN_EXTERNAL_KERNEL_MARK" = "true" ] || [ "$RUN_DOWNLOAD_TEST_DATA" = "true" ]; then
+          if [ "$USE_EXTERNAL_DATA" = "true" ]; then
             poetry run pytest --color=yes --cov --cov-report=xml
           else
             poetry run pytest --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,10 @@ jobs:
         id: test
         env:
           RUN_EXTERNAL_KERNEL_MARK: ${{ contains(matrix.os, 'ubuntu') && matrix.python-version == '3.9' }}
+          RUN_DOWNLOAD_TEST_DATA: ${{ contains(matrix.os, 'ubuntu') && matrix.python-version == '3.9' }}
         run: |
           # Ignore the network marks from the remote test environment
-          if [ "$RUN_EXTERNAL_KERNEL_MARK" = "true" ]; then
+          if [ "$RUN_EXTERNAL_KERNEL_MARK" = "true" ] || [ "$RUN_DOWNLOAD_TEST_DATA" = "true" ]; then
             poetry run pytest --color=yes --cov --cov-report=xml
           else
             poetry run pytest --color=yes --cov --cov-report=xml -m "not external_kernel"

--- a/imap_processing/tests/codice/conftest.py
+++ b/imap_processing/tests/codice/conftest.py
@@ -1,4 +1,4 @@
-import requests
+import pytest
 
 from imap_processing import imap_module_directory
 
@@ -44,13 +44,21 @@ VALIDATION_DATA = [
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_hi-pha_20241110193700_v0.0.0.cdf",
 ]  # fmt: skip
 
-# Download CoDICE L0 test data and write it to the appropriate directory
-response = requests.get(
-    "https://api.dev.imap-mission.com/download/test_data/imap_codice_l0_raw_20241110_v001.pkts"
-)
-if response.status_code == 200:
-    with open(TEST_L0_FILE, "wb") as file:
-        file.write(response.content)
-    print(f"Downloaded file: {TEST_L0_FILE}")
-else:
-    print(f"Failed to download file: {response.status_code}")
+# # Download CoDICE L0 test data if necessary and write it to the appropriate directory
+# if not TEST_L0_FILE.exists():
+#     response = requests.get(
+#         "https://api.dev.imap-mission.com/download/test_data/imap_codice_l0_raw_20241110_v001.pkts"
+#     )
+#     if response.status_code == 200:
+#         with open(TEST_L0_FILE, "wb") as file:
+#             file.write(response.content)
+#         print(f"Downloaded file: {TEST_L0_FILE}")
+#     else:
+#         print(f"Failed to download file: {response.status_code}")
+
+
+@pytest.fixture(scope="session")
+def download_codice_test_data(_download_test_data):
+    """"""
+
+    return "foo"

--- a/imap_processing/tests/codice/conftest.py
+++ b/imap_processing/tests/codice/conftest.py
@@ -43,9 +43,3 @@ VALIDATION_DATA = [
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_lo-pha_20241110193700_v0.0.0.cdf",
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_hi-pha_20241110193700_v0.0.0.cdf",
 ]  # fmt: skip
-
-
-@pytest.fixture(scope="session")
-def ensure_test_data_download(_download_test_data):
-    """"""
-    pass

--- a/imap_processing/tests/codice/conftest.py
+++ b/imap_processing/tests/codice/conftest.py
@@ -1,5 +1,3 @@
-import pytest
-
 from imap_processing import imap_module_directory
 
 TEST_DATA_PATH = imap_module_directory / "tests" / "codice" / "data"

--- a/imap_processing/tests/codice/conftest.py
+++ b/imap_processing/tests/codice/conftest.py
@@ -1,3 +1,5 @@
+import requests
+
 from imap_processing import imap_module_directory
 
 TEST_DATA_PATH = imap_module_directory / "tests" / "codice" / "data"
@@ -41,3 +43,14 @@ VALIDATION_DATA = [
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_lo-pha_20241110193700_v0.0.0.cdf",
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_hi-pha_20241110193700_v0.0.0.cdf",
 ]  # fmt: skip
+
+# Download CoDICE L0 test data and write it to the appropriate directory
+response = requests.get(
+    "https://api.dev.imap-mission.com/download/test_data/imap_codice_l0_raw_20241110_v001.pkts"
+)
+if response.status_code == 200:
+    with open(TEST_L0_FILE, "wb") as file:
+        file.write(response.content)
+    print(f"Downloaded file: {TEST_L0_FILE}")
+else:
+    print(f"Failed to download file: {response.status_code}")

--- a/imap_processing/tests/codice/conftest.py
+++ b/imap_processing/tests/codice/conftest.py
@@ -1,3 +1,5 @@
+import pytest
+
 from imap_processing import imap_module_directory
 
 TEST_DATA_PATH = imap_module_directory / "tests" / "codice" / "data"
@@ -41,3 +43,9 @@ VALIDATION_DATA = [
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_lo-pha_20241110193700_v0.0.0.cdf",
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_hi-pha_20241110193700_v0.0.0.cdf",
 ]  # fmt: skip
+
+
+@pytest.fixture(scope="session")
+def ensure_test_data_download(_download_test_data):
+    """"""
+    pass

--- a/imap_processing/tests/codice/conftest.py
+++ b/imap_processing/tests/codice/conftest.py
@@ -1,5 +1,3 @@
-import pytest
-
 from imap_processing import imap_module_directory
 
 TEST_DATA_PATH = imap_module_directory / "tests" / "codice" / "data"
@@ -43,22 +41,3 @@ VALIDATION_DATA = [
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_lo-pha_20241110193700_v0.0.0.cdf",
     TEST_DATA_PATH / "validation" / "imap_codice_l1a_hi-pha_20241110193700_v0.0.0.cdf",
 ]  # fmt: skip
-
-# # Download CoDICE L0 test data if necessary and write it to the appropriate directory
-# if not TEST_L0_FILE.exists():
-#     response = requests.get(
-#         "https://api.dev.imap-mission.com/download/test_data/imap_codice_l0_raw_20241110_v001.pkts"
-#     )
-#     if response.status_code == 200:
-#         with open(TEST_L0_FILE, "wb") as file:
-#             file.write(response.content)
-#         print(f"Downloaded file: {TEST_L0_FILE}")
-#     else:
-#         print(f"Failed to download file: {response.status_code}")
-
-
-@pytest.fixture(scope="session")
-def download_codice_test_data(_download_test_data):
-    """"""
-
-    return "foo"

--- a/imap_processing/tests/codice/test_codice_l0.py
+++ b/imap_processing/tests/codice/test_codice_l0.py
@@ -12,6 +12,8 @@ from imap_processing.codice import codice_l0
 from imap_processing.codice.codice_l1a import create_hskp_dataset
 from imap_processing.utils import convert_raw_to_eu
 
+pytestmark = pytest.mark.external_test_data
+
 # Define the CCSDS header fields (which will be ignored in these tests)
 CCSDS_HEADER_FIELDS = [
     "shcoarse",

--- a/imap_processing/tests/codice/test_codice_l0.py
+++ b/imap_processing/tests/codice/test_codice_l0.py
@@ -28,7 +28,7 @@ CCSDS_HEADER_FIELDS = [
 
 
 @pytest.fixture(scope="session")
-def decom_test_data() -> xr.Dataset:
+def decom_test_data(_download_test_data) -> xr.Dataset:
     """Read test data from file and return a decommutated housekeeping packet.
 
     Returns

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -79,6 +79,7 @@ EXPECTED_NUM_VARIABLES = [
 ]
 
 
+@pytest.mark.download_test_data()
 @pytest.fixture(scope="session")
 def test_l1a_data() -> xr.Dataset:
     """Return a ``xarray`` dataset containing test data.
@@ -94,6 +95,7 @@ def test_l1a_data() -> xr.Dataset:
     return processed_datasets
 
 
+@pytest.mark.download_test_data()
 @pytest.mark.parametrize("index", range(len(EXPECTED_ARRAY_SHAPES)))
 def test_l1a_data_array_shape(test_l1a_data, index):
     """Tests that the data arrays in the generated CDFs have the expected shape.
@@ -135,6 +137,7 @@ def test_l1a_data_array_shape(test_l1a_data, index):
             assert processed_dataset[variable].data.shape == expected_shape
 
 
+@pytest.mark.download_test_data()
 @pytest.mark.parametrize("index", range(len(DESCRIPTORS)))
 def test_l1a_logical_sources(test_l1a_data, index):
     """Tests that the Logical source of the dataset is what is expected.
@@ -164,6 +167,7 @@ def test_l1a_logical_sources(test_l1a_data, index):
     assert processed_dataset.attrs["Logical_source"] == expected_logical_source
 
 
+@pytest.mark.download_test_data()
 @pytest.mark.parametrize("index", range(len(EXPECTED_NUM_VARIABLES)))
 def test_l1a_num_data_variables(test_l1a_data, index):
     """Tests that the generated CDFs have the expected number of data variables.
@@ -189,6 +193,7 @@ def test_l1a_num_data_variables(test_l1a_data, index):
     assert len(processed_dataset) == EXPECTED_NUM_VARIABLES[index]
 
 
+@pytest.mark.download_test_data()
 @pytest.mark.parametrize("index", range(len(VALIDATION_DATA)))
 def test_l1a_validate_data_arrays(test_l1a_data: xr.Dataset, index):
     """Tests that the generated L1a CDF data array contents are valid.
@@ -223,6 +228,7 @@ def test_l1a_validate_data_arrays(test_l1a_data: xr.Dataset, index):
         pytest.xfail(f"Still need to implement validation for {descriptor}")
 
 
+@pytest.mark.download_test_data()
 def test_l1a_multiple_packets():
     """Tests that an input L0 file containing multiple APIDs can be processed."""
 

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -15,6 +15,8 @@ from .conftest import TEST_L0_FILE, VALIDATION_DATA
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+pytestmark = pytest.mark.external_test_data
+
 DESCRIPTORS = [
     "hi-ialirt",
     "lo-ialirt",
@@ -79,7 +81,6 @@ EXPECTED_NUM_VARIABLES = [
 ]
 
 
-@pytest.mark.download_test_data()
 @pytest.fixture(scope="session")
 def test_l1a_data() -> xr.Dataset:
     """Return a ``xarray`` dataset containing test data.
@@ -95,7 +96,6 @@ def test_l1a_data() -> xr.Dataset:
     return processed_datasets
 
 
-@pytest.mark.download_test_data()
 @pytest.mark.parametrize("index", range(len(EXPECTED_ARRAY_SHAPES)))
 def test_l1a_data_array_shape(test_l1a_data, index):
     """Tests that the data arrays in the generated CDFs have the expected shape.
@@ -137,7 +137,6 @@ def test_l1a_data_array_shape(test_l1a_data, index):
             assert processed_dataset[variable].data.shape == expected_shape
 
 
-@pytest.mark.download_test_data()
 @pytest.mark.parametrize("index", range(len(DESCRIPTORS)))
 def test_l1a_logical_sources(test_l1a_data, index):
     """Tests that the Logical source of the dataset is what is expected.
@@ -167,7 +166,6 @@ def test_l1a_logical_sources(test_l1a_data, index):
     assert processed_dataset.attrs["Logical_source"] == expected_logical_source
 
 
-@pytest.mark.download_test_data()
 @pytest.mark.parametrize("index", range(len(EXPECTED_NUM_VARIABLES)))
 def test_l1a_num_data_variables(test_l1a_data, index):
     """Tests that the generated CDFs have the expected number of data variables.
@@ -193,7 +191,6 @@ def test_l1a_num_data_variables(test_l1a_data, index):
     assert len(processed_dataset) == EXPECTED_NUM_VARIABLES[index]
 
 
-@pytest.mark.download_test_data()
 @pytest.mark.parametrize("index", range(len(VALIDATION_DATA)))
 def test_l1a_validate_data_arrays(test_l1a_data: xr.Dataset, index):
     """Tests that the generated L1a CDF data array contents are valid.
@@ -228,7 +225,6 @@ def test_l1a_validate_data_arrays(test_l1a_data: xr.Dataset, index):
         pytest.xfail(f"Still need to implement validation for {descriptor}")
 
 
-@pytest.mark.download_test_data()
 def test_l1a_multiple_packets():
     """Tests that an input L0 file containing multiple APIDs can be processed."""
 

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -91,7 +91,7 @@ def _download_external_kernels(spice_test_data_path):
                     raise
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def _download_test_data(test_data_paths):
     """"""
 

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -91,7 +91,7 @@ def _download_external_kernels(spice_test_data_path):
                     raise
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def _download_test_data(test_data_paths):
     """"""
 
@@ -140,8 +140,8 @@ def pytest_collection_modifyitems(items):
     | pytest mark         | fixture added              |
     +=====================+============================+
     | external_kernel     | _download_external_kernels |
-    | use_test_metakernel | use_test_metakernel        |
     | external_test_data  | _download_test_data        |
+    | use_test_metakernel | use_test_metakernel        |
     +---------------------+----------------------------+
 
     Notes
@@ -152,8 +152,8 @@ def pytest_collection_modifyitems(items):
     """
     markers_to_fixtures = {
         "external_kernel": "_download_external_kernels",
-        "use_test_metakernel": "use_test_metakernel",
         "external_test_data": "_download_test_data",
+        "use_test_metakernel": "use_test_metakernel",
     }
 
     for item in items:

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -91,7 +91,7 @@ def _download_external_kernels(spice_test_data_path):
                     raise
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def _download_test_data(test_data_paths):
     """"""
 

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -139,7 +139,7 @@ def pytest_collection_modifyitems(items):
     +=====================+============================+
     | external_kernel     | _download_external_kernels |
     | use_test_metakernel | use_test_metakernel        |
-    | download_test_data  | _download_test_data        |
+    | external_test_data  | _download_test_data        |
     +---------------------+----------------------------+
 
     Notes
@@ -151,7 +151,7 @@ def pytest_collection_modifyitems(items):
     markers_to_fixtures = {
         "external_kernel": "_download_external_kernels",
         "use_test_metakernel": "use_test_metakernel",
-        "download_test_data": "_download_test_data",
+        "external_test_data": "_download_test_data",
     }
 
     for item in items:

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -93,7 +93,11 @@ def _download_external_kernels(spice_test_data_path):
 
 @pytest.fixture(scope="session")
 def _download_test_data(test_data_paths):
-    """"""
+    """This fixture downloads externally-located test data files into a specific
+    location. The list of files and their storage locations are specified in
+    the `test_data_paths` parameter, which is a list of tuples; the zeroth
+    element being the source of the test file in the AWS S3 bucket, and the
+    first element being the location in which to store the downloaded file."""
 
     logger = logging.getLogger(__name__)
 
@@ -117,6 +121,8 @@ def _download_test_data(test_data_paths):
 
 @pytest.fixture(scope="session")
 def test_data_paths():
+    """Defines a list of test data files to download from the AWS S3 bucket
+    and the corresponding location in which to store the downloaded file"""
     test_data_path_list = [
         (
             "https://api.dev.imap-mission.com/download/test_data/imap_codice_l0_raw_20241110_v001.pkts",

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -95,6 +95,8 @@ def _download_external_kernels(spice_test_data_path):
 def _download_test_data(test_data_paths):
     """"""
 
+    logger = logging.getLogger(__name__)
+
     for test_data_path in test_data_paths:
         source = test_data_path[0]
         destination = test_data_path[1]
@@ -106,11 +108,11 @@ def _download_test_data(test_data_paths):
             if response.status_code == 200:
                 with open(destination, "wb") as file:
                     file.write(response.content)
-                print(f"Downloaded file: {source}")
+                logger.info(f"Downloaded file: {source}")
             else:
-                print(f"Failed to download file: {response.status_code}")
+                logger.error(f"Failed to download file: {response.status_code}")
         else:
-            print(f"File already exists: {source}")
+            logger.info(f"File already exists: {destination}")
 
 
 @pytest.fixture(scope="session")

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -91,6 +91,43 @@ def _download_external_kernels(spice_test_data_path):
                     raise
 
 
+@pytest.fixture(scope="session")
+def _download_test_data(test_data_paths):
+    """"""
+
+    for test_data_path in test_data_paths:
+        source = test_data_path[0]
+        destination = test_data_path[1]
+
+        # Download the test data if necessary and write it to the appropriate
+        # directory
+        if not destination.exists():
+            response = requests.get(source, timeout=60)
+            if response.status_code == 200:
+                with open(destination, "wb") as file:
+                    file.write(response.content)
+                print(f"Downloaded file: {source}")
+            else:
+                print(f"Failed to download file: {response.status_code}")
+        else:
+            print(f"File already exists: {source}")
+
+
+@pytest.fixture(scope="session")
+def test_data_paths():
+    test_data_path_list = [
+        (
+            "https://api.dev.imap-mission.com/download/test_data/imap_codice_l0_raw_20241110_v001.pkts",
+            imap_module_directory
+            / "tests"
+            / "codice"
+            / "data"
+            / "imap_codice_l0_raw_20241110_v001.pkts",
+        ),
+    ]
+    return test_data_path_list
+
+
 def pytest_collection_modifyitems(items):
     """
     The use of this hook allows modification of test `Items` after tests have
@@ -102,6 +139,7 @@ def pytest_collection_modifyitems(items):
     +=====================+============================+
     | external_kernel     | _download_external_kernels |
     | use_test_metakernel | use_test_metakernel        |
+    | download_test_data  | _download_test_data        |
     +---------------------+----------------------------+
 
     Notes
@@ -110,11 +148,16 @@ def pytest_collection_modifyitems(items):
     pytest hook:
     https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_collection_modifyitems
     """
+    markers_to_fixtures = {
+        "external_kernel": "_download_external_kernels",
+        "use_test_metakernel": "use_test_metakernel",
+        "download_test_data": "_download_test_data",
+    }
+
     for item in items:
-        if item.get_closest_marker("external_kernel") is not None:
-            item.fixturenames.append("_download_external_kernels")
-        if item.get_closest_marker("use_test_metakernel") is not None:
-            item.fixturenames.append("use_test_metakernel")
+        for marker, fixture in markers_to_fixtures.items():
+            if item.get_closest_marker(marker) is not None:
+                item.fixturenames.append(fixture)
 
 
 @pytest.fixture(scope="session")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ filterwarnings = [
 ]
 markers = [
     "external_kernel: marks tests as requiring external SPICE kernels (deselect with '-m \"not external_kernel\"')",
+    "external_test_data: marks tests as requiring external test data (deselect with '-m \"not external_test_data\"')",
     "use_test_metakernel: Mark test to use a test metakernel"
 ]
 


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds code to the CoDICE test suite to download the (rather large) test L0 file from AWS via the API instead of storing the file in the repository.

## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->
- `imap_processing/tests/codice/data/imap_codice_l0_raw_20241110_v001.pkts`
   - Removed test file from repo

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- `imap_processing/tests/codice/conftest.py`
    - Added code to retrieve and store test L0 file from the AWS S3 bucket 
