### PR TITLE
SWE: L2 update from SWE and I-ALiRT Discussion and added SPASE metadata

### DIFF
--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -1,7 +1,7 @@
 # <=== Coordinates ===>
 esa_step:
   CATDESC: Energy step id in lookup table
-  FIELDNAM: energy step
+  FIELDNAM: Energy Step
   FILLVAL: -9223370000000000000
   FORMAT: I2
   LABLAXIS: Energy Step
@@ -19,7 +19,7 @@ energy:
   LABLAXIS: Energy
   SCALE_TYP: linear
   UNITS: eV
-  VALIDMAX: 2000.0
+  VALIDMAX: 6000.0
   VALIDMIN: 0.0
   VAR_TYPE: support_data
 
@@ -36,13 +36,13 @@ spin_sector:
   VAR_TYPE: support_data
 
 inst_az:
-  CATDESC: Spin angle bins in instrument frame. Angle resolution is 12 degree nominally
-  FIELDNAM: spin angle
+  CATDESC: Spin angle in instrument frame. Angle resolution is 12 degree nominally
+  FIELDNAM: Spin Angle
   FILLVAL: -9223370000000000000
   FORMAT: E5.4
-  LABLAXIS: Angle
+  LABLAXIS: Degree
   SCALE_TYP: linear
-  UNITS: "Degree"
+  UNITS: Degree
   VALIDMAX: 359.999
   VALIDMIN: 0.00
   VAR_TYPE: support_data
@@ -52,33 +52,32 @@ inst_az:
     bin.
 
 cem_id:
-  CATDESC: Data of each CEM detector
-  FIELDNAM: CEM data
+  CATDESC: CEM detector number
+  FIELDNAM: CEM Number
   FILLVAL: -9223370000000000000
-  FORMAT: E14.7
-  LABLAXIS: Rates
+  FORMAT: I2
+  LABLAXIS: CEM Number
   SCALE_TYP: linear
   UNITS: " "
-  VALIDMAX: 0.000015514
-  VALIDMIN: 0.0
-  VAR_NOTES: " "
+  VALIDMAX: 6
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 inst_el:
   CATDESC: Angle of each CEM detector
-  FIELDNAM: CEM Angle
+  FIELDNAM: Polar Angle
   FILLVAL: -9223370000000000000
   FORMAT: I2
-  LABLAXIS: Angle
+  LABLAXIS: Degree
   SCALE_TYP: linear
   UNITS: Degree
-  VALIDMAX: 63
-  VALIDMIN: -63
+  VALIDMAX: 65
+  VALIDMIN: -65
   VAR_TYPE: support_data
 
 cycle:
   CATDESC: Full cycle data takes 4 spins' data
-  FIELDNAM: quarter cycle
+  FIELDNAM: Quarter Cycle
   FILLVAL: -9223370000000000000
   FORMAT: I2
   LABLAXIS: Cycle
@@ -129,7 +128,7 @@ inst_el_label:
 # <=== Data Variables ===>
 
 inst_az_spin_sector:
-  CATDESC: Spin angle organized by voltage step and spin sector
+  CATDESC: Spin angle organized by ESA step and spin sector
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
@@ -146,7 +145,7 @@ inst_az_spin_sector:
   DICT_KEY: SPASE>Support>SupportQuantity:SpinPhase,Qualifier:Array,CoordinateSystemName:SC,CoordinateRepresentation:Spherical
 
 phase_space_density_spin_sector:
-  CATDESC: Phase space density organized by voltage step and spin sector and CEM
+  CATDESC: Phase space density organized by ESA step and spin sector and CEM
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
@@ -157,10 +156,10 @@ phase_space_density_spin_sector:
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Phase Space Density
   FILLVAL: -1.0000000E+31
-  UNITS: s^3 / (cm^6 * ster)
+  UNITS: s^3 / cm^6
   FORMAT: E14.7
-  VALIDMAX: 0.000015514
-  VALIDMIN: 0
+  VALIDMAX: 1.0E-15
+  VALIDMIN: 1.0E-40
   VAR_TYPE: data
   DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:PhaseSpaceDensity,Qualifier:Array
 
@@ -177,15 +176,15 @@ phase_space_density:
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Phase Space Density
   FILLVAL: -1.0000000E+31
-  UNITS: s^3 / (cm^6 * ster)
+  UNITS: s^3 / cm^6
   FORMAT: E14.7
-  VALIDMAX: 0.000015514
-  VALIDMIN: 0
+  VALIDMAX: 1.0E-15
+  VALIDMIN: 1.0E-40
   VAR_TYPE: data
   DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:PhaseSpaceDensity,Qualifier:Array
 
 flux_spin_sector:
-  CATDESC: Flux organized by voltage step and spin sector and CEM
+  CATDESC: Number flux organized by ESA step and spin sector and CEM
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
@@ -198,13 +197,13 @@ flux_spin_sector:
   FILLVAL: -1.0000000E+31
   UNITS: 1 / (2 * eV * cm^2 * s * ster)
   FORMAT: E14.7
-  VALIDMAX: 0.000015514
-  VALIDMIN: 0
+  VALIDMAX: 1.0E9
+  VALIDMIN: 0.0
   VAR_TYPE: data
   DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:NumberFlux,Qualifier:Array
 
 flux:
-  CATDESC: Flux organized by energy (eV), spin angle, CEM angle
+  CATDESC: Number flux organized by energy (eV), spin angle, CEM angle
   DEPEND_0: epoch
   DEPEND_1: energy
   DEPEND_2: inst_az
@@ -217,21 +216,21 @@ flux:
   FILLVAL: -1.0000000E+31
   UNITS: 1 / (2 * eV * cm^2 * s * ster)
   FORMAT: E14.7
-  VALIDMAX: 0.000015514
-  VALIDMIN: 0
+  VALIDMAX: 1.0E9
+  VALIDMIN: 0.0
   VAR_TYPE: data
   DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:NumberFlux,Qualifier:Array
 
 
 acquisition_time:
-  CATDESC: Acquisition time organized by voltage step and spin sector
+  CATDESC: Acquisition time organized by ESA step and spin sector
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
   LABL_PTR_1: esa_step_label
   LABL_PTR_2: spin_sector_label
   DISPLAY_TYPE: spectrogram
-  FIELDNAM: Acquisition time by volt step and spin sector
+  FIELDNAM: Acquisition time by ESA step and spin sector
   FILLVAL: -1.0000000E+31
   FORMAT: I20
   VALIDMAX: 9223372036854775807
@@ -241,6 +240,6 @@ acquisition_time:
   VAR_NOTES: >
     This stores the acquisition times of each measurement. This time is
     calculated by combining ACQ_START_COARSE, ACQ_START_FINE,
-    acquisition duration and settle duration. It is time of each energy
-    step and each science measurement.
+    acquisition duration and settle duration. It is center time of each
+    science measurement (each energy and angle step).
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Array

--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -143,6 +143,7 @@ inst_az_spin_sector:
   VALIDMAX: 359.99
   VALIDMIN: 0.0
   VAR_TYPE: data
+  DICT_KEY: SPASE>Support>SupportQuantity:SpinPhase,Qualifier:Array,CoordinateSystemName:SC,CoordinateRepresentation:Spherical
 
 phase_space_density_spin_sector:
   CATDESC: Phase space density organized by voltage step and spin sector and CEM
@@ -161,6 +162,8 @@ phase_space_density_spin_sector:
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
+  DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:PhaseSpaceDensity,Qualifier:Array
+
 
 phase_space_density:
   CATDESC: Phase space density organized by energy (eV), spin angle, CEM angle
@@ -179,6 +182,7 @@ phase_space_density:
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
+  DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:PhaseSpaceDensity,Qualifier:Array
 
 flux_spin_sector:
   CATDESC: Flux organized by voltage step and spin sector and CEM
@@ -197,6 +201,7 @@ flux_spin_sector:
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
+  DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:NumberFlux,Qualifier:Array
 
 flux:
   CATDESC: Flux organized by energy (eV), spin angle, CEM angle
@@ -215,6 +220,8 @@ flux:
   VALIDMAX: 0.000015514
   VALIDMIN: 0
   VAR_TYPE: data
+  DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:NumberFlux,Qualifier:Array
+
 
 acquisition_time:
   CATDESC: Acquisition time organized by voltage step and spin sector
@@ -236,3 +243,4 @@ acquisition_time:
     calculated by combining ACQ_START_COARSE, ACQ_START_FINE,
     acquisition duration and settle duration. It is time of each energy
     step and each science measurement.
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Array

--- a/imap_processing/swe/l1a/swe_science.py
+++ b/imap_processing/swe/l1a/swe_science.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.swe.utils.swe_utils import SWEAPID
+from imap_processing.swe.utils.swe_utils import N_CEMS, SWEAPID
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ def swe_science(l0_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # 4. Reshape the data to 180 x 7
     raw_science_array = np.array(
         [
-            np.frombuffer(binary_string, dtype=np.uint8).reshape(180, 7)
+            np.frombuffer(binary_string, dtype=np.uint8).reshape(180, N_CEMS)
             for binary_string in l0_dataset["science_data"].values
         ]
     )
@@ -157,7 +157,7 @@ def swe_science(l0_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     )
 
     cem_id = xr.DataArray(
-        np.arange(7),
+        np.arange(N_CEMS),
         name="cem_id",
         dims=["cem_id"],
         attrs=cdf_attrs.get_variable_attributes("cem_id"),

--- a/imap_processing/swe/l1a/swe_science.py
+++ b/imap_processing/swe/l1a/swe_science.py
@@ -6,7 +6,8 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.swe.utils.swe_utils import N_CEMS, SWEAPID
+from imap_processing.swe.utils import swe_constants
+from imap_processing.swe.utils.swe_utils import SWEAPID
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +120,9 @@ def swe_science(l0_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # 4. Reshape the data to 180 x 7
     raw_science_array = np.array(
         [
-            np.frombuffer(binary_string, dtype=np.uint8).reshape(180, N_CEMS)
+            np.frombuffer(binary_string, dtype=np.uint8).reshape(
+                180, swe_constants.N_CEMS
+            )
             for binary_string in l0_dataset["science_data"].values
         ]
     )
@@ -157,7 +160,7 @@ def swe_science(l0_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     )
 
     cem_id = xr.DataArray(
-        np.arange(N_CEMS),
+        np.arange(swe_constants.N_CEMS),
         name="cem_id",
         dims=["cem_id"],
         attrs=cdf_attrs.get_variable_attributes("cem_id"),

--- a/imap_processing/swe/l1b/swe_l1b_science.py
+++ b/imap_processing/swe/l1b/swe_l1b_science.py
@@ -339,9 +339,12 @@ def populate_full_cycle_data(
                 #            (step * ( acq_duration + settle_duration) / 1000000 )
                 # where step goes from 0 to 179, acq_start_coarse is in seconds and
                 # acq_start_fine is in microseconds and acq_duration is in microseconds.
+                # To calculate center time of data acquisition time, we will add
+                #   each_count_acq_time + (acq_duration / 1000000) / 2
                 acquisition_times[esa_voltage_row_index][column_index] = (
                     base_quarter_cycle_acq_time
                     + (step * (acq_duration + settle_duration) / MICROSECONDS_IN_SECOND)
+                    + (acq_duration / MICROSECONDS_IN_SECOND) / 2
                 )
                 # Store acquisition duration for later calculation
                 acq_duration_arr[esa_voltage_row_index][column_index] = acq_duration

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -17,7 +17,6 @@ from imap_processing.swe.utils.swe_utils import (
     ESA_VOLTAGE_ROW_INDEX_DICT,
     FLUX_CONVERSION_FACTOR,
     GEOMETRIC_FACTORS,
-    MICROSECONDS_IN_SECOND,
     N_ANGLE_BINS,
     N_CEMS,
     N_ESA_STEPS,
@@ -413,28 +412,13 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
 
     # Calculate spin phase using SWE acquisition_time from the
     # L1B dataset. The L1B dataset stores acquisition_time with
-    # dimensions (epoch, esa_step, spin_sector). Use center time
-    # to calculate spin phase. This center time calculation is
-    # necessary to accurately determine the center angle of the data.
-    #
-    # To determine the center acquisition time, we adjust the
-    # recorded acquisition_time as follows:
-    #   acquisition_time + (acq_duration / 1000000) / 2
-    #
-    # Here, acq_duration is given in microseconds and is stored
-    # in the L1B dataset with dimensions (epoch, cycle). Since acq_duration
-    # remains the same for all quarter cycles within a full sweep,
-    # we use the first acq_duration value for each full sweep to perform
-    # this adjustment.
-
-    acq_duration = l1b_dataset["acq_duration"].data[:, 0] / (2 * MICROSECONDS_IN_SECOND)
-    data_acq_time = (
-        l1b_dataset["acquisition_time"].data + acq_duration[:, np.newaxis, np.newaxis]
-    )
+    # dimensions (epoch, esa_step, spin_sector). acquisition_time is
+    # center time of acquisition time of each science measurement which
+    # is necessary to accurately determine the center angle of the data.
 
     # Calculate spin phase
     inst_spin_phase = get_instrument_spin_phase(
-        query_met_times=data_acq_time.ravel(),
+        query_met_times=l1b_dataset["acquisition_time"].data.ravel(),
         instrument=SpiceFrame.IMAP_SWE,
     )
 

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -18,9 +18,9 @@ from imap_processing.swe.utils.swe_utils import (
     FLUX_CONVERSION_FACTOR,
     GEOMETRIC_FACTORS,
     N_ANGLE_BINS,
+    N_ANGLE_SECTORS,
     N_CEMS,
     N_ESA_STEPS,
-    N_MEASUREMENTS,
     VELOCITY_CONVERSION_FACTOR,
     read_lookup_table,
 )
@@ -103,7 +103,9 @@ def calculate_phase_space_density(l1b_dataset: xr.Dataset) -> xr.Dataset:
             for val in esa_table_nums
         ]
     )
-    particle_energy_data = particle_energy_data.reshape(-1, N_ESA_STEPS, N_MEASUREMENTS)
+    particle_energy_data = particle_energy_data.reshape(
+        -1, N_ESA_STEPS, N_ANGLE_SECTORS
+    )
 
     # Calculate phase space density using formula:
     #   2 * (C/tau) / (G * 1.237e31 * eV^2)
@@ -424,7 +426,7 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
 
     # Convert spin phase to spin angle in degrees.
     inst_spin_angle = get_spin_angle(inst_spin_phase, degrees=True).reshape(
-        -1, N_ESA_STEPS, N_MEASUREMENTS
+        -1, N_ESA_STEPS, N_ANGLE_SECTORS
     )
 
     # Save spin angle in dataset per SWE request.

--- a/imap_processing/swe/utils/swe_constants.py
+++ b/imap_processing/swe/utils/swe_constants.py
@@ -1,0 +1,63 @@
+"""Module containing constants used in the SWE processing pipeline."""
+
+import numpy as np
+
+N_ESA_STEPS = 24
+N_ANGLE_SECTORS = 30
+N_CEMS = 7
+N_QUARTER_CYCLES = 4
+N_ANGLE_BINS = 30
+
+MICROSECONDS_IN_SECOND = 1e6
+
+# TODO: add these to instrument status summary
+ENERGY_CONVERSION_FACTOR = 4.75
+# 7 CEMs geometric factors in cm^2 sr eV/eV units.
+GEOMETRIC_FACTORS = np.array(
+    [
+        435e-6,
+        599e-6,
+        808e-6,
+        781e-6,
+        876e-6,
+        548e-6,
+        432e-6,
+    ]
+)
+
+ELECTRON_MASS = 9.10938356e-31  # kg
+
+# See doc string of calculate_phase_space_density() for more details.
+VELOCITY_CONVERSION_FACTOR = 1.237e31
+# See doc string of calculate_flux() for more details.
+FLUX_CONVERSION_FACTOR = 6.187e30
+
+CEM_DETECTORS_ANGLE = np.array([-63, -42, -21, 0, 21, 42, 63])
+
+# ESA voltage and index in the final data table
+ESA_VOLTAGE_ROW_INDEX_DICT = {
+    0.56: 0,
+    0.78: 1,
+    1.08: 2,
+    1.51: 3,
+    2.10: 4,
+    2.92: 5,
+    4.06: 6,
+    5.64: 7,
+    7.85: 8,
+    10.92: 9,
+    15.19: 10,
+    21.13: 11,
+    29.39: 12,
+    40.88: 13,
+    56.87: 14,
+    79.10: 15,
+    110.03: 16,
+    153.05: 17,
+    212.89: 18,
+    296.14: 19,
+    411.93: 20,
+    572.99: 21,
+    797.03: 22,
+    1108.66: 23,
+}

--- a/imap_processing/swe/utils/swe_utils.py
+++ b/imap_processing/swe/utils/swe_utils.py
@@ -100,7 +100,7 @@ def combine_acquisition_time(
     and fine value. We will use that as base time to calculate each
     acquisition time for each count data.
     base_quarter_cycle_acq_time = acq_start_coarse +
-                                acq_start_fine / 1000000
+    |                            acq_start_fine / 1000000
 
     Parameters
     ----------
@@ -130,13 +130,13 @@ def calculate_data_acquisition_time(
     Center acquisition time (in seconds) of each count data
     point at each energy and at angle step will be
     calculated using this formula:
-        each_count_acq_time = acq_start_time +
-               (step * ( acq_duration + settle_duration) / 1000000 )
+    |    each_count_acq_time = acq_start_time +
+    |           (step * ( acq_duration + settle_duration) / 1000000 )
     where 'step' goes from 0 to 179, acq_start_time is in seconds and
     settle_duration and acq_duration are in microseconds.
 
     To calculate center time of data acquisition time, we will add
-        each_count_acq_time + (acq_duration / 1000000) / 2
+    |    each_count_acq_time + (acq_duration / 1000000) / 2
 
     Parameters
     ----------

--- a/imap_processing/swe/utils/swe_utils.py
+++ b/imap_processing/swe/utils/swe_utils.py
@@ -7,66 +7,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from imap_processing import imap_module_directory
-
-N_ESA_STEPS = 24
-N_ANGLE_SECTORS = 30
-N_CEMS = 7
-N_QUARTER_CYCLES = 4
-N_ANGLE_BINS = 30
-
-MICROSECONDS_IN_SECOND = 1e6
-
-# TODO: add these to instrument status summary
-ENERGY_CONVERSION_FACTOR = 4.75
-# 7 CEMs geometric factors in cm^2 sr eV/eV units.
-GEOMETRIC_FACTORS = np.array(
-    [
-        435e-6,
-        599e-6,
-        808e-6,
-        781e-6,
-        876e-6,
-        548e-6,
-        432e-6,
-    ]
-)
-
-ELECTRON_MASS = 9.10938356e-31  # kg
-
-# See doc string of calculate_phase_space_density() for more details.
-VELOCITY_CONVERSION_FACTOR = 1.237e31
-# See doc string of calculate_flux() for more details.
-FLUX_CONVERSION_FACTOR = 6.187e30
-
-CEM_DETECTORS_ANGLE = np.array([-63, -42, -21, 0, 21, 42, 63])
-
-# ESA voltage and index in the final data table
-ESA_VOLTAGE_ROW_INDEX_DICT = {
-    0.56: 0,
-    0.78: 1,
-    1.08: 2,
-    1.51: 3,
-    2.10: 4,
-    2.92: 5,
-    4.06: 6,
-    5.64: 7,
-    7.85: 8,
-    10.92: 9,
-    15.19: 10,
-    21.13: 11,
-    29.39: 12,
-    40.88: 13,
-    56.87: 14,
-    79.10: 15,
-    110.03: 16,
-    153.05: 17,
-    212.89: 18,
-    296.14: 19,
-    411.93: 20,
-    572.99: 21,
-    797.03: 22,
-    1108.66: 23,
-}
+from imap_processing.swe.utils import swe_constants
 
 
 class SWEAPID(IntEnum):
@@ -114,7 +55,9 @@ def combine_acquisition_time(
     np.ndarray
         Acquisition time in seconds.
     """
-    epoch_center_time = acq_start_coarse + (acq_start_fine / MICROSECONDS_IN_SECOND)
+    epoch_center_time = acq_start_coarse + (
+        acq_start_fine / swe_constants.MICROSECONDS_IN_SECOND
+    )
     return epoch_center_time
 
 
@@ -157,8 +100,12 @@ def calculate_data_acquisition_time(
     # Calculate time for each ESA step
     esa_step_number_acq_time = (
         acq_start_time
-        + (esa_step_number * (acq_duration + settle_duration) / MICROSECONDS_IN_SECOND)
-        + (acq_duration / MICROSECONDS_IN_SECOND) / 2
+        + (
+            esa_step_number
+            * (acq_duration + settle_duration)
+            / swe_constants.MICROSECONDS_IN_SECOND
+        )
+        + (acq_duration / swe_constants.MICROSECONDS_IN_SECOND) / 2
     )
 
     return esa_step_number_acq_time

--- a/imap_processing/swe/utils/swe_utils.py
+++ b/imap_processing/swe/utils/swe_utils.py
@@ -3,6 +3,7 @@
 from enum import IntEnum
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 from imap_processing import imap_module_directory
@@ -87,3 +88,77 @@ def read_lookup_table() -> pd.DataFrame:
     lookup_table_path = imap_module_directory / "swe/l1b/swe_esa_lookup_table.csv"
     esa_table = pd.read_csv(lookup_table_path)
     return esa_table
+
+
+def combine_acquisition_time(
+    acq_start_coarse: np.ndarray, acq_start_fine: np.ndarray
+) -> npt.NDArray:
+    """
+    Combine acquisition time of each quarter cycle measurement.
+
+    Each quarter cycle data should have same acquisition start time coarse
+    and fine value. We will use that as base time to calculate each
+    acquisition time for each count data.
+    base_quarter_cycle_acq_time = acq_start_coarse +
+                                acq_start_fine / 1000000
+
+    Parameters
+    ----------
+    acq_start_coarse : np.ndarray
+        Acq start coarse. It is in seconds.
+    acq_start_fine : np.ndarray
+        Acq start fine. It is in microseconds.
+
+    Returns
+    -------
+    np.ndarray
+        Acquisition time in seconds.
+    """
+    epoch_center_time = acq_start_coarse + (acq_start_fine / MICROSECONDS_IN_SECOND)
+    return epoch_center_time
+
+
+def calculate_data_acquisition_time(
+    acq_start_time: np.ndarray,
+    esa_step_number: int,
+    acq_duration: int,
+    settle_duration: int,
+) -> npt.NDArray:
+    """
+    Calculate center acquisition time of each science data point.
+
+    Center acquisition time (in seconds) of each count data
+    point at each energy and at angle step will be
+    calculated using this formula:
+        each_count_acq_time = acq_start_time +
+               (step * ( acq_duration + settle_duration) / 1000000 )
+    where 'step' goes from 0 to 179, acq_start_time is in seconds and
+    settle_duration and acq_duration are in microseconds.
+
+    To calculate center time of data acquisition time, we will add
+        each_count_acq_time + (acq_duration / 1000000) / 2
+
+    Parameters
+    ----------
+    acq_start_time : np.ndarray
+        Start acquisition time in seconds.
+    esa_step_number : int
+        Energy step.
+    acq_duration : int
+        Acquisition duration in microseconds.
+    settle_duration : int
+        Settle duration in microseconds.
+
+    Returns
+    -------
+    esa_step_number_acq_time : np.ndarray
+        ESA step number acquisition center time in seconds.
+    """
+    # Calculate time for each ESA step
+    esa_step_number_acq_time = (
+        acq_start_time
+        + (esa_step_number * (acq_duration + settle_duration) / MICROSECONDS_IN_SECOND)
+        + (acq_duration / MICROSECONDS_IN_SECOND) / 2
+    )
+
+    return esa_step_number_acq_time

--- a/imap_processing/swe/utils/swe_utils.py
+++ b/imap_processing/swe/utils/swe_utils.py
@@ -2,9 +2,42 @@
 
 from enum import IntEnum
 
+import numpy as np
 import pandas as pd
 
 from imap_processing import imap_module_directory
+
+N_ESA_STEPS = 24
+N_MEASUREMENTS = 30
+N_CEMS = 7
+N_QUARTER_CYCLES = 4
+N_ANGLE_BINS = 30
+
+MICROSECONDS_IN_SECOND = 1e6
+
+# TODO: add these to instrument status summary
+ENERGY_CONVERSION_FACTOR = 4.75
+# 7 CEMs geometric factors in cm^2 sr eV/eV units.
+GEOMETRIC_FACTORS = np.array(
+    [
+        435e-6,
+        599e-6,
+        808e-6,
+        781e-6,
+        876e-6,
+        548e-6,
+        432e-6,
+    ]
+)
+
+ELECTRON_MASS = 9.10938356e-31  # kg
+
+# See doc string of calculate_phase_space_density() for more details.
+VELOCITY_CONVERSION_FACTOR = 1.237e31
+# See doc string of calculate_flux() for more details.
+FLUX_CONVERSION_FACTOR = 6.187e30
+
+CEM_DETECTORS_ANGLE = np.array([-63, -42, -21, 0, 21, 42, 63])
 
 # ESA voltage and index in the final data table
 ESA_VOLTAGE_ROW_INDEX_DICT = {

--- a/imap_processing/swe/utils/swe_utils.py
+++ b/imap_processing/swe/utils/swe_utils.py
@@ -9,7 +9,7 @@ import pandas as pd
 from imap_processing import imap_module_directory
 
 N_ESA_STEPS = 24
-N_MEASUREMENTS = 30
+N_ANGLE_SECTORS = 30
 N_CEMS = 7
 N_QUARTER_CYCLES = 4
 N_ANGLE_BINS = 30

--- a/imap_processing/tests/swe/test_swe_l1b_science.py
+++ b/imap_processing/tests/swe/test_swe_l1b_science.py
@@ -9,11 +9,7 @@ from imap_processing.swe.l1b.swe_l1b_science import (
     apply_in_flight_calibration,
     get_indices_of_full_cycles,
 )
-from imap_processing.swe.utils.swe_utils import (
-    N_ANGLE_SECTORS,
-    N_CEMS,
-    N_ESA_STEPS,
-)
+from imap_processing.swe.utils import swe_constants
 
 
 @pytest.fixture(scope="session")
@@ -62,8 +58,17 @@ def test_in_flight_calibration_factor(mock_read_in_flight_cal_data, l1a_test_dat
 
     input_time = 453051355.0
     input_count = 19967
-    one_full_cycle_data = np.full((N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS), input_count)
-    acquisition_time = np.full((N_ESA_STEPS, N_ANGLE_SECTORS), input_time)
+    one_full_cycle_data = np.full(
+        (
+            swe_constants.N_ESA_STEPS,
+            swe_constants.N_ANGLE_SECTORS,
+            swe_constants.N_CEMS,
+        ),
+        input_count,
+    )
+    acquisition_time = np.full(
+        (swe_constants.N_ESA_STEPS, swe_constants.N_ANGLE_SECTORS), input_time
+    )
 
     # Test that calibration factor is within correct range given test data
     expected_cal_factor = 1 + ((2 - 1) / (453051900 - 453051300)) * (
@@ -78,14 +83,21 @@ def test_in_flight_calibration_factor(mock_read_in_flight_cal_data, l1a_test_dat
     np.testing.assert_allclose(
         calibrated_count,
         np.full(
-            (N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS), input_count * expected_cal_factor
+            (
+                swe_constants.N_ESA_STEPS,
+                swe_constants.N_ANGLE_SECTORS,
+                swe_constants.N_CEMS,
+            ),
+            input_count * expected_cal_factor,
         ),
         rtol=1e-9,
     )
 
     # Check for value outside of calibration time range
     input_time = 1.0
-    acquisition_time = np.full((N_ESA_STEPS, N_ANGLE_SECTORS), input_time)
+    acquisition_time = np.full(
+        (swe_constants.N_ESA_STEPS, swe_constants.N_ANGLE_SECTORS), input_time
+    )
 
     with pytest.raises(ValueError, match="Acquisition min/max times: "):
         apply_in_flight_calibration(one_full_cycle_data, acquisition_time)

--- a/imap_processing/tests/swe/test_swe_l1b_science.py
+++ b/imap_processing/tests/swe/test_swe_l1b_science.py
@@ -9,6 +9,11 @@ from imap_processing.swe.l1b.swe_l1b_science import (
     apply_in_flight_calibration,
     get_indices_of_full_cycles,
 )
+from imap_processing.swe.utils.swe_utils import (
+    N_CEMS,
+    N_ESA_STEPS,
+    N_MEASUREMENTS,
+)
 
 
 @pytest.fixture(scope="session")
@@ -57,8 +62,8 @@ def test_in_flight_calibration_factor(mock_read_in_flight_cal_data, l1a_test_dat
 
     input_time = 453051355.0
     input_count = 19967
-    one_full_cycle_data = np.full((24, 30, 7), input_count)
-    acquisition_time = np.full((24, 30), input_time)
+    one_full_cycle_data = np.full((N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), input_count)
+    acquisition_time = np.full((N_ESA_STEPS, N_MEASUREMENTS), input_time)
 
     # Test that calibration factor is within correct range given test data
     expected_cal_factor = 1 + ((2 - 1) / (453051900 - 453051300)) * (
@@ -72,13 +77,15 @@ def test_in_flight_calibration_factor(mock_read_in_flight_cal_data, l1a_test_dat
 
     np.testing.assert_allclose(
         calibrated_count,
-        np.full((24, 30, 7), input_count * expected_cal_factor),
+        np.full(
+            (N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), input_count * expected_cal_factor
+        ),
         rtol=1e-9,
     )
 
     # Check for value outside of calibration time range
     input_time = 1.0
-    acquisition_time = np.full((24, 30), input_time)
+    acquisition_time = np.full((N_ESA_STEPS, N_MEASUREMENTS), input_time)
 
     with pytest.raises(ValueError, match="Acquisition min/max times: "):
         apply_in_flight_calibration(one_full_cycle_data, acquisition_time)

--- a/imap_processing/tests/swe/test_swe_l1b_science.py
+++ b/imap_processing/tests/swe/test_swe_l1b_science.py
@@ -10,9 +10,9 @@ from imap_processing.swe.l1b.swe_l1b_science import (
     get_indices_of_full_cycles,
 )
 from imap_processing.swe.utils.swe_utils import (
+    N_ANGLE_SECTORS,
     N_CEMS,
     N_ESA_STEPS,
-    N_MEASUREMENTS,
 )
 
 
@@ -62,8 +62,8 @@ def test_in_flight_calibration_factor(mock_read_in_flight_cal_data, l1a_test_dat
 
     input_time = 453051355.0
     input_count = 19967
-    one_full_cycle_data = np.full((N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), input_count)
-    acquisition_time = np.full((N_ESA_STEPS, N_MEASUREMENTS), input_time)
+    one_full_cycle_data = np.full((N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS), input_count)
+    acquisition_time = np.full((N_ESA_STEPS, N_ANGLE_SECTORS), input_time)
 
     # Test that calibration factor is within correct range given test data
     expected_cal_factor = 1 + ((2 - 1) / (453051900 - 453051300)) * (
@@ -78,14 +78,14 @@ def test_in_flight_calibration_factor(mock_read_in_flight_cal_data, l1a_test_dat
     np.testing.assert_allclose(
         calibrated_count,
         np.full(
-            (N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), input_count * expected_cal_factor
+            (N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS), input_count * expected_cal_factor
         ),
         rtol=1e-9,
     )
 
     # Check for value outside of calibration time range
     input_time = 1.0
-    acquisition_time = np.full((N_ESA_STEPS, N_MEASUREMENTS), input_time)
+    acquisition_time = np.full((N_ESA_STEPS, N_ANGLE_SECTORS), input_time)
 
     with pytest.raises(ValueError, match="Acquisition min/max times: "):
         apply_in_flight_calibration(one_full_cycle_data, acquisition_time)

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -10,8 +10,6 @@ from imap_processing.cdf.utils import write_cdf
 from imap_processing.swe.l1a.swe_l1a import swe_l1a
 from imap_processing.swe.l1b.swe_l1b import swe_l1b
 from imap_processing.swe.l2.swe_l2 import (
-    ENERGY_CONVERSION_FACTOR,
-    VELOCITY_CONVERSION_FACTOR,
     calculate_flux,
     calculate_phase_space_density,
     find_angle_bin_indices,
@@ -19,7 +17,16 @@ from imap_processing.swe.l2.swe_l2 import (
     put_data_into_angle_bins,
     swe_l2,
 )
-from imap_processing.swe.utils.swe_utils import read_lookup_table
+from imap_processing.swe.utils.swe_utils import (
+    ENERGY_CONVERSION_FACTOR,
+    N_ANGLE_BINS,
+    N_CEMS,
+    N_ESA_STEPS,
+    N_MEASUREMENTS,
+    N_QUARTER_CYCLES,
+    VELOCITY_CONVERSION_FACTOR,
+    read_lookup_table,
+)
 
 
 def test_get_particle_energy():
@@ -29,7 +36,7 @@ def test_get_particle_energy():
     np.testing.assert_array_equal(all_energy["energy"], expected_energy)
 
 
-@patch("imap_processing.swe.l2.swe_l2.GEOMETRIC_FACTORS", new=np.full(7, 1))
+@patch("imap_processing.swe.l2.swe_l2.GEOMETRIC_FACTORS", new=np.full(N_CEMS, 1))
 @patch(
     "imap_processing.swe.l2.swe_l2.get_particle_energy",
     return_value=pd.DataFrame(
@@ -50,21 +57,26 @@ def test_calculate_phase_space_density(patch_get_particle_energy):
         {
             "science_data": (
                 ["epoch", "energy", "angle", "cem"],
-                np.full((total_sweeps, 24, 30, 7), 1),
+                np.full((total_sweeps, N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), 1),
             ),
-            "acq_duration": (["epoch", "cycle"], np.full((total_sweeps, 4), 80.0)),
+            "acq_duration": (
+                ["epoch", "cycle"],
+                np.full((total_sweeps, N_QUARTER_CYCLES), 80.0),
+            ),
             "esa_table_num": (
                 ["epoch", "cycle"],
-                np.repeat([0, 1], 4).reshape(total_sweeps, 4),
+                np.repeat([0, 1], N_QUARTER_CYCLES).reshape(
+                    total_sweeps, N_QUARTER_CYCLES
+                ),
             ),
         }
     )
     phase_space_density_ds = calculate_phase_space_density(l1b_dataset)
     assert phase_space_density_ds["phase_space_density"].shape == (
         total_sweeps,
-        24,
-        30,
-        7,
+        N_ESA_STEPS,
+        N_MEASUREMENTS,
+        N_CEMS,
     )
 
     # Test that first sweep has correct values. In patch,
@@ -73,7 +85,9 @@ def test_calculate_phase_space_density(patch_get_particle_energy):
     #   3. we have set science_data to 1.
     # Using this in the formula, we calculate expected density value.
     expected_calculated_density = (2 * 1) / (1 * VELOCITY_CONVERSION_FACTOR * 1**2)
-    expected_density = np.full((24, 30, 7), expected_calculated_density)
+    expected_density = np.full(
+        (N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), expected_calculated_density
+    )
     np.testing.assert_array_equal(
         phase_space_density_ds["phase_space_density"][0].data, expected_density
     )
@@ -81,7 +95,9 @@ def test_calculate_phase_space_density(patch_get_particle_energy):
     # Test that second sweep has correct values, similar to first sweep,
     # but with energy 2.
     expected_calculated_density = (2 * 1) / (1 * VELOCITY_CONVERSION_FACTOR * 2**2)
-    expected_density = np.full((24, 30, 7), expected_calculated_density)
+    expected_density = np.full(
+        (N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), expected_calculated_density
+    )
     np.testing.assert_array_equal(
         phase_space_density_ds["phase_space_density"][1].data, expected_density
     )
@@ -96,18 +112,23 @@ def test_calculate_flux():
         {
             "science_data": (
                 ["epoch", "energy", "angle", "cem"],
-                np.full((total_sweeps, 24, 30, 7), 1),
+                np.full((total_sweeps, N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), 1),
             ),
-            "acq_duration": (["epoch", "cycle"], np.full((total_sweeps, 4), 80.0)),
+            "acq_duration": (
+                ["epoch", "cycle"],
+                np.full((total_sweeps, N_QUARTER_CYCLES), 80.0),
+            ),
             "esa_table_num": (
                 ["epoch", "cycle"],
-                np.repeat([0, 1], 4).reshape(total_sweeps, 4),
+                np.repeat([0, 1], N_QUARTER_CYCLES).reshape(
+                    total_sweeps, N_QUARTER_CYCLES
+                ),
             ),
         }
     )
 
     flux = calculate_flux(l1b_dataset)
-    assert flux.shape == (total_sweeps, 24, 30, 7)
+    assert flux.shape == (total_sweeps, N_ESA_STEPS, N_MEASUREMENTS, N_CEMS)
     assert type(flux) == np.ndarray
 
 
@@ -142,18 +163,15 @@ def test_find_angle_bin_indices():
 def test_put_data_into_angle_bins():
     """Test put_data_into_angle_bins function."""
     num_cycles = 1
-    num_esa_step = 24
-    num_angle_bins = 30
-    num_cems = 7
     # Create test counts data to test
     # Find all even numbers in the range 0 to 30
     even_numbers = np.arange(0, 30, 2)
     # repeat it twice now to get:
     # [0, 0, 2, 2, ...., 28, 28]
     example_data = np.repeat(even_numbers, 2)
-    energy_angle_test_data = np.tile(example_data, (num_cycles, num_esa_step, 1))
+    energy_angle_test_data = np.tile(example_data, (num_cycles, N_ESA_STEPS, 1))
     # Expand to include 7 CEMs by repeating across last dimension
-    test_data = np.repeat(energy_angle_test_data[..., np.newaxis], num_cems, axis=-1)
+    test_data = np.repeat(energy_angle_test_data[..., np.newaxis], N_CEMS, axis=-1)
 
     # Took this example from intermediate output from actual data
     angle_bins_example = [
@@ -190,16 +208,16 @@ def test_put_data_into_angle_bins():
     ]
     # Now data with every row to be same as angle_bins_example
     test_angle_bin_indices_data = np.full(
-        (num_cycles, num_esa_step, num_angle_bins), angle_bins_example
+        (num_cycles, N_ESA_STEPS, N_MEASUREMENTS), angle_bins_example
     )
 
     binned_data = put_data_into_angle_bins(test_data, test_angle_bin_indices_data)
-    assert binned_data.shape == (num_cycles, num_esa_step, num_angle_bins, num_cems)
+    assert binned_data.shape == (num_cycles, N_ESA_STEPS, N_ANGLE_BINS, N_CEMS)
 
     # Test that the binned data has correct values in correct bins by
     # checking that odd number columns are filled with nan
     expected_binned_data = np.full(
-        (num_cycles, num_esa_step, num_angle_bins, num_cems), np.nan
+        (num_cycles, N_ESA_STEPS, N_ANGLE_BINS, N_CEMS), np.nan
     )
     np.testing.assert_array_equal(
         binned_data[0, 0, 1::2, 0], expected_binned_data[0, 0, 1::2, 0]
@@ -259,9 +277,19 @@ def test_swe_l2(mock_read_in_flight_cal_data, use_fake_spin_data_for_time):
     l2_dataset = swe_l2(l1b_dataset[0], "002")
 
     assert type(l2_dataset) == xr.Dataset
-    assert l2_dataset["phase_space_density_spin_sector"].shape == (6, 24, 30, 7)
-    assert l2_dataset["flux_spin_sector"].shape == (6, 24, 30, 7)
-    assert l2_dataset["acquisition_time"].shape == (6, 24, 30)
+    assert l2_dataset["phase_space_density_spin_sector"].shape == (
+        6,
+        N_ESA_STEPS,
+        N_MEASUREMENTS,
+        N_CEMS,
+    )
+    assert l2_dataset["flux_spin_sector"].shape == (
+        6,
+        N_ESA_STEPS,
+        N_MEASUREMENTS,
+        N_CEMS,
+    )
+    assert l2_dataset["acquisition_time"].shape == (6, N_ESA_STEPS, N_MEASUREMENTS)
 
     # Write L2 to CDF
     l2_cdf_filepath = write_cdf(l2_dataset)

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -20,9 +20,9 @@ from imap_processing.swe.l2.swe_l2 import (
 from imap_processing.swe.utils.swe_utils import (
     ENERGY_CONVERSION_FACTOR,
     N_ANGLE_BINS,
+    N_ANGLE_SECTORS,
     N_CEMS,
     N_ESA_STEPS,
-    N_MEASUREMENTS,
     N_QUARTER_CYCLES,
     VELOCITY_CONVERSION_FACTOR,
     read_lookup_table,
@@ -57,7 +57,7 @@ def test_calculate_phase_space_density(patch_get_particle_energy):
         {
             "science_data": (
                 ["epoch", "energy", "angle", "cem"],
-                np.full((total_sweeps, N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), 1),
+                np.full((total_sweeps, N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS), 1),
             ),
             "acq_duration": (
                 ["epoch", "cycle"],
@@ -75,7 +75,7 @@ def test_calculate_phase_space_density(patch_get_particle_energy):
     assert phase_space_density_ds["phase_space_density"].shape == (
         total_sweeps,
         N_ESA_STEPS,
-        N_MEASUREMENTS,
+        N_ANGLE_SECTORS,
         N_CEMS,
     )
 
@@ -86,7 +86,7 @@ def test_calculate_phase_space_density(patch_get_particle_energy):
     # Using this in the formula, we calculate expected density value.
     expected_calculated_density = (2 * 1) / (1 * VELOCITY_CONVERSION_FACTOR * 1**2)
     expected_density = np.full(
-        (N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), expected_calculated_density
+        (N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS), expected_calculated_density
     )
     np.testing.assert_array_equal(
         phase_space_density_ds["phase_space_density"][0].data, expected_density
@@ -96,7 +96,7 @@ def test_calculate_phase_space_density(patch_get_particle_energy):
     # but with energy 2.
     expected_calculated_density = (2 * 1) / (1 * VELOCITY_CONVERSION_FACTOR * 2**2)
     expected_density = np.full(
-        (N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), expected_calculated_density
+        (N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS), expected_calculated_density
     )
     np.testing.assert_array_equal(
         phase_space_density_ds["phase_space_density"][1].data, expected_density
@@ -112,7 +112,7 @@ def test_calculate_flux():
         {
             "science_data": (
                 ["epoch", "energy", "angle", "cem"],
-                np.full((total_sweeps, N_ESA_STEPS, N_MEASUREMENTS, N_CEMS), 1),
+                np.full((total_sweeps, N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS), 1),
             ),
             "acq_duration": (
                 ["epoch", "cycle"],
@@ -128,7 +128,7 @@ def test_calculate_flux():
     )
 
     flux = calculate_flux(l1b_dataset)
-    assert flux.shape == (total_sweeps, N_ESA_STEPS, N_MEASUREMENTS, N_CEMS)
+    assert flux.shape == (total_sweeps, N_ESA_STEPS, N_ANGLE_SECTORS, N_CEMS)
     assert type(flux) == np.ndarray
 
 
@@ -208,7 +208,7 @@ def test_put_data_into_angle_bins():
     ]
     # Now data with every row to be same as angle_bins_example
     test_angle_bin_indices_data = np.full(
-        (num_cycles, N_ESA_STEPS, N_MEASUREMENTS), angle_bins_example
+        (num_cycles, N_ESA_STEPS, N_ANGLE_SECTORS), angle_bins_example
     )
 
     binned_data = put_data_into_angle_bins(test_data, test_angle_bin_indices_data)
@@ -280,16 +280,16 @@ def test_swe_l2(mock_read_in_flight_cal_data, use_fake_spin_data_for_time):
     assert l2_dataset["phase_space_density_spin_sector"].shape == (
         6,
         N_ESA_STEPS,
-        N_MEASUREMENTS,
+        N_ANGLE_SECTORS,
         N_CEMS,
     )
     assert l2_dataset["flux_spin_sector"].shape == (
         6,
         N_ESA_STEPS,
-        N_MEASUREMENTS,
+        N_ANGLE_SECTORS,
         N_CEMS,
     )
-    assert l2_dataset["acquisition_time"].shape == (6, N_ESA_STEPS, N_MEASUREMENTS)
+    assert l2_dataset["acquisition_time"].shape == (6, N_ESA_STEPS, N_ANGLE_SECTORS)
 
     # Write L2 to CDF
     l2_cdf_filepath = write_cdf(l2_dataset)


### PR DESCRIPTION
# Change Summary
closes #1360 

## Overview
This PR refactors and moves constant into utils code. Then refactor some time calculation for I-ALiRT reusability. Ruth and I added SPASE metadata for L2 product.

## Updated Files
- imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
   - Ruth and I walked through L2 CDF attrs and updated per her guidance
- imap_processing/swe/l1a/swe_science.py
   - update to use constant variables
- imap_processing/swe/l1b/swe_l1b_science.py
   - updates to use constant variables
   - refactor of time calculations
   - update to calculate center time for both epoch and each point data's time
- imap_processing/swe/l2/swe_l2.py
   - removed time calculation and update to use constant variables
- imap_processing/swe/utils/swe_utils.py
   - refactored time functions





## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
