### PR TITLE
Use degrees internally for ENA Maps

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -146,7 +146,7 @@ def match_coords_to_indices(
         az_el=input_obj_az_el_input_frame,
         from_frame=input_object.spice_reference_frame,
         to_frame=output_object.spice_reference_frame,
-        degrees=False,
+        degrees=True,
     )
 
     # The way indices are matched depends on the tiling type of the 2nd object
@@ -311,14 +311,14 @@ class UltraPointingSet(PointingSet):
             [self.sky_grid.az_bin_midpoints, self.sky_grid.el_bin_midpoints],
         ):
             if not np.allclose(
-                sorted(np.rad2deg(constructed_bins)),
+                sorted(constructed_bins),
                 self.data[f"{dim}_bin_center"],
                 atol=1e-10,
                 rtol=0,
             ):
                 raise ValueError(
                     f"{dim} bin centers do not match."
-                    f"Constructed: {np.rad2deg(constructed_bins)}"
+                    f"Constructed: {constructed_bins}"
                     f"Dataset: {self.data[f'{dim}_bin_center']}"
                 )
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -181,8 +181,8 @@ def match_coords_to_indices(
         # which directly returns the index on the output frame's Healpix tessellation.
         flat_indices_input_grid_output_frame = hp.ang2pix(
             nside=output_object.nside,
-            theta=np.rad2deg(input_obj_az_el_output_frame[:, 0]),  # Lon
-            phi=np.rad2deg(input_obj_az_el_output_frame[:, 1]),  # Lat
+            theta=input_obj_az_el_output_frame[:, 0],  # Lon in degrees
+            phi=input_obj_az_el_output_frame[:, 1],  # Lat in degrees
             nest=output_object.nested,
             lonlat=True,
         )
@@ -596,18 +596,16 @@ class HealpixSkyMap(AbstractSkyMap):
         self.nside = nside
         self.nested = nested
 
-        # Calculate how many pixels cover the sky and the approximate resolution (rad)
+        # Calculate how many pixels cover the sky and the approximate resolution (deg)
         self.num_points = hp.nside2npix(nside)
-        self.approx_resolution = hp.nside2resol(nside, arcmin=False)
+        self.approx_resolution = np.rad2deg(hp.nside2resol(nside, arcmin=False))
         # Define binning_grid_shape for consistency with RectangularSkyMap
         self.binning_grid_shape = (self.num_points,)
 
         # The centers of each pixel in the Healpix tessellation in azimuth (az) and
-        # elevation (el) coordinates (radians) within the map's Spice frame.
-        pixel_az, pixel_el = np.deg2rad(
-            hp.pix2ang(
-                nside=nside, ipix=np.arange(self.num_points), nest=nested, lonlat=True
-            )
+        # elevation (el) coordinates (degrees) within the map's Spice frame.
+        pixel_az, pixel_el = hp.pix2ang(
+            nside=nside, ipix=np.arange(self.num_points), nest=nested, lonlat=True
         )
         # Stack so axis 0 is different pixels, and axis 1 is (az, el) of the pixel
         self.az_el_points = np.column_stack((pixel_az, pixel_el))

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -268,7 +268,7 @@ def frame_transform_az_el(
     spherical_coords_in = np.array(
         [np.ones_like(az_el[..., 0]), az_el[..., 0], az_el[..., 1]]
     ).T
-    from_frame_cartesian = spherical_to_cartesian(spherical_coords_in, degrees=degrees)
+    from_frame_cartesian = spherical_to_cartesian(spherical_coords_in)
     # Transform to to_frame
     to_frame_cartesian = frame_transform(et, from_frame_cartesian, from_frame, to_frame)
     # Convert to spherical and extract azimuth/elevation
@@ -425,14 +425,14 @@ def cartesian_to_spherical(
         - r : Distance of the point from the origin.
         - azimuth : angle in the xy-plane
           In degrees if degrees parameter is True (by default):
-          output range=[0, 360],
+          output range=[0, 360) degrees,
           otherwise in radians if degrees parameter is False:
-          output range=[0, 2*pi].
+          output range=[0, 2*pi) radians.
         - elevation : angle from the xy-plane
           In degrees if degrees parameter is True (by default):
-          output range=[0, 180],
+          output range=[-90, 90) degrees,
           otherwise in radians if degrees parameter is False:
-          output range=[-pi/2, pi/2].
+          output range=[-pi/2, pi/2) radians.
     """
     # Magnitude of the velocity vector
     magnitude_v = np.linalg.norm(v, axis=-1, keepdims=True)
@@ -457,9 +457,9 @@ def cartesian_to_spherical(
     return spherical_coords
 
 
-def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = True) -> NDArray:
+def spherical_to_cartesian(spherical_coords: NDArray) -> NDArray:
     """
-    Convert spherical coordinates to Cartesian coordinates.
+    Convert spherical coordinates (angles in degrees) to Cartesian coordinates.
 
     Parameters
     ----------
@@ -468,11 +468,10 @@ def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = True) -> N
         the spherical coordinates (r, azimuth, elevation):
 
         - r : Distance of the point from the origin.
-        - azimuth : angle in the xy-plane in radians [0, 2*pi].
-        - elevation : angle from the xy-plane in radians [-pi/2, pi/2].
-    degrees : bool
-        Set to True if input azimuth and elevation angles are in degrees.
-        Defaults to True.
+        - azimuth : angle in the xy-plane in degrees
+        Range is [0, 360) degrees.
+        - elevation : angle from the xy-plane in degrees
+        Range is [-90, 90) degrees.
 
     Returns
     -------
@@ -483,9 +482,9 @@ def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = True) -> N
     azimuth = spherical_coords[..., 1]
     elevation = spherical_coords[..., 2]
 
-    if degrees:
-        azimuth = np.radians(azimuth)
-        elevation = np.radians(elevation)
+    # Convert to radians for numpy trigonometric operations
+    azimuth = np.deg2rad(azimuth)
+    elevation = np.deg2rad(elevation)
 
     x = r * np.cos(elevation) * np.cos(azimuth)
     y = r * np.cos(elevation) * np.sin(azimuth)

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -457,7 +457,7 @@ def cartesian_to_spherical(
     return spherical_coords
 
 
-def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = False) -> NDArray:
+def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = True) -> NDArray:
     """
     Convert spherical coordinates to Cartesian coordinates.
 
@@ -472,7 +472,7 @@ def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = False) -> 
         - elevation : angle from the xy-plane in radians [-pi/2, pi/2].
     degrees : bool
         Set to True if input azimuth and elevation angles are in degrees.
-        Defaults to False.
+        Defaults to True.
 
     Returns
     -------
@@ -496,7 +496,7 @@ def spherical_to_cartesian(spherical_coords: NDArray, degrees: bool = False) -> 
     return cartesian_coords
 
 
-def cartesian_to_latitudinal(coords: NDArray, degrees: bool = False) -> NDArray:
+def cartesian_to_latitudinal(coords: NDArray, degrees: bool = True) -> NDArray:
     """
     Convert cartesian coordinates to latitudinal coordinates in radians.
 
@@ -511,7 +511,7 @@ def cartesian_to_latitudinal(coords: NDArray, degrees: bool = False) -> NDArray:
         with x, y, z-components.
     degrees : bool
         If True, the longitude and latitude coords are returned in degrees.
-        Defaults to False.
+        Defaults to True.
 
     Returns
     -------
@@ -532,7 +532,7 @@ def cartesian_to_latitudinal(coords: NDArray, degrees: bool = False) -> NDArray:
 
 def solar_longitude(
     et: Union[np.ndarray, float],
-    degrees: bool = False,
+    degrees: bool = True,
 ) -> Union[float, npt.NDArray]:
     """
     Compute the solar longitude of the Imap Spacecraft.
@@ -543,7 +543,7 @@ def solar_longitude(
         Ephemeris time(s) to at which to compute solar longitude.
     degrees : bool
         If True, the longitude is returned in degrees.
-        Defaults to False.
+        Defaults to True.
 
     Returns
     -------

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -468,10 +468,8 @@ def spherical_to_cartesian(spherical_coords: NDArray) -> NDArray:
         the spherical coordinates (r, azimuth, elevation):
 
         - r : Distance of the point from the origin.
-        - azimuth : angle in the xy-plane in degrees
-        Range is [0, 360) degrees.
-        - elevation : angle from the xy-plane in degrees
-        Range is [-90, 90) degrees.
+        - azimuth : angle in the xy-plane in degrees. Range is [0, 360) degrees.
+        - elevation : angle from the xy-plane in degrees. Range is [-90, 90) degrees.
 
     Returns
     -------

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -310,10 +310,10 @@ class TestHealpixSkyMap:
         assert hp_map.az_el_points.shape == (hp_map.num_points, 2)
         # The az must be in the range [0, 360) degrees
         # and el in the range [-90, 90)
-        assert np.all(hp_map.az_el_points[:, 0] >= np.deg2rad(0))
-        assert np.all(hp_map.az_el_points[:, 0] < np.deg2rad(360))
-        assert np.all(hp_map.az_el_points[:, 1] >= -np.deg2rad(90))
-        assert np.all(hp_map.az_el_points[:, 1] < np.deg2rad(90))
+        assert np.all(hp_map.az_el_points[:, 0] >= 0)
+        assert np.all(hp_map.az_el_points[:, 0] < 360)
+        assert np.all(hp_map.az_el_points[:, 1] >= -90)
+        assert np.all(hp_map.az_el_points[:, 1] < 90)
 
         # Check that the binning grid shape is just a tuple of num_points
         np.testing.assert_equal(hp_map.binning_grid_shape, (hp_map.num_points,))
@@ -391,8 +391,8 @@ class TestHealpixSkyMap:
 
         np.testing.assert_allclose(
             bright_hp_pixel_az_el,
-            np.deg2rad(input_bright_pixel_az_el_deg),
-            atol=np.deg2rad(degree_tolerance),
+            input_bright_pixel_az_el_deg,
+            atol=degree_tolerance,
         )
 
 
@@ -508,29 +508,27 @@ class TestIndexMatching:
         # Check that the map's az/el points at the matched indices
         # are the same as the input az/el points to within degree_tolerance,
         # but we must ignore the polar regions and azimuthal wrap-around regions
-        rect_equatorial_elevations_mask = np.abs(
-            mock_pset_input_frame.az_el_points[:, 1]
-        ) < np.deg2rad(70)
+        rect_equatorial_elevations_mask = (
+            np.abs(mock_pset_input_frame.az_el_points[:, 1]) < 70
+        )
         rect_az_non_wraparound_mask = (
-            mock_pset_input_frame.az_el_points[:, 0] < np.deg2rad(350)
-        ) & (mock_pset_input_frame.az_el_points[:, 0] > np.deg2rad(10))
+            mock_pset_input_frame.az_el_points[:, 0] < 350
+        ) & (mock_pset_input_frame.az_el_points[:, 0] > 10)
         rect_good_az_el_mask = (
             rect_equatorial_elevations_mask & rect_az_non_wraparound_mask
         )
-        matched_map_az_el = np.deg2rad(
-            np.column_stack(
-                hp.pix2ang(
-                    nside=nside,
-                    ipix=healpix_indices_of_rect_pixels,
-                    nest=nested,
-                    lonlat=True,
-                )
+        matched_map_az_el = np.column_stack(
+            hp.pix2ang(
+                nside=nside,
+                ipix=healpix_indices_of_rect_pixels,
+                nest=nested,
+                lonlat=True,
             )
         )
         np.testing.assert_allclose(
             matched_map_az_el[rect_good_az_el_mask, 0],
             mock_pset_input_frame.az_el_points[rect_good_az_el_mask, 0],
-            atol=np.deg2rad(degree_tolerance),
+            atol=degree_tolerance,
         )
 
     def test_match_coords_to_indices_pset_to_invalid_map(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -436,7 +436,7 @@ class TestIndexMatching:
                 [359.999999, 89.99999],
             ]
         )
-        mock_pset_input_frame.az_el_points = np.deg2rad(manual_az_el_coords)
+        mock_pset_input_frame.az_el_points = manual_az_el_coords
 
         # Manually calculate the resulting 1D pixel indices for each az/el pair
         # (num of pixels in an az row spanning 180 deg of elevation) * (current az row)
@@ -469,7 +469,7 @@ class TestIndexMatching:
         np.testing.assert_allclose(
             matched_map_az_el[:, 0],
             mock_pset_input_frame.az_el_points[:, 0],
-            atol=np.deg2rad(map_spacing_deg),
+            atol=map_spacing_deg,
         )
 
     @pytest.mark.parametrize(

--- a/imap_processing/tests/ena_maps/test_spatial_utils.py
+++ b/imap_processing/tests/ena_maps/test_spatial_utils.py
@@ -26,20 +26,20 @@ def test_build_spatial_bins():
     )
 
     assert az_bin_edges[0] == 0
-    assert az_bin_edges[-1] == 2 * np.pi
+    assert az_bin_edges[-1] == 360
     assert len(az_bin_edges) == 721
 
-    assert el_bin_edges[0] == -np.pi / 2
-    assert el_bin_edges[-1] == np.pi / 2
+    assert el_bin_edges[0] == -90
+    assert el_bin_edges[-1] == 90
     assert len(el_bin_edges) == 361
 
     assert len(az_bin_midpoints) == 720
-    np.testing.assert_allclose(az_bin_midpoints[0], np.deg2rad(0.25), atol=1e-4)
-    np.testing.assert_allclose(az_bin_midpoints[-1], np.deg2rad(359.75), atol=1e-4)
+    np.testing.assert_allclose(az_bin_midpoints[0], 0.25, atol=1e-4)
+    np.testing.assert_allclose(az_bin_midpoints[-1], 359.75, atol=1e-4)
 
     assert len(el_bin_midpoints) == 360
-    np.testing.assert_allclose(el_bin_midpoints[0], np.deg2rad(-89.75), atol=1e-4)
-    np.testing.assert_allclose(el_bin_midpoints[-1], np.deg2rad(89.75), atol=1e-4)
+    np.testing.assert_allclose(el_bin_midpoints[0], -89.75, atol=1e-4)
+    np.testing.assert_allclose(el_bin_midpoints[-1], 89.75, atol=1e-4)
 
 
 @pytest.mark.parametrize("spacing", valid_spacings)
@@ -141,21 +141,17 @@ class TestAzElSkyGrid:
         )
         npt.assert_allclose(
             grid.az_bin_midpoints,
-            np.deg2rad(expected_azimuth_bin_midpoints_deg),
+            expected_azimuth_bin_midpoints_deg,
             atol=1e-11,
         )
         npt.assert_allclose(
             grid.el_bin_midpoints,
-            np.deg2rad(expected_elevation_bin_midpoints_deg),
+            expected_elevation_bin_midpoints_deg,
             atol=1e-11,
         )
 
         # Check bin edges in degrees, radians
         expected_az_bin_edges_deg = np.arange(0, 360 + spacing, spacing)
         expected_el_bin_edges_deg = np.arange(-90, 90 + spacing, spacing)
-        npt.assert_allclose(
-            grid.az_bin_edges, np.deg2rad(expected_az_bin_edges_deg), atol=1e-11
-        )
-        npt.assert_allclose(
-            grid.el_bin_edges, np.deg2rad(expected_el_bin_edges_deg), atol=1e-11
-        )
+        npt.assert_allclose(grid.az_bin_edges, expected_az_bin_edges_deg, atol=1e-11)
+        npt.assert_allclose(grid.el_bin_edges, expected_el_bin_edges_deg, atol=1e-11)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -365,7 +365,9 @@ def test_spherical_to_cartesian():
     )
 
     for i in range(len(colat)):
-        cartesian_coords = spherical_to_cartesian(np.array([spherical_points[i]]))
+        cartesian_coords = spherical_to_cartesian(
+            np.array([spherical_points_degrees[i]]), degrees=True
+        )
         spice_coords = spiceypy.sphrec(r, colat[i], spherical_points[i, 1])
 
         np.testing.assert_allclose(cartesian_coords[0], spice_coords, atol=1e-5)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -208,8 +208,7 @@ def test_frame_transform_exceptions():
         SpiceFrame.ECLIPJ2000,
     ],
 )
-@pytest.mark.parametrize("degrees_bool", [True, False])
-def test_frame_transform_az_el_same_frame(spice_frame, degrees_bool):
+def test_frame_transform_az_el_same_frame(spice_frame):
     """Test that frame_transform returns az/el when input/output frames are same."""
     az_el_points = np.array(
         [
@@ -231,10 +230,8 @@ def test_frame_transform_az_el_same_frame(spice_frame, degrees_bool):
             [360, 90],
         ]
     )
-    if not degrees_bool:
-        az_el_points = np.deg2rad(az_el_points)
     result = frame_transform_az_el(
-        0, az_el_points, spice_frame, spice_frame, degrees=degrees_bool
+        0, az_el_points, spice_frame, spice_frame, degrees=True
     )
     np.testing.assert_allclose(result, az_el_points)
 
@@ -360,13 +357,11 @@ def test_spherical_to_cartesian():
     # Convert elevation to colatitude for SPICE
     colat = np.pi / 2 - spherical_points[:, 2]
 
-    cartesian_from_degrees = spherical_to_cartesian(
-        spherical_points_degrees, degrees=True
-    )
+    cartesian_from_degrees = spherical_to_cartesian(spherical_points_degrees)
 
     for i in range(len(colat)):
         cartesian_coords = spherical_to_cartesian(
-            np.array([spherical_points_degrees[i]]), degrees=True
+            np.array([spherical_points_degrees[i]])
         )
         spice_coords = spiceypy.sphrec(r, colat[i], spherical_points[i, 1])
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -52,7 +52,7 @@ def test_get_histogram(test_data):
     v, energy = test_data
 
     az_bin_edges, el_bin_edges, az_bin_midpoints, el_bin_midpoints = (
-        np.rad2deg(angle_radians) for angle_radians in (build_spatial_bins())
+        build_spatial_bins()
     )
     energy_bin_edges, _ = build_energy_bins()
 
@@ -101,7 +101,7 @@ def test_get_helio_exposure_times():
 
     energy_bin_edges, energy_midpoints = build_energy_bins()
     az_bin_edges, el_bin_edges, az_bin_midpoints, el_bin_midpoints = (
-        np.rad2deg(angle_radians) for angle_radians in (build_spatial_bins())
+        build_spatial_bins()
     )
 
     assert exposure_3d.shape == (

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -172,7 +172,7 @@ def get_helio_exposure_times(
     # Radial distance.
     r = np.ones(el_grid.shape)
     spherical_coords = np.stack((r, az_grid, el_grid), axis=-1)
-    cartesian_coords = spherical_to_cartesian(spherical_coords, degrees=True)
+    cartesian_coords = spherical_to_cartesian(spherical_coords)
     cartesian = cartesian_coords.reshape(-1, 3, order="F").T
 
     # Spacecraft velocity in the pointing (DPS) frame wrt heliosphere.

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -154,10 +154,10 @@ def get_helio_exposure_times(
     -----
     These calculations are performed once per pointing.
     """
-    # Get bins and midpoints, and convert from radians to degrees.
+    # Get bins and midpoints, with angles in degrees.
     _, energy_midpoints = build_energy_bins()
     az_bin_edges, el_bin_edges, az_bin_midpoints, el_bin_midpoints = (
-        np.rad2deg(angle_radians) for angle_radians in (build_spatial_bins())
+        build_spatial_bins()
     )
 
     # Initialize the exposure grid.
@@ -171,8 +171,8 @@ def get_helio_exposure_times(
 
     # Radial distance.
     r = np.ones(el_grid.shape)
-    spherical_coords = np.stack((r, np.radians(az_grid), np.radians(el_grid)), axis=-1)
-    cartesian_coords = spherical_to_cartesian(spherical_coords)
+    spherical_coords = np.stack((r, az_grid, el_grid), axis=-1)
+    cartesian_coords = spherical_to_cartesian(spherical_coords, degrees=True)
     cartesian = cartesian_coords.reshape(-1, 3, order="F").T
 
     # Spacecraft velocity in the pointing (DPS) frame wrt heliosphere.


### PR DESCRIPTION
# Change Summary

1. Changes internal working angular unit to degrees in ena_maps.py and spatial_utils.py
2. Changes default angular unit to degrees in spice.geometry

Closes #1448 #1449

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

At the [SDC Tagup - 2025/03/10](https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/248013628/SDC+Tagup+-+2025+03+10), we decided to use internal angular units of degrees for the ENA maps, to better mirror our input/output products. 


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/spice/geometry.py
   - Changed default angular units in angular functions. 
- imap_processing/ena_maps/utils/spatial_utils.py
   - Internally store angles as degrees in `build_spatial_bins()` function and `AzElSkyGrid` class. 
- imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
   - calls `build_spatial_bins()`, so remove deprecated angular conversion to degrees
-  imap_processing/ena_maps/ena_maps.py
   - Switch to internally representing angles as degrees. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
- Fix broken tests for all the above files. 