### PR TITLE
MNT: Update glows and mag DataLevel metadata for CDF properties

### DIFF
--- a/imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml
@@ -14,35 +14,35 @@ instrument_base: &instrument_base
 
 imap_glows_l1a_hist:
   <<: *instrument_base
-  Data_level: L1A
+  Data_level: 1A
   Data_type: L1A_hist>Level-1A histogram
   Logical_source: imap_glows_l1a_hist
   Logical_source_description: IMAP Mission GLOWS Histogram Level-1A Data.
 
 imap_glows_l1a_de:
   <<: *instrument_base
-  Data_level: L1A
+  Data_level: 1A
   Data_type: L1A_de>Level-1A direct event
   Logical_source: imap_glows_l1a_de
   Logical_source_description: IMAP Mission GLOWS Direct Event Level-1A Data.
 
 imap_glows_l1b_hist:
   <<: *instrument_base
-  Data_level: L1B
+  Data_level: 1B
   Data_type: L1B_hist>Level-1B histogram
   Logical_source: imap_glows_l1b_hist
   Logical_source_description: IMAP Mission GLOWS Instrument Level-1B Histogram Data.
 
 imap_glows_l1b_de:
   <<: *instrument_base
-  Data_level: L1B
+  Data_level: 1B
   Data_type: L1B_de>Level-1B Direct Events
   Logical_source: imap_glows_l1b_de
   Logical_source_description: IMAP Mission GLOWS Instrument Level-1B Direct Events Data.
 
 imap_glows_l2_hist:
   <<: *instrument_base
-  Data_level: L2
+  Data_level: 2
   Data_type: L2_hist>Level-2 histogram
   Logical_source: imap_glows_l2_hist
   Logical_source_description: IMAP Mission GLOWS Instrument Level-2 Histogram Data.

--- a/imap_processing/cdf/config/imap_mag_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_global_cdf_attrs.yaml
@@ -17,82 +17,82 @@ imap_mag_l1a_norm-raw:
     Data_type: L1A_norm-raw>Level-1A raw normal rate
     Logical_source: imap_mag_l1a_norm-raw
     Logical_source_description: IMAP Mission MAG Normal Rate Instrument Level-1A Data.
-    Data_level: L1A
+    Data_level: 1A
 
 imap_mag_l1a_burst-raw:
     <<: *default
     Data_type: L1A_burst-raw>Level-1A raw burst rate
     Logical_source: imap_mag_l1a_burst-raw
     Logical_source_description: IMAP Mission MAG Burst Rate Instrument Level-1A Data.
-    Data_level: L1A
+    Data_level: 1A
 
 imap_mag_l1a_norm-mago:
     <<: *default
     Data_type: L1A_norm-mago>Level 1A MAGo normal rate
     Logical_source: imap_mag_l1a_norm-mago
     Logical_source_description: IMAP Mission MAGo Normal Rate Instrument Level-1A Data.
-    Data_level: L1A
+    Data_level: 1A
 
 imap_mag_l1a_norm-magi:
     <<: *default
     Data_type: L1A_norm-magi>Level 1A MAGi normal rate
     Logical_source: imap_mag_l1a_norm-magi
     Logical_source_description: IMAP Mission MAGi Normal Rate Instrument Level-1A Data.
-    Data_level: L1A
+    Data_level: 1A
 
 imap_mag_l1a_burst-mago:
     <<: *default
     Data_type: L1A_burst-mago>Level 1A MAGo burst rate
     Logical_source: imap_mag_l1a_burst-mago
     Logical_source_description: IMAP Mission MAGo Burst Rate Instrument Level-1A Data.
-    Data_level: L1A
+    Data_level: 1A
 
 imap_mag_l1a_burst-magi:
     <<: *default
     Data_type: L1A_burst-magi>Level 1A MAGi burst rate
     Logical_source: imap_mag_l1a_burst-magi
     Logical_source_description: IMAP Mission MAGi Burst Rate Instrument Level-1A Data.
-    Data_level: L1A
+    Data_level: 1A
 
 imap_mag_l1b_norm-mago:
     <<: *default
     Data_type: L1B_norm-mago>Level 1B MAGo normal rate
     Logical_source: imap_mag_l1b_norm-mago
     Logical_source_description: IMAP Mission MAGo Normal Rate Instrument Level-1B Data.
-    Data_level: L1B
+    Data_level: 1B
 
 imap_mag_l1b_norm-magi:
     <<: *default
     Data_type: L1B_norm-magi>Level 1B MAGi normal rate
     Logical_source: imap_mag_l1b_norm-magi
     Logical_source_description: IMAP Mission MAGi Normal Rate Instrument Level-1B Data.
-    Data_level: L1B
+    Data_level: 1B
 
 imap_mag_l1b_burst-mago:
     <<: *default
     Data_type: L1B_burst-mago>Level 1B MAGo burst rate
     Logical_source: imap_mag_l1b_burst-mago
     Logical_source_description: IMAP Mission MAGo Burst Rate Instrument Level-1B Data.
-    Data_level: L1B
+    Data_level: 1B
 
 imap_mag_l1b_burst-magi:
     <<: *default
     Data_type: L1B_burst-magi>Level 1B MAGi burst rate
     Logical_source: imap_mag_l1b_burst-magi
     Logical_source_description: IMAP Mission MAGi Burst Rate Instrument Level-1B Data.
-    Data_level: L1B
+    Data_level: 1B
 
 imap_mag_l1c_norm-mago:
     <<: *default
     Data_type: L1C_norm-mago>Level 1C MAGo normal rate
     Logical_source: imap_mag_l1c_norm-mago
     Logical_source_description: IMAP Mission MAGo Normal Rate Instrument Level-1C Data.
-    Data_level: L1C
+    Data_level: 1C
 
 imap_mag_l1c_norm-magi:
     <<: *default
     Data_type: L1C_norm-magi>Level 1C MAGi normal rate
     Logical_source: imap_mag_l1c_norm-magi
     Logical_source_description: IMAP Mission MAGi Normal Rate Instrument Level-1C Data.
-    Data_level: L1C
+    Data_level: 1C
 

--- a/imap_processing/tests/mag/test_mag_l1b.py
+++ b/imap_processing/tests/mag/test_mag_l1b.py
@@ -75,7 +75,7 @@ def test_mag_attributes():
     output = mag_l1b(mag_l1a_dataset, "v001")
     assert output.attrs["Logical_source"] == "imap_mag_l1b_burst-magi"
 
-    assert output.attrs["Data_level"] == "L1B"
+    assert output.attrs["Data_level"] == "1B"
 
 
 def test_cdf_output():

--- a/imap_processing/tests/mag/test_mag_l1c.py
+++ b/imap_processing/tests/mag/test_mag_l1c.py
@@ -190,7 +190,7 @@ def test_mag_l1c(norm_dataset, burst_dataset):
 def test_mag_attributes(norm_dataset, burst_dataset):
     output = mag_l1c(norm_dataset, burst_dataset, "v001")
     assert output.attrs["Logical_source"] == "imap_mag_l1c_norm-mago"
-    assert output.attrs["Data_level"] == "L1C"
+    assert output.attrs["Data_level"] == "1C"
 
     expected_attrs = ["missing_sequences", "interpolation_method"]
     for attr in expected_attrs:


### PR DESCRIPTION
I noticed these were the only instruments that had "L" as a prefix in the DataLevel attribute. This updates these instruments to remove the "L" to be consistent with the other instruments. I'm not sure which way is official, so if we need to update the other instruments to add an "L", we can do that too, but I took the low-hanging fruit for now.

ping @tech3371 who may know better the requirements on naming these.