### PR TITLE
MNT: Add test_data directory to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ cython_debug/
 
 # Data that is downloaded
 data/
+test_data/
 
 # Ignore specific SPICE kernels that get downloaded from NAIF automatically for tests
 # marked with @pytest.mark.external_kernel


### PR DESCRIPTION
When running the entire test suite locally, I had some extra test files from IDEX and Ultra that appeared. I think these are actually stored on the remote and then downloaded locally, so they should be added to the gitignore so they don't get added to the repostiory.

For simplicity, I've just added all test_data/ directories. This means any smaller test files people want to add will have to be manually added with a `git add -f ` flag to force it to override gitignore, but this seems better than accidentally adding files.