### PR TITLE
Update pointing table to include subsecond fields

### DIFF
--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -24,8 +24,12 @@ def get_repoint_data() -> pd.DataFrame:
     repoint_df : pd.DataFrame
         The repointing csv loaded into a pandas dataframe. The dataframe will
         contain the following columns:
-            - `repoint_start_time`: Starting MET time of each repoint maneuver.
-            - `repoint_end_time`: Ending MET time of each repoint maneuver.
+            - `repoint_start_sec`: Starting MET seconds of repoint maneuver.
+            - `repoint_start_subsec`: Starting MET milliseconds of repoint maneuver.
+            - `repoint_start_met`: Starting MET time of repoint maneuver.
+            - `repoint_end_sec`: Ending MET seconds of repoint maneuver.
+            - `repoint_end_subsec`: Ending MET milliseconds of repoint maneuver.
+            - `repoint_end_met`: Ending MET time of repoint maneuver.
             - `repoint_id`: Unique ID number of each repoint maneuver.
     """
     repoint_data_filepath = os.getenv("REPOINT_DATA_FILEPATH")
@@ -37,6 +41,14 @@ def get_repoint_data() -> pd.DataFrame:
 
     logger.info(f"Reading repointing data from {path_to_spin_file}")
     repoint_df = pd.read_csv(path_to_spin_file, comment="#")
+
+    # Compute times by combining seconds and subseconds fields
+    repoint_df["repoint_start_met"] = (
+        repoint_df["repoint_start_sec"] + repoint_df["repoint_start_subsec"] / 1e3
+    )
+    repoint_df["repoint_end_met"] = (
+        repoint_df["repoint_end_sec"] + repoint_df["repoint_end_subsec"] / 1e3
+    )
 
     return repoint_df
 
@@ -68,8 +80,12 @@ def interpolate_repoint_data(
     repoint_df : pandas.DataFrame
         Repoint table data interpolated such that there is one row
         for each of the queried MET times. Output columns are:
-            - `repoint_start_time`
-            - `repoint_end_time`
+            - `repoint_start_sec`
+            - `repoint_start_subsec`
+            - `repoint_start_met`
+            - `repoint_end_sec`
+            - `repoint_end_subsec`
+            - `repoint_end_met`
             - `repoint_id`
             - `repoint_in_progress`
 
@@ -84,29 +100,29 @@ def interpolate_repoint_data(
     query_met_times = np.atleast_1d(query_met_times)
 
     # Make sure no query times are before the first repoint in the dataframe.
-    repoint_df_start_time = repoint_df["repoint_start_time"].values[0]
-    if np.any(query_met_times < repoint_df_start_time):
-        bad_times = query_met_times[query_met_times < repoint_df_start_time]
+    repoint_df_start_met = repoint_df["repoint_start_met"].values[0]
+    if np.any(query_met_times < repoint_df_start_met):
+        bad_times = query_met_times[query_met_times < repoint_df_start_met]
         raise ValueError(
             f"{bad_times.size} query times are before the first repoint start "
-            f" time in the repoint table. {bad_times=}, {repoint_df_start_time=}"
+            f" time in the repoint table. {bad_times=}, {repoint_df_start_met=}"
         )
     # Make sure that no query times are after the valid range of the dataframe.
     # We approximate the end time of the table by adding 24 hours to the last
     # known repoint start time.
-    repoint_df_end_time = repoint_df["repoint_start_time"].values[-1] + 24 * 60 * 60
-    if np.any(query_met_times >= repoint_df_end_time):
-        bad_times = query_met_times[query_met_times >= repoint_df_end_time]
+    repoint_df_end_met = repoint_df["repoint_start_met"].values[-1] + 24 * 60 * 60
+    if np.any(query_met_times >= repoint_df_end_met):
+        bad_times = query_met_times[query_met_times >= repoint_df_end_met]
         raise ValueError(
             f"{bad_times.size} query times are after the valid time of the "
             f"pointing table. The valid end time is 24-hours after the last "
-            f"repoint_start_time. {bad_times=}, {repoint_df_end_time=}"
+            f"repoint_start_time. {bad_times=}, {repoint_df_end_met=}"
         )
 
     # Find the row index for each queried MET time such that:
     # repoint_start_time[i] <= MET < repoint_start_time[i+1]
     row_indices = (
-        np.searchsorted(repoint_df["repoint_start_time"], query_met_times, side="right")
+        np.searchsorted(repoint_df["repoint_start_met"], query_met_times, side="right")
         - 1
     )
     out_df = repoint_df.iloc[row_indices]
@@ -115,6 +131,6 @@ def interpolate_repoint_data(
     # The table already has the correct row for each query time, so we
     # only need to check if the query time is less than the repoint end time to
     # get the same result as `repoint_start_time <= query_met_times < repoint_end_time`.
-    out_df["repoint_in_progress"] = query_met_times < out_df["repoint_end_time"].values
+    out_df["repoint_in_progress"] = query_met_times < out_df["repoint_end_met"].values
 
     return out_df

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -16,6 +16,11 @@ def get_repoint_data() -> pd.DataFrame:
     """
     Read repointing file using environment variable and return as dataframe.
 
+    Pointing and repointing nomenclature can be confusing. In this case,
+    repoint is taken to mean a repoint maneuver. Thus, repoint_start and repoint_end
+    are the times that bound when the spacecraft is performing a repointing maneuver.
+    This is different from a pointing which is the time between repointing maneuvers.
+
     REPOINT_DATA_FILEPATH environment variable should point to a local
     file where the repointing csv file is located.
 
@@ -26,10 +31,12 @@ def get_repoint_data() -> pd.DataFrame:
         contain the following columns:
             - `repoint_start_sec`: Starting MET seconds of repoint maneuver.
             - `repoint_start_subsec`: Starting MET milliseconds of repoint maneuver.
-            - `repoint_start_met`: Starting MET time of repoint maneuver.
+            - `repoint_start_met`: Floating point MET of repoint maneuver start time.
+            Derived by combining `repoint_start_sec` and `repoint_start_subsec`.
             - `repoint_end_sec`: Ending MET seconds of repoint maneuver.
             - `repoint_end_subsec`: Ending MET milliseconds of repoint maneuver.
-            - `repoint_end_met`: Ending MET time of repoint maneuver.
+            - `repoint_end_met`: Floating point MET of repoint maneuver end time.
+            Derived by combining `repoint_end_sec` and `repoint_end_subsec`.
             - `repoint_id`: Unique ID number of each repoint maneuver.
     """
     repoint_data_filepath = os.getenv("REPOINT_DATA_FILEPATH")

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -592,10 +592,8 @@ def generate_repoint_data(
         {
             "repoint_start_sec": repoint_start_times.astype(int),
             "repoint_start_subsec": ((repoint_start_times % 1.0) * 1e3).astype(int),
-            "repoint_start_met": repoint_start_times,
             "repoint_end_sec": repoint_end_met.astype(int),
             "repoint_end_subsec": ((repoint_end_met % 1.0) * 1e3).astype(int),
-            "repoint_end_met": np.array(repoint_end_met),
             "repoint_id": np.arange(repoint_start_times.size, dtype=int)
             + repoint_id_start,
         }

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -590,8 +590,12 @@ def generate_repoint_data(
         repoint_end_met = repoint_start_times + 15 * 60
     repoint_df = pd.DataFrame.from_dict(
         {
-            "repoint_start_time": repoint_start_times,
-            "repoint_end_time": np.array(repoint_end_met),
+            "repoint_start_sec": repoint_start_times.astype(int),
+            "repoint_start_subsec": ((repoint_start_times % 1.0) * 1e3).astype(int),
+            "repoint_start_met": repoint_start_times,
+            "repoint_end_sec": repoint_end_met.astype(int),
+            "repoint_end_subsec": ((repoint_end_met % 1.0) * 1e3).astype(int),
+            "repoint_end_met": np.array(repoint_end_met),
             "repoint_id": np.arange(repoint_start_times.size, dtype=int)
             + repoint_id_start,
         }

--- a/imap_processing/tests/spice/test_data/fake_repoint_data.csv
+++ b/imap_processing/tests/spice/test_data/fake_repoint_data.csv
@@ -1,5 +1,5 @@
 # This is a fake csv file for the sole purpose of testing repoint module functions
-repoint_start_time,repoint_end_time,repoint_id
-0,5,0
-15,20,1
-25,30,2
+repoint_start_sec,repoint_start_subsec,repoint_end_sec,repoint_end_subsec,repoint_id
+0,100,5,100,0
+15,200,20,200,1
+25,300,30,300,2

--- a/imap_processing/tests/spice/test_repoint.py
+++ b/imap_processing/tests/spice/test_repoint.py
@@ -20,8 +20,12 @@ def test_get_repoint_data(fake_repoint_data):
     repoint_df = get_repoint_data()
     assert isinstance(repoint_df, pd.DataFrame)
     assert set(repoint_df.columns) == {
-        "repoint_start_time",
-        "repoint_end_time",
+        "repoint_start_sec",
+        "repoint_start_subsec",
+        "repoint_start_met",
+        "repoint_end_sec",
+        "repoint_end_subsec",
+        "repoint_end_met",
         "repoint_id",
     }
 
@@ -36,10 +40,14 @@ def test_spin_data_no_table():
 
 def test_interpolate_repoint_data(fake_repoint_data):
     """Test coverage for get_repoint_data function."""
-    query_times = np.array([0, 6, 32])
+    query_times = np.array([0.1, 6, 32])
     expected_vals = {
-        "repoint_start_time": np.array([0, 0, 25]),
-        "repoint_end_time": np.array([5, 5, 30]),
+        "repoint_start_sec": np.array([0, 0, 25]),
+        "repoint_start_subsec": np.array([100, 100, 300]),
+        "repoint_start_met": np.array([0.1, 0.1, 25.3]),
+        "repoint_end_sec": np.array([5, 5, 30]),
+        "repoint_end_subsec": np.array([100, 100, 300]),
+        "repoint_end_met": np.array([5.1, 5.1, 30.3]),
         "repoint_id": np.array([0, 0, 2]),
         "repoint_in_progress": np.array([True, False, False]),
     }
@@ -57,7 +65,7 @@ def test_interpolate_repoint_data(fake_repoint_data):
             "1 query times are before",
         ),  # Query times before start of table
         (
-            np.array([0, 24 * 60 * 60 + 26]),
+            np.array([1, 24 * 60 * 60 + 26]),
             "1 query times are after",
         ),  # Query times after end of valid range
     ],
@@ -81,12 +89,12 @@ def test_interpolate_repoint_data_with_use_fake_fixture(use_fake_repoint_data_fo
 
     # Expected repoint_start_times are the seeded start times array repeated twice
     np.testing.assert_array_equal(
-        repoint_df["repoint_start_time"].values,
+        repoint_df["repoint_start_met"].values,
         np.concat([repoint_start_times, repoint_start_times]),
     )
     # Expected repoint_end_times are the seeded start times + 15 minutes
     np.testing.assert_array_equal(
-        repoint_df["repoint_end_time"].values,
+        repoint_df["repoint_end_met"].values,
         np.concat([repoint_start_times + 15 * 60, repoint_start_times + 15 * 60]),
     )
     # Expected repoint_id


### PR DESCRIPTION
# Change Summary

## Overview
This adds the sec and subsec columns to the pointing csv as well as the needed changes to the reader to compute the floating point start and end met columns.

## Updated Files
- imap_processing/spice/repoint.py
   - Update documentation to reflect the new columns
   - Compute floating point met columns by combining sec and subsec columns
   - Rename columns: `repoint_start_time` -> `repoint_start_met`, `repoint_end_time` -> `repoint_end_met`
- imap_processing/tests/conftest.py
   - Update fixture that generates a fake repoint table to include the correct columns.
- imap_processing/tests/spice/test_data/fake_repoint_data.csv
   - Update fake pointing test csv to have correct columns
- imap_processing/tests/spice/test_repoint.py
   - Check for new and renamed columns
   - Correct expected values to be floating point

Closes: #1441 