### PR TITLE
Implement "Pull" Index matching method and value binning/projection; Convert TT -> TDB

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -471,9 +471,9 @@ class RectangularSkyMap(AbstractSkyMap):
         """
         if value_keys is None:
             value_keys = list(pointing_set.data.data_vars.keys())
-        for pset_key in value_keys:
-            if pset_key not in pointing_set.data.data_vars:
-                raise ValueError(f"Value key {pset_key} not found in pointing set.")
+        for value_key in value_keys:
+            if value_key not in pointing_set.data.data_vars:
+                raise ValueError(f"Value key {value_key} not found in pointing set.")
 
         if index_match_method is IndexMatchMethod.PUSH:
             # Determine the indices of the sky map grid that correspond to
@@ -522,7 +522,7 @@ class RectangularSkyMap(AbstractSkyMap):
             elif index_match_method is IndexMatchMethod.PULL:
                 # We know that there will only be one value per sky map pixel,
                 # so we can use the matched indices directly
-                pointing_projected_values = raveled_pset_data[matched_indices_pull]
+                pointing_projected_values = raveled_pset_data[..., matched_indices_pull]
             else:
                 raise NotImplementedError(
                     "Only PUSH and PULL index matching methods are supported."

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -14,6 +14,7 @@ from numpy.typing import NDArray
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.ena_maps.utils import map_utils, spatial_utils
 from imap_processing.spice import geometry
+from imap_processing.spice.time import ttj2000ns_to_et
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,7 @@ def match_coords_to_indices(
         Event time at which to transform the input spatial object to the output frame.
         This can be manually specified, e.g., for converting between Maps which do not
         contain an epoch value.
+        If specified, must be in SPICE compatible ET.
         The default value is None, in which case the event time of the PointingSet
         object is used.
 
@@ -121,12 +123,14 @@ def match_coords_to_indices(
     if isinstance(input_object, PointingSet) and isinstance(output_object, PointingSet):
         raise ValueError("Cannot match indices between two PointingSet objects.")
 
-    # If event_time is not specified, use event_time of the PointingSet, if present.
+    # If event_time is not specified, use epoch of the PointingSet, if present.
+    # The epoch will be in units of terrestrial time (TT) J2000 nanoseconds,
+    # which must be converted to ephemeris time (ET) for SPICE.
     if event_time is None:
         if isinstance(input_object, PointingSet):
-            event_time = input_object.data["epoch"].values
+            event_time = ttj2000ns_to_et(input_object.data["epoch"].values)
         elif isinstance(output_object, PointingSet):
-            event_time = output_object.data["epoch"].values
+            event_time = ttj2000ns_to_et(output_object.data["epoch"].values)
         else:
             raise ValueError(
                 "Event time must be specified if both objects are SkyMaps."
@@ -492,6 +496,8 @@ class RectangularSkyMap(AbstractSkyMap):
                     input_object=pointing_set,
                     output_object=self,
                 )
+                # Bin the values at the matched indices. There may be multiple
+                # pointing set pixels that correspond to the same sky map pixel.
                 pointing_projected_values = map_utils.bin_single_array_at_indices(
                     value_array=raveled_pset_data,
                     projection_grid_shape=(
@@ -501,69 +507,20 @@ class RectangularSkyMap(AbstractSkyMap):
                     projection_indices=matched_indices_push,
                 )
             elif index_match_method is IndexMatchMethod.PULL:
+                # Determine the indices of the pointing set grid that correspond to
+                # each pixel in the sky map.
                 matched_indices_pull = match_coords_to_indices(
                     input_object=self,
                     output_object=pointing_set,
                 )
+                # We know that there will only be one value per sky map pixel,
+                # so we can use the matched indices directly
                 pointing_projected_values = raveled_pset_data[matched_indices_pull]
             else:
                 raise NotImplementedError(
                     "Only PUSH and PULL index matching methods are supported."
                 )
             self.data_dict[value_key] += pointing_projected_values
-
-    def to_dataset(
-        self,
-        output_value_keys_dims: dict[str, list[str]],
-        global_attrs: dict[str, str] | None = None,
-    ) -> xr.Dataset:
-        """
-        Convert the map data to an xarray Dataset.
-
-        Parameters
-        ----------
-        output_value_keys_dims : dict[str, list[str]]
-            Dictionary of dimensions for each data variable in the map.
-            Keys are the data variable names, and values are lists of dimension names.
-        global_attrs : dict[str, str], optional
-            Dictionary of attributes to add to the dataset.
-            Default is None.
-
-        Returns
-        -------
-        xr.Dataset
-            The xarray Dataset containing the map data.
-        """
-        if global_attrs is None:
-            global_attrs = {}
-
-        dataset = xr.Dataset(attrs=global_attrs)
-
-        # Add azimuth, elevation grid as coordinates
-        dataset["azimuth_bin_center"] = xr.DataArray(
-            np.rad2deg(self.sky_grid.az_bin_midpoints),
-            dims=["azimuth_bin_center"],
-            attrs={"units": "degrees"},
-        )
-        dataset["elevation_bin_center"] = xr.DataArray(
-            np.rad2deg(self.sky_grid.el_bin_midpoints),
-            dims=["elevation_bin_center"],
-            attrs={"units": "degrees"},
-        )
-
-        for key in output_value_keys_dims.keys():
-            wrapped_data = spatial_utils.rewrap_even_spaced_az_el_grid(
-                self.data_dict[key]
-            )
-            # Flatten any length-1 dimensions
-            # TODO: this may need to be tweaked to handle epoch coordinate?
-            wrapped_data = np.squeeze(wrapped_data)
-            dataset[key] = xr.DataArray(
-                wrapped_data,
-                dims=output_value_keys_dims[key],
-            )
-
-        return dataset
 
     def __repr__(self) -> str:
         """
@@ -579,10 +536,3 @@ class RectangularSkyMap(AbstractSkyMap):
             f"{self.spice_reference_frame.name} ({self.spice_reference_frame.value}), "
             f"spacing_deg={self.spacing_deg}, num_points={self.num_points})"
         )
-
-
-# TODO:
-# Add pulling index matching in match_pset_coords_to_indices
-
-# TODO:
-# Check units of time which will be read in. Do we need to add j2000ns_to_j2000s?

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -475,6 +475,25 @@ class RectangularSkyMap(AbstractSkyMap):
             if pset_key not in pointing_set.data.data_vars:
                 raise ValueError(f"Value key {pset_key} not found in pointing set.")
 
+        if index_match_method is IndexMatchMethod.PUSH:
+            # Determine the indices of the sky map grid that correspond to
+            # each pixel in the pointing set.
+            matched_indices_push = match_coords_to_indices(
+                input_object=pointing_set,
+                output_object=self,
+            )
+        elif index_match_method is IndexMatchMethod.PULL:
+            # Determine the indices of the pointing set grid that correspond to
+            # each pixel in the sky map.
+            matched_indices_pull = match_coords_to_indices(
+                input_object=self,
+                output_object=pointing_set,
+            )
+        else:
+            raise NotImplementedError(
+                "Only PUSH and PULL index matching methods are supported."
+            )
+
         for value_key in value_keys:
             pset_values = pointing_set.data[value_key]
 
@@ -490,12 +509,6 @@ class RectangularSkyMap(AbstractSkyMap):
                 self.data_dict[value_key] = np.zeros(output_shape)
 
             if index_match_method is IndexMatchMethod.PUSH:
-                # Determine the indices of the sky map grid that correspond to
-                # each pixel in the pointing set.
-                matched_indices_push = match_coords_to_indices(
-                    input_object=pointing_set,
-                    output_object=self,
-                )
                 # Bin the values at the matched indices. There may be multiple
                 # pointing set pixels that correspond to the same sky map pixel.
                 pointing_projected_values = map_utils.bin_single_array_at_indices(
@@ -507,12 +520,6 @@ class RectangularSkyMap(AbstractSkyMap):
                     projection_indices=matched_indices_push,
                 )
             elif index_match_method is IndexMatchMethod.PULL:
-                # Determine the indices of the pointing set grid that correspond to
-                # each pixel in the sky map.
-                matched_indices_pull = match_coords_to_indices(
-                    input_object=self,
-                    output_object=pointing_set,
-                )
                 # We know that there will only be one value per sky map pixel,
                 # so we can use the matched indices directly
                 pointing_projected_values = raveled_pset_data[matched_indices_pull]

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -451,7 +451,7 @@ class RectangularSkyMap(AbstractSkyMap):
         pointing_set : PointingSet
             The pointing set containing the values to project to the map.
         value_keys : list[tuple[str, IndexMatchMethod]] | None
-            The keys of the values to project to the map.
+            The keys of the values in the PointingSet to project to the map.
             Ex.: ["counts", "flux"]
             data_vars named each key must be present, and of the same dimensionality in
             each pointing set which is to be projected to the map.
@@ -467,18 +467,9 @@ class RectangularSkyMap(AbstractSkyMap):
         """
         if value_keys is None:
             value_keys = list(pointing_set.data.data_vars.keys())
-
-        for value_key in value_keys:
-            if value_key not in pointing_set.data.data_vars:
-                raise ValueError(f"Value key {value_key} not found in pointing set.")
-
-        # Determine the indices of the sky map grid that correspond to
-        # each pixel in the pointing set.
-        if index_match_method is IndexMatchMethod.PUSH:
-            matched_indices_push = match_coords_to_indices(
-                input_object=pointing_set,
-                output_object=self,
-            )
+        for pset_key in value_keys:
+            if pset_key not in pointing_set.data.data_vars:
+                raise ValueError(f"Value key {pset_key} not found in pointing set.")
 
         for value_key in value_keys:
             pset_values = pointing_set.data[value_key]
@@ -495,6 +486,12 @@ class RectangularSkyMap(AbstractSkyMap):
                 self.data_dict[value_key] = np.zeros(output_shape)
 
             if index_match_method is IndexMatchMethod.PUSH:
+                # Determine the indices of the sky map grid that correspond to
+                # each pixel in the pointing set.
+                matched_indices_push = match_coords_to_indices(
+                    input_object=pointing_set,
+                    output_object=self,
+                )
                 pointing_projected_values = map_utils.bin_single_array_at_indices(
                     value_array=raveled_pset_data,
                     projection_grid_shape=(
@@ -503,11 +500,70 @@ class RectangularSkyMap(AbstractSkyMap):
                     ),
                     projection_indices=matched_indices_push,
                 )
+            elif index_match_method is IndexMatchMethod.PULL:
+                matched_indices_pull = match_coords_to_indices(
+                    input_object=self,
+                    output_object=pointing_set,
+                )
+                pointing_projected_values = raveled_pset_data[matched_indices_pull]
             else:
                 raise NotImplementedError(
-                    "The 'pull' method of index matching is not yet implemented."
+                    "Only PUSH and PULL index matching methods are supported."
                 )
             self.data_dict[value_key] += pointing_projected_values
+
+    def to_dataset(
+        self,
+        output_value_keys_dims: dict[str, list[str]],
+        global_attrs: dict[str, str] | None = None,
+    ) -> xr.Dataset:
+        """
+        Convert the map data to an xarray Dataset.
+
+        Parameters
+        ----------
+        output_value_keys_dims : dict[str, list[str]]
+            Dictionary of dimensions for each data variable in the map.
+            Keys are the data variable names, and values are lists of dimension names.
+        global_attrs : dict[str, str], optional
+            Dictionary of attributes to add to the dataset.
+            Default is None.
+
+        Returns
+        -------
+        xr.Dataset
+            The xarray Dataset containing the map data.
+        """
+        if global_attrs is None:
+            global_attrs = {}
+
+        dataset = xr.Dataset(attrs=global_attrs)
+
+        # Add azimuth, elevation grid as coordinates
+        dataset["azimuth_bin_center"] = xr.DataArray(
+            np.rad2deg(self.sky_grid.az_bin_midpoints),
+            dims=["azimuth_bin_center"],
+            attrs={"units": "degrees"},
+        )
+        dataset["elevation_bin_center"] = xr.DataArray(
+            np.rad2deg(self.sky_grid.el_bin_midpoints),
+            dims=["elevation_bin_center"],
+            attrs={"units": "degrees"},
+        )
+
+        for key in output_value_keys_dims.keys():
+            wrapped_data = spatial_utils.rewrap_even_spaced_az_el_grid(
+                self.data_dict[key]
+            )
+            # Flatten any length-1 dimensions
+            # TODO: this may need to be tweaked to handle epoch coordinate?
+            wrapped_data = np.squeeze(wrapped_data)
+            dataset[key] = xr.DataArray(
+                wrapped_data,
+                dims=output_value_keys_dims[key],
+            )
+
+        return dataset
 
     def __repr__(self) -> str:
         """

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -175,7 +175,7 @@ class TestRectangularSkyMap:
             )
 
         # Check that the map has been updated
-        assert rectangular_map.data_dict != {}
+        assert "counts" in rectangular_map.data_dict
 
         # Check that the map has the same values as the PSETs, summed
         simple_summed_pset_counts = np.zeros_like(rectangular_map.data_dict["counts"])
@@ -251,7 +251,7 @@ class TestRectangularSkyMap:
             total_pset_counts += ultra_pset.data["counts"].values
 
         # Check that the map has been updated
-        assert rectangular_map.data_dict != {}
+        assert "counts" in rectangular_map.data_dict
 
         np.testing.assert_allclose(
             rectangular_map.data_dict["counts"],

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -16,7 +16,7 @@ from imap_processing.tests.ultra.test_data.mock_data import mock_l1c_pset_produc
 @pytest.fixture()
 def l1c_pset_products():
     """Make fake L1C Ultra PSET products for testing"""
-    l1c_spatial_bin_spacing_deg = 10
+    l1c_spatial_bin_spacing_deg = 2
     return {
         "spacing": l1c_spatial_bin_spacing_deg,
         "products": [
@@ -166,7 +166,7 @@ class TestRectangularSkyMap:
             spice_frame=geometry.SpiceFrame.ECLIPJ2000,
         )
 
-        # Project each PSET's values to the map
+        # Project each PSET's values to the map (push method)
         for ultra_pset in self.ultra_psets:
             rectangular_map.project_pset_values_to_map(
                 ultra_pset,
@@ -198,17 +198,54 @@ class TestRectangularSkyMap:
         """Test projection to Rect. Map fails w "pull" index matching method."""
 
         index_matching_method = ena_maps.IndexMatchMethod.PULL
+        skymap_spacing = 10
+
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
         rectangular_map = ena_maps.RectangularSkyMap(
-            spacing_deg=10,
+            spacing_deg=skymap_spacing,
             spice_frame=geometry.SpiceFrame.ECLIPJ2000,
         )
 
-        with pytest.raises(NotImplementedError):
+        # Each map pixel will add the value of a single PSET pixel, so we'll start at 0
+        # and add 0, 1, 2, 3, ... to the map
+        expected_value_every_pixel = 0
+
+        # Another way to test this is that (if the PSET pixels are
+        # smaller than the SkyMap pixels) the sum of the counts in all PSETs should
+        # be (PSET_spacing / SkyMap_spacing)^2 times the sum of the counts in the SkyMap
+        total_pset_counts = np.zeros_like(self.ultra_psets[0].data["counts"].values)
+
+        # Project each PSET's values to the map (pull method)
+        for pset_num, ultra_pset in enumerate(self.ultra_psets):
+            # Set the counts to be 0 in the first PSET, 1 in the second, etc.
+            ultra_pset.data["counts"].values = np.full_like(
+                ultra_pset.data["counts"].values, pset_num
+            )
+
             rectangular_map.project_pset_values_to_map(
-                self.ultra_psets[0],
+                ultra_pset,
                 value_keys=["counts", "exposure_time"],
                 index_match_method=index_matching_method,
             )
+            expected_value_every_pixel += pset_num
+
+            total_pset_counts += ultra_pset.data["counts"].values
+
+        # Check that the map has been updated
+        assert rectangular_map.data_dict != {}
+
+        np.testing.assert_allclose(
+            rectangular_map.data_dict["counts"],
+            expected_value_every_pixel,
+        )
+        downsample_ratio = skymap_spacing / self.l1c_spatial_bin_spacing_deg
+        np.testing.assert_allclose(
+            rectangular_map.data_dict["counts"].sum(),
+            total_pset_counts.sum() / (downsample_ratio**2),
+        )
 
 
 class TestIndexMatching:

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -349,3 +349,39 @@ class TestIndexMatching:
         mock_other_map.tiling_type = "INVALID"
         with pytest.raises(ValueError, match="Tiling type of the output frame"):
             ena_maps.match_coords_to_indices(mock_pset_input_frame, mock_other_map)
+
+    def test_match_coords_to_indices_pset_to_pset_error(self):
+        mock_pset_input_frame = ena_maps.UltraPointingSet(
+            l1c_dataset=self.l1c_pset_products[0],
+            spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+        )
+        mock_pset_output_frame = ena_maps.UltraPointingSet(
+            l1c_dataset=self.l1c_pset_products[1],
+            spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+        )
+        with pytest.raises(
+            ValueError, match="Cannot match indices between two PointingSet objects"
+        ):
+            ena_maps.match_coords_to_indices(
+                mock_pset_input_frame, mock_pset_output_frame
+            )
+
+    def test_match_coords_to_indices_map_to_map_no_et_error(self):
+        mock_rect_map = ena_maps.RectangularSkyMap(
+            spacing_deg=2,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+        mock_other_map = ena_maps.RectangularSkyMap(
+            spacing_deg=4,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+        with pytest.raises(
+            ValueError,
+            match="Event time must be specified if both objects are SkyMaps.",
+        ):
+            ena_maps.match_coords_to_indices(mock_rect_map, mock_other_map)
+
+        # No error if event time is specified
+        _ = ena_maps.match_coords_to_indices(
+            mock_rect_map, mock_other_map, event_time=0
+        )

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -193,6 +193,38 @@ class TestRectangularSkyMap:
         )
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
+    def test_project_pset_values_to_map_errors(self):
+        index_matching_method = ena_maps.IndexMatchMethod.PUSH
+        rectangular_map = ena_maps.RectangularSkyMap(
+            spacing_deg=1,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+
+        # An error should be raised if a key is not found in the PSET
+        with pytest.raises(ValueError, match="Value key invalid not found"):
+            rectangular_map.project_pset_values_to_map(
+                self.ultra_psets[0],
+                pset_value_keys=["invalid"],
+                index_match_method=index_matching_method,
+            )
+
+        # An error should be raised if the number of pset_value_keys does not match
+        # the number of skymap_value_keys
+        with pytest.raises(
+            ValueError,
+            match=(
+                "The number of pointing set value keys must match the number of"
+                " sky map value keys."
+            ),
+        ):
+            rectangular_map.project_pset_values_to_map(
+                self.ultra_psets[0],
+                pset_value_keys=["counts", "exposure_time"],
+                skymap_value_keys=["counts_map"],
+                index_match_method=index_matching_method,
+            )
+
+    @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
     def test_project_pset_values_to_map_pull_method(self, mock_frame_transform_az_el):
         """Test projection to Rect. Map fails w "pull" index matching method."""

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -204,23 +204,7 @@ class TestRectangularSkyMap:
         with pytest.raises(ValueError, match="Value key invalid not found"):
             rectangular_map.project_pset_values_to_map(
                 self.ultra_psets[0],
-                pset_value_keys=["invalid"],
-                index_match_method=index_matching_method,
-            )
-
-        # An error should be raised if the number of pset_value_keys does not match
-        # the number of skymap_value_keys
-        with pytest.raises(
-            ValueError,
-            match=(
-                "The number of pointing set value keys must match the number of"
-                " sky map value keys."
-            ),
-        ):
-            rectangular_map.project_pset_values_to_map(
-                self.ultra_psets[0],
-                pset_value_keys=["counts", "exposure_time"],
-                skymap_value_keys=["counts_map"],
+                value_keys=["invalid"],
                 index_match_method=index_matching_method,
             )
 

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -109,6 +109,12 @@ def mock_l1c_pset_product(
     counts = counts.astype(int)
     sensitivity = np.ones(grid_shape)
 
+    # Determine the epoch, which is TT time in nanoseconds since J2000 epoch
+    tdb_et = ensure_spice(spice.str2et, time_kernels_only=True)(timestr)
+    tt_j2000ns = (
+        ensure_spice(spice.unitim, time_kernels_only=True)(tdb_et, "ET", "TT") * 1e9
+    )
+
     pset_product = xr.Dataset(
         {
             "counts": (

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -5,6 +5,7 @@ import spiceypy as spice
 import xarray as xr
 
 from imap_processing.spice.kernels import ensure_spice
+from imap_processing.spice.time import str_to_et
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import build_energy_bins
 
 DEFAULT_SPACING_DEG_L1C = 0.5
@@ -110,7 +111,7 @@ def mock_l1c_pset_product(
     sensitivity = np.ones(grid_shape)
 
     # Determine the epoch, which is TT time in nanoseconds since J2000 epoch
-    tdb_et = ensure_spice(spice.str2et, time_kernels_only=True)(timestr)
+    tdb_et = str_to_et(timestr)
     tt_j2000ns = (
         ensure_spice(spice.unitim, time_kernels_only=True)(tdb_et, "ET", "TT") * 1e9
     )

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -145,9 +145,9 @@ def mock_l1c_pset_product(
             "epoch": [
                 tt_j2000ns,
             ],
+            "energy_bin_center": energy_bin_midpoints,
             "azimuth_bin_center": np.arange(0 + spacing_deg / 2, 360, spacing_deg),
             "elevation_bin_center": np.arange(-90 + spacing_deg / 2, 90, spacing_deg),
-            "energy_bin_center": energy_bin_midpoints,
         },
         attrs={
             "Logical_file_id": (

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -143,7 +143,7 @@ def mock_l1c_pset_product(
         },
         coords={
             "epoch": [
-                ensure_spice(spice.str2et, time_kernels_only=True)(timestr),
+                tt_j2000ns,
             ],
             "azimuth_bin_center": np.arange(0 + spacing_deg / 2, 360, spacing_deg),
             "elevation_bin_center": np.arange(-90 + spacing_deg / 2, 90, spacing_deg),


### PR DESCRIPTION
# Change Summary
Implement Pull index matching and projection, and fixes spice call using incorrect time format. 

## Overview
Implements the Pull method of index matching and projection (see [description](https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/247989696/Creating+L2+ENA+Sky+Maps+with+PointingSet+and+SkyMap+Objects#CreatingL2ENASkyMapswithPointingSetandSkyMapObjects-NoteonIndexMatchingIdx_match) for explanation of 'pull' vs 'push' matching.) 

It turns out the binning part of projection is very simple for pull matching projection, because there is a guaranteed, unique matching of one SkyMap pixel to a PointingSet pixel. 
Closes #1394

Also, the spice frame_transform had been using the wrong format of time, and the time specified in the PointingSet's epoch has to be converted from TT J2000ns --> TDB.
Closes #1395

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- `imap_processing/ena_maps/ena_maps.py`
   - Allow for pull index matching
   - If using the pull index matching, apply simple binning
   - Apply time conversion
- `imap_processing/tests/ultra/test_data/mock_data.py`
   - Change the stored epoch in the mocked L1C data to use TTJ2000ns

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
- Tests for pull method. 