### PR TITLE
HIT L1B - add algorithm for summed rates product

### DIFF
--- a/imap_processing/hit/l1b/constants.py
+++ b/imap_processing/hit/l1b/constants.py
@@ -14,7 +14,7 @@
 
 # TODO: rename particles to their full names? Waiting for confirmation from HIT
 PARTICLE_ENERGY_RANGE_MAPPING = {
-    "h": [
+    "hydrogen": [
         {
             "energy_min": 1.8,
             "energy_max": 3.6,
@@ -26,7 +26,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 6.0, "energy_max": 10.0, "R2": [], "R3": [6, 7], "R4": []},
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [8, 9], "R4": [1]},
     ],
-    "he3": [
+    "helium3": [
         {
             "energy_min": 4.0,
             "energy_max": 6.0,
@@ -37,7 +37,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 6.0, "energy_max": 10.0, "R2": [], "R3": [15, 16], "R4": []},
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [17, 18], "R4": []},
     ],
-    "he4": [
+    "helium4": [
         {
             "energy_min": 1.8,
             "energy_max": 3.6,
@@ -55,7 +55,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 6.0, "energy_max": 10.0, "R2": [], "R3": [26, 27], "R4": []},
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [28, 29], "R4": [4]},
     ],
-    "he": [
+    "helium": [
         {
             "energy_min": 4.0,
             "energy_max": 6.0,
@@ -78,7 +78,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
             "R4": [4],
         },
     ],
-    "c": [
+    "carbon": [
         {
             "energy_min": 4.0,
             "energy_max": 6.0,
@@ -96,7 +96,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [36, 37], "R4": []},
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [38, 39], "R4": [7]},
     ],
-    "n": [
+    "nitrogen": [
         {
             "energy_min": 4.0,
             "energy_max": 6.0,
@@ -114,7 +114,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [46, 47], "R4": []},
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [48, 49], "R4": [11]},
     ],
-    "o": [
+    "oxygen": [
         {
             "energy_min": 4.0,
             "energy_max": 6.0,
@@ -132,7 +132,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [56, 57], "R4": []},
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [58, 59], "R4": []},
     ],
-    "ne": [
+    "neon": [
         {"energy_min": 4.0, "energy_max": 6.0, "R2": [57, 58, 59], "R3": [], "R4": []},
         {
             "energy_min": 6.0,
@@ -144,11 +144,11 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [62], "R3": [65, 66], "R4": []},
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [67, 68], "R4": []},
     ],
-    "na": [
+    "sodium": [
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [75, 76], "R4": []},
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [77, 78], "R4": []},
     ],
-    "mg": [
+    "magnesium": [
         {"energy_min": 4.0, "energy_max": 6.0, "R2": [67, 68, 69], "R3": [], "R4": []},
         {
             "energy_min": 6.0,
@@ -166,12 +166,12 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         },
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [87, 88], "R4": []},
     ],
-    "al": [
+    "aluminum": [
         {"energy_min": 6.0, "energy_max": 10.0, "R2": [], "R3": [94, 95], "R4": []},
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [96, 97], "R4": []},
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [98, 99], "R4": []},
     ],
-    "si": [
+    "silicon": [
         {"energy_min": 4.0, "energy_max": 6.0, "R2": [78, 79, 80], "R3": [], "R4": []},
         {
             "energy_min": 6.0,
@@ -196,7 +196,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
             "R4": [26],
         },
     ],
-    "s": [
+    "sulfur": [
         {"energy_min": 4.0, "energy_max": 6.0, "R2": [88, 89, 90], "R3": [], "R4": []},
         {
             "energy_min": 6.0,
@@ -215,7 +215,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [120, 121], "R4": []},
         {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [122, 123], "R4": []},
     ],
-    "ar": [
+    "argon": [
         {"energy_min": 4.0, "energy_max": 6.0, "R2": [98, 99, 100], "R3": [], "R4": []},
         {
             "energy_min": 6.0,
@@ -240,7 +240,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         },
         {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [133, 134], "R4": []},
     ],
-    "ca": [
+    "calcium": [
         {
             "energy_min": 4.0,
             "energy_max": 6.0,
@@ -271,7 +271,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         },
         {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [143, 144], "R4": []},
     ],
-    "fe": [
+    "iron": [
         {
             "energy_min": 4.0,
             "energy_max": 6.0,
@@ -302,7 +302,7 @@ PARTICLE_ENERGY_RANGE_MAPPING = {
         },
         {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [153, 154], "R4": []},
     ],
-    "ni": [
+    "nickel": [
         {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [159, 160], "R4": []},
         {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [161, 162], "R4": []},
         {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [163, 164], "R4": []},

--- a/imap_processing/hit/l1b/constants.py
+++ b/imap_processing/hit/l1b/constants.py
@@ -1,5 +1,8 @@
 """HIT L1B constants."""
 
+# Expected number of livestim pulses per integration time.
+# This is used to calculate the fractional livetime
+livestim_pulses = 270
 
 # For the L1B summed rates product, counts are summed by particle type,
 # energy range, and detector penetration range (Range 2, Range 3, and Range 4).

--- a/imap_processing/hit/l1b/constants.py
+++ b/imap_processing/hit/l1b/constants.py
@@ -4,15 +4,19 @@
 # For the L1B summed rates product, counts are summed by particle type,
 # energy range, and detector penetration range (Range 2, Range 3, and Range 4).
 # See section 6.2 of the algorithm document for more details.
-# Indices for each penetration range are provided for each particle type
-# and energy range in the dictionary below. Counts at these indices will be
+
+# The counts to sum are in the L2FGRATES, L3FGRATES, and PENFGRATES data
+# variables in the L1A product. These variables represent different detector
+# ranges for each particle type and energy range.
+
+# Indices at each detector range are provided for each particle type
+# and energy range in the dictionary below and the counts at these indices will be
 # summed in l1B processing to produce the summed rates product.
 # R2 = Indices for Range 2 (L2FGRATES)
 # R3 = Indices for Range 3 (L3FGRATES)
 # R4 = Indices for Range 4 (PENFGRATES)
 # energy_units: MeV/n
 
-# TODO: rename particles to their full names? Waiting for confirmation from HIT
 PARTICLE_ENERGY_RANGE_MAPPING = {
     "hydrogen": [
         {

--- a/imap_processing/hit/l1b/constants.py
+++ b/imap_processing/hit/l1b/constants.py
@@ -1,0 +1,310 @@
+"""HIT L1B constants."""
+
+
+# For the L1B summed rates product, counts are summed by particle type,
+# energy range, and detector penetration range (Range 2, Range 3, and Range 4).
+# See section 6.2 of the algorithm document for more details.
+# Indices for each penetration range are provided for each particle type
+# and energy range in the dictionary below. Counts at these indices will be
+# summed in l1B processing to produce the summed rates product.
+# R2 = Indices for Range 2 (L2FGRATES)
+# R3 = Indices for Range 3 (L3FGRATES)
+# R4 = Indices for Range 4 (PENFGRATES)
+# energy_units: MeV/n
+
+# TODO: rename particles to their full names? Waiting for confirmation from HIT
+PARTICLE_ENERGY_RANGE_MAPPING = {
+    "h": [
+        {
+            "energy_min": 1.8,
+            "energy_max": 3.6,
+            "R2": [1, 2, 3, 4],
+            "R3": [0, 1],
+            "R4": [],
+        },
+        {"energy_min": 4.0, "energy_max": 6.0, "R2": [6, 7], "R3": [3, 4, 5], "R4": []},
+        {"energy_min": 6.0, "energy_max": 10.0, "R2": [], "R3": [6, 7], "R4": []},
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [8, 9], "R4": [1]},
+    ],
+    "he3": [
+        {
+            "energy_min": 4.0,
+            "energy_max": 6.0,
+            "R2": [14, 15, 16],
+            "R3": [12, 13, 14],
+            "R4": [],
+        },
+        {"energy_min": 6.0, "energy_max": 10.0, "R2": [], "R3": [15, 16], "R4": []},
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [17, 18], "R4": []},
+    ],
+    "he4": [
+        {
+            "energy_min": 1.8,
+            "energy_max": 3.6,
+            "R2": [19, 20, 21, 22],
+            "R3": [21],
+            "R4": [],
+        },
+        {
+            "energy_min": 4.0,
+            "energy_max": 6.0,
+            "R2": [24, 25],
+            "R3": [23, 24, 25],
+            "R4": [],
+        },
+        {"energy_min": 6.0, "energy_max": 10.0, "R2": [], "R3": [26, 27], "R4": []},
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [28, 29], "R4": [4]},
+    ],
+    "he": [
+        {
+            "energy_min": 4.0,
+            "energy_max": 6.0,
+            "R2": [14, 15, 16, 24, 25],
+            "R3": [12, 13, 14, 23, 24, 25],
+            "R4": [],
+        },
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [],
+            "R3": [15, 16, 26, 27],
+            "R4": [],
+        },
+        {
+            "energy_min": 10.0,
+            "energy_max": 15.0,
+            "R2": [],
+            "R3": [17, 18, 28, 29],
+            "R4": [4],
+        },
+    ],
+    "c": [
+        {
+            "energy_min": 4.0,
+            "energy_max": 6.0,
+            "R2": [30, 31, 32],
+            "R3": [32, 33],
+            "R4": [],
+        },
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [33, 34],
+            "R3": [34, 35],
+            "R4": [],
+        },
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [36, 37], "R4": []},
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [38, 39], "R4": [7]},
+    ],
+    "n": [
+        {
+            "energy_min": 4.0,
+            "energy_max": 6.0,
+            "R2": [39, 40, 41],
+            "R3": [43],
+            "R4": [],
+        },
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [42, 43],
+            "R3": [44, 45],
+            "R4": [],
+        },
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [46, 47], "R4": []},
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [48, 49], "R4": [11]},
+    ],
+    "o": [
+        {
+            "energy_min": 4.0,
+            "energy_max": 6.0,
+            "R2": [48, 49, 50],
+            "R3": [53],
+            "R4": [],
+        },
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [51, 52],
+            "R3": [54, 55],
+            "R4": [],
+        },
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [56, 57], "R4": []},
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [58, 59], "R4": []},
+    ],
+    "ne": [
+        {"energy_min": 4.0, "energy_max": 6.0, "R2": [57, 58, 59], "R3": [], "R4": []},
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [60, 61],
+            "R3": [63, 64],
+            "R4": [],
+        },
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [62], "R3": [65, 66], "R4": []},
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [67, 68], "R4": []},
+    ],
+    "na": [
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [75, 76], "R4": []},
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [77, 78], "R4": []},
+    ],
+    "mg": [
+        {"energy_min": 4.0, "energy_max": 6.0, "R2": [67, 68, 69], "R3": [], "R4": []},
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [70, 71],
+            "R3": [83, 84],
+            "R4": [],
+        },
+        {
+            "energy_min": 10.0,
+            "energy_max": 15.0,
+            "R2": [72, 73],
+            "R3": [85, 86],
+            "R4": [],
+        },
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [87, 88], "R4": []},
+    ],
+    "al": [
+        {"energy_min": 6.0, "energy_max": 10.0, "R2": [], "R3": [94, 95], "R4": []},
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [96, 97], "R4": []},
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [98, 99], "R4": []},
+    ],
+    "si": [
+        {"energy_min": 4.0, "energy_max": 6.0, "R2": [78, 79, 80], "R3": [], "R4": []},
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [81, 82],
+            "R3": [105, 106],
+            "R4": [],
+        },
+        {
+            "energy_min": 10.0,
+            "energy_max": 15.0,
+            "R2": [83, 84],
+            "R3": [107, 108],
+            "R4": [],
+        },
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [109, 110], "R4": []},
+        {
+            "energy_min": 27.0,
+            "energy_max": 40.0,
+            "R2": [],
+            "R3": [111, 112],
+            "R4": [26],
+        },
+    ],
+    "s": [
+        {"energy_min": 4.0, "energy_max": 6.0, "R2": [88, 89, 90], "R3": [], "R4": []},
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [91, 92],
+            "R3": [116, 117],
+            "R4": [],
+        },
+        {
+            "energy_min": 10.0,
+            "energy_max": 15.0,
+            "R2": [93, 94],
+            "R3": [118, 119],
+            "R4": [],
+        },
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [120, 121], "R4": []},
+        {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [122, 123], "R4": []},
+    ],
+    "ar": [
+        {"energy_min": 4.0, "energy_max": 6.0, "R2": [98, 99, 100], "R3": [], "R4": []},
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [101, 102],
+            "R3": [127, 128],
+            "R4": [],
+        },
+        {
+            "energy_min": 10.0,
+            "energy_max": 15.0,
+            "R2": [103, 104],
+            "R3": [129, 130],
+            "R4": [],
+        },
+        {
+            "energy_min": 15.0,
+            "energy_max": 27.0,
+            "R2": [105],
+            "R3": [131, 132],
+            "R4": [],
+        },
+        {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [133, 134], "R4": []},
+    ],
+    "ca": [
+        {
+            "energy_min": 4.0,
+            "energy_max": 6.0,
+            "R2": [109, 110, 111],
+            "R3": [],
+            "R4": [],
+        },
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [112, 113],
+            "R3": [138],
+            "R4": [],
+        },
+        {
+            "energy_min": 10.0,
+            "energy_max": 15.0,
+            "R2": [114, 115],
+            "R3": [139, 140],
+            "R4": [],
+        },
+        {
+            "energy_min": 15.0,
+            "energy_max": 27.0,
+            "R2": [116],
+            "R3": [141, 142],
+            "R4": [],
+        },
+        {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [143, 144], "R4": []},
+    ],
+    "fe": [
+        {
+            "energy_min": 4.0,
+            "energy_max": 6.0,
+            "R2": [122, 123, 124],
+            "R3": [],
+            "R4": [],
+        },
+        {
+            "energy_min": 6.0,
+            "energy_max": 10.0,
+            "R2": [125, 126],
+            "R3": [148],
+            "R4": [],
+        },
+        {
+            "energy_min": 10.0,
+            "energy_max": 15.0,
+            "R2": [127, 128],
+            "R3": [149, 150],
+            "R4": [],
+        },
+        {
+            "energy_min": 15.0,
+            "energy_max": 27.0,
+            "R2": [129],
+            "R3": [151, 152],
+            "R4": [],
+        },
+        {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [153, 154], "R4": []},
+    ],
+    "ni": [
+        {"energy_min": 10.0, "energy_max": 15.0, "R2": [], "R3": [159, 160], "R4": []},
+        {"energy_min": 15.0, "energy_max": 27.0, "R2": [], "R3": [161, 162], "R4": []},
+        {"energy_min": 27.0, "energy_max": 40.0, "R2": [], "R3": [163, 164], "R4": []},
+    ],
+}

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -146,7 +146,7 @@ def process_science_data(
 
 
 def process_standard_rates_data(
-    raw_counts_dataset: xr.Dataset, livetime: float
+    raw_counts_dataset: xr.Dataset, livetime: xr.DataArray
 ) -> xr.Dataset:
     """
     Will process L1B standard rates data from raw L1A counts data.
@@ -156,7 +156,7 @@ def process_standard_rates_data(
     raw_counts_dataset : xr.Dataset
         The L1A counts dataset.
 
-    livetime : float
+    livetime : xr.DataArray
         The livetime calculated from the livetime counter.
 
     Returns
@@ -222,8 +222,8 @@ def process_standard_rates_data(
 def create_particle_data_arrays(
     dataset: xr.Dataset,
     particle: str,
-    energy_ranges: dict,
-    raw_counts_dataset: xr.Dataset,
+    num_energy_ranges: int,
+    epoch_size: int,
 ) -> xr.Dataset:
     """
     Create data arrays for a given particle.
@@ -236,12 +236,12 @@ def create_particle_data_arrays(
     particle : str
         The particle name.
 
-    energy_ranges : list
-        List of energy range dictionaries for the particle.
+    num_energy_ranges : int
+        Number of energy ranges for the particle.
         Used to define the shape of the data arrays.
 
-    raw_counts_dataset : xr.Dataset
-        The L1A counts dataset. Used to define the shape of the data arrays.
+    epoch_size : int
+        Used to define the shape of the data arrays.
 
     Returns
     -------
@@ -249,28 +249,22 @@ def create_particle_data_arrays(
         The dataset with the added data arrays.
     """
     dataset[f"{particle}"] = xr.DataArray(
-        data=np.zeros(
-            (raw_counts_dataset.sizes["epoch"], len(energy_ranges)), dtype=np.float32
-        ),
+        data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
         dims=["epoch", f"{particle}_energy_index"],
         name=f"{particle}",
     )
     dataset[f"{particle}_delta_minus"] = xr.DataArray(
-        data=np.zeros(
-            (raw_counts_dataset.sizes["epoch"], len(energy_ranges)), dtype=np.float32
-        ),
+        data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
         dims=["epoch", f"{particle}_energy_index"],
         name=f"{particle}_delta_minus",
     )
     dataset[f"{particle}_delta_plus"] = xr.DataArray(
-        data=np.zeros(
-            (raw_counts_dataset.sizes["epoch"], len(energy_ranges)), dtype=np.float32
-        ),
+        data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
         dims=["epoch", f"{particle}_energy_index"],
         name=f"{particle}_delta_plus",
     )
     dataset.coords[f"{particle}_energy_index"] = xr.DataArray(
-        np.arange(len(energy_ranges), dtype=np.int8),
+        np.arange(num_energy_ranges, dtype=np.int8),
         dims=[f"{particle}_energy_index"],
         name=f"{particle}_energy_index",
     )
@@ -279,7 +273,7 @@ def create_particle_data_arrays(
 
 def calculate_summed_counts(
     raw_counts_dataset: xr.Dataset, count_indices: dict
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray]:
     """
     Calculate summed counts for a given energy range.
 
@@ -297,52 +291,39 @@ def calculate_summed_counts(
 
     Returns
     -------
-    summed_counts : np.ndarray
+    summed_counts : xr.DataArray
         The summed counts.
 
-    summed_counts_delta_minus : np.ndarray
+    summed_counts_delta_minus : xr.DataArray
         The summed counts for delta minus uncertainty.
 
-    summed_counts_delta_plus : np.ndarray
+    summed_counts_delta_plus : xr.DataArray
         The summed counts for delta plus uncertainty.
     """
-    summed_counts = np.zeros(raw_counts_dataset.sizes["epoch"], dtype=np.float32)
-    summed_counts_delta_minus = np.zeros(
-        raw_counts_dataset.sizes["epoch"], dtype=np.float32
+    summed_counts = (
+        raw_counts_dataset["l2fgrates"][:, count_indices["R2"]].sum(axis=1)
+        + raw_counts_dataset["l3fgrates"][:, count_indices["R3"]].sum(axis=1)
+        + raw_counts_dataset["penfgrates"][:, count_indices["R4"]].sum(axis=1)
     )
-    summed_counts_delta_plus = np.zeros(
-        raw_counts_dataset.sizes["epoch"], dtype=np.float32
+
+    summed_counts_delta_minus = (
+        raw_counts_dataset["l2fgrates_delta_minus"][:, count_indices["R2"]].sum(axis=1)
+        + raw_counts_dataset["l3fgrates_delta_minus"][:, count_indices["R3"]].sum(
+            axis=1
+        )
+        + raw_counts_dataset["penfgrates_delta_minus"][:, count_indices["R4"]].sum(
+            axis=1
+        )
     )
-    if "R2" in count_indices:
-        summed_counts += raw_counts_dataset["l2fgrates"][:, count_indices["R2"]].sum(
+
+    summed_counts_delta_plus = (
+        raw_counts_dataset["l2fgrates_delta_plus"][:, count_indices["R2"]].sum(axis=1)
+        + raw_counts_dataset["l3fgrates_delta_plus"][:, count_indices["R3"]].sum(axis=1)
+        + raw_counts_dataset["penfgrates_delta_plus"][:, count_indices["R4"]].sum(
             axis=1
         )
-        summed_counts_delta_minus += raw_counts_dataset["l2fgrates"][
-            :, count_indices["R2"]
-        ].sum(axis=1)
-        summed_counts_delta_plus += raw_counts_dataset["l2fgrates"][
-            :, count_indices["R2"]
-        ].sum(axis=1)
-    if "R3" in count_indices:
-        summed_counts += raw_counts_dataset["l3fgrates"][:, count_indices["R3"]].sum(
-            axis=1
-        )
-        summed_counts_delta_minus += raw_counts_dataset["l3fgrates"][
-            :, count_indices["R3"]
-        ].sum(axis=1)
-        summed_counts_delta_plus += raw_counts_dataset["l3fgrates"][
-            :, count_indices["R3"]
-        ].sum(axis=1)
-    if "R4" in count_indices:
-        summed_counts += raw_counts_dataset["penfgrates"][:, count_indices["R4"]].sum(
-            axis=1
-        )
-        summed_counts_delta_minus += raw_counts_dataset["penfgrates"][
-            :, count_indices["R4"]
-        ].sum(axis=1)
-        summed_counts_delta_plus += raw_counts_dataset["penfgrates"][
-            :, count_indices["R4"]
-        ].sum(axis=1)
+    )
+
     return summed_counts, summed_counts_delta_minus, summed_counts_delta_plus
 
 
@@ -351,7 +332,7 @@ def add_rates_to_dataset(
     particle: str,
     index: int,
     summed_counts: dict,
-    livetime: float,
+    livetime: xr.DataArray,
 ) -> xr.Dataset:
     """
     Add summed rates to the dataset.
@@ -370,7 +351,7 @@ def add_rates_to_dataset(
     summed_counts : dict
         A dictionary containing the summed counts.
 
-    livetime : float
+    livetime : xr.DataArray
         The livetime.
 
     Returns
@@ -378,18 +359,23 @@ def add_rates_to_dataset(
     dataset: xr.Dataset
         The dataset with the added rates.
     """
-    dataset[f"{particle}"][:, index] = summed_counts["summed_counts"] / livetime
+    dataset[f"{particle}"][:, index] = (
+        summed_counts["summed_counts"] / livetime
+    ).astype(np.float32)
     dataset[f"{particle}_delta_minus"][:, index] = (
         summed_counts["summed_counts_delta_minus"] / livetime
-    )
+    ).astype(np.float32)
     dataset[f"{particle}_delta_plus"][:, index] = (
         summed_counts["summed_counts_delta_plus"] / livetime
-    )
+    ).astype(np.float32)
     return dataset
 
 
 def add_energy_variables(
-    dataset: xr.Dataset, particle: str, energy_min: np.ndarray, energy_max: np.ndarray
+    dataset: xr.Dataset,
+    particle: str,
+    energy_min_values: np.ndarray,
+    energy_max_values: np.ndarray,
 ) -> xr.Dataset:
     """
     Add energy min and max variables to the dataset.
@@ -400,9 +386,9 @@ def add_energy_variables(
         The dataset to add the energy variables to.
     particle : str
         The particle name.
-    energy_min : np.ndarray
+    energy_min_values : np.ndarray
         The minimum energy values for each energy range.
-    energy_max : np.ndarray
+    energy_max_values : np.ndarray
         The maximum energy values for each energy range.
 
     Returns
@@ -411,12 +397,12 @@ def add_energy_variables(
         The dataset with the added energy variables.
     """
     dataset[f"{particle}_energy_min"] = xr.DataArray(
-        data=np.array(energy_min, dtype=np.int8),
+        data=np.array(energy_min_values, dtype=np.float32),
         dims=[f"{particle}_energy_index"],
         name=f"{particle}_energy_min",
     )
     dataset[f"{particle}_energy_max"] = xr.DataArray(
-        data=np.array(energy_max, dtype=np.int8),
+        data=np.array(energy_max_values, dtype=np.float32),
         dims=[f"{particle}_energy_index"],
         name=f"{particle}_energy_max",
     )
@@ -424,7 +410,7 @@ def add_energy_variables(
 
 
 def process_summed_rates_data(
-    raw_counts_dataset: xr.Dataset, livetime: float
+    raw_counts_dataset: xr.Dataset, livetime: xr.DataArray
 ) -> xr.Dataset:
     """
     Will process L1B summed rates data from raw L1A counts data.
@@ -444,7 +430,7 @@ def process_summed_rates_data(
     raw_counts_dataset : xr.Dataset
         The L1A counts dataset.
 
-    livetime : float
+    livetime : xr.DataArray
         The livetime calculated from the livetime counter.
 
     Returns
@@ -468,7 +454,10 @@ def process_summed_rates_data(
     # Calculate summed rates for each particle and add them to the dataset
     for particle, energy_ranges in PARTICLE_ENERGY_RANGE_MAPPING.items():
         l1b_summed_rates_dataset = create_particle_data_arrays(
-            l1b_summed_rates_dataset, particle, energy_ranges, raw_counts_dataset
+            l1b_summed_rates_dataset,
+            particle,
+            len(energy_ranges),
+            raw_counts_dataset.sizes["epoch"],
         )
 
         energy_min, energy_max = (

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -1,6 +1,7 @@
 """IMAP-HIT L1B data processing."""
 
 import logging
+from typing import NamedTuple
 
 import numpy as np
 import xarray as xr
@@ -157,7 +158,8 @@ def process_standard_rates_data(
         The L1A counts dataset.
 
     livetime : xr.DataArray
-        The livetime calculated from the livetime counter.
+        1D array of livetime values calculated from the livetime counter.
+        Shape equals the number of epochs in the dataset.
 
     Returns
     -------
@@ -186,10 +188,13 @@ def process_standard_rates_data(
         {coord: raw_counts_dataset.coords[coord] for coord in coords}
     )
 
-    # Add dynamic threshold field
+    # Add dynamic threshold variable from the L1A raw counts dataset
     l1b_standard_rates_dataset["dynamic_threshold_state"] = raw_counts_dataset[
         "hdr_dynamic_threshold_state"
     ]
+    l1b_standard_rates_dataset["dynamic_threshold_state"].attrs = raw_counts_dataset[
+        "hdr_dynamic_threshold_state"
+    ].attrs
 
     # Define fields from the raw_counts_dataset to calculate standard rates from
     standard_rate_fields = [
@@ -226,7 +231,7 @@ def create_particle_data_arrays(
     epoch_size: int,
 ) -> xr.Dataset:
     """
-    Create data arrays for a given particle.
+    Create empty data arrays for a given particle.
 
     Parameters
     ----------
@@ -234,7 +239,24 @@ def create_particle_data_arrays(
         The dataset to add the data arrays to.
 
     particle : str
-        The particle name.
+        The particle name. Valid names are:
+            hydrogen
+            helium3
+            helium4
+            helium
+            carbon
+            nitrogen
+            oxygen
+            neon
+            sodium
+            magnesium
+            aluminum
+            silicon
+            sulfur
+            argon
+            calcium
+            iron
+            nickel
 
     num_energy_ranges : int
         Number of energy ranges for the particle.
@@ -327,15 +349,26 @@ def calculate_summed_counts(
     return summed_counts, summed_counts_delta_minus, summed_counts_delta_plus
 
 
+class SummedCounts(NamedTuple):
+    """A namedtuple to store summed counts and uncertainties."""
+
+    summed_counts: xr.DataArray
+    summed_counts_delta_minus: xr.DataArray
+    summed_counts_delta_plus: xr.DataArray
+
+
 def add_rates_to_dataset(
     dataset: xr.Dataset,
     particle: str,
     index: int,
-    summed_counts: dict,
+    summed_counts: SummedCounts,
     livetime: xr.DataArray,
 ) -> xr.Dataset:
     """
     Add summed rates to the dataset.
+
+    This function divides the summed counts by livetime to calculate
+    the rates for a given particle then adds the rates to the dataset.
 
     Parameters
     ----------
@@ -343,30 +376,49 @@ def add_rates_to_dataset(
         The dataset to add the rates to.
 
     particle : str
-        The particle name.
+        The particle name. Valid names are:
+            hydrogen
+            helium3
+            helium4
+            helium
+            carbon
+            nitrogen
+            oxygen
+            neon
+            sodium
+            magnesium
+            aluminum
+            silicon
+            sulfur
+            argon
+            calcium
+            iron
+            nickel
 
     index : int
         The index of the energy range.
 
-    summed_counts : dict
-        A dictionary containing the summed counts.
+    summed_counts : namedtuple
+        A namedtuple containing the summed counts.
+        SummedCounts(summed_counts, summed_counts_delta_minus,
+                    summed_counts_delta_plus).
 
     livetime : xr.DataArray
-        The livetime.
+        1D array of livetime values. Shape equals the number of epochs in the dataset.
 
     Returns
     -------
     dataset: xr.Dataset
         The dataset with the added rates.
     """
-    dataset[f"{particle}"][:, index] = (
-        summed_counts["summed_counts"] / livetime
-    ).astype(np.float32)
+    dataset[f"{particle}"][:, index] = (summed_counts.summed_counts / livetime).astype(
+        np.float32
+    )
     dataset[f"{particle}_delta_minus"][:, index] = (
-        summed_counts["summed_counts_delta_minus"] / livetime
+        summed_counts.summed_counts_delta_minus / livetime
     ).astype(np.float32)
     dataset[f"{particle}_delta_plus"][:, index] = (
-        summed_counts["summed_counts_delta_plus"] / livetime
+        summed_counts.summed_counts_delta_plus / livetime
     ).astype(np.float32)
     return dataset
 
@@ -431,7 +483,8 @@ def process_summed_rates_data(
         The L1A counts dataset.
 
     livetime : xr.DataArray
-        The livetime calculated from the livetime counter.
+        1D array of livetime values calculated from the livetime counter.
+        Shape equals the number of epochs in the dataset.
 
     Returns
     -------
@@ -446,10 +499,15 @@ def process_summed_rates_data(
         {"epoch": raw_counts_dataset.coords["epoch"]}
     )
 
-    # Add the dynamic threshold field from the l1a dataset
+    # TODO: dynamic threshold might not be needed for this product.
+    #  Need confirmation from HIT
+    # Add dynamic threshold variable from L1A raw counts dataset
     l1b_summed_rates_dataset["dynamic_threshold_state"] = raw_counts_dataset[
         "hdr_dynamic_threshold_state"
     ]
+    l1b_summed_rates_dataset["dynamic_threshold_state"].attrs = raw_counts_dataset[
+        "hdr_dynamic_threshold_state"
+    ].attrs
 
     # Calculate summed rates for each particle and add them to the dataset
     for particle, energy_ranges in PARTICLE_ENERGY_RANGE_MAPPING.items():
@@ -468,15 +526,17 @@ def process_summed_rates_data(
             summed_counts, summed_counts_delta_minus, summed_counts_delta_plus = (
                 calculate_summed_counts(raw_counts_dataset, energy_range)
             )
+
+            # Create namedtuple to store summed counts and uncertainties
+            summed_counts = SummedCounts(
+                summed_counts, summed_counts_delta_minus, summed_counts_delta_plus
+            )
+
             l1b_summed_rates_dataset = add_rates_to_dataset(
                 l1b_summed_rates_dataset,
                 particle,
                 i,
-                {
-                    "summed_counts": summed_counts,
-                    "summed_counts_delta_minus": summed_counts_delta_minus,
-                    "summed_counts_delta_plus": summed_counts_delta_plus,
-                },
+                summed_counts,
                 livetime,
             )
             energy_min[i], energy_max[i] = (

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -93,11 +93,10 @@ def process_science_data(
 
     # Logical sources for the three L1B science products.
     # TODO: add logical sources for other l1b products once processing functions
-    #  are written. "imap_hit_l1b_summed-rates", "imap_hit_l1b_sectored-rates"
-    logical_sources = ["imap_hit_l1b_standard-rates"]
+    #  are written. ""imap_hit_l1b_sectored-rates"
+    logical_sources = ["imap_hit_l1b_standard-rates", "imap_hit_l1b_summed-rates"]
 
     # TODO: Write functions to create the following datasets
-    #  Process summed rates dataset
     #  Process sectored rates dataset
 
     # Calculate livetime from the livetime counter
@@ -106,9 +105,14 @@ def process_science_data(
     # Create a standard rates dataset
     standard_rates_dataset = process_standard_rates_data(raw_counts_dataset, livetime)
 
+    # Create a summed rates dataset
+    summed_rates_dataset = process_summed_rates_data(raw_counts_dataset, livetime)
+
     l1b_science_datasets = []
     # Update attributes and dimensions
-    for dataset, logical_source in zip([standard_rates_dataset], logical_sources):
+    for dataset, logical_source in zip(
+        [standard_rates_dataset, summed_rates_dataset], logical_sources
+    ):
         dataset.attrs = attr_mgr.get_global_attributes(logical_source)
 
         # TODO: Add CDF attributes to yaml once they're defined for L1B science data
@@ -215,11 +219,225 @@ def process_standard_rates_data(
     return l1b_standard_rates_dataset
 
 
+def create_particle_data_arrays(
+    dataset: xr.Dataset,
+    particle: str,
+    energy_ranges: dict,
+    raw_counts_dataset: xr.Dataset,
+) -> xr.Dataset:
+    """
+    Create data arrays for a given particle.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The dataset to add the data arrays to.
+
+    particle : str
+        The particle name.
+
+    energy_ranges : list
+        List of energy range dictionaries for the particle.
+        Used to define the shape of the data arrays.
+
+    raw_counts_dataset : xr.Dataset
+        The L1A counts dataset. Used to define the shape of the data arrays.
+
+    Returns
+    -------
+    dataset : xr.Dataset
+        The dataset with the added data arrays.
+    """
+    dataset[f"{particle}"] = xr.DataArray(
+        data=np.zeros(
+            (raw_counts_dataset.sizes["epoch"], len(energy_ranges)), dtype=np.float32
+        ),
+        dims=["epoch", f"{particle}_energy_index"],
+        name=f"{particle}",
+    )
+    dataset[f"{particle}_delta_minus"] = xr.DataArray(
+        data=np.zeros(
+            (raw_counts_dataset.sizes["epoch"], len(energy_ranges)), dtype=np.float32
+        ),
+        dims=["epoch", f"{particle}_energy_index"],
+        name=f"{particle}_delta_minus",
+    )
+    dataset[f"{particle}_delta_plus"] = xr.DataArray(
+        data=np.zeros(
+            (raw_counts_dataset.sizes["epoch"], len(energy_ranges)), dtype=np.float32
+        ),
+        dims=["epoch", f"{particle}_energy_index"],
+        name=f"{particle}_delta_plus",
+    )
+    dataset.coords[f"{particle}_energy_index"] = xr.DataArray(
+        np.arange(len(energy_ranges), dtype=np.int8),
+        dims=[f"{particle}_energy_index"],
+        name=f"{particle}_energy_index",
+    )
+    return dataset
+
+
+def calculate_summed_counts(
+    raw_counts_dataset: xr.Dataset, count_indices: dict
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Calculate summed counts for a given energy range.
+
+    Parameters
+    ----------
+    raw_counts_dataset : xr.Dataset
+        The L1A counts dataset that contains the l2fgrates, l3fgrates,
+        and penfgrates data variables with the particle counts data
+        needed for the calculation.
+
+    count_indices : dict
+        A dictionary containing the indices for particle counts to sum for a given
+        energy range.
+        R2=Indices for L2FGRATES, R3=Indices for L3FGRATES, R4=Indices for PENFGRATES.
+
+    Returns
+    -------
+    summed_counts : np.ndarray
+        The summed counts.
+
+    summed_counts_delta_minus : np.ndarray
+        The summed counts for delta minus uncertainty.
+
+    summed_counts_delta_plus : np.ndarray
+        The summed counts for delta plus uncertainty.
+    """
+    summed_counts = np.zeros(raw_counts_dataset.sizes["epoch"], dtype=np.float32)
+    summed_counts_delta_minus = np.zeros(
+        raw_counts_dataset.sizes["epoch"], dtype=np.float32
+    )
+    summed_counts_delta_plus = np.zeros(
+        raw_counts_dataset.sizes["epoch"], dtype=np.float32
+    )
+    if "R2" in count_indices:
+        summed_counts += raw_counts_dataset["l2fgrates"][:, count_indices["R2"]].sum(
+            axis=1
+        )
+        summed_counts_delta_minus += raw_counts_dataset["l2fgrates"][
+            :, count_indices["R2"]
+        ].sum(axis=1)
+        summed_counts_delta_plus += raw_counts_dataset["l2fgrates"][
+            :, count_indices["R2"]
+        ].sum(axis=1)
+    if "R3" in count_indices:
+        summed_counts += raw_counts_dataset["l3fgrates"][:, count_indices["R3"]].sum(
+            axis=1
+        )
+        summed_counts_delta_minus += raw_counts_dataset["l3fgrates"][
+            :, count_indices["R3"]
+        ].sum(axis=1)
+        summed_counts_delta_plus += raw_counts_dataset["l3fgrates"][
+            :, count_indices["R3"]
+        ].sum(axis=1)
+    if "R4" in count_indices:
+        summed_counts += raw_counts_dataset["penfgrates"][:, count_indices["R4"]].sum(
+            axis=1
+        )
+        summed_counts_delta_minus += raw_counts_dataset["penfgrates"][
+            :, count_indices["R4"]
+        ].sum(axis=1)
+        summed_counts_delta_plus += raw_counts_dataset["penfgrates"][
+            :, count_indices["R4"]
+        ].sum(axis=1)
+    return summed_counts, summed_counts_delta_minus, summed_counts_delta_plus
+
+
+def add_rates_to_dataset(
+    dataset: xr.Dataset,
+    particle: str,
+    index: int,
+    summed_counts: dict,
+    livetime: float,
+) -> xr.Dataset:
+    """
+    Add summed rates to the dataset.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The dataset to add the rates to.
+
+    particle : str
+        The particle name.
+
+    index : int
+        The index of the energy range.
+
+    summed_counts : dict
+        A dictionary containing the summed counts.
+
+    livetime : float
+        The livetime.
+
+    Returns
+    -------
+    dataset: xr.Dataset
+        The dataset with the added rates.
+    """
+    dataset[f"{particle}"][:, index] = summed_counts["summed_counts"] / livetime
+    dataset[f"{particle}_delta_minus"][:, index] = (
+        summed_counts["summed_counts_delta_minus"] / livetime
+    )
+    dataset[f"{particle}_delta_plus"][:, index] = (
+        summed_counts["summed_counts_delta_plus"] / livetime
+    )
+    return dataset
+
+
+def add_energy_variables(
+    dataset: xr.Dataset, particle: str, energy_min: np.ndarray, energy_max: np.ndarray
+) -> xr.Dataset:
+    """
+    Add energy min and max variables to the dataset.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The dataset to add the energy variables to.
+    particle : str
+        The particle name.
+    energy_min : np.ndarray
+        The minimum energy values for each energy range.
+    energy_max : np.ndarray
+        The maximum energy values for each energy range.
+
+    Returns
+    -------
+    xr.Dataset
+        The dataset with the added energy variables.
+    """
+    dataset[f"{particle}_energy_min"] = xr.DataArray(
+        data=np.array(energy_min, dtype=np.int8),
+        dims=[f"{particle}_energy_index"],
+        name=f"{particle}_energy_min",
+    )
+    dataset[f"{particle}_energy_max"] = xr.DataArray(
+        data=np.array(energy_max, dtype=np.int8),
+        dims=[f"{particle}_energy_index"],
+        name=f"{particle}_energy_max",
+    )
+    return dataset
+
+
 def process_summed_rates_data(
     raw_counts_dataset: xr.Dataset, livetime: float
 ) -> xr.Dataset:
     """
     Will process L1B summed rates data from raw L1A counts data.
+
+    This function calculates summed rates for each particle type and energy range.
+    The counts that are summed come from the l2fgrates, l3fgrates, and penfgrates
+    data variables in the L1A counts data. These variables represent counts
+    of different detector penetration ranges (Range 2, Range 3, and Range 4
+    respectively). Only the energy ranges specified in the
+    PARTICLE_ENERGY_RANGE_MAPPING dictionary are included in this product.
+
+    The summed rates are calculated by summing the counts for each energy range and
+    dividing by the livetime.
 
     Parameters
     ----------
@@ -237,122 +455,48 @@ def process_summed_rates_data(
     # Create a new dataset to store the L1B standard rates
     l1b_summed_rates_dataset = xr.Dataset()
 
-    # Assign the epoch coordinate from the raw_counts_dataset
+    # Assign the epoch coordinate from the l1a dataset
     l1b_summed_rates_dataset = l1b_summed_rates_dataset.assign_coords(
         {"epoch": raw_counts_dataset.coords["epoch"]}
     )
 
-    # Add dynamic threshold field
+    # Add the dynamic threshold field from the l1a dataset
     l1b_summed_rates_dataset["dynamic_threshold_state"] = raw_counts_dataset[
         "hdr_dynamic_threshold_state"
     ]
 
     # Calculate summed rates for each particle and add them to the dataset
     for particle, energy_ranges in PARTICLE_ENERGY_RANGE_MAPPING.items():
-        # Create a new data array for each particle
-        l1b_summed_rates_dataset[f"{particle}"] = xr.DataArray(
-            data=np.zeros(
-                (raw_counts_dataset.sizes["epoch"], len(energy_ranges)),
-                dtype=np.float32,
-            ),
-            dims=["epoch", f"{particle}_energy_index"],
-            name=f"{particle}",
+        l1b_summed_rates_dataset = create_particle_data_arrays(
+            l1b_summed_rates_dataset, particle, energy_ranges, raw_counts_dataset
         )
 
-        # Create a new data array for each particle's uncertainty
-        l1b_summed_rates_dataset[f"{particle}_delta_minus"] = xr.DataArray(
-            data=np.zeros(
-                (raw_counts_dataset.sizes["epoch"], len(energy_ranges)),
-                dtype=np.float32,
-            ),
-            dims=["epoch", f"{particle}_energy_index"],
-            name=f"{particle}",
+        energy_min, energy_max = (
+            np.zeros(len(energy_ranges), dtype=np.float32),
+            np.zeros(len(energy_ranges), dtype=np.float32),
         )
-        l1b_summed_rates_dataset[f"{particle}_delta_plus"] = xr.DataArray(
-            data=np.zeros(
-                (raw_counts_dataset.sizes["epoch"], len(energy_ranges)),
-                dtype=np.float32,
-            ),
-            dims=["epoch", f"{particle}_energy_index"],
-            name=f"{particle}",
-        )
-
-        # Add an index coordinate for each particle
-        l1b_summed_rates_dataset.coords[f"{particle}_energy_index"] = xr.DataArray(
-            np.arange(
-                l1b_summed_rates_dataset.sizes[f"{particle}_energy_index"],
-                dtype=np.int8,
-            ),
-            dims=[f"{particle}_index"],
-            name=f"{particle}_index",
-        )
-
-        energy_min = np.zeros(len(energy_ranges), dtype=np.float32)
-        energy_max = np.zeros(len(energy_ranges), dtype=np.float32)
         for i, energy_range in enumerate(energy_ranges):
-            summed_counts = np.zeros(
-                raw_counts_dataset.sizes["epoch"], dtype=np.float32
+            summed_counts, summed_counts_delta_minus, summed_counts_delta_plus = (
+                calculate_summed_counts(raw_counts_dataset, energy_range)
             )
-            summed_counts_delta_minus = np.zeros(
-                raw_counts_dataset.sizes["epoch"], dtype=np.float32
+            l1b_summed_rates_dataset = add_rates_to_dataset(
+                l1b_summed_rates_dataset,
+                particle,
+                i,
+                {
+                    "summed_counts": summed_counts,
+                    "summed_counts_delta_minus": summed_counts_delta_minus,
+                    "summed_counts_delta_plus": summed_counts_delta_plus,
+                },
+                livetime,
             )
-            summed_counts_delta_plus = np.zeros(
-                raw_counts_dataset.sizes["epoch"], dtype=np.float32
+            energy_min[i], energy_max[i] = (
+                energy_range["energy_min"],
+                energy_range["energy_max"],
             )
-            if "R2" in energy_range:
-                summed_counts += raw_counts_dataset["l2fgrates"][
-                    :, energy_range["R2"]
-                ].sum(axis=1)
-                summed_counts_delta_minus += raw_counts_dataset["l2fgrates"][
-                    :, energy_range["R2"]
-                ].sum(axis=1)
-                summed_counts_delta_plus += raw_counts_dataset["l2fgrates"][
-                    :, energy_range["R2"]
-                ].sum(axis=1)
-            if "R3" in energy_range:
-                summed_counts += raw_counts_dataset["l3fgrates"][
-                    :, energy_range["R3"]
-                ].sum(axis=1)
-                summed_counts_delta_minus += raw_counts_dataset["l3fgrates"][
-                    :, energy_range["R3"]
-                ].sum(axis=1)
-                summed_counts_delta_plus += raw_counts_dataset["l3fgrates"][
-                    :, energy_range["R3"]
-                ].sum(axis=1)
-            if "R4" in energy_range:
-                summed_counts += raw_counts_dataset["penfgrates"][
-                    :, energy_range["R4"]
-                ].sum(axis=1)
-                summed_counts_delta_minus += raw_counts_dataset["penfgrates"][
-                    :, energy_range["R4"]
-                ].sum(axis=1)
-                summed_counts_delta_plus += raw_counts_dataset["penfgrates"][
-                    :, energy_range["R4"]
-                ].sum(axis=1)
-            # Add rates to the dataset (counts / livetime)
-            l1b_summed_rates_dataset[f"{particle}"][:, i] = summed_counts / livetime
-            l1b_summed_rates_dataset[f"{particle}_delta_minus"][:, i] = (
-                summed_counts_delta_minus / livetime
-            )
-            l1b_summed_rates_dataset[f"{particle}_delta_plus"][:, i] = (
-                summed_counts_delta_plus / livetime
-            )
-            energy_min[i] = energy_range["energy_min"]
-            energy_max[i] = energy_range["energy_max"]
 
-        # Add energy min and max variables
-        l1b_summed_rates_dataset[f"{particle}_energy_min"] = xr.DataArray(
-            data=np.array(energy_min, dtype=np.int8),
-            dims=[f"{particle}_energy_index"],
-            name=f"{particle}_energy_min",
+        l1b_summed_rates_dataset = add_energy_variables(
+            l1b_summed_rates_dataset, particle, energy_min, energy_max
         )
-        l1b_summed_rates_dataset[f"{particle}_energy_max"] = xr.DataArray(
-            data=np.array(energy_max, dtype=np.int8),
-            dims=[f"{particle}_energy_index"],
-            name=f"{particle}_energy_max",
-        )
-
-    # print(l1b_summed_rates_dataset)
-    # print(l1b_summed_rates_dataset["h"][22:32])
 
     return l1b_summed_rates_dataset

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
@@ -11,6 +12,7 @@ from imap_processing.hit.hit_utils import (
     get_datasets_by_apid,
     process_housekeeping_data,
 )
+from imap_processing.hit.l1b.constants import PARTICLE_ENERGY_RANGE_MAPPING
 
 logger = logging.getLogger(__name__)
 
@@ -98,8 +100,11 @@ def process_science_data(
     #  Process summed rates dataset
     #  Process sectored rates dataset
 
+    # Calculate livetime from the livetime counter
+    livetime = raw_counts_dataset["livetime_counter"] / 270
+
     # Create a standard rates dataset
-    standard_rates_dataset = process_standard_rates_data(raw_counts_dataset)
+    standard_rates_dataset = process_standard_rates_data(raw_counts_dataset, livetime)
 
     l1b_science_datasets = []
     # Update attributes and dimensions
@@ -136,7 +141,9 @@ def process_science_data(
     return l1b_science_datasets
 
 
-def process_standard_rates_data(raw_counts_dataset: xr.Dataset) -> xr.Dataset:
+def process_standard_rates_data(
+    raw_counts_dataset: xr.Dataset, livetime: float
+) -> xr.Dataset:
     """
     Will process L1B standard rates data from raw L1A counts data.
 
@@ -144,6 +151,9 @@ def process_standard_rates_data(raw_counts_dataset: xr.Dataset) -> xr.Dataset:
     ----------
     raw_counts_dataset : xr.Dataset
         The L1A counts dataset.
+
+    livetime : float
+        The livetime calculated from the livetime counter.
 
     Returns
     -------
@@ -193,9 +203,6 @@ def process_standard_rates_data(raw_counts_dataset: xr.Dataset) -> xr.Dataset:
         "l4bgrates",
     ]
 
-    # Calculate livetime from the livetime counter
-    livetime = raw_counts_dataset["livetime_counter"] / 270
-
     # Calculate standard rates by dividing the raw counts by livetime for
     # data variables with names that contain a substring from a defined
     # list of field names.
@@ -206,3 +213,146 @@ def process_standard_rates_data(raw_counts_dataset: xr.Dataset) -> xr.Dataset:
             l1b_standard_rates_dataset[var] = raw_counts_dataset[var] / livetime
 
     return l1b_standard_rates_dataset
+
+
+def process_summed_rates_data(
+    raw_counts_dataset: xr.Dataset, livetime: float
+) -> xr.Dataset:
+    """
+    Will process L1B summed rates data from raw L1A counts data.
+
+    Parameters
+    ----------
+    raw_counts_dataset : xr.Dataset
+        The L1A counts dataset.
+
+    livetime : float
+        The livetime calculated from the livetime counter.
+
+    Returns
+    -------
+    xr.Dataset
+        The processed L1B summed rates dataset.
+    """
+    # Create a new dataset to store the L1B standard rates
+    l1b_summed_rates_dataset = xr.Dataset()
+
+    # Assign the epoch coordinate from the raw_counts_dataset
+    l1b_summed_rates_dataset = l1b_summed_rates_dataset.assign_coords(
+        {"epoch": raw_counts_dataset.coords["epoch"]}
+    )
+
+    # Add dynamic threshold field
+    l1b_summed_rates_dataset["dynamic_threshold_state"] = raw_counts_dataset[
+        "hdr_dynamic_threshold_state"
+    ]
+
+    # Calculate summed rates for each particle and add them to the dataset
+    for particle, energy_ranges in PARTICLE_ENERGY_RANGE_MAPPING.items():
+        # Create a new data array for each particle
+        l1b_summed_rates_dataset[f"{particle}"] = xr.DataArray(
+            data=np.zeros(
+                (raw_counts_dataset.sizes["epoch"], len(energy_ranges)),
+                dtype=np.float32,
+            ),
+            dims=["epoch", f"{particle}_energy_index"],
+            name=f"{particle}",
+        )
+
+        # Create a new data array for each particle's uncertainty
+        l1b_summed_rates_dataset[f"{particle}_delta_minus"] = xr.DataArray(
+            data=np.zeros(
+                (raw_counts_dataset.sizes["epoch"], len(energy_ranges)),
+                dtype=np.float32,
+            ),
+            dims=["epoch", f"{particle}_energy_index"],
+            name=f"{particle}",
+        )
+        l1b_summed_rates_dataset[f"{particle}_delta_plus"] = xr.DataArray(
+            data=np.zeros(
+                (raw_counts_dataset.sizes["epoch"], len(energy_ranges)),
+                dtype=np.float32,
+            ),
+            dims=["epoch", f"{particle}_energy_index"],
+            name=f"{particle}",
+        )
+
+        # Add an index coordinate for each particle
+        l1b_summed_rates_dataset.coords[f"{particle}_energy_index"] = xr.DataArray(
+            np.arange(
+                l1b_summed_rates_dataset.sizes[f"{particle}_energy_index"],
+                dtype=np.int8,
+            ),
+            dims=[f"{particle}_index"],
+            name=f"{particle}_index",
+        )
+
+        energy_min = np.zeros(len(energy_ranges), dtype=np.float32)
+        energy_max = np.zeros(len(energy_ranges), dtype=np.float32)
+        for i, energy_range in enumerate(energy_ranges):
+            summed_counts = np.zeros(
+                raw_counts_dataset.sizes["epoch"], dtype=np.float32
+            )
+            summed_counts_delta_minus = np.zeros(
+                raw_counts_dataset.sizes["epoch"], dtype=np.float32
+            )
+            summed_counts_delta_plus = np.zeros(
+                raw_counts_dataset.sizes["epoch"], dtype=np.float32
+            )
+            if "R2" in energy_range:
+                summed_counts += raw_counts_dataset["l2fgrates"][
+                    :, energy_range["R2"]
+                ].sum(axis=1)
+                summed_counts_delta_minus += raw_counts_dataset["l2fgrates"][
+                    :, energy_range["R2"]
+                ].sum(axis=1)
+                summed_counts_delta_plus += raw_counts_dataset["l2fgrates"][
+                    :, energy_range["R2"]
+                ].sum(axis=1)
+            if "R3" in energy_range:
+                summed_counts += raw_counts_dataset["l3fgrates"][
+                    :, energy_range["R3"]
+                ].sum(axis=1)
+                summed_counts_delta_minus += raw_counts_dataset["l3fgrates"][
+                    :, energy_range["R3"]
+                ].sum(axis=1)
+                summed_counts_delta_plus += raw_counts_dataset["l3fgrates"][
+                    :, energy_range["R3"]
+                ].sum(axis=1)
+            if "R4" in energy_range:
+                summed_counts += raw_counts_dataset["penfgrates"][
+                    :, energy_range["R4"]
+                ].sum(axis=1)
+                summed_counts_delta_minus += raw_counts_dataset["penfgrates"][
+                    :, energy_range["R4"]
+                ].sum(axis=1)
+                summed_counts_delta_plus += raw_counts_dataset["penfgrates"][
+                    :, energy_range["R4"]
+                ].sum(axis=1)
+            # Add rates to the dataset (counts / livetime)
+            l1b_summed_rates_dataset[f"{particle}"][:, i] = summed_counts / livetime
+            l1b_summed_rates_dataset[f"{particle}_delta_minus"][:, i] = (
+                summed_counts_delta_minus / livetime
+            )
+            l1b_summed_rates_dataset[f"{particle}_delta_plus"][:, i] = (
+                summed_counts_delta_plus / livetime
+            )
+            energy_min[i] = energy_range["energy_min"]
+            energy_max[i] = energy_range["energy_max"]
+
+        # Add energy min and max variables
+        l1b_summed_rates_dataset[f"{particle}_energy_min"] = xr.DataArray(
+            data=np.array(energy_min, dtype=np.int8),
+            dims=[f"{particle}_energy_index"],
+            name=f"{particle}_energy_min",
+        )
+        l1b_summed_rates_dataset[f"{particle}_energy_max"] = xr.DataArray(
+            data=np.array(energy_max, dtype=np.int8),
+            dims=[f"{particle}_energy_index"],
+            name=f"{particle}_energy_max",
+        )
+
+    # print(l1b_summed_rates_dataset)
+    # print(l1b_summed_rates_dataset["h"][22:32])
+
+    return l1b_summed_rates_dataset

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -13,7 +13,10 @@ from imap_processing.hit.hit_utils import (
     get_datasets_by_apid,
     process_housekeeping_data,
 )
-from imap_processing.hit.l1b.constants import PARTICLE_ENERGY_RANGE_MAPPING
+from imap_processing.hit.l1b.constants import (
+    PARTICLE_ENERGY_RANGE_MAPPING,
+    livestim_pulses,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,8 +103,8 @@ def process_science_data(
     # TODO: Write functions to create the following datasets
     #  Process sectored rates dataset
 
-    # Calculate livetime from the livetime counter
-    livetime = raw_counts_dataset["livetime_counter"] / 270
+    # Calculate fractional livetime from the livetime counter
+    livetime = raw_counts_dataset["livetime_counter"] / livestim_pulses
 
     # Create a standard rates dataset
     standard_rates_dataset = process_standard_rates_data(raw_counts_dataset, livetime)

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -5,9 +5,6 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.hit.l1a import hit_l1a
-from imap_processing.tests.hit.helpers.l1_validation import (
-    prepare_standard_rates_validation_data,
-)
 from imap_processing.hit.l1b.hit_l1b import (
     PARTICLE_ENERGY_RANGE_MAPPING,
     add_energy_variables,
@@ -17,6 +14,9 @@ from imap_processing.hit.l1b.hit_l1b import (
     hit_l1b,
     process_standard_rates_data,
     process_summed_rates_data,
+)
+from imap_processing.tests.hit.helpers.l1_validation import (
+    prepare_standard_rates_validation_data,
 )
 
 # TODO: Packet files are per apid at the moment so the tests currently
@@ -253,7 +253,7 @@ def test_create_particle_data_arrays():
 
 
 def test_process_summed_rates_data(l1a_counts_dataset, livetime):
-    """Test function for processing summed rates data"""
+    """Test the variables in the summed rates dataset"""
 
     l1b_summed_rates_dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
 
@@ -295,7 +295,7 @@ def test_process_summed_rates_data(l1a_counts_dataset, livetime):
 
 
 def test_process_standard_rates_data(l1a_counts_dataset, livetime):
-    """Test function for processing standard rates data"""
+    """Test the variables in the standard rates dataset"""
     l1b_standard_rates_dataset = process_standard_rates_data(
         l1a_counts_dataset, livetime
     )

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -9,6 +7,7 @@ from imap_processing import imap_module_directory
 from imap_processing.hit.l1a import hit_l1a
 from imap_processing.hit.l1b.hit_l1b import (
     PARTICLE_ENERGY_RANGE_MAPPING,
+    SummedCounts,
     add_energy_variables,
     add_rates_to_dataset,
     calculate_summed_counts,
@@ -182,7 +181,7 @@ def test_add_rates_to_dataset():
         }
     )
 
-    # Add a sample particle data array
+    # Add empty data arrays for a sample particle
     particle = "test_particle"
     dataset[particle] = xr.DataArray(
         data=np.zeros((10, 5), dtype=np.float32),
@@ -197,15 +196,14 @@ def test_add_rates_to_dataset():
         dims=["epoch", f"{particle}_energy_index"],
     )
 
-    # Define the summed counts in a namedtuple
-    SummedCounts = namedtuple(
-        "SummedCounts",
-        ["summed_counts", "summed_counts_delta_minus", "summed_counts_delta_plus"],
-    )
+    # Set the random seed for reproducibility
+    np.random.seed(42)
+
+    # Define the summed counts with random values in a namedtuple
     summed_counts = SummedCounts(
-        np.random.rand(10),
-        np.random.rand(10),
-        np.random.rand(10),
+        xr.DataArray(np.random.rand(10), dims=["epoch"]),
+        xr.DataArray(np.random.rand(10), dims=["epoch"]),
+        xr.DataArray(np.random.rand(10), dims=["epoch"]),
     )
 
     # Call the function

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -195,12 +197,16 @@ def test_add_rates_to_dataset():
         dims=["epoch", f"{particle}_energy_index"],
     )
 
-    # Define the summed counts
-    summed_counts = {
-        "summed_counts": np.random.rand(10),
-        "summed_counts_delta_minus": np.random.rand(10),
-        "summed_counts_delta_plus": np.random.rand(10),
-    }
+    # Define the summed counts in a namedtuple
+    SummedCounts = namedtuple(
+        "SummedCounts",
+        ["summed_counts", "summed_counts_delta_minus", "summed_counts_delta_plus"],
+    )
+    summed_counts = SummedCounts(
+        np.random.rand(10),
+        np.random.rand(10),
+        np.random.rand(10),
+    )
 
     # Call the function
     updated_dataset = add_rates_to_dataset(
@@ -210,15 +216,15 @@ def test_add_rates_to_dataset():
     # Check the results
     np.testing.assert_array_almost_equal(
         updated_dataset[particle][:, 0].values,
-        summed_counts["summed_counts"] / dataset["livetime"].values,
+        summed_counts.summed_counts / dataset["livetime"].values,
     )
     np.testing.assert_array_almost_equal(
         updated_dataset[f"{particle}_delta_minus"][:, 0].values,
-        summed_counts["summed_counts_delta_minus"] / dataset["livetime"].values,
+        summed_counts.summed_counts_delta_minus / dataset["livetime"].values,
     )
     np.testing.assert_array_almost_equal(
         updated_dataset[f"{particle}_delta_plus"][:, 0].values,
-        summed_counts["summed_counts_delta_plus"] / dataset["livetime"].values,
+        summed_counts.summed_counts_delta_plus / dataset["livetime"].values,
     )
 
 

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -5,9 +5,18 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.hit.l1a import hit_l1a
-from imap_processing.hit.l1b import hit_l1b
 from imap_processing.tests.hit.helpers.l1_validation import (
     prepare_standard_rates_validation_data,
+)
+from imap_processing.hit.l1b.hit_l1b import (
+    PARTICLE_ENERGY_RANGE_MAPPING,
+    add_energy_variables,
+    add_rates_to_dataset,
+    calculate_summed_counts,
+    create_particle_data_arrays,
+    hit_l1b,
+    process_standard_rates_data,
+    process_summed_rates_data,
 )
 
 # TODO: Packet files are per apid at the moment so the tests currently
@@ -48,7 +57,7 @@ def dependencies(packet_filepath, sci_packet_filepath):
 @pytest.fixture()
 def l1b_hk_dataset(dependencies):
     """Get the housekeeping dataset"""
-    datasets = hit_l1b.hit_l1b(dependencies, "001")
+    datasets = hit_l1b(dependencies, "001")
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_hk":
             return dataset
@@ -58,7 +67,7 @@ def l1b_hk_dataset(dependencies):
 def l1b_standard_rates_dataset(dependencies):
     """Get the standard rates dataset"""
     # TODO: use this fixture in future unit test to validate the standard rates dataset
-    datasets = hit_l1b.hit_l1b(dependencies, "001")
+    datasets = hit_l1b(dependencies, "001")
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_standard-rates":
             return dataset
@@ -73,11 +82,225 @@ def l1a_counts_dataset(sci_packet_filepath):
             return dataset
 
 
-def test_process_standard_rates_data(l1a_counts_dataset):
-    """Test function for processing standard rates data"""
-    l1b_standard_rates_dataset = hit_l1b.process_standard_rates_data(l1a_counts_dataset)
+@pytest.fixture()
+def livetime(l1a_counts_dataset):
+    """Calculate livetime for L1A counts dataset"""
+    return l1a_counts_dataset["livetime_counter"] / 270
 
-    # Check that a xarray dataset with the correct logical source is returned
+
+def test_calculate_summed_counts():
+    # Create a mock raw_counts_dataset
+    data = {
+        "l2fgrates": (
+            ("epoch", "index"),
+            np.array([[1, 2, 3, 4, 5]] * 5, dtype=np.int64),
+        ),
+        "l3fgrates": (
+            ("epoch", "index"),
+            np.array([[6, 7, 8, 9, 10]] * 5, dtype=np.int64),
+        ),
+        "penfgrates": (
+            ("epoch", "index"),
+            np.array([[11, 12, 13, 14, 15]] * 5, dtype=np.int64),
+        ),
+        "l2fgrates_delta_minus": (
+            ("epoch", "index"),
+            np.zeros((5, 5), dtype=np.float32),
+        ),
+        "l3fgrates_delta_minus": (
+            ("epoch", "index"),
+            np.full((5, 5), 0.01, dtype=np.float32),
+        ),
+        "penfgrates_delta_minus": (
+            ("epoch", "index"),
+            np.full((5, 5), 0.001, dtype=np.float32),
+        ),
+        "l2fgrates_delta_plus": (
+            ("epoch", "index"),
+            np.full((5, 5), 0.02, dtype=np.float32),
+        ),
+        "l3fgrates_delta_plus": (
+            ("epoch", "index"),
+            np.full((5, 5), 0.002, dtype=np.float32),
+        ),
+        "penfgrates_delta_plus": (
+            ("epoch", "index"),
+            np.full((5, 5), 0.003, dtype=np.float32),
+        ),
+    }
+    coords = {"epoch": np.arange(5), "index": np.arange(5)}
+    raw_counts_dataset = xr.Dataset(data, coords=coords)
+
+    # Define count_indices
+    count_indices = {
+        "R2": [0, 1],
+        "R3": [2, 3],
+        "R4": [4],
+    }
+
+    # Call the function
+    summed_counts, summed_counts_delta_minus, summed_counts_delta_plus = (
+        calculate_summed_counts(raw_counts_dataset, count_indices)
+    )
+
+    # Expected values based on `count_indices`
+    expected_summed_counts = np.array([35, 35, 35, 35, 35])
+    expected_summed_counts_delta_minus = np.array([0.021, 0.021, 0.021, 0.021, 0.021])
+    expected_summed_counts_delta_plus = np.array([0.047, 0.047, 0.047, 0.047, 0.047])
+
+    # Assertions
+    assert summed_counts.shape == (5,)
+    assert summed_counts_delta_minus.shape == (5,)
+    assert summed_counts_delta_plus.shape == (5,)
+
+    np.testing.assert_array_almost_equal(summed_counts.values, expected_summed_counts)
+    np.testing.assert_array_almost_equal(
+        summed_counts_delta_minus.values, expected_summed_counts_delta_minus
+    )
+    np.testing.assert_array_almost_equal(
+        summed_counts_delta_plus.values, expected_summed_counts_delta_plus
+    )
+
+    # Check dtype consistency
+    assert summed_counts.dtype == np.int64, f"Unexpected dtype: {summed_counts.dtype}"
+    assert (
+        summed_counts_delta_minus.dtype == np.float32
+    ), f"Unexpected dtype: {summed_counts_delta_minus.dtype}"
+    assert (
+        summed_counts_delta_plus.dtype == np.float32
+    ), f"Unexpected dtype: {summed_counts_delta_plus.dtype}"
+
+
+def test_add_rates_to_dataset():
+    # Create a sample dataset
+    dataset = xr.Dataset(
+        {
+            "epoch": ("epoch", np.arange(10)),
+            "livetime": ("epoch", np.random.rand(10) + 1),  # Avoid division by zero
+        }
+    )
+
+    # Add a sample particle data array
+    particle = "test_particle"
+    dataset[particle] = xr.DataArray(
+        data=np.zeros((10, 5), dtype=np.float32),
+        dims=["epoch", f"{particle}_energy_index"],
+    )
+    dataset[f"{particle}_delta_minus"] = xr.DataArray(
+        data=np.zeros((10, 5), dtype=np.float32),
+        dims=["epoch", f"{particle}_energy_index"],
+    )
+    dataset[f"{particle}_delta_plus"] = xr.DataArray(
+        data=np.zeros((10, 5), dtype=np.float32),
+        dims=["epoch", f"{particle}_energy_index"],
+    )
+
+    # Define the summed counts
+    summed_counts = {
+        "summed_counts": np.random.rand(10),
+        "summed_counts_delta_minus": np.random.rand(10),
+        "summed_counts_delta_plus": np.random.rand(10),
+    }
+
+    # Call the function
+    updated_dataset = add_rates_to_dataset(
+        dataset, particle, 0, summed_counts, dataset["livetime"]
+    )
+
+    # Check the results
+    np.testing.assert_array_almost_equal(
+        updated_dataset[particle][:, 0].values,
+        summed_counts["summed_counts"] / dataset["livetime"].values,
+    )
+    np.testing.assert_array_almost_equal(
+        updated_dataset[f"{particle}_delta_minus"][:, 0].values,
+        summed_counts["summed_counts_delta_minus"] / dataset["livetime"].values,
+    )
+    np.testing.assert_array_almost_equal(
+        updated_dataset[f"{particle}_delta_plus"][:, 0].values,
+        summed_counts["summed_counts_delta_plus"] / dataset["livetime"].values,
+    )
+
+
+def test_add_energy_variables():
+    dataset = xr.Dataset()
+    particle = "test_particle"
+    energy_min = np.array([1.8, 4.0, 6.0], dtype=np.float32)
+    energy_max = np.array([2.2, 6.0, 10.0], dtype=np.float32)
+    result = add_energy_variables(dataset, particle, energy_min, energy_max)
+    assert f"{particle}_energy_min" in result.data_vars
+    assert f"{particle}_energy_max" in result.data_vars
+    assert np.all(result[f"{particle}_energy_min"].values == energy_min)
+    assert np.all(result[f"{particle}_energy_max"].values == energy_max)
+
+
+def test_create_particle_data_arrays():
+    dataset = xr.Dataset()
+    particle = "test_particle"
+    result = create_particle_data_arrays(
+        dataset, particle, num_energy_ranges=3, epoch_size=10
+    )
+
+    assert f"{particle}" in result.data_vars
+    assert f"{particle}_delta_minus" in result.data_vars
+    assert f"{particle}_delta_plus" in result.data_vars
+    assert f"{particle}_energy_index" in result.coords
+
+    for var in result.data_vars:
+        assert result[var].shape == (10, 3)
+
+    assert result[f"{particle}_energy_index"].shape == (3,)
+
+
+def test_process_summed_rates_data(l1a_counts_dataset, livetime):
+    """Test function for processing summed rates data"""
+
+    l1b_summed_rates_dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
+
+    # Check that a xarray dataset is returned
+    assert isinstance(l1b_summed_rates_dataset, xr.Dataset)
+
+    valid_coords = {
+        "epoch",
+        "hydrogen_energy_index",
+        "helium3_energy_index",
+        "helium4_energy_index",
+        "helium_energy_index",
+        "carbon_energy_index",
+        "oxygen_energy_index",
+        "iron_energy_index",
+        "nitrogen_energy_index",
+        "silicon_energy_index",
+        "magnesium_energy_index",
+        "sulfur_energy_index",
+        "argon_energy_index",
+        "calcium_energy_index",
+        "sodium_energy_index",
+        "aluminum_energy_index",
+        "neon_energy_index",
+        "nickel_energy_index",
+    }
+
+    # Check that the dataset has the correct coords and variables
+    assert valid_coords == set(l1b_summed_rates_dataset.coords), "Coordinates mismatch"
+
+    assert "dynamic_threshold_state" in l1b_summed_rates_dataset.data_vars
+
+    for particle in PARTICLE_ENERGY_RANGE_MAPPING.keys():
+        assert f"{particle}" in l1b_summed_rates_dataset.data_vars
+        assert f"{particle}_delta_minus" in l1b_summed_rates_dataset.data_vars
+        assert f"{particle}_delta_plus" in l1b_summed_rates_dataset.data_vars
+        assert f"{particle}_energy_min" in l1b_summed_rates_dataset.data_vars
+        assert f"{particle}_energy_max" in l1b_summed_rates_dataset.data_vars
+
+
+def test_process_standard_rates_data(l1a_counts_dataset, livetime):
+    """Test function for processing standard rates data"""
+    l1b_standard_rates_dataset = process_standard_rates_data(
+        l1a_counts_dataset, livetime
+    )
+
+    # Check that a xarray dataset is returned
     assert isinstance(l1b_standard_rates_dataset, xr.Dataset)
 
     # Define the data variables that should be present in the dataset
@@ -239,7 +462,7 @@ def test_validate_l1b_hk_data(l1b_hk_dataset):
 
     Parameters
     ----------
-    hk_dataset : xr.Dataset
+    l1b_hk_dataset : xr.Dataset
         Housekeeping dataset created by the L1B processing.
     """
     # TODO: finish test. HIT will provide an updated validation file to fix issues:
@@ -344,10 +567,11 @@ def test_hit_l1b(dependencies):
         Dictionary of L1A datasets and CCSDS packet file path
     """
     # TODO: update assertions after science data processing is completed
-    datasets = hit_l1b.hit_l1b(dependencies, "001")
+    datasets = hit_l1b(dependencies, "001")
 
-    assert len(datasets) == 2
+    assert len(datasets) == 3
     for dataset in datasets:
         assert isinstance(dataset, xr.Dataset)
     assert datasets[0].attrs["Logical_source"] == "imap_hit_l1b_hk"
     assert datasets[1].attrs["Logical_source"] == "imap_hit_l1b_standard-rates"
+    assert datasets[2].attrs["Logical_source"] == "imap_hit_l1b_summed-rates"


### PR DESCRIPTION
This PR adds the algorithm to HIT L1B processing to create the summed rates product. It also adds unit tests for the functions added to support this work.

Closes #1061 

## New Files
- constants.py
   - Added file for constants needed to support L1B processing
   - Added a dictionary mapping particles, energy ranges, and detection ranges needed to calculate summed rates

## Updated Files
- hit_l1b.py
   - added functions to create summed rates product
   - updated science processing function to support added summed rates product
- test_hit_l1b.py
   - Added unit tests for the new functions in L1B processing

