### PR TITLE
MNT: Update SWAPI DataLevel metadata

### DIFF
--- a/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
@@ -12,22 +12,21 @@ instrument_base: &instrument_base
 
 imap_swapi_l1_sci:
   <<: *instrument_base
-  # NOTE: Right now, this Data_level is required to produce valid CDF
-  Data_level: "1"
+  Data_level: 1
   Data_type: L1_SCI>Level-1 Science data
   Logical_source: imap_swapi_l1_sci
   Logical_source_description: SWAPI Instrument Level-1 Science Data
 
 imap_swapi_l1_hk:
   <<: *instrument_base
-  Data_level: "1"
+  Data_level: 1
   Data_type: L1_HK>Level-1B Housekeeping data
   Logical_source: imap_swapi_l1_hk
   Logical_source_description: SWAPI Instrument Level-1 Housekeeping Data
 
 imap_swapi_l2_sci:
   <<: *instrument_base
-  Data_level: "2"
+  Data_level: 2
   Data_type: L2_SCI>Level-2 Science data
   Logical_source: imap_swapi_l2_sci
-  Logical_source_description: SWAPI Instrument Level-1 Science Data
+  Logical_source_description: SWAPI Instrument Level-2 Science Data


### PR DESCRIPTION
I noticed that the L2 file had the wrong data level in the description field when I was copying information over. Then I also noticed that other instruments don't put the quotes around the data level value, so I removed those too.