### PR TITLE
SWE: Put data into spin angle bins and add remaining CDF attrs

### DIFF
--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -39,12 +39,12 @@ inst_az:
   CATDESC: Spin angle bins in instrument frame. Angle resolution is 12 degree nominally
   FIELDNAM: spin angle
   FILLVAL: -9223370000000000000
-  FORMAT: I3
+  FORMAT: E5.4
   LABLAXIS: Angle
   SCALE_TYP: linear
   UNITS: "Degree"
-  VALIDMAX: 360
-  VALIDMIN: 0
+  VALIDMAX: 359.999
+  VALIDMIN: 0.00
   VAR_TYPE: support_data
   VAR_NOTES: >
     Bin CENTERS  - Assuming 0.5 sec measurements and a spin starting
@@ -68,7 +68,7 @@ inst_el:
   CATDESC: Angle of each CEM detectors
   FIELDNAM: CEM Angle
   FILLVAL: -9223370000000000000
-  FORMAT: E14.7
+  FORMAT: I2
   LABLAXIS: Angle
   SCALE_TYP: linear
   UNITS: Degree
@@ -127,19 +127,22 @@ inst_el_label:
   VAR_TYPE: metadata
 
 # <=== Data Variables ===>
-# Default Attrs for all data variables unless overridden
 
-default_attrs: &default
+inst_az_spin_sector:
+  CATDESC: Spin angle organized by voltage step and spin sector
   DEPEND_0: epoch
-  DISPLAY_TYPE: 'no_plot'
-  LABLAXIS: ' '
-  FILLVAL: -9223372036854775808
-  FORMAT: I19
-  UNITS: ' '
-  VALIDMIN: 0
-  VALIDMAX: 9223372036854769664
-  VAR_TYPE: support_data
-  SCALETYP: linear
+  DEPEND_1: esa_step
+  DEPEND_2: spin_sector
+  LABL_PTR_1: esa_step_label
+  LABL_PTR_2: spin_sector_label
+  DISPLAY_TYPE: spectrogram
+  FIELDNAM: Spin Angle
+  FILLVAL: -1.0000000E+31
+  FORMAT: E4.5
+  UNITS: Degree
+  VALIDMAX: 359.99
+  VALIDMIN: 0.0
+  VAR_TYPE: data
 
 phase_space_density_spin_sector:
   CATDESC: Phase space density organized by voltage step and spin sector and CEM
@@ -154,6 +157,7 @@ phase_space_density_spin_sector:
   FIELDNAM: Phase Space Density
   FILLVAL: -1.0000000E+31
   UNITS: s^3/ (cm^6 * ster)
+  FORMAT: E14.7
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
@@ -171,6 +175,7 @@ phase_space_density:
   FIELDNAM: Phase Space Density
   FILLVAL: -1.0000000E+31
   UNITS: s^3/ (cm^6 * ster)
+  FORMAT: E14.7
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
@@ -188,6 +193,7 @@ flux_spin_sector:
   FIELDNAM: Flux
   FILLVAL: -1.0000000E+31
   UNITS: 1 / (2 * eV * cm^2 * s * ster)
+  FORMAT: E14.7
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
@@ -205,6 +211,7 @@ flux:
   FIELDNAM: Flux
   FILLVAL: -1.0000000E+31
   UNITS: 1 / (2 * eV * cm^2 * s * ster)
+  FORMAT: E14.7
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
@@ -219,6 +226,9 @@ acquisition_time:
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Acquisition time by volt step and spin sector
   FILLVAL: -1.0000000E+31
+  FORMAT: I20
+  VALIDMAX: 9223372036854775807
+  VALIDMIN: 0
   UNITS: sec
   VAR_TYPE: support_data
   VAR_NOTES: >

--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -36,7 +36,7 @@ spin_sector:
   VAR_TYPE: support_data
 
 inst_az:
-  CATDESC: Spin angle bins. Angle resolution is 12 degree nominally
+  CATDESC: Spin angle bins in instrument frame. Angle resolution is 12 degree nominally
   FIELDNAM: spin angle
   FILLVAL: -9223370000000000000
   FORMAT: I3

--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -108,6 +108,24 @@ cem_id_label:
   FORMAT: A1
   VAR_TYPE: metadata
 
+energy_label:
+  CATDESC: Energy of the particle in eV
+  FIELDNAM: Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+inst_az_label:
+  CATDESC: Spin angle bins in instrument frame. Angle resolution is 12 degree nominally
+  FIELDNAM: Spin Angle
+  FORMAT: A3
+  VAR_TYPE: metadata
+
+inst_el_label:
+  CATDESC: Angle of each CEM detectors
+  FIELDNAM: CEM Angle
+  FORMAT: A3
+  VAR_TYPE: metadata
+
 # <=== Data Variables ===>
 # Default Attrs for all data variables unless overridden
 
@@ -135,7 +153,24 @@ phase_space_density_spin_sector:
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Phase Space Density
   FILLVAL: -1.0000000E+31
-  UNITS: " "
+  UNITS: s^3/ (cm^6 * ster)
+  VALIDMAX: 0.000015514
+  VALIDMIN: 0
+  VAR_TYPE: data
+
+phase_space_density:
+  CATDESC: Phase space density organized by energy(eV) and spin angle and CEM angle
+  DEPEND_0: epoch
+  DEPEND_1: energy
+  DEPEND_2: inst_az
+  DEPEND_3: inst_el
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: inst_az_label
+  LABL_PTR_3: inst_el_label
+  DISPLAY_TYPE: spectrogram
+  FIELDNAM: Phase Space Density
+  FILLVAL: -1.0000000E+31
+  UNITS: s^3/ (cm^6 * ster)
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
@@ -152,7 +187,24 @@ flux_spin_sector:
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Flux
   FILLVAL: -1.0000000E+31
-  UNITS: " "
+  UNITS: 1 / (2 * eV * cm^2 * s * ster)
+  VALIDMAX: 0.000015514
+  VALIDMIN: 0
+  VAR_TYPE: data
+
+flux:
+  CATDESC: Flux organized by energy(eV) and spin angle and CEM angle
+  DEPEND_0: epoch
+  DEPEND_1: energy
+  DEPEND_2: inst_az
+  DEPEND_3: inst_el
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: inst_az_label
+  LABL_PTR_3: inst_el_label
+  DISPLAY_TYPE: spectrogram
+  FIELDNAM: Flux
+  FILLVAL: -1.0000000E+31
+  UNITS: 1 / (2 * eV * cm^2 * s * ster)
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data

--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -11,17 +11,45 @@ esa_step:
   VALIDMIN: 0
   VAR_TYPE: support_data
 
-spin_angle:
-  CATDESC: Spin angle. Angle resolution is 12 degree nominally
-  FIELDNAM: spin angle
+energy:
+  CATDESC: Energy of the particle in eV
+  FIELDNAM: Energy (eV)
+  FILLVAL: -9223370000000000000
+  FORMAT: E5.4
+  LABLAXIS: Energy
+  SCALE_TYP: linear
+  UNITS: eV
+  VALIDMAX: 2000.0
+  VALIDMIN: 0.0
+  VAR_TYPE: support_data
+
+spin_sector:
+  CATDESC: Spin sector. 30 measurements nominally
+  FIELDNAM: Spin Sector
   FILLVAL: -9223370000000000000
   FORMAT: I2
-  LABLAXIS: Angle
+  LABLAXIS: Spin Sector
   SCALE_TYP: linear
-  UNITS: "Degree"
+  UNITS: " "
   VALIDMAX: 29
   VALIDMIN: 0
   VAR_TYPE: support_data
+
+inst_az:
+  CATDESC: Spin angle bins. Angle resolution is 12 degree nominally
+  FIELDNAM: spin angle
+  FILLVAL: -9223370000000000000
+  FORMAT: I3
+  LABLAXIS: Angle
+  SCALE_TYP: linear
+  UNITS: "Degree"
+  VALIDMAX: 360
+  VALIDMIN: 0
+  VAR_TYPE: support_data
+  VAR_NOTES: >
+    Bin CENTERS  - Assuming 0.5 sec measurements and a spin starting
+    at Angle=0, these are the angles at the middle of each measurement
+    bin.
 
 cem_id:
   CATDESC: Data of each CEM detectors
@@ -36,16 +64,16 @@ cem_id:
   VAR_NOTES: " "
   VAR_TYPE: support_data
 
-spin_sector:
-  CATDESC: Spin sector. 30 measurements nominally
-  FIELDNAM: Spin Sector
+inst_el:
+  CATDESC: Angle of each CEM detectors
+  FIELDNAM: CEM Angle
   FILLVAL: -9223370000000000000
-  FORMAT: I2
-  LABLAXIS: Spin Sector
+  FORMAT: E14.7
+  LABLAXIS: Angle
   SCALE_TYP: linear
-  UNITS: " "
-  VALIDMAX: 29
-  VALIDMIN: 0
+  UNITS: Degree
+  VALIDMAX: 63
+  VALIDMIN: -63
   VAR_TYPE: support_data
 
 cycle:

--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -52,7 +52,7 @@ inst_az:
     bin.
 
 cem_id:
-  CATDESC: Data of each CEM detectors
+  CATDESC: Data of each CEM detector
   FIELDNAM: CEM data
   FILLVAL: -9223370000000000000
   FORMAT: E14.7
@@ -65,7 +65,7 @@ cem_id:
   VAR_TYPE: support_data
 
 inst_el:
-  CATDESC: Angle of each CEM detectors
+  CATDESC: Angle of each CEM detector
   FIELDNAM: CEM Angle
   FILLVAL: -9223370000000000000
   FORMAT: I2
@@ -103,7 +103,7 @@ spin_sector_label:
   VAR_TYPE: metadata
 
 cem_id_label:
-  CATDESC: Data rates of each CEM detectors
+  CATDESC: Data rates of each CEM detector
   FIELDNAM: CEM Rates
   FORMAT: A1
   VAR_TYPE: metadata
@@ -121,7 +121,7 @@ inst_az_label:
   VAR_TYPE: metadata
 
 inst_el_label:
-  CATDESC: Angle of each CEM detectors
+  CATDESC: Angle of each CEM detector
   FIELDNAM: CEM Angle
   FORMAT: A3
   VAR_TYPE: metadata
@@ -156,14 +156,14 @@ phase_space_density_spin_sector:
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Phase Space Density
   FILLVAL: -1.0000000E+31
-  UNITS: s^3/ (cm^6 * ster)
+  UNITS: s^3 / (cm^6 * ster)
   FORMAT: E14.7
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
 
 phase_space_density:
-  CATDESC: Phase space density organized by energy(eV) and spin angle and CEM angle
+  CATDESC: Phase space density organized by energy (eV), spin angle, CEM angle
   DEPEND_0: epoch
   DEPEND_1: energy
   DEPEND_2: inst_az
@@ -174,7 +174,7 @@ phase_space_density:
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Phase Space Density
   FILLVAL: -1.0000000E+31
-  UNITS: s^3/ (cm^6 * ster)
+  UNITS: s^3 / (cm^6 * ster)
   FORMAT: E14.7
   VALIDMAX: 0.000015514
   VALIDMIN: 0
@@ -199,7 +199,7 @@ flux_spin_sector:
   VAR_TYPE: data
 
 flux:
-  CATDESC: Flux organized by energy(eV) and spin angle and CEM angle
+  CATDESC: Flux organized by energy (eV), spin angle, CEM angle
   DEPEND_0: epoch
   DEPEND_1: energy
   DEPEND_2: inst_az

--- a/imap_processing/swe/l1b/swe_l1b_science.py
+++ b/imap_processing/swe/l1b/swe_l1b_science.py
@@ -328,14 +328,9 @@ def populate_full_cycle_data(
 
             # Each quarter cycle data should have same acquisition start time coarse
             # and fine value. We will use that as base time to calculate each
-            # acquisition time for each count data. Acquisition time of each count
-            # data point will be calculated using this formula:
+            # acquisition time for each count data.
             #   base_quarter_cycle_acq_time = acq_start_coarse +
             #                                 acq_start_fine / 1000000
-            #   each_count_acq_time = base_quarter_cycle_acq_time +
-            #                         (step * ( acq_duration + settle_duration) / 1000 )
-            # where step goes from 0 to 179, acq_start_coarse is in seconds and
-            # acq_start_fine is in microseconds and acq_duration is in milliseconds.
             base_quarter_cycle_acq_time = (
                 l1a_data["acq_start_coarse"].data[packet_index + index]
                 + l1a_data["acq_start_fine"].data[packet_index + index] / 1000000
@@ -356,10 +351,18 @@ def populate_full_cycle_data(
                 full_cycle_data[esa_voltage_row_index][column_index] = corrected_counts[
                     step
                 ]
-                # Put acquisition time in acquisition_times array
+                # Acquisition time of each count data point will be calculated
+                # using this formula:
+                #   each_count_acq_time = base_quarter_cycle_acq_time +
+                #            (step * ( acq_duration + settle_duration) / 1000 )
+                # where step goes from 0 to 179, acq_start_coarse is in seconds and
+                # acq_start_fine is in microseconds and acq_duration is in milliseconds.
+                # To calculate center time of data acquisition time, we will add
+                #   each_count_acq_time + (acq_duration / 1000) / 2
                 acquisition_times[esa_voltage_row_index][column_index] = (
                     base_quarter_cycle_acq_time
                     + (step * (acq_duration + settle_duration) / 1000)
+                    + (acq_duration / 1000) / 2
                 )
                 # Store acquisition duration for later calculation
                 acq_duration_arr[esa_voltage_row_index][column_index] = acq_duration

--- a/imap_processing/swe/l1b/swe_l1b_science.py
+++ b/imap_processing/swe/l1b/swe_l1b_science.py
@@ -8,37 +8,12 @@ import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.swe.utils.swe_utils import read_lookup_table
+from imap_processing.swe.utils.swe_utils import (
+    ESA_VOLTAGE_ROW_INDEX_DICT,
+    read_lookup_table,
+)
 
 logger = logging.getLogger(__name__)
-
-# ESA voltage and index in the final data table
-esa_voltage_row_index_dict = {
-    0.56: 0,
-    0.78: 1,
-    1.08: 2,
-    1.51: 3,
-    2.10: 4,
-    2.92: 5,
-    4.06: 6,
-    5.64: 7,
-    7.85: 8,
-    10.92: 9,
-    15.19: 10,
-    21.13: 11,
-    29.39: 12,
-    40.88: 13,
-    56.87: 14,
-    79.10: 15,
-    110.03: 16,
-    153.05: 17,
-    212.89: 18,
-    296.14: 19,
-    411.93: 20,
-    572.99: 21,
-    797.03: 22,
-    1108.66: 23,
-}
 
 
 def get_esa_dataframe(esa_table_number: int) -> pd.DataFrame:
@@ -342,7 +317,7 @@ def populate_full_cycle_data(
                 # Get esa voltage value from esa lookup table and
                 # use that to get row index in full data array
                 esa_voltage_value = esa_lookup_table.loc[esa_step_number]["esa_v"]
-                esa_voltage_row_index = esa_voltage_row_index_dict[esa_voltage_value]
+                esa_voltage_row_index = ESA_VOLTAGE_ROW_INDEX_DICT[esa_voltage_value]
 
                 # every six steps, increment column index
                 if esa_step_number % 6 == 0:
@@ -357,12 +332,9 @@ def populate_full_cycle_data(
                 #            (step * ( acq_duration + settle_duration) / 1000 )
                 # where step goes from 0 to 179, acq_start_coarse is in seconds and
                 # acq_start_fine is in microseconds and acq_duration is in milliseconds.
-                # To calculate center time of data acquisition time, we will add
-                #   each_count_acq_time + (acq_duration / 1000) / 2
                 acquisition_times[esa_voltage_row_index][column_index] = (
                     base_quarter_cycle_acq_time
                     + (step * (acq_duration + settle_duration) / 1000)
-                    + (acq_duration / 1000) / 2
                 )
                 # Store acquisition duration for later calculation
                 acq_duration_arr[esa_voltage_row_index][column_index] = acq_duration

--- a/imap_processing/swe/l1b/swe_l1b_science.py
+++ b/imap_processing/swe/l1b/swe_l1b_science.py
@@ -326,7 +326,7 @@ def populate_full_cycle_data(
                 full_cycle_data[esa_voltage_row_index][column_index] = corrected_counts[
                     step
                 ]
-                # Acquisition time of each count data point will be calculated
+                # Acquisition time (in seconds) of each count data point will be
                 # using this formula:
                 #   each_count_acq_time = base_quarter_cycle_acq_time +
                 #            (step * ( acq_duration + settle_duration) / 1000000 )

--- a/imap_processing/swe/l1b/swe_l1b_science.py
+++ b/imap_processing/swe/l1b/swe_l1b_science.py
@@ -329,12 +329,12 @@ def populate_full_cycle_data(
                 # Acquisition time of each count data point will be calculated
                 # using this formula:
                 #   each_count_acq_time = base_quarter_cycle_acq_time +
-                #            (step * ( acq_duration + settle_duration) / 1000 )
+                #            (step * ( acq_duration + settle_duration) / 1000000 )
                 # where step goes from 0 to 179, acq_start_coarse is in seconds and
-                # acq_start_fine is in microseconds and acq_duration is in milliseconds.
+                # acq_start_fine is in microseconds and acq_duration is in microseconds.
                 acquisition_times[esa_voltage_row_index][column_index] = (
                     base_quarter_cycle_acq_time
-                    + (step * (acq_duration + settle_duration) / 1000)
+                    + (step * (acq_duration + settle_duration) / 1000000)
                 )
                 # Store acquisition duration for later calculation
                 acq_duration_arr[esa_voltage_row_index][column_index] = acq_duration

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -219,7 +219,7 @@ def put_data_in_bins(
     numpy.ndarray
         Data in bins.
     """
-    binned_data = np.full(data.shape, np.nan)
+    binned_data = np.full((data.shape[0], 24, 30), np.nan)
     full_cycle_data = data.shape[0]
     energy_step = data.shape[1]
     angle_bin = data.shape[2]
@@ -234,19 +234,23 @@ def put_data_in_bins(
                 # data for each 7 CEMs data. Then put that mean in
                 # its angle bin.
                 angle_indices = np.where(angle_bin_indices[cycle, energy] == angle)
-                data_mean = np.mean(data[cycle, energy, angle_indices], axis=1)
+                # TODO: undo this after binning work is checked
+                # data_mean = np.mean(data[cycle, energy, angle_indices], axis=1)
+                data_mean = np.mean(data[cycle, energy, angle_indices])
+                # print(data_mean)
                 binned_data[cycle, energy, angle] = data_mean
                 # store indices in binned_data
                 # binned_data[cycle, energy, angle] = angle_indices
                 if cycle == 5 and len(angle_indices[0]) > 0:
                     # print(
-                    #     f"cycle: {cycle}, energy: {energy}, angle: {angle},"
-                    #     f" angle_indices: {angle_indices[0]}"
+                    #     f"cycle: {cycle}, energy: {energy}, angle: {angle}"
                     # )
+                    # # print(f"angle: ", data[cycle, energy, angle_indices])
+                    # print(f"angle indices: ", angle_indices)
                     # print("data: ", data[cycle, energy, angle_indices].shape)
-                    # np.mean across 7 CEMs.
+                    # # np.mean across 7 CEMs.
                     # print(data_mean)
-                    continue
+                    pass
     # print(binned_data.shape)
     return binned_data
 
@@ -340,13 +344,13 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # Calculate spin phase using SWE acquisition_time calculated in l1b.
     # L1B dataset stores it by (epoch, esa_step, spin_sector).
     # To calculate center time of data acquisition time, we will add
-    #   acquisition_time + (acq_duration / 1000) / 2
-    # acq_duration is in milliseconds and is stored in L1B dataset by
+    #   acquisition_time + (acq_duration / 1000000) / 2
+    # acq_duration is in microseconds and is stored in L1B dataset by
     # (epoch, cycle). acq_duration should be same for all esa_steps in
     # a full sweep. We will take the first acq_duration value for each
     # full sweep. This center time calculation is done to get the center
     # angle of the data.
-    acq_duration = l1b_dataset["acq_duration"].data[:, 0] / 2000
+    acq_duration = l1b_dataset["acq_duration"].data[:, 0] / 2000000
     data_acq_time = (
         l1b_dataset["acquisition_time"].data + acq_duration[:, np.newaxis, np.newaxis]
     )
@@ -386,20 +390,36 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         spin_angle_bins_range, inst_spin_angle, side="right"
     )
     spin_angle_bins_indices = spin_angle_bins_indices - 1
+    # print(spin_angle_bins_indices[0])
+    print(l1b_dataset["acq_duration"].data[0])
+    print(l1b_dataset["settle_duration"].data[0])
 
-    # Set energy bins index for each data counts to be same as input data.
-    energy_steps = np.arange(24)
-    total_angle_bins = 30
-    total_full_cycle_data = l1b_dataset["science_data"].shape[0]
-    energy_bins_indices = np.tile(
-        energy_steps, (total_angle_bins, total_full_cycle_data)
-    ).T
-    energy_bins_indices = energy_bins_indices.reshape(-1, 24, 30)
+    # # Set energy bins index for each data counts to be same as input data.
+    # energy_steps = np.arange(24)
+    # total_angle_bins = 30
+    # total_full_cycle_data = l1b_dataset["science_data"].shape[0]
+    # energy_bins_indices = np.tile(
+    #     energy_steps, (total_angle_bins, total_full_cycle_data)
+    # ).T
+    # energy_bins_indices = energy_bins_indices.reshape(-1, 24, 30)
 
     # TODO: take flux data and put it in its spin angle bins using the indices.
-    put_data_in_bins(flux, spin_angle_bins_indices)
-    # print(pd.DataFrame(inst_spin_angle[0], columns=np.arange(30)
-    # ).to_csv("spin_angle.csv"))
-    # print(pd.DataFrame(spin_angle_bins_indices[0], columns=np.arange(30)
-    # ).to_csv("spin_angle_bins.csv"))
+    binned_data = put_data_in_bins(flux, spin_angle_bins_indices)
+    print(binned_data[0])
+    # print(
+    #     pd.DataFrame(inst_spin_angle[0],
+    # columns=np.arange(30)).to_csv("spin_angle.csv")
+    # )
+    # print(
+    #     pd.DataFrame(spin_angle_bins_indices[0], columns=np.arange(30)).to_csv(
+    #         "spin_angle_bins.csv"
+    #     )
+    # )
+    # print(pd.DataFrame(binned_data[0],
+    # columns=np.arange(30)).to_csv("binned_data.csv"))
+    # print(
+    #     pd.DataFrame(
+    #         l1b_dataset["acquisition_time"].data[0], columns=np.arange(30)
+    #     ).to_csv("acquisition_time.csv")
+    # )
     return dataset

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -9,8 +9,12 @@ import numpy.typing as npt
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.spice.spin import get_spacecraft_spin_phase
-from imap_processing.swe.utils.swe_utils import read_lookup_table
+from imap_processing.spice.geometry import SpiceFrame
+from imap_processing.spice.spin import get_instrument_spin_phase
+from imap_processing.swe.utils.swe_utils import (
+    ESA_VOLTAGE_ROW_INDEX_DICT,
+    read_lookup_table,
+)
 
 # TODO: add these to instrument status summary
 ENERGY_CONVERSION_FACTOR = 4.75
@@ -32,6 +36,8 @@ ELECTRON_MASS = 9.10938356e-31  # kg
 VELOCITY_CONVERSION_FACTOR = 1.237e31
 # See doc string of calculate_flux() for more details.
 FLUX_CONVERSION_FACTOR = 6.187e30
+
+CEM_DETECTORS_ANGLE = np.array([-63, -42, -21, 0, 21, 42, 63])
 
 
 def get_particle_energy() -> npt.NDArray:
@@ -216,12 +222,39 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     cdf_attributes.add_instrument_variable_attrs("swe", "l2")
     cdf_attributes.add_global_attribute("Data_version", data_version)
 
+    # Energy values in eV.
+    energy_xr = xr.DataArray(
+        np.array(list(ESA_VOLTAGE_ROW_INDEX_DICT.keys())) * ENERGY_CONVERSION_FACTOR,
+        name="energy",
+        dims=["energy"],
+        attrs=cdf_attributes.get_variable_attributes("energy"),
+    )
+
+    # Angle of each CEM detectors.
+    inst_el_xr = xr.DataArray(
+        CEM_DETECTORS_ANGLE,
+        name="inst_el",
+        dims=["inst_el"],
+        attrs=cdf_attributes.get_variable_attributes("inst_el"),
+    )
+
+    # Spin Angle bins storing bin center values.
+    inst_az_xr = xr.DataArray(
+        np.arange(6, 360, 12),
+        name="inst_az",
+        dims=["inst_az"],
+        attrs=cdf_attributes.get_variable_attributes("inst_az"),
+    )
+
     dataset = xr.Dataset(
         coords={
             "epoch": l1b_dataset["epoch"],
             "esa_step": l1b_dataset["esa_step"],
+            "energy": energy_xr,
             "spin_sector": l1b_dataset["spin_sector"],
+            "inst_az": inst_az_xr,
             "cem_id": l1b_dataset["cem_id"],
+            "inst_el": inst_el_xr,
             "esa_step_label": l1b_dataset["esa_step_label"],
             "spin_sector_label": l1b_dataset["spin_sector_label"],
             "cem_id_label": l1b_dataset["cem_id_label"],
@@ -229,12 +262,13 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         attrs=cdf_attributes.get_global_attributes("imap_swe_l2_sci"),
     )
 
+    ############################################################
+    # Calculate phase space density and flux. Store data in shape
+    # (epoch, esa_step, spin_sector, cem_id). This is for L3 purposes.
+    ############################################################
     phase_space_density = calculate_phase_space_density(l1b_dataset)[
         "phase_space_density"
     ]
-    # Phase space density in the spin sector. This is carrying over for L3 purposes.
-    # TODO: later, we will calculate and organize phase space density in the
-    # spin angle bins.
     dataset["phase_space_density_spin_sector"] = xr.DataArray(
         phase_space_density,
         name="phase_space_density_spin_sector",
@@ -242,8 +276,6 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         attrs=cdf_attributes.get_variable_attributes("phase_space_density_spin_sector"),
     )
 
-    # Flux in the spin sector. This is carrying over for L3 purposes.
-    # TODO: later, we will calculate and organize flux in the spin angle bins.
     flux = calculate_flux(l1b_dataset)
     dataset["flux_spin_sector"] = xr.DataArray(
         flux,
@@ -258,11 +290,14 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # TODO: remaining L2 work.
     # Calculate spin phase using SWE acquisition_time calculated in l1b.
     # L1B dataset stores it by (epoch, esa_step, spin_sector, cem_id).
+    # To calculate center time of data acquisition time, we will add
+    #   acquisition_time + (acq_duration / 1000) / 2
     data_acq_time = l1b_dataset["acquisition_time"].data.flatten()
 
     print(data_acq_time.shape)
     # calculate spin phase
-    get_spacecraft_spin_phase(
+    get_instrument_spin_phase(
         query_met_times=data_acq_time,
+        instrument=SpiceFrame.IMAP_SWE,
     ).reshape(-1, 24, 30)
     return dataset

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -246,11 +246,10 @@ def put_data_into_angle_bins(
     bin_counts = np.zeros_like(binned_data, dtype=float)
     np.add.at(bin_counts, (time_indices, energy_indices, angle_indices), 1)
 
-    # Compute the mean while avoiding division by zero
-    with np.errstate(invalid="ignore", divide="ignore"):
-        # Replace zero counts with NaN to indicate no data in the bin
-        # because zero counts could be valid data.
-        binned_data /= np.where(bin_counts == 0, np.nan, bin_counts)
+    # Compute the mean. Replace zero counts with NaN to indicate no data in the bin
+    # because zero counts could be valid data.
+    bin_counts[bin_counts == 0] = np.nan
+    binned_data /= bin_counts
 
     return binned_data
 
@@ -365,7 +364,9 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
 
     # Calculate spin phase using SWE acquisition_time from the
     # L1B dataset. The L1B dataset stores acquisition_time with
-    # dimensions (epoch, esa_step, spin_sector).
+    # dimensions (epoch, esa_step, spin_sector). Use center time
+    # to calculate spin phase. This center time calculation is
+    # necessary to accurately determine the center angle of the data.
     #
     # To determine the center acquisition time, we adjust the
     # recorded acquisition_time as follows:
@@ -376,21 +377,19 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # remains the same for all quarter cycles within a full sweep,
     # we use the first acq_duration value for each full sweep to perform
     # this adjustment.
-    #
-    # This center time calculation is necessary to accurately determine
-    # the center angle of the data.
 
     acq_duration = l1b_dataset["acq_duration"].data[:, 0] / 2000000
     data_acq_time = (
         l1b_dataset["acquisition_time"].data + acq_duration[:, np.newaxis, np.newaxis]
     )
 
-    # calculate spin phase
+    # Calculate spin phase
     inst_spin_phase = get_instrument_spin_phase(
         query_met_times=data_acq_time.flatten(),
         instrument=SpiceFrame.IMAP_SWE,
     )
 
+    # Convert spin phase to spin angle in degrees.
     inst_spin_angle = get_spin_angle(inst_spin_phase, degrees=True).reshape(-1, 24, 30)
     # The spin angle bins are centered at:
     #   [ 6, 18, 30, 42, 54, 66, 78, 90, 102, 114, 126, 138, 150, 162, 174,
@@ -417,7 +416,8 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     #   - `np.searchsorted(x, [12], side="right") -> [2]` (Bin end test)
     #   - `np.searchsorted(x, [0], side="right") -> [1]` (Bin start test)
     #
-    # Using `i-1` ensures that all input angles are assigned to the correct bin.
+    # Using `i-1` ensures that all input angles are assigned to the correct bin of
+    # centered angle bins.
 
     spin_angle_bins_range = np.arange(0, 360, 12)
     spin_angle_bins_indices = np.searchsorted(

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -235,19 +235,18 @@ def put_data_into_angle_bins(
     binned_data = np.zeros((data.shape[0], 24, 30, 7), dtype=np.float64)
 
     time_indices = np.arange(data.shape[0])[:, None, None]
-    energy_indices = np.arange(data.shape[1])[None, :, None]
-    angle_indices = angle_bin_indices
+    energy_indices = np.arange(24)[None, :, None]
 
     # Use np.add.at() to accumulate values into bins
-    np.add.at(binned_data, (time_indices, energy_indices, angle_indices), data)
+    np.add.at(binned_data, (time_indices, energy_indices, angle_bin_indices), data)
 
     # Count occurrences in each bin to compute the mean.
     # Ensure float dtype for division
     bin_counts = np.zeros_like(binned_data, dtype=float)
-    np.add.at(bin_counts, (time_indices, energy_indices, angle_indices), 1)
+    np.add.at(bin_counts, (time_indices, energy_indices, angle_bin_indices), 1)
 
     # Compute the mean. Replace zero counts with NaN to indicate no data in the bin
-    # because zero counts could be valid data.
+    # because zero physical counts could be valid data.
     bin_counts[bin_counts == 0] = np.nan
     binned_data /= bin_counts
 
@@ -306,13 +305,13 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
 
     # Spin Angle bins storing bin center values.
     inst_az_xr = xr.DataArray(
-        np.arange(6, 360, 12),
+        np.arange(0, 360, 12) + 6,
         name="inst_az",
         dims=["inst_az"],
         attrs=cdf_attributes.get_variable_attributes("inst_az"),
     )
     inst_az_label = xr.DataArray(
-        np.arange(6, 360, 12).astype(str),
+        inst_az_xr.values.astype(str),
         name="inst_az_label",
         dims=["inst_az"],
         attrs=cdf_attributes.get_variable_attributes("inst_az_label"),
@@ -385,7 +384,7 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
 
     # Calculate spin phase
     inst_spin_phase = get_instrument_spin_phase(
-        query_met_times=data_acq_time.flatten(),
+        query_met_times=data_acq_time.ravel(),
         instrument=SpiceFrame.IMAP_SWE,
     )
 
@@ -428,9 +427,9 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # Using `i-1` ensures that all input angles are assigned to the correct bin of
     # centered angle bins.
 
-    spin_angle_bins_range = np.arange(0, 360, 12)
+    spin_angle_bin_edges = np.arange(0, 360, 12)
     spin_angle_bins_indices = np.searchsorted(
-        spin_angle_bins_range, inst_spin_angle, side="right"
+        spin_angle_bin_edges, inst_spin_angle, side="right"
     )
     spin_angle_bins_indices = spin_angle_bins_indices - 1
 

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -207,6 +207,10 @@ def put_data_in_bins(
     """
     Put data in bins.
 
+    SWE data will need to bin data in 30 angle bins. This function will
+    walk through each full cycle data and keep energy step same for each
+    data but put data in its angle bin.
+
     Parameters
     ----------
     data : numpy.ndarray
@@ -219,7 +223,7 @@ def put_data_in_bins(
     numpy.ndarray
         Data in bins.
     """
-    binned_data = np.full((data.shape[0], 24, 30), np.nan)
+    binned_data = np.full((data.shape[0], 24, 30, 7), np.nan)
     full_cycle_data = data.shape[0]
     energy_step = data.shape[1]
     angle_bin = data.shape[2]
@@ -234,24 +238,8 @@ def put_data_in_bins(
                 # data for each 7 CEMs data. Then put that mean in
                 # its angle bin.
                 angle_indices = np.where(angle_bin_indices[cycle, energy] == angle)
-                # TODO: undo this after binning work is checked
-                # data_mean = np.mean(data[cycle, energy, angle_indices], axis=1)
-                data_mean = np.mean(data[cycle, energy, angle_indices])
-                # print(data_mean)
+                data_mean = np.mean(data[cycle, energy, angle_indices], axis=1)
                 binned_data[cycle, energy, angle] = data_mean
-                # store indices in binned_data
-                # binned_data[cycle, energy, angle] = angle_indices
-                if cycle == 5 and len(angle_indices[0]) > 0:
-                    # print(
-                    #     f"cycle: {cycle}, energy: {energy}, angle: {angle}"
-                    # )
-                    # # print(f"angle: ", data[cycle, energy, angle_indices])
-                    # print(f"angle indices: ", angle_indices)
-                    # print("data: ", data[cycle, energy, angle_indices].shape)
-                    # # np.mean across 7 CEMs.
-                    # print(data_mean)
-                    pass
-    # print(binned_data.shape)
     return binned_data
 
 
@@ -284,12 +272,25 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         attrs=cdf_attributes.get_variable_attributes("energy"),
     )
 
+    energy_label = xr.DataArray(
+        np.array(list(ESA_VOLTAGE_ROW_INDEX_DICT.keys())).astype(str),
+        name="energy_label",
+        dims=["energy"],
+        attrs=cdf_attributes.get_variable_attributes("energy_label"),
+    )
+
     # Angle of each CEM detectors.
     inst_el_xr = xr.DataArray(
         CEM_DETECTORS_ANGLE,
         name="inst_el",
         dims=["inst_el"],
         attrs=cdf_attributes.get_variable_attributes("inst_el"),
+    )
+    inst_el_label = xr.DataArray(
+        CEM_DETECTORS_ANGLE.astype(str),
+        name="inst_el_label",
+        dims=["inst_el"],
+        attrs=cdf_attributes.get_variable_attributes("inst_el_label"),
     )
 
     # Spin Angle bins storing bin center values.
@@ -298,6 +299,12 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         name="inst_az",
         dims=["inst_az"],
         attrs=cdf_attributes.get_variable_attributes("inst_az"),
+    )
+    inst_az_label = xr.DataArray(
+        np.arange(6, 360, 12).astype(str),
+        name="inst_az_label",
+        dims=["inst_az"],
+        attrs=cdf_attributes.get_variable_attributes("inst_az_label"),
     )
 
     dataset = xr.Dataset(
@@ -310,8 +317,11 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
             "cem_id": l1b_dataset["cem_id"],
             "inst_el": inst_el_xr,
             "esa_step_label": l1b_dataset["esa_step_label"],
+            "energy_label": energy_label,
             "spin_sector_label": l1b_dataset["spin_sector_label"],
+            "inst_az_label": inst_az_label,
             "cem_id_label": l1b_dataset["cem_id_label"],
+            "inst_el_label": inst_el_label,
         },
         attrs=cdf_attributes.get_global_attributes("imap_swe_l2_sci"),
     )
@@ -390,9 +400,6 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         spin_angle_bins_range, inst_spin_angle, side="right"
     )
     spin_angle_bins_indices = spin_angle_bins_indices - 1
-    # print(spin_angle_bins_indices[0])
-    print(l1b_dataset["acq_duration"].data[0])
-    print(l1b_dataset["settle_duration"].data[0])
 
     # # Set energy bins index for each data counts to be same as input data.
     # energy_steps = np.arange(24)
@@ -405,21 +412,17 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
 
     # TODO: take flux data and put it in its spin angle bins using the indices.
     binned_data = put_data_in_bins(flux, spin_angle_bins_indices)
-    print(binned_data[0])
-    # print(
-    #     pd.DataFrame(inst_spin_angle[0],
-    # columns=np.arange(30)).to_csv("spin_angle.csv")
-    # )
-    # print(
-    #     pd.DataFrame(spin_angle_bins_indices[0], columns=np.arange(30)).to_csv(
-    #         "spin_angle_bins.csv"
-    #     )
-    # )
-    # print(pd.DataFrame(binned_data[0],
-    # columns=np.arange(30)).to_csv("binned_data.csv"))
-    # print(
-    #     pd.DataFrame(
-    #         l1b_dataset["acquisition_time"].data[0], columns=np.arange(30)
-    #     ).to_csv("acquisition_time.csv")
-    # )
+    dataset["flux"] = xr.DataArray(
+        binned_data,
+        name="flux",
+        dims=["epoch", "energy", "inst_az", "inst_el"],
+        attrs=cdf_attributes.get_variable_attributes("flux"),
+    )
+    dataset["phase_space_density"] = xr.DataArray(
+        put_data_in_bins(phase_space_density.data, spin_angle_bins_indices),
+        name="phase_space_density",
+        dims=["epoch", "energy", "inst_az", "inst_el"],
+        attrs=cdf_attributes.get_variable_attributes("phase_space_density"),
+    )
+
     return dataset

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -255,7 +255,6 @@ def put_data_into_angle_bins(
 
 def find_angle_bin_indices(
     inst_spin_angle: np.ndarray,
-    spin_angle_bin_edges: np.ndarray,
 ) -> npt.NDArray[np.int_]:
     """
     Find angle bin indices.
@@ -292,14 +291,13 @@ def find_angle_bin_indices(
     ----------
     inst_spin_angle : numpy.ndarray
         Instrument spin angle.
-    spin_angle_bin_edges : numpy.ndarray
-        Spin angle bin edges to use for binning.
 
     Returns
     -------
     spin_angle_bins_indices : numpy.ndarray
         Spin angle bin indices.
     """
+    spin_angle_bin_edges = np.arange(0, 360, 12)
     # Ensure that inst_spin_angle is np.array for below conditions
     # check to work properly.
     inst_spin_angle = np.array(inst_spin_angle)
@@ -460,9 +458,7 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         attrs=cdf_attributes.get_variable_attributes("inst_az_spin_sector"),
     )
 
-    spin_angle_bins_indices = find_angle_bin_indices(
-        inst_spin_angle, np.arange(0, 360, 12)
-    )
+    spin_angle_bins_indices = find_angle_bin_indices(inst_spin_angle)
 
     # Put flux data in its spin angle bins using the indices.
     flux_binned_data = put_data_into_angle_bins(flux, spin_angle_bins_indices)

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -201,45 +201,57 @@ def calculate_flux(l1b_dataset: xr.Dataset) -> npt.NDArray:
     return flux
 
 
-def put_data_in_bins(
+def put_data_into_angle_bins(
     data: np.ndarray, angle_bin_indices: npt.NDArray[np.int_]
 ) -> npt.NDArray:
     """
-    Put data in bins.
+    Put data in its angle bins.
 
-    SWE data will need to bin data in 30 angle bins. This function will
-    walk through each full cycle data and keep energy step same for each
-    data but put data in its angle bin.
+    This function bins SWE data into 30 predefined angle bins
+    while preserving the original energy step structure. For each
+    full cycle, it assigns data to the corresponding angle bin
+    based on the provided indices.
+
+    Since multiple data points may fall into the same angle bin,
+    the function accumulates values and computes the average across
+    all 7 CEMs, ensuring that each bin contains a representative
+    mean value while maintaining the 7 CEM structure.
 
     Parameters
     ----------
     data : numpy.ndarray
-        Data to put in bins.
+        Data to put in bins. Shape: (full_cycle_data, energy_step, angle_bin, 7).
     angle_bin_indices : numpy.ndarray
-        Indices of angle bins to put data in.
+        Indices of angle bins to put data in. Shape:
+        (full_cycle_data, energy_step, angle_bin).
 
     Returns
     -------
     numpy.ndarray
-        Data in bins.
+        Data in bins. Shape: (full_cycle_data, 24, 30, 7).
     """
-    binned_data = np.full((data.shape[0], 24, 30, 7), np.nan)
-    full_cycle_data = data.shape[0]
-    energy_step = data.shape[1]
-    angle_bin = data.shape[2]
-    # For each full cycle data
-    for cycle in range(full_cycle_data):
-        # For each energy step
-        for energy in range(energy_step):
-            # For each angle bin
-            for angle in range(angle_bin):
-                # Find all data of current energy step row that has
-                # same angle bin index. Then calculate mean of all
-                # data for each 7 CEMs data. Then put that mean in
-                # its angle bin.
-                angle_indices = np.where(angle_bin_indices[cycle, energy] == angle)
-                data_mean = np.mean(data[cycle, energy, angle_indices], axis=1)
-                binned_data[cycle, energy, angle] = data_mean
+    # Initialize with zeros instead of NaN because np.add.at() does not
+    # work with nan values. It results in nan + value = nan
+    binned_data = np.zeros((data.shape[0], 24, 30, 7), dtype=np.float64)
+
+    time_indices = np.arange(data.shape[0])[:, None, None]
+    energy_indices = np.arange(data.shape[1])[None, :, None]
+    angle_indices = angle_bin_indices
+
+    # Use np.add.at() to accumulate values into bins
+    np.add.at(binned_data, (time_indices, energy_indices, angle_indices), data)
+
+    # Count occurrences in each bin to compute the mean.
+    # Ensure float dtype for division
+    bin_counts = np.zeros_like(binned_data, dtype=float)
+    np.add.at(bin_counts, (time_indices, energy_indices, angle_indices), 1)
+
+    # Compute the mean while avoiding division by zero
+    with np.errstate(invalid="ignore", divide="ignore"):
+        # Replace zero counts with NaN to indicate no data in the bin
+        # because zero counts could be valid data.
+        binned_data /= np.where(bin_counts == 0, np.nan, bin_counts)
+
     return binned_data
 
 
@@ -351,15 +363,23 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # Carry over acquisition times for L3 purposes.
     dataset["acquisition_time"] = l1b_dataset["acquisition_time"]
 
-    # Calculate spin phase using SWE acquisition_time calculated in l1b.
-    # L1B dataset stores it by (epoch, esa_step, spin_sector).
-    # To calculate center time of data acquisition time, we will add
+    # Calculate spin phase using SWE acquisition_time from the
+    # L1B dataset. The L1B dataset stores acquisition_time with
+    # dimensions (epoch, esa_step, spin_sector).
+    #
+    # To determine the center acquisition time, we adjust the
+    # recorded acquisition_time as follows:
     #   acquisition_time + (acq_duration / 1000000) / 2
-    # acq_duration is in microseconds and is stored in L1B dataset by
-    # (epoch, cycle). acq_duration should be same for all esa_steps in
-    # a full sweep. We will take the first acq_duration value for each
-    # full sweep. This center time calculation is done to get the center
-    # angle of the data.
+    #
+    # Here, acq_duration is given in microseconds and is stored
+    # in the L1B dataset with dimensions (epoch, cycle). Since acq_duration
+    # remains the same for all quarter cycles within a full sweep,
+    # we use the first acq_duration value for each full sweep to perform
+    # this adjustment.
+    #
+    # This center time calculation is necessary to accurately determine
+    # the center angle of the data.
+
     acq_duration = l1b_dataset["acq_duration"].data[:, 0] / 2000000
     data_acq_time = (
         l1b_dataset["acquisition_time"].data + acq_duration[:, np.newaxis, np.newaxis]
@@ -372,54 +392,54 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     )
 
     inst_spin_angle = get_spin_angle(inst_spin_phase, degrees=True).reshape(-1, 24, 30)
-    # Spin angle bins range is little different from spin angle bins.
-    # Spin angle bins are centered like:
+    # The spin angle bins are centered at:
     #   [ 6, 18, 30, 42, 54, 66, 78, 90, 102, 114, 126, 138, 150, 162, 174,
-    #   186, 198, 210, 222, 234, 246, 258, 270, 282, 294, 306, 318, 330,
-    #   342, 354]
-    # Where does an input angle goes into which bins is determined by the
-    # following logic:
-    #   phi_begin <= center - 6
-    #   phi_center = 6
-    #   phi_end < center + 6
-    # For example, if input_angle is 8.4, we would put in spin angle bin 6.
-    # To make binning easier, we will use following bin ranges:
+    #     186, 198, 210, 222, 234, 246, 258, 270, 282, 294, 306, 318, 330,
+    #     342, 354]
+    #
+    # An input angle is assigned to a bin based on the following conditions:
+    #   - phi_begin <= center - 6
+    #   - phi_center = 6
+    #   - phi_end < center + 6
+    #
+    # For example, if the input angle is 8.4, it falls within the bin centered at 6.
+    #
+    # To make binning easier, we define bin edges as:
     #   [0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168,
-    #   180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324,
-    #   336, 348]
-    # SWE want to use right side of np.searchsorted, a[i-1] <= v < a[i].
-    # Index of spin angle bins and spin angle range should match.
-    # For example,
-    #   np.searchsorted(x, [6], side="right") -> [1]. Bin center test.
-    #   np.searchsorted(x, [8.4], side="right"] -> [1]. Bin center edge test.
-    #   np.searchsorted(x, [12], side="right") -> [2]. Bin end test.
-    #   np.searchsorted(x, [0], side="right") -> [1]. Bin start test.
-    # [i-1] gives the correct bin index for all the above tests.
+    #    180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324,
+    #    336, 348]
+    #
+    # SWE uses the right-side behavior of `np.searchsorted`, where `a[i-1] <= v < a[i]`.
+    #
+    # Example test cases:
+    #   - `np.searchsorted(x, [6], side="right") -> [1]` (Bin center test)
+    #   - `np.searchsorted(x, [8.4], side="right") -> [1]` (Edge case near center)
+    #   - `np.searchsorted(x, [12], side="right") -> [2]` (Bin end test)
+    #   - `np.searchsorted(x, [0], side="right") -> [1]` (Bin start test)
+    #
+    # Using `i-1` ensures that all input angles are assigned to the correct bin.
+
     spin_angle_bins_range = np.arange(0, 360, 12)
     spin_angle_bins_indices = np.searchsorted(
         spin_angle_bins_range, inst_spin_angle, side="right"
     )
     spin_angle_bins_indices = spin_angle_bins_indices - 1
 
-    # # Set energy bins index for each data counts to be same as input data.
-    # energy_steps = np.arange(24)
-    # total_angle_bins = 30
-    # total_full_cycle_data = l1b_dataset["science_data"].shape[0]
-    # energy_bins_indices = np.tile(
-    #     energy_steps, (total_angle_bins, total_full_cycle_data)
-    # ).T
-    # energy_bins_indices = energy_bins_indices.reshape(-1, 24, 30)
-
-    # TODO: take flux data and put it in its spin angle bins using the indices.
-    binned_data = put_data_in_bins(flux, spin_angle_bins_indices)
+    # Put flux data in its spin angle bins using the indices.
+    flux_binned_data = put_data_into_angle_bins(flux, spin_angle_bins_indices)
     dataset["flux"] = xr.DataArray(
-        binned_data,
+        flux_binned_data,
         name="flux",
         dims=["epoch", "energy", "inst_az", "inst_el"],
         attrs=cdf_attributes.get_variable_attributes("flux"),
     )
+
+    # Put phase space density data in its spin angle bins using the indices.
+    phase_space_density_binned_data = put_data_into_angle_bins(
+        phase_space_density.data, spin_angle_bins_indices
+    )
     dataset["phase_space_density"] = xr.DataArray(
-        put_data_in_bins(phase_space_density.data, spin_angle_bins_indices),
+        phase_space_density_binned_data,
         name="phase_space_density",
         dims=["epoch", "energy", "inst_az", "inst_el"],
         attrs=cdf_attributes.get_variable_attributes("phase_space_density"),

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -300,6 +300,13 @@ def find_angle_bin_indices(
     spin_angle_bins_indices : numpy.ndarray
         Spin angle bin indices.
     """
+    # Ensure that inst_spin_angle is np.array for below conditions
+    # check to work properly.
+    inst_spin_angle = np.array(inst_spin_angle)
+    # Check that there are no angle values outside the range [0, 360).
+    if np.any((inst_spin_angle < 0) | (inst_spin_angle >= 360)):
+        raise ValueError("Input angle values must be in the range [0, 360)")
+
     spin_angle_bins_indices = np.searchsorted(
         spin_angle_bin_edges, inst_spin_angle, side="right"
     )

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -391,6 +391,15 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
 
     # Convert spin phase to spin angle in degrees.
     inst_spin_angle = get_spin_angle(inst_spin_phase, degrees=True).reshape(-1, 24, 30)
+
+    # Save spin angle in dataset per SWE request.
+    dataset["inst_az_spin_sector"] = xr.DataArray(
+        inst_spin_angle,
+        name="inst_az_spin_sector",
+        dims=["epoch", "energy", "inst_az"],
+        attrs=cdf_attributes.get_variable_attributes("inst_az_spin_sector"),
+    )
+
     # The spin angle bins are centered at:
     #   [ 6, 18, 30, 42, 54, 66, 78, 90, 102, 114, 126, 138, 150, 162, 174,
     #     186, 198, 210, 222, 234, 246, 258, 270, 282, 294, 306, 318, 330,

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -201,6 +201,56 @@ def calculate_flux(l1b_dataset: xr.Dataset) -> npt.NDArray:
     return flux
 
 
+def put_data_in_bins(
+    data: np.ndarray, angle_bin_indices: npt.NDArray[np.int_]
+) -> npt.NDArray:
+    """
+    Put data in bins.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Data to put in bins.
+    angle_bin_indices : numpy.ndarray
+        Indices of angle bins to put data in.
+
+    Returns
+    -------
+    numpy.ndarray
+        Data in bins.
+    """
+    binned_data = np.full(data.shape, np.nan)
+    full_cycle_data = data.shape[0]
+    energy_step = data.shape[1]
+    angle_bin = data.shape[2]
+    # For each full cycle data
+    for cycle in range(full_cycle_data):
+        # For each energy step
+        for energy in range(energy_step):
+            # For each angle bin
+            for angle in range(angle_bin):
+                # Find all data of current energy step row that has
+                # same angle bin index. Then calculate mean of all
+                # data for each 7 CEMs data. Then put that mean in
+                # its angle bin.
+                angle_indices = np.where(angle_bin_indices[cycle, energy] == angle)
+                data_mean = np.mean(data[cycle, energy, angle_indices], axis=1)
+                binned_data[cycle, energy, angle] = data_mean
+                # store indices in binned_data
+                # binned_data[cycle, energy, angle] = angle_indices
+                if cycle == 5 and len(angle_indices[0]) > 0:
+                    # print(
+                    #     f"cycle: {cycle}, energy: {energy}, angle: {angle},"
+                    #     f" angle_indices: {angle_indices[0]}"
+                    # )
+                    # print("data: ", data[cycle, energy, angle_indices].shape)
+                    # np.mean across 7 CEMs.
+                    # print(data_mean)
+                    continue
+    # print(binned_data.shape)
+    return binned_data
+
+
 def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     """
     Will process data to L2.
@@ -337,9 +387,17 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     )
     spin_angle_bins_indices = spin_angle_bins_indices - 1
 
-    # Now, take flux data and put it in its spin angle bins using the indices.
-    # TODO: do this
+    # Set energy bins index for each data counts to be same as input data.
+    energy_steps = np.arange(24)
+    total_angle_bins = 30
+    total_full_cycle_data = l1b_dataset["science_data"].shape[0]
+    energy_bins_indices = np.tile(
+        energy_steps, (total_angle_bins, total_full_cycle_data)
+    ).T
+    energy_bins_indices = energy_bins_indices.reshape(-1, 24, 30)
 
+    # TODO: take flux data and put it in its spin angle bins using the indices.
+    put_data_in_bins(flux, spin_angle_bins_indices)
     # print(pd.DataFrame(inst_spin_angle[0], columns=np.arange(30)
     # ).to_csv("spin_angle.csv"))
     # print(pd.DataFrame(spin_angle_bins_indices[0], columns=np.arange(30)

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -10,7 +10,7 @@ import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.spice.geometry import SpiceFrame
-from imap_processing.spice.spin import get_instrument_spin_phase
+from imap_processing.spice.spin import get_instrument_spin_phase, get_spin_angle
 from imap_processing.swe.utils.swe_utils import (
     ESA_VOLTAGE_ROW_INDEX_DICT,
     read_lookup_table,
@@ -287,17 +287,61 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # Carry over acquisition times for L3 purposes.
     dataset["acquisition_time"] = l1b_dataset["acquisition_time"]
 
-    # TODO: remaining L2 work.
     # Calculate spin phase using SWE acquisition_time calculated in l1b.
-    # L1B dataset stores it by (epoch, esa_step, spin_sector, cem_id).
+    # L1B dataset stores it by (epoch, esa_step, spin_sector).
     # To calculate center time of data acquisition time, we will add
     #   acquisition_time + (acq_duration / 1000) / 2
-    data_acq_time = l1b_dataset["acquisition_time"].data.flatten()
+    # acq_duration is in milliseconds and is stored in L1B dataset by
+    # (epoch, cycle). acq_duration should be same for all esa_steps in
+    # a full sweep. We will take the first acq_duration value for each
+    # full sweep. This center time calculation is done to get the center
+    # angle of the data.
+    acq_duration = l1b_dataset["acq_duration"].data[:, 0] / 2000
+    data_acq_time = (
+        l1b_dataset["acquisition_time"].data + acq_duration[:, np.newaxis, np.newaxis]
+    )
 
-    print(data_acq_time.shape)
     # calculate spin phase
-    get_instrument_spin_phase(
-        query_met_times=data_acq_time,
+    inst_spin_phase = get_instrument_spin_phase(
+        query_met_times=data_acq_time.flatten(),
         instrument=SpiceFrame.IMAP_SWE,
-    ).reshape(-1, 24, 30)
+    )
+
+    inst_spin_angle = get_spin_angle(inst_spin_phase, degrees=True).reshape(-1, 24, 30)
+    # Spin angle bins range is little different from spin angle bins.
+    # Spin angle bins are centered like:
+    #   [ 6, 18, 30, 42, 54, 66, 78, 90, 102, 114, 126, 138, 150, 162, 174,
+    #   186, 198, 210, 222, 234, 246, 258, 270, 282, 294, 306, 318, 330,
+    #   342, 354]
+    # Where does an input angle goes into which bins is determined by the
+    # following logic:
+    #   phi_begin <= center - 6
+    #   phi_center = 6
+    #   phi_end < center + 6
+    # For example, if input_angle is 8.4, we would put in spin angle bin 6.
+    # To make binning easier, we will use following bin ranges:
+    #   [0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168,
+    #   180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324,
+    #   336, 348]
+    # SWE want to use right side of np.searchsorted, a[i-1] <= v < a[i].
+    # Index of spin angle bins and spin angle range should match.
+    # For example,
+    #   np.searchsorted(x, [6], side="right") -> [1]. Bin center test.
+    #   np.searchsorted(x, [8.4], side="right"] -> [1]. Bin center edge test.
+    #   np.searchsorted(x, [12], side="right") -> [2]. Bin end test.
+    #   np.searchsorted(x, [0], side="right") -> [1]. Bin start test.
+    # [i-1] gives the correct bin index for all the above tests.
+    spin_angle_bins_range = np.arange(0, 360, 12)
+    spin_angle_bins_indices = np.searchsorted(
+        spin_angle_bins_range, inst_spin_angle, side="right"
+    )
+    spin_angle_bins_indices = spin_angle_bins_indices - 1
+
+    # Now, take flux data and put it in its spin angle bins using the indices.
+    # TODO: do this
+
+    # print(pd.DataFrame(inst_spin_angle[0], columns=np.arange(30)
+    # ).to_csv("spin_angle.csv"))
+    # print(pd.DataFrame(spin_angle_bins_indices[0], columns=np.arange(30)
+    # ).to_csv("spin_angle_bins.csv"))
     return dataset

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -229,11 +229,14 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         attrs=cdf_attributes.get_global_attributes("imap_swe_l2_sci"),
     )
 
+    phase_space_density = calculate_phase_space_density(l1b_dataset)[
+        "phase_space_density"
+    ]
     # Phase space density in the spin sector. This is carrying over for L3 purposes.
     # TODO: later, we will calculate and organize phase space density in the
     # spin angle bins.
     dataset["phase_space_density_spin_sector"] = xr.DataArray(
-        calculate_phase_space_density(l1b_dataset)["phase_space_density"],
+        phase_space_density,
         name="phase_space_density_spin_sector",
         dims=["epoch", "esa_step", "spin_sector", "cem_id"],
         attrs=cdf_attributes.get_variable_attributes("phase_space_density_spin_sector"),
@@ -241,8 +244,9 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
 
     # Flux in the spin sector. This is carrying over for L3 purposes.
     # TODO: later, we will calculate and organize flux in the spin angle bins.
+    flux = calculate_flux(l1b_dataset)
     dataset["flux_spin_sector"] = xr.DataArray(
-        calculate_flux(l1b_dataset),
+        flux,
         name="flux_spin_sector",
         dims=["epoch", "esa_step", "spin_sector", "cem_id"],
         attrs=cdf_attributes.get_variable_attributes("flux_spin_sector"),
@@ -256,6 +260,7 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # L1B dataset stores it by (epoch, esa_step, spin_sector, cem_id).
     data_acq_time = l1b_dataset["acquisition_time"].data.flatten()
 
+    print(data_acq_time.shape)
     # calculate spin phase
     get_spacecraft_spin_phase(
         query_met_times=data_acq_time,

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -253,6 +253,60 @@ def put_data_into_angle_bins(
     return binned_data
 
 
+def find_angle_bin_indices(
+    inst_spin_angle: np.ndarray,
+    spin_angle_bin_edges: np.ndarray,
+) -> npt.NDArray[np.int_]:
+    """
+    Find angle bin indices.
+
+    The spin angle bins are centered at:
+      [ 6, 18, 30, 42, 54, 66, 78, 90, 102, 114, 126, 138, 150, 162, 174,
+        186, 198, 210, 222, 234, 246, 258, 270, 282, 294, 306, 318, 330,
+        342, 354]
+
+    An input angle is assigned to a bin based on the following conditions:
+      - phi_begin <= center - 6
+      - phi_center = 6
+      - phi_end < center + 6
+
+    For example, if the input angle is 8.4, it falls within the bin centered at 6.
+
+    To make binning easier, we define bin edges as:
+      [0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168,
+       180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324,
+       336, 348]
+
+    SWE uses the right-side behavior of `np.searchsorted`, where `a[i-1] <= v < a[i]`.
+
+    Example test cases:
+      - `np.searchsorted(x, [6], side="right") -> [1]` (Bin center test)
+      - `np.searchsorted(x, [8.4], side="right") -> [1]` (Edge case near center)
+      - `np.searchsorted(x, [12], side="right") -> [2]` (Bin end test)
+      - `np.searchsorted(x, [0], side="right") -> [1]` (Bin start test)
+
+    Using `i-1` ensures that all input angles are assigned to the correct bin of
+    centered angle bins.
+
+    Parameters
+    ----------
+    inst_spin_angle : numpy.ndarray
+        Instrument spin angle.
+    spin_angle_bin_edges : numpy.ndarray
+        Spin angle bin edges to use for binning.
+
+    Returns
+    -------
+    spin_angle_bins_indices : numpy.ndarray
+        Spin angle bin indices.
+    """
+    spin_angle_bins_indices = np.searchsorted(
+        spin_angle_bin_edges, inst_spin_angle, side="right"
+    )
+    spin_angle_bins_indices = spin_angle_bins_indices - 1
+    return spin_angle_bins_indices
+
+
 def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     """
     Will process data to L2.
@@ -399,39 +453,9 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         attrs=cdf_attributes.get_variable_attributes("inst_az_spin_sector"),
     )
 
-    # The spin angle bins are centered at:
-    #   [ 6, 18, 30, 42, 54, 66, 78, 90, 102, 114, 126, 138, 150, 162, 174,
-    #     186, 198, 210, 222, 234, 246, 258, 270, 282, 294, 306, 318, 330,
-    #     342, 354]
-    #
-    # An input angle is assigned to a bin based on the following conditions:
-    #   - phi_begin <= center - 6
-    #   - phi_center = 6
-    #   - phi_end < center + 6
-    #
-    # For example, if the input angle is 8.4, it falls within the bin centered at 6.
-    #
-    # To make binning easier, we define bin edges as:
-    #   [0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168,
-    #    180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324,
-    #    336, 348]
-    #
-    # SWE uses the right-side behavior of `np.searchsorted`, where `a[i-1] <= v < a[i]`.
-    #
-    # Example test cases:
-    #   - `np.searchsorted(x, [6], side="right") -> [1]` (Bin center test)
-    #   - `np.searchsorted(x, [8.4], side="right") -> [1]` (Edge case near center)
-    #   - `np.searchsorted(x, [12], side="right") -> [2]` (Bin end test)
-    #   - `np.searchsorted(x, [0], side="right") -> [1]` (Bin start test)
-    #
-    # Using `i-1` ensures that all input angles are assigned to the correct bin of
-    # centered angle bins.
-
-    spin_angle_bin_edges = np.arange(0, 360, 12)
-    spin_angle_bins_indices = np.searchsorted(
-        spin_angle_bin_edges, inst_spin_angle, side="right"
+    spin_angle_bins_indices = find_angle_bin_indices(
+        inst_spin_angle, np.arange(0, 360, 12)
     )
-    spin_angle_bins_indices = spin_angle_bins_indices - 1
 
     # Put flux data in its spin angle bins using the indices.
     flux_binned_data = put_data_into_angle_bins(flux, spin_angle_bins_indices)

--- a/imap_processing/swe/utils/swe_utils.py
+++ b/imap_processing/swe/utils/swe_utils.py
@@ -6,6 +6,34 @@ import pandas as pd
 
 from imap_processing import imap_module_directory
 
+# ESA voltage and index in the final data table
+ESA_VOLTAGE_ROW_INDEX_DICT = {
+    0.56: 0,
+    0.78: 1,
+    1.08: 2,
+    1.51: 3,
+    2.10: 4,
+    2.92: 5,
+    4.06: 6,
+    5.64: 7,
+    7.85: 8,
+    10.92: 9,
+    15.19: 10,
+    21.13: 11,
+    29.39: 12,
+    40.88: 13,
+    56.87: 14,
+    79.10: 15,
+    110.03: 16,
+    153.05: 17,
+    212.89: 18,
+    296.14: 19,
+    411.93: 20,
+    572.99: 21,
+    797.03: 22,
+    1108.66: 23,
+}
+
 
 class SWEAPID(IntEnum):
     """Create ENUM for apid."""

--- a/imap_processing/tests/spice/test_spin.py
+++ b/imap_processing/tests/spice/test_spin.py
@@ -70,6 +70,10 @@ def test_interpolate_spin_data(query_met_times, expected, fake_spin_data):
             np.array([7.5, 30, 61, 75, 106, 121, 136]),
             np.array([0.5, 0, np.nan, 0, np.nan, np.nan, 1 / 15]),
         ),
+        # Test that this spin phase range [0, 1) is valid which
+        # is same as [0, 360) degree angle. At 15 seconds the spacecraft
+        # has completed a full spin
+        (np.array([0, 15]), np.zeros(2)),
     ],
 )
 def test_get_spacecraft_spin_phase(query_met_times, expected, fake_spin_data):

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -14,7 +14,9 @@ from imap_processing.swe.l2.swe_l2 import (
     VELOCITY_CONVERSION_FACTOR,
     calculate_flux,
     calculate_phase_space_density,
+    find_angle_bin_indices,
     get_particle_energy,
+    put_data_into_angle_bins,
     swe_l2,
 )
 from imap_processing.swe.utils.swe_utils import read_lookup_table
@@ -107,6 +109,201 @@ def test_calculate_flux():
     flux = calculate_flux(l1b_dataset)
     assert flux.shape == (total_sweeps, 24, 30, 7)
     assert type(flux) == np.ndarray
+
+
+def test_find_angle_bin_indices():
+    """Test find_angle_bin_indices function."""
+    spin_angle_bin_center = np.arange(6, 360, 12)
+    spin_angle_bin_edges = np.arange(0, 360, 12)
+
+    start_angles = [0, 12, 24, 36, 48, 60, 72, 84, 96, 108]
+    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    angle_bin_indices = find_angle_bin_indices(start_angles, spin_angle_bin_edges)
+    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
+    # Test that angle bin indices lands in correct center bin
+    np.testing.assert_array_equal(
+        spin_angle_bin_center[angle_bin_indices],
+        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
+    )
+
+    middle_angles = [6, 18, 30, 42, 54, 66, 78, 90, 102, 114]
+    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    angle_bin_indices = find_angle_bin_indices(middle_angles, spin_angle_bin_edges)
+    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
+    # Test that angle bin indices lands in correct center bin
+    np.testing.assert_array_equal(
+        spin_angle_bin_center[angle_bin_indices],
+        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
+    )
+
+    end_angles = [12, 24, 36, 48, 60, 72, 84, 96, 108, 120]
+    expected_angle_bin_indices = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    angle_bin_indices = find_angle_bin_indices(end_angles, spin_angle_bin_edges)
+    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
+    # Test that angle bin indices lands in correct center bin
+    np.testing.assert_array_equal(
+        spin_angle_bin_center[angle_bin_indices],
+        np.array([18, 30, 42, 54, 66, 78, 90, 102, 114, 126]),
+    )
+
+    left_middle_angles = [3, 15, 27, 39, 51, 63, 75, 87, 99, 111]
+    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    angle_bin_indices = find_angle_bin_indices(left_middle_angles, spin_angle_bin_edges)
+    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
+    # Test that angle bin indices lands in correct center bin
+    np.testing.assert_array_equal(
+        spin_angle_bin_center[angle_bin_indices],
+        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
+    )
+
+    right_middle_angles = [9, 21, 33, 45, 57, 69, 81, 93, 105, 117]
+    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    angle_bin_indices = find_angle_bin_indices(
+        right_middle_angles, spin_angle_bin_edges
+    )
+    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
+    # Test that angle bin indices lands in correct center bin
+    np.testing.assert_array_equal(
+        spin_angle_bin_center[angle_bin_indices],
+        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
+    )
+
+    far_left_edge_angles = [0.5, 12.5, 24.5, 36.5, 48.5, 60.5, 72.5, 84.5, 96.5, 108.5]
+    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    angle_bin_indices = find_angle_bin_indices(
+        far_left_edge_angles, spin_angle_bin_edges
+    )
+    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
+    # Test that angle bin indices lands in correct center bin
+    np.testing.assert_array_equal(
+        spin_angle_bin_center[angle_bin_indices],
+        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
+    )
+
+    far_right_edge_angles = [
+        11.99,
+        23.99,
+        35.99,
+        47.99,
+        59.99,
+        71.99,
+        83.99,
+        95.99,
+        107.99,
+        119.99,
+    ]
+    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    angle_bin_indices = find_angle_bin_indices(
+        far_right_edge_angles, spin_angle_bin_edges
+    )
+    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
+    # Test that angle bin indices lands in correct center bin
+    np.testing.assert_array_equal(
+        spin_angle_bin_center[angle_bin_indices],
+        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
+    )
+
+    # Test for angles that are outside the range
+    with pytest.raises(
+        ValueError, match=r"Input angle values must be in the range \[0, 360\)"
+    ):
+        find_angle_bin_indices(np.array([-1]), spin_angle_bin_edges)
+
+    with pytest.raises(
+        ValueError, match=r"Input angle values must be in the range \[0, 360\)"
+    ):
+        find_angle_bin_indices(np.array([360]), spin_angle_bin_edges)
+
+
+def test_put_data_into_angle_bins():
+    """Test put_data_into_angle_bins function."""
+    num_cycles = 1
+    num_esa_step = 24
+    num_angle_bins = 30
+    num_cems = 7
+    # Create test counts data to test
+    # Find all even numbers in the range 0 to 30
+    even_numbers = np.arange(0, 30, 2)
+    # repeat it twice now to get:
+    # [0, 0, 2, 2, ...., 28, 28]
+    example_data = np.repeat(even_numbers, 2)
+    energy_angle_test_data = np.tile(example_data, (num_cycles, num_esa_step, 1))
+    # Expand to include 7 CEMs by repeating across last dimension
+    test_data = np.repeat(energy_angle_test_data[..., np.newaxis], num_cems, axis=-1)
+
+    # Took this example from intermediate output from actual data
+    angle_bins_example = [
+        12,
+        14,
+        14,
+        16,
+        16,
+        18,
+        18,
+        20,
+        20,
+        22,
+        22,
+        24,
+        24,
+        26,
+        26,
+        28,
+        28,
+        0,
+        0,
+        2,
+        2,
+        4,
+        4,
+        6,
+        6,
+        8,
+        8,
+        10,
+        10,
+        12,
+    ]
+    # Now data with every row to be same as angle_bins_example
+    test_angle_bin_indices_data = np.full(
+        (num_cycles, num_esa_step, num_angle_bins), angle_bins_example
+    )
+
+    binned_data = put_data_into_angle_bins(test_data, test_angle_bin_indices_data)
+    assert binned_data.shape == (num_cycles, num_esa_step, num_angle_bins, num_cems)
+
+    # Test that the binned data has correct values in correct bins by
+    # checking that odd number columns are filled with nan
+    expected_binned_data = np.full(
+        (num_cycles, num_esa_step, num_angle_bins, num_cems), np.nan
+    )
+    np.testing.assert_array_equal(
+        binned_data[0, 0, 1::2, 0], expected_binned_data[0, 0, 1::2, 0]
+    )
+
+    # Now check that mean calculation is correct
+    even_col_mean_data = binned_data[0, 0, 0::2, 0]
+    # Expected mean of even columns is below
+    expected_mean_data = np.array(
+        [
+            17.0,
+            19.0,
+            21.0,
+            23.0,
+            25.0,
+            27.0,
+            14.0,
+            1.0,
+            3.0,
+            5.0,
+            7.0,
+            9.0,
+            11.0,
+            13.0,
+            15.0,
+        ]
+    )
+    np.testing.assert_array_equal(even_col_mean_data, expected_mean_data)
 
 
 @patch(

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -128,7 +128,7 @@ def test_calculate_flux():
 def test_swe_l2(mock_read_in_flight_cal_data, use_fake_spin_data_for_time):
     """Test L2 processing."""
     data_start_time = 453051293.099714
-    data_end_time = 453066734
+    data_end_time = 453070000.0
     use_fake_spin_data_for_time(data_start_time, data_end_time)
 
     test_data_path = "tests/swe/l0_data/2024051010_SWE_SCIENCE_packet.bin"

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -114,105 +114,29 @@ def test_calculate_flux():
 def test_find_angle_bin_indices():
     """Test find_angle_bin_indices function."""
     spin_angle_bin_center = np.arange(6, 360, 12)
-    spin_angle_bin_edges = np.arange(0, 360, 12)
 
-    start_angles = [0, 12, 24, 36, 48, 60, 72, 84, 96, 108]
-    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    angle_bin_indices = find_angle_bin_indices(start_angles, spin_angle_bin_edges)
+    # List with various start, middle, end angles or
+    # far left or far right edge angles
+    start_angles = [0, 0.11, 3, 6, 11.99, 12, 355]
+    expected_angle_bin_indices = np.array([0, 0, 0, 0, 0, 1, 29])
+    angle_bin_indices = find_angle_bin_indices(start_angles)
     np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
     # Test that angle bin indices lands in correct center bin
     np.testing.assert_array_equal(
         spin_angle_bin_center[angle_bin_indices],
-        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
-    )
-
-    middle_angles = [6, 18, 30, 42, 54, 66, 78, 90, 102, 114]
-    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    angle_bin_indices = find_angle_bin_indices(middle_angles, spin_angle_bin_edges)
-    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
-    # Test that angle bin indices lands in correct center bin
-    np.testing.assert_array_equal(
-        spin_angle_bin_center[angle_bin_indices],
-        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
-    )
-
-    end_angles = [12, 24, 36, 48, 60, 72, 84, 96, 108, 120]
-    expected_angle_bin_indices = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-    angle_bin_indices = find_angle_bin_indices(end_angles, spin_angle_bin_edges)
-    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
-    # Test that angle bin indices lands in correct center bin
-    np.testing.assert_array_equal(
-        spin_angle_bin_center[angle_bin_indices],
-        np.array([18, 30, 42, 54, 66, 78, 90, 102, 114, 126]),
-    )
-
-    left_middle_angles = [3, 15, 27, 39, 51, 63, 75, 87, 99, 111]
-    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    angle_bin_indices = find_angle_bin_indices(left_middle_angles, spin_angle_bin_edges)
-    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
-    # Test that angle bin indices lands in correct center bin
-    np.testing.assert_array_equal(
-        spin_angle_bin_center[angle_bin_indices],
-        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
-    )
-
-    right_middle_angles = [9, 21, 33, 45, 57, 69, 81, 93, 105, 117]
-    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    angle_bin_indices = find_angle_bin_indices(
-        right_middle_angles, spin_angle_bin_edges
-    )
-    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
-    # Test that angle bin indices lands in correct center bin
-    np.testing.assert_array_equal(
-        spin_angle_bin_center[angle_bin_indices],
-        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
-    )
-
-    far_left_edge_angles = [0.5, 12.5, 24.5, 36.5, 48.5, 60.5, 72.5, 84.5, 96.5, 108.5]
-    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    angle_bin_indices = find_angle_bin_indices(
-        far_left_edge_angles, spin_angle_bin_edges
-    )
-    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
-    # Test that angle bin indices lands in correct center bin
-    np.testing.assert_array_equal(
-        spin_angle_bin_center[angle_bin_indices],
-        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
-    )
-
-    far_right_edge_angles = [
-        11.99,
-        23.99,
-        35.99,
-        47.99,
-        59.99,
-        71.99,
-        83.99,
-        95.99,
-        107.99,
-        119.99,
-    ]
-    expected_angle_bin_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    angle_bin_indices = find_angle_bin_indices(
-        far_right_edge_angles, spin_angle_bin_edges
-    )
-    np.testing.assert_array_equal(angle_bin_indices, expected_angle_bin_indices)
-    # Test that angle bin indices lands in correct center bin
-    np.testing.assert_array_equal(
-        spin_angle_bin_center[angle_bin_indices],
-        np.array([6, 18, 30, 42, 54, 66, 78, 90, 102, 114]),
+        np.array([6, 6, 6, 6, 6, 18, 354]),
     )
 
     # Test for angles that are outside the range
     with pytest.raises(
         ValueError, match=r"Input angle values must be in the range \[0, 360\)"
     ):
-        find_angle_bin_indices(np.array([-1]), spin_angle_bin_edges)
+        find_angle_bin_indices(np.array([-1]))
 
     with pytest.raises(
         ValueError, match=r"Input angle values must be in the range \[0, 360\)"
     ):
-        find_angle_bin_indices(np.array([360]), spin_angle_bin_edges)
+        find_angle_bin_indices(np.array([360]))
 
 
 def test_put_data_into_angle_bins():


### PR DESCRIPTION
# Change Summary
closes #887 

## Overview
This PR does last piece of L2 which is organize data by energy and spin angle. I also added new data variables and their CDF attrs per SWE's requet.

## Updated Files
- imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
   - add CDF attrs for new data variables
- imap_processing/swe/l1b/swe_l1b_science.py
   - Fix time bug. Change milliseconds to be microseconds
- imap_processing/swe/l2/swe_l2.py
   - Main code change of this PR
   - bin flux and phase space density data into its bin.
   - New data variables and their CDF attrs
- imap_processing/swe/utils/swe_utils.py
   - Minor refactor to share energy index and value.




## Testing
- imap_processing/tests/swe/test_swe_l2.py
