### PR TITLE
Ultra l1b - remove aux dependency

### DIFF
--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -233,21 +233,15 @@ def faux_aux_dataset():
 
 @pytest.fixture()
 @mock.patch("imap_processing.ultra.l1b.de.get_annotated_particle_velocity")
-def l1b_datasets(
+def l1b_de_dataset(
     mock_get_annotated_particle_velocity,
     de_dataset,
     use_fake_spin_data_for_time,
-    rates_dataset,
-    faux_aux_dataset,
 ):
     """L1B test data"""
 
     data_dict = {}
     data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
-    data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
-    # TODO: this is a placeholder for the hk dataset.
-    data_dict["imap_ultra_l1a_45sensor-hk"] = faux_aux_dataset
-    data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
     use_fake_spin_data_for_time(0, 15 * 147)
 
     # Mock get_annotated_particle_velocity to avoid needing kernels
@@ -265,6 +259,25 @@ def l1b_datasets(
         )
 
     mock_get_annotated_particle_velocity.side_effect = side_effect_func
+
+    output_datasets = ultra_l1b(data_dict, data_version="001")
+
+    return output_datasets
+
+
+@pytest.fixture()
+def l1b_extendedspin_dataset(
+    l1b_de_dataset,
+    rates_dataset,
+    faux_aux_dataset,
+):
+    """L1B de test data"""
+    data_dict = {}
+    data_dict["imap_ultra_l1b_45sensor-de"] = l1b_de_dataset[0]
+    data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
+    # TODO: this is a placeholder for the hk dataset.
+    data_dict["imap_ultra_l1a_45sensor-hk"] = faux_aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
 
     output_datasets = ultra_l1b(data_dict, data_version="001")
 

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -242,7 +242,8 @@ def l1b_de_dataset(
 
     data_dict = {}
     data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
-    use_fake_spin_data_for_time(0, 15 * 147)
+    # Create a spin table that cover spin 0-141
+    use_fake_spin_data_for_time(0, 141 * 15)
 
     # Mock get_annotated_particle_velocity to avoid needing kernels
     def side_effect_func(event_times, position, ultra_frame, dps_frame, sc_frame):

--- a/imap_processing/tests/ultra/unit/test_badtimes.py
+++ b/imap_processing/tests/ultra/unit/test_badtimes.py
@@ -11,6 +11,7 @@ def test_calculate_badtimes():
 
     spin_numbers = np.array([0, 1, 2, 3])
     energy_bins = np.array([10, 20, 30, 40])
+    spin_start_time = np.array([0, 1, 2, 3])
 
     quality_attitude = np.full(
         spin_numbers.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
@@ -36,6 +37,7 @@ def test_calculate_badtimes():
                 ("energy_bin_geometric_mean", "spin_number"),
                 quality_ena_rates,
             ),
+            "spin_start_time": (("spin_number",), spin_start_time),
         },
         coords={
             "spin_number": spin_numbers,

--- a/imap_processing/tests/ultra/unit/test_cullingmask.py
+++ b/imap_processing/tests/ultra/unit/test_cullingmask.py
@@ -10,6 +10,7 @@ def test_calculate_cullingmask_attitude():
 
     spin_numbers = np.array([0, 1])
     energy_bins = np.array([10, 20, 30, 40])
+    spin_start_time = np.array([0, 1])
 
     quality_attitude = np.full(
         spin_numbers.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
@@ -29,6 +30,7 @@ def test_calculate_cullingmask_attitude():
                 ("energy_bin_geometric_mean", "spin_number"),
                 quality_ena_rates,
             ),
+            "spin_start_time": (("spin_number",), spin_start_time),
         },
         coords={
             "spin_number": spin_numbers,
@@ -47,6 +49,7 @@ def test_calculate_cullingmask_rates():
     """Test calculate_cullingmask for rates culling."""
     spin_numbers = np.array([0, 1, 2, 3])
     energy_bins = np.array([10, 20, 30, 40])
+    spin_start_time = np.array([0, 1, 2, 3])
 
     quality_attitude = np.full(
         spin_numbers.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
@@ -72,6 +75,7 @@ def test_calculate_cullingmask_rates():
                 ("energy_bin_geometric_mean", "spin_number"),
                 quality_ena_rates,
             ),
+            "spin_start_time": (("spin_number",), spin_start_time),
         },
         coords={
             "spin_number": spin_numbers,

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -17,10 +17,10 @@ def df_filt(de_dataset, events_fsw_comparison_theta_0):
     return df_filt
 
 
-def test_calculate_de(l1b_datasets, df_filt):
+def test_calculate_de(l1b_de_dataset, df_filt):
     """Tests calculate_de function."""
 
-    l1b_de_dataset = l1b_datasets[0]
+    l1b_de_dataset = l1b_de_dataset[0]
     l1b_de_dataset = l1b_de_dataset.where(
         l1b_de_dataset["start_type"] != np.iinfo(np.int64).min, drop=True
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -326,9 +326,7 @@ def test_cdf_events(ccsds_path_theta_0, decom_ultra_aux, decom_test_data):
     assert test_data_path.exists()
     assert test_data_path.name == "imap_ultra_l1a_45sensor-de_20240207_v001.cdf"
 
-    dataset_events = create_dataset(
-        {ULTRA_EVENTS.apid[0]: decom_ultra_events, ULTRA_AUX.apid[0]: decom_ultra_aux}
-    )
+    dataset_events = create_dataset({ULTRA_EVENTS.apid[0]: decom_ultra_events})
     input_xarray_events = load_cdf(test_data_path)
 
     # write_cdf() injects some attributes that are not in the xarray

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -50,10 +50,12 @@ def mock_data_l1b_extendedspin_dict():
         [0, 1],
         dtype="int32",
     )
+    spin_start_time = np.array([0, 1, 2], dtype="uint64")
     quality = np.zeros((2, 3), dtype="uint16")
     data_dict = {
         "spin_number": spin,
         "energy_bin_geometric_mean": energy,
+        "spin_start_time": spin_start_time,
         "quality_ena_rates": quality,
     }
     return data_dict

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from imap_processing.cdf.utils import write_cdf
 from imap_processing.ultra.l1b.ultra_l1b import ultra_l1b
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
@@ -101,6 +102,13 @@ def test_ultra_l1b(l1b_de_dataset):
     )
 
 
+def test_cdf_de(l1b_de_dataset):
+    """Tests that CDF file is created and contains same attributes as xarray."""
+    test_data_path = write_cdf(l1b_de_dataset[0], istp=False)
+    assert test_data_path.exists()
+    assert test_data_path.name == "imap_ultra_l1b_45sensor-de_20240207_v001.cdf"
+
+
 def test_ultra_l1b_extendedspin(l1b_extendedspin_dataset):
     """Tests that L1b data is created."""
 
@@ -116,6 +124,15 @@ def test_ultra_l1b_extendedspin(l1b_extendedspin_dataset):
             l1b_extendedspin_dataset[i].attrs["Logical_source"]
             == expected_logical_source
         )
+
+
+def test_cdf_extendedspin(l1b_extendedspin_dataset):
+    """Tests that CDF file is created and contains same attributes as xarray."""
+    test_data_path = write_cdf(l1b_extendedspin_dataset[0], istp=False)
+    assert test_data_path.exists()
+    assert (
+        test_data_path.name == "imap_ultra_l1b_45sensor-extendedspin_20000101_v001.cdf"
+    )
 
 
 def test_ultra_l1b_error(mock_data_l1a_rates_dict):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -90,23 +90,32 @@ def test_create_de_dataset(mock_data_l1b_de_dict):
     np.testing.assert_array_equal(dataset["x_front"], np.zeros(3))
 
 
-def test_ultra_l1b(l1b_datasets):
+def test_ultra_l1b(l1b_de_dataset):
     """Tests that L1b data is created."""
 
-    assert len(l1b_datasets) == 4
+    assert len(l1b_de_dataset) == 1
+
+    assert (
+        l1b_de_dataset[0].attrs["Logical_source_description"]
+        == "IMAP-Ultra Instrument Level-1B Direct Event Data."
+    )
+
+
+def test_ultra_l1b_extendedspin(l1b_extendedspin_dataset):
+    """Tests that L1b data is created."""
+
+    assert len(l1b_extendedspin_dataset) == 3
 
     # Define the suffixes and prefix
     prefix = "imap_ultra_l1b_45sensor"
-    suffixes = ["de", "extendedspin", "cullingmask", "badtimes"]
+    suffixes = ["extendedspin", "cullingmask", "badtimes"]
 
     for i in range(len(suffixes)):
         expected_logical_source = f"{prefix}-{suffixes[i]}"
-        assert l1b_datasets[i].attrs["Logical_source"] == expected_logical_source
-
-    assert (
-        l1b_datasets[0].attrs["Logical_source_description"]
-        == "IMAP-Ultra Instrument Level-1B Direct Event Data."
-    )
+        assert (
+            l1b_extendedspin_dataset[i].attrs["Logical_source"]
+            == expected_logical_source
+        )
 
 
 def test_ultra_l1b_error(mock_data_l1a_rates_dict):

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -270,33 +270,20 @@ def ultra_l1a(
     output_datasets = []
 
     # This is used for two purposes currently:
-    # 1. For testing purposes to only generate a dataset for a single apid.
+    #    For testing purposes to only generate a dataset for a single apid.
     #    Each test dataset is only for a single apid while the rest of the apids
     #    contain zeros. Ideally we would have
     #    test data for all apids and remove this parameter.
-    # 2. When we are generating the l1a dataset for the events packet since
-    #    right now we need to combine the events and aux packets to get the
-    #    correct event timestamps (get_event_time). This part will change
-    #    when we begin using the spin table in the database instead of the aux packet.
     if apid is not None:
         apids = [apid]
     else:
         apids = list(grouped_data.keys())
 
     for apid in apids:
-        if apid == ULTRA_EVENTS.apid[0]:
-            decom_ultra_dict = {
-                apid: process_ultra_apids(grouped_data[apid], apid),
-                ULTRA_AUX.apid[0]: process_ultra_apids(
-                    grouped_data[ULTRA_AUX.apid[0]], ULTRA_AUX.apid[0]
-                ),
-            }
-        else:
-            decom_ultra_dict = {
-                apid: process_ultra_apids(grouped_data[apid], apid),
-            }
+        decom_ultra_dict = {
+            apid: process_ultra_apids(grouped_data[apid], apid),
+        }
         dataset = create_dataset(decom_ultra_dict)
-        # TODO: move this to use ImapCdfAttributes().add_global_attribute()
         dataset.attrs["Data_version"] = data_version
         output_datasets.append(dataset)
 

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -284,6 +284,7 @@ def ultra_l1a(
             apid: process_ultra_apids(grouped_data[apid], apid),
         }
         dataset = create_dataset(decom_ultra_dict)
+        # TODO: move this to use ImapCdfAttributes().add_global_attribute()
         dataset.attrs["Data_version"] = data_version
         output_datasets.append(dataset)
 

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -10,37 +10,34 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_extendedspin(  # noqa: PLR0913
-    aux_dataset: xr.Dataset,
-    hk_dataset: xr.Dataset,
-    rates_dataset: xr.Dataset,
-    de_dataset: xr.Dataset,
+def calculate_extendedspin(
+    dict_datasets: dict[str, xr.Dataset],
     name: str,
     data_version: str,
+    instrument_id: int,
 ) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Extended Spin Data.
 
     Parameters
     ----------
-    aux_dataset : xarray.Dataset
-        Dataset containing l1a aux data.
-    hk_dataset : xarray.Dataset
-        Dataset containing l1a hk data.
-    rates_dataset : xarray.Dataset
-        Dataset containing l1a rates data.
-    de_dataset : xarray.Dataset
-        Dataset containing l1b de data.
+    dict_datasets : dict
+        Dictionary containing all the datasets.
     name : str
         Name of the dataset.
     data_version : str
         Version of the data.
+    instrument_id : int
+        Instrument ID.
 
     Returns
     -------
     extendedspin_dataset : xarray.Dataset
         Dataset containing the data.
     """
+    aux_dataset = dict_datasets[f"imap_ultra_l1a_{instrument_id}sensor-aux"]
+    de_dataset = dict_datasets[f"imap_ultra_l1b_{instrument_id}sensor-de"]
+
     extendedspin_dict = {}
     rates_qf, spin, energy_midpoints, n_sigma_per_energy = flag_spin(
         de_dataset["spin"].values,

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -23,6 +23,13 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
     -------
     output_datasets : list[xarray.Dataset]
         List of xarray.Dataset.
+
+    Notes
+    -----
+    General flow:
+    1. l1a data products are created (upstream to this code)
+    2. l1b de is created here and dropped in s3 kicking off processing again
+    3. l1b extended, culling, badtimes created here
     """
     output_datasets = []
     instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -27,6 +27,7 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
     output_datasets = []
     instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90
 
+    # L1b de data will be created if L1a de data is available
     if f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict:
         de_dataset = calculate_de(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
@@ -34,6 +35,8 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
             data_version,
         )
         output_datasets.append(de_dataset)
+    # L1b extended data will be created if L1a hk, rates,
+    # aux and l1b de data are available
     elif (
         f"imap_ultra_l1a_{instrument_id}sensor-hk" in data_dict
         and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
@@ -41,12 +44,23 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
         and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
     ):
         extendedspin_dataset = calculate_extendedspin(
-            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
-            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-hk"],
-            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
-            data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
+            {
+                f"imap_ultra_l1a_{instrument_id}sensor-aux": data_dict[
+                    f"imap_ultra_l1a_{instrument_id}sensor-aux"
+                ],
+                f"imap_ultra_l1a_{instrument_id}sensor-hk": data_dict[
+                    f"imap_ultra_l1a_{instrument_id}sensor-hk"
+                ],
+                f"imap_ultra_l1a_{instrument_id}sensor-rates": data_dict[
+                    f"imap_ultra_l1a_{instrument_id}sensor-rates"
+                ],
+                f"imap_ultra_l1b_{instrument_id}sensor-de": data_dict[
+                    f"imap_ultra_l1b_{instrument_id}sensor-de"
+                ],
+            },
             f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
             data_version,
+            instrument_id,
         )
         cullingmask_dataset = calculate_cullingmask(
             extendedspin_dataset,

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -27,22 +27,24 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
     output_datasets = []
     instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90
 
-    if (
-        f"imap_ultra_l1a_{instrument_id}sensor-hk" in data_dict
-        and f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict
-        and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
-        and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
-    ):
+    if f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict:
         de_dataset = calculate_de(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
             f"imap_ultra_l1b_{instrument_id}sensor-de",
             data_version,
         )
+        output_datasets.append(de_dataset)
+    elif (
+        f"imap_ultra_l1a_{instrument_id}sensor-hk" in data_dict
+        and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
+        and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
+        and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
+    ):
         extendedspin_dataset = calculate_extendedspin(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-hk"],
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
-            de_dataset,
+            data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
             f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
             data_version,
         )
@@ -58,7 +60,7 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
             data_version,
         )
         output_datasets.extend(
-            [de_dataset, extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
+            [extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
         )
     else:
         raise ValueError("Data dictionary does not contain the expected keys.")

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -36,6 +36,7 @@ def create_dataset(
         coords = {
             "spin_number": data_dict["spin_number"],
             "energy_bin_geometric_mean": data_dict["energy_bin_geometric_mean"],
+            # Start time aligns with the universal spin table
             "epoch": data_dict["spin_start_time"],
         }
         default_dimension = "spin_number"

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -36,6 +36,7 @@ def create_dataset(
         coords = {
             "spin_number": data_dict["spin_number"],
             "energy_bin_geometric_mean": data_dict["energy_bin_geometric_mean"],
+            "epoch": data_dict["spin_start_time"],
         }
         default_dimension = "spin_number"
 


### PR DESCRIPTION
# Change Summary

## Overview
Removes aux dependency for l1 de data product.

## Updated Files
- ultra_l1a.py
   - Removes aux dependency required to process Ultra de l1a
- ultra_l1b.py
   - Changed dependencies for producing l1b data products
- conftest.py
   - Created l1b extended spin dataset separately from de dataset
- ultra_l1_utils.py
   - Added dimension "epoch" because I had to

## Tests
- test_de.py
- test_ultra_l1a.py
- test_ultra_l1b.py