### PR TITLE
Reorder ultra map code dimensions -> (epoch, energy, az, el)

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -207,6 +207,9 @@ class PointingSet(ABC):
     """
     Abstract class to contain pointing set (PSET) data in the context of ENA sky maps.
 
+    Any spatial axes - (azimuth, elevation) for Rectangularly gridded tilings or
+    (pixel index) for Healpix - must be stored in the last axis/axes of each data array.
+
     Parameters
     ----------
     dataset : xr.Dataset
@@ -362,7 +365,14 @@ class UltraPointingSet(PointingSet):
 
 # Define the Map classes
 class AbstractSkyMap(ABC):
-    """Abstract base class to contain map data in the context of ENA sky maps."""
+    """
+    Abstract base class to contain map data in the context of ENA sky maps.
+
+    Data values are stored in a dictionary, where the 0th axis is the
+    only spatial dimension. If the map is rectangular,
+    this axis is the raveled 2D grid.
+    If the map is Healpix, this axis is the 1D array of Healpix pixel indices.
+    """
 
     @abstractmethod
     def __init__(self) -> None:
@@ -384,7 +394,8 @@ class RectangularSkyMap(AbstractSkyMap):
     """
     Map which tiles the sky with a 2D rectangular grid of azimuth/elevation pixels.
 
-    NOTE: Internally, the map is stored as a 1D array of pixels.
+    NOTE: Internally, the map is stored as a 1D array of pixels,
+    with the 0th axis as the spatial axis.
 
     Parameters
     ----------
@@ -470,15 +481,17 @@ class RectangularSkyMap(AbstractSkyMap):
             )
 
         for value_key in value_keys:
-            # If multiple spatial axes present
-            # (i.e (az, el) for rectangular coordinate PSET),
-            # flatten them in the values array to match the raveled indices
-            raveled_pset_data = pointing_set.data[value_key].data.reshape(
-                pointing_set.num_points, -1
-            )
+            pset_values = pointing_set.data[value_key]
+
+            # If there is an epoch dim with size 1, flatten it out
+            if "epoch" in pset_values.dims and pset_values["epoch"].size == 1:
+                pset_values = pset_values.squeeze("epoch")
+
+            raveled_pset_data = pset_values.data.reshape(-1, pointing_set.num_points)
+
             if value_key not in self.data_dict:
                 # Initialize the map data array if it doesn't exist (values start at 0)
-                output_shape = (self.num_points, *raveled_pset_data.shape[1:])
+                output_shape = (self.num_points, *raveled_pset_data.shape[:-1])
                 self.data_dict[value_key] = np.zeros(output_shape)
 
             if index_match_method is IndexMatchMethod.PUSH:
@@ -489,12 +502,16 @@ class RectangularSkyMap(AbstractSkyMap):
                         len(self.sky_grid.el_bin_midpoints),
                     ),
                     projection_indices=matched_indices_push,
+                    spatial_axis=-1,
                 )
             else:
                 raise NotImplementedError(
                     "The 'pull' method of index matching is not yet implemented."
                 )
             self.data_dict[value_key] += pointing_projected_values
+
+            # These are not used after the loop, and can be large - Delete them.
+            del pset_values, raveled_pset_data, pointing_projected_values
 
     def __repr__(self) -> str:
         """

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -368,8 +368,8 @@ class AbstractSkyMap(ABC):
     """
     Abstract base class to contain map data in the context of ENA sky maps.
 
-    Data values are stored in a dictionary, where the 0th axis is the
-    only spatial dimension. If the map is rectangular,
+    Data values are stored in a dictionary, where the final (-1) axis
+    is the only spatial dimension. If the map is rectangular,
     this axis is the raveled 2D grid.
     If the map is Healpix, this axis is the 1D array of Healpix pixel indices.
     """
@@ -395,7 +395,7 @@ class RectangularSkyMap(AbstractSkyMap):
     Map which tiles the sky with a 2D rectangular grid of azimuth/elevation pixels.
 
     NOTE: Internally, the map is stored as a 1D array of pixels,
-    with the 0th axis as the spatial axis.
+    with the final (-1) axis as the spatial axis.
 
     Parameters
     ----------
@@ -491,7 +491,7 @@ class RectangularSkyMap(AbstractSkyMap):
 
             if value_key not in self.data_dict:
                 # Initialize the map data array if it doesn't exist (values start at 0)
-                output_shape = (self.num_points, *raveled_pset_data.shape[:-1])
+                output_shape = (*raveled_pset_data.shape[:-1], self.num_points)
                 self.data_dict[value_key] = np.zeros(output_shape)
 
             if index_match_method is IndexMatchMethod.PUSH:
@@ -502,16 +502,12 @@ class RectangularSkyMap(AbstractSkyMap):
                         len(self.sky_grid.el_bin_midpoints),
                     ),
                     projection_indices=matched_indices_push,
-                    spatial_axis=-1,
                 )
             else:
                 raise NotImplementedError(
                     "The 'pull' method of index matching is not yet implemented."
                 )
             self.data_dict[value_key] += pointing_projected_values
-
-            # These are not used after the loop, and can be large - Delete them.
-            del pset_values, raveled_pset_data, pointing_projected_values
 
     def __repr__(self) -> str:
         """

--- a/imap_processing/ena_maps/utils/map_utils.py
+++ b/imap_processing/ena_maps/utils/map_utils.py
@@ -15,17 +15,16 @@ def bin_single_array_at_indices(
     projection_grid_shape: tuple[int, int],
     projection_indices: NDArray,
     input_indices: NDArray | None = None,
-    spatial_axis: int = 0,
 ) -> NDArray:
     """
     Bin an array of values at the given indices.
 
-    NOTE: The output array's spatial axis is always the 0th axis.
+    NOTE: The output array's spatial axis is always the final (-1) axis.
 
     Parameters
     ----------
     value_array : NDArray
-        Array of values to bin. spatial_axis must be the one and only spatial axis.
+        Array of values to bin. The final axis be the one and only spatial axis.
         If other axes are present, they will be binned independently
         along the spatial axis.
     projection_grid_shape : tuple[int]
@@ -39,9 +38,7 @@ def bin_single_array_at_indices(
         Ordered indices for input grid, corresponding to indices in projection grid.
         1 dimensional. May be non-unique, depending on the projection method.
         If None (default), an arange of the same length as the
-        0th axis of value_array is used.
-    spatial_axis : int, optional
-        The axis along which the spatial indices are defined, by default 0.
+        final axis of value_array is used.
 
     Returns
     -------
@@ -57,10 +54,7 @@ def bin_single_array_at_indices(
         If the input value_array has dimensionality less than 1.
     """
     if input_indices is None:
-        input_indices = np.arange(value_array.shape[spatial_axis])
-
-    # Transpose the value array so the spatial axis is the 0th axis
-    value_array = np.moveaxis(value_array, spatial_axis, 0)
+        input_indices = np.arange(value_array.shape[-1])
 
     # Both sets of indices must be 1D with the same number of elements
     if input_indices.ndim != 1 or projection_indices.ndim != 1:
@@ -88,16 +82,11 @@ def bin_single_array_at_indices(
         binned_values = np.apply_along_axis(
             lambda x: np.bincount(
                 projection_indices,
-                weights=x[input_indices, ...],
+                weights=x[..., input_indices],
                 minlength=num_projection_indices,
             ),
-            axis=0,
+            axis=-1,
             arr=value_array,
-        )
-    else:
-        raise NotImplementedError(
-            "Only 1+ Dimensional arrays are supported for binning. "
-            f"Received array with shape {value_array.shape}."
         )
     return binned_values
 
@@ -107,7 +96,6 @@ def bin_values_at_indices(
     projection_grid_shape: tuple[int, int],
     projection_indices: NDArray,
     input_indices: NDArray | None = None,
-    spatial_axis: int = 0,
 ) -> dict[str, NDArray]:
     """
     Project values from input grid to projection grid based on matched indices.
@@ -116,9 +104,9 @@ def bin_values_at_indices(
     ----------
     input_values_to_bin : dict[str, NDArray]
         Dict matching variable names to arrays of values to bin.
-        The spatial_axis of each array must be the one and only spatial axis,
+        The final (-1) axis of each array must be the one and only spatial axis,
         which the indices correspond to and on which the values will be binned.
-        The other axes will be binned independently along this 0th axis.
+        The other axes will be binned independently along this final axis.
     projection_grid_shape : tuple[int, int]
         The shape of the grid onto which values are projected (rows, columns).
         This size of the resulting grid (rows * columns) will be the size of the
@@ -130,8 +118,6 @@ def bin_values_at_indices(
         Ordered indices for input grid, corresponding to indices in projection grid.
         1 dimensional. May be non-unique, depending on the projection method.
         If None (default), behavior is determined by bin_single_array_at_indices.
-    spatial_axis : int, optional
-        The axis along which the spatial indices are defined, by default 0.
 
     Returns
     -------
@@ -151,7 +137,6 @@ def bin_values_at_indices(
             projection_grid_shape=projection_grid_shape,
             projection_indices=projection_indices,
             input_indices=input_indices,
-            spatial_axis=spatial_axis,
         )
 
     return binned_values_dict

--- a/imap_processing/ena_maps/utils/map_utils.py
+++ b/imap_processing/ena_maps/utils/map_utils.py
@@ -15,16 +15,19 @@ def bin_single_array_at_indices(
     projection_grid_shape: tuple[int, int],
     projection_indices: NDArray,
     input_indices: NDArray | None = None,
+    spatial_axis: int = 0,
 ) -> NDArray:
     """
     Bin an array of values at the given indices.
 
+    NOTE: The output array's spatial axis is always the 0th axis.
+
     Parameters
     ----------
     value_array : NDArray
-        Array of values to bin. The 0th axis must be the one and only spatial axis.
+        Array of values to bin. spatial_axis must be the one and only spatial axis.
         If other axes are present, they will be binned independently
-        along the 0th (spatial) axis.
+        along the spatial axis.
     projection_grid_shape : tuple[int]
         The shape of the grid onto which values are projected
         (rows, columns) if the grid is rectangular,
@@ -37,6 +40,8 @@ def bin_single_array_at_indices(
         1 dimensional. May be non-unique, depending on the projection method.
         If None (default), an arange of the same length as the
         0th axis of value_array is used.
+    spatial_axis : int, optional
+        The axis along which the spatial indices are defined, by default 0.
 
     Returns
     -------
@@ -52,7 +57,10 @@ def bin_single_array_at_indices(
         If the input value_array has dimensionality less than 1.
     """
     if input_indices is None:
-        input_indices = np.arange(value_array.shape[0])
+        input_indices = np.arange(value_array.shape[spatial_axis])
+
+    # Transpose the value array so the spatial axis is the 0th axis
+    value_array = np.moveaxis(value_array, spatial_axis, 0)
 
     # Both sets of indices must be 1D with the same number of elements
     if input_indices.ndim != 1 or projection_indices.ndim != 1:
@@ -99,6 +107,7 @@ def bin_values_at_indices(
     projection_grid_shape: tuple[int, int],
     projection_indices: NDArray,
     input_indices: NDArray | None = None,
+    spatial_axis: int = 0,
 ) -> dict[str, NDArray]:
     """
     Project values from input grid to projection grid based on matched indices.
@@ -107,7 +116,7 @@ def bin_values_at_indices(
     ----------
     input_values_to_bin : dict[str, NDArray]
         Dict matching variable names to arrays of values to bin.
-        The 0th axis of each array must be the one and only spatial axis,
+        The spatial_axis of each array must be the one and only spatial axis,
         which the indices correspond to and on which the values will be binned.
         The other axes will be binned independently along this 0th axis.
     projection_grid_shape : tuple[int, int]
@@ -121,6 +130,8 @@ def bin_values_at_indices(
         Ordered indices for input grid, corresponding to indices in projection grid.
         1 dimensional. May be non-unique, depending on the projection method.
         If None (default), behavior is determined by bin_single_array_at_indices.
+    spatial_axis : int, optional
+        The axis along which the spatial indices are defined, by default 0.
 
     Returns
     -------
@@ -140,6 +151,7 @@ def bin_values_at_indices(
             projection_grid_shape=projection_grid_shape,
             projection_indices=projection_indices,
             input_indices=input_indices,
+            spatial_axis=spatial_axis,
         )
 
     return binned_values_dict

--- a/imap_processing/ena_maps/utils/spatial_utils.py
+++ b/imap_processing/ena_maps/utils/spatial_utils.py
@@ -102,6 +102,9 @@ def rewrap_even_spaced_az_el_grid(
     """
     Take an unwrapped (raveled) 1D array and reshapes it into a 2D az/el grid.
 
+    In the input, unwrapped grid, the spatial axis is the 0th axis.
+    In the output, the spatial axes are the 0th (az) and 1st (el) axes.
+
     Assumes the following must be true of the original grid:
     1. Grid was evenly spaced in angular space,
     2. Grid had the same spacing in both azimuth and elevation.

--- a/imap_processing/ena_maps/utils/spatial_utils.py
+++ b/imap_processing/ena_maps/utils/spatial_utils.py
@@ -96,26 +96,26 @@ def build_solid_angle_map(
 @typing.no_type_check
 def rewrap_even_spaced_az_el_grid(
     raveled_values: NDArray,
-    shape: tuple[int] | None = None,
+    grid_shape: tuple[int] | None = None,
     order: typing.Literal["C"] | typing.Literal["F"] = "C",
 ) -> NDArray:
     """
     Take an unwrapped (raveled) 1D array and reshapes it into a 2D az/el grid.
 
-    In the input, unwrapped grid, the spatial axis is the 0th axis.
-    In the output, the spatial axes are the 0th (az) and 1st (el) axes.
+    In the input, unwrapped grid, the spatial axis is the final (-1) axis.
+    In the output, the spatial axes are the -2 (azimuth) and -1 (elevation) axes.
 
     Assumes the following must be true of the original grid:
     1. Grid was evenly spaced in angular space,
     2. Grid had the same spacing in both azimuth and elevation.
-    3. Azimuth is axis 0 (and extends a total of 360 degrees).
-    4. Elevation is axis 1 (and extends a total of 180 degrees),
+    3. Azimuth is the first spatial axis (and extends a total of 360 degrees).
+    4. Elevation is the second spatial axis (and extends a total of 180 degrees).
 
     Parameters
     ----------
     raveled_values : NDArray
         1D array of values to be reshaped into a 2D grid.
-    shape : tuple[int], optional
+    grid_shape : tuple[int], optional
         The shape of the original grid, if known, by default None.
         If None, the shape will be inferred from the size of the input array.
     order : {'C', 'F'}, optional
@@ -124,26 +124,18 @@ def rewrap_even_spaced_az_el_grid(
     Returns
     -------
     NDArray
-        The reshaped 2D grid of values.
-
-    Raises
-    ------
-    ValueError
-        If the input is not a 1D array or 2D array with an 'extra' non-spatial axis.
+        The reshaped 2D grid of values with (azimuth, elevation) as the final 2 axes.
     """
-    if raveled_values.ndim > 2:
-        raise ValueError(
-            "Input must be a 1D array or 2D array with only one spatial axis as axis 0."
-        )
-
     # We can infer the shape if its evenly spaced and 2D
-    if not shape:
-        spacing_deg = 1 / np.sqrt(raveled_values.shape[0] / (360 * 180))
-        shape = (int(360 // spacing_deg), int(180 // spacing_deg))
+    if not grid_shape:
+        spacing_deg = 1 / np.sqrt(raveled_values.shape[-1] / (360 * 180))
+        grid_shape = (int(360 // spacing_deg), int(180 // spacing_deg))
 
-    if raveled_values.ndim == 2:
-        shape = (shape[0], shape[1], raveled_values.shape[1])
-    return raveled_values.reshape(shape, order=order)
+    if raveled_values.ndim == 1:
+        array_shape = grid_shape
+    else:
+        array_shape = (*raveled_values.shape[:-1], *grid_shape)
+    return raveled_values.reshape(array_shape, order=order)
 
 
 class AzElSkyGrid:

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -178,9 +178,14 @@ class TestRectangularSkyMap:
         assert rectangular_map.data_dict != {}
 
         # Check that the map has the same values as the PSETs, summed
-        simple_summed_pset_counts = np.sum(
-            [pset["counts"].values for pset in self.l1c_pset_products], axis=0
-        ).reshape(rectangular_map.data_dict["counts"].shape)
+        simple_summed_pset_counts = np.zeros(rectangular_map.data_dict["counts"].shape)
+        for pset in self.l1c_pset_products:
+            reshaped_pset_counts = pset["counts"].squeeze("epoch")
+            # transpose to put az, el first and then reshape to the map's counts shape
+            reshaped_pset_counts = reshaped_pset_counts.transpose(
+                "azimuth_bin_center", "elevation_bin_center", "energy_bin_center"
+            ).data.reshape(rectangular_map.data_dict["counts"].shape)
+            simple_summed_pset_counts += reshaped_pset_counts
 
         np.testing.assert_allclose(
             rectangular_map.data_dict["counts"],

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -183,7 +183,9 @@ class TestRectangularSkyMap:
             reshaped_pset_counts = pset["counts"].squeeze("epoch")
             # transpose to put az, el first and then reshape to the map's counts shape
             reshaped_pset_counts = reshaped_pset_counts.transpose(
-                "azimuth_bin_center", "elevation_bin_center", "energy_bin_center"
+                "energy_bin_center",
+                "azimuth_bin_center",
+                "elevation_bin_center",
             ).data.reshape(rectangular_map.data_dict["counts"].shape)
             simple_summed_pset_counts += reshaped_pset_counts
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -178,18 +178,16 @@ class TestRectangularSkyMap:
         assert rectangular_map.data_dict != {}
 
         # Check that the map has the same values as the PSETs, summed
-        simple_summed_pset_counts = np.zeros(rectangular_map.data_dict["counts"].shape)
+        simple_summed_pset_counts = np.zeros_like(rectangular_map.data_dict["counts"])
         for pset in self.l1c_pset_products:
             reshaped_pset_counts = pset["counts"].squeeze("epoch")
-            # transpose to put az, el first and then reshape to the map's counts shape
-            reshaped_pset_counts = reshaped_pset_counts.transpose(
-                "energy_bin_center",
-                "azimuth_bin_center",
-                "elevation_bin_center",
-            ).data.reshape(rectangular_map.data_dict["counts"].shape)
+            # Reshape to the map's counts shape
+            reshaped_pset_counts = reshaped_pset_counts.data.reshape(
+                rectangular_map.data_dict["counts"].shape
+            )
             simple_summed_pset_counts += reshaped_pset_counts
 
-        np.testing.assert_allclose(
+        np.testing.assert_array_equal(
             rectangular_map.data_dict["counts"],
             simple_summed_pset_counts,
         )

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -28,37 +28,25 @@ class TestENAMapMappingUtils:
         """Test coverage for bin_single_array_at_indices function w/ simple 2D input,
         Corresponding to an extra axis that is not spatially binned.
         """
-        # Binning will occur along axis 0 seen below
+        # Binning will occur along axis 1 seen below
         # (combining 1, 2, 3 and 4, 5, 6 separately).
-        # However, we will first transpose the array seen below, to test the
-        # binning along the specified spatial axis
         value_array = np.array(
             [
-                [1, 4],
-                [2, 5],
-                [3, 6],
+                [1, 2, 3],
+                [4, 5, 6],
             ]
-        ).transpose(1, 0)
+        )
         input_indices = np.array([0, 1, 2, 2])
         projection_indices = np.array([1, 0, 1, 6])
         projection_grid_shape = (7, 1)
         expected_projection_values = np.array(
-            [
-                [2, 5],
-                [4, 10],
-                [0, 0],
-                [0, 0],
-                [0, 0],
-                [0, 0],
-                [3, 6],
-            ]
+            [[2, 4, 0, 0, 0, 0, 3], [5, 10, 0, 0, 0, 0, 6]]
         )
         projection_values = map_utils.bin_single_array_at_indices(
             value_array,
             input_indices=input_indices,
             projection_indices=projection_indices,
             projection_grid_shape=projection_grid_shape,
-            spatial_axis=1,
         )
 
         np.testing.assert_equal(projection_values, expected_projection_values)
@@ -80,7 +68,7 @@ class TestENAMapMappingUtils:
         extra_axis_size = 11  # Another axis which is not spatially binned, e.g. energy
         input_grid_size = np.prod(input_grid_shape)
         projection_grid_size = np.prod(projection_grid_shape)
-        value_array = np.random.rand(input_grid_size, extra_axis_size)
+        value_array = np.random.rand(extra_axis_size, input_grid_size)
         input_indices = np.random.randint(0, input_grid_size, size=1000)
         projection_indices = np.random.randint(0, projection_grid_size, size=1000)
         projection_values = map_utils.bin_single_array_at_indices(
@@ -94,16 +82,16 @@ class TestENAMapMappingUtils:
         np.testing.assert_equal(
             projection_values.shape,
             (
-                projection_grid_size,
                 extra_axis_size,
+                projection_grid_size,
             ),
         )
 
         # Create the expected projection values by summing the input values in a loop
         # This is different from the binning function, which uses np.bincount
-        expected_projection_values = np.zeros((projection_grid_size, extra_axis_size))
+        expected_projection_values = np.zeros((extra_axis_size, projection_grid_size))
         for ii, ip in zip(input_indices, projection_indices):
-            expected_projection_values[ip, :] += value_array[ii, :]
+            expected_projection_values[:, ip] += value_array[:, ii]
 
         np.testing.assert_allclose(projection_values, expected_projection_values)
 
@@ -121,7 +109,7 @@ class TestENAMapMappingUtils:
         extra_axes_sizes = np.full(num_extra_dims, 3, dtype=int).tolist()
         input_grid_size = np.prod(input_grid_shape)
         projection_grid_size = np.prod(projection_grid_shape)
-        value_array = np.random.rand(input_grid_size, *extra_axes_sizes)
+        value_array = np.random.rand(*extra_axes_sizes, input_grid_size)
         input_indices = np.random.randint(0, input_grid_size, size=1000)
         projection_indices = np.random.randint(0, projection_grid_size, size=1000)
         projection_values = map_utils.bin_single_array_at_indices(
@@ -134,14 +122,14 @@ class TestENAMapMappingUtils:
         # Explicitly check that the shape of the output is the same as projection grid
         np.testing.assert_equal(
             projection_values.shape,
-            (projection_grid_size, *extra_axes_sizes),
+            (*extra_axes_sizes, projection_grid_size),
         )
 
         # Create the expected projection values by summing the input values in a loop
         # This is different from the binning function, which uses np.bincount
-        expected_projection_values = np.zeros((projection_grid_size, *extra_axes_sizes))
+        expected_projection_values = np.zeros((*extra_axes_sizes, projection_grid_size))
         for ii, ip in zip(input_indices, projection_indices):
-            expected_projection_values[ip, ...] += value_array[ii, ...]
+            expected_projection_values[..., ip] += value_array[..., ii]
 
         np.testing.assert_allclose(projection_values, expected_projection_values)
 
@@ -159,28 +147,59 @@ class TestENAMapMappingUtils:
         scale_factor_1d = 1.5
         input_values_1d_2 = input_values_1d_1 * scale_factor_1d
 
-        # 2D input values. The second axis (different cols) will be summed independently
+        # 2D input values. The 0 axis (different rows) will be summed independently
         input_values_2d = np.array(
             [
-                [-0.5, 0, 0.5],
-                [1, 2, 3],
-                [4, 5, 6],
-                [7, 8, 9],
-                [0, 0, 0],
-                [0, 0, 0],
-                [0, 0, 0],
-                [0, 0, 0],
-                [0, 0, 0],
-                [0, 0, 0],
-                [0, 0, 0],
-                [0, 0, 0],
+                [
+                    -0.5,
+                    1,
+                    4,
+                    7,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    2,
+                    5,
+                    8,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0.5,
+                    3,
+                    6,
+                    9,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
             ]
         )
-        extra_axis_size_2d = input_values_2d.shape[1]
+
+        extra_axis_size_2d = input_values_2d.shape[0]
 
         # 3D input values
-        input_values_3d = np.zeros((input_values_2d.shape[0], 3, 3))
-        input_values_3d[:2] = np.array(
+        input_values_3d = np.zeros((3, 3, input_values_2d.shape[-1]))
+        input_values_3d[:, :, :2] = np.array(
             [
                 [
                     [1, 2, 3],
@@ -193,8 +212,8 @@ class TestENAMapMappingUtils:
                     [16, 17, 18],
                 ],
             ]
-        )
-        extra_axes_size_3d = input_values_3d.shape[1:]
+        ).transpose(1, 2, 0)
+        extra_axes_size_3d = input_values_3d.shape[:-1]
 
         # Set up the expected projection values
         expected_projection_values_1d_1 = np.zeros(projection_grid_shape).ravel()
@@ -203,13 +222,13 @@ class TestENAMapMappingUtils:
             expected_projection_values_1d_1 * scale_factor_1d
         )
         expected_projection_values_2d = np.zeros(
-            (np.prod(projection_grid_shape), extra_axis_size_2d)
+            (extra_axis_size_2d, np.prod(projection_grid_shape))
         )
-        expected_projection_values_2d[0, :] = np.array([11.5, 15, 18.5])
+        expected_projection_values_2d[:, 0] = np.array([11.5, 15, 18.5])
         expected_projection_values_3d = np.zeros(
-            (np.prod(projection_grid_shape), *extra_axes_size_3d)
+            (*extra_axes_size_3d, np.prod(projection_grid_shape))
         )
-        expected_projection_values_3d[0, :, :] = np.array(
+        expected_projection_values_3d[:, :, 0] = np.array(
             [
                 [11, 13, 15],
                 [17, 19, 21],

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -28,14 +28,17 @@ class TestENAMapMappingUtils:
         """Test coverage for bin_single_array_at_indices function w/ simple 2D input,
         Corresponding to an extra axis that is not spatially binned.
         """
-        # Binning will occur along axis 0 (combining 1, 2, 3 and 4, 5, 6 separately)
+        # Binning will occur along axis 0 seen below
+        # (combining 1, 2, 3 and 4, 5, 6 separately).
+        # However, we will first transpose the array seen below, to test the
+        # binning along the specified spatial axis
         value_array = np.array(
             [
                 [1, 4],
                 [2, 5],
                 [3, 6],
             ]
-        )
+        ).transpose(1, 0)
         input_indices = np.array([0, 1, 2, 2])
         projection_indices = np.array([1, 0, 1, 6])
         projection_grid_shape = (7, 1)
@@ -55,6 +58,7 @@ class TestENAMapMappingUtils:
             input_indices=input_indices,
             projection_indices=projection_indices,
             projection_grid_shape=projection_grid_shape,
+            spatial_axis=1,
         )
 
         np.testing.assert_equal(projection_values, expected_projection_values)

--- a/imap_processing/tests/ena_maps/test_spatial_utils.py
+++ b/imap_processing/tests/ena_maps/test_spatial_utils.py
@@ -91,7 +91,7 @@ def test_rewrap_even_spaced_az_el_grid_1d(order):
     )
     rewrapped_grid_known_shape = spatial_utils.rewrap_even_spaced_az_el_grid(
         raveled_values,
-        shape=orig_shape,
+        grid_shape=orig_shape,
         order=order,
     )
 
@@ -102,19 +102,19 @@ def test_rewrap_even_spaced_az_el_grid_1d(order):
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_rewrap_even_spaced_az_el_grid_2d(order):
     """Test rewrap_even_spaced_az_el_grid function, with extra axis."""
-    orig_shape = (360 * 12, 180 * 12, 5)
+    orig_shape = (5, 360 * 12, 180 * 12)
     orig_grid = np.fromfunction(lambda i, j, k: i**2 + j + k, orig_shape, dtype=int)
-    raveled_values = orig_grid.reshape(-1, 5, order=order)
+    raveled_values = orig_grid.reshape(5, -1, order=order)
     rewrapped_grid_infer_shape = spatial_utils.rewrap_even_spaced_az_el_grid(
         raveled_values,
         order=order,
     )
     rewrapped_grid_known_shape = spatial_utils.rewrap_even_spaced_az_el_grid(
         raveled_values,
-        shape=orig_shape,
+        grid_shape=orig_shape[-2:],
         order=order,
     )
-    assert raveled_values.shape == (360 * 12 * 180 * 12, 5)
+    assert raveled_values.shape == (5, 360 * 12 * 180 * 12)
     assert np.array_equal(rewrapped_grid_infer_shape, orig_grid)
     assert np.array_equal(rewrapped_grid_known_shape, orig_grid)
 

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -22,17 +22,18 @@ def mock_l1c_pset_product(
     This is not meant to perfectly mimic the real data, but to provide a
     recognizable structure for L2 testing purposes.
     Function will produce an xarray.Dataset with at least the variables and shapes:
-    counts: (num_lat_bins, num_lon_bins, num_energy_bins)
-    exposure_time: (num_lat_bins, num_lon_bins)
-    sensitivity: (num_lat_bins, num_lon_bins, num_energy_bins)
+    counts: (1 epoch, num_energy_bins, num_lon_bins, num_lat_bins)
+    exposure_time: (num_lon_bins, num_lat_bins)
+    sensitivity: (1 epoch, num_energy_bins, num_lon_bins, num_lat_bins)
 
     and the coordinate variables:
-    latitude: (num_lat_bins)
-    longitude: (num_lon_bins)
+    the epoch (assumed to be a single time for each product).
     energy: (determined by build_energy_bins function)
-    head: Either '45' or '90'. Default is '45'.
+    longitude: (num_lon_bins)
+    latitude: (num_lat_bins)
 
-    as well as the epoch (assumed to be a single time for each product).
+    While not a coordinate, PSETs can also be distinguished by the 'head' attribute.
+    head: Either '45' or '90'. Default is '45'.
 
     The counts are generated along a stripe, centered at a given longitude.
     This stripe can be thought of as a 'vertical' line if the lon/az axis is plotted
@@ -51,23 +52,6 @@ def mock_l1c_pset_product(
     Azimuth/Longitude ->
 
     Fig. 1: Example of the '90' sensor head stripe
-
-    To distinguish between the two sensor heads, the counts are halved in the '45' head
-    at latitudes above 0 degrees.
-
-    ^  Elevation/Latitude
-    |
-    |    000000000000000000000000000123432100000000000000000
-    |    000000000000000000000000000123432100000000000000000
-    |    000000000000000000000000000123432100000000000000000
-    |    000000000000000000000000000123432100000000000000000
-    |    000000000000000000000000000246864200000000000000000
-    |    000000000000000000000000000246864200000000000000000
-    |    000000000000000000000000000246864200000000000000000
-    --------------------------------------------------------->
-    Azimuth/Longitude ->
-
-    Fig. 2: Example of the '45' sensor head stripe
 
     Parameters
     ----------

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -85,13 +85,14 @@ def mock_l1c_pset_product(
     stripe_center_lon_bin = int(stripe_center_lon / spacing_deg)
 
     _, energy_bin_midpoints = build_energy_bins()
-    energy_bin_midpoints = energy_bin_midpoints[1:]
     num_energy_bins = len(energy_bin_midpoints)
 
-    grid_shape = (num_lon_bins, num_lat_bins, num_energy_bins)
+    # 1 epoch x num_energy_bins x num_lon_bins x num_lat_bins
+    grid_shape = (1, num_energy_bins, num_lon_bins, num_lat_bins)
 
     def get_binomial_counts(distance_scaling, lon_bin, central_lon_bin):
-        # Note, this is not quite correct, as it won't wrap around at 720
+        # Note, this is not quite correct, as it won't wrap around at 360 degrees
+        # but it's all meant to provide a recognizable pattern for testing
         distance_lon_bin = np.abs(lon_bin - central_lon_bin)
 
         rng = np.random.default_rng(seed=42)
@@ -101,7 +102,7 @@ def mock_l1c_pset_product(
         )
 
     counts = np.fromfunction(
-        lambda lon_bin, lat_bin, energy_bin: get_binomial_counts(
+        lambda epoch, energy_bin, lon_bin, lat_bin: get_binomial_counts(
             distance_scaling=20,
             lon_bin=lon_bin,
             central_lon_bin=stripe_center_lon_bin,
@@ -109,30 +110,30 @@ def mock_l1c_pset_product(
         shape=grid_shape,
     )
 
-    exposure_time = np.zeros(grid_shape[:2]) + 0.1
+    exposure_time = np.zeros(grid_shape[2:]) + 0.1
     if head == "90":
         exposure_time[
             stripe_center_lon_bin : stripe_center_lon_bin + int(20 / spacing_deg),
             :,
         ] = 1
     else:
-        counts[
-            :,
-            : int(90 / spacing_deg),
-            :,
-        ] / 2
-        counts = counts.astype(int)
         exposure_time[
             stripe_center_lon_bin : stripe_center_lon_bin + int(70 / spacing_deg),
             : int(90 / spacing_deg),
         ] = 1
 
+    counts = counts.astype(int)
     sensitivity = np.ones(grid_shape)
 
     pset_product = xr.Dataset(
         {
             "counts": (
-                ["azimuth_bin_center", "elevation_bin_center", "energy_bin_center"],
+                [
+                    "epoch",
+                    "energy_bin_center",
+                    "azimuth_bin_center",
+                    "elevation_bin_center",
+                ],
                 counts,
             ),
             "exposure_time": (
@@ -140,12 +141,19 @@ def mock_l1c_pset_product(
                 exposure_time,
             ),
             "sensitivity": (
-                ["azimuth_bin_center", "elevation_bin_center", "energy_bin_center"],
+                [
+                    "epoch",
+                    "energy_bin_center",
+                    "azimuth_bin_center",
+                    "elevation_bin_center",
+                ],
                 sensitivity,
             ),
-            "epoch": ensure_spice(spice.str2et, time_kernels_only=True)(timestr),
         },
         coords={
+            "epoch": [
+                ensure_spice(spice.str2et, time_kernels_only=True)(timestr),
+            ],
             "azimuth_bin_center": np.arange(0 + spacing_deg / 2, 360, spacing_deg),
             "elevation_bin_center": np.arange(-90 + spacing_deg / 2, 90, spacing_deg),
             "energy_bin_center": energy_bin_midpoints,


### PR DESCRIPTION
# Change Summary

Reorder expected L1C PSET dimensions to put spatial dims last. 

## Overview

Spinoff of PR #1396: The Ultra/Hi/Lo PSETs are now expected to have dimensions of the order: `(epoch, energy, az, el)`, rather than the previously assumed `(az, el, epoch, energy)`.

Reorders the L1C data created in the data mocking tools, and fixes the binning to allow this order.


~~NOTE:~~
---
~~I've decided that the SkyMaps themselves should keep the spatial axis (always a 1D axis of unwrapped pixel on the sky) as axis 0. Given their state as a spatially tiled object, I think that this makes the most sense, and tasks like re-wrapping the unwrapped pixels onto a 2D grid is much simpler if we can assume that the only spatial axis is axis 0.~~

~~I spent quite a long time trying to make the above task work in an dimension-order-agnostic way, and I really couldn't without lots of conditionals, etc. The Ultra/Lo/Hi L2 code will need to decide how to order the `SkyMap.data_dict = dict[NDarray]` output into their own dataset anyways, so reordering will already be happening there.~~

I ended up making this work. Both the PSET and Maps now treat the last 1-2 axes as the spatial axes. 

Close #1413

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/tests/ultra/test_data/mock_data.py
  - switch dim order of mocked L1c pset
- imap_processing/ena_maps/ena_maps.py
  - Fix binning for spatial_axis as last axis of PSET arrays
- imap_processing/ena_maps/utils/map_utils.py
  - Allow for spatial_axis parameter
- imap_processing/ena_maps/utils/spatial_utils.py
  - Clarify docs
## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
- imap_processing/tests/ena_maps/test_ena_maps.py
- imap_processing/tests/ena_maps/test_map_utils.py