### PR TITLE
1150 hi l1c   bin l1b counts into pset bins

### DIFF
--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -131,7 +131,6 @@ def generate_pset_dataset(
     attr_mgr.add_instrument_global_attrs("hi")
     attr_mgr.add_instrument_variable_attrs(instrument="hi", level=None)
     for var_name in [
-        "counts",
         "background_rates",
         "background_rates_uncertainty",
     ]:

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -118,6 +118,8 @@ def generate_pset_dataset(
     # Calculate and add despun_z, hae_latitude, and hae_longitude variables to
     # the pset_dataset
     pset_dataset.update(pset_geometry(pset_et, logical_source_parts["sensor"]))
+    # Bin the counts into the spin-bins
+    pset_dataset.update(pset_counts(pset_dataset.coords, config_df, de_dataset))
     # Calculate and add the exposure time to the pset_dataset
     pset_dataset.update(pset_exposure(pset_dataset.coords, de_dataset))
 
@@ -312,6 +314,103 @@ def pset_geometry(pset_et: float, sensor_str: str) -> dict[str, xr.DataArray]:
         np.newaxis, :
     ]
     return geometry_vars
+
+
+def pset_counts(
+    pset_coords: dict[str, xr.DataArray],
+    config_df: pd.DataFrame,
+    l1b_de_dataset: xr.Dataset,
+) -> dict[str, xr.DataArray]:
+    """
+    Bin direct events into PSET spin-bins.
+
+    Parameters
+    ----------
+    pset_coords : dict[str, xr.DataArray]
+        The PSET coordinates from the xr.Dataset.
+    config_df : pd.DataFrame
+        The calibration product configuration dataframe.
+    l1b_de_dataset : xr.Dataset
+        The L1B dataset for the pointing being processed.
+
+    Returns
+    -------
+    dict[str, xr.DataArray]
+        Dictionary containing new exposure_times DataArray to be added to the PSET
+        dataset.
+    """
+    # Generate exposure time variable filled with zeros
+    counts_var = create_dataset_variables(
+        ["counts"],
+        coords=pset_coords,
+        att_manager_lookup_str="hi_pset_{0}",
+        fill_value=0,
+    )
+
+    # Convert list of DEs to pandas dataframe for ease indexing/filtering
+    de_df = l1b_de_dataset.drop_dims("epoch").to_pandas()
+
+    # Remove DEs not in Goodtimes/angles
+    good_mask = good_time_and_phase_mask(
+        l1b_de_dataset.event_met.values, l1b_de_dataset.spin_phase.values
+    )
+    de_df = de_df[good_mask]
+
+    # Add a calibration product array that will be used to bin DEs.
+    # Only DEs that belong to a calibration product and have TOF times that
+    # are within the configuration time window will be assigned a cal_product
+    # value.
+    de_df["cal_product"] = np.full(len(de_df), np.nan, dtype=float)
+
+    # The calibration product configuration potentially has different coincidence
+    # types for each ESA and different TOF windows for each calibration product,
+    # esa energy step combination. Because of this we need to filter DEs that
+    # belong to each combo individually.
+    # Loop over the esa_energy_step values first
+    for esa_energy, esa_df in config_df.groupby(level="esa_energy_step"):
+        # Create a mask for all DEs at the current esa_energy_step
+        # esa_energy_step is recorded for each packet, so we have to use ccsds_index
+        # to get the esa_energy_step for each DE
+        esa_mask = (
+            l1b_de_dataset["esa_energy_step"].data[de_df["ccsds_index"].to_numpy()]
+            == esa_energy
+        )
+        for row in esa_df.itertuples():
+            # Filter DEs by coincidence type
+            type_mask = de_df["coincidence_type"].isin(row.coincidence_type_values)
+            filtered_de_df = de_df[(esa_mask & type_mask)]
+
+            # Generate TOF window masks for the filtered df
+            detector_pairs = ["ab", "ac1", "bc1", "c1c2"]
+            tof_in_window_mask = np.empty(
+                (len(detector_pairs), len(filtered_de_df)), dtype=bool
+            )
+            for i_pair, detector_pair in enumerate(detector_pairs):
+                low_limit = getattr(row, f"tof_{detector_pair}_low")
+                high_limit = getattr(row, f"tof_{detector_pair}_high")
+                tof_array = filtered_de_df[f"tof_{detector_pair}"].to_numpy()
+                # The TOF in window mask contains True wherever the TOF is within
+                # the configuration low/high bounds OR the FILLVAL is present. The
+                # FILLVAL indicates that the detector pair was not hit. DEs with
+                # the incorrect coincidence_type are already filtered out and this
+                # implementation simplifies combining the TOF in window mask in
+                # the next step.
+                tof_in_window_mask[i_pair] = np.logical_or(
+                    np.logical_and(low_limit <= tof_array, tof_array <= high_limit),
+                    tof_array
+                    == l1b_de_dataset[f"tof_{detector_pair}"].attrs["FILLVAL"],
+                )
+            filtered_de_df = filtered_de_df[np.all(tof_in_window_mask, axis=0)]
+
+            # Bin remaining DEs into spin-bins
+            i_esa = np.flatnonzero(pset_coords["esa_energy_step"].data == esa_energy)[0]
+            spin_bin_indices = (
+                filtered_de_df["spin_phase"].to_numpy() * N_SPIN_BINS
+            ).astype(int)
+            np.add.at(
+                counts_var["counts"].data[0, i_esa, row.Index[0]], spin_bin_indices, 1
+            )
+    return counts_var
 
 
 def pset_exposure(
@@ -592,10 +691,10 @@ class CalibrationProductConfig:
         # Add a column that consists of the coincidence type strings converted
         # to integer values
         self._obj["coincidence_type_values"] = self._obj.apply(
-            lambda row: [
+            lambda row: tuple(
                 CoincidenceBitmap.detector_hit_str_to_int(entry)
                 for entry in row["coincidence_type_list"]
-            ],
+            ),
             axis=1,
         )
 
@@ -617,7 +716,7 @@ class CalibrationProductConfig:
         df = pd.read_csv(
             path,
             index_col=cls.index_columns,
-            converters={"coincidence_type_list": lambda s: s.split("|")},
+            converters={"coincidence_type_list": lambda s: tuple(s.split("|"))},
             comment="#",
         )
         # Force the _init_ method to run by using the namespace

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import NamedTuple
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 from numpy import typing as npt
+from numpy._typing import NDArray
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import parse_filename_like
@@ -356,61 +358,100 @@ def pset_counts(
     )
     de_df = de_df[good_mask]
 
-    # Add a calibration product array that will be used to bin DEs.
-    # Only DEs that belong to a calibration product and have TOF times that
-    # are within the configuration time window will be assigned a cal_product
-    # value.
-    de_df["cal_product"] = np.full(len(de_df), np.nan, dtype=float)
-
     # The calibration product configuration potentially has different coincidence
     # types for each ESA and different TOF windows for each calibration product,
     # esa energy step combination. Because of this we need to filter DEs that
     # belong to each combo individually.
     # Loop over the esa_energy_step values first
     for esa_energy, esa_df in config_df.groupby(level="esa_energy_step"):
-        # Create a mask for all DEs at the current esa_energy_step
-        # esa_energy_step is recorded for each packet, so we have to use ccsds_index
-        # to get the esa_energy_step for each DE
+        # Create a mask for all DEs at the current esa_energy_step.
+        # esa_energy_step is recorded for each packet rather than for each DE,
+        # so we use ccsds_index to get the esa_energy_step for each DE
         esa_mask = (
             l1b_de_dataset["esa_energy_step"].data[de_df["ccsds_index"].to_numpy()]
             == esa_energy
         )
-        for row in esa_df.itertuples():
-            # Filter DEs by coincidence type
-            type_mask = de_df["coincidence_type"].isin(row.coincidence_type_values)
+        # Now loop over the calibration products for the current ESA energy
+        for config_row in esa_df.itertuples():
+            # Remove DEs that are not at the current ESA energy and in the list
+            # of coincidence types for the current calibration product
+            type_mask = de_df["coincidence_type"].isin(
+                config_row.coincidence_type_values
+            )
             filtered_de_df = de_df[(esa_mask & type_mask)]
 
-            # Generate TOF window masks for the filtered df
-            detector_pairs = ["ab", "ac1", "bc1", "c1c2"]
-            tof_in_window_mask = np.empty(
-                (len(detector_pairs), len(filtered_de_df)), dtype=bool
+            # Use the TOF window mask to remove DEs with TOFs outside the allowed range
+            tof_fill_vals = {
+                f"tof_{detector_pair}": l1b_de_dataset[f"tof_{detector_pair}"].attrs[
+                    "FILLVAL"
+                ]
+                for detector_pair in CalibrationProductConfig.tof_detector_pairs
+            }
+            tof_in_window_mask = get_tof_window_mask(
+                filtered_de_df, config_row, tof_fill_vals
             )
-            for i_pair, detector_pair in enumerate(detector_pairs):
-                low_limit = getattr(row, f"tof_{detector_pair}_low")
-                high_limit = getattr(row, f"tof_{detector_pair}_high")
-                tof_array = filtered_de_df[f"tof_{detector_pair}"].to_numpy()
-                # The TOF in window mask contains True wherever the TOF is within
-                # the configuration low/high bounds OR the FILLVAL is present. The
-                # FILLVAL indicates that the detector pair was not hit. DEs with
-                # the incorrect coincidence_type are already filtered out and this
-                # implementation simplifies combining the TOF in window mask in
-                # the next step.
-                tof_in_window_mask[i_pair] = np.logical_or(
-                    np.logical_and(low_limit <= tof_array, tof_array <= high_limit),
-                    tof_array
-                    == l1b_de_dataset[f"tof_{detector_pair}"].attrs["FILLVAL"],
-                )
-            filtered_de_df = filtered_de_df[np.all(tof_in_window_mask, axis=0)]
+            filtered_de_df = filtered_de_df[tof_in_window_mask]
 
             # Bin remaining DEs into spin-bins
             i_esa = np.flatnonzero(pset_coords["esa_energy_step"].data == esa_energy)[0]
+            # spin_phase is in the range [0, 1). Multiplying by N_SPIN_BINS and
+            # truncating to an integer gives the correct bin index
             spin_bin_indices = (
                 filtered_de_df["spin_phase"].to_numpy() * N_SPIN_BINS
             ).astype(int)
+            # When iterating over rows of a dataframe, the names of the multi-index
+            # are not preserved. Below, `config_row.Index[0]` gets the cal_prod_num
+            # value from the namedtuple representing the dataframe row.
             np.add.at(
-                counts_var["counts"].data[0, i_esa, row.Index[0]], spin_bin_indices, 1
+                counts_var["counts"].data[0, i_esa, config_row.Index[0]],
+                spin_bin_indices,
+                1,
             )
     return counts_var
+
+
+def get_tof_window_mask(
+    de_df: pd.DataFrame, prod_config_row: NamedTuple, fill_vals: dict
+) -> NDArray[bool]:
+    """
+    Generate a mask indicating which DEs to keep based on TOF windows.
+
+    Parameters
+    ----------
+    de_df : pd.DataFrame
+        The Direct Event dataframe for the DEs to filter based on the TOF
+        windows.
+    prod_config_row : namedtuple
+        A single row of the prod config dataframe represented as a named tuple.
+    fill_vals : dict
+        A dictionary containing the fill values used in the input DE TOF
+        dataframe values. This value should be derived from the L1B DE CDF
+        TOF variable attributes.
+
+    Returns
+    -------
+    window_mask : np.ndarray
+        A mask with one entry per DE in the input `de_df` indicating which DEs
+        contain TOF values within the windows specified by `prod_config_row`.
+        The mask is intended to directly filter the DE dataframe.
+    """
+    detector_pairs = CalibrationProductConfig.tof_detector_pairs
+    tof_in_window_mask = np.empty((len(detector_pairs), len(de_df)), dtype=bool)
+    for i_pair, detector_pair in enumerate(detector_pairs):
+        low_limit = getattr(prod_config_row, f"tof_{detector_pair}_low")
+        high_limit = getattr(prod_config_row, f"tof_{detector_pair}_high")
+        tof_array = de_df[f"tof_{detector_pair}"].to_numpy()
+        # The TOF in window mask contains True wherever the TOF is within
+        # the configuration low/high bounds OR the FILLVAL is present. The
+        # FILLVAL indicates that the detector pair was not hit. DEs with
+        # the incorrect coincidence_type are already filtered out and this
+        # implementation simplifies combining the tof_in_window_masks in
+        # the next step.
+        tof_in_window_mask[i_pair] = np.logical_or(
+            np.logical_and(low_limit <= tof_array, tof_array <= high_limit),
+            tof_array == fill_vals[f"tof_{detector_pair}"],
+        )
+    return np.all(tof_in_window_mask, axis=0)
 
 
 def pset_exposure(
@@ -644,16 +685,14 @@ class CalibrationProductConfig:
         "cal_prod_num",
         "esa_energy_step",
     )
+    tof_detector_pairs = ("ab", "ac1", "bc1", "c1c2")
     required_columns = (
         "coincidence_type_list",
-        "tof_ab_low",
-        "tof_ab_high",
-        "tof_ac1_low",
-        "tof_ac1_high",
-        "tof_bc1_low",
-        "tof_bc1_high",
-        "tof_c1c2_low",
-        "tof_c1c2_high",
+        *[
+            f"tof_{det_pair}_{limit}"
+            for det_pair in tof_detector_pairs
+            for limit in ["low", "high"]
+        ],
     )
 
     def __init__(self, pandas_obj: pd.DataFrame) -> None:

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -137,6 +137,22 @@ def test_pset_geometry(mock_frame_transform, mock_geom_frame_transform, sensor_s
     )
 
 
+def test_pset_counts(hi_l1_test_data_path, hi_test_cal_prod_config_path):
+    """Test coverage for pset_counts function."""
+    l1b_de_path = hi_l1_test_data_path / "imap_hi_l1b_45sensor-de_20250415_v999.cdf"
+    l1b_dataset = load_cdf(l1b_de_path)
+    cal_config_df = hi_l1c.CalibrationProductConfig.from_csv(
+        hi_test_cal_prod_config_path
+    )
+    empty_pset = hi_l1c.empty_pset_dataset(
+        l1b_dataset.esa_energy_step.data,
+        cal_config_df.cal_prod_config.number_of_products,
+        HIAPID.H90_SCI_DE.sensor,
+    )
+    counts_var = hi_l1c.pset_counts(empty_pset.coords, cal_config_df, l1b_dataset)
+    assert "counts" in counts_var
+
+
 @mock.patch("imap_processing.hi.l1c.hi_l1c.get_spin_data", return_value=None)
 @mock.patch("imap_processing.hi.l1c.hi_l1c.get_instrument_spin_phase")
 @mock.patch("imap_processing.hi.l1c.hi_l1c.get_de_clock_ticks_for_esa_step")

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -1,5 +1,6 @@
 """Test coverage for imap_processing.hi.l1c.hi_l1c.py"""
 
+from collections import namedtuple
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -137,6 +138,7 @@ def test_pset_geometry(mock_frame_transform, mock_geom_frame_transform, sensor_s
     )
 
 
+@pytest.mark.external_test_data()
 def test_pset_counts(hi_l1_test_data_path, hi_test_cal_prod_config_path):
     """Test coverage for pset_counts function."""
     l1b_de_path = hi_l1_test_data_path / "imap_hi_l1b_45sensor-de_20250415_v999.cdf"
@@ -151,6 +153,52 @@ def test_pset_counts(hi_l1_test_data_path, hi_test_cal_prod_config_path):
     )
     counts_var = hi_l1c.pset_counts(empty_pset.coords, cal_config_df, l1b_dataset)
     assert "counts" in counts_var
+
+
+def test_get_tof_window_mask():
+    """Test coverage for get_tof_window_mask function."""
+    # Create a synthetic dataframe with required columns containing data
+    # intended to test all aspects of the function.
+    fill_vals = {
+        "tof_ab": -11,
+        "tof_ac1": -12,
+        "tof_bc1": -13,
+        "tof_c1c2": -14,
+    }
+    Row = namedtuple(
+        "Row",
+        [
+            "Index",
+            "tof_ab_low",
+            "tof_ab_high",
+            "tof_ac1_low",
+            "tof_ac1_high",
+            "tof_bc1_low",
+            "tof_bc1_high",
+            "tof_c1c2_low",
+            "tof_c1c2_high",
+        ],
+    )
+    prod_config_row = Row((1, 0), 0, 1, -1, 2, 1, 5, 4, 6)
+    synth_df = pd.DataFrame(
+        {
+            "tof_ab": np.array(
+                [0, 2, 1, 0, -1, -5, -11], dtype=np.int32
+            ),  # T, F, T, T, F, F, FILL
+            "tof_ac1": np.array(
+                [-1, 2, -2, 0, 3, 0, -12], dtype=np.int32
+            ),  # T, T, F, T, F, T, FILL
+            "tof_bc1": np.array(
+                [1, 5, 3, 0, 6, 2, -13], dtype=np.int32
+            ),  # T, T, T, F, F, T, FILL
+            "tof_c1c2": np.array(
+                [4, 6, 5, 3, 7, -9, -14], dtype=np.int32
+            ),  # T, T, T, F, F, F, FILL
+        },
+    )
+    expected_mask = np.array([True, False, False, False, False, False, True])
+    window_mask = hi_l1c.get_tof_window_mask(synth_df, prod_config_row, fill_vals)
+    np.testing.assert_array_equal(expected_mask, window_mask)
 
 
 @mock.patch("imap_processing.hi.l1c.hi_l1c.get_spin_data", return_value=None)
@@ -319,7 +367,7 @@ class TestCalibrationProductConfig:
     def test_from_csv(self, hi_test_cal_prod_config_path):
         """Test coverage for read_csv function."""
         df = hi_l1c.CalibrationProductConfig.from_csv(hi_test_cal_prod_config_path)
-        assert isinstance(df["coincidence_type_list"][0, 1], list)
+        assert isinstance(df["coincidence_type_list"][0, 1], tuple)
 
     def test_added_coincidence_type_values_column(self, hi_test_cal_prod_config_path):
         df = CalibrationProductConfig.from_csv(hi_test_cal_prod_config_path)


### PR DESCRIPTION
# Change Summary

## Overview
This adds the L1C PSET function that bins DEs from the L1B DE list into the 3D (4D if you count the size 1 epoch dimension) array of PSET counts.

## Updated Files
- imap_processing/hi/l1c/hi_l1c.py
   - Add the `pset_counts` function 
   - Remove "counts" from the PSET variables that are not implemented
   - Add `get_tof_window_mask` function that generates a mask used to remove DEs not in the specified TOF windows.
   - Add `tof_detector_pairs` to the attributes that belong to the `CalibrationProductConfig` class.
   - Convert "coincidence_type_list" store a tuple so that it is hashable
- imap_processing/tests/hi/test_hi_l1c.py
   - Add test coverage for `pset_counts` function
   - Add test coverage for `get_tof_window_mask` function

Closes: #1150 
