### PR TITLE
Changes to rename hi l1b delta_t variables to tof

### DIFF
--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -343,34 +343,34 @@ hi_de_esa_energy_step:
   <<: *default_esa_energy_step
   LABLAXIS: Energy Step
 
-default_delta_t: &default_delta_t
+default_l1b_tof: &default_l1b_tof
   <<: *default_int32
   DEPEND_0: event_met
   FORMAT: I3
-  LABLAXIS: delta T
+  LABLAXIS: Time of Flight
   UNITS: ns
   VALIDMIN: -512
   VALIDMAX: 512
 
-hi_de_delta_t_ab:
-  <<: *default_delta_t
+hi_de_tof_ab:
+  <<: *default_l1b_tof
   CATDESC: Time difference between detector A and B events (t_B - t_A)
-  FIELDNAM: Delta T, event A to B
+  FIELDNAM: ToF, event A to B
 
-hi_de_delta_t_ac1:
-  <<: *default_delta_t
+hi_de_tof_ac1:
+  <<: *default_l1b_tof
   CATDESC: Time difference between detector A and C1 events (t_C1 - t_A)
-  FIELDNAM: Delta T, event A to C1
+  FIELDNAM: ToF, event A to C1
 
-hi_de_delta_t_bc1:
-  <<: *default_delta_t
+hi_de_tof_bc1:
+  <<: *default_l1b_tof
   CATDESC: Time difference between detector B and C1 events (t_C1 - t_B)
-  FIELDNAM: Delta T, event B to C1
+  FIELDNAM: ToF, event B to C1
 
-hi_de_delta_t_c1c2:
-  <<: *default_delta_t
+hi_de_tof_c1c2:
+  <<: *default_l1b_tof
   CATDESC: Time difference between detector C1 and C2 events (t_C2 - t_C1)
-  FIELDNAM: Delta T, event C1 to C2
+  FIELDNAM: ToF, event C1 to C2
 
 hi_de_spin_phase:
   <<: *default_float32

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -9,7 +9,7 @@ import xarray as xr
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.hi.l1a.hi_l1a import hi_l1a
 from imap_processing.hi.l1b.hi_l1b import (
-    compute_coincidence_type_and_time_deltas,
+    compute_coincidence_type_and_tofs,
     compute_hae_coordinates,
     de_esa_energy_step,
     de_nominal_bin_and_spin_phase,
@@ -112,15 +112,13 @@ def synthetic_trigger_id_and_tof_data():
 def test_compute_coincidence_type_and_time_deltas(synthetic_trigger_id_and_tof_data):
     """Test coverage for
     `imap_processing.hi.hi_l1b.compute_coincidence_type_and_time_deltas`."""
-    new_vars = compute_coincidence_type_and_time_deltas(
-        synthetic_trigger_id_and_tof_data[0]
-    )
+    new_vars = compute_coincidence_type_and_tofs(synthetic_trigger_id_and_tof_data[0])
     for var_name in [
         "coincidence_type",
-        "delta_t_ab",
-        "delta_t_ac1",
-        "delta_t_bc1",
-        "delta_t_c1c2",
+        "tof_ab",
+        "tof_ac1",
+        "tof_bc1",
+        "tof_c1c2",
     ]:
         assert var_name in new_vars
     # verify coincidence type values
@@ -130,27 +128,27 @@ def test_compute_coincidence_type_and_time_deltas(synthetic_trigger_id_and_tof_d
     np.testing.assert_array_equal(
         coincidence_hist, synthetic_trigger_id_and_tof_data[1]
     )
-    # verify delta_t values are valid in the correct locations
+    # verify tof values are valid in the correct locations
     np.testing.assert_array_equal(
-        new_vars["delta_t_ab"] != new_vars["delta_t_ab"].FILLVAL,
+        new_vars["tof_ab"] != new_vars["tof_ab"].FILLVAL,
         new_vars["coincidence_type"] >= 12,
     )
     np.testing.assert_array_equal(
-        new_vars["delta_t_ac1"] != new_vars["delta_t_ac1"].FILLVAL,
+        new_vars["tof_ac1"] != new_vars["tof_ac1"].FILLVAL,
         np.logical_and(
             np.bitwise_and(new_vars["coincidence_type"], CoincidenceBitmap.A.value),
             np.bitwise_and(new_vars["coincidence_type"], CoincidenceBitmap.C1),
         ),
     )
     np.testing.assert_array_equal(
-        new_vars["delta_t_bc1"] != new_vars["delta_t_bc1"].FILLVAL,
+        new_vars["tof_bc1"] != new_vars["tof_bc1"].FILLVAL,
         np.logical_and(
             np.bitwise_and(new_vars["coincidence_type"], CoincidenceBitmap.B.value),
             np.bitwise_and(new_vars["coincidence_type"], CoincidenceBitmap.C1),
         ),
     )
     np.testing.assert_array_equal(
-        new_vars["delta_t_c1c2"] != new_vars["delta_t_c1c2"].FILLVAL,
+        new_vars["tof_c1c2"] != new_vars["tof_c1c2"].FILLVAL,
         np.logical_and(
             np.bitwise_and(new_vars["coincidence_type"], CoincidenceBitmap.C1),
             np.bitwise_and(new_vars["coincidence_type"], CoincidenceBitmap.C2),

--- a/imap_processing/tests/hi/test_utils.py
+++ b/imap_processing/tests/hi/test_utils.py
@@ -75,13 +75,13 @@ def test_full_dataarray(name, shape, fill_value, expected_shape):
 @pytest.mark.parametrize(
     "var_names, shape, fill_value, lookup_str",
     [
-        (["delta_t_ab", "delta_t_ac1"], 5, None, "hi_de_{0}"),
+        (["tof_ab", "tof_ac1"], 5, None, "hi_de_{0}"),
         (["hae_latitude"], (3, 5), 0, "hi_pset_{0}"),
     ],
 )
 def test_create_dataset_variables(var_names, shape, fill_value, lookup_str):
     """Test coverage for `imap_processing.hi.utils.create_dataset_variables`"""
-    var_names = ["delta_t_ab", "delta_t_ac1", "delta_t_bc1"]
+    var_names = ["tof_ab", "tof_ac1", "tof_bc1"]
     l1b_de_vars = create_dataset_variables(
         var_names, shape, fill_value=fill_value, att_manager_lookup_str="hi_de_{0}"
     )


### PR DESCRIPTION
# Change Summary

## Overview
Update variable names in L1B DE products for all `delta_t` variables. Something I had named early on recently came up as nor really matching Paul's nomenclature, so I am updating it.

## Updated Files
- imap_processing/cdf/config/imap_hi_variable_attrs.yaml
   - Update delta_t variable names and attributes
- imap_processing/hi/l1b/hi_l1b.py
   - Update delta_t variable names
- imap_processing/tests/hi/test_hi_l1b.py
   - Update tests to reflect variable name changes
- imap_processing/tests/hi/test_utils.py
   - Update unrelated tests that were using `delta_t` variables to retrieve attributes.


Closes: #1436 
