### PR TITLE
Set terminate_on_warning to False for L1 products

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -138,8 +138,8 @@ def write_cdf(
 
     # Convert the xarray object to a CDF
     if "l1" in data_level:
-        if "istp" not in extra_cdf_kwargs:
-            extra_cdf_kwargs["istp"] = False  # type: ignore
+        if "terminate_on_warning" not in extra_cdf_kwargs:
+            extra_cdf_kwargs["terminate_on_warning"] = False  # type: ignore
     else:
         if "terminate_on_warning" not in extra_cdf_kwargs:
             extra_cdf_kwargs["terminate_on_warning"] = True  # type: ignore


### PR DESCRIPTION
This PR updates handling for L1 products when writing to CDF to support datasets that don't have attributes defined.

When `xarray_to_cdf(dataset, filename, istp=True)` is called, one thing it will do is try its best to determine what the DEPEND_0/1/2/etc are and automatically add them to the data variables in the CDF file. Then when calling `cdf_to_xarray`, cdflib knows which variables to set as dimensions in the dataset.

If `istp=False`, cdflib will not do this work and so it's important that attributes are defined in the dataset. For datasets that don't have attributes defined, because they're still in development or it isn't required, this becomes a problem. When reading the CDF file back out to xarray, cdflib will make up dimension names (dim0, dim1, dim2, etc.) as a result.

By instead setting `terminate_on_warning=False`, cdflib will assign the proper dimensions and coordinates whether or not attributes are defined, while not raising errors on ISTP compliance issues.

related to PR #1443 and issue #1442
