### PR TITLE
fix: restrict poetry version for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,6 @@ FROM mcr.microsoft.com/devcontainers/python:3.11
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get install -y libgtk-3-dev
 
 # Installs poetry and ipython
-RUN pip install poetry ipython
+RUN pip install "poetry>=1.0.0,<2.0" ipython
 
 WORKDIR /workspaces/imap_processing


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Updated devcontainer Dockerfile to install version of `poetry` supported by application.

## New Dependencies
<!--List any new dependencies introduced by these changes-->
N/A

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
N/A

## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->
N/A

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- `devcontainer/Dockerfile`

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Verified building of docker container is successful.