### PR TITLE
frame_transform checks for same frame

### DIFF
--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -189,6 +189,10 @@ def frame_transform(
     result : np.ndarray
         3d Cartesian position vector(s) in reference frame `to_frame`.
     """
+    # If from_frame and to_frame are the same, no rotation needed
+    if from_frame == to_frame:
+        return position
+
     if position.ndim == 1:
         if not len(position) == 3:
             raise ValueError(
@@ -208,10 +212,6 @@ def frame_transform(
                     f"Position has {len(position)} elements and et has "
                     f"{np.asarray(et).size} elements."
                 )
-
-    # If from_frame and to_frame are the same, no rotation needed
-    if from_frame == to_frame:
-        return position
 
     # rotate will have shape = (3, 3) or (n, 3, 3)
     # position will have shape = (3,) or (n, 3)

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -209,6 +209,10 @@ def frame_transform(
                     f"{np.asarray(et).size} elements."
                 )
 
+    # If from_frame and to_frame are the same, no rotation needed
+    if from_frame == to_frame:
+        return position
+
     # rotate will have shape = (3, 3) or (n, 3, 3)
     # position will have shape = (3,) or (n, 3)
     rotate = get_rotation_matrix(et, from_frame, to_frame)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -169,9 +169,8 @@ def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_ker
 )
 def test_frame_transform_same_frame(position, spice_frame):
     """Test that frame_transform returns position when input/output frames are same."""
-    position = np.array([1, 0, 0])
     result = frame_transform(0, position, spice_frame, spice_frame)
-    np.testing.assert_array_equal(result, position)
+    assert result is position
 
 
 def test_frame_transform_exceptions():
@@ -199,50 +198,6 @@ def test_frame_transform_exceptions():
             SpiceFrame.ECLIPJ2000,
             SpiceFrame.IMAP_HIT,
         )
-
-
-@pytest.mark.parametrize(
-    "az_range, el_range",
-    [
-        (
-            np.arange(0, 2 * np.pi, np.pi / 50),
-            np.arange(-np.pi / 2, np.pi / 2, np.pi / 50),
-        ),
-        (np.pi / 2, np.pi / 2),
-    ],
-)
-@mock.patch("imap_processing.spice.geometry.get_rotation_matrix")
-def test_frame_transform_az_el(mock_get_rotation_matrix, az_range, el_range):
-    """Test transforming azimuth and elevation between frames"""
-    et = 0
-    az, el = np.meshgrid(az_range, el_range)
-    az_el = np.squeeze(np.vstack((az.flatten(), el.flatten())).T)
-
-    # Mock get_rotation_matrix to return a 90-degree rotation in xy-plane
-    mock_get_rotation_matrix.side_effect = (
-        lambda t, from_frame, to_frame: np.broadcast_to(
-            [[0, -1, 0], [1, 0, 0], [0, 0, 1]], (3, 3)
-        )
-    )
-
-    to_az_el_radians = frame_transform_az_el(
-        et, az_el, SpiceFrame.IMAP_DPS, SpiceFrame.ECLIPJ2000, degrees=False
-    )
-    to_az_el_degrees = frame_transform_az_el(
-        et, np.degrees(az_el), SpiceFrame.IMAP_DPS, SpiceFrame.ECLIPJ2000, degrees=True
-    )
-
-    expected_az = np.asarray(az_el[..., 0] + np.pi / 2)
-    expected_az[expected_az > 2 * np.pi] -= 2 * np.pi
-    np.testing.assert_allclose(to_az_el_radians[..., 0], expected_az, atol=1e-14)
-    np.testing.assert_allclose(to_az_el_radians[..., 1], az_el[..., 1], atol=1e-14)
-    # Check degrees
-    np.testing.assert_allclose(
-        to_az_el_degrees[..., 0], np.degrees(expected_az), atol=1e-14
-    )
-    np.testing.assert_allclose(
-        to_az_el_degrees[..., 1], np.degrees(az_el[..., 1]), atol=1e-14
-    )
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -151,6 +151,29 @@ def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_ker
             np.testing.assert_allclose(test_result, spice_result, atol=1e-12)
 
 
+@pytest.mark.parametrize(
+    "spice_frame",
+    [
+        SpiceFrame.IMAP_DPS,
+        SpiceFrame.IMAP_SPACECRAFT,
+        SpiceFrame.ECLIPJ2000,
+    ],
+)
+@pytest.mark.parametrize(
+    "position",
+    [
+        np.array([1, 0, 0]),
+        np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+        np.random.rand(10, 3),
+    ],
+)
+def test_frame_transform_same_frame(position, spice_frame):
+    """Test that frame_transform returns position when input/output frames are same."""
+    position = np.array([1, 0, 0])
+    result = frame_transform(0, position, spice_frame, spice_frame)
+    np.testing.assert_array_equal(result, position)
+
+
 def test_frame_transform_exceptions():
     """Test that the proper exceptions get raised when input arguments are invalid."""
     with pytest.raises(
@@ -220,6 +243,45 @@ def test_frame_transform_az_el(mock_get_rotation_matrix, az_range, el_range):
     np.testing.assert_allclose(
         to_az_el_degrees[..., 1], np.degrees(az_el[..., 1]), atol=1e-14
     )
+
+
+@pytest.mark.parametrize(
+    "spice_frame",
+    [
+        SpiceFrame.IMAP_DPS,
+        SpiceFrame.IMAP_SPACECRAFT,
+        SpiceFrame.ECLIPJ2000,
+    ],
+)
+@pytest.mark.parametrize("degrees_bool", [True, False])
+def test_frame_transform_az_el_same_frame(spice_frame, degrees_bool):
+    """Test that frame_transform returns az/el when input/output frames are same."""
+    az_el_points = np.array(
+        [
+            [0, -90],
+            [0, 0],
+            [0, 89.999999],
+            [90, -90],
+            [90, 0],
+            [90, 89.999999],
+            [180, -90],
+            [180, 0],
+            [180, 89.999999],
+            [270, -90],
+            [270, 0],
+            [270, 89.999999],
+            [359.999999, -90],
+            [359.999999, 0],
+            [359.999999, 89.999999],
+            [360, 90],
+        ]
+    )
+    if not degrees_bool:
+        az_el_points = np.deg2rad(az_el_points)
+    result = frame_transform_az_el(
+        0, az_el_points, spice_frame, spice_frame, degrees=degrees_bool
+    )
+    np.testing.assert_allclose(result, az_el_points)
 
 
 def test_get_rotation_matrix(furnish_kernels):
@@ -376,8 +438,8 @@ def test_cartesian_to_latitudinal():
 def test_solar_longitude(mock_state):
     """Test solar_longitude()."""
 
-    mock_state.side_effect = (
-        lambda t, observer: np.ones(6) if (isinstance(t, int)) else np.ones((len(t), 6))
+    mock_state.side_effect = lambda t, observer: (
+        np.ones(6) if (isinstance(t, int)) else np.ones((len(t), 6))
     )
     # example et time
     et = 798033670


### PR DESCRIPTION
# Change Summary

## Overview
Small change suggested by @greglucas: Check that the frames are not the same before applying frame_transform(). If they are the same, return vector without Spice call 

Closes #1370

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- geometry.py
   - frame_transform() checks if input/output are the same frame before using spice to generate rotation matrix. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Add tests for multiple frames, multiple input shapes. Test that frame_transform_az_el() still works as well. 