### PR TITLE
HIT L0 - Add sectorate angles

### DIFF
--- a/imap_processing/hit/l0/constants.py
+++ b/imap_processing/hit/l0/constants.py
@@ -116,3 +116,12 @@ FRAME_SIZE = len(FLAG_PATTERN)
 # decompressing data
 MANTISSA_BITS = 12
 EXPONENT_BITS = 4
+
+# Define sectorate angles
+DECLINATION_ANGLES = np.array(
+    [11.25, 33.75, 56.25, 78.75, 101.25, 123.75, 146.25, 168.75], dtype=np.float32
+)
+AZIMUTH_ANGLES = np.array(
+    [12, 36, 60, 84, 108, 132, 156, 180, 204, 228, 252, 276, 300, 324, 348],
+    dtype=np.float32,
+)

--- a/imap_processing/tests/hit/test_decom_hit.py
+++ b/imap_processing/tests/hit/test_decom_hit.py
@@ -7,6 +7,7 @@ from imap_processing import imap_module_directory
 from imap_processing.hit.hit_utils import (
     HitAPID,
 )
+from imap_processing.hit.l0.constants import AZIMUTH_ANGLES, DECLINATION_ANGLES
 from imap_processing.hit.l0.decom_hit import (
     assemble_science_frames,
     decom_hit,
@@ -121,6 +122,9 @@ def test_parse_count_rates(sci_dataset):
     ]
     if count_rate_vars in list(sci_dataset.keys()):
         assert True
+
+    assert np.allclose(sci_dataset["declination"].values, DECLINATION_ANGLES)
+    assert np.allclose(sci_dataset["azimuth"].values, AZIMUTH_ANGLES)
 
 
 def test_is_sequential():


### PR DESCRIPTION
This PR replaces index values with angle values for the declination and azimuth coordinates that are dimensions for sectorates.

Closes issue #1492 

## Updated Files
- hit/l0/constants.py
   - Add angle constants
   - Update dimension dtypes to match CDF definitions
- hit/l0/decom_hit.py
   - Use angles for sectorate dimensions
- tests/hit/test_decom_hit.py
   - Add assertions for new angle values 
