### PR TITLE
MNT: Removing ISTP check for l1 data files

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -135,12 +135,22 @@ def write_cdf(
         ]
 
     # Convert the xarray object to a CDF
-    xarray_to_cdf(
-        dataset,
-        str(file_path),
-        terminate_on_warning=True,
-        **extra_cdf_kwargs,
-    )  # Terminate if not ISTP compliant
+    if "l2" in data_level:
+        # Terminate if not ISTP compliant
+        xarray_to_cdf(
+            dataset,
+            str(file_path),
+            terminate_on_warning=True,
+            **extra_cdf_kwargs,
+        )
+    else:
+        # Skip ISTP check for L1 files
+        xarray_to_cdf(
+            dataset,
+            str(file_path),
+            istp=False,
+            **extra_cdf_kwargs,
+        )
 
     return file_path
 

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import imap_data_access
 import numpy as np
@@ -60,7 +60,9 @@ def load_cdf(
 
 
 def write_cdf(
-    dataset: xr.Dataset, parent_files: Optional[list] = None, **extra_cdf_kwargs: dict
+    dataset: xr.Dataset,
+    parent_files: Optional[list] = None,
+    **extra_cdf_kwargs: dict[Any, Any],
 ) -> Path:
     """
     Write the contents of "data" to a CDF file using cdflib.xarray_to_cdf.
@@ -135,22 +137,16 @@ def write_cdf(
         ]
 
     # Convert the xarray object to a CDF
-    if "l2" in data_level:
-        # Terminate if not ISTP compliant
-        xarray_to_cdf(
-            dataset,
-            str(file_path),
-            terminate_on_warning=True,
-            **extra_cdf_kwargs,
-        )
+    if "l1" in data_level:
+        if "istp" not in extra_cdf_kwargs:
+            extra_cdf_kwargs["istp"] = False  # type: ignore
     else:
-        # Skip ISTP check for L1 files
-        xarray_to_cdf(
-            dataset,
-            str(file_path),
-            istp=False,
-            **extra_cdf_kwargs,
-        )
+        if "terminate_on_warning" not in extra_cdf_kwargs:
+            extra_cdf_kwargs["terminate_on_warning"] = True  # type: ignore
+        if "istp" not in extra_cdf_kwargs:
+            extra_cdf_kwargs["istp"] = True  # type: ignore
+
+    xarray_to_cdf(dataset, str(file_path), **extra_cdf_kwargs)
 
     return file_path
 

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 import imap_data_access
 import numpy as np
@@ -62,7 +62,7 @@ def load_cdf(
 def write_cdf(
     dataset: xr.Dataset,
     parent_files: Optional[list] = None,
-    **extra_cdf_kwargs: dict[Any, Any],
+    **extra_cdf_kwargs: dict,
 ) -> Path:
     """
     Write the contents of "data" to a CDF file using cdflib.xarray_to_cdf.

--- a/imap_processing/tests/idex/test_idex_l1a.py
+++ b/imap_processing/tests/idex/test_idex_l1a.py
@@ -4,9 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
-import pytest
 import xarray as xr
-from cdflib.xarray.xarray_to_cdf import ISTPError
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import load_cdf, write_cdf
@@ -27,61 +25,6 @@ def test_idex_cdf_file(decom_test_data: xr.Dataset):
 
     assert file_name.exists()
     assert file_name.name == "imap_idex_l1a_sci-1week_20231214_v001.cdf"
-
-
-def test_bad_cdf_attributes(decom_test_data: xr.Dataset):
-    """Ensure an ``ISTPError`` is raised when using bad CDF attributes.
-
-    Parameters
-    ----------
-    decom_test_data : xarray.Dataset
-        The dataset to test with
-    """
-    tof_catdesc = decom_test_data["TOF_High"].attrs["CATDESC"]
-    del decom_test_data["TOF_High"].attrs["CATDESC"]
-
-    with pytest.raises(ISTPError):
-        write_cdf(decom_test_data)
-
-    # Add attributes back so future tests do not fail
-    decom_test_data["TOF_High"].attrs["CATDESC"] = tof_catdesc
-
-
-def test_bad_cdf_file_data(decom_test_data: xr.Dataset):
-    """Ensure an ``ISTPError`` is raised when using bad data.
-
-    Parameters
-    ----------
-    decom_test_data : xarray.Dataset
-        The dataset to test with
-    """
-    bad_data_attrs = {
-        "CATDESC": "Bad_Data",
-        "DEPEND_0": "epoch",
-        "DISPLAY_TYPE": "no_plot",
-        "FIELDNAM": "Bad_Data",
-        "FILLVAL": "",
-        "FORMAT": "E12.2",
-        "LABLAXIS": "Bad_Data",
-        "UNITS": "",
-        "VALIDMIN": "1",
-        "VALIDMAX": "50",
-        "VAR_TYPE": "support_data",
-        "VAR_NOTES": """How did this data end up in here?
-                        The CDF creation better fail.""",
-    }
-    bad_data_xr = xr.DataArray(
-        name="bad_data",
-        data=np.linspace(1, 50, 50),
-        dims=("bad_data"),
-        attrs=bad_data_attrs,
-    )
-    decom_test_data["Bad_data"] = bad_data_xr
-
-    with pytest.raises(ISTPError):
-        write_cdf(decom_test_data)
-
-    del decom_test_data["Bad_data"]
 
 
 def test_idex_tof_high_data_from_cdf(decom_test_data: xr.Dataset):

--- a/imap_processing/tests/idex/test_idex_l1a.py
+++ b/imap_processing/tests/idex/test_idex_l1a.py
@@ -4,7 +4,9 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
+import pytest
 import xarray as xr
+from cdflib.xarray.xarray_to_cdf import ISTPError
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import load_cdf, write_cdf
@@ -25,6 +27,61 @@ def test_idex_cdf_file(decom_test_data: xr.Dataset):
 
     assert file_name.exists()
     assert file_name.name == "imap_idex_l1a_sci-1week_20231214_v001.cdf"
+
+
+def test_bad_cdf_attributes(decom_test_data: xr.Dataset):
+    """Ensure an ``ISTPError`` is raised when using bad CDF attributes.
+
+    Parameters
+    ----------
+    decom_test_data : xarray.Dataset
+        The dataset to test with
+    """
+    tof_catdesc = decom_test_data["TOF_High"].attrs["CATDESC"]
+    del decom_test_data["TOF_High"].attrs["CATDESC"]
+
+    with pytest.raises(ISTPError):
+        write_cdf(decom_test_data, istp=True, terminate_on_warning=True)
+
+    # Add attributes back so future tests do not fail
+    decom_test_data["TOF_High"].attrs["CATDESC"] = tof_catdesc
+
+
+def test_bad_cdf_file_data(decom_test_data: xr.Dataset):
+    """Ensure an ``ISTPError`` is raised when using bad data.
+
+    Parameters
+    ----------
+    decom_test_data : xarray.Dataset
+        The dataset to test with
+    """
+    bad_data_attrs = {
+        "CATDESC": "Bad_Data",
+        "DEPEND_0": "epoch",
+        "DISPLAY_TYPE": "no_plot",
+        "FIELDNAM": "Bad_Data",
+        "FILLVAL": "",
+        "FORMAT": "E12.2",
+        "LABLAXIS": "Bad_Data",
+        "UNITS": "",
+        "VALIDMIN": "1",
+        "VALIDMAX": "50",
+        "VAR_TYPE": "support_data",
+        "VAR_NOTES": """How did this data end up in here?
+                        The CDF creation better fail.""",
+    }
+    bad_data_xr = xr.DataArray(
+        name="bad_data",
+        data=np.linspace(1, 50, 50),
+        dims=("bad_data"),
+        attrs=bad_data_attrs,
+    )
+    decom_test_data["Bad_data"] = bad_data_xr
+
+    with pytest.raises(ISTPError):
+        write_cdf(decom_test_data, istp=True, terminate_on_warning=True)
+
+    del decom_test_data["Bad_data"]
 
 
 def test_idex_tof_high_data_from_cdf(decom_test_data: xr.Dataset):


### PR DESCRIPTION
# Change Summary
closes #1442

## Overview
Removing ISTP checks for L1 files


## Updated Files
- imap_processing/cdf/utils.py
   - code to remove ISTP checks for L1 files


## Testing
-  imap_processing/tests/idex/test_idex_l1a.py
    - remove bad CDF test for IDEX l1a
