### PR TITLE
HIT L1A - update sector rates data

### DIFF
--- a/imap_processing/hit/l0/constants.py
+++ b/imap_processing/hit/l0/constants.py
@@ -6,16 +6,16 @@ import numpy as np
 
 # energy_units: MeV/n
 MOD_10_MAPPING = {
-    0: {"species": "H", "energy_min": 1.8, "energy_max": 3.6},
-    1: {"species": "H", "energy_min": 4, "energy_max": 6},
-    2: {"species": "H", "energy_min": 6, "energy_max": 10},
-    3: {"species": "He4", "energy_min": 4, "energy_max": 6},
-    4: {"species": "He4", "energy_min": 6, "energy_max": 12},
-    5: {"species": "CNO", "energy_min": 4, "energy_max": 6},
-    6: {"species": "CNO", "energy_min": 6, "energy_max": 12},
-    7: {"species": "NeMgSi", "energy_min": 4, "energy_max": 6},
-    8: {"species": "NeMgSi", "energy_min": 6, "energy_max": 12},
-    9: {"species": "Fe", "energy_min": 4, "energy_max": 12},
+    0: {"species": "h", "energy_min": 1.8, "energy_max": 3.6},
+    1: {"species": "h", "energy_min": 4, "energy_max": 6},
+    2: {"species": "h", "energy_min": 6, "energy_max": 10},
+    3: {"species": "he4", "energy_min": 4, "energy_max": 6},
+    4: {"species": "he4", "energy_min": 6, "energy_max": 12},
+    5: {"species": "cno", "energy_min": 4, "energy_max": 6},
+    6: {"species": "cno", "energy_min": 6, "energy_max": 12},
+    7: {"species": "nemgsi", "energy_min": 4, "energy_max": 6},
+    8: {"species": "nemgsi", "energy_min": 6, "energy_max": 12},
+    9: {"species": "fe", "energy_min": 4, "energy_max": 12},
 }
 
 # Structure to hold binary details for a
@@ -100,7 +100,7 @@ COUNTS_DATA_STRUCTURE = {
     "penfgrates": HITPacking(16, 528, (33,)),  # range 4 foreground rates
     "penbgrates": HITPacking(16, 240, (15,)),  # range 4 background rates
     "ialirtrates": HITPacking(16, 320, (20,)),  # ialirt rates
-    "sectorates": HITPacking(16, 1920, (8, 15)),  # sectored rates
+    "sectorates": HITPacking(16, 1920, (15, 8)),  # sectored rates
     "l4fgrates": HITPacking(16, 768, (48,)),  # all range foreground rates
     "l4bgrates": HITPacking(16, 384, (24,)),  # all range foreground rates
 }

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -92,9 +92,9 @@ def parse_count_rates(sci_dataset: xr.Dataset) -> None:
         # Get dims for data variables (yaml file not created yet)
         if len(field_meta.shape) > 1:
             if "sectorates" in field:
-                # Reshape data to 8x15 for declination and azimuth look directions
+                # Reshape data to 15x8 for azimuth and declination look directions
                 parsed_data = np.array(parsed_data).reshape((-1, *field_meta.shape))
-                dims = ["epoch", "declination", "azimuth"]
+                dims = ["epoch", "azimuth", "declination"]
                 # Add angle values to coordinates
                 sci_dataset.coords["declination"] = xr.DataArray(
                     data=DECLINATION_ANGLES,

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -8,6 +8,7 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hit.hit_utils import (
     HitAPID,
+    add_energy_variables,
     get_attribute_manager,
     get_datasets_by_apid,
     process_housekeeping_data,
@@ -66,9 +67,9 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
     """
     Subcommutate sectorates data.
 
-    Sector rates data contains rates for 5 species and 10
-    energy ranges. This function subcommutates the sector
-    rates data by organizing the rates by species. Which
+    Sectored rates data contains raw counts for 5 species and 10
+    energy ranges. This function subcommutates the sectored
+    rates data by organizing the counts by species. Which
     species and energy range the data belongs to is determined
     by taking the mod 10 value of the corresponding header
     minute count value in the dataset. A mapping of mod 10
@@ -84,10 +85,10 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
 
     The data is added to the dataset as new data fields named
     according to their species. They have 4 dimensions: epoch
-    energy index, azimuth, and declination. The energy index
+    energy mean, azimuth, and declination. The energy mean
     dimension is used to distinguish between the different energy
-    ranges the data belongs to. The energy min and max values for
-    each species are also added to the dataset as new data fields.
+    ranges the data belongs to. The energy deltas for each species
+    are also added to the dataset as new data fields.
 
     Parameters
     ----------
@@ -100,62 +101,53 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
     # Reference mod 10 mapping to initialize data structure for species and
     # energy ranges and add 15x8 arrays with fill values for each science frame.
     num_frames = len(hdr_min_count_mod_10)
-    # TODO: add more specific dtype for rates (ex. int16) once this is defined by HIT
     data_by_species_and_energy_range = {
         key: {
             **value,
-            "rates": np.full((num_frames, 15, 8), fill_value=fillval, dtype=int),
+            "counts": np.full((num_frames, 15, 8), fill_value=fillval, dtype=np.int64),
         }
         for key, value in MOD_10_MAPPING.items()
     }
 
-    # Update rates for science frames where data is available
+    # Update counts for science frames where data is available
     for i, mod_10 in enumerate(hdr_min_count_mod_10):
-        data_by_species_and_energy_range[mod_10]["rates"][i] = sci_dataset[
+        data_by_species_and_energy_range[mod_10]["counts"][i] = sci_dataset[
             "sectorates"
         ].values[i]
 
     # H has 3 energy ranges, 4He, CNO, NeMgSi have 2, and Fe has 1.
-    # Aggregate sector rates and energy min/max values for each species.
+    # Aggregate sectored rates and energy min/max values for each species.
     # First, initialize dictionaries to store rates and min/max energy values by species
     data_by_species: dict = {
-        value["species"]: {"rates": [], "energy_min": [], "energy_max": []}
+        value["species"]: {"counts": [], "energy_min": [], "energy_max": []}
         for value in data_by_species_and_energy_range.values()
     }
 
     for value in data_by_species_and_energy_range.values():
         species = value["species"]
-        data_by_species[species]["rates"].append(value["rates"])
+        data_by_species[species]["counts"].append(value["counts"])
         data_by_species[species]["energy_min"].append(value["energy_min"])
         data_by_species[species]["energy_max"].append(value["energy_max"])
 
-    # Add sector rates by species to the dataset
+    # Add sectored rates by species to the dataset
     for species, data in data_by_species.items():
-        # Rates data has shape: energy_index, epoch, azimuth, declination
+        # Rates data has shape: energy_mean, epoch, azimuth, declination
         # Convert rates to numpy array and transpose axes to get
-        # shape: epoch, energy_index, azimuth, declination
-        rates_data = np.transpose(np.array(data["rates"]), axes=(1, 0, 2, 3))
+        # shape: epoch, energy_mean, azimuth, declination
+        rates_data = np.transpose(np.array(data["counts"]), axes=(1, 0, 2, 3))
 
-        sci_dataset[f"{species}_counts_sectored"] = xr.DataArray(
+        sci_dataset[f"{species}_sectored_counts"] = xr.DataArray(
             data=rates_data,
-            dims=["epoch", f"{species}_energy_index", "azimuth", "declination"],
+            dims=["epoch", f"{species}_energy_mean", "azimuth", "declination"],
             name=f"{species}_counts_sectored",
         )
-        sci_dataset[f"{species}_energy_min"] = xr.DataArray(
-            data=np.array(data["energy_min"], dtype=np.int8),
-            dims=[f"{species}_energy_index"],
-            name=f"{species}_energy_min",
-        )
-        sci_dataset[f"{species}_energy_max"] = xr.DataArray(
-            data=np.array(data["energy_max"], dtype=np.int8),
-            dims=[f"{species}_energy_index"],
-            name=f"{species}_energy_max",
-        )
-        # add energy index coordinate to the dataset
-        sci_dataset.coords[f"{species}_energy_index"] = xr.DataArray(
-            np.arange(sci_dataset.sizes[f"{species}_energy_index"], dtype=np.int8),
-            dims=[f"{species}_energy_index"],
-            name=f"{species}_energy_index",
+
+        # Add energy mean and deltas for each species
+        sci_dataset = add_energy_variables(
+            sci_dataset,
+            species,
+            np.array(data["energy_min"]),
+            np.array(data["energy_max"]),
         )
 
 
@@ -201,16 +193,16 @@ def calculate_uncertainties(dataset: xr.Dataset) -> xr.Dataset:
         "hdr_code_ok",
         "hdr_minute_cnt",
         "livetime_counter",
-        "h_energy_min",
-        "h_energy_max",
-        "he4_energy_min",
-        "he4_energy_max",
-        "cno_energy_min",
-        "cno_energy_max",
-        "nemgsi_energy_min",
-        "nemgsi_energy_max",
-        "fe_energy_min",
-        "fe_energy_max",
+        "h_energy_delta_minus",
+        "h_energy_delta_plus",
+        "he4_energy_delta_minus",
+        "he4_energy_delta_plus",
+        "cno_energy_delta_minus",
+        "cno_energy_delta_plus",
+        "nemgsi_energy_delta_minus",
+        "nemgsi_energy_delta_plus",
+        "fe_energy_delta_minus",
+        "fe_energy_delta_plus",
     ]
 
     # Counts data that need uncertainties calculated
@@ -268,7 +260,7 @@ def process_science(
     # Decommutate and decompress the science data
     sci_dataset = decom_hit(dataset)
 
-    # Organize sector rates by species type
+    # Organize sectored rates by species type
     subcom_sectorates(sci_dataset)
 
     # Split the science data into count rates and event datasets

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -75,16 +75,16 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
     values to species and energy ranges is provided in constants.py.
 
     MOD_10_MAPPING = {
-        0: {"species": "H", "energy_min": 1.8, "energy_max": 3.6},
-        1: {"species": "H", "energy_min": 4, "energy_max": 6},
-        2: {"species": "H", "energy_min": 6, "energy_max": 10},
-        3: {"species": "4He", "energy_min": 4, "energy_max": 6},
+        0: {"species": "h", "energy_min": 1.8, "energy_max": 3.6},
+        1: {"species": "h", "energy_min": 4, "energy_max": 6},
+        2: {"species": "h", "energy_min": 6, "energy_max": 10},
+        3: {"species": "he4", "energy_min": 4, "energy_max": 6},
         ...
-        9: {"species": "Fe", "energy_min": 4, "energy_max": 12}}
+        9: {"species": "fe", "energy_min": 4, "energy_max": 12}}
 
     The data is added to the dataset as new data fields named
     according to their species. They have 4 dimensions: epoch
-    energy index, declination, and azimuth. The energy index
+    energy index, azimuth, and declination. The energy index
     dimension is used to distinguish between the different energy
     ranges the data belongs to. The energy min and max values for
     each species are also added to the dataset as new data fields.
@@ -98,13 +98,13 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
     hdr_min_count_mod_10 = sci_dataset.hdr_minute_cnt.values % 10
 
     # Reference mod 10 mapping to initialize data structure for species and
-    # energy ranges and add 8x15 arrays with fill values for each science frame.
+    # energy ranges and add 15x8 arrays with fill values for each science frame.
     num_frames = len(hdr_min_count_mod_10)
     # TODO: add more specific dtype for rates (ex. int16) once this is defined by HIT
     data_by_species_and_energy_range = {
         key: {
             **value,
-            "rates": np.full((num_frames, 8, 15), fill_value=fillval, dtype=int),
+            "rates": np.full((num_frames, 15, 8), fill_value=fillval, dtype=int),
         }
         for key, value in MOD_10_MAPPING.items()
     }
@@ -130,16 +130,15 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
         data_by_species[species]["energy_max"].append(value["energy_max"])
 
     # Add sector rates by species to the dataset
-    for species_type, data in data_by_species.items():
-        # Rates data has shape: energy_index, epoch, declination, azimuth
+    for species, data in data_by_species.items():
+        # Rates data has shape: energy_index, epoch, azimuth, declination
         # Convert rates to numpy array and transpose axes to get
-        # shape: epoch, energy_index, declination, azimuth
+        # shape: epoch, energy_index, azimuth, declination
         rates_data = np.transpose(np.array(data["rates"]), axes=(1, 0, 2, 3))
 
-        species = species_type.lower()
         sci_dataset[f"{species}_counts_sectored"] = xr.DataArray(
             data=rates_data,
-            dims=["epoch", f"{species}_energy_index", "declination", "azimuth"],
+            dims=["epoch", f"{species}_energy_index", "azimuth", "declination"],
             name=f"{species}_counts_sectored",
         )
         sci_dataset[f"{species}_energy_min"] = xr.DataArray(

--- a/imap_processing/tests/hit/helpers/l1_validation.py
+++ b/imap_processing/tests/hit/helpers/l1_validation.py
@@ -48,16 +48,16 @@ RENAME_COLUMNS = {
 }
 
 MOD_VALUE_TO_SPECIES_ENERGY_MAP = {
-    0: {"species": "H", "energy_bin": 0},
-    1: {"species": "H", "energy_bin": 1},
-    2: {"species": "H", "energy_bin": 2},
-    3: {"species": "He4", "energy_bin": 0},
-    4: {"species": "He4", "energy_bin": 1},
-    5: {"species": "CNO", "energy_bin": 0},
-    6: {"species": "CNO", "energy_bin": 1},
-    7: {"species": "NeMgSi", "energy_bin": 0},
-    8: {"species": "NeMgSi", "energy_bin": 1},
-    9: {"species": "Fe", "energy_bin": 0},
+    0: {"species": "h", "energy_bin": 0},
+    1: {"species": "h", "energy_bin": 1},
+    2: {"species": "h", "energy_bin": 2},
+    3: {"species": "he4", "energy_bin": 0},
+    4: {"species": "he4", "energy_bin": 1},
+    5: {"species": "cno", "energy_bin": 0},
+    6: {"species": "cno", "energy_bin": 1},
+    7: {"species": "nemgsi", "energy_bin": 0},
+    8: {"species": "nemgsi", "energy_bin": 1},
+    9: {"species": "fe", "energy_bin": 0},
 }
 
 
@@ -304,7 +304,7 @@ def add_species_energy(data: pd.DataFrame) -> pd.DataFrame:
         )
     )
     data["species"] = data["mod_10"].apply(
-        lambda row: MOD_VALUE_TO_SPECIES_ENERGY_MAP[row]["species"].lower()
+        lambda row: MOD_VALUE_TO_SPECIES_ENERGY_MAP[row]["species"]
         if row is not None
         else None
     )

--- a/imap_processing/tests/hit/helpers/l1_validation.py
+++ b/imap_processing/tests/hit/helpers/l1_validation.py
@@ -215,13 +215,13 @@ def consolidate_sectorates(data: pd.DataFrame) -> pd.DataFrame:
     ).columns
 
     data["sectorates"] = data[sectorates_three_digits].apply(
-        lambda row: row.values.reshape(8, 15), axis=1
+        lambda row: row.values.reshape(15, 8), axis=1
     )
     data["sectorates_delta_plus"] = data[sectorates_delta_plus_three_digits].apply(
-        lambda row: row.values.reshape(8, 15), axis=1
+        lambda row: row.values.reshape(15, 8), axis=1
     )
     data["sectorates_delta_minus"] = data[sectorates_delta_minus_three_digits].apply(
-        lambda row: row.values.reshape(8, 15), axis=1
+        lambda row: row.values.reshape(15, 8), axis=1
     )
 
     sectorates_four_digits = data.filter(regex=r"^SECTORATES_\d{3}_\d{1}$").columns
@@ -348,7 +348,7 @@ def compare_data(
                     # which are only present in the validation data. In the actual
                     # data, sector rates are organized by species in 4D arrays.
                     #    i.e. h_counts_sectored has shape
-                    #         (epoch, h_energy_index, declination, azimuth).
+                    #         (epoch, h_energy_index, azimuth, declination).
                     # species and energy index are used to find the correct
                     # array of sector rate data from the actual data for comparison.
                     species = expected_data[field][frame]

--- a/imap_processing/tests/hit/helpers/l1_validation.py
+++ b/imap_processing/tests/hit/helpers/l1_validation.py
@@ -48,16 +48,16 @@ RENAME_COLUMNS = {
 }
 
 MOD_VALUE_TO_SPECIES_ENERGY_MAP = {
-    0: {"species": "H", "energy_idx": 0},
-    1: {"species": "H", "energy_idx": 1},
-    2: {"species": "H", "energy_idx": 2},
-    3: {"species": "He4", "energy_idx": 0},
-    4: {"species": "He4", "energy_idx": 1},
-    5: {"species": "CNO", "energy_idx": 0},
-    6: {"species": "CNO", "energy_idx": 1},
-    7: {"species": "NeMgSi", "energy_idx": 0},
-    8: {"species": "NeMgSi", "energy_idx": 1},
-    9: {"species": "Fe", "energy_idx": 0},
+    0: {"species": "H", "energy_bin": 0},
+    1: {"species": "H", "energy_bin": 1},
+    2: {"species": "H", "energy_bin": 2},
+    3: {"species": "He4", "energy_bin": 0},
+    4: {"species": "He4", "energy_bin": 1},
+    5: {"species": "CNO", "energy_bin": 0},
+    6: {"species": "CNO", "energy_bin": 1},
+    7: {"species": "NeMgSi", "energy_bin": 0},
+    8: {"species": "NeMgSi", "energy_bin": 1},
+    9: {"species": "Fe", "energy_bin": 0},
 }
 
 
@@ -170,7 +170,7 @@ def consolidate_rate_columns(
 def consolidate_sectorates(data: pd.DataFrame) -> pd.DataFrame:
     """Consolidate sector rate data into arrays.
 
-    This function distinguishes between sector rate columns with three digits
+    This function distinguishes between sectored rate columns with three digits
     and those with four digits in their names.
 
     SECTORATES_000 SECTORATES_000_0 SECTORATES_000_1 SECTORATES_000_2...SECTORATES_120_9
@@ -185,9 +185,9 @@ def consolidate_sectorates(data: pd.DataFrame) -> pd.DataFrame:
 
     Columns with four digits (e.g., SECTORATES_000_0) include the sectorate
     values with a mod 10 value appended (e.g., 0). The mod 10 value determines
-    the species and energy range the sector rates represent in the science frame.
+    the species and energy range the sectored rates represent in the science frame.
     There are 10 possible species and energy ranges, but only one has data per
-    science frame. The validation data has 10 columns per 120 sector rates,
+    science frame. The validation data has 10 columns per 120 sectored rates,
     totaling 1200 columns per science frame. Each set of 10 columns will have
     only one value, resulting in an array that looks like this:
 
@@ -279,7 +279,7 @@ def process_single_rates(data: pd.DataFrame) -> pd.DataFrame:
 def add_species_energy(data: pd.DataFrame) -> pd.DataFrame:
     """Add species and energy index to the validation data.
 
-    The sector rate data is organized by species and energy index
+    The sectored rate data is organized by species and energy index
     in the processed data so this function adds this information
     to each row (i.e. science frame) in the validation data.
 
@@ -308,8 +308,8 @@ def add_species_energy(data: pd.DataFrame) -> pd.DataFrame:
         if row is not None
         else None
     )
-    data["energy_idx"] = data["mod_10"].apply(
-        lambda row: MOD_VALUE_TO_SPECIES_ENERGY_MAP[row]["energy_idx"]
+    data["energy_bin"] = data["mod_10"].apply(
+        lambda row: MOD_VALUE_TO_SPECIES_ENERGY_MAP[row]["energy_bin"]
         if row is not None
         else None
     )
@@ -336,7 +336,7 @@ def compare_data(
         if field not in [
             "sc_tick_by_frame",
             "species",
-            "energy_idx",
+            "energy_bin",
         ]:
             assert (
                 field in actual_data.data_vars.keys()
@@ -344,47 +344,47 @@ def compare_data(
         if field not in skip:
             for frame in range(expected_data.shape[0]):
                 if field == "species":
-                    # Compare sector rates data using species and energy index.
+                    # Compare sectored rates data using species and energy index.
                     # which are only present in the validation data. In the actual
-                    # data, sector rates are organized by species in 4D arrays.
-                    #    i.e. h_counts_sectored has shape
+                    # data, sectored rates are organized by species in 4D arrays.
+                    #    i.e. h_sectored_counts has shape
                     #         (epoch, h_energy_index, azimuth, declination).
                     # species and energy index are used to find the correct
-                    # array of sector rate data from the actual data for comparison.
+                    # array of sectored rate data from the actual data for comparison.
                     species = expected_data[field][frame]
-                    energy_idx = expected_data["energy_idx"][frame]
+                    energy_bin = expected_data["energy_bin"][frame]
                     if "sectorates_delta_plus" in expected_data.columns:
                         np.testing.assert_allclose(
-                            actual_data[f"{species}_counts_sectored_delta_plus"][frame][
-                                energy_idx
+                            actual_data[f"{species}_sectored_counts_delta_plus"][frame][
+                                energy_bin
                             ].data,
                             expected_data["sectorates_delta_plus"][frame],
                             rtol=1e-7,  # relative tolerance
                             atol=1e-8,  # absolute tolerance
-                            err_msg=f"Mismatch in {species}_counts_sectored_delta_"
-                            f"plus at frame {frame}, energy_idx {energy_idx}",
+                            err_msg=f"Mismatch in {species}_sectored_counts_delta_"
+                            f"plus at frame {frame}, energy_bin {energy_bin}",
                         )
                     if "sectorates_delta_minus" in expected_data.columns:
                         np.testing.assert_allclose(
-                            actual_data[f"{species}_counts_sectored_delta_minus"][
+                            actual_data[f"{species}_sectored_counts_delta_minus"][
                                 frame
-                            ][energy_idx].data,
+                            ][energy_bin].data,
                             expected_data["sectorates_delta_minus"][frame],
                             rtol=1e-7,
                             atol=1e-8,
-                            err_msg=f"Mismatch in {species}_counts_sectored_delta_"
-                            f"minus at frame {frame}, energy_idx {energy_idx}",
+                            err_msg=f"Mismatch in {species}_sectored_counts_delta_"
+                            f"minus at frame {frame}, energy_bin {energy_bin}",
                         )
                     else:
                         np.testing.assert_allclose(
-                            actual_data[f"{species}_counts_sectored"][frame][
-                                energy_idx
+                            actual_data[f"{species}_sectored_counts"][frame][
+                                energy_bin
                             ].data,
                             expected_data["sectorates"][frame],
                             rtol=1e-7,
                             atol=1e-8,
-                            err_msg=f"Mismatch in {species}_counts_sectored at"
-                            f"frame {frame}, energy_idx {energy_idx}",
+                            err_msg=f"Mismatch in {species}_sectored_counts at"
+                            f"frame {frame}, energy_bin {energy_bin}",
                         )
                 elif field == "sc_tick_by_frame":
                     # Get the sc_tick values for each frame in the actual data

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -75,13 +75,13 @@ def test_subcom_sectorates(sci_packet_filepath):
 
         # Check the shape of the new data variables
         if species == "h":
-            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 3, 8, 15)
+            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 3, 15, 8)
             assert sci_dataset[f"{species}_energy_min"].shape == (3,)
-        elif species in ("4he", "cno", "nemgsi"):
-            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 2, 8, 15)
+        elif species in ("he4", "cno", "nemgsi"):
+            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 2, 15, 8)
             assert sci_dataset[f"{species}_energy_min"].shape == (2,)
         elif species == "fe":
-            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 1, 8, 15)
+            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 1, 15, 8)
             assert sci_dataset[f"{species}_energy_min"].shape == (1,)
         assert (
             sci_dataset[f"{species}_energy_max"].shape

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -52,7 +52,7 @@ def validation_data():
 def test_subcom_sectorates(sci_packet_filepath):
     """Test the subcom_sectorates function.
 
-    This function organizes the sector rates data
+    This function organizes the sectored rates data
     by species and adds the data as new variables
     to the dataset.
     """
@@ -67,26 +67,26 @@ def test_subcom_sectorates(sci_packet_filepath):
     # Number of science frames in the dataset
     frames = sci_dataset["epoch"].shape[0]
 
-    # Check if the dataset has the expected new variables
-    for species in ["h", "he4", "cno", "nemgsi", "fe"]:
-        assert f"{species}_counts_sectored" in sci_dataset
-        assert f"{species}_energy_min" in sci_dataset
-        assert f"{species}_energy_max" in sci_dataset
+    # Shape of the new data variables
+    expected_shapes = {
+        "h": (3, 15, 8),
+        "he4": (2, 15, 8),
+        "cno": (2, 15, 8),
+        "nemgsi": (2, 15, 8),
+        "fe": (1, 15, 8),
+    }
 
+    for species, shape in expected_shapes.items():
+        # Check if the dataset has the new  data variables
+        assert f"{species}_sectored_counts" in sci_dataset
+        assert f"{species}_energy_mean" in sci_dataset
+        assert f"{species}_energy_delta_minus" in sci_dataset
+        assert f"{species}_energy_delta_plus" in sci_dataset
         # Check the shape of the new data variables
-        if species == "h":
-            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 3, 15, 8)
-            assert sci_dataset[f"{species}_energy_min"].shape == (3,)
-        elif species in ("he4", "cno", "nemgsi"):
-            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 2, 15, 8)
-            assert sci_dataset[f"{species}_energy_min"].shape == (2,)
-        elif species == "fe":
-            assert sci_dataset[f"{species}_counts_sectored"].shape == (frames, 1, 15, 8)
-            assert sci_dataset[f"{species}_energy_min"].shape == (1,)
-        assert (
-            sci_dataset[f"{species}_energy_max"].shape
-            == sci_dataset[f"{species}_energy_min"].shape
-        )
+        assert sci_dataset[f"{species}_sectored_counts"].shape == (frames, *shape)
+        assert sci_dataset[f"{species}_energy_mean"].shape == (shape[0],)
+        assert sci_dataset[f"{species}_energy_delta_minus"].shape == (shape[0],)
+        assert sci_dataset[f"{species}_energy_delta_plus"].shape == (shape[0],)
 
 
 def test_calculate_uncertainties():
@@ -240,7 +240,7 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
         "seq_flgs",
         "src_seq_ctr",
         "pkt_len",
-        "energy_idx",
+        "energy_bin",
     ]
 
     # Compare processed data to validation data


### PR DESCRIPTION
This PR implements updates to the structure of sectored rates data in the L1A counts dataset to conform with mission requirements: 

- Switch angle dimension order to azimuth x declination
- Replace energy variables with mean and deltas

Closes #1539 

## Updated Files
- constants.py
   - change shape of sectored rates data from 8x15 to 15x8
   - change species keys to lower case
- decom_hit.py
   - switch angle dimension order during binary parsing
- hit_l1a.py
   - switch angle dimension order during subcommutation of sectored rates
   - update energy variables using function in hit utils
   - update sectored counts variable names to match request by HIT
   - update comments and docstrings
- l1_validation.py
   - switch angle dimension order when processing validation data
- test_hit_l1a.py
   - update tests to reflect changes above
   - simplify test for function that subcommutates sectored rates

