### PR TITLE
Conversions for ena map dictionaries to `xarray DataArray/Datasets`

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -503,8 +503,9 @@ class AbstractSkyMap(ABC):
     If the map is rectangular, this axis is the raveled 2D grid.
     If the map is Healpix, this axis is the 1D array of Healpix pixel indices.
 
-    The data can be accessed via the .data property, which rewraps the data to the
-    original 2D grid shape if the map is rectangular.
+    The data can be also accessed via the to_dataset method, which rewraps the data to
+    a 2D grid shape if the map is rectangular and formats the data as an xarray
+    Dataset with the correct dims and coords.
     """
 
     @abstractmethod
@@ -517,8 +518,7 @@ class AbstractSkyMap(ABC):
         self.binning_grid_shape: tuple[int, ...]
         self.data_1d: xr.Dataset
 
-    @property
-    def data(self) -> xr.Dataset:
+    def to_dataset(self) -> xr.Dataset:
         """
         Get the SkyMap data as a formatted xarray Dataset.
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -526,11 +526,15 @@ class AbstractSkyMap(ABC):
         -------
         xr.Dataset
             The SkyMap data as a formatted xarray Dataset with dims and coords.
+            If the SkyMap is empty, an empty xarray Dataset is returned.
             If the SkyMap is Rectangular, the data is rewrapped to a 2D grid of
             lon/lat (AKA az/el) coordinates.
             If the SkyMap is Healpix, the data is unchanged from the data_1d, but
             the pixel coordinate is renamed to CoordNames.HEALPIX_INDEX.value.
         """
+        if len(self.data_1d.data_vars) == 0:
+            return xr.Dataset()
+
         if self.tiling_type is SkyTilingType.HEALPIX:
             # return the data_1d as is, but with the pixel coordinate
             # renamed to CoordNames.HEALPIX_INDEX.value
@@ -631,7 +635,15 @@ class AbstractSkyMap(ABC):
             # If multiple spatial axes present
             # (i.e (az, el) for rectangular coordinate PSET),
             # flatten them in the values array to match the raveled indices
-            raveled_pset_data = pset_values.data.reshape(1, -1, pointing_set.num_points)
+            non_spatial_axes_shape = tuple(
+                size
+                for key, size in pset_values.sizes.items()
+                if key not in pointing_set.spatial_coords
+            )
+            raveled_pset_data = pset_values.data.reshape(
+                *non_spatial_axes_shape,
+                pointing_set.num_points,
+            )
 
             if value_key not in self.data_1d.data_vars:
                 # Initialize the map data array if it doesn't exist (values start at 0)

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -258,7 +258,7 @@ class PointingSet(ABC):
         -------
         non_spatial_coords : dict[str, xr.DataArray]
             Dictionary of coordinate names and their data arrays.
-            E.g.: {"epoch": [12345,], "energy_bin_center": [100, 200, 300]} .
+            E.g.: {"epoch": [12345,], "energy": [100, 200, 300]} .
         """
         non_spatial_coords = {}
         for coord_name in self.data.coords:
@@ -292,8 +292,8 @@ class RectangularPointingSet(PointingSet):
         Currently, the dataset is expected to be tiled in a rectangular grid,
         with data_vars indexed along the coordinates:
             - 'epoch' : time value (1 value per PSET)
-            - 'longitude_bin_center' : (number of longitude/az bins in L1C)
-            - 'latitude_bin_center' : (number of latitude/el bins in L1C)
+            - 'longitude' : (number of longitude/az bins in L1C)
+            - 'latitude' : (number of latitude/el bins in L1C)
     spice_reference_frame : geometry.SpiceFrame
         The reference Spice frame of the pointing set. Default is IMAP_DPS.
 
@@ -398,9 +398,9 @@ class UltraPointingSet(PointingSet):
         Currently, the dataset is expected to be tiled in a HEALPix tessellation,
         with data_vars indexed along the coordinates:
             - 'epoch' : time value (1 value per PSET, from the mean of the PSET)
-            - 'energy_bin_center' : (number of energy bins in L1C)
-            - 'healpix_pixel_index' : HEALPix pixel index
-        Only the 'healpix_pixel_index' coordinate is used in this class for projection.
+            - 'energy' : (number of energy bins in L1C)
+            - 'healpix_index' : HEALPix pixel index
+        Only the 'healpix_index' coordinate is used in this class for projection.
     spice_reference_frame : geometry.SpiceFrame
         The reference Spice frame of the pointing set. Default is IMAP_DPS.
 
@@ -534,7 +534,12 @@ class AbstractSkyMap(ABC):
             the pixel coordinate is renamed to CoordNames.HEALPIX_INDEX.value.
         """
         if len(self.data_1d.data_vars) == 0:
-            return xr.Dataset()
+            # If the map is empty, return an empty xarray Dataset,
+            # with the unaltered spatial coords of the map
+            return xr.Dataset(
+                {},
+                coords={**self.spatial_coords},
+            )
 
         if self.tiling_type is SkyTilingType.HEALPIX:
             # return the data_1d as is, but with the pixel coordinate
@@ -834,9 +839,9 @@ class HealpixSkyMap(AbstractSkyMap):
         # Define binning_grid_shape for consistency with RectangularSkyMap
         self.binning_grid_shape = (self.num_points,)
         self.spatial_coords = {
-            "healpix_pixel_number": xr.DataArray(
+            CoordNames.HEALPIX_INDEX.value: xr.DataArray(
                 np.arange(self.num_points),
-                dims=["healpix_pixel_number"],
+                dims=[CoordNames.HEALPIX_INDEX.value],
             )
         }
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -222,6 +222,49 @@ class PointingSet(ABC):
         self.num_points = 0
         self.az_el_points = np.zeros((self.num_points, 2))
         self.data = xr.Dataset()
+        self.spatial_coords: tuple[str, ...] = ()
+
+    @property
+    def unwrapped_dims_dict(self) -> dict[str, tuple[str, ...]]:
+        """
+        Get dimensions of each variable in the pointing set, with only 1 spatial dim.
+
+        Returns
+        -------
+        unwrapped_dims_dict : dict[str, tuple[str, ...]]
+            Dictionary of variable names and their dimensions, with only 1 spatial dim.
+            The generic pixel dimension is always included.
+            E.g.: {"counts": ("epoch", "energy_bin_center", "pixel")} .
+        """
+        variable_dims = {}
+        for var_name in self.data.data_vars:
+            pset_dims = self.data[var_name].dims
+            non_spatial_dims = tuple(
+                dim for dim in pset_dims if dim not in self.spatial_coords
+            )
+
+            variable_dims[var_name] = (
+                *non_spatial_dims,
+                CoordNames.GENERIC_PIXEL.value,
+            )
+        return variable_dims
+
+    @property
+    def non_spatial_coords(self) -> dict[str, xr.DataArray]:
+        """
+        Get the non-spatial coordinates of the pointing set.
+
+        Returns
+        -------
+        non_spatial_coords : dict[str, xr.DataArray]
+            Dictionary of coordinate names and their data arrays.
+            E.g.: {"epoch": [12345,], "energy_bin_center": [100, 200, 300]} .
+        """
+        non_spatial_coords = {}
+        for coord_name in self.data.coords:
+            if coord_name not in self.spatial_coords:
+                non_spatial_coords[coord_name] = self.data[coord_name]
+        return non_spatial_coords
 
     def __repr__(self) -> str:
         """
@@ -283,6 +326,10 @@ class RectangularPointingSet(PointingSet):
             raise ValueError("Multiple epochs found in the dataset.")
 
         self.tiling_type = SkyTilingType.RECTANGULAR
+        self.spatial_coords = (
+            CoordNames.AZIMUTH_L1C.value,
+            CoordNames.ELEVATION_L1C.value,
+        )
 
         # Ensure 1D axes grids are uniformly spaced,
         # then set spacing based on data's azimuth bin spacing.
@@ -451,10 +498,13 @@ class AbstractSkyMap(ABC):
     """
     Abstract base class to contain map data in the context of ENA sky maps.
 
-    Data values are stored in a dictionary, where the final (-1) axis
-    is the only spatial dimension. If the map is rectangular,
-    this axis is the raveled 2D grid.
+    Data values are stored internally in an xarray Dataset, in the .data_1d attribute.
+    where the final (-1) axis is the only spatial dimension.
+    If the map is rectangular, this axis is the raveled 2D grid.
     If the map is Healpix, this axis is the 1D array of Healpix pixel indices.
+
+    The data can be accessed via the .data property, which rewraps the data to the
+    original 2D grid shape if the map is rectangular.
     """
 
     @abstractmethod
@@ -462,9 +512,61 @@ class AbstractSkyMap(ABC):
         self.tiling_type: SkyTilingType
         self.sky_grid: spatial_utils.AzElSkyGrid
         self.num_points: int
+        self.non_spatial_coords: dict[str, xr.DataArray | NDArray]
         self.spatial_coords: dict[str, xr.DataArray | NDArray]
         self.binning_grid_shape: tuple[int, ...]
-        self.data_dict: dict[str, NDArray]
+        self.data_1d: xr.Dataset
+
+    @property
+    def data(self) -> xr.Dataset:
+        """
+        Get the SkyMap data as a formatted xarray Dataset.
+
+        Returns
+        -------
+        xr.Dataset
+            The SkyMap data as a formatted xarray Dataset with dims and coords.
+            If the SkyMap is Rectangular, the data is rewrapped to a 2D grid of
+            lon/lat (AKA az/el) coordinates.
+            If the SkyMap is Healpix, the data is unchanged from the data_1d, but
+            the pixel coordinate is renamed to CoordNames.HEALPIX_INDEX.value.
+        """
+        if self.tiling_type is SkyTilingType.HEALPIX:
+            # return the data_1d as is, but with the pixel coordinate
+            # renamed to CoordNames.HEALPIX_INDEX.value
+            return self.data_1d.rename(
+                {CoordNames.GENERIC_PIXEL.value: CoordNames.HEALPIX_INDEX.value}
+            )
+        elif self.tiling_type is SkyTilingType.RECTANGULAR:
+            # Rewrap each data array in the data_1d to the original 2D grid shape
+            rewrapped_data = {}
+            for key in self.data_1d.data_vars:
+                # drop pixel dim from the end, and add the spatial coords as dims
+                rewrapped_dims = [
+                    dim
+                    for dim in self.data_1d[key].dims
+                    if dim != CoordNames.GENERIC_PIXEL.value
+                ]
+                rewrapped_dims.extend(self.spatial_coords.keys())
+                rewrapped_data[key] = xr.DataArray(
+                    spatial_utils.rewrap_even_spaced_az_el_grid(
+                        self.data_1d[key].values,
+                        self.binning_grid_shape,
+                    ),
+                    dims=rewrapped_dims,
+                )
+            # Add the output coordinates to the rewrapped data, excluding the pixel
+            self.non_spatial_coords.update(
+                {
+                    key: self.data_1d[key].coords[key]
+                    for key in self.data_1d[key].coords
+                    if key != CoordNames.GENERIC_PIXEL.value
+                }
+            )
+            return xr.Dataset(
+                rewrapped_data,
+                coords={**self.non_spatial_coords, **self.spatial_coords},
+            )
 
     def project_pset_values_to_map(
         self,
@@ -526,19 +628,27 @@ class AbstractSkyMap(ABC):
         for value_key in value_keys:
             pset_values = pointing_set.data[value_key]
 
-            # If there is an epoch dim with size 1, flatten it out
-            if "epoch" in pset_values.dims and pset_values["epoch"].size == 1:
-                pset_values = pset_values.squeeze("epoch")
-
             # If multiple spatial axes present
             # (i.e (az, el) for rectangular coordinate PSET),
             # flatten them in the values array to match the raveled indices
-            raveled_pset_data = pset_values.data.reshape(-1, pointing_set.num_points)
+            raveled_pset_data = pset_values.data.reshape(1, -1, pointing_set.num_points)
 
-            if value_key not in self.data_dict:
+            if value_key not in self.data_1d.data_vars:
                 # Initialize the map data array if it doesn't exist (values start at 0)
                 output_shape = (*raveled_pset_data.shape[:-1], self.num_points)
-                self.data_dict[value_key] = np.zeros(output_shape)
+                self.data_1d[value_key] = xr.DataArray(
+                    np.zeros(output_shape),
+                    dims=pointing_set.unwrapped_dims_dict[value_key],
+                )
+
+                # Make coordinates for the map data array if they don't exist
+                self.data_1d.coords.update(
+                    {
+                        dim: pointing_set.data[dim]
+                        for dim in self.data_1d[value_key].dims
+                        if dim not in self.data_1d.coords
+                    }
+                )
 
             if index_match_method is IndexMatchMethod.PUSH:
                 # Bin the values at the matched indices. There may be multiple
@@ -557,109 +667,7 @@ class AbstractSkyMap(ABC):
                     "Only PUSH and PULL index matching methods are supported."
                 )
 
-            self.data_dict[value_key] += pointing_projected_values
-
-    def data_dict_value_to_dataarray(
-        self,
-        data_dict_key: str,
-        dims: list[str] | None = None,
-        **kwargs: dict,
-    ) -> xr.DataArray:
-        """
-        Convert an individual array in the data_dict to an xarray DataArray.
-
-        In the case of a rectangular grid, the data array is rewrapped to the original
-        2D grid shape before conversion to an xarray DataArray.
-
-        Parameters
-        ----------
-        data_dict_key : str
-            The key of the data array in the data_dict.
-        dims : list[str] | None, optional
-            The ordered dimensions of the data array. Default is None.
-        **kwargs : dict
-            Additional keyword arguments to pass to the xarray DataArray constructor.
-
-        Returns
-        -------
-        xr.DataArray
-            The data array converted to an xarray DataArray.
-        """
-        data = self.data_dict[data_dict_key]
-
-        # Rewrap the data to the original 2D grid shape if rectangular
-        if self.tiling_type is SkyTilingType.RECTANGULAR:
-            data = spatial_utils.rewrap_even_spaced_az_el_grid(
-                data, self.binning_grid_shape
-            )
-
-        # Add an extra dim at the start for epoch:
-        if dims is not None and dims[0] == "epoch":
-            data = np.expand_dims(data, axis=0)
-
-        return xr.DataArray(
-            data,
-            dims=dims,
-            **kwargs,
-        )
-
-    def to_xarray(
-        self,
-        non_spatial_coords: dict[str, xr.DataArray | NDArray],
-        data_variables_and_dims: dict[str, list[str]],
-    ) -> xr.Dataset:
-        """
-        Convert the data_dict to an xarray Dataset, including spatial coords.
-
-        In the case of a rectangular grid, all data arrays are rewrapped to the
-        original 2D grid shape before conversion to xarray DataArrays.
-
-        Parameters
-        ----------
-        non_spatial_coords : dict[str, xr.DataArray | NDArray],
-            Dictionary of the non-spatial coordinates to include in the dataset.
-            The keys are the names of the coordinates, and the values are either
-            numpy arrays or xarray DataArrays, the latter of which can include
-            coordinate attributes.
-
-            Example using DataArrays to give coord attributes:
-            ```
-            {
-                "epoch": xr.DataArray(
-                    [1234.5], dims=["epoch"], attrs={"units": "J2000ns"}),
-                "energy_bin_center": xr.DataArray(
-                    [1.0, 2.0, 3.0], dims=["energy_bin_center"],
-                    attrs={"units": "keV"}),
-            }
-            ```
-            Example using NDArrays:
-            ```
-            {
-                "epoch": np.array([1234.5]),
-                "energy_bin_center": np.array([1.0, 2.0, 3.0]),
-            }
-            ```.
-        data_variables_and_dims : dict[str, list[str]]
-            The dictionary of data variables (key) and their dimensions (value).
-
-        Returns
-        -------
-        xr.Dataset
-            An xarray Dataset containing the data variables and coordinates.
-        """
-        # Get full dict of coordinates
-        coords = {**non_spatial_coords, **self.spatial_coords}
-
-        return xr.Dataset(
-            data_vars={
-                key: self.data_dict_value_to_dataarray(
-                    key,
-                    dims=dims,
-                )
-                for key, dims in data_variables_and_dims.items()
-            },
-            coords=coords,
-        )
+            self.data_1d[value_key] += pointing_projected_values
 
 
 class RectangularSkyMap(AbstractSkyMap):
@@ -731,6 +739,7 @@ class RectangularSkyMap(AbstractSkyMap):
         # The shape of the map (num_az_bins, num_el_bins) is used to bin the data
         self.binning_grid_shape = self.sky_grid.grid_shape
 
+        self.non_spatial_coords = {}
         self.spatial_coords = {
             CoordNames.AZIMUTH_L1C.value: xr.DataArray(
                 self.sky_grid.az_bin_midpoints,
@@ -758,8 +767,12 @@ class RectangularSkyMap(AbstractSkyMap):
         )
         self.solid_angle_points = self.solid_angle_grid.ravel()
 
-        # Initialize empty data dictionary to store map data
-        self.data_dict: dict[str, NDArray] = {}
+        # Initialize xarray Dataset to store map data projected from pointing sets
+        self.data_1d: xr.Dataset = xr.Dataset(
+            coords={
+                CoordNames.GENERIC_PIXEL.value: np.arange(self.num_points),
+            }
+        )
 
     def __repr__(self) -> str:
         """
@@ -829,8 +842,12 @@ class HealpixSkyMap(AbstractSkyMap):
         # solid_angle_points to be consistent with RectangularSkyMap
         self.solid_angle_points = np.full(self.num_points, self.solid_angle)
 
-        # Initialize the data dictionary to store map data projected from pointing sets
-        self.data_dict: dict[str, NDArray] = {}
+        # Initialize xarray Dataset to store map data projected from pointing sets
+        self.data_1d: xr.Dataset = xr.Dataset(
+            coords={
+                CoordNames.GENERIC_PIXEL.value: np.arange(self.num_points),
+            }
+        )
 
     def __repr__(self) -> str:
         """

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -462,6 +462,7 @@ class AbstractSkyMap(ABC):
         self.tiling_type: SkyTilingType
         self.sky_grid: spatial_utils.AzElSkyGrid
         self.num_points: int
+        self.spatial_coords: dict[str, xr.DataArray | NDArray]
         self.binning_grid_shape: tuple[int, ...]
         self.data_dict: dict[str, NDArray]
 
@@ -558,6 +559,108 @@ class AbstractSkyMap(ABC):
 
             self.data_dict[value_key] += pointing_projected_values
 
+    def data_dict_value_to_dataarray(
+        self,
+        data_dict_key: str,
+        dims: list[str] | None = None,
+        **kwargs: dict,
+    ) -> xr.DataArray:
+        """
+        Convert an individual array in the data_dict to an xarray DataArray.
+
+        In the case of a rectangular grid, the data array is rewrapped to the original
+        2D grid shape before conversion to an xarray DataArray.
+
+        Parameters
+        ----------
+        data_dict_key : str
+            The key of the data array in the data_dict.
+        dims : list[str] | None, optional
+            The ordered dimensions of the data array. Default is None.
+        **kwargs : dict
+            Additional keyword arguments to pass to the xarray DataArray constructor.
+
+        Returns
+        -------
+        xr.DataArray
+            The data array converted to an xarray DataArray.
+        """
+        data = self.data_dict[data_dict_key]
+
+        # Rewrap the data to the original 2D grid shape if rectangular
+        if self.tiling_type is SkyTilingType.RECTANGULAR:
+            data = spatial_utils.rewrap_even_spaced_az_el_grid(
+                data, self.binning_grid_shape
+            )
+
+        # Add an extra dim at the start for epoch:
+        if dims is not None and dims[0] == "epoch":
+            data = np.expand_dims(data, axis=0)
+
+        return xr.DataArray(
+            data,
+            dims=dims,
+            **kwargs,
+        )
+
+    def to_xarray(
+        self,
+        non_spatial_coords: dict[str, xr.DataArray | NDArray],
+        data_variables_and_dims: dict[str, list[str]],
+    ) -> xr.Dataset:
+        """
+        Convert the data_dict to an xarray Dataset, including spatial coords.
+
+        In the case of a rectangular grid, all data arrays are rewrapped to the
+        original 2D grid shape before conversion to xarray DataArrays.
+
+        Parameters
+        ----------
+        non_spatial_coords : dict[str, xr.DataArray | NDArray],
+            Dictionary of the non-spatial coordinates to include in the dataset.
+            The keys are the names of the coordinates, and the values are either
+            numpy arrays or xarray DataArrays, the latter of which can include
+            coordinate attributes.
+
+            Example using DataArrays to give coord attributes:
+            ```
+            {
+                "epoch": xr.DataArray(
+                    [1234.5], dims=["epoch"], attrs={"units": "J2000ns"}),
+                "energy_bin_center": xr.DataArray(
+                    [1.0, 2.0, 3.0], dims=["energy_bin_center"],
+                    attrs={"units": "keV"}),
+            }
+            ```
+            Example using NDArrays:
+            ```
+            {
+                "epoch": np.array([1234.5]),
+                "energy_bin_center": np.array([1.0, 2.0, 3.0]),
+            }
+            ```.
+        data_variables_and_dims : dict[str, list[str]]
+            The dictionary of data variables (key) and their dimensions (value).
+
+        Returns
+        -------
+        xr.Dataset
+            An xarray Dataset containing the data variables and coordinates.
+        """
+        # Get full dict of coordinates
+        coords = {**non_spatial_coords, **self.spatial_coords}
+
+        return xr.Dataset(
+            data_vars={
+                key: self.data_dict_value_to_dataarray(
+                    key,
+                    dims=dims,
+                )
+                for key, dims in data_variables_and_dims.items()
+            },
+            coords=coords,
+        )
+
 
 class RectangularSkyMap(AbstractSkyMap):
     """
@@ -628,6 +731,19 @@ class RectangularSkyMap(AbstractSkyMap):
         # The shape of the map (num_az_bins, num_el_bins) is used to bin the data
         self.binning_grid_shape = self.sky_grid.grid_shape
 
+        self.spatial_coords = {
+            CoordNames.AZIMUTH_L1C.value: xr.DataArray(
+                self.sky_grid.az_bin_midpoints,
+                dims=[CoordNames.AZIMUTH_L1C.value],
+                attrs={"units": "degrees"},
+            ),
+            CoordNames.ELEVATION_L1C.value: xr.DataArray(
+                self.sky_grid.el_bin_midpoints,
+                dims=[CoordNames.ELEVATION_L1C.value],
+                attrs={"units": "degrees"},
+            ),
+        }
+
         # Unwrap the az, el grids to 1D array of points tiling the sky
         az_points = self.sky_grid.az_grid.ravel()
         el_points = self.sky_grid.el_grid.ravel()
@@ -691,6 +807,12 @@ class HealpixSkyMap(AbstractSkyMap):
         self.approx_resolution = np.rad2deg(hp.nside2resol(nside, arcmin=False))
         # Define binning_grid_shape for consistency with RectangularSkyMap
         self.binning_grid_shape = (self.num_points,)
+        self.spatial_coords = {
+            "healpix_pixel_number": xr.DataArray(
+                np.arange(self.num_points),
+                dims=["healpix_pixel_number"],
+            )
+        }
 
         # The centers of each pixel in the Healpix tessellation in azimuth (az) and
         # elevation (el) coordinates (degrees) within the map's Spice frame.

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -434,6 +434,7 @@ class UltraPointingSet(PointingSet):
 
         # Set the tiling type and number of points
         self.tiling_type = SkyTilingType.HEALPIX
+        self.spatial_coords = (CoordNames.HEALPIX_INDEX.value,)
         self.num_points = self.data[CoordNames.HEALPIX_INDEX.value].size
         self.nside = hp.npix_to_nside(self.num_points)
 

--- a/imap_processing/ena_maps/utils/coordinates.py
+++ b/imap_processing/ena_maps/utils/coordinates.py
@@ -6,6 +6,8 @@ from enum import Enum
 class CoordNames(Enum):
     """Enumeration of the names of the coordinates in the L1C and L2 ENA datasets."""
 
+    GENERIC_PIXEL = "pixel"
+
     TIME = "epoch"
     ENERGY = "energy"
     HEALPIX_INDEX = "healpix_index"

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -11,6 +11,7 @@ import pytest
 import xarray as xr
 
 from imap_processing.ena_maps import ena_maps
+from imap_processing.ena_maps.utils import spatial_utils
 from imap_processing.ena_maps.utils.coordinates import CoordNames
 from imap_processing.spice import geometry
 
@@ -342,6 +343,34 @@ class TestRectangularSkyMap:
             total_pset_counts.sum() / (downsample_ratio**2),
         )
 
+        # Convert to xarray Dataset and check the data is as expected
+        # This is a method, which could be tested separately, but that would be
+        # innefficient, as it would require all the same, computationally intensive
+        # operations to be repeated as this test
+        rect_map_ds = rectangular_map.to_dataset()
+        assert "counts" in rect_map_ds.data_vars
+        assert rect_map_ds["counts"].shape == (
+            1,
+            ultra_pset.data["counts"].sizes[CoordNames.ENERGY.value],
+            360 / skymap_spacing,
+            180 / skymap_spacing,
+        )
+        assert rect_map_ds["counts"].dims == (
+            CoordNames.TIME.value,
+            CoordNames.ENERGY.value,
+            CoordNames.AZIMUTH_L2.value,
+            CoordNames.ELEVATION_L2.value,
+        )
+
+        # Check that the data is as expected
+        np.testing.assert_array_equal(
+            rect_map_ds["counts"].values,
+            spatial_utils.rewrap_even_spaced_az_el_grid(
+                rectangular_map.data_1d["counts"].values,
+                rectangular_map.binning_grid_shape,
+            ),
+        )
+
 
 class TestHealpixSkyMap:
     @pytest.fixture(autouse=True)
@@ -487,114 +516,19 @@ class TestHealpixSkyMap:
             atol=degree_tolerance,
         )
 
-    @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
-    @pytest.mark.parametrize(
-        "nside,degree_tolerance",
-        [
-            (8, 6),
-            (16, 3),
-            (32, 2),
-        ],
-    )
-    @pytest.mark.parametrize("nested", [True, False], ids=["nested", "ring"])
-    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
-    def test_project_healpix_pset_values_to_map_push_method(
-        self, mock_frame_transform_az_el, nside, degree_tolerance, nested
-    ):
-        """
-        Test that PointingSet which contains bright spot pushes to correct spot in map.
-
-        Parameterized over nside (of the map, not the PSET), nested.
-        The tolerance for lower nsides must be higher because the
-        Healpix pixels are larger.
-        """
-
-        # Mock frame_transform to return the az and el unchanged
-        mock_frame_transform_az_el.side_effect = (
-            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        # Convert to xarray Dataset and check the data is as expected
+        hp_map_ds = hp_map.to_dataset()
+        assert "counts" in hp_map_ds.data_vars
+        assert hp_map_ds["counts"].shape == (
+            1,
+            mock_pset_input_frame.data["counts"].sizes[CoordNames.ENERGY.value],
+            hp_map.num_points,
         )
-
-        index_matching_method = ena_maps.IndexMatchMethod.PUSH
-
-        # Create a PointingSet with a bright spot
-        mock_pset_input_frame = ena_maps.UltraPointingSet(
-            l1c_dataset=self.ultra_l1c_pset_products[0],
-            spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+        assert hp_map_ds["counts"].dims == (
+            CoordNames.TIME.value,
+            CoordNames.ENERGY.value,
+            CoordNames.HEALPIX_INDEX.value,
         )
-        mock_pset_input_frame.data["counts"].values = np.zeros_like(
-            mock_pset_input_frame.data["counts"].values
-        )
-
-        input_bright_pixel_number = hp.ang2pix(
-            nside=mock_pset_input_frame.nside,
-            theta=180,
-            phi=0,
-            nest=mock_pset_input_frame.nested,
-            lonlat=True,
-        )
-        input_bright_pixel_az_el_deg = mock_pset_input_frame.az_el_points[
-            input_bright_pixel_number
-        ]
-        mock_pset_input_frame.data["counts"].values[
-            :,
-            :,
-            input_bright_pixel_number,
-        ] = 1
-
-        # Create a Healpix map
-        hp_map = ena_maps.HealpixSkyMap(
-            nside=nside,
-            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
-            nested=nested,
-        )
-
-        # Project the PointingSet to the Healpix map
-        hp_map.project_pset_values_to_map(
-            mock_pset_input_frame,
-            value_keys=[
-                "counts",
-            ],
-            index_match_method=index_matching_method,
-        )
-
-        # Check that the map has been updated
-        assert "counts" in hp_map.data_dict
-
-        # Find the maximum value in the spatial pixel dimension of the healpix map
-        bright_hp_pixel_index = hp_map.data_dict["counts"][0, :].argmax()
-        bright_hp_pixel_az_el = hp_map.az_el_points[bright_hp_pixel_index]
-
-        np.testing.assert_allclose(
-            bright_hp_pixel_az_el,
-            input_bright_pixel_az_el_deg,
-            atol=degree_tolerance,
-        )
-
-    def test_to_xarray(self):
-        """Test conversion of HealpixSkyMap to xarray Dataset"""
-        hp_map = ena_maps.HealpixSkyMap(
-            nside=8,
-            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
-            nested=True,
-        )
-        num_energy_bins = 10
-        num_points = hp_map.num_points
-        hp_map.data_dict["counts"] = np.ones((num_energy_bins, num_points))
-
-        xarray_dataset = hp_map.to_xarray(
-            non_spatial_coords={
-                "epoch": [
-                    -1,
-                ],
-                "energy_bin_center": xr.DataArray(np.arange(num_energy_bins)),
-            },
-            data_variables_and_dims={
-                "counts": ["epoch", "energy_bin_center", "healpix_pixel_index"],
-            },
-        )
-        assert "counts" in xarray_dataset
-        assert xarray_dataset["counts"].shape == (1, num_energy_bins, num_points)
-        np.testing.assert_equal(xarray_dataset["counts"].values, 1)
 
 
 class TestIndexMatching:

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -8,6 +8,7 @@ from unittest import mock
 import astropy_healpix.healpy as hp
 import numpy as np
 import pytest
+import xarray as xr
 
 from imap_processing.ena_maps import ena_maps
 from imap_processing.ena_maps.utils.coordinates import CoordNames
@@ -323,6 +324,52 @@ class TestRectangularSkyMap:
             total_pset_counts.sum() / (downsample_ratio**2),
         )
 
+    def test_data_dict_value_to_dataarray(self):
+        """Test conversion of data_dict values to xarray DataArrays"""
+        rm = ena_maps.RectangularSkyMap(
+            spacing_deg=1,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+        rm.data_dict["variable"] = np.ones((1, 10, 360 * 180))
+        da = rm.data_dict_value_to_dataarray("variable")
+        assert da.shape == (1, 10, 360, 180)
+        assert da.values.sum() == rm.data_dict["variable"].size
+
+    def test_to_xarray(self):
+        """Test conversion of RectangularSkyMap to xarray Dataset"""
+        rm = ena_maps.RectangularSkyMap(
+            spacing_deg=1,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+        num_energy_bins = 10
+        num_points = rm.num_points
+        rm.data_dict["counts"] = np.ones((num_energy_bins, num_points))
+
+        xarray_dataset = rm.to_xarray(
+            non_spatial_coords={
+                "epoch": [
+                    -1,
+                ],
+                "energy_bin_center": xr.DataArray(np.arange(num_energy_bins)),
+            },
+            data_variables_and_dims={
+                "counts": [
+                    "epoch",
+                    "energy_bin_center",
+                    CoordNames.AZIMUTH_L2,
+                    CoordNames.ELEVATION_L2,
+                ],
+            },
+        )
+        assert "counts" in xarray_dataset
+        assert xarray_dataset["counts"].shape == (
+            1,
+            num_energy_bins,
+            360 // rm.spacing_deg,
+            180 // rm.spacing_deg,
+        )
+        np.testing.assert_equal(xarray_dataset["counts"].values, 1)
+
 
 class TestHealpixSkyMap:
     @pytest.fixture(autouse=True)
@@ -549,6 +596,32 @@ class TestHealpixSkyMap:
             input_bright_pixel_az_el_deg,
             atol=degree_tolerance,
         )
+
+    def test_to_xarray(self):
+        """Test conversion of HealpixSkyMap to xarray Dataset"""
+        hp_map = ena_maps.HealpixSkyMap(
+            nside=8,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+            nested=True,
+        )
+        num_energy_bins = 10
+        num_points = hp_map.num_points
+        hp_map.data_dict["counts"] = np.ones((num_energy_bins, num_points))
+
+        xarray_dataset = hp_map.to_xarray(
+            non_spatial_coords={
+                "epoch": [
+                    -1,
+                ],
+                "energy_bin_center": xr.DataArray(np.arange(num_energy_bins)),
+            },
+            data_variables_and_dims={
+                "counts": ["epoch", "energy_bin_center", "healpix_pixel_index"],
+            },
+        )
+        assert "counts" in xarray_dataset
+        assert xarray_dataset["counts"].shape == (1, num_energy_bins, num_points)
+        np.testing.assert_equal(xarray_dataset["counts"].values, 1)
 
 
 class TestIndexMatching:

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -460,6 +460,89 @@ class TestHealpixSkyMap:
         # Check that the binning grid shape is just a tuple of num_points
         np.testing.assert_equal(hp_map.binning_grid_shape, (hp_map.num_points,))
 
+    @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
+    @pytest.mark.parametrize(
+        "nside,degree_tolerance",
+        [
+            (8, 6),
+            (16, 3),
+            (32, 2),
+        ],
+    )
+    @pytest.mark.parametrize("nested", [True, False], ids=["nested", "ring"])
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_project_healpix_pset_values_to_map_push_method(
+        self, mock_frame_transform_az_el, nside, degree_tolerance, nested
+    ):
+        """
+        Test that PointingSet which contains bright spot pushes to correct spot in map.
+
+        Parameterized over nside (of the map, not the PSET), nested.
+        The tolerance for lower nsides must be higher because the
+        Healpix pixels are larger.
+        """
+
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        index_matching_method = ena_maps.IndexMatchMethod.PUSH
+
+        # Create a PointingSet with a bright spot
+        mock_pset_input_frame = ena_maps.UltraPointingSet(
+            l1c_dataset=self.ultra_l1c_pset_products[0],
+            spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+        )
+        mock_pset_input_frame.data["counts"].values = np.zeros_like(
+            mock_pset_input_frame.data["counts"].values
+        )
+
+        input_bright_pixel_number = hp.ang2pix(
+            nside=mock_pset_input_frame.nside,
+            theta=180,
+            phi=0,
+            nest=mock_pset_input_frame.nested,
+            lonlat=True,
+        )
+        input_bright_pixel_az_el_deg = mock_pset_input_frame.az_el_points[
+            input_bright_pixel_number
+        ]
+        mock_pset_input_frame.data["counts"].values[
+            :,
+            :,
+            input_bright_pixel_number,
+        ] = 1
+
+        # Create a Healpix map
+        hp_map = ena_maps.HealpixSkyMap(
+            nside=nside,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+            nested=nested,
+        )
+
+        # Project the PointingSet to the Healpix map
+        hp_map.project_pset_values_to_map(
+            mock_pset_input_frame,
+            value_keys=[
+                "counts",
+            ],
+            index_match_method=index_matching_method,
+        )
+
+        # Check that the map has been updated
+        assert "counts" in hp_map.data_1d.data_vars
+
+        # Find the maximum value in the spatial pixel dimension of the healpix map
+        bright_hp_pixel_index = hp_map.data_1d["counts"][0, :].argmax()
+        bright_hp_pixel_az_el = hp_map.az_el_points[bright_hp_pixel_index]
+
+        np.testing.assert_allclose(
+            bright_hp_pixel_az_el,
+            input_bright_pixel_az_el_deg,
+            atol=degree_tolerance,
+        )
+
     @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
     @pytest.mark.parametrize(
         "nside,degree_tolerance",

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -143,8 +143,8 @@ class TestRectangularSkyMap:
         )
 
         # Check that the map data is an empty xarray Dataset
-        assert isinstance(rm.data, xr.Dataset)
-        assert rm.data.data_vars == {}
+        assert isinstance(rm.data_1d, xr.Dataset)
+        assert rm.data_1d.data_vars == {}
 
         # Check that the reference frame is correctly set
         assert rm.spice_reference_frame == geometry.SpiceFrame.ECLIPJ2000
@@ -244,7 +244,7 @@ class TestRectangularSkyMap:
             )
 
         # Check that the map has been updated
-        assert "counts" in rectangular_map.data.data_vars
+        assert "counts" in rectangular_map.data_1d.data_vars
 
         # Check that the map has the same values as the PSETs, summed
         simple_summed_pset_counts = 0
@@ -260,7 +260,7 @@ class TestRectangularSkyMap:
             simple_summed_pset_counts += reshaped_pset_counts
 
         np.testing.assert_array_equal(
-            rectangular_map.data["counts"].sum(),
+            rectangular_map.data_1d["counts"].sum(),
             simple_summed_pset_counts,
         )
 
@@ -330,15 +330,15 @@ class TestRectangularSkyMap:
             total_pset_counts += rectangular_pset.data["counts"].values
 
         # Check that the map has been updated
-        assert "counts" in rectangular_map.data
+        assert "counts" in rectangular_map.data_1d
 
         np.testing.assert_allclose(
-            rectangular_map.data["counts"],
+            rectangular_map.data_1d["counts"],
             expected_value_every_pixel,
         )
         downsample_ratio = skymap_spacing / self.rectangular_l1c_spacing_deg
         np.testing.assert_allclose(
-            rectangular_map.data["counts"].sum(),
+            rectangular_map.data_1d["counts"].sum(),
             total_pset_counts.sum() / (downsample_ratio**2),
         )
 
@@ -388,8 +388,8 @@ class TestHealpixSkyMap:
         )
 
         # Check that the map data is an empty xarray Dataset
-        assert isinstance(hp_map.data, xr.Dataset)
-        assert hp_map.data.data_vars == {}
+        assert isinstance(hp_map.data_1d, xr.Dataset)
+        assert hp_map.data_1d.data_vars == {}
 
         # Check that the reference frame is correctly set
         assert hp_map.spice_reference_frame is geometry.SpiceFrame.ECLIPJ2000
@@ -475,12 +475,10 @@ class TestHealpixSkyMap:
         )
 
         # Check that the map has been updated
-        assert "counts" in hp_map.data.data_vars
+        assert "counts" in hp_map.data_1d.data_vars
 
         # Find the maximum value in the spatial pixel dimension of the healpix map
-        bright_hp_pixel_index = hp_map.data["counts"][0, 0].argmax(
-            dim="healpix_pixel_index"
-        )
+        bright_hp_pixel_index = hp_map.data_1d["counts"][0, 0].argmax(dim="pixel")
         bright_hp_pixel_az_el = hp_map.az_el_points[bright_hp_pixel_index]
 
         np.testing.assert_allclose(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -78,13 +78,13 @@ class TestUltraPointingSet:
             # Check that the unwrapped_dims_dict is as expected
             assert ultra_pset.unwrapped_dims_dict["counts"] == (
                 "epoch",
-                "energy_bin_center",
+                "energy",
                 "pixel",
             )
             # Check the non_spatial_coords are as expected
             assert tuple(ultra_pset.non_spatial_coords.keys()) == (
                 "epoch",
-                "energy_bin_center",
+                "energy",
             )
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
@@ -185,9 +185,9 @@ class TestRectangularSkyMap:
         )
 
         # Project each PSET's values to the map (push method)
-        for rectangular_pset in self.rectangular_psets:
+        for ultra_pset in self.ultra_psets:
             rectangular_map.project_pset_values_to_map(
-                rectangular_pset,
+                ultra_pset,
                 value_keys=["counts", "exposure_time"],
                 index_match_method=index_matching_method,
             )
@@ -196,18 +196,29 @@ class TestRectangularSkyMap:
         assert "counts" in rectangular_map.data_1d.data_vars
 
         # Check that the map has the same values as the PSETs, summed
-        simple_summed_pset_counts = np.zeros_like(
-            self.ultra_l1c_pset_products[0]["counts"]
+        simple_summed_pset_counts_by_energy = np.zeros(
+            shape=(
+                self.ultra_l1c_pset_products[0]["counts"].sizes[
+                    CoordNames.ENERGY.value
+                ],
+            )
         )
         for pset in self.ultra_l1c_pset_products:
-            simple_summed_pset_counts += pset["counts"].values
+            simple_summed_pset_counts_by_energy += pset["counts"].sum(
+                dim=[d for d in pset["counts"].dims if d != CoordNames.ENERGY.value]
+            )
 
-        rm_counts_per_energy_bin = rectangular_map.data_1d["counts"].sum(axis=1)
-        summed_pset_counts_per_energy_bin = simple_summed_pset_counts.sum(axis=(0, 2))
+        rmap_counts_per_energy_bin = rectangular_map.data_1d["counts"].sum(
+            dim=[
+                d
+                for d in rectangular_map.data_1d["counts"].dims
+                if d != CoordNames.ENERGY.value
+            ]
+        )
 
         np.testing.assert_array_equal(
-            rm_counts_per_energy_bin,
-            summed_pset_counts_per_energy_bin,
+            rmap_counts_per_energy_bin,
+            simple_summed_pset_counts_by_energy,
         )
 
     @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
@@ -248,21 +259,29 @@ class TestRectangularSkyMap:
         assert "counts" in rectangular_map.data_1d.data_vars
 
         # Check that the map has the same values as the PSETs, summed
-        simple_summed_pset_counts = 0
-        for pset in self.l1c_pset_products:
-            simple_summed_pset_counts += pset["counts"].sum()
-        simple_summed_pset_counts = np.zeros_like(rectangular_map.data_dict["counts"])
-        for pset in self.rectangular_l1c_pset_products:
-            reshaped_pset_counts = pset["counts"].squeeze("epoch")
-            # Reshape to the map's counts shape
-            reshaped_pset_counts = reshaped_pset_counts.data.reshape(
-                rectangular_map.data_dict["counts"].shape
+        simple_summed_pset_counts_by_energy = np.zeros(
+            shape=(
+                self.rectangular_l1c_pset_products[0]["counts"].sizes[
+                    CoordNames.ENERGY.value
+                ],
             )
-            simple_summed_pset_counts += reshaped_pset_counts
+        )
+        for pset in self.rectangular_l1c_pset_products:
+            simple_summed_pset_counts_by_energy += pset["counts"].sum(
+                dim=[d for d in pset["counts"].dims if d != CoordNames.ENERGY.value]
+            )
+
+        rmap_counts_per_energy_bin = rectangular_map.data_1d["counts"].sum(
+            dim=[
+                d
+                for d in rectangular_map.data_1d["counts"].dims
+                if d != CoordNames.ENERGY.value
+            ]
+        )
 
         np.testing.assert_array_equal(
-            rectangular_map.data_1d["counts"].sum(),
-            simple_summed_pset_counts,
+            rmap_counts_per_energy_bin,
+            simple_summed_pset_counts_by_energy,
         )
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
@@ -283,7 +302,9 @@ class TestRectangularSkyMap:
 
     @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
-    def test_project_pset_values_to_map_pull_method(self, mock_frame_transform_az_el):
+    def test_project_rect_pset_values_to_map_pull_method(
+        self, mock_frame_transform_az_el
+    ):
         """
         Test projection Rect PSET to Rect. Map with "pull" index matching method.
 
@@ -351,7 +372,7 @@ class TestRectangularSkyMap:
         assert "counts" in rect_map_ds.data_vars
         assert rect_map_ds["counts"].shape == (
             1,
-            ultra_pset.data["counts"].sizes[CoordNames.ENERGY.value],
+            rectangular_pset.data["counts"].sizes[CoordNames.ENERGY.value],
             360 / skymap_spacing,
             180 / skymap_spacing,
         )

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -73,6 +73,20 @@ class TestUltraPointingSet:
             # Check the repr exists
             assert "UltraPointingSet" in repr(ultra_pset)
 
+            # Checks for the property methods:
+            # Check that the unwrapped_dims_dict is as expected
+            assert ultra_pset.unwrapped_dims_dict["counts"] == (
+                "epoch",
+                "energy_bin_center",
+                "pixel",
+            )
+            # Check the non_spatial_coords are as expected
+            assert tuple(ultra_pset.non_spatial_coords.keys()) == (
+                "epoch",
+                "energy_bin_center",
+            )
+
+    @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
     def test_different_spacing_raises_error(self):
         """Test that different spaced az/el from the L1C dataset raises ValueError"""
@@ -128,8 +142,9 @@ class TestRectangularSkyMap:
             spice_frame=geometry.SpiceFrame.ECLIPJ2000,
         )
 
-        # Check that the map is empty
-        assert rm.data_dict == {}
+        # Check that the map data is an empty xarray Dataset
+        assert isinstance(rm.data, xr.Dataset)
+        assert rm.data.data_vars == {}
 
         # Check that the reference frame is correctly set
         assert rm.spice_reference_frame == geometry.SpiceFrame.ECLIPJ2000
@@ -169,15 +184,15 @@ class TestRectangularSkyMap:
         )
 
         # Project each PSET's values to the map (push method)
-        for ultra_pset in self.ultra_psets:
+        for rectangular_pset in self.rectangular_psets:
             rectangular_map.project_pset_values_to_map(
-                ultra_pset,
+                rectangular_pset,
                 value_keys=["counts", "exposure_time"],
                 index_match_method=index_matching_method,
             )
 
         # Check that the map has been updated
-        assert "counts" in rectangular_map.data_dict
+        assert "counts" in rectangular_map.data_1d.data_vars
 
         # Check that the map has the same values as the PSETs, summed
         simple_summed_pset_counts = np.zeros_like(
@@ -186,7 +201,7 @@ class TestRectangularSkyMap:
         for pset in self.ultra_l1c_pset_products:
             simple_summed_pset_counts += pset["counts"].values
 
-        rm_counts_per_energy_bin = rectangular_map.data_dict["counts"].sum(axis=1)
+        rm_counts_per_energy_bin = rectangular_map.data_1d["counts"].sum(axis=1)
         summed_pset_counts_per_energy_bin = simple_summed_pset_counts.sum(axis=(0, 2))
 
         np.testing.assert_array_equal(
@@ -229,9 +244,12 @@ class TestRectangularSkyMap:
             )
 
         # Check that the map has been updated
-        assert "counts" in rectangular_map.data_dict
+        assert "counts" in rectangular_map.data.data_vars
 
         # Check that the map has the same values as the PSETs, summed
+        simple_summed_pset_counts = 0
+        for pset in self.l1c_pset_products:
+            simple_summed_pset_counts += pset["counts"].sum()
         simple_summed_pset_counts = np.zeros_like(rectangular_map.data_dict["counts"])
         for pset in self.rectangular_l1c_pset_products:
             reshaped_pset_counts = pset["counts"].squeeze("epoch")
@@ -242,7 +260,7 @@ class TestRectangularSkyMap:
             simple_summed_pset_counts += reshaped_pset_counts
 
         np.testing.assert_array_equal(
-            rectangular_map.data_dict["counts"],
+            rectangular_map.data["counts"].sum(),
             simple_summed_pset_counts,
         )
 
@@ -312,63 +330,17 @@ class TestRectangularSkyMap:
             total_pset_counts += rectangular_pset.data["counts"].values
 
         # Check that the map has been updated
-        assert "counts" in rectangular_map.data_dict
+        assert "counts" in rectangular_map.data
 
         np.testing.assert_allclose(
-            rectangular_map.data_dict["counts"],
+            rectangular_map.data["counts"],
             expected_value_every_pixel,
         )
         downsample_ratio = skymap_spacing / self.rectangular_l1c_spacing_deg
         np.testing.assert_allclose(
-            rectangular_map.data_dict["counts"].sum(),
+            rectangular_map.data["counts"].sum(),
             total_pset_counts.sum() / (downsample_ratio**2),
         )
-
-    def test_data_dict_value_to_dataarray(self):
-        """Test conversion of data_dict values to xarray DataArrays"""
-        rm = ena_maps.RectangularSkyMap(
-            spacing_deg=1,
-            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
-        )
-        rm.data_dict["variable"] = np.ones((1, 10, 360 * 180))
-        da = rm.data_dict_value_to_dataarray("variable")
-        assert da.shape == (1, 10, 360, 180)
-        assert da.values.sum() == rm.data_dict["variable"].size
-
-    def test_to_xarray(self):
-        """Test conversion of RectangularSkyMap to xarray Dataset"""
-        rm = ena_maps.RectangularSkyMap(
-            spacing_deg=1,
-            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
-        )
-        num_energy_bins = 10
-        num_points = rm.num_points
-        rm.data_dict["counts"] = np.ones((num_energy_bins, num_points))
-
-        xarray_dataset = rm.to_xarray(
-            non_spatial_coords={
-                "epoch": [
-                    -1,
-                ],
-                "energy_bin_center": xr.DataArray(np.arange(num_energy_bins)),
-            },
-            data_variables_and_dims={
-                "counts": [
-                    "epoch",
-                    "energy_bin_center",
-                    CoordNames.AZIMUTH_L2,
-                    CoordNames.ELEVATION_L2,
-                ],
-            },
-        )
-        assert "counts" in xarray_dataset
-        assert xarray_dataset["counts"].shape == (
-            1,
-            num_energy_bins,
-            360 // rm.spacing_deg,
-            180 // rm.spacing_deg,
-        )
-        np.testing.assert_equal(xarray_dataset["counts"].values, 1)
 
 
 class TestHealpixSkyMap:
@@ -415,8 +387,9 @@ class TestHealpixSkyMap:
             nested=nested,
         )
 
-        # Check that the map is empty
-        assert hp_map.data_dict == {}
+        # Check that the map data is an empty xarray Dataset
+        assert isinstance(hp_map.data, xr.Dataset)
+        assert hp_map.data.data_vars == {}
 
         # Check that the reference frame is correctly set
         assert hp_map.spice_reference_frame is geometry.SpiceFrame.ECLIPJ2000
@@ -502,10 +475,12 @@ class TestHealpixSkyMap:
         )
 
         # Check that the map has been updated
-        assert "counts" in hp_map.data_dict
+        assert "counts" in hp_map.data.data_vars
 
         # Find the maximum value in the spatial pixel dimension of the healpix map
-        bright_hp_pixel_index = hp_map.data_dict["counts"][0, :].argmax()
+        bright_hp_pixel_index = hp_map.data["counts"][0, 0].argmax(
+            dim="healpix_pixel_index"
+        )
         bright_hp_pixel_az_el = hp_map.az_el_points[bright_hp_pixel_index]
 
         np.testing.assert_allclose(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -529,6 +529,10 @@ class TestHealpixSkyMap:
             CoordNames.ENERGY.value,
             CoordNames.HEALPIX_INDEX.value,
         )
+        np.testing.assert_array_equal(
+            hp_map_ds["counts"].values,
+            hp_map.data_1d["counts"].values,
+        )
 
 
 class TestIndexMatching:

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -148,11 +148,8 @@ def mock_l1c_pset_product_rectangular(  # noqa: PLR0913
                 counts,
             ),
             "exposure_time": (
-                [
-                    CoordNames.AZIMUTH_L1C.value,
-                    CoordNames.ELEVATION_L1C.value,
-                ],
-                exposure_time,
+                ["epoch", "longitude_bin_center", "latitude_bin_center"],
+                np.expand_dims(exposure_time, axis=0),
             ),
             "sensitivity": (
                 [

--- a/imap_processing/tests/ultra/test_data/mock_data.py
+++ b/imap_processing/tests/ultra/test_data/mock_data.py
@@ -148,7 +148,11 @@ def mock_l1c_pset_product_rectangular(  # noqa: PLR0913
                 counts,
             ),
             "exposure_time": (
-                ["epoch", "longitude_bin_center", "latitude_bin_center"],
+                [
+                    CoordNames.TIME.value,
+                    CoordNames.AZIMUTH_L1C.value,
+                    CoordNames.ELEVATION_L1C.value,
+                ],
                 np.expand_dims(exposure_time, axis=0),
             ),
             "sensitivity": (


### PR DESCRIPTION
# Change Summary

The ENA SkyMaps - both Healpix and Rectangularly tiled - keep their pixels' values (e.g., "counts") in dictionaries, with multiple spatial dims unwrapped in the case of Rectangular maps. This PR defines functions to produce xarray DataArray's of individual dict key/val pairs, and a dataset of all the contained DataArrays. 

Closes #1481

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
The SkyMap holds projected data in a dict:
```python
sky_map.data_dict = {
    "counts": NDArray<M energy bins, N unwrapped spatial pixels >
    "exposure_time": NDArray<N unwrapped spatial pixels >
}
```
where `N` is the number of healpix pixels or the number of rectangular grid pixels, the latter of which is equal to `num_az_bins * num_el_bins`

This PR changes the core way that `SkyMap` objects store data from a dictionary to a Dataset. The core dataset (`sky_map.data_1d`) remains an unwrapped tiling of the sky, where the last dimension is always a generic "pixel", regardless of whether it's a Healpix or Rectangular tiling. However, there is now also a `sky_map.data` property, which rewraps this data, fixes the resulting coordinates, etc.



NOTE: Previously, this PR had created functions to convert from the `data_dict` (see strikethrough text below)

~~This PR defines a function which produces an xarray dataset from this dictionary, and handles all re-wrapping of spatial dimensions as necessary.~~

~~This PR also enables calling the `sky_map.to_xarray` method to produce a formatted, xarray dataset containing the data_dict's values. The user must specify the coordinates of each output DataArray (e.g., `{'counts': ['epoch', 'energy_bin_center', 'longitude_bin_center', 'latitude_bin_center'], 'exposure_time': ['epoch', 'longitude_bin_center', 'latitude_bin_center']}`). These spatial coordinates are determined by the SkyMap object itself, while the user inputs the other coordinates.~~

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
-  imap_processing/ena_maps/ena_maps.py
   - Change core data storage in SkyMap object to an xr.Dataset
   - ~~Add `to_xarray` and `data_dict_value_to_dataarray` methods to the `AbstractSkyMap`~~
   - ~~Add `spatial_coords` attributes to both types of `SkyMap` objects~~
- Also added the CoordNames Enum here - see #1484 for more details. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Fix tests to work with Dataset method of storage. 