### PR TITLE
Update release build to ignore metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,32 +18,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # We need the full history to generate the proper version number
-          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install dependencies
         run: python -m pip install build twine
 
-      - name: Build wheel and source distribution
+      - name: Build wheel and source tarball
         run: |
           python -m build
 
-      - name: Check README rendering for PyPI
-        run: twine check dist/*
+      # TODO: Update once setuptools emits proper metadata for PEP 639
+      # - name: Check README rendering for PyPI
+      #   run: twine check dist/*
 
-      - name: Upload sdist result
+      - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
           if-no-files-found: error
 
-  pypi-publish:
+  publish-to-pypi:
     name: Upload release to PyPI
     needs: build
     runs-on: ubuntu-latest
@@ -60,4 +60,6 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verify-metadata: false


### PR DESCRIPTION
Similar to what @greglucas did in https://github.com/IMAP-Science-Operations-Center/imap-data-access/pull/139, this PR updates the release GitHub Actions build to ignore metadata.