### PR TITLE
XTCE - Strip spaces from strings

### DIFF
--- a/imap_processing/ccsds/excel_to_xtce.py
+++ b/imap_processing/ccsds/excel_to_xtce.py
@@ -443,8 +443,8 @@ class XTCEGenerator:
         for _, state_row in state_sheet.iterrows():
             enumeration = Et.SubElement(enumeration_list, "xtce:Enumeration")
             valid_state = self._ensure_state_value_is_int(state_row)
-            enumeration.attrib["value"] = str(valid_state["value"])
-            enumeration.attrib["label"] = str(valid_state["state"])
+            enumeration.attrib["value"] = str(valid_state["value"]).strip()
+            enumeration.attrib["label"] = str(valid_state["state"]).strip()
 
     def _ensure_state_value_is_int(self, state: dict) -> dict:
         """

--- a/imap_processing/tests/ccsds/test_excel_to_xtce.py
+++ b/imap_processing/tests/ccsds/test_excel_to_xtce.py
@@ -203,7 +203,7 @@ def xtce_excel_file(tmp_path):
         "packetName": ["TEST_PACKET"] * 3,
         "mnemonic": ["VAR_STATE"] * 3,
         "value": [0, 1, "0x2"],
-        "state": ["OFF", "ON", "NONE"],
+        "state": ["OFF  ", "ON", "NONE"],
     }
 
     # Write the DataFrame to an excel file


### PR DESCRIPTION
This PR makes a minor change to excel_to_xtce.py to remove leading and trailing spaces from state conversion string values

## Updated Files
imap_processing/ccsds/excel_to_xtce.py

