### PR TITLE
SWE: Add CDF attrs for non-science apid

### DIFF
--- a/imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml
@@ -16,6 +16,20 @@ imap_swe_l1a_sci:
   Logical_source: imap_swe_l1a_sci
   Logical_source_description: SWE Instrument Level-1A Science Data
 
+imap_swe_l1a_hk:
+  <<: *instrument_base
+  Data_level: 1A
+  Data_type: L1A_HK>Level-1A Housekeeping data
+  Logical_source: imap_swe_l1a_hk
+  Logical_source_description: SWE Instrument Level-1A Housekeeping Data
+
+imap_swe_l1a_cem-raw:
+  <<: *instrument_base
+  Data_level: 1A
+  Data_type: L1A_CEM-RAW>Level-1A CEM Raw data
+  Logical_source: imap_swe_l1a_cem-raw
+  Logical_source_description: SWE Instrument Level-1A CEM Raw Data
+
 imap_swe_l1b_sci:
   <<: *instrument_base
   Data_level: 1A

--- a/imap_processing/cdf/config/imap_swe_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l1a_variable_attrs.yaml
@@ -234,3 +234,17 @@ cksum:
   FIELDNAM: Checksum
   FORMAT: I5
   VALIDMAX: 65535
+
+# <=== Non Science Data Variables ===>
+non_science_attrs:
+  CATDESC: SWE data
+  DEPEND_0: epoch
+  FIELDNAM: SWE Raw Data
+  FILLVAL: -9223372036854775808
+  FORMAT: I19
+  UNITS: ' '
+  LABLAXIS: Values
+  VALIDMIN: 0
+  VALIDMAX: 9223372036854769664
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: time_series

--- a/imap_processing/swe/l1a/swe_l1a.py
+++ b/imap_processing/swe/l1a/swe_l1a.py
@@ -60,7 +60,7 @@ def swe_l1a(packet_file: str, data_version: str) -> xr.Dataset:
     imap_attrs.add_instrument_global_attrs("swe")
     imap_attrs.add_global_attribute("Data_version", data_version)
     imap_attrs.add_instrument_variable_attrs("swe", "l1a")
-    common_var_attrs = imap_attrs.get_variable_attributes("non_science_attrs")
+    non_science_attrs = imap_attrs.get_variable_attributes("non_science_attrs")
     epoch_attrs = imap_attrs.get_variable_attributes("epoch", check_schema=False)
 
     if SWEAPID.SWE_APP_HK in datasets_by_apid:
@@ -70,7 +70,7 @@ def swe_l1a(packet_file: str, data_version: str) -> xr.Dataset:
         hk_ds["epoch"].attrs.update(epoch_attrs)
         # Add attrs to HK data variables
         for var_name in hk_ds.data_vars:
-            hk_ds[var_name].attrs.update(common_var_attrs)
+            hk_ds[var_name].attrs.update(non_science_attrs)
         processed_data.append(hk_ds)
 
     if SWEAPID.SWE_CEM_RAW in datasets_by_apid:
@@ -83,7 +83,7 @@ def swe_l1a(packet_file: str, data_version: str) -> xr.Dataset:
 
         # Add attrs to CEM raw data variables
         for var_name in cem_raw_ds.data_vars:
-            cem_raw_ds[var_name].attrs.update(common_var_attrs)
+            cem_raw_ds[var_name].attrs.update(non_science_attrs)
         processed_data.append(cem_raw_ds)
 
     if len(processed_data) == 0:

--- a/imap_processing/swe/l1a/swe_l1a.py
+++ b/imap_processing/swe/l1a/swe_l1a.py
@@ -5,6 +5,7 @@ import logging
 import xarray as xr
 
 from imap_processing import imap_module_directory
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.swe.l1a.swe_science import swe_science
 from imap_processing.swe.utils.swe_utils import (
     SWEAPID,
@@ -42,12 +43,50 @@ def swe_l1a(packet_file: str, data_version: str) -> xr.Dataset:
         packet_file, xtce_document, use_derived_value=False
     )
 
-    if SWEAPID.SWE_SCIENCE not in datasets_by_apid:
-        logger.info("No science data found in packet file.")
-        return []
-    # TODO: figure out how to handle non-science data
-    return [
-        swe_science(
-            l0_dataset=datasets_by_apid[SWEAPID.SWE_SCIENCE], data_version=data_version
+    processed_data = []
+
+    if SWEAPID.SWE_SCIENCE in datasets_by_apid:
+        logger.info("Processing SWE science data.")
+        processed_data.append(
+            swe_science(
+                l0_dataset=datasets_by_apid[SWEAPID.SWE_SCIENCE],
+                data_version=data_version,
+            )
         )
-    ]
+
+    # Process non-science data
+    # Define minimal CDF attrs for the non science dataset
+    imap_attrs = ImapCdfAttributes()
+    imap_attrs.add_instrument_global_attrs("swe")
+    imap_attrs.add_global_attribute("Data_version", data_version)
+    imap_attrs.add_instrument_variable_attrs("swe", "l1a")
+    common_var_attrs = imap_attrs.get_variable_attributes("non_science_attrs")
+    epoch_attrs = imap_attrs.get_variable_attributes("epoch", check_schema=False)
+
+    if SWEAPID.SWE_APP_HK in datasets_by_apid:
+        logger.info("Processing SWE housekeeping data.")
+        hk_ds = datasets_by_apid[SWEAPID.SWE_APP_HK]
+        hk_ds.attrs.update(imap_attrs.get_global_attributes("imap_swe_l1a_hk"))
+        hk_ds["epoch"].attrs.update(epoch_attrs)
+        # Add attrs to HK data variables
+        for var_name in hk_ds.data_vars:
+            hk_ds[var_name].attrs.update(common_var_attrs)
+        processed_data.append(hk_ds)
+
+    if SWEAPID.SWE_CEM_RAW in datasets_by_apid:
+        logger.info("Processing SWE CEM raw data.")
+        cem_raw_ds = datasets_by_apid[SWEAPID.SWE_CEM_RAW]
+        cem_raw_ds.attrs.update(
+            imap_attrs.get_global_attributes("imap_swe_l1a_cem-raw")
+        )
+        cem_raw_ds["epoch"].attrs.update(epoch_attrs)
+
+        # Add attrs to CEM raw data variables
+        for var_name in cem_raw_ds.data_vars:
+            cem_raw_ds[var_name].attrs.update(common_var_attrs)
+        processed_data.append(cem_raw_ds)
+
+    if len(processed_data) == 0:
+        logger.info("Data contains unknown APID.")
+
+    return processed_data

--- a/imap_processing/tests/swe/test_swe_l1a.py
+++ b/imap_processing/tests/swe/test_swe_l1a.py
@@ -10,3 +10,21 @@ def test_cdf_creation():
     cem_raw_cdf_filepath = write_cdf(processed_data[0])
 
     assert cem_raw_cdf_filepath.name == "imap_swe_l1a_sci_20240510_v001.cdf"
+
+
+def test_cdf_creation_hk():
+    test_data_path = "tests/swe/l0_data/2024051010_SWE_HK_packet.bin"
+    processed_data = swe_l1a(imap_module_directory / test_data_path, "001")
+
+    hk_cdf_filepath = write_cdf(processed_data[0])
+
+    assert hk_cdf_filepath.name == "imap_swe_l1a_hk_20240510_v001.cdf"
+
+
+def test_cdf_creation_cem_raw():
+    test_data_path = "tests/swe/l0_data/2024051011_SWE_CEM_RAW_packet.bin"
+    processed_data = swe_l1a(imap_module_directory / test_data_path, "001")
+
+    cem_raw_cdf_filepath = write_cdf(processed_data[0])
+
+    assert cem_raw_cdf_filepath.name == "imap_swe_l1a_cem-raw_20240510_v001.cdf"


### PR DESCRIPTION
# Change Summary
closes #1387 

## Overview
Adding minimal CDF attrs for non-science apid

## Updated Files
- attrs file
   - update to add basic attrs for non-science apid
- imap_processing/swe/l1a/swe_l1a.py
   - Update to process all expected SWE apid

