### PR TITLE
Lo L1B - Create Lo Spin Bin Direct Event Field

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -50,7 +50,6 @@ def lo_l1b(dependencies: dict, data_version: str) -> list[Path]:
         # Get the average spin durations for each epoch
         avg_spin_durations = get_avg_spin_durations(acq_start, acq_end)  # noqa: F841
         # get spin phase for each DE
-        # get spin phase for each DE
         spin_phase = get_spin_phase(l1a_de)
         # calculate and set the spin bin based on the spin phase
         # spin bins are 0 - 60 bins

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -49,7 +49,7 @@ def lo_l1b(dependencies: dict, data_version: str) -> list[Path]:
         acq_start, acq_end = convert_start_end_acq_times(spin_data)
         # Get the average spin durations for each epoch
         avg_spin_durations = get_avg_spin_durations(acq_start, acq_end)  # noqa: F841
-        # get spin phase for each DE
+        # get spin phase (0 - 360 degrees) for each DE
         spin_phase = get_spin_phase(l1a_de)
         # calculate and set the spin bin based on the spin phase
         # spin bins are 0 - 60 bins

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -184,7 +184,7 @@ def get_spin_phase(l1a_de_data: xr.Dataset) -> Union[np.ndarray[np.float64], Any
     for asc_de_times in de_time_asc_groups:
         # DE Time is 12 bit DN. The max possible value is 4096
         spin_phase.extend(asc_de_times / 4096 * 360)
-    return np.array(spin_phase).astype(np.float64)
+    return np.array(spin_phase, dtype=np.float64)
 
 
 def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -189,7 +189,7 @@ def get_spin_phase(l1a_de_data: xr.Dataset) -> Union[np.ndarray[np.float64], Any
 
 def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:
     """
-    Set the spin bin (0 - 60 bins) for each Direct Event.
+    Set the spin bin (0 - 60 bins) for each Direct Event where each bin is 6 degrees.
 
     Parameters
     ----------
@@ -204,6 +204,7 @@ def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:
         The L1B DE dataset with the spin bin added.
     """
     # Get the spin bin for each DE
+    # Spin bins are 0 - 60 where each bin is 6 degrees
     spin_bin = (spin_phase // 6).astype(int)
     l1b_de["spin_bin"] = xr.DataArray(
         spin_bin,

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -163,13 +163,13 @@ def get_avg_spin_durations(
     return avg_spin_durations
 
 
-def get_spin_phase(l1a_de_data: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
+def get_spin_phase(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
     """
     Get the spin phase (0 - 360 degrees) for each DE.
 
     Parameters
     ----------
-    l1a_de_data : xarray.Dataset
+    l1a_de : xarray.Dataset
         The L1A DE dataset.
 
     Returns
@@ -177,7 +177,7 @@ def get_spin_phase(l1a_de_data: xr.Dataset) -> Union[np.ndarray[np.float64], Any
     spin_phase : np.ndarray
         The spin phase for each DE.
     """
-    de_times = l1a_de_data["de_time"].values
+    de_times = l1a_de["de_time"].values
     # DE Time is 12 bit DN. The max possible value is 4096
     spin_phase = np.array(de_times / 4096 * 360, dtype=np.float64)
     return spin_phase

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -49,11 +49,11 @@ def lo_l1b(dependencies: dict, data_version: str) -> list[Path]:
         acq_start, acq_end = convert_start_end_acq_times(spin_data)
         # Get the average spin durations for each epoch
         avg_spin_durations = get_avg_spin_durations(acq_start, acq_end)  # noqa: F841
-        # get spin phase (0 - 360 degrees) for each DE
-        spin_phase = get_spin_phase(l1a_de)
-        # calculate and set the spin bin based on the spin phase
+        # get spin angle (0 - 360 degrees) for each DE
+        spin_angle = get_spin_angle(l1a_de)
+        # calculate and set the spin bin based on the spin angle
         # spin bins are 0 - 60 bins
-        l1b_de = set_spin_bin(l1b_de, spin_phase)
+        l1b_de = set_spin_bin(l1b_de, spin_angle)
 
     return [l1b_de]
 
@@ -163,9 +163,9 @@ def get_avg_spin_durations(
     return avg_spin_durations
 
 
-def get_spin_phase(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
+def get_spin_angle(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
     """
-    Get the spin phase (0 - 360 degrees) for each DE.
+    Get the spin angle (0 - 360 degrees) for each DE.
 
     Parameters
     ----------
@@ -174,16 +174,16 @@ def get_spin_phase(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
 
     Returns
     -------
-    spin_phase : np.ndarray
-        The spin phase for each DE.
+    spin_angle : np.ndarray
+        The spin angle for each DE.
     """
     de_times = l1a_de["de_time"].values
     # DE Time is 12 bit DN. The max possible value is 4096
-    spin_phase = np.array(de_times / 4096 * 360, dtype=np.float64)
-    return spin_phase
+    spin_angle = np.array(de_times / 4096 * 360, dtype=np.float64)
+    return spin_angle
 
 
-def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:
+def set_spin_bin(l1b_de: xr.Dataset, spin_angle: np.ndarray) -> xr.Dataset:
     """
     Set the spin bin (0 - 60 bins) for each Direct Event where each bin is 6 degrees.
 
@@ -191,8 +191,8 @@ def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:
     ----------
     l1b_de : xarray.Dataset
         The L1B Direct Event dataset.
-    spin_phase : np.ndarray
-        The spin phase (0-360 degrees) for each Direct Event.
+    spin_angle : np.ndarray
+        The spin angle (0-360 degrees) for each Direct Event.
 
     Returns
     -------
@@ -201,11 +201,11 @@ def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:
     """
     # Get the spin bin for each DE
     # Spin bins are 0 - 60 where each bin is 6 degrees
-    spin_bin = (spin_phase // 6).astype(int)
+    spin_bin = (spin_angle // 6).astype(int)
     l1b_de["spin_bin"] = xr.DataArray(
         spin_bin,
         dims=["epoch"],
-        # TODO: Add spin phase to YAML file
+        # TODO: Add spin angle to YAML file
         # attrs=attr_mgr.get_variable_attributes("spin_bin"),
     )
     return l1b_de

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -189,7 +189,7 @@ def get_spin_phase(l1a_de_data: xr.Dataset) -> Union[np.ndarray[np.float64], Any
 
 def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:
     """
-    Set the spin bin (0 - 60 bins) for each DE.
+    Set the spin bin (0 - 60 bins) for each Direct Event.
 
     Parameters
     ----------
@@ -207,7 +207,7 @@ def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:
     spin_bin = (spin_phase // 6).astype(int)
     l1b_de["spin_bin"] = xr.DataArray(
         spin_bin,
-        dims=["direct_event"],
+        dims=["epoch"],
         # TODO: Add spin phase to YAML file
         # attrs=attr_mgr.get_variable_attributes("spin_bin"),
     )

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2,6 +2,7 @@
 
 from dataclasses import Field
 from pathlib import Path
+from typing import Any, Union
 
 import numpy as np
 import xarray as xr
@@ -49,6 +50,11 @@ def lo_l1b(dependencies: dict, data_version: str) -> list[Path]:
         # Get the average spin durations for each epoch
         avg_spin_durations = get_avg_spin_durations(acq_start, acq_end)  # noqa: F841
         # get spin phase for each DE
+        # get spin phase for each DE
+        spin_phase = get_spin_phase(l1a_de)
+        # calculate and set the spin bin based on the spin phase
+        # spin bins are 0 - 60 bins
+        l1b_de = set_spin_bin(l1b_de, spin_phase)
 
     return [l1b_de]
 
@@ -156,6 +162,56 @@ def get_avg_spin_durations(
     # There are 28 spins per epoch (1 aggregated science cycle)
     avg_spin_durations = (acq_end - acq_start) / 28
     return avg_spin_durations
+
+
+def get_spin_phase(l1a_de_data: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
+    """
+    Get the spin phase (0 - 360 degrees) for each DE.
+
+    Parameters
+    ----------
+    l1a_de_data : xarray.Dataset
+        The L1A DE dataset.
+
+    Returns
+    -------
+    spin_phase : np.ndarray
+        The spin phase for each DE.
+    """
+    counts = l1a_de_data["de_count"].values
+    de_time_asc_groups = np.split(l1a_de_data["de_time"].values, np.cumsum(counts)[:-1])
+    spin_phase: list[float] = []
+    for asc_de_times in de_time_asc_groups:
+        # DE Time is 12 bit DN. The max possible value is 4096
+        spin_phase.extend(asc_de_times / 4096 * 360)
+    return np.array(spin_phase).astype(np.float64)
+
+
+def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:
+    """
+    Set the spin bin (0 - 60 bins) for each DE.
+
+    Parameters
+    ----------
+    l1b_de : xarray.Dataset
+        The L1B Direct Event dataset.
+    spin_phase : np.ndarray
+        The spin phase (0-360 degrees) for each Direct Event.
+
+    Returns
+    -------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset with the spin bin added.
+    """
+    # Get the spin bin for each DE
+    spin_bin = (spin_phase // 6).astype(int)
+    l1b_de["spin_bin"] = xr.DataArray(
+        spin_bin,
+        dims=["direct_event"],
+        # TODO: Add spin phase to YAML file
+        # attrs=attr_mgr.get_variable_attributes("spin_bin"),
+    )
+    return l1b_de
 
 
 # TODO: This is going to work differently when I sample data.

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -178,13 +178,10 @@ def get_spin_phase(l1a_de_data: xr.Dataset) -> Union[np.ndarray[np.float64], Any
     spin_phase : np.ndarray
         The spin phase for each DE.
     """
-    counts = l1a_de_data["de_count"].values
-    de_time_asc_groups = np.split(l1a_de_data["de_time"].values, np.cumsum(counts)[:-1])
-    spin_phase: list[float] = []
-    for asc_de_times in de_time_asc_groups:
-        # DE Time is 12 bit DN. The max possible value is 4096
-        spin_phase.extend(asc_de_times / 4096 * 360)
-    return np.array(spin_phase, dtype=np.float64)
+    de_times = l1a_de_data["de_time"].values
+    # DE Time is 12 bit DN. The max possible value is 4096
+    spin_phase = np.array(de_times / 4096 * 360, dtype=np.float64)
+    return spin_phase
 
 
 def set_spin_bin(l1b_de: xr.Dataset, spin_phase: np.ndarray) -> xr.Dataset:

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -179,7 +179,7 @@ def get_spin_angle(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
     """
     de_times = l1a_de["de_time"].values
     # DE Time is 12 bit DN. The max possible value is 4096
-    spin_angle = np.mod(de_times / 4096 * 360, 360).astype(np.float64)
+    spin_angle = np.array(de_times / 4096 * 360, dtype=np.float64)
     return spin_angle
 
 

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -179,7 +179,7 @@ def get_spin_angle(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
     """
     de_times = l1a_de["de_time"].values
     # DE Time is 12 bit DN. The max possible value is 4096
-    spin_angle = np.array(de_times / 4096 * 360, dtype=np.float64)
+    spin_angle = np.mod(de_times / 4096 * 360, 360).astype(np.float64)
     return spin_angle
 
 

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -187,11 +187,11 @@ def test_get_spin_angle():
     de = xr.Dataset(
         {
             "de_count": ("epoch", [2, 3]),
-            "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000]),
+            "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000, 4096]),
         },
-        coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4]},
+        coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4, 5]},
     )
-    spin_angle_expected = np.array([0, 87.89, 175.78, 263.67, 351.56])
+    spin_angle_expected = np.array([0, 87.89, 175.78, 263.67, 351.56, 0])
 
     # Act
     spin_angle = get_spin_angle(de)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -11,7 +11,7 @@ from imap_processing.lo.l1b.lo_l1b import (
     convert_start_end_acq_times,
     create_datasets,
     get_avg_spin_durations,
-    get_spin_phase,
+    get_spin_angle,
     initialize_l1b_de,
     lo_l1b,
     set_spin_bin,
@@ -182,7 +182,7 @@ def test_get_avg_spin_durations():
     np.testing.assert_array_equal(avg_spin_durations, expected_avg_spin_durations)
 
 
-def test_get_spin_phase():
+def test_get_spin_angle():
     # Arrange
     de = xr.Dataset(
         {
@@ -191,28 +191,28 @@ def test_get_spin_phase():
         },
         coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4]},
     )
-    spin_phase_expected = np.array([0, 87.89, 175.78, 263.67, 351.56])
+    spin_angle_expected = np.array([0, 87.89, 175.78, 263.67, 351.56])
 
     # Act
-    spin_phase = get_spin_phase(de)
+    spin_angle = get_spin_angle(de)
 
     # Assert
     np.testing.assert_allclose(
-        spin_phase,
-        spin_phase_expected,
+        spin_angle,
+        spin_angle_expected,
         atol=1e-2,
-        err_msg=f"Spin phase: {spin_phase} vs {spin_phase_expected}",
+        err_msg=f"Spin angle: {spin_angle} vs {spin_angle_expected}",
     )
 
 
 def test_spin_bin():
     # Arrange
     l1b_de = xr.Dataset()
-    spin_phase = np.array([0, 50, 150, 250, 365])
+    spin_angle = np.array([0, 50, 150, 250, 365])
     expected_spin_bins = np.array([0, 8, 25, 41, 60])
 
     # Act
-    l1b_de = set_spin_bin(l1b_de, spin_phase)
+    l1b_de = set_spin_bin(l1b_de, spin_angle)
 
     # Assert
     np.testing.assert_array_equal(l1b_de["spin_bin"], expected_spin_bins)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -187,11 +187,11 @@ def test_get_spin_angle():
     de = xr.Dataset(
         {
             "de_count": ("epoch", [2, 3]),
-            "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000, 4096]),
+            "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000]),
         },
         coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4, 5]},
     )
-    spin_angle_expected = np.array([0, 87.89, 175.78, 263.67, 351.56, 0])
+    spin_angle_expected = np.array([0, 87.89, 175.78, 263.67, 351.56])
 
     # Act
     spin_angle = get_spin_angle(de)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -11,8 +11,10 @@ from imap_processing.lo.l1b.lo_l1b import (
     convert_start_end_acq_times,
     create_datasets,
     get_avg_spin_durations,
+    get_spin_phase,
     initialize_l1b_de,
     lo_l1b,
+    set_spin_bin,
 )
 
 
@@ -178,3 +180,39 @@ def test_get_avg_spin_durations():
 
     # Assert
     np.testing.assert_array_equal(avg_spin_durations, expected_avg_spin_durations)
+
+
+def test_get_spin_phase():
+    # Arrange
+    de = xr.Dataset(
+        {
+            "de_count": ("epoch", [2, 3]),
+            "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000]),
+        },
+        coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4]},
+    )
+    spin_phase_expected = np.array([0, 87.89, 175.78, 263.67, 351.56])
+
+    # Act
+    spin_phase = get_spin_phase(de)
+
+    # Assert
+    np.testing.assert_allclose(
+        spin_phase,
+        spin_phase_expected,
+        atol=1e-2,
+        err_msg=f"Spin phase: {spin_phase} vs {spin_phase_expected}",
+    )
+
+
+def test_spin_bin():
+    # Arrange
+    l1b_de = xr.Dataset()
+    spin_phase = np.array([0, 50, 150, 250, 365])
+    expected_spin_bins = np.array([0, 8, 25, 41, 60])
+
+    # Act
+    l1b_de = set_spin_bin(l1b_de, spin_phase)
+
+    # Assert
+    np.testing.assert_array_equal(l1b_de["spin_bin"], expected_spin_bins)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -189,7 +189,7 @@ def test_get_spin_angle():
             "de_count": ("epoch", [2, 3]),
             "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000]),
         },
-        coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4, 5]},
+        coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4]},
     )
     spin_angle_expected = np.array([0, 87.89, 175.78, 263.67, 351.56])
 


### PR DESCRIPTION
# Change Summary

## Overview
This PR calculates the spin phase and spin bin for each direct event. There are 60 spin bins that the spin can be binned into for each direct event.

## Updated Files
- imap_processing/lo/l1b/lo_l1b.py
   - Add spin phase calculation
   - Add binning for spin bin

## Testing
- Added new unit tests for both spin phase and spin bin functions

Closes #1509 