### PR TITLE
FIX: L0 is not a valid processing step, we only process l1a+

### DIFF
--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -19,7 +19,6 @@ from imap_processing._version import __version__, __version_tuple__  # noqa: F40
 # Eg. imap_module_directory = /usr/local/lib/python3.11/site-packages/imap_processing
 imap_module_directory = Path(__file__).parent
 
-# TODO: should we move this to imap-data-access?
 PROCESSING_LEVELS = {
     "codice": ["l1a", "l1b", "l2"],
     "glows": ["l1a", "l1b", "l2"],

--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -27,7 +27,7 @@ PROCESSING_LEVELS = {
     "hit": ["l1a", "l1b", "l2"],
     "idex": ["l1a", "l1b", "l2a", "l2b"],
     "lo": ["l1a", "l1b", "l1c", "l2"],
-    "mag": ["l1a", "l1b", "l1c", "l2pre", "l2"],
+    "mag": ["l1a", "l1b", "l1c", "l1d", "l2"],
     "swapi": ["l1", "l2", "l3a", "l3b"],
     "swe": ["l1a", "l1b", "l2"],
     "ultra": ["l1a", "l1b", "l1c", "l2"],

--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -21,14 +21,14 @@ imap_module_directory = Path(__file__).parent
 
 # TODO: should we move this to imap-data-access?
 PROCESSING_LEVELS = {
-    "codice": ["l0", "l1a", "l1b", "l2"],
-    "glows": ["l0", "l1a", "l1b", "l2"],
-    "hi": ["l0", "l1a", "l1b", "l1c", "l2"],
-    "hit": ["l0", "l1a", "l1b", "l2"],
-    "idex": ["l0", "l1a", "l1b", "l2a", "l2b"],
-    "lo": ["l0", "l1a", "l1b", "l1c", "l2"],
-    "mag": ["l0", "l1a", "l1b", "l1c", "l2pre", "l2"],
-    "swapi": ["l0", "l1", "l2", "l3a", "l3b"],
-    "swe": ["l0", "l1a", "l1b", "l2"],
-    "ultra": ["l0", "l1a", "l1b", "l1c", "l2"],
+    "codice": ["l1a", "l1b", "l2"],
+    "glows": ["l1a", "l1b", "l2"],
+    "hi": ["l1a", "l1b", "l1c", "l2"],
+    "hit": ["l1a", "l1b", "l2"],
+    "idex": ["l1a", "l1b", "l2a", "l2b"],
+    "lo": ["l1a", "l1b", "l1c", "l2"],
+    "mag": ["l1a", "l1b", "l1c", "l2pre", "l2"],
+    "swapi": ["l1", "l2", "l3a", "l3b"],
+    "swe": ["l1a", "l1b", "l2"],
+    "ultra": ["l1a", "l1b", "l1c", "l2"],
 }

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -62,8 +62,8 @@ def test_main(mock_instrument):
 @pytest.mark.parametrize(
     "instrument, data_level, raises_value_error",
     [
-        ("mag", "l0", ""),
-        ("foo", "l0", "foo is not in the supported .*"),
+        ("mag", "l1a", ""),
+        ("foo", "l1a", "foo is not in the supported .*"),
         ("codice", "l1z", "l1z is not a supported .*"),
     ],
 )


### PR DESCRIPTION
Noticed this when going through the cli options. It is nicer if we don't print this as an option if we don't do anything with it on any of the instruments.