### PR TITLE
MNT: Remove Data_level as a field from the CDF variables

### DIFF
--- a/docs/source/external-tools/cdf/cdf_requirements.rst
+++ b/docs/source/external-tools/cdf/cdf_requirements.rst
@@ -16,7 +16,6 @@ CDF files are composed of these main components: Global Attributes, Data Variabl
 Required Global Attributes
 ==========================
 
-* Data_level
 * Data_type
 * Data_version
 * Descriptor

--- a/imap_processing/cdf/config/imap_codice_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_global_cdf_attrs.yaml
@@ -16,112 +16,96 @@ instrument_base: &instrument_base
 # L1a
 imap_codice_l1a_hskp:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_hskp->Level-1A Housekeeping Data
     Logical_source: imap_codice_l1a_hskp
     Logical_source_description: IMAP Mission CoDICE Instrument Level-1A Housekeeping Data.
 
 imap_codice_l1a_hi-counters-aggregated:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_hi-counters-aggregated->Level-1A Hi Aggregated Instrument Counts Data
     Logical_source: imap_codice_l1a_hi-counters-aggregated
     Logical_source_description: IMAP Mission CoDICE Hi Level-1A Aggregated Instrument Counts Data.
 
 imap_codice_l1a_hi-counters-singles:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_hi-counters-singles->Level-1A Hi Single Instrument Counts Data
     Logical_source: imap_codice_l1a_hi-counters-singles
     Logical_source_description: IMAP Mission CoDICE Hi Level-1A Single Instrument Counts Data.
 
 imap_codice_l1a_hi-omni:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_hi-omni->Level-1A Hi Omnidirectional Data
     Logical_source: imap_codice_l1a_hi-omni
     Logical_source_description: IMAP Mission CoDICE Hi Level-1A Omnidirectional Data.
 
 imap_codice_l1a_hi-priority:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_hi-priority->Level-1A Hi Priority Data
     Logical_source: imap_codice_l1a_hi-priority
     Logical_source_description: IMAP Mission CoDICE Hi Level-1A Priority Data.
 
 imap_codice_l1a_hi-sectored:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_hi-sectored->Level-1A Hi Sectored Data
     Logical_source: imap_codice_l1a_hi-sectored
     Logical_source_description: IMAP Mission CoDICE Hi Level-1A Sectored Data.
 
 imap_codice_l1a_hi-pha:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_hi-pha->Level-1A Hi Event Data
     Logical_source: imap_codice_l1a_hi-pha
     Logical_source_description: IMAP Mission CoDICE Hi Level-1A Event Data.
 
 imap_codice_l1a_lo-counters-aggregated:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-counters-aggregated->Level-1A Lo Aggregated Instrument Counts Data
     Logical_source: imap_codice_l1a_lo-counters-aggregated
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Aggregated Instrument Counts Data.
 
 imap_codice_l1a_lo-counters-singles:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-counters-singles->Level-1A Lo Single Instrument Counts Data
     Logical_source: imap_codice_l1a_lo-counters-singles
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Single Instrument Counts Data.
 
 imap_codice_l1a_lo-sw-angular:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-sw-angular->Level-1A Lo Sunward Angular Counts Data
     Logical_source: imap_codice_l1a_lo-sw-angular
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Sunward Angular Counts Data.
 
 imap_codice_l1a_lo-nsw-angular:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-nsw-angular->Level-1A Lo Non-Sunward Angular Counts Data
     Logical_source: imap_codice_l1a_lo-nsw-angular
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Non-Sunward Angular Counts Data.
 
 imap_codice_l1a_lo-sw-priority:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-sw-priority->Level-1A Lo Sunward Priority Counts Data
     Logical_source: imap_codice_l1a_lo-sw-priority
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Sunward Priority Counts Data.
 
 imap_codice_l1a_lo-nsw-priority:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-nsw-priority->Level-1A Lo Non-Sunward Priority Counts Data
     Logical_source: imap_codice_l1a_lo-nsw-priority
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Non-Sunward Priority Counts Data.
 
 imap_codice_l1a_lo-sw-species:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-sw-species->Level-1A Lo Sunward Species Counts Data
     Logical_source: imap_codice_l1a_lo-sw-species
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Sunward Species Counts Data.
 
 imap_codice_l1a_lo-nsw-species:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-nsw-species->Level-1A Lo Non-Sunward Species Counts Data
     Logical_source: imap_codice_l1a_lo-nsw-species
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Non-Sunward Species Counts Data.
 
 imap_codice_l1a_lo-pha:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_lo-pha->Level-1A Lo Event Data
     Logical_source: imap_codice_l1a_lo-pha
     Logical_source_description: IMAP Mission CoDICE Lo Level-1A Event Data.
@@ -129,91 +113,78 @@ imap_codice_l1a_lo-pha:
 # L1b
 imap_codice_l1b_hskp:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_hskp->Level-1B Housekeeping Data
     Logical_source: imap_codice_l1b_hskp
     Logical_source_description: IMAP Mission CoDICE Instrument Level-1B Housekeeping Data.
 
 imap_codice_l1b_hi_counters_aggregated:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_hi-counters-aggregated->Level-1B Hi Aggregated Instrument Rates Data
     Logical_source: imap_codice_l1b_hi-counters-aggregated
     Logical_source_description: IMAP Mission CoDICE Hi Level-1B Aggregated Instrument Rates Data.
 
 imap_codice_l1b_hi_counters_singles:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_hi-counters-singles->Level-1B Hi Single Instrument Rates Data
     Logical_source: imap_codice_l1b_hi-counters-singles
     Logical_source_description: IMAP Mission CoDICE Hi Level-1B Single Instrument Rates Data.
 
 imap_codice_l1b_hi_omni:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_hi-omni->Level-1B Hi Omnidirectional Data
     Logical_source: imap_codice_l1b_hi-omni
     Logical_source_description: IMAP Mission CoDICE Hi Level-1B Omnidirectional Data.
 
 imap_codice_l1b_hi_sectored:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_hi-sectored->Level-1B Hi Sectored Data
     Logical_source: imap_codice_l1b_hi-sectored
     Logical_source_description: IMAP Mission CoDICE Hi Level-1B Sectored Data.
 
 imap_codice_l1b_lo_counters_aggregated:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_lo-counters-aggregated->Level-1B Lo Aggregated Instrument Rates Data
     Logical_source: imap_codice_l1b_lo-counters-aggregated
     Logical_source_description: IMAP Mission CoDICE Lo Level-1B Aggregated Instrument Rates Data.
 
 imap_codice_l1b_lo_counters_singles:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_lo-counters-aggregated->Level-1B Lo Single Instrument Rates Data
     Logical_source: imap_codice_l1b_lo-counters-singles
     Logical_source_description: IMAP Mission CoDICE Lo Level-1B Single Instrument Rates Data.
 
 imap_codice_l1b_lo_sw_angular:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_lo-sw-angular->Level-1B Lo Sunward Angular Rates Data
     Logical_source: imap_codice_l1b_lo-sw-angular
     Logical_source_description: IMAP Mission CoDICE Lo Level-1B Sunward Angular Rates Data.
 
 imap_codice_l1b_lo_nsw_angular:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_lo-nsw-angular->Level-1B Lo Non-Sunward Angular Rates Data
     Logical_source: imap_codice_l1b_lo-nsw-angular
     Logical_source_description: IMAP Mission CoDICE Lo Level-1B Non-Sunward Angular Rates Data.
 
 imap_codice_l1b_lo_sw_priority:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_lo-sw-priority->Level-1B Lo Sunward Priority Rates Data
     Logical_source: imap_codice_l1b_lo-sw-priority
     Logical_source_description: IMAP Mission CoDICE Lo Level-1B Sunward Priority Rates Data.
 
 imap_codice_l1b_lo_nsw_priority:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_lo-nsw-priority->Level-1B Lo Non-Sunward Priority Rates Data
     Logical_source: imap_codice_l1b_lo-nsw-priority
     Logical_source_description: IMAP Mission CoDICE Lo Level-1B Non-Sunward Priority Rates Data.
 
 imap_codice_l1b_lo_sw_species:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_lo-sw-species->Level-1B Lo Sunward Species Rates Data
     Logical_source: imap_codice_l1b_lo-sw-species
     Logical_source_description: IMAP Mission CoDICE Lo Level-1B Sunward Species Rates Data.
 
 imap_codice_l1b_lo_nsw_species:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_lo-nsw-species->Level-1B Lo Non-Sunward Species Rates Data
     Logical_source: imap_codice_l1b_lo-nsw-species
     Logical_source_description: IMAP Mission CoDICE Lo Level-1B Non-Sunward Species Rates Data.

--- a/imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml
@@ -14,35 +14,30 @@ instrument_base: &instrument_base
 
 imap_glows_l1a_hist:
   <<: *instrument_base
-  Data_level: L1A
   Data_type: L1A_hist>Level-1A histogram
   Logical_source: imap_glows_l1a_hist
   Logical_source_description: IMAP Mission GLOWS Histogram Level-1A Data.
 
 imap_glows_l1a_de:
   <<: *instrument_base
-  Data_level: L1A
   Data_type: L1A_de>Level-1A direct event
   Logical_source: imap_glows_l1a_de
   Logical_source_description: IMAP Mission GLOWS Direct Event Level-1A Data.
 
 imap_glows_l1b_hist:
   <<: *instrument_base
-  Data_level: L1B
   Data_type: L1B_hist>Level-1B histogram
   Logical_source: imap_glows_l1b_hist
   Logical_source_description: IMAP Mission GLOWS Instrument Level-1B Histogram Data.
 
 imap_glows_l1b_de:
   <<: *instrument_base
-  Data_level: L1B
   Data_type: L1B_de>Level-1B Direct Events
   Logical_source: imap_glows_l1b_de
   Logical_source_description: IMAP Mission GLOWS Instrument Level-1B Direct Events Data.
 
 imap_glows_l2_hist:
   <<: *instrument_base
-  Data_level: L2
   Data_type: L2_hist>Level-2 histogram
   Logical_source: imap_glows_l2_hist
   Logical_source_description: IMAP Mission GLOWS Instrument Level-2 Histogram Data.

--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -15,43 +15,36 @@ Instrument_type: Particles (space)
 
 # -------------- Product specific global attributes defined below --------------
 imap_hi_l1a_de_attrs:
-    Data_level: 1A
     Data_type: L1A_DE>Level-1A Direct Event
     Logical_source: imap_hi_l1a_{sensor}-de
     Logical_source_description: IMAP-Hi Instrument Level-1A Direct Event Data.
 
 imap_hi_l1b_de_attrs:
-    Data_level: 1B
     Data_type: L1B_DE>Level-1B Direct Event
     Logical_source: imap_hi_l1b_{sensor}-de
     Logical_source_description: IMAP-Hi Instrument Level-1B Direct Event Data.
 
 imap_hi_l1a_diagfee_attrs:
-    Data_level: 1A
     Data_type: L1A_DIAGFEE>Level-1A Diagnostic Front End Electronics
     Logical_source: imap_hi_l1a_{sensor}-diagfee
     Logical_source_description: IMAP-Hi Instrument Level-1A Diagnostic Front End Electronics.
 
 imap_hi_l1a_hist_attrs:
-    Data_level: 1A
     Data_type: L1A_HIST>Level-1A Histogram
     Logical_source: imap_hi_l1a_{sensor}-hist
     Logical_source_description: IMAP-Hi Instrument Level-1A Histogram Data.
 
 imap_hi_l1a_hk_attrs:
-    Data_level: 1A
     Data_type: L1A_HK>Level-1A Housekeeping
     Logical_source: imap_hi_l1a_{sensor}-hk
     Logical_source_description: IMAP-Hi Instrument Level-1A Housekeeping Data.
 
 imap_hi_l1b_hk_attrs:
-    Data_level: 1B
     Data_type: L1B_HK>Level-1B Housekeeping
     Logical_source: imap_hi_l1b_{sensor}-hk
     Logical_source_description: IMAP-Hi Instrument Level-1B Housekeeping Data.
 
 imap_hi_l1c_pset_attrs:
-    Data_level: 1C
     Data_type: L1C_PSET>Level-1C Pointing Set
     Logical_source: imap_hi_l1c_{sensor}-pset
     Logical_source_description: IMAP-Hi Instrument Level-1C Pointing Set Data.

--- a/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
@@ -13,21 +13,18 @@ instrument_base: &instrument_base
   # L1a
 imap_hit_l1a_hk:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_HK>Level-1A Housekeeping
     Logical_source: imap_hit_l1a_hk
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Housekeeping Data.
 
 imap_hit_l1a_counts:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_counts>Level-1A Counts
     Logical_source: imap_hit_l1a_counts
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Count Rates Data.
 
 imap_hit_l1a_direct-events:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_pha>Level-1A Direct Events
     Logical_source: imap_hit_l1a_direct-events
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Pulse Height Events Data.
@@ -35,28 +32,24 @@ imap_hit_l1a_direct-events:
   # L1b
 imap_hit_l1b_hk:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_HK>Level-1B Housekeeping
     Logical_source: imap_hit_l1b_hk
     Logical_source_description: IMAP Mission HIT Instrument Level-1B Housekeeping Data.
 
 imap_hit_l1b_standard-rates:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_rates>Level-1B Standard Rates
     Logical_source: imap_hit_l1b_standard-rates
     Logical_source_description: IMAP Mission HIT Instrument Level-1B Standard Rates Data.
 
 imap_hit_l1b_summed-rates:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_summed-rates>Level-1B Summed Rates
     Logical_source: imap_hit_l1b_summed-rates
     Logical_source_description: IMAP Mission HIT Instrument Level-1B Summed Rates Data.
 
 imap_hit_l1b_sectored-rates:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_sectored-rates>Level-1B Sectored Rates
     Logical_source: imap_hit_l1b_sectored-rates
     Logical_source_description: IMAP Mission HIT Instrument Level-1B Sectored Rates Data.
@@ -65,21 +58,18 @@ imap_hit_l1b_sectored-rates:
 
 imap_hit_l2_standard-intensity:
     <<: *instrument_base
-    Data_level: 2
     Data_type: L2_rates>Level-2 Standard Intensity
     Logical_source: imap_hit_l2_standard-intensity
     Logical_source_description: IMAP Mission HIT Instrument Level-2 Standard Intensity Data.
 
 imap_hit_l2_summed-intensity:
     <<: *instrument_base
-    Data_level: 2
     Data_type: L2_summed-rates>Level-2 Summed Intensity
     Logical_source: imap_hit_l2_summed-intensity
     Logical_source_description: IMAP Mission HIT Instrument Level-2 Summed Intensity Data.
 
 imap_hit_l2_sectored-intensity:
     <<: *instrument_base
-    Data_level: 2
     Data_type: L2_sectored-rates>Level-2 Macro Pixel Intensity
     Logical_source: imap_hit_l2_macropixel-intensity
     Logical_source_description: IMAP Mission HIT Instrument Level-2 Macro Pixel Intensity Data.

--- a/imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml
@@ -11,21 +11,18 @@ instrument_base: &instrument_base
 
 imap_idex_l1a_sci:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1A_SCI>Level-1A Science Data
   Logical_source: imap_idex_l1a_sci-1week
   Logical_source_description: IMAP Mission IDEX Instrument Level-1A Data.
 
 imap_idex_l1b_sci:
   <<: *instrument_base
-  Data_level: 1B
   Data_type: L1B_SCI>Level-1B Science Data
   Logical_source: imap_idex_l1b_sci-1week
   Logical_source_description: IMAP Mission IDEX Instrument Level-1B Data.
 
 imap_idex_l2a_sci:
   <<: *instrument_base
-  Data_level: 2A
   Data_type: L2A_SCI>Level-2A Science Data
   Logical_source: imap_idex_l2a_sci-1week
   Logical_source_description: IMAP Mission IDEX Instrument Level-2A Data

--- a/imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
@@ -7,84 +7,72 @@ instrument_base: &instrument_base
 
 imap_lo_l1a_de:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1A_de>Level-1A Science Direct Events
   Logical_source: imap_lo_l1a_de
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1A Data
 
 imap_lo_l1a_histogram:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1A_histogram>Level-1A Science Counts
   Logical_source: imap_lo_l1a_histogram
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1A Data
 
 imap_lo_l1a_star:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1A_star>Level-1A Star Sensor
   Logical_source: imap_lo_l1a_star
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1A Data
 
 imap_lo_l1a_spin:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1A_star>Level-1A Spin
   Logical_source: imap_lo_l1a_spin
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1A Data
 
 imap_lo_l1b_badtimes:
   <<: *instrument_base
-  Data_level: 1B
   Data_type: L1B_badtimes>Level-1B Badtimes
   Logical_source: imap_lo_l1b_badtimes
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1B Data
 
 imap_lo_l1b_de:
   <<: *instrument_base
-  Data_level: 1B
   Data_type: L1B_de>Level-1B Annotated Direct Events
   Logical_source: imap_lo_l1b_de
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1B Data
 
 imap_lo_l1b_monitorrates:
   <<: *instrument_base
-  Data_level: 1B
   Data_type: L1B_monitorrates>Level-1B Monitor Rates
   Logical_source: imap_lo_l1b_monitorrates
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1B Data
 
 imap_lo_l1b_histogramrates:
   <<: *instrument_base
-  Data_level: 1B
   Data_type: L1B_histogramrates>Level-1B Histogram Rates
   Logical_source: imap_lo_l1b_histogramrrates
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1B Data
 
 imap_lo_l1b_derates:
   <<: *instrument_base
-  Data_level: 1B
   Data_type: L1B_derates>Level-1B Direct Event Rates
   Logical_source: imap_lo_l1b_derates
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1B Data
 
 imap_lo_l1b_prostar:
   <<: *instrument_base
-  Data_level: 1B
   Data_type: L1B_prostar>Level-1B Processed Star Sensor
   Logical_source: imap_lo_l1b_prostar
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1B Data
 
 imap_lo_l1c_goodtimes:
   <<: *instrument_base
-  Data_level: 1C
   Data_type: L1C_goodtimes>Level-1C Goodtimes List
   Logical_source: imap_lo_l1c_goodtimes
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1C Data
 
 imap_lo_l1c_pset:
   <<: *instrument_base
-  Data_level: 1C
   Data_type: L1C_pset>Level-1C Pointing Set
   Logical_source: imap_lo_l1c_pset
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1C Data

--- a/imap_processing/cdf/config/imap_mag_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_global_cdf_attrs.yaml
@@ -17,82 +17,69 @@ imap_mag_l1a_norm-raw:
     Data_type: L1A_norm-raw>Level-1A raw normal rate
     Logical_source: imap_mag_l1a_norm-raw
     Logical_source_description: IMAP Mission MAG Normal Rate Instrument Level-1A Data.
-    Data_level: L1A
 
 imap_mag_l1a_burst-raw:
     <<: *default
     Data_type: L1A_burst-raw>Level-1A raw burst rate
     Logical_source: imap_mag_l1a_burst-raw
     Logical_source_description: IMAP Mission MAG Burst Rate Instrument Level-1A Data.
-    Data_level: L1A
 
 imap_mag_l1a_norm-mago:
     <<: *default
     Data_type: L1A_norm-mago>Level 1A MAGo normal rate
     Logical_source: imap_mag_l1a_norm-mago
     Logical_source_description: IMAP Mission MAGo Normal Rate Instrument Level-1A Data.
-    Data_level: L1A
 
 imap_mag_l1a_norm-magi:
     <<: *default
     Data_type: L1A_norm-magi>Level 1A MAGi normal rate
     Logical_source: imap_mag_l1a_norm-magi
     Logical_source_description: IMAP Mission MAGi Normal Rate Instrument Level-1A Data.
-    Data_level: L1A
 
 imap_mag_l1a_burst-mago:
     <<: *default
     Data_type: L1A_burst-mago>Level 1A MAGo burst rate
     Logical_source: imap_mag_l1a_burst-mago
     Logical_source_description: IMAP Mission MAGo Burst Rate Instrument Level-1A Data.
-    Data_level: L1A
 
 imap_mag_l1a_burst-magi:
     <<: *default
     Data_type: L1A_burst-magi>Level 1A MAGi burst rate
     Logical_source: imap_mag_l1a_burst-magi
     Logical_source_description: IMAP Mission MAGi Burst Rate Instrument Level-1A Data.
-    Data_level: L1A
 
 imap_mag_l1b_norm-mago:
     <<: *default
     Data_type: L1B_norm-mago>Level 1B MAGo normal rate
     Logical_source: imap_mag_l1b_norm-mago
     Logical_source_description: IMAP Mission MAGo Normal Rate Instrument Level-1B Data.
-    Data_level: L1B
 
 imap_mag_l1b_norm-magi:
     <<: *default
     Data_type: L1B_norm-magi>Level 1B MAGi normal rate
     Logical_source: imap_mag_l1b_norm-magi
     Logical_source_description: IMAP Mission MAGi Normal Rate Instrument Level-1B Data.
-    Data_level: L1B
 
 imap_mag_l1b_burst-mago:
     <<: *default
     Data_type: L1B_burst-mago>Level 1B MAGo burst rate
     Logical_source: imap_mag_l1b_burst-mago
     Logical_source_description: IMAP Mission MAGo Burst Rate Instrument Level-1B Data.
-    Data_level: L1B
 
 imap_mag_l1b_burst-magi:
     <<: *default
     Data_type: L1B_burst-magi>Level 1B MAGi burst rate
     Logical_source: imap_mag_l1b_burst-magi
     Logical_source_description: IMAP Mission MAGi Burst Rate Instrument Level-1B Data.
-    Data_level: L1B
 
 imap_mag_l1c_norm-mago:
     <<: *default
     Data_type: L1C_norm-mago>Level 1C MAGo normal rate
     Logical_source: imap_mag_l1c_norm-mago
     Logical_source_description: IMAP Mission MAGo Normal Rate Instrument Level-1C Data.
-    Data_level: L1C
 
 imap_mag_l1c_norm-magi:
     <<: *default
     Data_type: L1C_norm-magi>Level 1C MAGi normal rate
     Logical_source: imap_mag_l1c_norm-magi
     Logical_source_description: IMAP Mission MAGi Normal Rate Instrument Level-1C Data.
-    Data_level: L1C
-

--- a/imap_processing/cdf/config/imap_spacecraft_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_spacecraft_global_cdf_attrs.yaml
@@ -8,13 +8,11 @@ Instrument_type: Ephemeris
 
 # -------------- Product specific global attributes defined below --------------
 imap_spacecraft_l1a_quaternions:
-    Data_level: 1A
     Data_type: L1A_QUAT>Level-1A Quaternions
     Logical_source: imap_spacecraft_l1a_quaternions
     Logical_source_description: IMAP Quaternion Level-1A Data From the Spacecraft.
 
 imap_spacecraft_l1b_quaternions:
-    Data_level: 1B
     Data_type: L1B_QUAT>Level-1B Quaternions
     Logical_source: imap_spacecraft_l1b_quaternions
     Logical_source_description: IMAP Quaternion Level-1B Data From the Spacecraft.

--- a/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
@@ -12,21 +12,18 @@ instrument_base: &instrument_base
 
 imap_swapi_l1_sci:
   <<: *instrument_base
-  Data_level: 1
   Data_type: L1_SCI>Level-1 Science data
   Logical_source: imap_swapi_l1_sci
   Logical_source_description: SWAPI Instrument Level-1 Science Data
 
 imap_swapi_l1_hk:
   <<: *instrument_base
-  Data_level: 1
   Data_type: L1_HK>Level-1B Housekeeping data
   Logical_source: imap_swapi_l1_hk
   Logical_source_description: SWAPI Instrument Level-1 Housekeeping Data
 
 imap_swapi_l2_sci:
   <<: *instrument_base
-  Data_level: 2
   Data_type: L2_SCI>Level-2 Science data
   Logical_source: imap_swapi_l2_sci
   Logical_source_description: SWAPI Instrument Level-2 Science Data

--- a/imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml
@@ -10,36 +10,30 @@ instrument_base: &instrument_base
 
 imap_swe_l1a_sci:
   <<: *instrument_base
-  # NOTE: Right now, this Data_level is required to produce valid CDF
-  Data_level: 1A
   Data_type: L1A_SCI>Level-1A Science data
   Logical_source: imap_swe_l1a_sci
   Logical_source_description: SWE Instrument Level-1A Science Data
 
 imap_swe_l1a_hk:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1A_HK>Level-1A Housekeeping data
   Logical_source: imap_swe_l1a_hk
   Logical_source_description: SWE Instrument Level-1A Housekeeping Data
 
 imap_swe_l1a_cem-raw:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1A_CEM-RAW>Level-1A CEM Raw data
   Logical_source: imap_swe_l1a_cem-raw
   Logical_source_description: SWE Instrument Level-1A CEM Raw Data
 
 imap_swe_l1b_sci:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1B_SCI>Level-1B Science data
   Logical_source: imap_swe_l1b_sci
   Logical_source_description: SWE Instrument Level-1B Science Data
 
 imap_swe_l2_sci:
   <<: *instrument_base
-  Data_level: 2
   Data_type: L2_SCI>Level-2 Science data
   Logical_source: imap_swe_l2_sci
   Logical_source_description: SWE Instrument Level-2 Science Data

--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -11,28 +11,24 @@ instrument_base: &instrument_base
 # TODO: revisit this to be more specific
 imap_ultra_l1a_sci:
     <<: *instrument_base
-    Data_level: 1A
     Data_type: L1A_SCI>Level-1A Science data
     Logical_source: imap_ultra_l1a_sci
     Logical_source_description: IMAP-Ultra Instrument Level-1A Science Data.
 
 imap_ultra_l1b_45sensor-de:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_45Sensor-DE>Level-1B Direct Events for Ultra45
     Logical_source: imap_ultra_l1b_45sensor-de
     Logical_source_description: IMAP-Ultra Instrument Level-1B Direct Event Data.
 
 imap_ultra_l1b_90sensor-de:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_90Sensor-DE>Level-1B Direct Events for Ultra90
     Logical_source: imap_ultra_l1b_90sensor-de
     Logical_source_description: IMAP-Ultra Instrument Level-1B Direct Event Data.
 
 imap_ultra_l1b_45sensor-extendedspin:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_45Sensor-ExtendedSpin>Level-1B Extended Spin for Ultra45
     Logical_source: imap_ultra_l1b_45sensor-extendedspin
     Logical_source_description: IMAP-Ultra Instrument Level-1B Extended Spin Data.
@@ -45,56 +41,48 @@ imap_ultra_l1b_90sensor-extendedspin:
 
 imap_ultra_l1b_45sensor-cullingmask:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_45Sensor-CullingMask>Level-1B Culling Mask for Ultra45
     Logical_source: imap_ultra_l1b_45sensor-cullingmask
     Logical_source_description: IMAP-Ultra Instrument Level-1B Culling Mask Data.
 
 imap_ultra_l1b_90sensor-cullingmask:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_90Sensor-CullingMask>Level-1B Culling Mask for Ultra90
     Logical_source: imap_ultra_l1b_90sensor-cullingmask
     Logical_source_description: IMAP-Ultra Instrument Level-1B Culling Mask Data.
 
 imap_ultra_l1b_45sensor-badtimes:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_45Sensor-Badtimes>Level-1B Badtimes for Ultra45
     Logical_source: imap_ultra_l1b_45sensor-badtimes
     Logical_source_description: IMAP-Ultra Instrument Level-1B Badtimes Data.
 
 imap_ultra_l1b_90sensor-badtimes:
     <<: *instrument_base
-    Data_level: 1B
     Data_type: L1B_90Sensor-Badtimes>Level-1B Badtimes for Ultra90
     Logical_source: imap_ultra_l1b_90sensor-badtimes
     Logical_source_description: IMAP-Ultra Instrument Level-1B Badtimes Data.
 
 imap_ultra_l1c_45sensor-pset:
     <<: *instrument_base
-    Data_level: 1C
     Data_type: L1C_45Sensor-PSET>Level-1C Pointing Set Grid for Ultra45
     Logical_source: imap_ultra_l1c_45sensor-pset
     Logical_source_description: IMAP-Ultra Instrument Level-1C Pointing Set Grid Exposure Data.
 
 imap_ultra_l1c_90sensor-pset:
     <<: *instrument_base
-    Data_level: 1C
     Data_type: L1C_90Sensor-PSET>Level-1C Pointing Set Grid for Ultra90
     Logical_source: imap_ultra_l1c_90sensor-pset
     Logical_source_description: IMAP-Ultra Instrument Level-1C Pointing Set Grid Exposure Data.
 
 imap_ultra_l1c_45sensor-histogram:
     <<: *instrument_base
-    Data_level: 1C
     Data_type: L1C_45Sensor-Histogram>Level-1C Histogram for Ultra45
     Logical_source: imap_ultra_l1c_45sensor-histogram
     Logical_source_description: IMAP-Ultra Instrument Level-1C Pointing Set Grid Histogram Data.
 
 imap_ultra_l1c_90sensor-histogram:
     <<: *instrument_base
-    Data_level: 1C
     Data_type: L1C_45Sensor-Histogram>Level-1C Histogram for Ultra90
     Logical_source: imap_ultra_l1c_90sensor-histogram
     Logical_source_description: IMAP-Ultra Instrument Level-1C Pointing Set Grid Histogram Data.

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -62,7 +62,6 @@ def swapi_l2(l1_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # Update L2 specific attributes
     l2_dataset.attrs["Data_version"] = data_version
     l2_global_attrs = cdf_manager.get_global_attributes("imap_swapi_l2_sci")
-    l2_dataset.attrs["Data_level"] = l2_global_attrs["Data_level"]
     l2_dataset.attrs["Data_type"] = l2_global_attrs["Data_type"]
     l2_dataset.attrs["Logical_source"] = l2_global_attrs["Logical_source"]
     l2_dataset.attrs["Logical_source_description"] = l2_global_attrs[

--- a/imap_processing/tests/cdf/test_data/imap_instrument2_global_cdf_attrs.yaml
+++ b/imap_processing/tests/cdf/test_data/imap_instrument2_global_cdf_attrs.yaml
@@ -10,14 +10,12 @@ instrument_base: &instrument_base
 
 imap_swe_l1a_sci:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1A_SCI>Level-1A Science data
   Logical_source: imap_swe_l1a_sci
   Logical_source_description: SWE Instrument Level-1A Science Data
 
 imap_swe_l1b_sci:
   <<: *instrument_base
-  Data_level: 1A
   Data_type: L1B_SCI>Level-1B Science data
   Logical_source: imap_swe_l1b_sci
   Logical_source_description: SWE Instrument Level-1B Science Data

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -178,7 +178,6 @@ def test_process_housekeeping(housekeeping_dataset, attribute_manager):
         "Acknowledgement": "Please acknowledge the IMAP Mission Principal "
         "Investigator, Prof. David J. McComas of Princeton "
         "University.\n",
-        "Data_level": "1A",
         "Data_type": "L1A_HK>Level-1A Housekeeping",
         "Data_version": "001",
         "Descriptor": "HIT>IMAP High-energy Ion Telescope",

--- a/imap_processing/tests/mag/test_mag_l1b.py
+++ b/imap_processing/tests/mag/test_mag_l1b.py
@@ -75,8 +75,6 @@ def test_mag_attributes():
     output = mag_l1b(mag_l1a_dataset, "v001")
     assert output.attrs["Logical_source"] == "imap_mag_l1b_burst-magi"
 
-    assert output.attrs["Data_level"] == "L1B"
-
 
 def test_cdf_output():
     l1a_cdf = load_cdf(

--- a/imap_processing/tests/mag/test_mag_l1c.py
+++ b/imap_processing/tests/mag/test_mag_l1c.py
@@ -190,7 +190,6 @@ def test_mag_l1c(norm_dataset, burst_dataset):
 def test_mag_attributes(norm_dataset, burst_dataset):
     output = mag_l1c(norm_dataset, burst_dataset, "v001")
     assert output.attrs["Logical_source"] == "imap_mag_l1c_norm-mago"
-    assert output.attrs["Data_level"] == "L1C"
 
     expected_attrs = ["missing_sequences", "interpolation_method"]
     for attr in expected_attrs:

--- a/imap_processing/tests/spacecraft/test_quaternions.py
+++ b/imap_processing/tests/spacecraft/test_quaternions.py
@@ -67,7 +67,5 @@ def test_process_quaternions():
         / "SSR_2024_190_20_08_12_0483851794_2_DA_apid0594_1packet.pkts"
     )
     l1a_ds, l1b_ds = quaternions.process_quaternions(packet_file)
-    assert l1a_ds.attrs["Data_level"] == "1A"
-    assert l1b_ds.attrs["Data_level"] == "1B"
     assert len(l1a_ds["epoch"]) == 1
     assert len(l1b_ds["epoch"]) == 10


### PR DESCRIPTION
This is unused and is not a required data attribute. We were inconsistent in the naming, so remove it to avoid confusion.

supersedes #1528