### PR TITLE
ENA Maps: Change UltraPointingSet to Healpix

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -372,6 +372,7 @@ class AbstractSkyMap(ABC):
         self.tiling_type: SkyTilingType
         self.sky_grid: spatial_utils.AzElSkyGrid
         self.num_points: int
+        self.spatial_coords: dict[str, xr.DataArray | NDArray]
         self.binning_grid_shape: tuple[int, ...]
         self.data_dict: dict[str, NDArray]
 
@@ -468,6 +469,108 @@ class AbstractSkyMap(ABC):
 
             self.data_dict[value_key] += pointing_projected_values
 
+    def data_dict_value_to_dataarray(
+        self,
+        data_dict_key: str,
+        dims: list[str] | None = None,
+        **kwargs: dict,
+    ) -> xr.DataArray:
+        """
+        Convert an individual array in the data_dict to an xarray DataArray.
+
+        In the case of a rectangular grid, the data array is rewrapped to the original
+        2D grid shape before conversion to an xarray DataArray.
+
+        Parameters
+        ----------
+        data_dict_key : str
+            The key of the data array in the data_dict.
+        dims : list[str] | None, optional
+            The ordered dimensions of the data array. Default is None.
+        **kwargs : dict
+            Additional keyword arguments to pass to the xarray DataArray constructor.
+
+        Returns
+        -------
+        xr.DataArray
+            The data array converted to an xarray DataArray.
+        """
+        data = self.data_dict[data_dict_key]
+
+        # Rewrap the data to the original 2D grid shape if rectangular
+        if self.tiling_type is SkyTilingType.RECTANGULAR:
+            data = spatial_utils.rewrap_even_spaced_az_el_grid(
+                data, self.binning_grid_shape
+            )
+
+        # Add an extra dim at the start for epoch:
+        if dims is not None and dims[0] == "epoch":
+            data = np.expand_dims(data, axis=0)
+
+        return xr.DataArray(
+            data,
+            dims=dims,
+            **kwargs,
+        )
+
+    def to_xarray(
+        self,
+        non_spatial_coords: dict[str, xr.DataArray | NDArray],
+        data_variables_and_dims: dict[str, list[str]],
+    ) -> xr.Dataset:
+        """
+        Convert the data_dict to an xarray Dataset, including spatial coords.
+
+        In the case of a rectangular grid, all data arrays are rewrapped to the
+        original 2D grid shape before conversion to xarray DataArrays.
+
+        Parameters
+        ----------
+        non_spatial_coords : dict[str, xr.DataArray | NDArray],
+            Dictionary of the non-spatial coordinates to include in the dataset.
+            The keys are the names of the coordinates, and the values are either
+            numpy arrays or xarray DataArrays, the latter of which can include
+            coordinate attributes.
+
+            Example using DataArrays to give coord attributes:
+            ```
+            {
+                "epoch": xr.DataArray(
+                    [1234.5], dims=["epoch"], attrs={"units": "J2000ns"}),
+                "energy_bin_center": xr.DataArray(
+                    [1.0, 2.0, 3.0], dims=["energy_bin_center"],
+                    attrs={"units": "keV"}),
+            }
+            ```
+            Example using NDArrays:
+            ```
+            {
+                "epoch": np.array([1234.5]),
+                "energy_bin_center": np.array([1.0, 2.0, 3.0]),
+            }
+            ```.
+        data_variables_and_dims : dict[str, list[str]]
+            The dictionary of data variables (key) and their dimensions (value).
+
+        Returns
+        -------
+        xr.Dataset
+            An xarray Dataset containing the data variables and coordinates.
+        """
+        # Get full dict of coordinates
+        coords = {**non_spatial_coords, **self.spatial_coords}
+
+        return xr.Dataset(
+            data_vars={
+                key: self.data_dict_value_to_dataarray(
+                    key,
+                    dims=dims,
+                )
+                for key, dims in data_variables_and_dims.items()
+            },
+            coords=coords,
+        )
+
 
 class RectangularSkyMap(AbstractSkyMap):
     """
@@ -538,6 +641,19 @@ class RectangularSkyMap(AbstractSkyMap):
         # The shape of the map (num_az_bins, num_el_bins) is used to bin the data
         self.binning_grid_shape = self.sky_grid.grid_shape
 
+        self.spatial_coords = {
+            "azimuth_bin_center": xr.DataArray(
+                self.sky_grid.az_bin_midpoints,
+                dims=["azimuth_bin_center"],
+                attrs={"units": "degrees"},
+            ),
+            "elevation_bin_center": xr.DataArray(
+                self.sky_grid.el_bin_midpoints,
+                dims=["elevation_bin_center"],
+                attrs={"units": "degrees"},
+            ),
+        }
+
         # Unwrap the az, el grids to 1D array of points tiling the sky
         az_points = self.sky_grid.az_grid.ravel()
         el_points = self.sky_grid.el_grid.ravel()
@@ -601,6 +717,12 @@ class HealpixSkyMap(AbstractSkyMap):
         self.approx_resolution = np.rad2deg(hp.nside2resol(nside, arcmin=False))
         # Define binning_grid_shape for consistency with RectangularSkyMap
         self.binning_grid_shape = (self.num_points,)
+        self.spatial_coords = {
+            "healpix_pixel_number": xr.DataArray(
+                np.arange(self.num_points),
+                dims=["healpix_pixel_number"],
+            )
+        }
 
         # The centers of each pixel in the Healpix tessellation in azimuth (az) and
         # elevation (el) coordinates (degrees) within the map's Spice frame.

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -14,6 +14,7 @@ from numpy.typing import NDArray
 
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.ena_maps.utils import map_utils, spatial_utils
+from imap_processing.ena_maps.utils.coordinates import CoordNames
 from imap_processing.spice import geometry
 from imap_processing.spice.time import ttj2000ns_to_et
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -14,6 +14,9 @@ from numpy.typing import NDArray
 
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.ena_maps.utils import map_utils, spatial_utils
+
+# The coordinate names can vary between L1C and L2 data (e.g. azimuth vs longitude),
+# so we define an enum to handle the coordinate names.
 from imap_processing.ena_maps.utils.coordinates import CoordNames
 from imap_processing.spice import geometry
 from imap_processing.spice.time import ttj2000ns_to_et
@@ -246,15 +249,15 @@ class RectangularPointingSet(PointingSet):
         Currently, the dataset is expected to be tiled in a rectangular grid,
         with data_vars indexed along the coordinates:
             - 'epoch' : time value (1 value per PSET)
-            - 'longitude_bin_center' : (number of longitude bins in L1C)
-            - 'latitude_bin_center' : (number of latitude bins in L1C)
+            - 'longitude_bin_center' : (number of longitude/az bins in L1C)
+            - 'latitude_bin_center' : (number of latitude/el bins in L1C)
     spice_reference_frame : geometry.SpiceFrame
         The reference Spice frame of the pointing set. Default is IMAP_DPS.
 
     Raises
     ------
     ValueError
-        If the longitude or latitude bin centers don't match the constructed grid.
+        If the longitude/az or latitude/el bin centers don't match the constructed grid.
         Or if the longitude or latitude bin spacing is not uniform.
     ValueError
         If multiple epochs are found in the dataset.
@@ -339,7 +342,7 @@ class RectangularPointingSet(PointingSet):
 
 class UltraPointingSet(PointingSet):
     """
-    PSET object specifically for Healpix-tiled ULTRA data, nominally at Level 1C.
+    Pointing set object specifically for Healpix-tiled ULTRA data, nominally at Level1C.
 
     Parameters
     ----------
@@ -347,7 +350,7 @@ class UltraPointingSet(PointingSet):
         L1c xarray dataset containing the pointing set data or the path to the dataset.
         Currently, the dataset is expected to be tiled in a HEALPix tessellation,
         with data_vars indexed along the coordinates:
-            - 'epoch' : time value (1 value per PSET)
+            - 'epoch' : time value (1 value per PSET, from the mean of the PSET)
             - 'energy_bin_center' : (number of energy bins in L1C)
             - 'healpix_pixel_index' : HEALPix pixel index
         Only the 'healpix_pixel_index' coordinate is used in this class for projection.
@@ -382,6 +385,7 @@ class UltraPointingSet(PointingSet):
         if len(np.unique(self.epoch)) > 1:
             raise ValueError("Multiple epochs found in the dataset.")
 
+        # Set the tiling type and number of points
         self.tiling_type = SkyTilingType.HEALPIX
         self.num_points = self.data[CoordNames.HEALPIX_INDEX.value].size
         self.nside = hp.npix_to_nside(self.num_points)
@@ -391,7 +395,7 @@ class UltraPointingSet(PointingSet):
             self.data[CoordNames.HEALPIX_INDEX.value].attrs.get("nested", False)
         )
 
-        # Get the azimuth and elevation pixel centers
+        # Get the azimuth and elevation coordinates of the healpix pixel centers (deg)
         self.azimuth_pixel_center, self.elevation_pixel_center = hp.pix2ang(
             nside=self.nside,
             ipix=np.arange(self.num_points),
@@ -419,6 +423,9 @@ class UltraPointingSet(PointingSet):
                     f"Dataset: {self.data[dim]}"
                 )
 
+        # The coordinates of the healpix pixel centers are stored as a 2D array
+        # of shape (num_points, 2) where column 0 is the lon/az
+        # and column 1 is the lat/el.
         self.az_el_points = np.column_stack(
             (self.azimuth_pixel_center, self.elevation_pixel_center)
         )

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -60,20 +60,6 @@ class IndexMatchMethod(Enum):
     PULL = "Pull"
 
 
-class CoordNames(Enum):
-    """Enumeration of the names of the coordinates in the L1C and L2 datasets."""
-
-    TIME = "epoch"
-    ENERGY = "energy_bin_center"
-    HEALPIX_INDEX = "healpix_pixel_index"
-
-    # The names of the az/el angular coordinates may differ between L1C and L2 data
-    AZIMUTH_L1C = "longitude_bin_center"
-    ELEVATION_L1C = "latitude_bin_center"
-    AZIMUTH_L2 = "longitude_bin_center"
-    ELEVATION_L2 = "latitude_bin_center"
-
-
 def match_coords_to_indices(
     input_object: PointingSet | AbstractSkyMap,
     output_object: PointingSet | AbstractSkyMap,

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -59,6 +59,20 @@ class IndexMatchMethod(Enum):
     PULL = "Pull"
 
 
+class CoordNames(Enum):
+    """Enumeration of the names of the coordinates in the L1C dataset."""
+
+    TIME = "epoch"
+    ENERGY = "energy_bin_center"
+    HEALPIX_INDEX = "healpix_pixel_index"
+
+    # The names of the az/el angular coordinates may differ between L1C and L2 data
+    AZIMUTH_L1C = "longitude_bin_center"
+    ELEVATION_L1C = "latitude_bin_center"
+    AZIMUTH_L2 = "longitude_bin_center"
+    ELEVATION_L2 = "latitude_bin_center"
+
+
 def match_coords_to_indices(
     input_object: PointingSet | AbstractSkyMap,
     output_object: PointingSet | AbstractSkyMap,
@@ -234,29 +248,27 @@ class PointingSet(ABC):
         )
 
 
-class UltraPointingSet(PointingSet):
+class RectangularPointingSet(PointingSet):
     """
-    PSET object specifically for ULTRA data, nominally at Level 1C.
+    Pointing set object for rectangularly tiled data. Currently used in testing.
 
     Parameters
     ----------
     l1c_dataset : xr.Dataset | pathlib.Path | str
         L1c xarray dataset containing the pointing set data or the path to the dataset.
-        Currently, the dataset is expected to be in a rectangular grid,
+        Currently, the dataset is expected to be tiled in a rectangular grid,
         with data_vars indexed along the coordinates:
             - 'epoch' : time value (1 value per PSET)
-            - 'azimuth_bin_center' : azimuth bin center values
-            - 'elevation_bin_center' : elevation bin center values
-        Some data_vars may additionally be indexed by energy bin;
-        however, only the spatial axes are used in this class.
+            - 'longitude_bin_center' : (number of longitude bins in L1C)
+            - 'latitude_bin_center' : (number of latitude bins in L1C)
     spice_reference_frame : geometry.SpiceFrame
         The reference Spice frame of the pointing set. Default is IMAP_DPS.
 
     Raises
     ------
     ValueError
-        If the azimuth or elevation bin centers do not match the constructed grid.
-        Or if the azimuth or elevation bin spacing is not uniform.
+        If the longitude or latitude bin centers don't match the constructed grid.
+        Or if the longitude or latitude bin spacing is not uniform.
     ValueError
         If multiple epochs are found in the dataset.
     """
@@ -280,15 +292,12 @@ class UltraPointingSet(PointingSet):
         if len(np.unique(self.epoch)) > 1:
             raise ValueError("Multiple epochs found in the dataset.")
 
-        # The rest of the constructor handles the rectangular grid
-        # aspects of the Ultra PSET.
-        # NOTE: This may be changed to Healpix tessellation in the future
         self.tiling_type = SkyTilingType.RECTANGULAR
 
         # Ensure 1D axes grids are uniformly spaced,
         # then set spacing based on data's azimuth bin spacing.
-        az_bin_delta = np.diff(self.data["azimuth_bin_center"])
-        el_bin_delta = np.diff(self.data["elevation_bin_center"])
+        az_bin_delta = np.diff(self.data[CoordNames.AZIMUTH_L1C.value])
+        el_bin_delta = np.diff(self.data[CoordNames.ELEVATION_L1C.value])
         if not np.allclose(az_bin_delta, az_bin_delta[0], atol=1e-10, rtol=0):
             raise ValueError("Azimuth bin spacing is not uniform.")
         if not np.allclose(el_bin_delta, el_bin_delta[0], atol=1e-10, rtol=0):
@@ -300,26 +309,26 @@ class UltraPointingSet(PointingSet):
             )
         self.spacing_deg = az_bin_delta[0]
 
-        # Build the azimuth and elevation grids with an AzElSkyGrid object
+        # Build the az/azimuth and el/elevation grids with an AzElSkyGrid object
         # and check that the 1D axes match the dataset's az and el.
         self.sky_grid = spatial_utils.AzElSkyGrid(
             spacing_deg=self.spacing_deg,
         )
 
         for dim, constructed_bins in zip(
-            ["azimuth", "elevation"],
+            [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
             [self.sky_grid.az_bin_midpoints, self.sky_grid.el_bin_midpoints],
         ):
             if not np.allclose(
                 sorted(constructed_bins),
-                self.data[f"{dim}_bin_center"],
+                self.data[dim],
                 atol=1e-10,
                 rtol=0,
             ):
                 raise ValueError(
                     f"{dim} bin centers do not match."
                     f"Constructed: {constructed_bins}"
-                    f"Dataset: {self.data[f'{dim}_bin_center']}"
+                    f"Dataset: {self.data[dim]}"
                 )
 
         # Unwrap the az, el grids to series of points tiling the sky and combine them
@@ -339,6 +348,93 @@ class UltraPointingSet(PointingSet):
         # These are 1D arrays of different lengths and cannot be stacked.
         self.az_bin_edges = self.sky_grid.az_bin_edges
         self.el_bin_edges = self.sky_grid.el_bin_edges
+
+
+class UltraPointingSet(PointingSet):
+    """
+    PSET object specifically for Healpix-tiled ULTRA data, nominally at Level 1C.
+
+    Parameters
+    ----------
+    l1c_dataset : xr.Dataset | pathlib.Path | str
+        L1c xarray dataset containing the pointing set data or the path to the dataset.
+        Currently, the dataset is expected to be tiled in a HEALPix tessellation,
+        with data_vars indexed along the coordinates:
+            - 'epoch' : time value (1 value per PSET)
+            - 'energy_bin_center' : (number of energy bins in L1C)
+            - 'healpix_pixel_index' : HEALPix pixel index
+        Only the 'healpix_pixel_index' coordinate is used in this class for projection.
+    spice_reference_frame : geometry.SpiceFrame
+        The reference Spice frame of the pointing set. Default is IMAP_DPS.
+
+    Raises
+    ------
+    ValueError
+        If the longitude/az or latitude/el bin centers don't match the constructed grid.
+        Or if the longitude or latitude bin spacing is not uniform.
+    ValueError
+        If multiple epochs are found in the dataset.
+    """
+
+    def __init__(
+        self,
+        l1c_dataset: xr.Dataset | pathlib.Path | str,
+        spice_reference_frame: geometry.SpiceFrame = geometry.SpiceFrame.IMAP_DPS,
+    ):
+        # Store the reference frame of the pointing set
+        self.spice_reference_frame = spice_reference_frame
+
+        # Read in the data and store the xarray dataset as data attr
+        if isinstance(l1c_dataset, (str, pathlib.Path)):
+            self.data = load_cdf(pathlib.Path(l1c_dataset))
+        elif isinstance(l1c_dataset, xr.Dataset):
+            self.data = l1c_dataset
+
+        # A PSET must have a single epoch
+        self.epoch = self.data["epoch"].values
+        if len(np.unique(self.epoch)) > 1:
+            raise ValueError("Multiple epochs found in the dataset.")
+
+        self.tiling_type = SkyTilingType.HEALPIX
+        self.num_points = self.data[CoordNames.HEALPIX_INDEX.value].size
+        self.nside = hp.npix_to_nside(self.num_points)
+
+        # Determine if the HEALPix tessellation is nested, default is False
+        self.nested = bool(
+            self.data[CoordNames.HEALPIX_INDEX.value].attrs.get("nested", False)
+        )
+
+        # Get the azimuth and elevation pixel centers
+        self.azimuth_pixel_center, self.elevation_pixel_center = hp.pix2ang(
+            nside=self.nside,
+            ipix=np.arange(self.num_points),
+            nest=self.nested,
+            lonlat=True,
+        )
+
+        # Verify that the azimuth and elevation of the healpix pixel centers
+        # match the data's azimuth and elevation bin centers.
+        # NOTE: They can have different names in the L1C dataset
+        # (e.g. "longitude"/"latitude" vs "azimuth"/"elevation").
+        for dim, constructed_bins in zip(
+            [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
+            [self.azimuth_pixel_center, self.elevation_pixel_center],
+        ):
+            if not np.allclose(
+                self.data[dim],
+                constructed_bins,
+                atol=1e-10,
+                rtol=0,
+            ):
+                raise ValueError(
+                    f"{dim} pixel centers do not match the data's {dim} bin centers."
+                    f"Constructed: {constructed_bins}"
+                    f"Dataset: {self.data[dim]}"
+                )
+
+        self.az_el_points = np.column_stack(
+            (self.azimuth_pixel_center, self.elevation_pixel_center)
+        )
 
     def __repr__(self) -> str:
         """
@@ -642,14 +738,14 @@ class RectangularSkyMap(AbstractSkyMap):
         self.binning_grid_shape = self.sky_grid.grid_shape
 
         self.spatial_coords = {
-            "azimuth_bin_center": xr.DataArray(
+            CoordNames.AZIMUTH_L1C.value: xr.DataArray(
                 self.sky_grid.az_bin_midpoints,
-                dims=["azimuth_bin_center"],
+                dims=[CoordNames.AZIMUTH_L1C.value],
                 attrs={"units": "degrees"},
             ),
-            "elevation_bin_center": xr.DataArray(
+            CoordNames.ELEVATION_L1C.value: xr.DataArray(
                 self.sky_grid.el_bin_midpoints,
-                dims=["elevation_bin_center"],
+                dims=[CoordNames.ELEVATION_L1C.value],
                 attrs={"units": "degrees"},
             ),
         }

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -468,7 +468,6 @@ class AbstractSkyMap(ABC):
         self.tiling_type: SkyTilingType
         self.sky_grid: spatial_utils.AzElSkyGrid
         self.num_points: int
-        self.spatial_coords: dict[str, xr.DataArray | NDArray]
         self.binning_grid_shape: tuple[int, ...]
         self.data_dict: dict[str, NDArray]
 
@@ -565,108 +564,6 @@ class AbstractSkyMap(ABC):
 
             self.data_dict[value_key] += pointing_projected_values
 
-    def data_dict_value_to_dataarray(
-        self,
-        data_dict_key: str,
-        dims: list[str] | None = None,
-        **kwargs: dict,
-    ) -> xr.DataArray:
-        """
-        Convert an individual array in the data_dict to an xarray DataArray.
-
-        In the case of a rectangular grid, the data array is rewrapped to the original
-        2D grid shape before conversion to an xarray DataArray.
-
-        Parameters
-        ----------
-        data_dict_key : str
-            The key of the data array in the data_dict.
-        dims : list[str] | None, optional
-            The ordered dimensions of the data array. Default is None.
-        **kwargs : dict
-            Additional keyword arguments to pass to the xarray DataArray constructor.
-
-        Returns
-        -------
-        xr.DataArray
-            The data array converted to an xarray DataArray.
-        """
-        data = self.data_dict[data_dict_key]
-
-        # Rewrap the data to the original 2D grid shape if rectangular
-        if self.tiling_type is SkyTilingType.RECTANGULAR:
-            data = spatial_utils.rewrap_even_spaced_az_el_grid(
-                data, self.binning_grid_shape
-            )
-
-        # Add an extra dim at the start for epoch:
-        if dims is not None and dims[0] == "epoch":
-            data = np.expand_dims(data, axis=0)
-
-        return xr.DataArray(
-            data,
-            dims=dims,
-            **kwargs,
-        )
-
-    def to_xarray(
-        self,
-        non_spatial_coords: dict[str, xr.DataArray | NDArray],
-        data_variables_and_dims: dict[str, list[str]],
-    ) -> xr.Dataset:
-        """
-        Convert the data_dict to an xarray Dataset, including spatial coords.
-
-        In the case of a rectangular grid, all data arrays are rewrapped to the
-        original 2D grid shape before conversion to xarray DataArrays.
-
-        Parameters
-        ----------
-        non_spatial_coords : dict[str, xr.DataArray | NDArray],
-            Dictionary of the non-spatial coordinates to include in the dataset.
-            The keys are the names of the coordinates, and the values are either
-            numpy arrays or xarray DataArrays, the latter of which can include
-            coordinate attributes.
-
-            Example using DataArrays to give coord attributes:
-            ```
-            {
-                "epoch": xr.DataArray(
-                    [1234.5], dims=["epoch"], attrs={"units": "J2000ns"}),
-                "energy_bin_center": xr.DataArray(
-                    [1.0, 2.0, 3.0], dims=["energy_bin_center"],
-                    attrs={"units": "keV"}),
-            }
-            ```
-            Example using NDArrays:
-            ```
-            {
-                "epoch": np.array([1234.5]),
-                "energy_bin_center": np.array([1.0, 2.0, 3.0]),
-            }
-            ```.
-        data_variables_and_dims : dict[str, list[str]]
-            The dictionary of data variables (key) and their dimensions (value).
-
-        Returns
-        -------
-        xr.Dataset
-            An xarray Dataset containing the data variables and coordinates.
-        """
-        # Get full dict of coordinates
-        coords = {**non_spatial_coords, **self.spatial_coords}
-
-        return xr.Dataset(
-            data_vars={
-                key: self.data_dict_value_to_dataarray(
-                    key,
-                    dims=dims,
-                )
-                for key, dims in data_variables_and_dims.items()
-            },
-            coords=coords,
-        )
-
 
 class RectangularSkyMap(AbstractSkyMap):
     """
@@ -737,19 +634,6 @@ class RectangularSkyMap(AbstractSkyMap):
         # The shape of the map (num_az_bins, num_el_bins) is used to bin the data
         self.binning_grid_shape = self.sky_grid.grid_shape
 
-        self.spatial_coords = {
-            CoordNames.AZIMUTH_L1C.value: xr.DataArray(
-                self.sky_grid.az_bin_midpoints,
-                dims=[CoordNames.AZIMUTH_L1C.value],
-                attrs={"units": "degrees"},
-            ),
-            CoordNames.ELEVATION_L1C.value: xr.DataArray(
-                self.sky_grid.el_bin_midpoints,
-                dims=[CoordNames.ELEVATION_L1C.value],
-                attrs={"units": "degrees"},
-            ),
-        }
-
         # Unwrap the az, el grids to 1D array of points tiling the sky
         az_points = self.sky_grid.az_grid.ravel()
         el_points = self.sky_grid.el_grid.ravel()
@@ -813,12 +697,6 @@ class HealpixSkyMap(AbstractSkyMap):
         self.approx_resolution = np.rad2deg(hp.nside2resol(nside, arcmin=False))
         # Define binning_grid_shape for consistency with RectangularSkyMap
         self.binning_grid_shape = (self.num_points,)
-        self.spatial_coords = {
-            "healpix_pixel_number": xr.DataArray(
-                np.arange(self.num_points),
-                dims=["healpix_pixel_number"],
-            )
-        }
 
         # The centers of each pixel in the Healpix tessellation in azimuth (az) and
         # elevation (el) coordinates (degrees) within the map's Spice frame.

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -60,7 +60,7 @@ class IndexMatchMethod(Enum):
 
 
 class CoordNames(Enum):
-    """Enumeration of the names of the coordinates in the L1C dataset."""
+    """Enumeration of the names of the coordinates in the L1C and L2 datasets."""
 
     TIME = "epoch"
     ENERGY = "energy_bin_center"

--- a/imap_processing/ena_maps/utils/coordinates.py
+++ b/imap_processing/ena_maps/utils/coordinates.py
@@ -1,0 +1,17 @@
+"""Define utils and classes related to coordinates of the ENA maps."""
+
+from enum import Enum
+
+
+class CoordNames(Enum):
+    """Enumeration of the names of the coordinates in the L1C and L2 ENA datasets."""
+
+    TIME = "epoch"
+    ENERGY = "energy_bin_center"
+    HEALPIX_INDEX = "healpix_pixel_index"
+
+    # The names of the az/el angular coordinates may differ between L1C and L2 data
+    AZIMUTH_L1C = "longitude_bin_center"
+    ELEVATION_L1C = "latitude_bin_center"
+    AZIMUTH_L2 = "longitude_bin_center"
+    ELEVATION_L2 = "latitude_bin_center"

--- a/imap_processing/tests/ena_maps/conftest.py
+++ b/imap_processing/tests/ena_maps/conftest.py
@@ -1,0 +1,48 @@
+"""Shared fixtures for ENA maps tests."""
+
+import numpy as np
+import pytest
+
+from imap_processing.tests.ultra.test_data.mock_data import (
+    mock_l1c_pset_product_healpix,
+    mock_l1c_pset_product_rectangular,
+)
+
+
+@pytest.fixture(scope="module")
+def ultra_l1c_pset_datasets():
+    """Make fake L1C Ultra PSET products on a HEALPix tiling for testing"""
+    l1c_nside = 64
+    return {
+        "nside": l1c_nside,
+        "products": [
+            mock_l1c_pset_product_healpix(
+                nside=l1c_nside,
+                stripe_center_lat=mid_latitude,
+                width_scale=5,
+                counts_scaling_params=(50, 0.5),
+                peak_exposure=1000,
+                timestr=f"2025-09-{i + 1:02d}T12:00:00",
+                head="90",
+            )
+            for i, mid_latitude in enumerate(np.arange(-90, 90, 22.5))
+        ],
+    }
+
+
+@pytest.fixture(scope="session")
+def rectangular_l1c_pset_datasets():
+    """Make fake L1C Ultra PSET products on a rectangular tiling for testing"""
+    l1c_spacing_deg = 1
+    return {
+        "spacing": l1c_spacing_deg,
+        "products": [
+            mock_l1c_pset_product_rectangular(
+                spacing_deg=l1c_spacing_deg,
+                stripe_center_lon=mid_longitude,
+                timestr=f"2025-09-{i + 1:02d}T12:00:00",
+                head="90",
+            )
+            for i, mid_longitude in enumerate(np.arange(0, 360, 45))
+        ],
+    }

--- a/imap_processing/tests/ena_maps/conftest.py
+++ b/imap_processing/tests/ena_maps/conftest.py
@@ -39,10 +39,13 @@ def rectangular_l1c_pset_datasets():
         "products": [
             mock_l1c_pset_product_rectangular(
                 spacing_deg=l1c_spacing_deg,
-                stripe_center_lon=mid_longitude,
+                stripe_center_lat=mid_latitude,
+                width_scale=5,
+                counts_scaling_params=(50, 0.5),
+                peak_exposure=1000,
                 timestr=f"2025-09-{i + 1:02d}T12:00:00",
                 head="90",
             )
-            for i, mid_longitude in enumerate(np.arange(0, 360, 45))
+            for i, mid_latitude in enumerate(np.arange(-90, 90, 22.5))
         ],
     }

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -7,43 +7,17 @@ from unittest import mock
 import astropy_healpix.healpy as hp
 import numpy as np
 import pytest
-import xarray as xr
 
 from imap_processing.ena_maps import ena_maps
 from imap_processing.spice import geometry
-from imap_processing.tests.ultra.test_data.mock_data import mock_l1c_pset_product
-
-
-@pytest.fixture()
-def l1c_pset_products():
-    """Make fake L1C Ultra PSET products for testing"""
-    l1c_spatial_bin_spacing_deg = 2
-    return {
-        "spacing": l1c_spatial_bin_spacing_deg,
-        "products": [
-            mock_l1c_pset_product(
-                spacing_deg=l1c_spatial_bin_spacing_deg,
-                stripe_center_lon=mid_longitude,
-                timestr=f"2025-09-{i + 1:02d}T12:00:00",
-                head=("45" if (i % 2 == 0) else "90"),
-            )
-            for i, mid_longitude in enumerate(
-                np.arange(
-                    0,
-                    360,
-                    45,
-                )
-            )
-        ],
-    }
 
 
 class TestUltraPointingSet:
     @pytest.fixture(autouse=True)
-    def _setup_ultra_l1c_pset_products(self, l1c_pset_products):
+    def _setup_ultra_l1c_pset_products(self, ultra_l1c_pset_datasets):
         """Setup fixture data as class attributes"""
-        self.l1c_spatial_bin_spacing_deg = l1c_pset_products["spacing"]
-        self.l1c_pset_products = l1c_pset_products["products"]
+        self.nside = ultra_l1c_pset_datasets["nside"]
+        self.l1c_pset_products = ultra_l1c_pset_datasets["products"]
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
     def test_instantiate(self):
@@ -57,71 +31,63 @@ class TestUltraPointingSet:
         ]
 
         for ultra_pset in ultra_psets:
-            # Check tiling is rectangular
-            assert ultra_pset.tiling_type == ena_maps.SkyTilingType.RECTANGULAR
+            # Check tiling is HEALPix
+            assert ultra_pset.tiling_type is ena_maps.SkyTilingType.HEALPIX
 
             # Check that the reference frame is correctly set
-            assert ultra_pset.spice_reference_frame == geometry.SpiceFrame.IMAP_DPS
+            assert ultra_pset.spice_reference_frame is geometry.SpiceFrame.IMAP_DPS
 
             # Check the number of points is (360/0.5) * (180/0.5)
             np.testing.assert_equal(
                 ultra_pset.num_points,
-                int(360 * 180 / (self.l1c_spatial_bin_spacing_deg**2)),
+                hp.nside2npix(self.nside),
             )
 
             # Check the repr exists
             assert "UltraPointingSet" in repr(ultra_pset)
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
-    def test_uneven_spacing_raises_error(self):
-        """Test that uneven spacing in az/el raises ValueError"""
+    def test_different_spacing_raises_error(self):
+        """Test that different spaced az/el from the L1C dataset raises ValueError"""
 
-        # Create dataset with uneven az spacing
-        uneven_az_dataset = xr.Dataset()
-        uneven_az_dataset["epoch"] = 1
-        uneven_az_dataset["azimuth_bin_center"] = np.array([0, 5, 15, 20, 30])
-        uneven_az_dataset["elevation_bin_center"] = np.arange(5)
+        ultra_pset_ds = self.l1c_pset_products[0]
+        # Modify the dataset to have different spacing
+        ultra_pset_ds["latitude_bin_center"].values = np.arange(
+            ultra_pset_ds["latitude_bin_center"].size
+        )
 
-        with pytest.raises(ValueError, match="Azimuth bin spacing is not uniform"):
+        with pytest.raises(ValueError, match="do not match"):
             ena_maps.UltraPointingSet(
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=uneven_az_dataset,
-            )
-
-        uneven_az_dataset["azimuth_bin_center"] = np.arange(5)
-        uneven_az_dataset["elevation_bin_center"] = np.array([0, 5, 15, 20, 30])
-
-        with pytest.raises(ValueError, match="Elevation bin spacing is not uniform"):
-            ena_maps.UltraPointingSet(
-                spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=uneven_az_dataset,
-            )
-
-        # Even but not the same spacing between az and el
-        uneven_az_dataset["azimuth_bin_center"] = np.arange(5)
-        uneven_az_dataset["elevation_bin_center"] = np.arange(5) * 2
-
-        with pytest.raises(
-            ValueError, match="Azimuth and elevation bin spacing do not match:"
-        ):
-            ena_maps.UltraPointingSet(
-                spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=uneven_az_dataset,
+                l1c_dataset=ultra_pset_ds,
             )
 
 
 class TestRectangularSkyMap:
     @pytest.fixture(autouse=True)
-    def _setup_ultra_l1c_pset_products(self, l1c_pset_products):
+    def _setup_ultra_l1c_pset_products(self, ultra_l1c_pset_datasets):
         """Setup fixture data as class attributes"""
-        self.l1c_spatial_bin_spacing_deg = l1c_pset_products["spacing"]
-        self.l1c_pset_products = l1c_pset_products["products"]
+        self.ultra_l1c_nside = ultra_l1c_pset_datasets["nside"]
+        self.ultra_l1c_pset_products = ultra_l1c_pset_datasets["products"]
         self.ultra_psets = [
             ena_maps.UltraPointingSet(
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
                 l1c_dataset=l1c_product,
             )
-            for l1c_product in self.l1c_pset_products
+            for l1c_product in self.ultra_l1c_pset_products
+        ]
+
+    @pytest.fixture(autouse=True)
+    def _setup_rectangular_l1c_pset_products(self, rectangular_l1c_pset_datasets):
+        """Setup fixture data as class attributes"""
+        self.rectangular_l1c_spacing_deg = rectangular_l1c_pset_datasets["spacing"]
+        self.rectangular_l1c_pset_products = rectangular_l1c_pset_datasets["products"]
+        self.rectangular_psets = [
+            ena_maps.RectangularPointingSet(
+                spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+                l1c_dataset=l1c_product,
+            )
+            for l1c_product in self.rectangular_l1c_pset_products
         ]
 
     def test_instantiate(self):
@@ -149,17 +115,17 @@ class TestRectangularSkyMap:
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
-    def test_project_pset_values_to_map_push_method(self, mock_frame_transform_az_el):
+    def test_project_healpix_pset_values_to_map_push_method(
+        self, mock_frame_transform_az_el
+    ):
         """
-        Test projection of PSET values to Rect. Map w "push" index matching method.
+        Test projection of Healpix tiled PSET values to RectMap w "push" index matching.
 
-        If frame_transform_az_el is mocked to return the az and el unchanged, and the
-        map has the same spacing as the PSETs, then the map should have
-        the same values as the PSETs, summed.
+        If frame_transform_az_el is mocked to return the az and el unchanged,
+        then the map should have the same total counts in each energy bin
+        as the PSETs, summed.
         """
         index_matching_method = ena_maps.IndexMatchMethod.PUSH
-
-        pset_spacing_deg = self.ultra_psets[0].spacing_deg
 
         # Mock frame_transform to return the az and el unchanged
         mock_frame_transform_az_el.side_effect = (
@@ -167,7 +133,7 @@ class TestRectangularSkyMap:
         )
 
         rectangular_map = ena_maps.RectangularSkyMap(
-            spacing_deg=pset_spacing_deg,
+            spacing_deg=2,
             spice_frame=geometry.SpiceFrame.ECLIPJ2000,
         )
 
@@ -183,8 +149,60 @@ class TestRectangularSkyMap:
         assert "counts" in rectangular_map.data_dict
 
         # Check that the map has the same values as the PSETs, summed
+        simple_summed_pset_counts = np.zeros_like(
+            self.ultra_l1c_pset_products[0]["counts"]
+        )
+        for pset in self.ultra_l1c_pset_products:
+            simple_summed_pset_counts += pset["counts"].values
+
+        rm_counts_per_energy_bin = rectangular_map.data_dict["counts"].sum(axis=1)
+        summed_pset_counts_per_energy_bin = simple_summed_pset_counts.sum(axis=(0, 2))
+
+        np.testing.assert_array_equal(
+            rm_counts_per_energy_bin,
+            summed_pset_counts_per_energy_bin,
+        )
+
+    @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_project_rect_pset_values_to_map_push_method(
+        self, mock_frame_transform_az_el
+    ):
+        """
+        Test projection of Rect PSET values to Rect Map w "push" index matching method.
+
+        If frame_transform_az_el is mocked to return the az and el unchanged, and the
+        map has the same spacing as the PSETs, then the map should have
+        the same values as the PSETs, summed.
+        """
+        index_matching_method = ena_maps.IndexMatchMethod.PUSH
+
+        pset_spacing_deg = self.rectangular_psets[0].spacing_deg
+
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        rectangular_map = ena_maps.RectangularSkyMap(
+            spacing_deg=pset_spacing_deg,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+
+        # Project each PSET's values to the map (push method)
+        for rectangular_pset in self.rectangular_psets:
+            rectangular_map.project_pset_values_to_map(
+                rectangular_pset,
+                value_keys=["counts", "exposure_time"],
+                index_match_method=index_matching_method,
+            )
+
+        # Check that the map has been updated
+        assert "counts" in rectangular_map.data_dict
+
+        # Check that the map has the same values as the PSETs, summed
         simple_summed_pset_counts = np.zeros_like(rectangular_map.data_dict["counts"])
-        for pset in self.l1c_pset_products:
+        for pset in self.rectangular_l1c_pset_products:
             reshaped_pset_counts = pset["counts"].squeeze("epoch")
             # Reshape to the map's counts shape
             reshaped_pset_counts = reshaped_pset_counts.data.reshape(
@@ -213,10 +231,15 @@ class TestRectangularSkyMap:
                 index_match_method=index_matching_method,
             )
 
-    @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
+    @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
     def test_project_pset_values_to_map_pull_method(self, mock_frame_transform_az_el):
-        """Test projection to Rect. Map with "pull" index matching method."""
+        """
+        Test projection Rect PSET to Rect. Map with "pull" index matching method.
+
+        NOTE: Pull index matching is only expected to be done with Rectangularly tiled
+        PointingSet objects.
+        """
 
         index_matching_method = ena_maps.IndexMatchMethod.PULL
         skymap_spacing = 10
@@ -237,23 +260,25 @@ class TestRectangularSkyMap:
         # Another way to test this is that (if the PSET pixels are
         # smaller than the SkyMap pixels) the sum of the counts in all PSETs should
         # be (PSET_spacing / SkyMap_spacing)^2 times the sum of the counts in the SkyMap
-        total_pset_counts = np.zeros_like(self.ultra_psets[0].data["counts"].values)
+        total_pset_counts = np.zeros_like(
+            self.rectangular_l1c_pset_products[0]["counts"].values
+        )
 
         # Project each PSET's values to the map (pull method)
-        for pset_num, ultra_pset in enumerate(self.ultra_psets):
+        for pset_num, rectangular_pset in enumerate(self.rectangular_psets):
             # Set the counts to be 0 in the first PSET, 1 in the second, etc.
-            ultra_pset.data["counts"].values = np.full_like(
-                ultra_pset.data["counts"].values, pset_num
+            rectangular_pset.data["counts"].values = np.full_like(
+                rectangular_pset.data["counts"].values, pset_num
             )
 
             rectangular_map.project_pset_values_to_map(
-                ultra_pset,
+                rectangular_pset,
                 value_keys=["counts", "exposure_time"],
                 index_match_method=index_matching_method,
             )
             expected_value_every_pixel += pset_num
 
-            total_pset_counts += ultra_pset.data["counts"].values
+            total_pset_counts += rectangular_pset.data["counts"].values
 
         # Check that the map has been updated
         assert "counts" in rectangular_map.data_dict
@@ -262,7 +287,7 @@ class TestRectangularSkyMap:
             rectangular_map.data_dict["counts"],
             expected_value_every_pixel,
         )
-        downsample_ratio = skymap_spacing / self.l1c_spatial_bin_spacing_deg
+        downsample_ratio = skymap_spacing / self.rectangular_l1c_spacing_deg
         np.testing.assert_allclose(
             rectangular_map.data_dict["counts"].sum(),
             total_pset_counts.sum() / (downsample_ratio**2),
@@ -271,16 +296,29 @@ class TestRectangularSkyMap:
 
 class TestHealpixSkyMap:
     @pytest.fixture(autouse=True)
-    def _setup_ultra_l1c_pset_products(self, l1c_pset_products):
+    def _setup_ultra_l1c_pset_products(self, ultra_l1c_pset_datasets):
         """Setup fixture data as class attributes"""
-        self.l1c_spatial_bin_spacing_deg = l1c_pset_products["spacing"]
-        self.l1c_pset_products = l1c_pset_products["products"]
+        self.ultra_l1c_nside = ultra_l1c_pset_datasets["nside"]
+        self.ultra_l1c_pset_products = ultra_l1c_pset_datasets["products"]
         self.ultra_psets = [
             ena_maps.UltraPointingSet(
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
                 l1c_dataset=l1c_product,
             )
-            for l1c_product in self.l1c_pset_products
+            for l1c_product in self.ultra_l1c_pset_products
+        ]
+
+    @pytest.fixture(autouse=True)
+    def _setup_rectangular_l1c_pset_products(self, rectangular_l1c_pset_datasets):
+        """Setup fixture data as class attributes"""
+        self.rectangular_l1c_spacing_deg = rectangular_l1c_pset_datasets["spacing"]
+        self.rectangular_l1c_pset_products = rectangular_l1c_pset_datasets["products"]
+        self.rectangular_psets = [
+            ena_maps.RectangularPointingSet(
+                spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+                l1c_dataset=l1c_product,
+            )
+            for l1c_product in self.rectangular_l1c_pset_products
         ]
 
     @pytest.mark.parametrize(
@@ -318,18 +356,18 @@ class TestHealpixSkyMap:
         # Check that the binning grid shape is just a tuple of num_points
         np.testing.assert_equal(hp_map.binning_grid_shape, (hp_map.num_points,))
 
-    @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
+    @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
     @pytest.mark.parametrize(
         "nside,degree_tolerance",
         [
             (8, 6),
-            (16, 2),
+            (16, 3),
             (32, 2),
         ],
     )
     @pytest.mark.parametrize("nested", [True, False], ids=["nested", "ring"])
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
-    def test_project_pset_values_to_map_push_method(
+    def test_project_rect_pset_values_to_map_push_method(
         self, mock_frame_transform_az_el, nside, degree_tolerance, nested
     ):
         """
@@ -347,8 +385,8 @@ class TestHealpixSkyMap:
         index_matching_method = ena_maps.IndexMatchMethod.PUSH
 
         # Create a PointingSet with a bright spot
-        mock_pset_input_frame = ena_maps.UltraPointingSet(
-            l1c_dataset=self.l1c_pset_products[0],
+        mock_pset_input_frame = ena_maps.RectangularPointingSet(
+            l1c_dataset=self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         mock_pset_input_frame.data["counts"].values = np.zeros_like(
@@ -395,20 +433,110 @@ class TestHealpixSkyMap:
             atol=degree_tolerance,
         )
 
+    @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
+    @pytest.mark.parametrize(
+        "nside,degree_tolerance",
+        [
+            (8, 6),
+            (16, 3),
+            (32, 2),
+        ],
+    )
+    @pytest.mark.parametrize("nested", [True, False], ids=["nested", "ring"])
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_project_healpix_pset_values_to_map_push_method(
+        self, mock_frame_transform_az_el, nside, degree_tolerance, nested
+    ):
+        """
+        Test that PointingSet which contains bright spot pushes to correct spot in map.
+
+        Parameterized over nside (of the map, not the PSET), nested.
+        The tolerance for lower nsides must be higher because the
+        Healpix pixels are larger.
+        """
+
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        index_matching_method = ena_maps.IndexMatchMethod.PUSH
+
+        # Create a PointingSet with a bright spot
+        mock_pset_input_frame = ena_maps.UltraPointingSet(
+            l1c_dataset=self.ultra_l1c_pset_products[0],
+            spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+        )
+        mock_pset_input_frame.data["counts"].values = np.zeros_like(
+            mock_pset_input_frame.data["counts"].values
+        )
+
+        input_bright_pixel_number = hp.ang2pix(
+            nside=mock_pset_input_frame.nside,
+            theta=180,
+            phi=0,
+            nest=mock_pset_input_frame.nested,
+            lonlat=True,
+        )
+        input_bright_pixel_az_el_deg = mock_pset_input_frame.az_el_points[
+            input_bright_pixel_number
+        ]
+        mock_pset_input_frame.data["counts"].values[
+            :,
+            :,
+            input_bright_pixel_number,
+        ] = 1
+
+        # Create a Healpix map
+        hp_map = ena_maps.HealpixSkyMap(
+            nside=nside,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+            nested=nested,
+        )
+
+        # Project the PointingSet to the Healpix map
+        hp_map.project_pset_values_to_map(
+            mock_pset_input_frame,
+            value_keys=[
+                "counts",
+            ],
+            index_match_method=index_matching_method,
+        )
+
+        # Check that the map has been updated
+        assert "counts" in hp_map.data_dict
+
+        # Find the maximum value in the spatial pixel dimension of the healpix map
+        bright_hp_pixel_index = hp_map.data_dict["counts"][0, :].argmax()
+        bright_hp_pixel_az_el = hp_map.az_el_points[bright_hp_pixel_index]
+
+        np.testing.assert_allclose(
+            bright_hp_pixel_az_el,
+            input_bright_pixel_az_el_deg,
+            atol=degree_tolerance,
+        )
+
 
 class TestIndexMatching:
     @pytest.fixture(autouse=True)
-    def _setup_ultra_l1c_pset_products(self, l1c_pset_products):
+    def _setup_rectangular_l1c_pset_products(self, rectangular_l1c_pset_datasets):
         """Setup fixture data as class attributes"""
-        self.l1c_spatial_bin_spacing_deg = l1c_pset_products["spacing"]
-        self.l1c_pset_products = l1c_pset_products["products"]
+        self.rectangular_l1c_spacing_deg = rectangular_l1c_pset_datasets["spacing"]
+        self.rectangular_l1c_pset_products = rectangular_l1c_pset_datasets["products"]
+        self.rectangular_psets = [
+            ena_maps.RectangularPointingSet(
+                spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+                l1c_dataset=l1c_product,
+            )
+            for l1c_product in self.rectangular_l1c_pset_products
+        ]
 
     @pytest.mark.parametrize(
         "map_spacing_deg",
         [0.5, 1, 10],
     )
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
-    def test_match_coords_to_indices_pset_to_rect_map(
+    def test_match_coords_to_indices_rect_pset_to_rect_map(
         self, mock_frame_transform_az_el, map_spacing_deg
     ):
         # Mock frame_transform to return the az and el unchanged
@@ -417,8 +545,8 @@ class TestIndexMatching:
         )
 
         # Mock a PSET, overriding the az/el points
-        mock_pset_input_frame = ena_maps.UltraPointingSet(
-            l1c_dataset=self.l1c_pset_products[0],
+        mock_pset_input_frame = ena_maps.RectangularPointingSet(
+            l1c_dataset=self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         manual_az_el_coords = np.array(
@@ -483,7 +611,7 @@ class TestIndexMatching:
     )
     @pytest.mark.parametrize("nested", [True, False], ids=["nested", "ring"])
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
-    def test_match_coords_to_indices_pset_to_healpix_map(
+    def test_match_coords_to_indices_rect_pset_to_healpix_map(
         self, mock_frame_transform_az_el, nside, degree_tolerance, nested
     ):
         # Mock frame_transform to return the az and el unchanged
@@ -495,8 +623,8 @@ class TestIndexMatching:
         )
 
         # Make a PointingSet
-        mock_pset_input_frame = ena_maps.UltraPointingSet(
-            l1c_dataset=self.l1c_pset_products[0],
+        mock_pset_input_frame = ena_maps.RectangularPointingSet(
+            l1c_dataset=self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
 
@@ -509,11 +637,11 @@ class TestIndexMatching:
         # are the same as the input az/el points to within degree_tolerance,
         # but we must ignore the polar regions and azimuthal wrap-around regions
         rect_equatorial_elevations_mask = (
-            np.abs(mock_pset_input_frame.az_el_points[:, 1]) < 70
+            np.abs(mock_pset_input_frame.az_el_points[:, 1]) < 60
         )
         rect_az_non_wraparound_mask = (
-            mock_pset_input_frame.az_el_points[:, 0] < 350
-        ) & (mock_pset_input_frame.az_el_points[:, 0] > 10)
+            mock_pset_input_frame.az_el_points[:, 0] < 340
+        ) & (mock_pset_input_frame.az_el_points[:, 0] > 20)
         rect_good_az_el_mask = (
             rect_equatorial_elevations_mask & rect_az_non_wraparound_mask
         )
@@ -534,8 +662,8 @@ class TestIndexMatching:
     def test_match_coords_to_indices_pset_to_invalid_map(
         self,
     ):
-        mock_pset_input_frame = ena_maps.UltraPointingSet(
-            l1c_dataset=self.l1c_pset_products[0],
+        mock_pset_input_frame = ena_maps.RectangularPointingSet(
+            l1c_dataset=self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.ECLIPJ2000,
         )
         # Until implemented, just change the tiling on a RectangularSkyMap
@@ -550,12 +678,12 @@ class TestIndexMatching:
             ena_maps.match_coords_to_indices(mock_pset_input_frame, mock_invalid_map)
 
     def test_match_coords_to_indices_pset_to_pset_error(self):
-        mock_pset_input_frame = ena_maps.UltraPointingSet(
-            l1c_dataset=self.l1c_pset_products[0],
+        mock_pset_input_frame = ena_maps.RectangularPointingSet(
+            l1c_dataset=self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
-        mock_pset_output_frame = ena_maps.UltraPointingSet(
-            l1c_dataset=self.l1c_pset_products[1],
+        mock_pset_output_frame = ena_maps.RectangularPointingSet(
+            l1c_dataset=self.rectangular_l1c_pset_products[1],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         with pytest.raises(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from unittest import mock
 
 import astropy_healpix.healpy as hp
@@ -12,12 +13,36 @@ from imap_processing.ena_maps import ena_maps
 from imap_processing.spice import geometry
 
 
+@pytest.fixture(autouse=True, scope="module")
+def setup_all_pset_products(ultra_l1c_pset_datasets, rectangular_l1c_pset_datasets):
+    """
+    Setup fixture data once for all tests.
+
+    This is relatively computationally intensive for the high resolution PSETs,
+    so we use a module-level fixture to avoid repeating the setup code. However,
+    some tests need to modify the PSETs, so we use a function-level fixture to
+    make a deepcopy of the PSETs for each test function.
+    """
+    hp_ultra_nside = ultra_l1c_pset_datasets["nside"]
+    hp_ultra_l1c_pset_products = ultra_l1c_pset_datasets["products"]
+    rect_spacing = rectangular_l1c_pset_datasets["spacing"]
+    rect_rectangular_l1c_pset_products = rectangular_l1c_pset_datasets["products"]
+    return {
+        "hp_ultra_nside": hp_ultra_nside,
+        "hp_ultra_l1c_pset_products": hp_ultra_l1c_pset_products,
+        "rect_spacing": rect_spacing,
+        "rect_rectangular_l1c_pset_products": rect_rectangular_l1c_pset_products,
+    }
+
+
 class TestUltraPointingSet:
     @pytest.fixture(autouse=True)
-    def _setup_ultra_l1c_pset_products(self, ultra_l1c_pset_datasets):
+    def _setup_ultra_l1c_pset_products(self, setup_all_pset_products):
         """Setup fixture data as class attributes"""
-        self.nside = ultra_l1c_pset_datasets["nside"]
-        self.l1c_pset_products = ultra_l1c_pset_datasets["products"]
+        self.nside = setup_all_pset_products["hp_ultra_nside"]
+        self.l1c_pset_products = deepcopy(
+            setup_all_pset_products["hp_ultra_l1c_pset_products"]
+        )
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
     def test_instantiate(self):
@@ -65,10 +90,12 @@ class TestUltraPointingSet:
 
 class TestRectangularSkyMap:
     @pytest.fixture(autouse=True)
-    def _setup_ultra_l1c_pset_products(self, ultra_l1c_pset_datasets):
+    def _setup_ultra_l1c_pset_products(self, setup_all_pset_products):
         """Setup fixture data as class attributes"""
-        self.ultra_l1c_nside = ultra_l1c_pset_datasets["nside"]
-        self.ultra_l1c_pset_products = ultra_l1c_pset_datasets["products"]
+        self.ultra_l1c_nside = setup_all_pset_products["hp_ultra_nside"]
+        self.ultra_l1c_pset_products = deepcopy(
+            setup_all_pset_products["hp_ultra_l1c_pset_products"]
+        )
         self.ultra_psets = [
             ena_maps.UltraPointingSet(
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
@@ -78,10 +105,12 @@ class TestRectangularSkyMap:
         ]
 
     @pytest.fixture(autouse=True)
-    def _setup_rectangular_l1c_pset_products(self, rectangular_l1c_pset_datasets):
+    def _setup_rectangular_l1c_pset_products(self, setup_all_pset_products):
         """Setup fixture data as class attributes"""
-        self.rectangular_l1c_spacing_deg = rectangular_l1c_pset_datasets["spacing"]
-        self.rectangular_l1c_pset_products = rectangular_l1c_pset_datasets["products"]
+        self.rectangular_l1c_spacing_deg = setup_all_pset_products["rect_spacing"]
+        self.rectangular_l1c_pset_products = deepcopy(
+            setup_all_pset_products["rect_rectangular_l1c_pset_products"]
+        )
         self.rectangular_psets = [
             ena_maps.RectangularPointingSet(
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
@@ -296,10 +325,12 @@ class TestRectangularSkyMap:
 
 class TestHealpixSkyMap:
     @pytest.fixture(autouse=True)
-    def _setup_ultra_l1c_pset_products(self, ultra_l1c_pset_datasets):
+    def _setup_ultra_l1c_pset_products(self, setup_all_pset_products):
         """Setup fixture data as class attributes"""
-        self.ultra_l1c_nside = ultra_l1c_pset_datasets["nside"]
-        self.ultra_l1c_pset_products = ultra_l1c_pset_datasets["products"]
+        self.ultra_l1c_nside = setup_all_pset_products["hp_ultra_nside"]
+        self.ultra_l1c_pset_products = deepcopy(
+            setup_all_pset_products["hp_ultra_l1c_pset_products"]
+        )
         self.ultra_psets = [
             ena_maps.UltraPointingSet(
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
@@ -309,10 +340,12 @@ class TestHealpixSkyMap:
         ]
 
     @pytest.fixture(autouse=True)
-    def _setup_rectangular_l1c_pset_products(self, rectangular_l1c_pset_datasets):
+    def _setup_rectangular_l1c_pset_products(self, setup_all_pset_products):
         """Setup fixture data as class attributes"""
-        self.rectangular_l1c_spacing_deg = rectangular_l1c_pset_datasets["spacing"]
-        self.rectangular_l1c_pset_products = rectangular_l1c_pset_datasets["products"]
+        self.rectangular_l1c_spacing_deg = setup_all_pset_products["rect_spacing"]
+        self.rectangular_l1c_pset_products = deepcopy(
+            setup_all_pset_products["rect_rectangular_l1c_pset_products"]
+        )
         self.rectangular_psets = [
             ena_maps.RectangularPointingSet(
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
@@ -519,10 +552,12 @@ class TestHealpixSkyMap:
 
 class TestIndexMatching:
     @pytest.fixture(autouse=True)
-    def _setup_rectangular_l1c_pset_products(self, rectangular_l1c_pset_datasets):
+    def _setup_rectangular_l1c_pset_products(self, setup_all_pset_products):
         """Setup fixture data as class attributes"""
-        self.rectangular_l1c_spacing_deg = rectangular_l1c_pset_datasets["spacing"]
-        self.rectangular_l1c_pset_products = rectangular_l1c_pset_datasets["products"]
+        self.rectangular_l1c_spacing_deg = setup_all_pset_products["rect_spacing"]
+        self.rectangular_l1c_pset_products = deepcopy(
+            setup_all_pset_products["rect_rectangular_l1c_pset_products"]
+        )
         self.rectangular_psets = [
             ena_maps.RectangularPointingSet(
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -281,11 +281,11 @@ def mock_l1c_pset_product_healpix(  # noqa: PLR0913
                 ],
                 sensitivity,
             ),
-            "azimuth_pixel_center": (
+            "longitude_bin_center": (
                 ["healpix_pixel_index"],
                 lon_pix,
             ),
-            "elevation_pixel_center": (
+            "latitude_bin_center": (
                 ["healpix_pixel_index"],
                 lat_pix,
             ),

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -1,5 +1,6 @@
 """Mock expected data for use in some tests."""
 
+import astropy_healpix.healpy as hp
 import numpy as np
 import spiceypy as spice
 import xarray as xr
@@ -8,11 +9,12 @@ from imap_processing.spice.kernels import ensure_spice
 from imap_processing.spice.time import str_to_et
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import build_energy_bins
 
-DEFAULT_SPACING_DEG_L1C = 0.5
+DEFAULT_RECT_SPACING_DEG_L1C = 0.5
+DEFAULT_HEALPIX_NSIDE_L1C = 128
 
 
-def mock_l1c_pset_product(
-    spacing_deg: float = DEFAULT_SPACING_DEG_L1C,
+def mock_l1c_pset_product_rectangular(
+    spacing_deg: float = DEFAULT_RECT_SPACING_DEG_L1C,
     stripe_center_lon: int = 0,
     timestr: str = "2025-01-01T00:00:00",
     head: str = "45",
@@ -122,21 +124,21 @@ def mock_l1c_pset_product(
                 [
                     "epoch",
                     "energy_bin_center",
-                    "azimuth_bin_center",
-                    "elevation_bin_center",
+                    "longitude_bin_center",
+                    "latitude_bin_center",
                 ],
                 counts,
             ),
             "exposure_time": (
-                ["azimuth_bin_center", "elevation_bin_center"],
+                ["longitude_bin_center", "latitude_bin_center"],
                 exposure_time,
             ),
             "sensitivity": (
                 [
                     "epoch",
                     "energy_bin_center",
-                    "azimuth_bin_center",
-                    "elevation_bin_center",
+                    "longitude_bin_center",
+                    "latitude_bin_center",
                 ],
                 sensitivity,
             ),
@@ -146,8 +148,154 @@ def mock_l1c_pset_product(
                 tt_j2000ns,
             ],
             "energy_bin_center": energy_bin_midpoints,
-            "azimuth_bin_center": np.arange(0 + spacing_deg / 2, 360, spacing_deg),
-            "elevation_bin_center": np.arange(-90 + spacing_deg / 2, 90, spacing_deg),
+            "longitude_bin_center": np.arange(0 + spacing_deg / 2, 360, spacing_deg),
+            "latitude_bin_center": np.arange(-90 + spacing_deg / 2, 90, spacing_deg),
+        },
+        attrs={
+            "Logical_file_id": (
+                f"imap_ultra_l1c_{head}sensor-pset_{timestr[:4]}"
+                f"{timestr[5:7]}{timestr[8:10]}-repointNNNNN_vNNN"
+            )
+        },
+    )
+
+    return pset_product
+
+
+def mock_l1c_pset_product_healpix(  # noqa: PLR0913
+    nside: int = DEFAULT_HEALPIX_NSIDE_L1C,
+    stripe_center_lat: int = 0,
+    width_scale: float = 10.0,
+    counts_scaling_params: tuple[int, float] = (100, 0.01),
+    peak_exposure: float = 1000.0,
+    timestr: str = "2025-01-01T00:00:00",
+    head: str = "45",
+) -> xr.Dataset:
+    """
+    Mock the L1C PSET product with recognizable but unrealistic counts.
+
+    This is not meant to perfectly mimic the real data, but to provide a
+    recognizable structure for L2 testing purposes.
+    Function will produce an xarray.Dataset with at least the variables and shapes:
+    counts: (1 epoch, num_energy_bins, num_lon_bins, num_lat_bins)
+    exposure_time: (num_lon_bins, num_lat_bins)
+    sensitivity: (1 epoch, num_energy_bins, num_lon_bins, num_lat_bins)
+
+    and the coordinate variables:
+    the epoch (assumed to be a single time for each product).
+    energy: (determined by build_energy_bins function)
+    longitude: (num_lon_bins)
+    latitude: (num_lat_bins)
+
+    While not a coordinate, PSETs can also be distinguished by the 'head' attribute.
+    head: Either '45' or '90'. Default is '45'.
+
+    The counts are generated along a stripe, centered at a given latitude.
+    This stripe can be thought of as a 'vertical' line if the lon/az axis is plotted
+    as the x-axis and the lat/el axis is plotted as the y-axis. See the figure below.
+
+    ^  Elevation/Latitude
+    |
+    |                   00000000000000000000
+    |               0000000000000000000000000000
+    |           0000000000000000000000000000000000000
+    |        0000000000000000000000000000000000000000000
+    |      00000000000000000000000000000000000000000000000
+    |     0000000000000000000000000000000000000000000000000
+    |    222222222222222222222222222222222222222222222222222
+    |    444444444444444444444444444444444444444444444444444
+    |    666666666666666666666666666666666666666666666666666
+    |     4444444444444444444444444444444444444444444444444
+    |      22222222222222222222222222222222222222222222222
+    |        0000000000000000000000000000000000000000000
+    |           0000000000000000000000000000000000000
+    |               0000000000000000000000000000
+    |                   00000000000000000000
+    --------------------------------------------------------->
+    Azimuth/Longitude ->
+
+    Fig. 1: Example of the '90' sensor head stripe on a HEALPix grid
+
+    """
+    _, energy_bin_midpoints = build_energy_bins()
+    num_energy_bins = len(energy_bin_midpoints)
+    npix = hp.nside2npix(nside)
+    counts = np.zeros(npix)
+    exposure_time = np.zeros(npix)
+
+    # Get latitude for each healpix pixel
+    pix_indices = np.arange(npix)
+    lon_pix, lat_pix = hp.pix2ang(nside, pix_indices, lonlat=True)
+
+    counts = np.zeros(shape=(num_energy_bins, npix))
+
+    # Calculate probability based on distance from target latitude
+    lat_diff = np.abs(lat_pix - stripe_center_lat)
+    prob_scaling_factor = counts_scaling_params[1] * np.exp(
+        -(lat_diff**2) / (2 * width_scale**2)
+    )
+    # Generate counts using binomial distribution
+
+    rng = np.random.default_rng(seed=42)
+    counts = np.array(
+        [
+            rng.binomial(n=counts_scaling_params[0], p=prob_scaling_factor)
+            for _ in range(num_energy_bins)
+        ]
+    )
+
+    # Generate exposure times using gaussian distribution
+    exposure_time = peak_exposure * prob_scaling_factor
+
+    # Ensure counts are integers
+    counts = counts.astype(int)
+    # add an epoch dimension
+    counts = np.expand_dims(counts, axis=0)
+    sensitivity = np.ones_like(counts)
+
+    # Determine the epoch, which is TT time in nanoseconds since J2000 epoch
+    tdb_et = str_to_et(timestr)
+    tt_j2000ns = (
+        ensure_spice(spice.unitim, time_kernels_only=True)(tdb_et, "ET", "TT") * 1e9
+    )
+
+    pset_product = xr.Dataset(
+        {
+            "counts": (
+                [
+                    "epoch",
+                    "energy_bin_center",
+                    "healpix_pixel_index",
+                ],
+                counts,
+            ),
+            "exposure_time": (
+                ["healpix_pixel_index"],
+                exposure_time,
+            ),
+            "sensitivity": (
+                [
+                    "epoch",
+                    "energy_bin_center",
+                    "healpix_pixel_index",
+                ],
+                sensitivity,
+            ),
+            "azimuth_pixel_center": (
+                ["healpix_pixel_index"],
+                lon_pix,
+            ),
+            "elevation_pixel_center": (
+                ["healpix_pixel_index"],
+                lat_pix,
+            ),
+        },
+        coords={
+            "epoch": [
+                tt_j2000ns,
+            ],
+            "energy_bin_center": energy_bin_midpoints,
+            "healpix_pixel_index": pix_indices,
         },
         attrs={
             "Logical_file_id": (

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -13,9 +13,12 @@ DEFAULT_RECT_SPACING_DEG_L1C = 0.5
 DEFAULT_HEALPIX_NSIDE_L1C = 128
 
 
-def mock_l1c_pset_product_rectangular(
+def mock_l1c_pset_product_rectangular(  # noqa: PLR0913
     spacing_deg: float = DEFAULT_RECT_SPACING_DEG_L1C,
-    stripe_center_lon: int = 0,
+    stripe_center_lat: int = 0,
+    width_scale: float = 10.0,
+    counts_scaling_params: tuple[int, float] = (100, 0.01),
+    peak_exposure: float = 1000.0,
     timestr: str = "2025-01-01T00:00:00",
     head: str = "45",
 ) -> xr.Dataset:
@@ -38,19 +41,24 @@ def mock_l1c_pset_product_rectangular(
     While not a coordinate, PSETs can also be distinguished by the 'head' attribute.
     head: Either '45' or '90'. Default is '45'.
 
-    The counts are generated along a stripe, centered at a given longitude.
-    This stripe can be thought of as a 'vertical' line if the lon/az axis is plotted
+    The counts are generated along a stripe, centered at a given latitude.
+    This stripe can be thought of as a 'horizontal' line if the lon/az axis is plotted
     as the x-axis and the lat/el axis is plotted as the y-axis. See the figure below.
 
     ^  Elevation/Latitude
     |
-    |    000000000000002468642000000000000000000000000000000
-    |    000000000000002468642000000000000000000000000000000
-    |    000000000000002468642000000000000000000000000000000
-    |    000000000000002468642000000000000000000000000000000
-    |    000000000000002468642000000000000000000000000000000
-    |    000000000000002468642000000000000000000000000000000
-    |    000000000000002468642000000000000000000000000000000
+    |    000000000000000000000000000000000000000000000000000     |
+    |    000000000000000000000000000000000000000000000000000     |
+    |    000000000000000000000000000000000000000000000000000     |
+    |    000000000000000000000000000000000000000000000000000     |
+    |    000000000000000000000000000000000000000000000000000      \
+    |    222222222222222222222222222222222222222222222222222       \
+    |    444444444444444444444444444444444444444444444444444        \
+    |    666666666666666666666666666666666666666666666666666         |
+    |    444444444444444444444444444444444444444444444444444        /
+    |    222222222222222222222222222222222222222222222222222       /
+    |    000000000000000000000000000000000000000000000000000      /
+    |    000000000000000000000000000000000000000000000000000     |
     --------------------------------------------------------->
     Azimuth/Longitude ->
 
@@ -60,8 +68,16 @@ def mock_l1c_pset_product_rectangular(
     ----------
     spacing_deg : float, optional
         The bin spacing in degrees (default is 0.5 degrees).
-    stripe_center_lon : int, optional
-        The center longitude of the stripe in degrees (default is 0).
+    stripe_center_lat : int, optional
+        The center latitude of the stripe in degrees (default is 0).
+    width_scale : float, optional
+        The width of the stripe in degrees (default is 20 degrees).
+    counts_scaling_params : tuple[int, float], optional
+        The parameters for the binomial distribution of counts (default is (100, 0.01)).
+        The 0th element is the number of trials to draw,
+        the 1st element scales the probability of success for each trial.
+    peak_exposure : float, optional
+        The peak exposure time (default is 1000.0).
     timestr : str, optional
         The time string for the epoch (default is "2025-01-01T00:00:00").
     head : str, optional
@@ -69,7 +85,7 @@ def mock_l1c_pset_product_rectangular(
     """
     num_lat_bins = int(180 / spacing_deg)
     num_lon_bins = int(360 / spacing_deg)
-    stripe_center_lon_bin = int(stripe_center_lon / spacing_deg)
+    stripe_center_lat_bin = int((stripe_center_lat + 90) / spacing_deg)
 
     _, energy_bin_midpoints = build_energy_bins()
     num_energy_bins = len(energy_bin_midpoints)
@@ -77,38 +93,39 @@ def mock_l1c_pset_product_rectangular(
     # 1 epoch x num_energy_bins x num_lon_bins x num_lat_bins
     grid_shape = (1, num_energy_bins, num_lon_bins, num_lat_bins)
 
-    def get_binomial_counts(distance_scaling, lon_bin, central_lon_bin):
+    def get_binomial_counts(distance_scaling, lat_bin, central_lat_bin):
         # Note, this is not quite correct, as it won't wrap around at 360 degrees
         # but it's all meant to provide a recognizable pattern for testing
-        distance_lon_bin = np.abs(lon_bin - central_lon_bin)
+        distance_lat_bin = np.abs(lat_bin - central_lat_bin)
 
         rng = np.random.default_rng(seed=42)
         return rng.binomial(
-            n=50,
-            p=np.maximum(1 - (distance_lon_bin / distance_scaling), 0.01),
+            n=counts_scaling_params[0],
+            p=np.maximum(
+                1 - (distance_lat_bin / distance_scaling), counts_scaling_params[1]
+            ),
         )
 
     counts = np.fromfunction(
         lambda epoch, energy_bin, lon_bin, lat_bin: get_binomial_counts(
-            distance_scaling=20,
-            lon_bin=lon_bin,
-            central_lon_bin=stripe_center_lon_bin,
+            distance_scaling=width_scale,
+            lat_bin=lat_bin,
+            central_lat_bin=stripe_center_lat_bin,
         ),
         shape=grid_shape,
     )
 
-    exposure_time = np.zeros(grid_shape[2:]) + 0.1
-    if head == "90":
-        exposure_time[
-            stripe_center_lon_bin : stripe_center_lon_bin + int(20 / spacing_deg),
-            :,
-        ] = 1
-    else:
-        exposure_time[
-            stripe_center_lon_bin : stripe_center_lon_bin + int(70 / spacing_deg),
-            : int(90 / spacing_deg),
-        ] = 1
-
+    # exposure_time should be a gaussian distribution centered on the stripe
+    # with a width of 20 degrees
+    exposure_time = np.zeros(grid_shape[2:])
+    exposure_time = np.fromfunction(
+        lambda lon_bin, lat_bin: np.exp(
+            -((lat_bin - stripe_center_lat_bin) ** 2) / (2 * width_scale**2)
+        ),
+        shape=grid_shape[2:],
+    )
+    exposure_time /= exposure_time.max()
+    exposure_time *= peak_exposure
     counts = counts.astype(int)
     sensitivity = np.ones(grid_shape)
 
@@ -174,21 +191,11 @@ def mock_l1c_pset_product_healpix(  # noqa: PLR0913
     """
     Mock the L1C PSET product with recognizable but unrealistic counts.
 
-    This is not meant to perfectly mimic the real data, but to provide a
-    recognizable structure for L2 testing purposes.
-    Function will produce an xarray.Dataset with at least the variables and shapes:
-    counts: (1 epoch, num_energy_bins, num_lon_bins, num_lat_bins)
-    exposure_time: (num_lon_bins, num_lat_bins)
-    sensitivity: (1 epoch, num_energy_bins, num_lon_bins, num_lat_bins)
-
-    and the coordinate variables:
-    the epoch (assumed to be a single time for each product).
-    energy: (determined by build_energy_bins function)
-    longitude: (num_lon_bins)
-    latitude: (num_lat_bins)
-
-    While not a coordinate, PSETs can also be distinguished by the 'head' attribute.
-    head: Either '45' or '90'. Default is '45'.
+    See the docstring for mock_l1c_pset_product_rectangular for more details about
+    the structure of the dataset.
+    The rectangular and Healpix mocked datasets are very similar in structure, though
+    the actual values at a given latitude and longitude may be different. This is only
+    meant to provide a recognizable structure for L2 testing purposes.
 
     The counts are generated along a stripe, centered at a given latitude.
     This stripe can be thought of as a 'vertical' line if the lon/az axis is plotted
@@ -196,26 +203,44 @@ def mock_l1c_pset_product_healpix(  # noqa: PLR0913
 
     ^  Elevation/Latitude
     |
-    |                   00000000000000000000
-    |               0000000000000000000000000000
-    |           0000000000000000000000000000000000000
-    |        0000000000000000000000000000000000000000000
-    |      00000000000000000000000000000000000000000000000
-    |     0000000000000000000000000000000000000000000000000
-    |    222222222222222222222222222222222222222222222222222
-    |    444444444444444444444444444444444444444444444444444
-    |    666666666666666666666666666666666666666666666666666
-    |     4444444444444444444444444444444444444444444444444
-    |      22222222222222222222222222222222222222222222222
-    |        0000000000000000000000000000000000000000000
-    |           0000000000000000000000000000000000000
-    |               0000000000000000000000000000
-    |                   00000000000000000000
+    |                   00000000000000000000                     |
+    |               0000000000000000000000000000                 |
+    |           0000000000000000000000000000000000000            |
+    |        0000000000000000000000000000000000000000000         |
+    |      00000000000000000000000000000000000000000000000       |
+    |     0000000000000000000000000000000000000000000000000       \
+    |    222222222222222222222222222222222222222222222222222       \
+    |    444444444444444444444444444444444444444444444444444        \
+    |    666666666666666666666666666666666666666666666666666         |
+    |     4444444444444444444444444444444444444444444444444         /
+    |      22222222222222222222222222222222222222222222222         /
+    |        0000000000000000000000000000000000000000000          /
+    |           0000000000000000000000000000000000000            |
+    |               0000000000000000000000000000                 |
+    |                   00000000000000000000                     |
     --------------------------------------------------------->
     Azimuth/Longitude ->
 
     Fig. 1: Example of the '90' sensor head stripe on a HEALPix grid
 
+    Parameters
+    ----------
+    nside : int, optional
+        The HEALPix nside parameter (default is 128).
+    stripe_center_lat : int, optional
+        The center latitude of the stripe in degrees (default is 0).
+    width_scale : float, optional
+        The width of the stripe in degrees (default is 10 degrees).
+    counts_scaling_params : tuple[int, float], optional
+        The parameters for the binomial distribution of counts (default is (100, 0.01)).
+        The 0th element is the number of trials to draw,
+        the 1st element scales the probability of success for each trial.
+    peak_exposure : float, optional
+        The peak exposure time (default is 1000.0).
+    timestr : str, optional
+        The time string for the epoch (default is "2025-01-01T00:00:00").
+    head : str, optional
+        The sensor head (either '45' or '90') (default is '45').
     """
     _, energy_bin_midpoints = build_energy_bins()
     num_energy_bins = len(energy_bin_midpoints)
@@ -235,7 +260,6 @@ def mock_l1c_pset_product_healpix(  # noqa: PLR0913
         -(lat_diff**2) / (2 * width_scale**2)
     )
     # Generate counts using binomial distribution
-
     rng = np.random.default_rng(seed=42)
     counts = np.array(
         [
@@ -245,7 +269,7 @@ def mock_l1c_pset_product_healpix(  # noqa: PLR0913
     )
 
     # Generate exposure times using gaussian distribution
-    exposure_time = peak_exposure * prob_scaling_factor
+    exposure_time = peak_exposure * (prob_scaling_factor / prob_scaling_factor.max())
 
     # Ensure counts are integers
     counts = counts.astype(int)

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -40,6 +40,8 @@ def create_dataset(
         coords = {
             "spin_number": data_dict["spin_number"],
             "energy_bin_geometric_mean": data_dict["energy_bin_geometric_mean"],
+            # Start time aligns with the universal spin table
+            "epoch": data_dict["spin_start_time"],
         }
         default_dimension = "spin_number"
 

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -1,8 +1,12 @@
 """Create dataset."""
 
+import logging
+
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+
+logger = logging.getLogger(__name__)
 
 
 def create_dataset(
@@ -36,8 +40,6 @@ def create_dataset(
         coords = {
             "spin_number": data_dict["spin_number"],
             "energy_bin_geometric_mean": data_dict["energy_bin_geometric_mean"],
-            # Start time aligns with the universal spin table
-            "epoch": data_dict["spin_start_time"],
         }
         default_dimension = "spin_number"
 
@@ -106,3 +108,47 @@ def create_dataset(
             )
 
     return dataset
+
+
+def is_ultra45(
+    str_or_dataset: str | xr.Dataset,
+) -> bool:
+    """
+    Determine if the input is a 45 sensor (return True) or 90 sensor (False) product.
+
+    Parameters
+    ----------
+    str_or_dataset : str | xr.Dataset
+        Either the string descriptor or the xarray.Dataset object
+        which contains the descriptor as an attribute "Logical_file_id".
+
+    Returns
+    -------
+    bool
+        True if the descriptor contains '45sensor', else False.
+
+    Raises
+    ------
+    ValueError
+        If the input is not a string or xarray.Dataset.
+
+    Notes
+    -----
+    Issues a logger warning if neither '45sensor' nor '90sensor'
+    is found in the descriptor string.
+    """
+    # Get the global attr which should contain the substring '45sensor' or '90sensor'
+    if isinstance(str_or_dataset, str):
+        descriptor_str = str_or_dataset
+    elif isinstance(str_or_dataset, xr.Dataset):
+        descriptor_str = str_or_dataset.attrs["Logical_file_id"]
+    else:
+        raise ValueError("Input must be a string or xarray.Dataset")
+
+    if "45sensor" in descriptor_str:
+        return True
+    elif "90sensor" not in descriptor_str:
+        logger.warning(
+            f"Found neither 45, nor 90 in descriptor string: {descriptor_str}"
+        )
+    return False

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -1,12 +1,8 @@
 """Create dataset."""
 
-import logging
-
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-
-logger = logging.getLogger(__name__)
 
 
 def create_dataset(
@@ -110,47 +106,3 @@ def create_dataset(
             )
 
     return dataset
-
-
-def is_ultra45(
-    str_or_dataset: str | xr.Dataset,
-) -> bool:
-    """
-    Determine if the input is a 45 sensor (return True) or 90 sensor (False) product.
-
-    Parameters
-    ----------
-    str_or_dataset : str | xr.Dataset
-        Either the string descriptor or the xarray.Dataset object
-        which contains the descriptor as an attribute "Logical_file_id".
-
-    Returns
-    -------
-    bool
-        True if the descriptor contains '45sensor', else False.
-
-    Raises
-    ------
-    ValueError
-        If the input is not a string or xarray.Dataset.
-
-    Notes
-    -----
-    Issues a logger warning if neither '45sensor' nor '90sensor'
-    is found in the descriptor string.
-    """
-    # Get the global attr which should contain the substring '45sensor' or '90sensor'
-    if isinstance(str_or_dataset, str):
-        descriptor_str = str_or_dataset
-    elif isinstance(str_or_dataset, xr.Dataset):
-        descriptor_str = str_or_dataset.attrs["Logical_file_id"]
-    else:
-        raise ValueError("Input must be a string or xarray.Dataset")
-
-    if "45sensor" in descriptor_str:
-        return True
-    elif "90sensor" not in descriptor_str:
-        logger.warning(
-            f"Found neither 45, nor 90 in descriptor string: {descriptor_str}"
-        )
-    return False


### PR DESCRIPTION
# Change Summary

Previously, we had defined UltraPointingSet as a rectangularly-binned grid. Switch to a Healpix Tessellation with nominal `nside` of 128.

Closes #1480
Closes #1483 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
1. Rename the existing implementation of `UltraPointingSet` to `RectangularPointingSet`. Keep it for reference or future use by Lo/Hi, and to continue testing the projection and index matching from rectangular PSETs to both types of `SkyMap`. 
2. Implement a new `UltraPointingSet` with Healpix tiling.
3. Extract the hardcoded coordinate names for L1C, L2 into an enum to prevent issues with typos, etc. This was spurred by the change from "elevation/azimuth_bin_center" -> "latitude /elevation_bin_center" at the project level, and remaining uncertainty about coordinate names. 
4. Mock the healpix tessellated L1C data, with a horizontal stripe of counts and exptime at constant latitude. The Ultra team asked me to use a horizontal stripe rather than a vertical stripe, so I also changed the Rectangular PSET mocking. 

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
-  imap_processing/tests/ena_maps/conftest.py
   - fixtures for data mocking. 
-  imap_processing/ena_maps/utils/coordinates.py
   - Enum of coordinate names for making ENA maps. 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/ena_maps/ena_maps.py
   - Define Healpix tessellated `UltraPointingSet`
   - Rename rectangularly gridded PSET
- imap_processing/tests/ultra/test_data/mock_data.py
   - Now mocks both healpix and rectangular Pointing Set datasets with horizontal stripe in counts

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Adapt existing tests to use `RectangularPointingSet`, and add new tests with Healpix gridded `UltraPointingSet`. 