### PR TITLE
HIT - Fix dimension name

### DIFF
--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -90,9 +90,9 @@ def parse_count_rates(sci_dataset: xr.Dataset) -> None:
         # Get dims for data variables (yaml file not created yet)
         if len(field_meta.shape) > 1:
             if "sectorates" in field:
-                # Reshape data to 8x15 for declination and azimuth look directions
+                # Reshape data to 8x15 for declination and inclination look directions
                 parsed_data = np.array(parsed_data).reshape((-1, *field_meta.shape))
-                dims = ["epoch", "declination", "azimuth"]
+                dims = ["epoch", "declination", "inclination"]
             elif "sngrates" in field:
                 dims = ["epoch", "gain", f"{field}_index"]
         elif field_meta.shape[0] > 1:

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -84,7 +84,7 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
 
     The data is added to the dataset as new data fields named
     according to their species. They have 4 dimensions: epoch
-    energy index, declination, and azimuth. The energy index
+    energy index, declination, and inclination. The energy index
     dimension is used to distinguish between the different energy
     ranges the data belongs to. The energy min and max values for
     each species are also added to the dataset as new data fields.
@@ -131,15 +131,15 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
 
     # Add sector rates by species to the dataset
     for species_type, data in data_by_species.items():
-        # Rates data has shape: energy_index, epoch, declination, azimuth
+        # Rates data has shape: energy_index, epoch, declination, inclination
         # Convert rates to numpy array and transpose axes to get
-        # shape: epoch, energy_index, declination, azimuth
+        # shape: epoch, energy_index, declination, inclination
         rates_data = np.transpose(np.array(data["rates"]), axes=(1, 0, 2, 3))
 
         species = species_type.lower()
         sci_dataset[f"{species}_counts_sectored"] = xr.DataArray(
             data=rates_data,
-            dims=["epoch", f"{species}_energy_index", "declination", "azimuth"],
+            dims=["epoch", f"{species}_energy_index", "declination", "inclination"],
             name=f"{species}_counts_sectored",
         )
         sci_dataset[f"{species}_energy_min"] = xr.DataArray(

--- a/imap_processing/tests/hit/helpers/l1a_validation.py
+++ b/imap_processing/tests/hit/helpers/l1a_validation.py
@@ -317,7 +317,7 @@ def compare_data(expected_data, actual_data, skip):
                     # validation data. In the actual data, sector rates are organized
                     # by species in 4D arrays with energy index as a dimension.
                     #    i.e. h_counts_sectored has shape
-                    #         (epoch, h_energy_index, declination, azimuth).
+                    #         (epoch, h_energy_index, declination, inclination).
                     # species and energy index are used to find the correct
                     # array of sector rate data from the actual data for comparison.
                     species = expected_data[field][frame]

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -279,4 +279,3 @@ def test_hit_l1a(hk_packet_filepath, sci_packet_filepath):
                 processed_datasets[1].attrs["Logical_source"]
                 == "imap_hit_l1a_pulse-height-events"
             )
-    print(processed_datasets[0].coords)

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -279,3 +279,4 @@ def test_hit_l1a(hk_packet_filepath, sci_packet_filepath):
                 processed_datasets[1].attrs["Logical_source"]
                 == "imap_hit_l1a_pulse-height-events"
             )
+    print(processed_datasets[0].coords)


### PR DESCRIPTION
This PR is for a small change to update the coordinate and dimension name `azimuth` to `inclination` requested by the HIT team. Inclination is used in the algorithm document, but azimuth is used in the telemetry file. 

## Updated Files
- decom_hit.py
   - updated variable name and documentation references
- hit_l1a.py
   - updated variable name and documentation references
- l1a_validation.py
   - updated documentation

Closes #1348 
