### PR TITLE
Add auto generation of calibration product integer values column from…

### DIFF
--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -12,6 +12,7 @@ from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.hi.l1a.science_direct_event import HALF_CLOCK_TICK_S
 from imap_processing.hi.utils import (
     HIAPID,
+    CoincidenceBitmap,
     HiConstants,
     create_dataset_variables,
     parse_sensor_number,
@@ -34,15 +35,6 @@ class TriggerId(IntEnum):
     A = 1
     B = 2
     C = 3
-
-
-class CoincidenceBitmap(IntEnum):
-    """IntEnum class for coincidence type bitmap values."""
-
-    A = 2**3
-    B = 2**2
-    C1 = 2**1
-    C2 = 2**0
 
 
 logger = logging.getLogger(__name__)

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -527,6 +527,13 @@ def coincidence_type_string_to_int(coincidence_type_str: str) -> int:
     """
     Convert a coincidence type string to a coincidence type integer value.
 
+    A coincidence string is a string containing all detectors that were hit
+    for a direct event. Possible detectors include: [A, B, C1, C2]. Converting
+    the coincidence type string to a coincidence type integer value involves
+    summing the coincidence bitmap value for each detector hit. e.g. "AC1C2"
+    results in 2**3 + 2**1 + 2**0 = 11. See `CoincidenceBitmap` for the mapping
+    from detector name to integer value.
+
     Parameters
     ----------
     coincidence_type_str : str
@@ -538,6 +545,9 @@ def coincidence_type_string_to_int(coincidence_type_str: str) -> int:
     coincidence_type : int
         The integer value of the coincidence type.
     """
+    # CoincidenceBitmap defines the detector names and their associated
+    # values. Use regex to find matches to the detector names.
     pattern = r"|".join(c.name for c in CoincidenceBitmap)
     matches = re.findall(pattern, coincidence_type_str)
+    # Sum the integer value assigned to the detector name for each match
     return sum(CoincidenceBitmap[m] for m in matches)

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 
 import numpy as np
@@ -12,6 +13,7 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.hi.l1a.science_direct_event import DE_CLOCK_TICK_S
+from imap_processing.hi.l1b.hi_l1b import CoincidenceBitmap
 from imap_processing.hi.utils import create_dataset_variables, full_dataarray
 from imap_processing.spice.geometry import (
     SpiceFrame,
@@ -443,6 +445,7 @@ class CalibrationProductConfig:
     def __init__(self, pandas_obj: pd.DataFrame) -> None:
         self._validate(pandas_obj)
         self._obj = pandas_obj
+        self._add_coincidence_values_column()
 
     def _validate(self, df: pd.DataFrame) -> None:
         """
@@ -469,6 +472,18 @@ class CalibrationProductConfig:
         # TODO: Verify that the same ESA energy steps exist in all unique calibration
         #   product numbers
 
+    def _add_coincidence_values_column(self) -> None:
+        """Generate and add the coincidence_type_values column to the dataframe."""
+        # Add a column that consists of the coincidence type strings converted
+        # to integer values
+        self._obj["coincidence_type_values"] = self._obj.apply(
+            lambda row: [
+                coincidence_type_string_to_int(entry)
+                for entry in row["coincidence_type_list"]
+            ],
+            axis=1,
+        )
+
     @classmethod
     def from_csv(cls, path: Path) -> pd.DataFrame:
         """
@@ -484,12 +499,15 @@ class CalibrationProductConfig:
         dataframe : pandas.DataFrame
             Validated calibration product configuration data frame.
         """
-        return pd.read_csv(
+        df = pd.read_csv(
             path,
             index_col=cls.index_columns,
             converters={"coincidence_type_list": lambda s: s.split("|")},
             comment="#",
         )
+        # Force the _init_ method to run by using the namespace
+        _ = df.cal_prod_config.number_of_products
+        return df
 
     @property
     def number_of_products(self) -> int:
@@ -503,3 +521,23 @@ class CalibrationProductConfig:
             calibration product definitions.
         """
         return len(self._obj.index.unique(level="cal_prod_num"))
+
+
+def coincidence_type_string_to_int(coincidence_type_str: str) -> int:
+    """
+    Convert a coincidence type string to a coincidence type integer value.
+
+    Parameters
+    ----------
+    coincidence_type_str : str
+        The coincidence type string containing the list of detectors hit.
+        e.g. "AC1C2".
+
+    Returns
+    -------
+    coincidence_type : int
+        The integer value of the coincidence type.
+    """
+    pattern = r"|".join(c.name for c in CoincidenceBitmap)
+    matches = re.findall(pattern, coincidence_type_str)
+    return sum(CoincidenceBitmap[m] for m in matches)

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 
 import numpy as np
@@ -13,8 +12,11 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.hi.l1a.science_direct_event import DE_CLOCK_TICK_S
-from imap_processing.hi.l1b.hi_l1b import CoincidenceBitmap
-from imap_processing.hi.utils import create_dataset_variables, full_dataarray
+from imap_processing.hi.utils import (
+    CoincidenceBitmap,
+    create_dataset_variables,
+    full_dataarray,
+)
 from imap_processing.spice.geometry import (
     SpiceFrame,
     frame_transform,
@@ -478,7 +480,7 @@ class CalibrationProductConfig:
         # to integer values
         self._obj["coincidence_type_values"] = self._obj.apply(
             lambda row: [
-                coincidence_type_string_to_int(entry)
+                CoincidenceBitmap.detector_hit_str_to_int(entry)
                 for entry in row["coincidence_type_list"]
             ],
             axis=1,
@@ -521,33 +523,3 @@ class CalibrationProductConfig:
             calibration product definitions.
         """
         return len(self._obj.index.unique(level="cal_prod_num"))
-
-
-def coincidence_type_string_to_int(coincidence_type_str: str) -> int:
-    """
-    Convert a coincidence type string to a coincidence type integer value.
-
-    A coincidence string is a string containing all detectors that were hit
-    for a direct event. Possible detectors include: [A, B, C1, C2]. Converting
-    the coincidence type string to a coincidence type integer value involves
-    summing the coincidence bitmap value for each detector hit. e.g. "AC1C2"
-    results in 2**3 + 2**1 + 2**0 = 11. See `CoincidenceBitmap` for the mapping
-    from detector name to integer value.
-
-    Parameters
-    ----------
-    coincidence_type_str : str
-        The coincidence type string containing the list of detectors hit.
-        e.g. "AC1C2".
-
-    Returns
-    -------
-    coincidence_type : int
-        The integer value of the coincidence type.
-    """
-    # CoincidenceBitmap defines the detector names and their associated
-    # values. Use regex to find matches to the detector names.
-    pattern = r"|".join(c.name for c in CoincidenceBitmap)
-    matches = re.findall(pattern, coincidence_type_str)
-    # Sum the integer value assigned to the detector name for each match
-    return sum(CoincidenceBitmap[m] for m in matches)

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -200,3 +200,40 @@ def create_dataset_variables(
             var, attrs, shape=variable_shape, coords=coords, fill_value=fill_value
         )
     return new_variables
+
+
+class CoincidenceBitmap(IntEnum):
+    """IntEnum class for coincidence type bitmap values."""
+
+    A = 2**3
+    B = 2**2
+    C1 = 2**1
+    C2 = 2**0
+
+    @staticmethod
+    def detector_hit_str_to_int(detector_hit_str: str) -> int:
+        """
+        Convert a detector hit string to a coincidence type integer value.
+
+        A detector hit string is a string containing all detectors that were hit
+        for a direct event. Possible detectors include: [A, B, C1, C2]. Converting
+        the detector hit string to a coincidence type integer value involves
+        summing the coincidence bitmap value for each detector hit. e.g. "AC1C2"
+        results in 2**3 + 2**1 + 2**0 = 11.
+
+        Parameters
+        ----------
+        detector_hit_str : str
+            The string containing the set of detectors hit.
+            e.g. "AC1C2".
+
+        Returns
+        -------
+        coincidence_type : int
+            The integer value of the coincidence type.
+        """
+        # Join all detector names with a pipe for use with regex
+        pattern = r"|".join(c.name for c in CoincidenceBitmap)
+        matches = re.findall(pattern, detector_hit_str)
+        # Sum the integer value assigned to the detector name for each match
+        return sum(CoincidenceBitmap[m] for m in matches)

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -9,14 +9,13 @@ import xarray as xr
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.l1b.hi_l1b import (
-    CoincidenceBitmap,
     compute_coincidence_type_and_time_deltas,
     compute_hae_coordinates,
     de_esa_energy_step,
     de_nominal_bin_and_spin_phase,
     hi_l1b,
 )
-from imap_processing.hi.utils import HiConstants
+from imap_processing.hi.utils import CoincidenceBitmap, HiConstants
 from imap_processing.spice.geometry import SpiceFrame
 
 

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -236,7 +236,37 @@ class TestCalibrationProductConfig:
         df = CalibrationProductConfig.from_csv(hi_test_cal_prod_config_path)
         assert isinstance(df["coincidence_type_list"][0, 1], list)
 
+    def test_added_coincidence_type_values_column(self, hi_test_cal_prod_config_path):
+        df = CalibrationProductConfig.from_csv(hi_test_cal_prod_config_path)
+        assert "coincidence_type_values" in df.columns
+        for _, row in df.iterrows():
+            for detect_string, val in zip(
+                row["coincidence_type_list"], row["coincidence_type_values"]
+            ):
+                assert val == hi_l1c.coincidence_type_string_to_int(detect_string)
+
     def test_number_of_products(self, hi_test_cal_prod_config_path):
         """Test coverage for number of products accessor."""
         df = CalibrationProductConfig.from_csv(hi_test_cal_prod_config_path)
         assert df.cal_prod_config.number_of_products == 2
+
+
+@pytest.mark.parametrize(
+    "sensor_hit_str, expected_val",
+    [
+        ("ABC1C2", 15),
+        ("ABC1", 14),
+        ("AB", 12),
+        ("AC1C2", 11),
+        ("AC1", 10),
+        ("A", 8),
+        ("BC1C2", 7),
+        ("BC1", 6),
+        ("B", 4),
+        ("C1C2", 3),
+        ("C1", 2),
+    ],
+)
+def test_coincidence_type_string_to_int(sensor_hit_str, expected_val):
+    """Test coverage for coincidence_type_string_to_int function"""
+    assert hi_l1c.coincidence_type_string_to_int(sensor_hit_str) == expected_val

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -12,7 +12,7 @@ from imap_processing.cdf.utils import load_cdf, write_cdf
 from imap_processing.hi.l1a.science_direct_event import DE_CLOCK_TICK_S
 from imap_processing.hi.l1c import hi_l1c
 from imap_processing.hi.l1c.hi_l1c import CalibrationProductConfig
-from imap_processing.hi.utils import HIAPID
+from imap_processing.hi.utils import HIAPID, CoincidenceBitmap
 
 
 @pytest.fixture(scope="module")
@@ -243,30 +243,9 @@ class TestCalibrationProductConfig:
             for detect_string, val in zip(
                 row["coincidence_type_list"], row["coincidence_type_values"]
             ):
-                assert val == hi_l1c.coincidence_type_string_to_int(detect_string)
+                assert val == CoincidenceBitmap.detector_hit_str_to_int(detect_string)
 
     def test_number_of_products(self, hi_test_cal_prod_config_path):
         """Test coverage for number of products accessor."""
         df = CalibrationProductConfig.from_csv(hi_test_cal_prod_config_path)
         assert df.cal_prod_config.number_of_products == 2
-
-
-@pytest.mark.parametrize(
-    "sensor_hit_str, expected_val",
-    [
-        ("ABC1C2", 15),
-        ("ABC1", 14),
-        ("AB", 12),
-        ("AC1C2", 11),
-        ("AC1", 10),
-        ("A", 8),
-        ("BC1C2", 7),
-        ("BC1", 6),
-        ("B", 4),
-        ("C1C2", 3),
-        ("C1", 2),
-    ],
-)
-def test_coincidence_type_string_to_int(sensor_hit_str, expected_val):
-    """Test coverage for coincidence_type_string_to_int function"""
-    assert hi_l1c.coincidence_type_string_to_int(sensor_hit_str) == expected_val

--- a/imap_processing/tests/hi/test_utils.py
+++ b/imap_processing/tests/hi/test_utils.py
@@ -7,6 +7,7 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hi.utils import (
     HIAPID,
+    CoincidenceBitmap,
     create_dataset_variables,
     full_dataarray,
     parse_sensor_number,
@@ -100,3 +101,24 @@ def test_create_dataset_variables(var_names, shape, fill_value, lookup_str):
             assert data_array.shape == shape
         expected_fill_value = fill_value if fill_value is not None else attrs["FILLVAL"]
         np.testing.assert_array_equal(data_array, expected_fill_value)
+
+
+@pytest.mark.parametrize(
+    "sensor_hit_str, expected_val",
+    [
+        ("ABC1C2", 15),
+        ("ABC1", 14),
+        ("AB", 12),
+        ("AC1C2", 11),
+        ("AC1", 10),
+        ("A", 8),
+        ("BC1C2", 7),
+        ("BC1", 6),
+        ("B", 4),
+        ("C1C2", 3),
+        ("C1", 2),
+    ],
+)
+def test_coincidence_type_string_to_int(sensor_hit_str, expected_val):
+    """Test coverage for coincidence_type_string_to_int function"""
+    assert CoincidenceBitmap.detector_hit_str_to_int(sensor_hit_str) == expected_val


### PR DESCRIPTION
… detector strings

# Change Summary

## Overview
Adds functionality to the calibration product configuration DataFrame accessor for converting the coincidence_type_list of strings to a list of values that can be used to compare to the coincidence type values stored in the L1B DE product.

## Updated Files
- imap_processing/hi/l1c/hi_l1c.py
   - Add `_add_coincidence_values_column` function to dataframe accessor class.
   - Add function that converts a single string of detectors to a integer coincidence type value.
   - Manually access the registered `cal_prod_config` namespace in the custom `from_csv` method to force `_init_` to run.
- imap_processing/tests/hi/test_hi_l1c.py
   - Add test coverage for the two new functions in the `hi_l1c.py` module.

Closes: #1407 
