### PR TITLE
Lo - Add SHCOARSE and MET to L1A Direct Events

### DIFF
--- a/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
@@ -110,7 +110,7 @@ esa_step_coord:
 shcoarse:
   <<: *default_uint32
   CATDESC: Mission Elapsed Time
-  DEPEND_0: shcoarse
+  DEPEND_1: shcoarse
   FIELDNAM: Spacecraft Time
   Units: 'ns'
   VAR_TYPE: support_data

--- a/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
@@ -110,7 +110,7 @@ esa_step_coord:
 shcoarse:
   <<: *default_uint32
   CATDESC: Mission Elapsed Time
-  DEPEND_0: epoch
+  DEPEND_0: shcoarse
   FIELDNAM: Spacecraft Time
   Units: 'ns'
   VAR_TYPE: support_data

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -410,9 +410,9 @@ def combine_segmented_packets(dataset: xr.Dataset) -> xr.Dataset:
     dataset.coords["epoch"] = dataset["epoch"].values[seg_starts]
     # drop any group of segmented epochs that aren't sequential
     dataset.coords["epoch"] = dataset["epoch"].values[valid_groups]
-    # Set met to the first segment start times for the valid groups
+    # Set met to the first segment start times for the valid groups.
     # shcoarse will be retained as a per packet coordinate and met
-    # is used as the met for each segment
+    # is used as the mission elapsed time for each segment
     dataset["met"] = xr.DataArray(
         dataset["shcoarse"].values[seg_starts][valid_groups], dims="epoch"
     )

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -410,6 +410,10 @@ def combine_segmented_packets(dataset: xr.Dataset) -> xr.Dataset:
     dataset.coords["epoch"] = dataset["epoch"].values[seg_starts]
     # drop any group of segmented epochs that aren't sequential
     dataset.coords["epoch"] = dataset["epoch"].values[valid_groups]
+    # Set met to the first segment start times for the valid groups
+    dataset["met"] = xr.DataArray(
+        dataset["shcoarse"].values[seg_starts][valid_groups], dims="epoch"
+    )
 
     return dataset
 

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -411,6 +411,8 @@ def combine_segmented_packets(dataset: xr.Dataset) -> xr.Dataset:
     # drop any group of segmented epochs that aren't sequential
     dataset.coords["epoch"] = dataset["epoch"].values[valid_groups]
     # Set met to the first segment start times for the valid groups
+    # shcoarse will be retained as a per packet coordinate and met
+    # is used as the met for each segment
     dataset["met"] = xr.DataArray(
         dataset["shcoarse"].values[seg_starts][valid_groups], dims="epoch"
     )

--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -286,7 +286,6 @@ def add_dataset_attrs(
                 "seq_flgs",
                 "src_seq_ctr",
                 "pkt_len",
-                "shcoarse",
                 "data",
                 "events",
             ]

--- a/imap_processing/tests/lo/test_lo_science.py
+++ b/imap_processing/tests/lo/test_lo_science.py
@@ -261,6 +261,7 @@ def test_combine_segmented_packets(segmented_pkts_fake_data):
         ),
     )
     np.testing.assert_array_equal(dataset["epoch"].values, np.array([0, 10, 30]))
+    np.testing.assert_array_equal(dataset["met"].values, np.array([0, 10, 30]))
 
 
 def test_validate_parse_events(sample_data, attr_mgr):


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds `shcoarse` to the Lo L1A DE dataset and adds a `met` field. The `shcoarse` is retained per packet and the `met` is the `shcoarse`, but only one time per packet group in retained, similar to the `epoch` field. The `met` field is needed to officially validate the L1A DE and will be used in L1B to determine which spin a DE was measured in.

## Updated Files
- imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
   - changed shcoarse depends to shcoarse instead of epoch. Epoch will be per packet group and shocoarse will be per packet so their lengths will differ.
- imap_processing/lo/l0/lo_science.py
   - added a met field which is just the shcoarse, but on a per packet group interval. This is mostly being used for validation
- imap_processing/lo/l1a/lo_l1a.py
   - removed shcoarse as a variable to be dropped from the dataset


## Testing
- imap_processing/tests/lo/test_lo_science.py
   - added met to the unit test
- ran cli and examined resulting CDF

Closes #1506 