### PR TITLE
Add fill_value keyword to dataarray creation utilities

### DIFF
--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import IntEnum
+from numbers import Number
 from typing import Optional, Union
 
 import numpy as np
@@ -99,6 +100,7 @@ def full_dataarray(
     attrs: dict,
     coords: Optional[dict[str, xr.DataArray]] = None,
     shape: Optional[Union[int, Sequence[int]]] = None,
+    fill_value: Optional[Number] = None,
 ) -> xr.DataArray:
     """
     Generate an empty xarray.DataArray with appropriate attributes.
@@ -117,6 +119,9 @@ def full_dataarray(
         Coordinate variables for the Dataset.
     shape : int or tuple
         Shape of ndarray data array to instantiate in the xarray.DataArray.
+    fill_value : optional, float
+        Override the fill value that the DataArray will be filled with. If not
+        supplied, the "FILLVAL" value from `attrs` will be used.
 
     Returns
     -------
@@ -133,9 +138,11 @@ def full_dataarray(
         shape = [coords[k].data.size for k in dims]  # type: ignore
     if hasattr(shape, "__len__") and len(shape) > len(dims):
         dims.append("")
+    if fill_value is None:
+        fill_value = _attrs["FILLVAL"]
 
     data_array = xr.DataArray(
-        np.full(shape, _attrs["FILLVAL"], dtype=dtype),
+        np.full(shape, fill_value, dtype=dtype),
         name=name,
         dims=dims,
         attrs=_attrs,
@@ -146,6 +153,8 @@ def full_dataarray(
 def create_dataset_variables(
     variable_names: list[str],
     variable_shape: Union[int, Sequence[int]],
+    coords: Optional[dict[str, xr.DataArray]] = None,
+    fill_value: Optional[Number] = None,
     att_manager_lookup_str: str = "{0}",
 ) -> dict[str, xr.DataArray]:
     """
@@ -157,8 +166,14 @@ def create_dataset_variables(
     ----------
     variable_names : list[str]
         List of variable names to create.
-    variable_shape : tuple[int]
+    variable_shape : int or sequence of int
         Shape of the new variables data ndarray.
+    coords : dict
+        Coordinate variables for the Dataset.
+    fill_value : optional, number
+        Value to fill the new variables data arrays with. If not supplied,
+        the fill value is pulled from the CDF variable attributes "FILLVAL"
+        attribute.
     att_manager_lookup_str : str
         String defining how to build the string passed to the
         CdfAttributeManager in order to retrieve the CdfAttributes for each
@@ -181,5 +196,7 @@ def create_dataset_variables(
         attrs = attr_mgr.get_variable_attributes(
             att_manager_lookup_str.format(var), check_schema=False
         )
-        new_variables[var] = full_dataarray(var, attrs, shape=variable_shape)
+        new_variables[var] = full_dataarray(
+            var, attrs, shape=variable_shape, coords=coords, fill_value=fill_value
+        )
     return new_variables


### PR DESCRIPTION
# Change Summary

## Overview
This is a short one. I found a need to add a fill_value argument to the utility function I use for creating xr.DataArrays.

## Updated Files
- imap_processing/hi/utils.py
   - Add fill_value keyword argument to two utility funcitons
- imap_processing/tests/hi/test_utils.py
   - Test that filled DataArrays have expected values.

Closes: #1362 
