### PR TITLE
Update parsing of DE binary blob to match updated order of DE fields

### DIFF
--- a/imap_processing/tests/hi/test_science_direct_event.py
+++ b/imap_processing/tests/hi/test_science_direct_event.py
@@ -21,8 +21,8 @@ def test_parse_direct_events():
     # Encode the random events data into a bit-string
     bin_str = ""
     for i in range(n_events):
-        bin_str += f"{exp_dict['trigger_id'][i]:02b}"  # 2-bits for trigger_id
         bin_str += f"{exp_dict['de_tag'][i]:016b}"  # 16-bits for de_tag
+        bin_str += f"{exp_dict['trigger_id'][i]:02b}"  # 2-bits for trigger_id
         bin_str += f"{exp_dict['tof_1'][i]:010b}"  # 10-bits for tof_1
         bin_str += f"{exp_dict['tof_2'][i]:010b}"  # 10-bits for tof_2
         bin_str += f"{exp_dict['tof_3'][i]:010b}"  # 10-bits for tof_3


### PR DESCRIPTION
Update test to match updated DE field order

# Change Summary

## Overview
As part of L0/L1A validation for Hi DE, I found that the FSW has changed the order of fields that are encoded for each DE. This PR consists of the changed needed to correctly parse the DE binary blob. Validation with external data has been completed and is documented in the artifact attached to the Hi Alg. development milestones confluence page: https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/193401990/IMAP-Hi+Algorithm+Development+Milestone


## Updated Files
- imap_processing/hi/l1a/science_direct_event.py
   - Updates to docstrings reflecting the change in order of DE binary fields
   - Update the parsing to match change in order of DE binary fields
- imap_processing/tests/hi/test_science_direct_event.py
   - Update test to encode DE fields in the correct order

Closes: #1186 
