### PR TITLE
Add repoint module, test coverage, and general conftest fixture for g…

### DIFF
--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -1,0 +1,118 @@
+"""Functions for retrieving repointing table data."""
+
+import logging
+import os
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from numpy import typing as npt
+
+logger = logging.getLogger(__name__)
+
+
+def get_repoint_data() -> pd.DataFrame:
+    """
+    Read repointing file using environment variable and return as dataframe.
+
+    REPOINT_DATA_FILEPATH environment variable should point to a local
+    file where the repointing csv file is located.
+
+    Returns
+    -------
+    repoint_df : pd.DataFrame
+        The repointing csv loaded into a pandas dataframe. The dataframe will
+        contain the following columns:
+            - `repoint_start_time`: Starting MET time of each repoint maneuver.
+            - `repoint_end_time`: Ending MET time of each repoint maneuver.
+            - `repoint_id`: Unique ID number of each repoint maneuver.
+    """
+    repoint_data_filepath = os.getenv("REPOINT_DATA_FILEPATH")
+    if repoint_data_filepath is not None:
+        path_to_spin_file = Path(repoint_data_filepath)
+    else:
+        # Handle the case where the environment variable is not set
+        raise ValueError("REPOINT_DATA_FILEPATH environment variable is not set.")
+
+    logger.info(f"Reading repointing data from {path_to_spin_file}")
+    repoint_df = pd.read_csv(path_to_spin_file, comment="#")
+
+    return repoint_df
+
+
+def interpolate_repoint_data(
+    query_met_times: Union[float, npt.NDArray],
+) -> pd.DataFrame:
+    """
+    Interpolate repointing data to the queried MET times.
+
+    Query times that are between a pointing end time and the next pointing start
+    time will cause an exception to be raised.
+
+    Parameters
+    ----------
+    query_met_times : float or np.ndarray
+        Query times in Mission Elapsed Time (MET).
+
+    Returns
+    -------
+    repoint_df : pandas.DataFrame
+        Repoint table data with the interpolated such that there is one row
+        for each of the queried MET times. Output columns are:
+            - `repoint_start_time`
+            - `repoint_end_time`
+            - `repoint_id`
+            - `repoint_in_progress`
+
+    Raises
+    ------
+    ValueError : If any of the query_met_times are outside the set of
+    [repoint_start_time, repoint_end_time] time ranges defined in the repoint
+    table.
+    """
+    repoint_df = get_repoint_data()
+
+    # Ensure query_met_times is an array
+    query_met_times = np.asarray(query_met_times)
+    is_scalar = query_met_times.ndim == 0
+    if is_scalar:
+        # Force scalar to array because np.asarray() will not
+        # convert scalar to array
+        query_met_times = np.atleast_1d(query_met_times)
+
+    # Make sure no query times are before the first repoint in the dataframe.
+    repoint_df_start_time = repoint_df["repoint_start_time"].values[0]
+    if np.any(query_met_times < repoint_df_start_time):
+        bad_times = query_met_times[query_met_times < repoint_df_start_time]
+        raise ValueError(
+            f"{bad_times.size} query times are before the first repoint start "
+            f" time in the repoint table. {bad_times=}, {repoint_df_start_time=}"
+        )
+    # Make sure that no query times are after the valid range of the dataframe.
+    # We approximate the end time of the table by adding 24 hours to the last
+    # known repoint start time.
+    repoint_df_end_time = repoint_df["repoint_start_time"].values[-1] + 24 * 60 * 60
+    if np.any(query_met_times >= repoint_df_end_time):
+        bad_times = query_met_times[query_met_times >= repoint_df_end_time]
+        raise ValueError(
+            f"{bad_times.size} query times are after the valid time of the "
+            f"pointing table. The valid end time is 24-hours after the last "
+            f"repoint_start_time. {bad_times=}, {repoint_df_end_time=}"
+        )
+
+    # Find the row index for each queried MET time such that:
+    # repoint_start_time[i] <= MET < repoint_start_time[i+1]
+    row_indices = (
+        np.searchsorted(repoint_df["repoint_start_time"], query_met_times, side="right")
+        - 1
+    )
+    out_df = repoint_df.iloc[row_indices]
+
+    # Add a column indicating if the query time is during a repoint or not.
+    # The table already has the correct row for each query time, so we
+    # only need to check if the query time is less than the repoint end time to
+    # get the same result as `repoint_start_time <= query_met_times < repoint_end_time`.
+    out_df["repoint_in_progress"] = query_met_times < out_df["repoint_end_time"].values
+
+    return out_df

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -47,8 +47,16 @@ def interpolate_repoint_data(
     """
     Interpolate repointing data to the queried MET times.
 
-    Query times that are between a pointing end time and the next pointing start
-    time will cause an exception to be raised.
+    In addition to the repoint start, end, and id values that come directly from
+    the universal repointing table, a column is added to the output dataframe
+    which indicates whether each query met time occurs during a repoint maneuver
+    i.e. between the repoint start and end times of a row in the repointing
+    table.
+
+    Query times that are more than 24-hours after that last repoint start time
+    in the repoint table will cause an error to be raised. The assumption here
+    is that we shouldn't be processing data that occurs that close to the next
+    expected repoint start time before getting an updated repoint table.
 
     Parameters
     ----------
@@ -67,19 +75,13 @@ def interpolate_repoint_data(
 
     Raises
     ------
-    ValueError : If any of the query_met_times are outside the set of
-    [repoint_start_time, repoint_end_time] time ranges defined in the repoint
-    table.
+    ValueError : If any of the query_met_times are before the first repoint
+    start time or after the last repoint start time plus 24-hours.
     """
     repoint_df = get_repoint_data()
 
     # Ensure query_met_times is an array
-    query_met_times = np.asarray(query_met_times)
-    is_scalar = query_met_times.ndim == 0
-    if is_scalar:
-        # Force scalar to array because np.asarray() will not
-        # convert scalar to array
-        query_met_times = np.atleast_1d(query_met_times)
+    query_met_times = np.atleast_1d(query_met_times)
 
     # Make sure no query times are before the first repoint in the dataframe.
     repoint_df_start_time = repoint_df["repoint_start_time"].values[0]

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -58,7 +58,7 @@ def interpolate_repoint_data(
     Returns
     -------
     repoint_df : pandas.DataFrame
-        Repoint table data with the interpolated such that there is one row
+        Repoint table data interpolated such that there is one row
         for each of the queried MET times. Output columns are:
             - `repoint_start_time`
             - `repoint_end_time`

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -500,6 +500,7 @@ def use_test_repoint_data_csv(monkeypatch):
 def generate_repoint_data(
     repoint_start_met: Union[float, np.ndarray],
     repoint_end_met: Optional[Union[float, np.ndarray]] = None,
+    repoint_id_start: Optional[int] = 0,
 ) -> pd.DataFrame:
     """
     Generate a repoint dataframe for the star/end times provided.
@@ -511,6 +512,9 @@ def generate_repoint_data(
     repoint_end_met : float, np.ndarray, optional
         Provides the repoint end time(s) in MET. If not provided, end times
         will be 15 minutes after start times.
+    repoint_id_start : int, optional
+        Provides the starting repoint id number of the first repoint in the
+        generated data.
 
     Returns
     -------
@@ -525,7 +529,8 @@ def generate_repoint_data(
         {
             "repoint_start_time": repoint_start_times,
             "repoint_end_time": np.array(repoint_end_met),
-            "repoint_id": np.arange(repoint_start_times.size, dtype=int),
+            "repoint_id": np.arange(repoint_start_times.size, dtype=int)
+            + repoint_id_start,
         }
     )
     return repoint_df
@@ -548,6 +553,7 @@ def use_fake_repoint_data_for_time(use_test_repoint_data_csv, tmpdir):
     def wrapped_repoint_data_filepath(
         repoint_start_met: Union[float, np.ndarray],
         repoint_end_met: Optional[Union[float, np.ndarray]] = None,
+        repoint_id_start: Optional[int] = 0,
     ) -> pd.DataFrame:
         """
         Generate and use fake repoint data for testing.
@@ -558,8 +564,15 @@ def use_fake_repoint_data_for_time(use_test_repoint_data_csv, tmpdir):
         repoint_end_met : float, np.ndarray
             Provides the repoint end time(s) in MET. If not provided, end times
             will be 15 minutes after start times.
+        repoint_id_start : int, optional
+            Provides the starting repoint id number of the first repoint in the
+            generated data.
         """
-        repoint_df = generate_repoint_data(repoint_start_met, repoint_end_met)
+        repoint_df = generate_repoint_data(
+            repoint_start_met,
+            repoint_end_met=repoint_end_met,
+            repoint_id_start=repoint_id_start,
+        )
         repoint_csv_file_path = tmpdir / "repoint_data.repointing.csv"
         repoint_df.to_csv(repoint_csv_file_path, index=False)
         use_test_repoint_data_csv(repoint_csv_file_path)

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -6,7 +6,7 @@ import re
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import cdflib
 import imap_data_access
@@ -485,3 +485,83 @@ def generate_spin_data():
         return spin_df
 
     return make_data
+
+
+@pytest.fixture()
+def use_test_repoint_data_csv(monkeypatch):
+    """Sets the REPOINT_DATA_FILEPATH environment variable to input path."""
+
+    def wrapped_set_repoint_data_filepath(path: Path):
+        monkeypatch.setenv("REPOINT_DATA_FILEPATH", str(path))
+
+    return wrapped_set_repoint_data_filepath
+
+
+def generate_repoint_data(
+    repoint_start_met: Union[float, np.ndarray],
+    repoint_end_met: Optional[Union[float, np.ndarray]] = None,
+) -> pd.DataFrame:
+    """
+    Generate a repoint dataframe for the star/end times provided.
+
+    Parameters
+    ----------
+    repoint_start_met : float, np.ndarray
+            Provides the repoint start time(s) in Mission Elapsed Time (MET).
+    repoint_end_met : float, np.ndarray, optional
+        Provides the repoint end time(s) in MET. If not provided, end times
+        will be 15 minutes after start times.
+
+    Returns
+    -------
+    repoint_df : pd.DataFrame
+        Repoint dataframe with start and end repoint times provided and incrementing
+        repoint_ids starting at 1.
+    """
+    repoint_start_times = np.array(repoint_start_met)
+    if repoint_end_met is None:
+        repoint_end_met = repoint_start_times + 15 * 60
+    repoint_df = pd.DataFrame.from_dict(
+        {
+            "repoint_start_time": repoint_start_times,
+            "repoint_end_time": np.array(repoint_end_met),
+            "repoint_id": np.arange(repoint_start_times.size, dtype=int),
+        }
+    )
+    return repoint_df
+
+
+@pytest.fixture()
+def use_fake_repoint_data_for_time(use_test_repoint_data_csv, tmpdir):
+    """
+    Generate and use fake spin data for testing.
+
+    Returns
+    -------
+    callable
+        Returns a callable function that takes start_met and optionally n_repoints
+        as inputs, generates fake repoint data, writes the data to a csv file,
+        and sets the REPOINT_DATA_FILEPATH environment variable to point to the
+        fake repoint data file.
+    """
+
+    def wrapped_repoint_data_filepath(
+        repoint_start_met: Union[float, np.ndarray],
+        repoint_end_met: Optional[Union[float, np.ndarray]] = None,
+    ) -> pd.DataFrame:
+        """
+        Generate and use fake repoint data for testing.
+        Parameters
+        ----------
+        repoint_start_met : float, np.ndarray
+            Provides the repoint start time(s) in Mission Elapsed Time (MET).
+        repoint_end_met : float, np.ndarray
+            Provides the repoint end time(s) in MET. If not provided, end times
+            will be 15 minutes after start times.
+        """
+        repoint_df = generate_repoint_data(repoint_start_met, repoint_end_met)
+        repoint_csv_file_path = tmpdir / "repoint_data.repointing.csv"
+        repoint_df.to_csv(repoint_csv_file_path, index=False)
+        use_test_repoint_data_csv(repoint_csv_file_path)
+
+    return wrapped_repoint_data_filepath

--- a/imap_processing/tests/spice/test_data/fake_repoint_data.csv
+++ b/imap_processing/tests/spice/test_data/fake_repoint_data.csv
@@ -1,0 +1,5 @@
+# This is a fake csv file for the sole purpose of testing repoint module functions
+repoint_start_time,repoint_end_time,repoint_id
+0,5,0
+15,20,1
+25,30,2

--- a/imap_processing/tests/spice/test_repoint.py
+++ b/imap_processing/tests/spice/test_repoint.py
@@ -74,7 +74,7 @@ def test_interpolate_repoint_data_with_use_fake_fixture(use_fake_repoint_data_fo
     """Test coverage for using use_fake_repoint_data_for_time fixutre."""
     repoint_period = 24 * 60 * 60
     repoint_start_times = np.arange(1000, 1000 + 10 * repoint_period, repoint_period)
-    _ = use_fake_repoint_data_for_time(repoint_start_times)
+    _ = use_fake_repoint_data_for_time(repoint_start_times, repoint_id_start=10)
     # Query times are all start times concatenated with 16 minutes after each start time
     query_times = np.concat([repoint_start_times, repoint_start_times + 16 * 60])
     repoint_df = interpolate_repoint_data(query_times)
@@ -93,7 +93,10 @@ def test_interpolate_repoint_data_with_use_fake_fixture(use_fake_repoint_data_fo
     np.testing.assert_array_equal(
         repoint_df["repoint_id"].values,
         np.concat(
-            [np.arange(repoint_start_times.size), np.arange(repoint_start_times.size)]
+            [
+                np.arange(repoint_start_times.size) + 10,
+                np.arange(repoint_start_times.size) + 10,
+            ]
         ),
     )
     # Expected repoint_in_progress

--- a/imap_processing/tests/spice/test_repoint.py
+++ b/imap_processing/tests/spice/test_repoint.py
@@ -1,0 +1,108 @@
+"""Test coverage for imap_processing.spice.repoint.py"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from imap_processing.spice.repoint import get_repoint_data, interpolate_repoint_data
+
+
+@pytest.fixture()
+def fake_repoint_data(monkeypatch, spice_test_data_path):
+    """Generate fake spin dataframe for testing"""
+    fake_repoint_path = spice_test_data_path / "fake_repoint_data.csv"
+    monkeypatch.setenv("REPOINT_DATA_FILEPATH", str(fake_repoint_path))
+    return fake_repoint_path
+
+
+def test_get_repoint_data(fake_repoint_data):
+    """Test coverarge for get_repoint_data function."""
+    repoint_df = get_repoint_data()
+    assert isinstance(repoint_df, pd.DataFrame)
+    assert set(repoint_df.columns) == {
+        "repoint_start_time",
+        "repoint_end_time",
+        "repoint_id",
+    }
+
+
+def test_spin_data_no_table():
+    """Test coverage for get_repoint_data function when the env var is not set."""
+    with pytest.raises(
+        ValueError, match="REPOINT_DATA_FILEPATH environment variable is not set."
+    ):
+        get_repoint_data()
+
+
+def test_interpolate_repoint_data(fake_repoint_data):
+    """Test coverage for get_repoint_data function."""
+    query_times = np.array([0, 6, 32])
+    expected_vals = {
+        "repoint_start_time": np.array([0, 0, 25]),
+        "repoint_end_time": np.array([5, 5, 30]),
+        "repoint_id": np.array([0, 0, 2]),
+        "repoint_in_progress": np.array([True, False, False]),
+    }
+    repoint_df = interpolate_repoint_data(query_times)
+
+    for key, expected_array in expected_vals.items():
+        np.testing.assert_array_equal(repoint_df[key].values, expected_array)
+
+
+@pytest.mark.parametrize(
+    "query_times, match_str",
+    [
+        (
+            np.array([-1, 9]),
+            "1 query times are before",
+        ),  # Query times before start of table
+        (
+            np.array([0, 24 * 60 * 60 + 26]),
+            "1 query times are after",
+        ),  # Query times after end of valid range
+    ],
+)
+def test_interpolate_repoint_data_exceptions(query_times, match_str, fake_repoint_data):
+    # Test when query time is
+    # Test raising a ValueError when the query time is in between an end and the
+    # next start time.
+    with pytest.raises(ValueError, match=match_str):
+        _ = interpolate_repoint_data(query_times)
+
+
+def test_interpolate_repoint_data_with_use_fake_fixture(use_fake_repoint_data_for_time):
+    """Test coverage for using use_fake_repoint_data_for_time fixutre."""
+    repoint_period = 24 * 60 * 60
+    repoint_start_times = np.arange(1000, 1000 + 10 * repoint_period, repoint_period)
+    _ = use_fake_repoint_data_for_time(repoint_start_times)
+    # Query times are all start times concatenated with 16 minutes after each start time
+    query_times = np.concat([repoint_start_times, repoint_start_times + 16 * 60])
+    repoint_df = interpolate_repoint_data(query_times)
+
+    # Expected repoint_start_times are the seeded start times array repeated twice
+    np.testing.assert_array_equal(
+        repoint_df["repoint_start_time"].values,
+        np.concat([repoint_start_times, repoint_start_times]),
+    )
+    # Expected repoint_end_times are the seeded start times + 15 minutes
+    np.testing.assert_array_equal(
+        repoint_df["repoint_end_time"].values,
+        np.concat([repoint_start_times + 15 * 60, repoint_start_times + 15 * 60]),
+    )
+    # Expected repoint_id
+    np.testing.assert_array_equal(
+        repoint_df["repoint_id"].values,
+        np.concat(
+            [np.arange(repoint_start_times.size), np.arange(repoint_start_times.size)]
+        ),
+    )
+    # Expected repoint_in_progress
+    np.testing.assert_array_equal(
+        repoint_df["repoint_in_progress"].values,
+        np.concat(
+            [
+                np.full(repoint_start_times.size, True),
+                np.full(repoint_start_times.size, False),
+            ]
+        ),
+    )


### PR DESCRIPTION
…enerating fake repoint data on the fly.

# Change Summary

## Overview
This adds some basic repoint utility functions as listed in the New Files section.

## New Files
- imap_processing/spice/repoint.py
   - Add `get_repoint_data`function that reads a CSV pointed to by the `REPOINT_DATA_FILEPATH` environment variable.
   - Add `interpolate_repoint_data` function that interpolates the repoint data to the input query times and adds a column that indicates if the query time is during a repoint maneuver or not.
- imap_processing/tests/spice/test_data/fake_repoint_data.csv
   - This is a fake repoint CSV used for unit tests
- imap_processing/tests/spice/test_repoint.py
   - Add test coverage for the new functions in the `repoint` module

## Updated Files
- imap_processing/tests/conftest.py
   - Add general fixtures for generating fake repoint data on the fly based on input times.

Closes: #1384 
