### PR TITLE
Lo L1B - Average Spin Duration Calculation

### DIFF
--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -1,9 +1,42 @@
 from collections import namedtuple
 
+import numpy as np
+import pytest
+import xarray as xr
+
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import load_cdf
-from imap_processing.lo.l1b.lo_l1b import create_datasets, lo_l1b
+from imap_processing.lo.l1b.lo_l1b import (
+    convert_start_end_acq_times,
+    create_datasets,
+    get_avg_spin_durations,
+    initialize_l1b_de,
+    lo_l1b,
+)
+
+
+@pytest.fixture()
+def dependencies():
+    return {
+        "imap_lo_l1a_de": load_cdf(
+            imap_module_directory
+            / "tests/lo/test_cdfs/imap_lo_l1a_de_20241022_v002.cdf"
+        ),
+        "imap_lo_l1a_spin": load_cdf(
+            imap_module_directory
+            / "tests/lo/test_cdfs/imap_lo_l1a_spin_20241022_v002.cdf"
+        ),
+    }
+
+
+@pytest.fixture()
+def attr_mgr_l1b():
+    attr_mgr_l1b = ImapCdfAttributes()
+    attr_mgr_l1b.add_instrument_global_attrs(instrument="lo")
+    attr_mgr_l1b.add_instrument_variable_attrs(instrument="lo", level="l1b")
+    attr_mgr_l1b.add_global_attribute("Data_version", "000")
+    return attr_mgr_l1b
 
 
 def test_lo_l1b():
@@ -72,3 +105,76 @@ def test_create_datasets():
     assert dataset.badtime.shape[0] == 3
     assert len(dataset.esa_step.shape) == 1
     assert dataset.esa_step.shape[0] == 3
+
+
+def test_initialize_dataset(dependencies, attr_mgr_l1b):
+    # Arrange
+    l1a_de = dependencies["imap_lo_l1a_de"]
+    logical_source = "imap_lo_l1b_de"
+
+    # Act
+    l1b_de = initialize_l1b_de(l1a_de, attr_mgr_l1b, logical_source)
+
+    # Assert
+    assert l1b_de.attrs["Logical_source"] == logical_source
+    assert list(l1b_de.coords.keys()) == []
+    assert len(l1b_de.data_vars) == 4
+    assert len(l1b_de.coords) == 0
+    for l1b_name, l1a_name in {
+        "pos": "pos",
+        "mode": "mode",
+        "absent": "coincidence_type",
+        "esa_step": "esa_step",
+    }.items():
+        assert l1b_name in l1b_de.data_vars
+        np.testing.assert_array_equal(l1b_de[l1b_name], l1a_de[l1a_name])
+
+
+def test_convert_start_end_acq_times():
+    # Arrange
+    spin = xr.Dataset(
+        {
+            "acq_start_sec": ("epoch", [1, 2, 3]),
+            "acq_start_subsec": ("epoch", [4, 5, 6]),
+            "acq_end_sec": ("epoch", [7, 8, 9]),
+            "acq_end_subsec": ("epoch", [10, 11, 12]),
+        },
+        coords={"epoch": [0, 1, 2]},
+    )
+
+    acq_start_expected = xr.DataArray(
+        [
+            spin["acq_start_sec"][0] + spin["acq_start_subsec"][0] * 1e-6,
+            spin["acq_start_sec"][1] + spin["acq_start_subsec"][1] * 1e-6,
+            spin["acq_start_sec"][2] + spin["acq_start_subsec"][2] * 1e-6,
+        ],
+        dims="epoch",
+    )
+    acq_end_expected = xr.DataArray(
+        [
+            spin["acq_end_sec"][0] + spin["acq_end_subsec"][0] * 1e-6,
+            spin["acq_end_sec"][1] + spin["acq_end_subsec"][1] * 1e-6,
+            spin["acq_end_sec"][2] + spin["acq_end_subsec"][2] * 1e-6,
+        ],
+        dims="epoch",
+    )
+
+    # Act
+    acq_start, acq_end = convert_start_end_acq_times(spin)
+
+    # Assert
+    np.testing.assert_array_equal(acq_start.values, acq_start_expected.values)
+    np.testing.assert_array_equal(acq_end.values, acq_end_expected.values)
+
+
+def test_get_avg_spin_durations():
+    # Arrange
+    acq_start = xr.DataArray([0, 423, 846.2], dims="epoch")
+    acq_end = xr.DataArray([422.8, 846, 1269.7], dims="epoch")
+    expected_avg_spin_durations = np.array([422.8, 423, 423.5]) / 28
+
+    # Act
+    avg_spin_durations = get_avg_spin_durations(acq_start, acq_end)
+
+    # Assert
+    np.testing.assert_array_equal(avg_spin_durations, expected_avg_spin_durations)


### PR DESCRIPTION
# Change Summary

## Overview
This PR calculates the average spin duration for each Aggregated Science Cycle (ASC) which corresponds to each epoch in the L1A spin data.

## Updated Files
- imap_processing/lo/l1b/lo_l1b.py
   - function was added to combine the acq start/end time seconds and sub seconds fields from L1A into a single time in seconds
   - function was added to calculate the average spin duration for each ASC

## Testing
New unit tests added for functions

Closes #1508 