### PR TITLE
Ultra l1b aux quality flags

### DIFF
--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -52,6 +52,7 @@ class ImapAttitudeUltraFlags(FlagNameMixin):
 
     NONE = CommonFlags.NONE
     SPINRATE = 2**0  # bit 0
+    AUXMISMATCH = 2**1  # bit 1 # aux packet does not match Universal Spin Table
 
 
 class ImapRatesUltraFlags(FlagNameMixin):

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -205,13 +205,15 @@ def aux_dataset(ccsds_path_theta_0, xtce_path):
 def test_aux_dataset():
     """Fixture to compute and return aux test data."""
 
-    epoch = np.arange(760591716184000000, 760591716184000000 + 7 * 15000000000, 15000000000)
-    spin_number = np.arange(127,142)
-    spin_start_time = np.arange(0, 105, 15)
-    spin_period_sec = np.full(7, 15)
+    num_spins = 15
+
+    epoch = np.arange(760591716184000000, 760591716184000000 + num_spins * 15000000000, 15000000000)
+    spin_number = np.arange(127, 142)
+    spin_start_time = np.arange(1905, 2115 + 15, 15)
+    spin_period_sec = np.full(num_spins, 15)
     spin_period_sec[-1] = 14
-    spin_start_sec = np.arange(0, 105, 15)
-    spin_start_subsec = np.zeros(7)
+    spin_start_sec = np.arange(1905, 2115 + 15, 15)
+    spin_start_subsec = np.zeros(num_spins)
 
     test_aux_dataset = xr.Dataset(
         data_vars={

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -207,7 +207,9 @@ def test_aux_dataset():
 
     num_spins = 15
 
-    epoch = np.arange(760591716184000000, 760591716184000000 + num_spins * 15000000000, 15000000000)
+    epoch = np.arange(
+        760591716184000000, 760591716184000000 + num_spins * 15000000000, 15000000000
+    )
     spin_number = np.arange(127, 142)
     spin_start_time = np.arange(1905, 2115 + 15, 15)
     spin_period_sec = np.full(num_spins, 15)
@@ -224,9 +226,8 @@ def test_aux_dataset():
             "TIMESPINDATA": ("epoch", spin_start_time),
             "SPINPERIOD": ("epoch", spin_period_sec),
         },
-        coords={
-            "epoch": ("epoch", epoch)
-        })
+        coords={"epoch": ("epoch", epoch)},
+    )
 
     return test_aux_dataset
 
@@ -234,8 +235,11 @@ def test_aux_dataset():
 @pytest.fixture()
 @mock.patch("imap_processing.ultra.l1b.de.get_annotated_particle_velocity")
 def l1b_datasets(
-    mock_get_annotated_particle_velocity, de_dataset, use_fake_spin_data_for_time,
-    rates_dataset, test_aux_dataset
+    mock_get_annotated_particle_velocity,
+    de_dataset,
+    use_fake_spin_data_for_time,
+    rates_dataset,
+    test_aux_dataset,
 ):
     """L1B test data"""
 

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -202,19 +202,18 @@ def aux_dataset(ccsds_path_theta_0, xtce_path):
 
 
 @pytest.fixture()
-def test_aux_dataset():
+def faux_aux_dataset():
     """Fixture to compute and return aux test data."""
 
     num_spins = 15
+    spin_duration = 15  # in seconds
 
-    epoch = np.arange(
-        760591716184000000, 760591716184000000 + num_spins * 15000000000, 15000000000
-    )
+    epoch = np.arange(0, num_spins, 1)
     spin_number = np.arange(127, 142)
-    spin_start_time = np.arange(1905, 2115 + 15, 15)
+    spin_start_time = np.arange(1905, 2115 + spin_duration, spin_duration)
     spin_period_sec = np.full(num_spins, 15)
     spin_period_sec[-1] = 14
-    spin_start_sec = np.arange(1905, 2115 + 15, 15)
+    spin_start_sec = np.arange(1905, 2130, 15)
     spin_start_subsec = np.zeros(num_spins)
 
     test_aux_dataset = xr.Dataset(

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -238,15 +238,15 @@ def l1b_datasets(
     de_dataset,
     use_fake_spin_data_for_time,
     rates_dataset,
-    test_aux_dataset,
+    faux_aux_dataset,
 ):
     """L1B test data"""
 
     data_dict = {}
     data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
-    data_dict["imap_ultra_l1a_45sensor-aux"] = test_aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
     # TODO: this is a placeholder for the hk dataset.
-    data_dict["imap_ultra_l1a_45sensor-hk"] = test_aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-hk"] = faux_aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
     use_fake_spin_data_for_time(0, 15 * 147)
 

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import numpy as np
 import pytest
+import xarray as xr
 
 from imap_processing import decom, imap_module_directory
 from imap_processing.ultra.l0.decom_ultra import process_ultra_apids
@@ -201,19 +202,48 @@ def aux_dataset(ccsds_path_theta_0, xtce_path):
 
 
 @pytest.fixture()
+def test_aux_dataset():
+    """Fixture to compute and return aux test data."""
+
+    epoch = np.arange(760591716184000000, 760591716184000000 + 7 * 15000000000, 15000000000)
+    spin_number = np.arange(127,142)
+    spin_start_time = np.arange(0, 105, 15)
+    spin_period_sec = np.full(7, 15)
+    spin_period_sec[-1] = 14
+    spin_start_sec = np.arange(0, 105, 15)
+    spin_start_subsec = np.zeros(7)
+
+    test_aux_dataset = xr.Dataset(
+        data_vars={
+            "TIMESPINSTART": ("epoch", spin_start_sec),
+            "TIMESPINSTARTSUB": ("epoch", spin_start_subsec),
+            "DURATION": ("epoch", spin_period_sec),
+            "SPINNUMBER": ("epoch", spin_number),
+            "TIMESPINDATA": ("epoch", spin_start_time),
+            "SPINPERIOD": ("epoch", spin_period_sec),
+        },
+        coords={
+            "epoch": ("epoch", epoch)
+        })
+
+    return test_aux_dataset
+
+
+@pytest.fixture()
 @mock.patch("imap_processing.ultra.l1b.de.get_annotated_particle_velocity")
 def l1b_datasets(
-    mock_get_annotated_particle_velocity, de_dataset, use_fake_spin_data_for_time
+    mock_get_annotated_particle_velocity, de_dataset, use_fake_spin_data_for_time,
+    rates_dataset, test_aux_dataset
 ):
     """L1B test data"""
 
     data_dict = {}
     data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
+    data_dict["imap_ultra_l1a_45sensor-aux"] = test_aux_dataset
     # TODO: this is a placeholder for the hk dataset.
-    data_dict["imap_ultra_l1a_45sensor-hk"] = aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-hk"] = test_aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
-    # Create a spin table that cover spin 0-141
-    use_fake_spin_data_for_time(0, 141 * 15)
+    use_fake_spin_data_for_time(0, 15 * 147)
 
     # Mock get_annotated_particle_velocity to avoid needing kernels
     def side_effect_func(event_times, position, ultra_frame, dps_frame, sc_frame):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -2,10 +2,12 @@
 
 import numpy as np
 import pytest
+import xarray as xr
 
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
+    compare_aux_univ_spin_table,
     flag_attitude,
     flag_spin,
     get_energy_histogram,
@@ -39,6 +41,32 @@ def test_data(use_fake_spin_data_for_time):
 
     return time, spin_number, energy, expected_counts
 
+
+@pytest.fixture()
+def test_aux_dataset(use_fake_spin_data_for_time):
+    """Fixture to compute and return aux test data."""
+
+    epoch = np.arange(760591716184000000, 760591716184000000 + 7 * 15000000000, 15000000000)
+    spin_number = np.arange(7)
+    spin_start_time = np.arange(0, 105, 15)
+    spin_period_sec = np.full(7, 15)
+    spin_start_sec = np.arange(0, 105, 15)
+    spin_start_subsec = np.zeros(7)
+
+    test_aux_dataset = xr.Dataset(
+        data_vars={
+            "TIMESPINSTART": ("epoch", spin_start_sec),
+            "TIMESPINSTARTSUB": ("epoch", spin_start_subsec),
+            "DURATION": ("epoch", spin_period_sec),
+            "SPINNUMBER": ("epoch", spin_number),
+            "TIMESPINDATA": ("epoch", spin_start_time),
+            "SPINPERIOD": ("epoch", spin_period_sec),
+        },
+        coords={
+            "epoch": ("epoch", epoch)
+        })
+
+    return test_aux_dataset
 
 def test_get_spin(use_fake_spin_data_for_time):
     """Tests get_spin function."""
@@ -112,3 +140,14 @@ def test_flag_spin(test_data):
     )
     high_rates_flag = quality_flags[expected_counts / 15 > threshold[:, np.newaxis]]
     assert np.all(high_rates_flag == ImapRatesUltraFlags.HIGHRATES.value)
+
+
+def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time,
+                                     test_aux_dataset):
+    """Tests compare_aux_univ_spin_table function."""
+    use_fake_spin_data_for_time(0,15*7)
+    spins = test_aux_dataset["SPINNUMBER"].values
+    spins = np.array([0,1,99])
+
+    result = compare_aux_univ_spin_table(test_aux_dataset,
+                                         spins)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -12,7 +12,6 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_spin,
     get_energy_histogram,
     get_n_sigma,
-    get_spin,
 )
 
 
@@ -50,6 +49,7 @@ def test_aux_dataset(use_fake_spin_data_for_time):
     spin_number = np.arange(7)
     spin_start_time = np.arange(0, 105, 15)
     spin_period_sec = np.full(7, 15)
+    spin_period_sec[-1] = 14
     spin_start_sec = np.arange(0, 105, 15)
     spin_start_subsec = np.zeros(7)
 
@@ -68,20 +68,6 @@ def test_aux_dataset(use_fake_spin_data_for_time):
 
     return test_aux_dataset
 
-def test_get_spin(use_fake_spin_data_for_time):
-    """Tests get_spin function."""
-
-    nspins = 5
-    spin_period = 15
-    start = 0
-    stop = start + (nspins + 1) * spin_period
-    use_fake_spin_data_for_time(start, stop)
-    spin_number = get_spin(np.linspace(start, stop, num=20))
-
-    assert len(spin_number) == len(np.linspace(start, stop, num=20))
-    expected_num_spins = np.ceil((stop - start) / 15) + 1
-    assert np.array_equal(len(np.unique(spin_number)), expected_num_spins)
-
 
 def test_get_energy_histogram(test_data):
     """Tests get_energy_histogram function."""
@@ -95,14 +81,17 @@ def test_get_energy_histogram(test_data):
     assert duration == 15
 
 
-def test_flag_attitude(use_fake_spin_data_for_time):
+def test_flag_attitude(use_fake_spin_data_for_time, test_aux_dataset):
     """Tests flag_attitude function."""
 
     start = 4.45015658e08
     stop = 4.45015873e08
     use_fake_spin_data_for_time(start, stop)
+    spins = np.array([ 0,  0,  1,  2,  3,  3,  4,  5,  6,  6,  7,  8,  9,  9, 10, 11, 12,
+       12, 13, 14])
     quality_flags, spin_rates, spin_period, spin_start_time = flag_attitude(
-        np.linspace(start, stop, num=20)
+        spins,
+        test_aux_dataset
     )
 
     flag = ImapAttitudeUltraFlags(quality_flags[0])
@@ -130,8 +119,8 @@ def test_get_n_sigma():
 def test_flag_spin(test_data):
     """Tests flag_spin function."""
 
-    time, _, energy, expected_counts = test_data
-    quality_flags, spin, energy, _ = flag_spin(time, energy, 1)
+    _, spin_number, energy, expected_counts = test_data
+    quality_flags, spin, energy, _ = flag_spin(spin_number, energy, 1)
     threshold = get_n_sigma(expected_counts / 15, 15, 1)
 
     # At the first energy level were the rates > threshold and the counts > threshold?
@@ -145,9 +134,10 @@ def test_flag_spin(test_data):
 def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time,
                                      test_aux_dataset):
     """Tests compare_aux_univ_spin_table function."""
-    use_fake_spin_data_for_time(0,15*7)
+    use_fake_spin_data_for_time(0, 15 * 6)
     spins = test_aux_dataset["SPINNUMBER"].values
-    spins = np.array([0,1,99])
 
     result = compare_aux_univ_spin_table(test_aux_dataset,
                                          spins)
+
+    assert np.all(result == np.array([False, False, False, False, False, False, True]))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -105,26 +105,6 @@ def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time, test_aux_datas
     spin_df = get_spin_data()
 
     result = compare_aux_univ_spin_table(test_aux_dataset, spins, spin_df)
+    expected = np.array([False] * 14 + [True])
 
-    assert np.all(
-        result
-        == np.array(
-            [
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                True,
-            ]
-        )
-    )
+    assert np.all(result == expected)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pytest
-import xarray as xr
 
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
 from imap_processing.ultra.constants import UltraConstants
@@ -39,13 +38,13 @@ def test_data(use_fake_spin_data_for_time):
             )
             expected_counts[energy_idx, spin_idx] = count
 
-    return time, spin_number, energy, expected_counts
+    return spin_number, energy, expected_counts
 
 
 def test_get_energy_histogram(test_data):
     """Tests get_energy_histogram function."""
 
-    _, spin_number, energy, expected_counts = test_data
+    spin_number, energy, expected_counts = test_data
 
     hist, _, counts, duration = get_energy_histogram(spin_number, energy)
 
@@ -58,10 +57,8 @@ def test_flag_attitude(use_fake_spin_data_for_time, test_aux_dataset):
     """Tests flag_attitude function."""
 
     use_fake_spin_data_for_time(0, 15 * 147)
-    spins = np.array([ 0,  0,  1,  2,  3,  3,  4,  5,  6,  6])
     quality_flags, spin_rates, spin_period, spin_start_time = flag_attitude(
-        test_aux_dataset["SPINNUMBER"].values,
-        test_aux_dataset
+        test_aux_dataset["SPINNUMBER"].values, test_aux_dataset
     )
 
     flag = ImapAttitudeUltraFlags(quality_flags[0])
@@ -89,7 +86,7 @@ def test_get_n_sigma():
 def test_flag_spin(test_data):
     """Tests flag_spin function."""
 
-    _, spin_number, energy, expected_counts = test_data
+    spin_number, energy, expected_counts = test_data
     quality_flags, spin, energy, _ = flag_spin(spin_number, energy, 1)
     threshold = get_n_sigma(expected_counts / 15, 15, 1)
 
@@ -101,17 +98,33 @@ def test_flag_spin(test_data):
     assert np.all(high_rates_flag == ImapRatesUltraFlags.HIGHRATES.value)
 
 
-def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time,
-                                     test_aux_dataset):
+def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time, test_aux_dataset):
     """Tests compare_aux_univ_spin_table function."""
     use_fake_spin_data_for_time(0, 15 * 147)
     spins = test_aux_dataset["SPINNUMBER"].values
     spin_df = get_spin_data()
 
-    result = compare_aux_univ_spin_table(test_aux_dataset,
-                                         spins,
-                                         spin_df)
+    result = compare_aux_univ_spin_table(test_aux_dataset, spins, spin_df)
 
-    assert np.all(result == np.array([False, False, False, False, False,
-                                      False, False, False, False, False,
-                                      False, False, False, False,  True]))
+    assert np.all(
+        result
+        == np.array(
+            [
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                True,
+            ]
+        )
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -57,10 +57,10 @@ def test_get_energy_histogram(test_data):
 def test_flag_attitude(use_fake_spin_data_for_time, test_aux_dataset):
     """Tests flag_attitude function."""
 
-    use_fake_spin_data_for_time(0, 15 * 6)
+    use_fake_spin_data_for_time(0, 15 * 147)
     spins = np.array([ 0,  0,  1,  2,  3,  3,  4,  5,  6,  6])
     quality_flags, spin_rates, spin_period, spin_start_time = flag_attitude(
-        spins,
+        test_aux_dataset["SPINNUMBER"].values,
         test_aux_dataset
     )
 
@@ -112,4 +112,6 @@ def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time,
                                          spins,
                                          spin_df)
 
-    assert np.all(result == np.array([False, False, False, False, False, False, True]))
+    assert np.all(result == np.array([False, False, False, False, False,
+                                      False, False, False, False, False,
+                                      False, False, False, False,  True]))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -53,12 +53,12 @@ def test_get_energy_histogram(test_data):
     assert duration == 15
 
 
-def test_flag_attitude(use_fake_spin_data_for_time, test_aux_dataset):
+def test_flag_attitude(use_fake_spin_data_for_time, faux_aux_dataset):
     """Tests flag_attitude function."""
 
     use_fake_spin_data_for_time(0, 15 * 147)
     quality_flags, spin_rates, spin_period, spin_start_time = flag_attitude(
-        test_aux_dataset["SPINNUMBER"].values, test_aux_dataset
+        faux_aux_dataset["SPINNUMBER"].values, faux_aux_dataset
     )
 
     flag = ImapAttitudeUltraFlags(quality_flags[0])
@@ -98,13 +98,13 @@ def test_flag_spin(test_data):
     assert np.all(high_rates_flag == ImapRatesUltraFlags.HIGHRATES.value)
 
 
-def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time, test_aux_dataset):
+def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time, faux_aux_dataset):
     """Tests compare_aux_univ_spin_table function."""
     use_fake_spin_data_for_time(0, 15 * 147)
-    spins = test_aux_dataset["SPINNUMBER"].values
+    spins = faux_aux_dataset["SPINNUMBER"].values
     spin_df = get_spin_data()
 
-    result = compare_aux_univ_spin_table(test_aux_dataset, spins, spin_df)
+    result = compare_aux_univ_spin_table(faux_aux_dataset, spins, spin_df)
     expected = np.array([False] * 14 + [True])
 
     assert np.all(result == expected)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -12,6 +12,7 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_spin,
     get_energy_histogram,
     get_n_sigma,
+    get_spin_data,
 )
 
 
@@ -41,34 +42,6 @@ def test_data(use_fake_spin_data_for_time):
     return time, spin_number, energy, expected_counts
 
 
-@pytest.fixture()
-def test_aux_dataset(use_fake_spin_data_for_time):
-    """Fixture to compute and return aux test data."""
-
-    epoch = np.arange(760591716184000000, 760591716184000000 + 7 * 15000000000, 15000000000)
-    spin_number = np.arange(7)
-    spin_start_time = np.arange(0, 105, 15)
-    spin_period_sec = np.full(7, 15)
-    spin_period_sec[-1] = 14
-    spin_start_sec = np.arange(0, 105, 15)
-    spin_start_subsec = np.zeros(7)
-
-    test_aux_dataset = xr.Dataset(
-        data_vars={
-            "TIMESPINSTART": ("epoch", spin_start_sec),
-            "TIMESPINSTARTSUB": ("epoch", spin_start_subsec),
-            "DURATION": ("epoch", spin_period_sec),
-            "SPINNUMBER": ("epoch", spin_number),
-            "TIMESPINDATA": ("epoch", spin_start_time),
-            "SPINPERIOD": ("epoch", spin_period_sec),
-        },
-        coords={
-            "epoch": ("epoch", epoch)
-        })
-
-    return test_aux_dataset
-
-
 def test_get_energy_histogram(test_data):
     """Tests get_energy_histogram function."""
 
@@ -84,11 +57,8 @@ def test_get_energy_histogram(test_data):
 def test_flag_attitude(use_fake_spin_data_for_time, test_aux_dataset):
     """Tests flag_attitude function."""
 
-    start = 4.45015658e08
-    stop = 4.45015873e08
-    use_fake_spin_data_for_time(start, stop)
-    spins = np.array([ 0,  0,  1,  2,  3,  3,  4,  5,  6,  6,  7,  8,  9,  9, 10, 11, 12,
-       12, 13, 14])
+    use_fake_spin_data_for_time(0, 15 * 6)
+    spins = np.array([ 0,  0,  1,  2,  3,  3,  4,  5,  6,  6])
     quality_flags, spin_rates, spin_period, spin_start_time = flag_attitude(
         spins,
         test_aux_dataset
@@ -96,7 +66,7 @@ def test_flag_attitude(use_fake_spin_data_for_time, test_aux_dataset):
 
     flag = ImapAttitudeUltraFlags(quality_flags[0])
     assert flag.name == "NONE"
-    assert np.all(quality_flags == ImapAttitudeUltraFlags.NONE.value)
+    assert quality_flags[-1] == ImapAttitudeUltraFlags.AUXMISMATCH.value
     assert np.all(spin_rates == 60 / spin_period)
     assert np.all(np.diff(spin_start_time) == 15)
 
@@ -134,10 +104,12 @@ def test_flag_spin(test_data):
 def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time,
                                      test_aux_dataset):
     """Tests compare_aux_univ_spin_table function."""
-    use_fake_spin_data_for_time(0, 15 * 6)
+    use_fake_spin_data_for_time(0, 15 * 147)
     spins = test_aux_dataset["SPINNUMBER"].values
+    spin_df = get_spin_data()
 
     result = compare_aux_univ_spin_table(test_aux_dataset,
-                                         spins)
+                                         spins,
+                                         spin_df)
 
     assert np.all(result == np.array([False, False, False, False, False, False, True]))

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -61,8 +61,9 @@ def calculate_de(de_dataset: xr.Dataset, name: str, data_version: str) -> xr.Dat
         "event_type",
         "de_event_met",
         "phase_angle",
+        "spin",
     ]
-    dataset_keys = ["COIN_TYPE", "START_TYPE", "STOP_TYPE", "SHCOARSE", "PHASE_ANGLE"]
+    dataset_keys = ["COIN_TYPE", "START_TYPE", "STOP_TYPE", "SHCOARSE", "PHASE_ANGLE", "SPIN"]
 
     de_dict.update(
         {key: de_dataset[dataset_key] for key, dataset_key in zip(keys, dataset_keys)}

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -63,7 +63,14 @@ def calculate_de(de_dataset: xr.Dataset, name: str, data_version: str) -> xr.Dat
         "phase_angle",
         "spin",
     ]
-    dataset_keys = ["COIN_TYPE", "START_TYPE", "STOP_TYPE", "SHCOARSE", "PHASE_ANGLE", "SPIN"]
+    dataset_keys = [
+        "COIN_TYPE",
+        "START_TYPE",
+        "STOP_TYPE",
+        "SHCOARSE",
+        "PHASE_ANGLE",
+        "SPIN",
+    ]
 
     de_dict.update(
         {key: de_dataset[dataset_key] for key, dataset_key in zip(keys, dataset_keys)}

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -11,6 +11,7 @@ from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
 def calculate_extendedspin(
+    aux_dataset: xr.Dataset,
     hk_dataset: xr.Dataset,
     rates_dataset: xr.Dataset,
     de_dataset: xr.Dataset,
@@ -22,6 +23,8 @@ def calculate_extendedspin(
 
     Parameters
     ----------
+    aux_dataset : xarray.Dataset
+        Dataset containing l1a aux data.
     hk_dataset : xarray.Dataset
         Dataset containing l1a hk data.
     rates_dataset : xarray.Dataset
@@ -40,15 +43,15 @@ def calculate_extendedspin(
     """
     extendedspin_dict = {}
     rates_qf, spin, energy_midpoints, n_sigma_per_energy = flag_spin(
-        de_dataset["event_times"].values,
+        de_dataset["spin"].values,
         de_dataset["energy"].values,
     )
-    spin_number = get_spin(de_dataset["event_times"].values)
     count_rates, _, counts, _ = get_energy_histogram(
-        spin_number, de_dataset["energy"].values
+        de_dataset["spin"].values, de_dataset["energy"].values
     )
     attitude_qf, spin_rates, spin_period, spin_starttime = flag_attitude(
-        de_dataset["event_times"].values
+        de_dataset["spin"].values,
+        aux_dataset
     )
 
     # These will be the coordinates.

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -10,7 +10,7 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_extendedspin(
+def calculate_extendedspin(  # noqa: PLR0913
     aux_dataset: xr.Dataset,
     hk_dataset: xr.Dataset,
     rates_dataset: xr.Dataset,
@@ -50,8 +50,7 @@ def calculate_extendedspin(
         de_dataset["spin"].values, de_dataset["energy"].values
     )
     attitude_qf, spin_rates, spin_period, spin_starttime = flag_attitude(
-        de_dataset["spin"].values,
-        aux_dataset
+        de_dataset["spin"].values, aux_dataset
     )
 
     # These will be the coordinates.

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -6,7 +6,6 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_attitude,
     flag_spin,
     get_energy_histogram,
-    get_spin,
 )
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -31,6 +31,7 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
         f"imap_ultra_l1a_{instrument_id}sensor-hk" in data_dict
         and f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict
         and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
+        and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
     ):
         de_dataset = calculate_de(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
@@ -38,6 +39,7 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
             data_version,
         )
         extendedspin_dataset = calculate_extendedspin(
+            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-hk"],
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
             de_dataset,

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from numpy.typing import NDArray
+import xarray as xr
 
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
 from imap_processing.spice.spin import get_spin_data, interpolate_spin_data
@@ -77,7 +78,8 @@ def get_energy_histogram(
     return hist, spin_edges, counts, mean_duration
 
 
-def flag_attitude(eventtimes_met: NDArray) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+def flag_attitude(eventtimes_met: NDArray,
+                  aux_dataset: xr.Dataset) -> tuple[NDArray, NDArray, NDArray, NDArray]:
     """
     Flag data based on attitude.
 
@@ -85,6 +87,8 @@ def flag_attitude(eventtimes_met: NDArray) -> tuple[NDArray, NDArray, NDArray, N
     ----------
     eventtimes_met : NDArray
         Event Times in Mission Elapsed Time.
+    aux_dataset : xarray.Dataset
+        Auxiliary dataset.
 
     Returns
     -------
@@ -111,6 +115,8 @@ def flag_attitude(eventtimes_met: NDArray) -> tuple[NDArray, NDArray, NDArray, N
         spin_rates.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
     )
     quality_flags[bad_spin_rate_indices] |= ImapAttitudeUltraFlags.SPINRATE.value
+    mismatch_indices = compare_aux_univ_spin_table(aux_dataset, spins)
+    quality_flags[mismatch_indices] |= ImapAttitudeUltraFlags.AUXMISMATCH.value
 
     return quality_flags, spin_rates, spin_period, spin_starttime
 
@@ -188,3 +194,51 @@ def flag_spin(
     quality_flags[indices_n_sigma] |= ImapRatesUltraFlags.HIGHRATES.value
 
     return quality_flags, spin, energy_midpoints, threshold
+
+
+def compare_aux_univ_spin_table(
+    aux_dataset: xr.Dataset,
+    spins: NDArray,
+) -> NDArray:
+    """
+    Compare the auxiliary and Universal Spin Table.
+
+    Parameters
+    ----------
+    aux_dataset : xarray.Dataset
+        Auxiliary dataset.
+    spins : np.ndarray
+        Array of spin numbers to compare.
+
+    Returns
+    -------
+    mismatch_indices : np.ndarray
+        Boolean array indicating which spins have mismatches.
+    """
+    spin_df = get_spin_data()
+
+    indices_univ = np.nonzero(np.isin(spin_df["spin_number"].values, spins))[0]
+    indices_aux = np.nonzero(np.isin(aux_dataset["SPINNUMBER"].values, spins))[0]
+
+    if not len(indices_univ) == len(spins):
+        raise ValueError("Some spin numbers are missing from Universal Spin Table.")
+
+    if not len(indices_aux) == len(spins):
+        raise ValueError("Some spin numbers are missing from Aux Packet.")
+
+    fields_to_compare = [
+        ("TIMESPINSTART", "spin_start_sec"),
+        ("TIMESPINSTARTSUB", "spin_start_subsec"),
+        ("DURATION", "spin_period_sec"),
+        ("TIMESPINDATA", "spin_start_time"),
+        ("SPINPERIOD", "spin_period_sec"),
+    ]
+
+    mismatch_indices = np.zeros(len(indices_aux), dtype=bool)
+
+    for aux_field, spin_field in fields_to_compare:
+        aux_values = aux_dataset[aux_field].values[indices_aux]
+        spin_values = spin_df[spin_field].values[indices_univ]
+        mismatch_indices |= (aux_values != spin_values)
+
+    return mismatch_indices

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -1,9 +1,9 @@
 """Culls Events for ULTRA L1b."""
 
 import numpy as np
-from numpy.typing import NDArray
 import pandas as pd
 import xarray as xr
+from numpy.typing import NDArray
 
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
 from imap_processing.spice.spin import get_spin_data
@@ -61,8 +61,9 @@ def get_energy_histogram(
     return hist, spin_edges, counts, mean_duration
 
 
-def flag_attitude(spin_number: NDArray,
-                  aux_dataset: xr.Dataset) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+def flag_attitude(
+    spin_number: NDArray, aux_dataset: xr.Dataset
+) -> tuple[NDArray, NDArray, NDArray, NDArray]:
     """
     Flag data based on attitude.
 
@@ -158,7 +159,9 @@ def flag_spin(
     n_sigma_per_energy_reshape : NDArray
         N sigma per energy.
     """
-    count_rates, spin_edges, counts, duration = get_energy_histogram(spin_number, energy)
+    count_rates, spin_edges, counts, duration = get_energy_histogram(
+        spin_number, energy
+    )
     quality_flags = np.full(
         count_rates.shape, ImapRatesUltraFlags.NONE.value, dtype=np.uint16
     )
@@ -179,9 +182,7 @@ def flag_spin(
 
 
 def compare_aux_univ_spin_table(
-    aux_dataset: xr.Dataset,
-    spins: NDArray,
-    spin_df: pd.DataFrame
+    aux_dataset: xr.Dataset, spins: NDArray, spin_df: pd.DataFrame
 ) -> NDArray:
     """
     Compare the auxiliary and Universal Spin Table.
@@ -192,6 +193,8 @@ def compare_aux_univ_spin_table(
         Auxiliary dataset.
     spins : np.ndarray
         Array of spin numbers to compare.
+    spin_df : pd.DataFrame
+        Universal Spin Table.
 
     Returns
     -------
@@ -218,6 +221,6 @@ def compare_aux_univ_spin_table(
         aux_values = filtered_aux[aux_field]
         spin_values = filtered_univ[spin_field].values
 
-        mismatch_indices |= (aux_values != spin_values)
+        mismatch_indices |= aux_values != spin_values
 
     return mismatch_indices

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -157,7 +157,7 @@ def flag_spin(
     n_sigma_per_energy_reshape : NDArray
         N sigma per energy.
     """
-    count_rates, spin_edges, counts, duration = get_energy_histogram(spin, energy)
+    count_rates, spin_edges, counts, duration = get_energy_histogram(spin_number, energy)
     quality_flags = np.full(
         count_rates.shape, ImapRatesUltraFlags.NONE.value, dtype=np.uint16
     )
@@ -196,17 +196,15 @@ def compare_aux_univ_spin_table(
     mismatch_indices : np.ndarray
         Boolean array indicating which spins have mismatches.
     """
-    # Load the Universal Spin Table
     spin_df = get_spin_data()
 
-    if not spins in spin_df["spin_number"].values:
-        raise ValueError("Some spin numbers are missing from the Universal Spin Table.")
+    univ_mask = np.isin(spin_df["spin_number"].values, spins)
+    aux_mask = np.isin(aux_dataset["SPINNUMBER"].values, spins)
 
-    if not spins in aux_dataset["SPINNUMBER"]:
-        raise ValueError("Some spin numbers are missing from Aux Packet.")
+    filtered_univ = spin_df[univ_mask]
+    filtered_aux = {field: aux_dataset[field].values[aux_mask] for field in aux_dataset}
 
-    indices_univ = np.nonzero(np.isin(spin_df["spin_number"].values, spins))[0]
-    indices_aux = np.nonzero(np.isin(aux_dataset["SPINNUMBER"].values, spins))[0]
+    mismatch_indices = np.zeros(len(spins), dtype=bool)
 
     fields_to_compare = [
         ("TIMESPINSTART", "spin_start_sec"),
@@ -216,11 +214,10 @@ def compare_aux_univ_spin_table(
         ("SPINPERIOD", "spin_period_sec"),
     ]
 
-    mismatch_indices = np.zeros(len(indices_aux), dtype=bool)
-
     for aux_field, spin_field in fields_to_compare:
-        aux_values = aux_dataset[aux_field].values[indices_aux]
-        spin_values = spin_df[spin_field].values[indices_univ]
+        aux_values = filtered_aux[aux_field]
+        spin_values = filtered_univ[spin_field].values
+
         mismatch_indices |= (aux_values != spin_values)
 
     return mismatch_indices

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -9,24 +9,6 @@ from imap_processing.spice.spin import get_spin_data, interpolate_spin_data
 from imap_processing.ultra.constants import UltraConstants
 
 
-def get_spin(eventtimes_met: NDArray) -> NDArray:
-    """
-    Get spin number for each event.
-
-    Parameters
-    ----------
-    eventtimes_met : NDArray
-        Event Times in Mission Elapsed Time.
-
-    Returns
-    -------
-    spin_number : NDArray
-        Spin number at each event derived the from Universal Spin Table.
-    """
-    spin_df = interpolate_spin_data(eventtimes_met)
-    return spin_df["spin_number"].values
-
-
 def get_energy_histogram(
     spin_number: NDArray, energy: NDArray
 ) -> tuple[NDArray, NDArray, NDArray, float]:
@@ -78,15 +60,15 @@ def get_energy_histogram(
     return hist, spin_edges, counts, mean_duration
 
 
-def flag_attitude(eventtimes_met: NDArray,
+def flag_attitude(spin_number: NDArray,
                   aux_dataset: xr.Dataset) -> tuple[NDArray, NDArray, NDArray, NDArray]:
     """
     Flag data based on attitude.
 
     Parameters
     ----------
-    eventtimes_met : NDArray
-        Event Times in Mission Elapsed Time.
+    spin_number : NDArray
+        Spin number at each direct event.
     aux_dataset : xarray.Dataset
         Auxiliary dataset.
 
@@ -101,7 +83,7 @@ def flag_attitude(eventtimes_met: NDArray,
     spin_starttime : NDArray
         Spin start time.
     """
-    spins = np.unique(get_spin(eventtimes_met))  # Get unique spins
+    spins = np.unique(spin_number)  # Get unique spins
     spin_df = get_spin_data()  # Load spin data
 
     spin_period = spin_df.loc[spin_df.spin_number.isin(spins), "spin_period_sec"]
@@ -150,15 +132,15 @@ def get_n_sigma(count_rates: NDArray, mean_duration: float, sigma: int = 6) -> N
 
 
 def flag_spin(
-    eventtimes_met: NDArray, energy: NDArray, sigma: int = 6
+    spin_number: NDArray, energy: NDArray, sigma: int = 6
 ) -> tuple[NDArray, NDArray, NDArray, NDArray]:
     """
     Flag data based on counts and negative energies.
 
     Parameters
     ----------
-    eventtimes_met : NDArray
-        Event Times in Mission Elapsed Time.
+    spin_number : NDArray
+        Spin number at each direct event.
     energy : NDArray
         Energy data.
     sigma : int (default=6)
@@ -175,7 +157,6 @@ def flag_spin(
     n_sigma_per_energy_reshape : NDArray
         N sigma per energy.
     """
-    spin = get_spin(eventtimes_met)
     count_rates, spin_edges, counts, duration = get_energy_histogram(spin, energy)
     quality_flags = np.full(
         count_rates.shape, ImapRatesUltraFlags.NONE.value, dtype=np.uint16
@@ -187,7 +168,7 @@ def flag_spin(
 
     bin_edges = np.array(UltraConstants.CULLING_ENERGY_BIN_EDGES)
     energy_midpoints = np.sqrt(bin_edges[:-1] * bin_edges[1:])
-    spin = np.unique(spin)
+    spin = np.unique(spin_number)
 
     # Indices where the counts exceed the threshold
     indices_n_sigma = count_rates > threshold[:, np.newaxis]
@@ -215,16 +196,17 @@ def compare_aux_univ_spin_table(
     mismatch_indices : np.ndarray
         Boolean array indicating which spins have mismatches.
     """
+    # Load the Universal Spin Table
     spin_df = get_spin_data()
+
+    if not spins in spin_df["spin_number"].values:
+        raise ValueError("Some spin numbers are missing from the Universal Spin Table.")
+
+    if not spins in aux_dataset["SPINNUMBER"]:
+        raise ValueError("Some spin numbers are missing from Aux Packet.")
 
     indices_univ = np.nonzero(np.isin(spin_df["spin_number"].values, spins))[0]
     indices_aux = np.nonzero(np.isin(aux_dataset["SPINNUMBER"].values, spins))[0]
-
-    if not len(indices_univ) == len(spins):
-        raise ValueError("Some spin numbers are missing from Universal Spin Table.")
-
-    if not len(indices_aux) == len(spins):
-        raise ValueError("Some spin numbers are missing from Aux Packet.")
 
     fields_to_compare = [
         ("TIMESPINSTART", "spin_start_sec"),

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -2,10 +2,11 @@
 
 import numpy as np
 from numpy.typing import NDArray
+import pandas as pd
 import xarray as xr
 
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
-from imap_processing.spice.spin import get_spin_data, interpolate_spin_data
+from imap_processing.spice.spin import get_spin_data
 from imap_processing.ultra.constants import UltraConstants
 
 
@@ -97,7 +98,7 @@ def flag_attitude(spin_number: NDArray,
         spin_rates.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
     )
     quality_flags[bad_spin_rate_indices] |= ImapAttitudeUltraFlags.SPINRATE.value
-    mismatch_indices = compare_aux_univ_spin_table(aux_dataset, spins)
+    mismatch_indices = compare_aux_univ_spin_table(aux_dataset, spins, spin_df)
     quality_flags[mismatch_indices] |= ImapAttitudeUltraFlags.AUXMISMATCH.value
 
     return quality_flags, spin_rates, spin_period, spin_starttime
@@ -180,6 +181,7 @@ def flag_spin(
 def compare_aux_univ_spin_table(
     aux_dataset: xr.Dataset,
     spins: NDArray,
+    spin_df: pd.DataFrame
 ) -> NDArray:
     """
     Compare the auxiliary and Universal Spin Table.
@@ -196,8 +198,6 @@ def compare_aux_univ_spin_table(
     mismatch_indices : np.ndarray
         Boolean array indicating which spins have mismatches.
     """
-    spin_df = get_spin_data()
-
     univ_mask = np.isin(spin_df["spin_number"].values, spins)
     aux_mask = np.isin(aux_dataset["SPINNUMBER"].values, spins)
 


### PR DESCRIPTION
# Change Summary

## Overview
One flag that the Ultra team thought is important is the comparison between their aux packet and the Universal Spin Table. They should contain the same information. This PR creates a quality flag for a mismatch between the aux packet and Universal Spin Table. I also recognized some minor changes that need to happen as I was working.

## Updated Files
- ultra_l1b_culling.py
    - Updated since we don't need to interpolate based on time to get the spin number. It is already in the de_dataset
    - Created function that compares the aux dataset to the Universal Spin Table
- quality_flags.py
   - added new flag
- imap_ultra_l1b_variable_attrs.yaml
   - added an attribute
- extendedspin.py
   - Pass in the aux packet now. 
   - Updated since we don't need to interpolate based on time to get the spin number. It is already in the de_dataset
-  ultra_l1b.py
    - Pass in aux packet
-  de.py
    - Create spin data field.
    
## Testing
- conftest.py
   - added mocked aux dataset
- test_ultra_l1b_culling.py