### PR TITLE
Ultra l1c healpix - create spacecraft histogram

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -1,6 +1,7 @@
 "Tests pointing sets"
 
 import cdflib
+import healpy as hp
 import numpy as np
 import pytest
 from cdflib import CDF
@@ -10,7 +11,7 @@ from imap_processing.ena_maps.utils.spatial_utils import build_spatial_bins
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_helio_exposure_times,
-    get_histogram,
+    get_spacecraft_histogram,
     get_pointing_frame_exposure_times,
     get_pointing_frame_sensitivity,
 )
@@ -24,7 +25,7 @@ def test_data():
     vx_sc = np.array([-186.5575, 508.5697, 508.5697, 508.5697])
     vy_sc = np.array([-707.5707, -516.0282, -516.0282, -516.0282])
     vz_sc = np.array([618.0569, 892.6931, 892.6931, 892.6931])
-    energy = np.array([3.384, 3.385, 200, 200])
+    energy = np.array([3.384, 3.385, 4.138, 4.138])
     v = np.column_stack((vx_sc, vy_sc, vz_sc))
 
     return v, energy
@@ -51,18 +52,24 @@ def test_get_histogram(test_data):
     """Tests get_histogram function."""
     v, energy = test_data
 
-    az_bin_edges, el_bin_edges, az_bin_midpoints, el_bin_midpoints = (
-        build_spatial_bins()
-    )
     energy_bin_edges, _ = build_energy_bins()
+    subset_energy_bin_edges = energy_bin_edges[:3]
 
-    hist = get_histogram(v, energy, az_bin_edges, el_bin_edges, energy_bin_edges)
+    hist = get_spacecraft_histogram(v, energy, subset_energy_bin_edges, nside=1)
+    assert hist.shape == (hp.nside2npix(1), len(subset_energy_bin_edges))
 
-    assert hist.shape == (
-        len(az_bin_edges) - 1,
-        len(el_bin_edges) - 1,
-        len(energy_bin_edges),
-    )
+    # Spot check that 2 counts are in the third energy bin
+    assert np.sum(hist[:, 2]) == 2
+
+    # Test overlapping energy bins
+    overlapping_bins = [
+        (0.0, 3.385),
+        (2.5, 4.137),
+        (3.385, 5.057),
+    ]
+    hist = get_spacecraft_histogram(v, energy, overlapping_bins, nside=1)
+    # Spot check that 3 counts are in the third energy bin
+    assert np.sum(hist[:, 2]) == 3
 
 
 def test_get_pointing_frame_exposure_times():

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -1,7 +1,7 @@
 "Tests pointing sets"
 
+import astropy_healpix.healpy as hp
 import cdflib
-import healpy as hp
 import numpy as np
 import pytest
 from cdflib import CDF

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -11,9 +11,9 @@ from imap_processing.ena_maps.utils.spatial_utils import build_spatial_bins
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_helio_exposure_times,
-    get_spacecraft_histogram,
     get_pointing_frame_exposure_times,
     get_pointing_frame_sensitivity,
+    get_spacecraft_histogram,
 )
 
 BASE_PATH = imap_module_directory / "ultra" / "lookup_tables"
@@ -48,7 +48,7 @@ def test_build_energy_bins():
     np.testing.assert_allclose(energy_bin_end[-1], 341.989, atol=1e-4)
 
 
-def test_get_histogram(test_data):
+def test_get_spacecraft_histogram(test_data):
     """Tests get_histogram function."""
     v, energy = test_data
 

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -15,7 +15,6 @@ from imap_processing.spice.geometry import (
     spherical_to_cartesian,
 )
 from imap_processing.ultra.constants import UltraConstants
-from imap_processing.ena_maps.utils.map_utils import bin_single_array_at_indices
 
 # TODO: add species binning.
 
@@ -50,12 +49,12 @@ def build_energy_bins() -> tuple[list[tuple[float, float]], np.ndarray]:
     return intervals, energy_midpoints
 
 
-def get_histogram(
+def get_spacecraft_histogram(
     vhat: tuple[np.ndarray, np.ndarray, np.ndarray],
     energy: np.ndarray,
     energy_bin_edges: list[tuple[float, float]],
     nside: int = 32,
-    nested: bool = True,
+    nested: bool = False,
 ) -> NDArray:
     """
     Compute a 3D histogram of the particle data using HEALPix binning.
@@ -68,42 +67,49 @@ def get_histogram(
         The particle energy.
     energy_bin_edges : list[tuple[float, float]]
         Array of energy bin edges.
-    nside : int
+    nside : int, optional
         The nside parameter of the Healpix tessellation.
+        Default is 32.
     nested : bool, optional
         Whether the Healpix tessellation is nested. Default is False.
 
     Returns
     -------
-    hist_total : np.ndarray
+    hist : np.ndarray
         A 3D histogram array with shape (n_pix, n_energy_bins).
+
+    Notes
+    -----
+    The histogram will work properly for overlapping energy bins, i.e.
+    the same energy value can fall into multiple bins if the intervals overlap.
+
+    azimuthal angle [0, 360], elevation angle [-90, 90]
     """
     spherical_coords = cartesian_to_spherical(vhat, degrees=True)
-    az, el = spherical_coords[..., 1], spherical_coords[..., 2]
+    az, el = (
+        spherical_coords[..., 1],
+        spherical_coords[..., 2],
+    )
 
-    # Convert elevation to HEALPix-compatible latitude
-    lat = np.degrees(90 - el)  # Ensure lat is degrees
-
-    # Compute number of HEALPix pixels
+    # Compute number of HEALPix pixels that cover the sphere
     n_pix = hp.nside2npix(nside)
 
-    # Get HEALPix pixel indices
-    hpix_idx = hp.ang2pix(nside, np.degrees(az), lat, nest=nested, lonlat=True)
+    # Get HEALPix pixel indices for each event
+    # HEALPix expects latitude in [-90, 90] so we don't need to change elevation
+    hpix_idx = hp.ang2pix(nside, az, el, nest=nested, lonlat=True)
 
     # Initialize histogram: (n_HEALPix pixels, n_energy_bins)
-    hist_total = np.zeros((n_pix, len(energy_bin_edges)), dtype=np.float64)
+    # TODO: float? int?
+    hist = np.zeros((n_pix, len(energy_bin_edges)))
 
     # Bin data in energy & HEALPix space
     for i, (e_min, e_max) in enumerate(energy_bin_edges):
         mask = (energy >= e_min) & (energy < e_max)
+        # Only count the events that fall within the energy bin
+        hist[:, i] += np.bincount(hpix_idx[mask],
+                                        minlength=n_pix).astype(np.float64)
 
-        hist_total[:, i] = bin_single_array_at_indices(
-            value_array=np.ones(mask.sum(), dtype=np.float64),  # Count occurrences
-            projection_grid_shape=(n_pix,),
-            projection_indices=hpix_idx[mask],
-        )
-
-    return hist_total
+    return hist
 
 
 def get_pointing_frame_exposure_times(

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import cdflib
+import healpy as hp
 import numpy as np
 from numpy.typing import NDArray
 
@@ -14,6 +15,7 @@ from imap_processing.spice.geometry import (
     spherical_to_cartesian,
 )
 from imap_processing.ultra.constants import UltraConstants
+from imap_processing.ena_maps.utils.map_utils import bin_single_array_at_indices
 
 # TODO: add species binning.
 
@@ -51,12 +53,12 @@ def build_energy_bins() -> tuple[list[tuple[float, float]], np.ndarray]:
 def get_histogram(
     vhat: tuple[np.ndarray, np.ndarray, np.ndarray],
     energy: np.ndarray,
-    az_bin_edges: np.ndarray,
-    el_bin_edges: np.ndarray,
     energy_bin_edges: list[tuple[float, float]],
+    nside: int = 32,
+    nested: bool = True,
 ) -> NDArray:
     """
-    Compute a 3D histogram of the particle data.
+    Compute a 3D histogram of the particle data using HEALPix binning.
 
     Parameters
     ----------
@@ -64,43 +66,42 @@ def get_histogram(
         The x,y,z-components of the unit velocity vector.
     energy : np.ndarray
         The particle energy.
-    az_bin_edges : np.ndarray
-        Array of azimuth bin boundary values.
-    el_bin_edges : np.ndarray
-        Array of elevation bin boundary values.
     energy_bin_edges : list[tuple[float, float]]
         Array of energy bin edges.
+    nside : int
+        The nside parameter of the Healpix tessellation.
+    nested : bool, optional
+        Whether the Healpix tessellation is nested. Default is False.
 
     Returns
     -------
-    hist : np.ndarray
-        A 3D histogram array.
-
-    Notes
-    -----
-    The histogram will now work properly for overlapping energy bins, i.e.
-    the same energy value can fall into multiple bins if the intervals overlap.
+    hist_total : np.ndarray
+        A 3D histogram array with shape (n_pix, n_energy_bins).
     """
-    spherical_coords = cartesian_to_spherical(vhat)
-    az, el = (
-        spherical_coords[..., 1],
-        spherical_coords[..., 2],
-    )
+    spherical_coords = cartesian_to_spherical(vhat, degrees=True)
+    az, el = spherical_coords[..., 1], spherical_coords[..., 2]
 
-    # Initialize histogram
-    hist_total = np.zeros(
-        (len(az_bin_edges) - 1, len(el_bin_edges) - 1, len(energy_bin_edges))
-    )
+    # Convert elevation to HEALPix-compatible latitude
+    lat = np.degrees(90 - el)  # Ensure lat is degrees
 
+    # Compute number of HEALPix pixels
+    n_pix = hp.nside2npix(nside)
+
+    # Get HEALPix pixel indices
+    hpix_idx = hp.ang2pix(nside, np.degrees(az), lat, nest=nested, lonlat=True)
+
+    # Initialize histogram: (n_HEALPix pixels, n_energy_bins)
+    hist_total = np.zeros((n_pix, len(energy_bin_edges)), dtype=np.float64)
+
+    # Bin data in energy & HEALPix space
     for i, (e_min, e_max) in enumerate(energy_bin_edges):
-        # Filter data for current energy bin.
         mask = (energy >= e_min) & (energy < e_max)
-        hist, _ = np.histogramdd(
-            sample=(az[mask], el[mask], energy[mask]),
-            bins=[az_bin_edges, el_bin_edges, [e_min, e_max]],
+
+        hist_total[:, i] = bin_single_array_at_indices(
+            value_array=np.ones(mask.sum(), dtype=np.float64),  # Count occurrences
+            projection_grid_shape=(n_pix,),
+            projection_indices=hpix_idx[mask],
         )
-        # Assign 2D histogram to current energy bin.
-        hist_total[:, :, i] = hist[:, :, 0]
 
     return hist_total
 

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -2,8 +2,8 @@
 
 from pathlib import Path
 
+import astropy_healpix.healpy as hp
 import cdflib
-import healpy as hp
 import numpy as np
 from numpy.typing import NDArray
 
@@ -105,8 +105,7 @@ def get_spacecraft_histogram(
     for i, (e_min, e_max) in enumerate(energy_bin_edges):
         mask = (energy >= e_min) & (energy < e_max)
         # Only count the events that fall within the energy bin
-        hist[:, i] += np.bincount(hpix_idx[mask],
-                                        minlength=n_pix).astype(np.float64)
+        hist[:, i] += np.bincount(hpix_idx[mask], minlength=n_pix).astype(np.float64)
 
     return hist
 

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -99,7 +99,6 @@ def get_spacecraft_histogram(
     hpix_idx = hp.ang2pix(nside, az, el, nest=nested, lonlat=True)
 
     # Initialize histogram: (n_HEALPix pixels, n_energy_bins)
-    # TODO: float? int?
     hist = np.zeros((n_pix, len(energy_bin_edges)))
 
     # Bin data in energy & HEALPix space


### PR DESCRIPTION
# Change Summary

## Overview
Create spacecraft histogram in healpix coordinates

## Updated Files
- ultra_l1c_pset_bins.py
   - Changed from rectangular binning to healpix for spacecraft histogram

## Testing
- test_ultra_l1c_pset_bins.py
