### PR TITLE
HIT - Refactor processing to use functions in hit utils

### DIFF
--- a/imap_processing/hit/hit_utils.py
+++ b/imap_processing/hit/hit_utils.py
@@ -391,3 +391,68 @@ def add_energy_variables(
     )
 
     return dataset
+
+
+def add_summed_particle_data_to_dataset(
+    dataset_to_update: xr.Dataset,
+    source_dataset: xr.Dataset,
+    particle: str,
+    energy_ranges: list,
+) -> None:
+    """
+    Add summed particle data to the dataset.
+
+    This function performs the following steps:
+      1) sum data (raw counts or rates, including statistical uncertainties),
+         from the l2fgrates, l3fgrates, and penfgrates data variables in the source
+         dataset (i.e. l1a counts dataset or l1b standard rates dataset).
+      2) add the summed data to the dataset to update (i.e. L1B summed rates dataset
+         or L2 standard intensity dataset) by particle type and energy range.
+
+    Parameters
+    ----------
+    dataset_to_update : xr.Dataset
+        The dataset to add the rates to.
+    source_dataset : xr.Dataset
+        The dataset containing data to sum (counts or rates).
+    particle : str
+        The particle name.
+    energy_ranges : list
+        A list of energy range dictionaries for the particle.
+        For example:
+        {'energy_min': 1.8, 'energy_max': 2.2, "R2": [1], "R3": [], "R4": []}.
+    """
+    # Initialize arrays to store summed data and statistical uncertainties
+    dataset_to_update = initialize_particle_data_arrays(
+        dataset_to_update,
+        particle,
+        len(energy_ranges),
+        source_dataset.sizes["epoch"],
+    )
+
+    # initialize arrays to store energy min and max values
+    energy_min = np.zeros(len(energy_ranges), dtype=np.float32)
+    energy_max = np.zeros(len(energy_ranges), dtype=np.float32)
+
+    # Sum particle data and statistical uncertainties for each energy range
+    # and add them to the dataset
+    for i, energy_range_dict in enumerate(energy_ranges):
+        summed_data, summed_data_delta_minus, summed_data_delta_plus = (
+            sum_particle_data(source_dataset, energy_range_dict)
+        )
+
+        dataset_to_update[f"{particle}"][:, i] = summed_data.astype(np.float32)
+        dataset_to_update[f"{particle}_delta_minus"][:, i] = (
+            summed_data_delta_minus.astype(np.float32)
+        )
+        dataset_to_update[f"{particle}_delta_plus"][:, i] = (
+            summed_data_delta_plus.astype(np.float32)
+        )
+
+        # Fill energy min and max values for each energy range
+        energy_min[i] = energy_range_dict["energy_min"]
+        energy_max[i] = energy_range_dict["energy_max"]
+
+    dataset_to_update = add_energy_variables(
+        dataset_to_update, particle, energy_min, energy_max
+    )

--- a/imap_processing/hit/hit_utils.py
+++ b/imap_processing/hit/hit_utils.py
@@ -225,9 +225,9 @@ def initialize_particle_data_arrays(
     particle: str,
     num_energy_ranges: int,
     epoch_size: int,
-) -> None:
+) -> xr.Dataset:
     """
-    Create empty data arrays for a given particle.
+    Add empty data arrays for a given particle.
 
     Valid particle names:
         h
@@ -252,38 +252,43 @@ def initialize_particle_data_arrays(
     ----------
     dataset : xr.Dataset
         The dataset to add the data arrays to.
-
     particle : str
         The abbreviated particle name.
-
     num_energy_ranges : int
         Number of energy ranges for the particle.
         Used to define the shape of the data arrays.
-
     epoch_size : int
         Used to define the shape of the data arrays.
+
+    Returns
+    -------
+    updated_ds : xr.Dataset
+        The updated dataset with the particle data arrays added.
     """
-    dataset[f"{particle}"] = xr.DataArray(
+    updated_ds = dataset.copy()
+
+    updated_ds[f"{particle}"] = xr.DataArray(
         data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
         dims=["epoch", f"{particle}_energy_mean"],
         name=f"{particle}",
     )
-    dataset[f"{particle}_delta_minus"] = xr.DataArray(
+    updated_ds[f"{particle}_delta_minus"] = xr.DataArray(
         data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
         dims=["epoch", f"{particle}_energy_mean"],
         name=f"{particle}_delta_minus",
     )
-    dataset[f"{particle}_delta_plus"] = xr.DataArray(
+    updated_ds[f"{particle}_delta_plus"] = xr.DataArray(
         data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
         dims=["epoch", f"{particle}_energy_mean"],
         name=f"{particle}_delta_plus",
     )
-
-    dataset.coords[f"{particle}_energy_mean"] = xr.DataArray(
+    updated_ds.coords[f"{particle}_energy_mean"] = xr.DataArray(
         np.zeros(num_energy_ranges, dtype=np.int8),
         dims=[f"{particle}_energy_mean"],
         name=f"{particle}_energy_mean",
     )
+
+    return updated_ds
 
 
 def sum_particle_data(
@@ -344,7 +349,7 @@ def add_energy_variables(
     particle: str,
     energy_min_values: np.ndarray,
     energy_max_values: np.ndarray,
-) -> None:
+) -> xr.Dataset:
     """
     Add energy min and max variables to the dataset.
 
@@ -358,86 +363,152 @@ def add_energy_variables(
         The minimum energy values for each energy range.
     energy_max_values : np.ndarray
         The maximum energy values for each energy range.
+
+    Returns
+    -------
+    updated_ds : xr.Dataset
+        The updated dataset with the energy variables added.
     """
+    updated_ds = dataset.copy()
+
     energy_mean = np.mean(
         np.array([energy_min_values, energy_max_values]), axis=0
     ).astype(np.float32)
 
-    dataset[f"{particle}_energy_mean"] = xr.DataArray(
+    updated_ds[f"{particle}_energy_mean"] = xr.DataArray(
         data=energy_mean,
         dims=[f"{particle}_energy_mean"],
         name=f"{particle}_energy_mean",
     )
-    dataset[f"{particle}_energy_delta_minus"] = xr.DataArray(
+    updated_ds[f"{particle}_energy_delta_minus"] = xr.DataArray(
         data=np.array(energy_mean - np.array(energy_min_values), dtype=np.float32),
         dims=[f"{particle}_energy_mean"],
         name=f"{particle}_energy_delta_minus",
     )
-    dataset[f"{particle}_energy_delta_plus"] = xr.DataArray(
+    updated_ds[f"{particle}_energy_delta_plus"] = xr.DataArray(
         data=np.array(energy_max_values - energy_mean, dtype=np.float32),
         dims=[f"{particle}_energy_mean"],
         name=f"{particle}_energy_delta_plus",
     )
 
+    return updated_ds
+
+
+# def add_summed_particle_data_to_dataset(
+#     dataset_to_update: xr.Dataset,
+#     source_dataset: xr.Dataset,
+#     particle: str,
+#     energy_ranges: list,
+# ) -> None:
+#     """
+#     Add summed particle data to the dataset.
+#
+#     This function performs the following steps:
+#       1) sum data (raw counts or rates, including statistical uncertainties),
+#          from the l2fgrates, l3fgrates, and penfgrates data variables in the source
+#          dataset (i.e. l1a counts dataset or l1b standard rates dataset).
+#       2) add the summed data to the dataset to update (i.e. L1B summed rates dataset
+#          or L2 standard intensity dataset) by particle type and energy range.
+#
+#     Parameters
+#     ----------
+#     dataset_to_update : xr.Dataset
+#         The dataset to add the rates to.
+#     source_dataset : xr.Dataset
+#         The dataset containing data to sum (counts or rates).
+#     particle : str
+#         The particle name.
+#     energy_ranges : list
+#         A list of energy range dictionaries for the particle.
+#         For example:
+#         {'energy_min': 1.8, 'energy_max': 2.2, "R2": [1], "R3": [], "R4": []}.
+#     """
+#     # Initialize arrays to store summed data and statistical uncertainties
+#     initialize_particle_data_arrays(
+#         dataset_to_update,
+#         particle,
+#         len(energy_ranges),
+#         source_dataset.sizes["epoch"],
+#     )
+#
+#     # initialize arrays to store energy min and max values
+#     energy_min = np.zeros(len(energy_ranges), dtype=np.float32)
+#     energy_max = np.zeros(len(energy_ranges), dtype=np.float32)
+#
+#     # Sum particle data and statistical uncertainties for each energy range
+#     # and add them to the dataset
+#     for i, energy_range_dict in enumerate(energy_ranges):
+#         summed_data, summed_data_delta_minus, summed_data_delta_plus = (
+#             sum_particle_data(source_dataset, energy_range_dict)
+#         )
+#
+#         dataset_to_update[f"{particle}"][:, i] = summed_data.astype(np.float32)
+#         dataset_to_update[f"{particle}_delta_minus"][:, i] = (
+#             summed_data_delta_minus.astype(np.float32)
+#         )
+#         dataset_to_update[f"{particle}_delta_plus"][:, i] = (
+#             summed_data_delta_plus.astype(np.float32)
+#         )
+#
+#         # Fill energy min and max values for each energy range
+#         energy_min[i] = energy_range_dict["energy_min"]
+#         energy_max[i] = energy_range_dict["energy_max"]
+#
+#     add_energy_variables(dataset_to_update, particle, energy_min, energy_max)
+
 
 def add_summed_particle_data_to_dataset(
-    dataset_to_update: xr.Dataset,
+    dataset: xr.Dataset,
     source_dataset: xr.Dataset,
     particle: str,
     energy_ranges: list,
-) -> None:
+) -> xr.Dataset:
     """
     Add summed particle data to the dataset.
 
-    This function performs the following steps:
-      1) sum data (raw counts or rates, including statistical uncertainties),
-         from the l2fgrates, l3fgrates, and penfgrates data variables in the source
-         dataset (i.e. l1a counts dataset or l1b standard rates dataset).
-      2) add the summed data to the dataset to update (i.e. L1B summed rates dataset
-         or L2 standard intensity dataset) by particle type and energy range.
-
     Parameters
     ----------
-    dataset_to_update : xr.Dataset
-        The dataset to add the rates to.
+    dataset : xr.Dataset
+        The dataset to add the rates to (not modified in-place).
     source_dataset : xr.Dataset
         The dataset containing data to sum (counts or rates).
     particle : str
         The particle name.
     energy_ranges : list
         A list of energy range dictionaries for the particle.
-        For example:
-        {'energy_min': 1.8, 'energy_max': 2.2, "R2": [1], "R3": [], "R4": []}.
+
+    Returns
+    -------
+    xr.Dataset
+        A new dataset with summed particle data added.
     """
-    # Initialize arrays to store summed data and statistical uncertainties
-    initialize_particle_data_arrays(
-        dataset_to_update,
-        particle,
-        len(energy_ranges),
-        source_dataset.sizes["epoch"],
+    # Make a copy of the dataset to update
+    ds = dataset.copy()
+
+    # Initialize particle data arrays
+    ds = initialize_particle_data_arrays(
+        ds, particle, len(energy_ranges), source_dataset.sizes["epoch"]
     )
 
-    # initialize arrays to store energy min and max values
+    # Initialize arrays for energy values
     energy_min = np.zeros(len(energy_ranges), dtype=np.float32)
     energy_max = np.zeros(len(energy_ranges), dtype=np.float32)
 
-    # Sum particle data and statistical uncertainties for each energy range
-    # and add them to the dataset
+    # Compute summed data and update the dataset
     for i, energy_range_dict in enumerate(energy_ranges):
         summed_data, summed_data_delta_minus, summed_data_delta_plus = (
             sum_particle_data(source_dataset, energy_range_dict)
         )
 
-        dataset_to_update[f"{particle}"][:, i] = summed_data.astype(np.float32)
-        dataset_to_update[f"{particle}_delta_minus"][:, i] = (
-            summed_data_delta_minus.astype(np.float32)
-        )
-        dataset_to_update[f"{particle}_delta_plus"][:, i] = (
-            summed_data_delta_plus.astype(np.float32)
-        )
+        ds[f"{particle}"][:, i] = summed_data.astype(np.float32)
+        ds[f"{particle}_delta_minus"][:, i] = summed_data_delta_minus.astype(np.float32)
+        ds[f"{particle}_delta_plus"][:, i] = summed_data_delta_plus.astype(np.float32)
 
-        # Fill energy min and max values for each energy range
+        # Store energy range values
         energy_min[i] = energy_range_dict["energy_min"]
         energy_max[i] = energy_range_dict["energy_max"]
 
-    add_energy_variables(dataset_to_update, particle, energy_min, energy_max)
+    # Add energy variables
+    ds = add_energy_variables(ds, particle, energy_min, energy_max)
+
+    return ds  # Return the fully updated dataset

--- a/imap_processing/hit/hit_utils.py
+++ b/imap_processing/hit/hit_utils.py
@@ -225,7 +225,7 @@ def initialize_particle_data_arrays(
     particle: str,
     num_energy_ranges: int,
     epoch_size: int,
-) -> xr.Dataset:
+) -> None:
     """
     Create empty data arrays for a given particle.
 
@@ -262,11 +262,6 @@ def initialize_particle_data_arrays(
 
     epoch_size : int
         Used to define the shape of the data arrays.
-
-    Returns
-    -------
-    dataset : xr.Dataset
-        The dataset with the added empty data arrays.
     """
     dataset[f"{particle}"] = xr.DataArray(
         data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
@@ -289,7 +284,6 @@ def initialize_particle_data_arrays(
         dims=[f"{particle}_energy_mean"],
         name=f"{particle}_energy_mean",
     )
-    return dataset
 
 
 def sum_particle_data(
@@ -416,7 +410,7 @@ def add_summed_particle_data_to_dataset(
         {'energy_min': 1.8, 'energy_max': 2.2, "R2": [1], "R3": [], "R4": []}.
     """
     # Initialize arrays to store summed data and statistical uncertainties
-    dataset_to_update = initialize_particle_data_arrays(
+    initialize_particle_data_arrays(
         dataset_to_update,
         particle,
         len(energy_ranges),

--- a/imap_processing/hit/hit_utils.py
+++ b/imap_processing/hit/hit_utils.py
@@ -350,7 +350,7 @@ def add_energy_variables(
     particle: str,
     energy_min_values: np.ndarray,
     energy_max_values: np.ndarray,
-) -> xr.Dataset:
+) -> None:
     """
     Add energy min and max variables to the dataset.
 
@@ -364,11 +364,6 @@ def add_energy_variables(
         The minimum energy values for each energy range.
     energy_max_values : np.ndarray
         The maximum energy values for each energy range.
-
-    Returns
-    -------
-    xr.Dataset
-        The dataset with the added energy variables.
     """
     energy_mean = np.mean(
         np.array([energy_min_values, energy_max_values]), axis=0
@@ -389,8 +384,6 @@ def add_energy_variables(
         dims=[f"{particle}_energy_mean"],
         name=f"{particle}_energy_delta_plus",
     )
-
-    return dataset
 
 
 def add_summed_particle_data_to_dataset(
@@ -453,6 +446,4 @@ def add_summed_particle_data_to_dataset(
         energy_min[i] = energy_range_dict["energy_min"]
         energy_max[i] = energy_range_dict["energy_max"]
 
-    dataset_to_update = add_energy_variables(
-        dataset_to_update, particle, energy_min, energy_max
-    )
+    add_energy_variables(dataset_to_update, particle, energy_min, energy_max)

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -63,7 +63,7 @@ def hit_l1a(packet_file: str, data_version: str) -> list[xr.Dataset]:
     return l1a_datasets
 
 
-def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
+def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
     """
     Subcommutate sectorates data.
 
@@ -94,9 +94,16 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
     ----------
     sci_dataset : xarray.Dataset
         Xarray dataset containing parsed HIT science data.
+
+    Returns
+    -------
+    sci_dataset : xarray.Dataset
+        Xarray dataset with sectored rates data organized by species.
     """
+    updated_dataset = sci_dataset.copy()
+
     # Calculate mod 10 values
-    hdr_min_count_mod_10 = sci_dataset.hdr_minute_cnt.values % 10
+    hdr_min_count_mod_10 = updated_dataset.hdr_minute_cnt.values % 10
 
     # Reference mod 10 mapping to initialize data structure for species and
     # energy ranges and add 15x8 arrays with fill values for each science frame.
@@ -111,7 +118,7 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
 
     # Update counts for science frames where data is available
     for i, mod_10 in enumerate(hdr_min_count_mod_10):
-        data_by_species_and_energy_range[mod_10]["counts"][i] = sci_dataset[
+        data_by_species_and_energy_range[mod_10]["counts"][i] = updated_dataset[
             "sectorates"
         ].values[i]
 
@@ -136,19 +143,21 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
         # shape: epoch, energy_mean, azimuth, declination
         rates_data = np.transpose(np.array(data["counts"]), axes=(1, 0, 2, 3))
 
-        sci_dataset[f"{species}_sectored_counts"] = xr.DataArray(
+        updated_dataset[f"{species}_sectored_counts"] = xr.DataArray(
             data=rates_data,
             dims=["epoch", f"{species}_energy_mean", "azimuth", "declination"],
             name=f"{species}_counts_sectored",
         )
 
         # Add energy mean and deltas for each species
-        add_energy_variables(
-            sci_dataset,
+        updated_dataset = add_energy_variables(
+            updated_dataset,
             species,
             np.array(data["energy_min"]),
             np.array(data["energy_max"]),
         )
+
+    return updated_dataset
 
 
 def calculate_uncertainties(dataset: xr.Dataset) -> xr.Dataset:
@@ -261,7 +270,7 @@ def process_science(
     sci_dataset = decom_hit(dataset)
 
     # Organize sectored rates by species type
-    subcom_sectorates(sci_dataset)
+    sci_dataset = subcom_sectorates(sci_dataset)
 
     # Split the science data into count rates and event datasets
     pha_raw_dataset = xr.Dataset(

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -143,7 +143,7 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> None:
         )
 
         # Add energy mean and deltas for each species
-        sci_dataset = add_energy_variables(
+        add_energy_variables(
             sci_dataset,
             species,
             np.array(data["energy_min"]),

--- a/imap_processing/hit/l1b/constants.py
+++ b/imap_processing/hit/l1b/constants.py
@@ -20,7 +20,7 @@ livestim_pulses = 270
 # R4 = Indices for Range 4 (PENFGRATES)
 # energy_units: MeV/n
 
-PARTICLE_ENERGY_RANGE_MAPPING = {
+SUMMED_PARTICLE_ENERGY_RANGE_MAPPING = {
     "h": [
         {
             "energy_min": 1.8,

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -315,7 +315,6 @@ def process_summed_rates_data(
         "hdr_dynamic_threshold_state"
     ].attrs
 
-    # Calculate summed rates for each particle and add them to the dataset
     for particle, energy_ranges in SUMMED_PARTICLE_ENERGY_RANGE_MAPPING.items():
         # Sum counts for each energy range and add to dataset
         add_summed_particle_data_to_dataset(

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -317,7 +317,7 @@ def process_summed_rates_data(
 
     for particle, energy_ranges in SUMMED_PARTICLE_ENERGY_RANGE_MAPPING.items():
         # Sum counts for each energy range and add to dataset
-        add_summed_particle_data_to_dataset(
+        l1b_summed_rates_dataset = add_summed_particle_data_to_dataset(
             l1b_summed_rates_dataset,
             l1a_counts_dataset,
             particle,

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -1,7 +1,6 @@
 """IMAP-HIT L1B data processing."""
 
 import logging
-from typing import NamedTuple
 
 import numpy as np
 import xarray as xr
@@ -9,12 +8,13 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hit.hit_utils import (
     HitAPID,
+    add_summed_particle_data_to_dataset,
     get_attribute_manager,
     get_datasets_by_apid,
     process_housekeeping_data,
 )
 from imap_processing.hit.l1b.constants import (
-    PARTICLE_ENERGY_RANGE_MAPPING,
+    SUMMED_PARTICLE_ENERGY_RANGE_MAPPING,
     livestim_pulses,
 )
 
@@ -72,7 +72,7 @@ def hit_l1b(dependencies: dict, data_version: str) -> list[xr.Dataset]:
 
 
 def process_science_data(
-    raw_counts_dataset: xr.Dataset, attr_mgr: ImapCdfAttributes
+    l1a_counts_dataset: xr.Dataset, attr_mgr: ImapCdfAttributes
 ) -> list[xr.Dataset]:
     """
     Will create L1B science datasets for CDF products.
@@ -86,7 +86,7 @@ def process_science_data(
 
     Parameters
     ----------
-    raw_counts_dataset : xr.Dataset
+    l1a_counts_dataset : xr.Dataset
         The L1A counts dataset.
     attr_mgr : AttributeManager
         The attribute manager for the L1B data level.
@@ -107,13 +107,13 @@ def process_science_data(
     #  Process sectored rates dataset
 
     # Calculate fractional livetime from the livetime counter
-    livetime = raw_counts_dataset["livetime_counter"] / livestim_pulses
+    livetime = l1a_counts_dataset["livetime_counter"] / livestim_pulses
 
     # Create a standard rates dataset
-    standard_rates_dataset = process_standard_rates_data(raw_counts_dataset, livetime)
+    standard_rates_dataset = process_standard_rates_data(l1a_counts_dataset, livetime)
 
     # Create a summed rates dataset
-    summed_rates_dataset = process_summed_rates_data(raw_counts_dataset, livetime)
+    summed_rates_dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
 
     l1b_science_datasets = []
     # Update attributes and dimensions
@@ -153,14 +153,14 @@ def process_science_data(
 
 
 def process_standard_rates_data(
-    raw_counts_dataset: xr.Dataset, livetime: xr.DataArray
+    l1a_counts_dataset: xr.Dataset, livetime: xr.DataArray
 ) -> xr.Dataset:
     """
-    Will process L1B standard rates data from raw L1A counts data.
+    Will process L1B standard rates data from L1A raw counts data.
 
     Parameters
     ----------
-    raw_counts_dataset : xr.Dataset
+    l1a_counts_dataset : xr.Dataset
         The L1A counts dataset.
 
     livetime : xr.DataArray
@@ -175,7 +175,7 @@ def process_standard_rates_data(
     # Create a new dataset to store the L1B standard rates
     l1b_standard_rates_dataset = xr.Dataset()
 
-    # Add required coordinates from the raw_counts_dataset
+    # Add required coordinates from the l1A counts dataset
     coords = [
         "epoch",
         "gain",
@@ -191,18 +191,18 @@ def process_standard_rates_data(
         "ialirtrates_index",
     ]
     l1b_standard_rates_dataset = l1b_standard_rates_dataset.assign_coords(
-        {coord: raw_counts_dataset.coords[coord] for coord in coords}
+        {coord: l1a_counts_dataset.coords[coord] for coord in coords}
     )
 
-    # Add dynamic threshold variable from the L1A raw counts dataset
-    l1b_standard_rates_dataset["dynamic_threshold_state"] = raw_counts_dataset[
+    # Add dynamic threshold state from the L1A counts dataset
+    l1b_standard_rates_dataset["dynamic_threshold_state"] = l1a_counts_dataset[
         "hdr_dynamic_threshold_state"
     ]
-    l1b_standard_rates_dataset["dynamic_threshold_state"].attrs = raw_counts_dataset[
+    l1b_standard_rates_dataset["dynamic_threshold_state"].attrs = l1a_counts_dataset[
         "hdr_dynamic_threshold_state"
     ].attrs
 
-    # Define fields from the raw_counts_dataset to calculate standard rates from
+    # Define fields from the L1A counts dataset to calculate standard rates from
     standard_rate_fields = [
         "sngrates",
         "coinrates",
@@ -218,274 +218,76 @@ def process_standard_rates_data(
         "l4bgrates",
     ]
 
-    # Calculate standard rates by dividing the raw counts by livetime for
-    # data variables with names that contain a substring from a defined
-    # list of field names.
-    for var in raw_counts_dataset.data_vars:
-        if var != "livetime_counter" and any(
-            base_var in var for base_var in standard_rate_fields
-        ):
-            l1b_standard_rates_dataset[var] = raw_counts_dataset[var] / livetime
+    for var in standard_rate_fields:
+        # Add counts and uncertainty data to the dataset
+        l1b_standard_rates_dataset[var] = l1a_counts_dataset[var]
+        l1b_standard_rates_dataset[f"{var}_delta_minus"] = l1a_counts_dataset[
+            f"{var}_delta_minus"
+        ]
+        l1b_standard_rates_dataset[f"{var}_delta_plus"] = l1a_counts_dataset[
+            f"{var}_delta_plus"
+        ]
+        # Calculate rates using livetime
+        l1b_standard_rates_dataset = calculate_rates(
+            l1b_standard_rates_dataset, var, livetime
+        )
 
     return l1b_standard_rates_dataset
 
 
-def create_particle_data_arrays(
+def calculate_rates(
     dataset: xr.Dataset,
-    particle: str,
-    num_energy_ranges: int,
-    epoch_size: int,
-) -> xr.Dataset:
-    """
-    Create empty data arrays for a given particle.
-
-    Parameters
-    ----------
-    dataset : xr.Dataset
-        The dataset to add the data arrays to.
-
-    particle : str
-        The abbreviated particle name. Valid names are:
-            h
-            he3
-            he4
-            he
-            c
-            n
-            o
-            ne
-            na
-            mg
-            al
-            si
-            s
-            ar
-            ca
-            fe
-            ni
-
-    num_energy_ranges : int
-        Number of energy ranges for the particle.
-        Used to define the shape of the data arrays.
-
-    epoch_size : int
-        Used to define the shape of the data arrays.
-
-    Returns
-    -------
-    dataset : xr.Dataset
-        The dataset with the added data arrays.
-    """
-    dataset[f"{particle}"] = xr.DataArray(
-        data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
-        dims=["epoch", f"{particle}_energy_index"],
-        name=f"{particle}",
-    )
-    dataset[f"{particle}_delta_minus"] = xr.DataArray(
-        data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
-        dims=["epoch", f"{particle}_energy_index"],
-        name=f"{particle}_delta_minus",
-    )
-    dataset[f"{particle}_delta_plus"] = xr.DataArray(
-        data=np.zeros((epoch_size, num_energy_ranges), dtype=np.float32),
-        dims=["epoch", f"{particle}_energy_index"],
-        name=f"{particle}_delta_plus",
-    )
-    dataset.coords[f"{particle}_energy_index"] = xr.DataArray(
-        np.arange(num_energy_ranges, dtype=np.int8),
-        dims=[f"{particle}_energy_index"],
-        name=f"{particle}_energy_index",
-    )
-    return dataset
-
-
-def calculate_summed_counts(
-    raw_counts_dataset: xr.Dataset, count_indices: dict
-) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray]:
-    """
-    Calculate summed counts for a given energy range.
-
-    Parameters
-    ----------
-    raw_counts_dataset : xr.Dataset
-        The L1A counts dataset that contains the l2fgrates, l3fgrates,
-        and penfgrates data variables with the particle counts data
-        needed for the calculation.
-
-    count_indices : dict
-        A dictionary containing the indices for particle counts to sum for a given
-        energy range.
-        R2=Indices for L2FGRATES, R3=Indices for L3FGRATES, R4=Indices for PENFGRATES.
-
-    Returns
-    -------
-    summed_counts : xr.DataArray
-        The summed counts.
-
-    summed_counts_delta_minus : xr.DataArray
-        The summed counts for delta minus uncertainty.
-
-    summed_counts_delta_plus : xr.DataArray
-        The summed counts for delta plus uncertainty.
-    """
-    summed_counts = (
-        raw_counts_dataset["l2fgrates"][:, count_indices["R2"]].sum(axis=1)
-        + raw_counts_dataset["l3fgrates"][:, count_indices["R3"]].sum(axis=1)
-        + raw_counts_dataset["penfgrates"][:, count_indices["R4"]].sum(axis=1)
-    )
-
-    summed_counts_delta_minus = (
-        raw_counts_dataset["l2fgrates_delta_minus"][:, count_indices["R2"]].sum(axis=1)
-        + raw_counts_dataset["l3fgrates_delta_minus"][:, count_indices["R3"]].sum(
-            axis=1
-        )
-        + raw_counts_dataset["penfgrates_delta_minus"][:, count_indices["R4"]].sum(
-            axis=1
-        )
-    )
-
-    summed_counts_delta_plus = (
-        raw_counts_dataset["l2fgrates_delta_plus"][:, count_indices["R2"]].sum(axis=1)
-        + raw_counts_dataset["l3fgrates_delta_plus"][:, count_indices["R3"]].sum(axis=1)
-        + raw_counts_dataset["penfgrates_delta_plus"][:, count_indices["R4"]].sum(
-            axis=1
-        )
-    )
-
-    return summed_counts, summed_counts_delta_minus, summed_counts_delta_plus
-
-
-class SummedCounts(NamedTuple):
-    """A namedtuple to store summed counts and uncertainties."""
-
-    summed_counts: xr.DataArray
-    summed_counts_delta_minus: xr.DataArray
-    summed_counts_delta_plus: xr.DataArray
-
-
-def add_rates_to_dataset(
-    dataset: xr.Dataset,
-    particle: str,
-    index: int,
-    summed_counts: SummedCounts,
+    var: str,
     livetime: xr.DataArray,
 ) -> xr.Dataset:
     """
-    Add summed rates to the dataset.
-
-    This function divides the summed counts by livetime to calculate
-    the rates for a given particle then adds the rates to the dataset.
+    Calculate rates by dividing counts by livetime.
 
     Parameters
     ----------
     dataset : xr.Dataset
-        The dataset to add the rates to.
-
-    particle : str
-        The abbreviated particle name. Valid names are:
-            h
-            he3
-            he4
-            he
-            c
-            n
-            o
-            ne
-            na
-            mg
-            al
-            si
-            s
-            ar
-            ca
-            fe
-            ni
-
-    index : int
-        The index of the energy range.
-
-    summed_counts : namedtuple
-        A namedtuple containing the summed counts.
-        SummedCounts(summed_counts, summed_counts_delta_minus,
-                    summed_counts_delta_plus).
-
+        The L1B dataset containing counts data.
+    var : str
+        The name of the variable to calculate rates for.
     livetime : xr.DataArray
-        1D array of livetime values. Shape equals the number of epochs in the dataset.
-
-    Returns
-    -------
-    dataset: xr.Dataset
-        The dataset with the added rates.
-    """
-    dataset[f"{particle}"][:, index] = (summed_counts.summed_counts / livetime).astype(
-        np.float32
-    )
-    dataset[f"{particle}_delta_minus"][:, index] = (
-        summed_counts.summed_counts_delta_minus / livetime
-    ).astype(np.float32)
-    dataset[f"{particle}_delta_plus"][:, index] = (
-        summed_counts.summed_counts_delta_plus / livetime
-    ).astype(np.float32)
-    return dataset
-
-
-def add_energy_variables(
-    dataset: xr.Dataset,
-    particle: str,
-    energy_min_values: np.ndarray,
-    energy_max_values: np.ndarray,
-) -> xr.Dataset:
-    """
-    Add energy min and max variables to the dataset.
-
-    Parameters
-    ----------
-    dataset : xr.Dataset
-        The dataset to add the energy variables to.
-    particle : str
-        The particle name.
-    energy_min_values : np.ndarray
-        The minimum energy values for each energy range.
-    energy_max_values : np.ndarray
-        The maximum energy values for each energy range.
+        1D array of livetime values. Shape equals the
+        number of epochs in the dataset.
 
     Returns
     -------
     xr.Dataset
-        The dataset with the added energy variables.
+        The dataset with rates.
     """
-    dataset[f"{particle}_energy_min"] = xr.DataArray(
-        data=np.array(energy_min_values, dtype=np.float32),
-        dims=[f"{particle}_energy_index"],
-        name=f"{particle}_energy_min",
+    dataset[f"{var}"] = (dataset[f"{var}"] / livetime).astype(np.float32)
+    dataset[f"{var}_delta_minus"] = (dataset[f"{var}_delta_minus"] / livetime).astype(
+        np.float32
     )
-    dataset[f"{particle}_energy_max"] = xr.DataArray(
-        data=np.array(energy_max_values, dtype=np.float32),
-        dims=[f"{particle}_energy_index"],
-        name=f"{particle}_energy_max",
+    dataset[f"{var}_delta_plus"] = (dataset[f"{var}_delta_plus"] / livetime).astype(
+        np.float32
     )
+
     return dataset
 
 
 def process_summed_rates_data(
-    raw_counts_dataset: xr.Dataset, livetime: xr.DataArray
+    l1a_counts_dataset: xr.Dataset, livetime: xr.DataArray
 ) -> xr.Dataset:
     """
-    Will process L1B summed rates data from raw L1A counts data.
+    Will process L1B summed rates data from L1A raw counts data.
 
     This function calculates summed rates for each particle type and energy range.
     The counts that are summed come from the l2fgrates, l3fgrates, and penfgrates
     data variables in the L1A counts data. These variables represent counts
     of different detector penetration ranges (Range 2, Range 3, and Range 4
     respectively). Only the energy ranges specified in the
-    PARTICLE_ENERGY_RANGE_MAPPING dictionary are included in this product.
+    SUMMED_PARTICLE_ENERGY_RANGE_MAPPING dictionary are included in this product.
 
     The summed rates are calculated by summing the counts for each energy range and
     dividing by the livetime.
 
     Parameters
     ----------
-    raw_counts_dataset : xr.Dataset
+    l1a_counts_dataset : xr.Dataset
         The L1A counts dataset.
 
     livetime : xr.DataArray
@@ -500,58 +302,31 @@ def process_summed_rates_data(
     # Create a new dataset to store the L1B standard rates
     l1b_summed_rates_dataset = xr.Dataset()
 
-    # Assign the epoch coordinate from the l1a dataset
+    # Assign the epoch coordinate from the L1A dataset
     l1b_summed_rates_dataset = l1b_summed_rates_dataset.assign_coords(
-        {"epoch": raw_counts_dataset.coords["epoch"]}
+        {"epoch": l1a_counts_dataset.coords["epoch"]}
     )
 
-    # TODO: dynamic threshold might not be needed for this product.
-    #  Need confirmation from HIT
-    # Add dynamic threshold variable from L1A raw counts dataset
-    l1b_summed_rates_dataset["dynamic_threshold_state"] = raw_counts_dataset[
+    # Add dynamic threshold state from L1A raw counts dataset
+    l1b_summed_rates_dataset["dynamic_threshold_state"] = l1a_counts_dataset[
         "hdr_dynamic_threshold_state"
     ]
-    l1b_summed_rates_dataset["dynamic_threshold_state"].attrs = raw_counts_dataset[
+    l1b_summed_rates_dataset["dynamic_threshold_state"].attrs = l1a_counts_dataset[
         "hdr_dynamic_threshold_state"
     ].attrs
 
     # Calculate summed rates for each particle and add them to the dataset
-    for particle, energy_ranges in PARTICLE_ENERGY_RANGE_MAPPING.items():
-        l1b_summed_rates_dataset = create_particle_data_arrays(
+    for particle, energy_ranges in SUMMED_PARTICLE_ENERGY_RANGE_MAPPING.items():
+        # Sum counts for each energy range and add to dataset
+        add_summed_particle_data_to_dataset(
             l1b_summed_rates_dataset,
+            l1a_counts_dataset,
             particle,
-            len(energy_ranges),
-            raw_counts_dataset.sizes["epoch"],
+            energy_ranges,
         )
-
-        energy_min, energy_max = (
-            np.zeros(len(energy_ranges), dtype=np.float32),
-            np.zeros(len(energy_ranges), dtype=np.float32),
-        )
-        for i, energy_range in enumerate(energy_ranges):
-            summed_counts, summed_counts_delta_minus, summed_counts_delta_plus = (
-                calculate_summed_counts(raw_counts_dataset, energy_range)
-            )
-
-            # Create namedtuple to store summed counts and uncertainties
-            summed_counts = SummedCounts(
-                summed_counts, summed_counts_delta_minus, summed_counts_delta_plus
-            )
-
-            l1b_summed_rates_dataset = add_rates_to_dataset(
-                l1b_summed_rates_dataset,
-                particle,
-                i,
-                summed_counts,
-                livetime,
-            )
-            energy_min[i], energy_max[i] = (
-                energy_range["energy_min"],
-                energy_range["energy_max"],
-            )
-
-        l1b_summed_rates_dataset = add_energy_variables(
-            l1b_summed_rates_dataset, particle, energy_min, energy_max
+        # Calculate rates using livetime
+        l1b_summed_rates_dataset = calculate_rates(
+            l1b_summed_rates_dataset, particle, livetime
         )
 
     return l1b_summed_rates_dataset

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -186,7 +186,7 @@ def calculate_intensities(
 
 def calculate_intensities_for_a_species(
     species_variable: str, l2_dataset: xr.Dataset, ancillary_data_frames: dict
-) -> None:
+) -> xr.Dataset:
     """
     Calculate the intensity for a given species in the dataset.
 
@@ -201,15 +201,21 @@ def calculate_intensities_for_a_species(
         Dictionary containing ancillary data for each dynamic threshold state where
         the key is the dynamic threshold state and the value is a pandas DataFrame
         containing the ancillary data.
+
+    Returns
+    -------
+    updated_ds : xr.Dataset
+        The updated dataset with the intensity calculated for the given species.
     """
+    updated_ds = l2_dataset.copy()
     species = (
         species_variable.split("_")[0]
         if "_delta_" in species_variable
         else species_variable
     )
     energy_min = (
-        l2_dataset[f"{species}_energy_mean"].values
-        - l2_dataset[f"{species}_energy_delta_minus"].values
+        updated_ds[f"{species}_energy_mean"].values
+        - updated_ds[f"{species}_energy_delta_minus"].values
     )
     # TODO: Add check for energy max after ancillary file is updated
     #  to fix errors
@@ -217,10 +223,10 @@ def calculate_intensities_for_a_species(
     # Calculate the intensity for each epoch and energy bin since the
     # dynamic threshold state can vary by epoch and that determines the
     # ancillary data to use.
-    for epoch in range(l2_dataset[species_variable].shape[0]):
+    for epoch in range(updated_ds[species_variable].shape[0]):
         # Get ancillary data using the dynamic threshold state for this epoch
         species_ancillary_data = get_species_ancillary_data(
-            int(l2_dataset["dynamic_threshold_state"][epoch].values),
+            int(updated_ds["dynamic_threshold_state"][epoch].values),
             ancillary_data_frames,
             species,
         )
@@ -230,9 +236,9 @@ def calculate_intensities_for_a_species(
         factors: IntensityFactors = get_intensity_factors(
             energy_min, species_ancillary_data
         )
-        rates: xr.DataArray = l2_dataset[species_variable][epoch]
+        rates: xr.DataArray = updated_ds[species_variable][epoch]
 
-        l2_dataset[species_variable][epoch] = calculate_intensities(
+        updated_ds[species_variable][epoch] = calculate_intensities(
             rates,
             factors.delta_e_factor,
             factors.geometry_factor,
@@ -240,10 +246,12 @@ def calculate_intensities_for_a_species(
             factors.b,
         )
 
+    return updated_ds
+
 
 def calculate_intensities_for_all_species(
     l2_dataset: xr.Dataset, ancillary_data_frames: dict
-) -> None:
+) -> xr.Dataset:
     """
     Calculate the intensity for each species in the dataset.
 
@@ -255,8 +263,14 @@ def calculate_intensities_for_all_species(
         Dictionary containing ancillary data for each dynamic threshold state
         where the key is the dynamic threshold state and the value is a pandas
         DataFrame containing the ancillary data.
+
+    Returns
+    -------
+    updated_ds : xr.Dataset
+        The updated dataset with the intensity calculated for each species.
     """
     # TODO: update to also calculate intensity for sectorates?
+    updated_ds = l2_dataset.copy()
     # List of valid species data variables to calculate intensity for
     valid_data_variables = [
         "h",
@@ -285,9 +299,9 @@ def calculate_intensities_for_all_species(
 
     # Calculate the intensity for each valid data variable
     for species_variable in valid_data_variables:
-        if species_variable in l2_dataset.data_vars:
-            calculate_intensities_for_a_species(
-                species_variable, l2_dataset, ancillary_data_frames
+        if species_variable in updated_ds.data_vars:
+            updated_ds = calculate_intensities_for_a_species(
+                species_variable, updated_ds, ancillary_data_frames
             )
         else:
             logger.warning(
@@ -295,10 +309,12 @@ def calculate_intensities_for_all_species(
                 f"Skipping intensity calculation."
             )
 
+    return updated_ds
+
 
 def add_systematic_uncertainties(
     dataset: xr.Dataset, particle: str, energy_bins: int
-) -> None:
+) -> xr.Dataset:
     """
     Add systematic uncertainties to the dataset.
 
@@ -313,17 +329,26 @@ def add_systematic_uncertainties(
         The particle name.
     energy_bins : int
         Number of energy bins for the particle.
+
+    Returns
+    -------
+    updated_ds : xr.Dataset
+        The dataset with the systematic uncertainties added.
     """
-    dataset[f"{particle}_sys_delta_minus"] = xr.DataArray(
+    updated_ds = dataset.copy()
+
+    updated_ds[f"{particle}_sys_delta_minus"] = xr.DataArray(
         data=np.zeros(energy_bins, dtype=np.float32),
         dims=[f"{particle}_energy_mean"],
         name=f"{particle}_sys_delta_minus",
     )
-    dataset[f"{particle}_sys_delta_plus"] = xr.DataArray(
+    updated_ds[f"{particle}_sys_delta_plus"] = xr.DataArray(
         data=np.zeros(energy_bins, dtype=np.float32),
         dims=[f"{particle}_energy_mean"],
         name=f"{particle}_sys_delta_plus",
     )
+
+    return updated_ds
 
 
 def get_species_ancillary_data(
@@ -425,12 +450,12 @@ def process_summed_intensity_data(l1b_summed_rates_dataset: xr.Dataset) -> xr.Da
     for var in l2_summed_intensity_dataset.data_vars:
         if "_" not in var:
             particle = str(var)
-            add_systematic_uncertainties(
+            l2_summed_intensity_dataset = add_systematic_uncertainties(
                 l2_summed_intensity_dataset,
                 particle,
                 l2_summed_intensity_dataset[var].shape[1],
             )
-    calculate_intensities_for_all_species(
+    l2_summed_intensity_dataset = calculate_intensities_for_all_species(
         l2_summed_intensity_dataset, ancillary_data_frames
     )
 
@@ -498,11 +523,11 @@ def process_standard_intensity_data(
     for particle, energy_ranges in STANDARD_PARTICLE_ENERGY_RANGE_MAPPING.items():
         # Add systematic uncertainties to the dataset. These will not have the intensity
         # calculation applied to them and values will be zeros
-        add_systematic_uncertainties(
+        l2_standard_intensity_dataset = add_systematic_uncertainties(
             l2_standard_intensity_dataset, particle, len(energy_ranges)
         )
         # Add standard particle rates and statistical uncertainties to the dataset
-        add_summed_particle_data_to_dataset(
+        l2_standard_intensity_dataset = add_summed_particle_data_to_dataset(
             l2_standard_intensity_dataset,
             l1b_standard_rates_dataset,
             particle,

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -9,10 +9,8 @@ import pandas as pd
 import xarray as xr
 
 from imap_processing.hit.hit_utils import (
-    add_energy_variables,
+    add_summed_particle_data_to_dataset,
     get_attribute_manager,
-    initialize_particle_data_arrays,
-    sum_particle_data,
 )
 from imap_processing.hit.l2.constants import (
     L2_STANDARD_ANCILLARY_PATH_PREFIX,
@@ -25,6 +23,7 @@ logger = logging.getLogger(__name__)
 # TODO:
 #  - review logging levels to use (debug vs. info)
 #  - determine where to pull ancillary data. Storing it locally for now
+#  - add function to calculate combined uncertainty and add this to L2 datasets
 
 
 def hit_l2(dependency: xr.Dataset, data_version: str) -> list[xr.Dataset]:
@@ -327,73 +326,6 @@ def add_systematic_uncertainties(
     )
 
 
-def add_standard_particle_rates_to_dataset(
-    l2_standard_intensity_dataset: xr.Dataset,
-    l1b_standard_rates_dataset: xr.Dataset,
-    particle: str,
-    energy_ranges: list,
-) -> None:
-    """
-    Add summed standard particle rates to the dataset.
-
-    This function performs the following steps:
-      1) sum the standard rates, including statistical uncertainties,
-         from the l2fgrates, l3fgrates, and penfgrates data variables in the L1B
-         standard rates data.
-      2) add the summed rates to the L2 standard intensity dataset by particle type
-         and energy range.
-
-    Parameters
-    ----------
-    l2_standard_intensity_dataset : xr.Dataset
-        The L2 standard intensity dataset to add the rates to.
-    l1b_standard_rates_dataset : xr.Dataset
-        The L1B standard rates dataset containing rates to sum.
-    particle : str
-        The particle name.
-    energy_ranges : list
-        A list of energy range dictionaries for the particle.
-        For example:
-        {'energy_min': 1.8, 'energy_max': 2.2, "R2": [1], "R3": [], "R4": []}.
-    """
-    # Initialize arrays to store summed rates and statistical uncertainties
-    l2_standard_intensity_dataset = initialize_particle_data_arrays(
-        l2_standard_intensity_dataset,
-        particle,
-        len(energy_ranges),
-        l1b_standard_rates_dataset.sizes["epoch"],
-    )
-
-    # initialize arrays to store energy min and max values
-    energy_min = np.zeros(len(energy_ranges), dtype=np.float32)
-    energy_max = np.zeros(len(energy_ranges), dtype=np.float32)
-
-    # Sum particle rates and statistical uncertainties for each energy range
-    # and add them to the dataset
-    for i, energy_range_dict in enumerate(energy_ranges):
-        summed_rates, summed_rates_delta_minus, summed_rates_delta_plus = (
-            sum_particle_data(l1b_standard_rates_dataset, energy_range_dict)
-        )
-
-        l2_standard_intensity_dataset[f"{particle}"][:, i] = summed_rates.astype(
-            np.float32
-        )
-        l2_standard_intensity_dataset[f"{particle}_delta_minus"][:, i] = (
-            summed_rates_delta_minus.astype(np.float32)
-        )
-        l2_standard_intensity_dataset[f"{particle}_delta_plus"][:, i] = (
-            summed_rates_delta_plus.astype(np.float32)
-        )
-
-        # Fill energy min and max values for each energy range
-        energy_min[i] = energy_range_dict["energy_min"]
-        energy_max[i] = energy_range_dict["energy_max"]
-
-    l2_standard_intensity_dataset = add_energy_variables(
-        l2_standard_intensity_dataset, particle, energy_min, energy_max
-    )
-
-
 def get_species_ancillary_data(
     dynamic_threshold_state: int, ancillary_data_frames: dict, species: str
 ) -> pd.DataFrame:
@@ -488,47 +420,16 @@ def process_summed_intensity_data(l1b_summed_rates_dataset: xr.Dataset) -> xr.Da
         L2_SUMMED_ANCILLARY_PATH_PREFIX,
     )
 
-    # Add systematic uncertainties and energy variables to the dataset
+    # Add systematic uncertainties to the dataset. These will not
+    # have the intensity calculation applied to them
     for var in l2_summed_intensity_dataset.data_vars:
         if "_" not in var:
             particle = str(var)
-            # Add systematic uncertainties to the dataset. These will not have the
-            # intensity calculation applied to them and values will be zeros
             add_systematic_uncertainties(
                 l2_summed_intensity_dataset,
                 particle,
                 l2_summed_intensity_dataset[var].shape[1],
             )
-
-            # TODO: remove this code after L1B is updated to have energy mean and deltas
-            #       instead of energy index, min, and max
-            # Add energy variables to the dataset (energy mean and deltas)
-            l2_summed_intensity_dataset = add_energy_variables(
-                l2_summed_intensity_dataset,
-                particle,
-                l2_summed_intensity_dataset[f"{particle}_energy_min"].values,
-                l2_summed_intensity_dataset[f"{particle}_energy_max"].values,
-            )
-
-            # Replace energy index with energy mean as a coordinate
-            l2_summed_intensity_dataset = l2_summed_intensity_dataset.assign_coords(
-                {
-                    f"{particle}_energy_mean": (
-                        f"{particle}_energy_index",
-                        l2_summed_intensity_dataset[f"{particle}_energy_mean"].values,
-                    )
-                }
-            ).swap_dims({f"{particle}_energy_index": f"{particle}_energy_mean"})
-
-            # Drop energy min, max, and index variables
-            l2_summed_intensity_dataset = l2_summed_intensity_dataset.drop_vars(
-                [
-                    f"{particle}_energy_min",
-                    f"{particle}_energy_max",
-                    f"{particle}_energy_index",
-                ]
-            )
-
     calculate_intensities_for_all_species(
         l2_summed_intensity_dataset, ancillary_data_frames
     )
@@ -601,7 +502,7 @@ def process_standard_intensity_data(
             l2_standard_intensity_dataset, particle, len(energy_ranges)
         )
         # Add standard particle rates and statistical uncertainties to the dataset
-        add_standard_particle_rates_to_dataset(
+        add_summed_particle_data_to_dataset(
             l2_standard_intensity_dataset,
             l1b_standard_rates_dataset,
             particle,

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -62,7 +62,7 @@ def test_subcom_sectorates(sci_packet_filepath):
     sci_dataset = decom_hit(sci_dataset)
 
     # Call the function to be tested
-    subcom_sectorates(sci_dataset)
+    sci_dataset = subcom_sectorates(sci_dataset)
 
     # Number of science frames in the dataset
     frames = sci_dataset["epoch"].shape[0]
@@ -79,7 +79,7 @@ def test_subcom_sectorates(sci_packet_filepath):
     for species, shape in expected_shapes.items():
         # Check if the dataset has the new  data variables
         assert f"{species}_sectored_counts" in sci_dataset
-        assert f"{species}_energy_mean" in sci_dataset
+        assert f"{species}_energy_mean" in sci_dataset.coords
         assert f"{species}_energy_delta_minus" in sci_dataset
         assert f"{species}_energy_delta_plus" in sci_dataset
         # Check the shape of the new data variables

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -212,7 +212,9 @@ def test_calculate_intensities_for_all_species():
     )
 
     # Call the function
-    calculate_intensities_for_all_species(l2_dataset, ancillary_data_frames)
+    l2_dataset = calculate_intensities_for_all_species(
+        l2_dataset, ancillary_data_frames
+    )
 
     # Assertions
     assert np.allclose(
@@ -276,7 +278,7 @@ def test_calculate_intensities_for_a_species():
     )
 
     # Call the function
-    calculate_intensities_for_a_species(
+    l2_dataset = calculate_intensities_for_a_species(
         species_variable, l2_dataset, ancillary_data_frames
     )
 
@@ -323,7 +325,7 @@ def test_add_systematic_uncertainties():
     dataset = xr.Dataset()
 
     # Call the function
-    add_systematic_uncertainties(dataset, particle, len(energy_ranges))
+    dataset = add_systematic_uncertainties(dataset, particle, len(energy_ranges))
 
     # Assertions
     assert f"{particle}_sys_delta_minus" in dataset.data_vars

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -6,7 +6,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.hit.l1a import hit_l1a
 from imap_processing.hit.l1b.hit_l1b import (
-    PARTICLE_ENERGY_RANGE_MAPPING,
+    SUMMED_PARTICLE_ENERGY_RANGE_MAPPING,
     hit_l1b,
 )
 from imap_processing.hit.l2.hit_l2 import (
@@ -22,8 +22,6 @@ from imap_processing.hit.l2.hit_l2 import (
     process_standard_intensity_data,
     process_summed_intensity_data,
 )
-
-# TODO: add unit test for add_standard_particle_rates_to_dataset
 
 
 @pytest.fixture(scope="module")
@@ -374,12 +372,14 @@ def test_process_summed_intensity_data(l1b_summed_rates_dataset):
 
     assert "dynamic_threshold_state" in l1b_summed_rates_dataset.data_vars
 
-    for particle in PARTICLE_ENERGY_RANGE_MAPPING.keys():
+    for particle in SUMMED_PARTICLE_ENERGY_RANGE_MAPPING.keys():
         assert f"{particle}" in l2_summed_intensity_dataset.data_vars
         assert f"{particle}_delta_minus" in l2_summed_intensity_dataset.data_vars
         assert f"{particle}_delta_plus" in l2_summed_intensity_dataset.data_vars
         assert f"{particle}_sys_delta_minus" in l2_summed_intensity_dataset.data_vars
         assert f"{particle}_sys_delta_plus" in l2_summed_intensity_dataset.data_vars
+        assert f"{particle}_energy_delta_minus" in l2_summed_intensity_dataset.data_vars
+        assert f"{particle}_energy_delta_plus" in l2_summed_intensity_dataset.data_vars
 
 
 def test_process_standard_intensity_data(l1b_standard_rates_dataset):

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -241,27 +241,32 @@ def test_process_housekeeping(housekeeping_dataset, attribute_manager):
 
 
 def test_add_energy_variables():
+    """Test adding energy variables to a dataset"""
+    # Create an empty dataset
     dataset = xr.Dataset()
+
+    # Create sample data
     particle = "test_particle"
     energy_min = np.array([1.8, 4.0, 6.0], dtype=np.float32)
     energy_max = np.array([2.2, 6.0, 10.0], dtype=np.float32)
     energy_mean = np.mean([energy_min, energy_max], axis=0)
-    result = add_energy_variables(dataset, particle, energy_min, energy_max)
-    assert f"{particle}_energy_delta_minus" in result.data_vars
-    assert f"{particle}_energy_delta_plus" in result.data_vars
-    assert f"{particle}_energy_mean" in result.coords
+
+    # Call the function
+    add_energy_variables(dataset, particle, energy_min, energy_max)
+
+    # Assertions
+    assert f"{particle}_energy_delta_minus" in dataset.data_vars
+    assert f"{particle}_energy_delta_plus" in dataset.data_vars
+    assert f"{particle}_energy_mean" in dataset.coords
     assert np.all(
-        result[f"{particle}_energy_delta_minus"].values
+        dataset[f"{particle}_energy_delta_minus"].values
         == np.array(energy_mean - np.array(energy_min), dtype=np.float32)
     )
     assert np.all(
-        result[f"{particle}_energy_delta_plus"].values
+        dataset[f"{particle}_energy_delta_plus"].values
         == np.array(energy_max - energy_mean, dtype=np.float32)
     )
-    assert np.all(
-        result[f"{particle}_energy_mean"].values
-        == np.mean([energy_min, energy_max], axis=0)
-    )
+    assert np.all(dataset[f"{particle}_energy_mean"].values == energy_mean)
 
 
 def test_sum_particle_data(sample_dataset):

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -7,6 +7,7 @@ from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hit.hit_utils import (
     HitAPID,
     add_energy_variables,
+    add_summed_particle_data_to_dataset,
     concatenate_leak_variables,
     get_attribute_manager,
     get_datasets_by_apid,
@@ -41,6 +42,23 @@ def housekeeping_dataset(packet_filepath):
     # Unpack ccsds file to xarray datasets
     datasets_by_apid = get_datasets_by_apid(packet_filepath)
     return datasets_by_apid[HitAPID.HIT_HSKP]
+
+
+@pytest.fixture()
+def sample_dataset():
+    """Create a sample dataset for summing particle data"""
+    data = {
+        "l2fgrates": (("epoch", "energy"), np.random.rand(10, 5)),
+        "l3fgrates": (("epoch", "energy"), np.random.rand(10, 5)),
+        "penfgrates": (("epoch", "energy"), np.random.rand(10, 5)),
+        "l2fgrates_delta_minus": (("epoch", "energy"), np.random.rand(10, 5)),
+        "l3fgrates_delta_minus": (("epoch", "energy"), np.random.rand(10, 5)),
+        "penfgrates_delta_minus": (("epoch", "energy"), np.random.rand(10, 5)),
+        "l2fgrates_delta_plus": (("epoch", "energy"), np.random.rand(10, 5)),
+        "l3fgrates_delta_plus": (("epoch", "energy"), np.random.rand(10, 5)),
+        "penfgrates_delta_plus": (("epoch", "energy"), np.random.rand(10, 5)),
+    }
+    return xr.Dataset(data)
 
 
 def test_get_datasets_by_apid(packet_filepath):
@@ -246,20 +264,9 @@ def test_add_energy_variables():
     )
 
 
-def test_sum_particle_data():
+def test_sum_particle_data(sample_dataset):
     # Create a sample dataset
-    data = {
-        "l2fgrates": (("epoch", "energy"), np.random.rand(10, 5)),
-        "l3fgrates": (("epoch", "energy"), np.random.rand(10, 5)),
-        "penfgrates": (("epoch", "energy"), np.random.rand(10, 5)),
-        "l2fgrates_delta_minus": (("epoch", "energy"), np.random.rand(10, 5)),
-        "l3fgrates_delta_minus": (("epoch", "energy"), np.random.rand(10, 5)),
-        "penfgrates_delta_minus": (("epoch", "energy"), np.random.rand(10, 5)),
-        "l2fgrates_delta_plus": (("epoch", "energy"), np.random.rand(10, 5)),
-        "l3fgrates_delta_plus": (("epoch", "energy"), np.random.rand(10, 5)),
-        "penfgrates_delta_plus": (("epoch", "energy"), np.random.rand(10, 5)),
-    }
-    dataset = xr.Dataset(data)
+    dataset = xr.Dataset(sample_dataset)
 
     # Define indices for summing
     indices = {
@@ -294,6 +301,54 @@ def test_sum_particle_data():
         == dataset["l2fgrates_delta_plus"][:, indices["R2"]].sum(axis=1)
         + dataset["l3fgrates_delta_plus"][:, indices["R3"]].sum(axis=1)
         + dataset["penfgrates_delta_plus"][:, indices["R4"]].sum(axis=1)
+    )
+
+
+def test_add_summed_particle_data_to_dataset(sample_dataset):
+    """Test adding summed particle data to a dataset"""
+    # Create a sample source dataset
+    source_dataset = xr.Dataset(sample_dataset)
+
+    # Create an empty dataset to update
+    dataset_to_update = xr.Dataset()
+
+    # Define particle and energy ranges
+    particle = "test_particle"
+    energy_ranges = [
+        {"energy_min": 1.8, "energy_max": 2.2, "R2": [0], "R3": [1], "R4": [2]},
+        {"energy_min": 4.0, "energy_max": 6.0, "R2": [3], "R3": [4], "R4": []},
+    ]
+
+    # Call the function
+    add_summed_particle_data_to_dataset(
+        dataset_to_update, source_dataset, particle, energy_ranges
+    )
+
+    # Assertions
+    assert f"{particle}" in dataset_to_update.data_vars
+    assert f"{particle}_delta_minus" in dataset_to_update.data_vars
+    assert f"{particle}_delta_plus" in dataset_to_update.data_vars
+    assert f"{particle}_energy_delta_minus" in dataset_to_update.data_vars
+    assert f"{particle}_energy_delta_plus" in dataset_to_update.data_vars
+    assert f"{particle}_energy_mean" in dataset_to_update.coords
+
+    assert dataset_to_update[f"{particle}"].shape == (10, len(energy_ranges))
+    assert dataset_to_update[f"{particle}_delta_minus"].shape == (
+        10,
+        len(energy_ranges),
+    )
+    assert dataset_to_update[f"{particle}_delta_plus"].shape == (10, len(energy_ranges))
+    assert dataset_to_update[f"{particle}_energy_mean"].shape == (len(energy_ranges),)
+    assert dataset_to_update[f"{particle}_energy_delta_minus"].shape == (
+        len(energy_ranges),
+    )
+    assert dataset_to_update[f"{particle}_energy_delta_plus"].shape == (
+        len(energy_ranges),
+    )
+
+    assert np.all(
+        dataset_to_update[f"{particle}_energy_mean"].values
+        == np.mean([[1.8, 4.0], [2.2, 6.0]], axis=0)
     )
 
 

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -367,22 +367,20 @@ def test_initialize_particle_data_arrays():
     epoch_size = 10
 
     # Call the function
-    result = initialize_particle_data_arrays(
-        dataset, particle, num_energy_ranges, epoch_size
-    )
+    initialize_particle_data_arrays(dataset, particle, num_energy_ranges, epoch_size)
 
     # Assertions
-    assert f"{particle}" in result.data_vars
-    assert f"{particle}_delta_minus" in result.data_vars
-    assert f"{particle}_delta_plus" in result.data_vars
-    assert f"{particle}_energy_mean" in result.coords
+    assert f"{particle}" in dataset.data_vars
+    assert f"{particle}_delta_minus" in dataset.data_vars
+    assert f"{particle}_delta_plus" in dataset.data_vars
+    assert f"{particle}_energy_mean" in dataset.coords
 
-    assert result[f"{particle}"].shape == (epoch_size, num_energy_ranges)
-    assert result[f"{particle}_delta_minus"].shape == (epoch_size, num_energy_ranges)
-    assert result[f"{particle}_delta_plus"].shape == (epoch_size, num_energy_ranges)
-    assert result[f"{particle}_energy_mean"].shape == (num_energy_ranges,)
+    assert dataset[f"{particle}"].shape == (epoch_size, num_energy_ranges)
+    assert dataset[f"{particle}_delta_minus"].shape == (epoch_size, num_energy_ranges)
+    assert dataset[f"{particle}_delta_plus"].shape == (epoch_size, num_energy_ranges)
+    assert dataset[f"{particle}_energy_mean"].shape == (num_energy_ranges,)
 
-    assert np.all(result[f"{particle}"].values == 0)
-    assert np.all(result[f"{particle}_delta_minus"].values == 0)
-    assert np.all(result[f"{particle}_delta_plus"].values == 0)
-    assert np.all(result[f"{particle}_energy_mean"].values == 0)
+    assert np.all(dataset[f"{particle}"].values == 0)
+    assert np.all(dataset[f"{particle}_delta_minus"].values == 0)
+    assert np.all(dataset[f"{particle}_delta_plus"].values == 0)
+    assert np.all(dataset[f"{particle}_energy_mean"].values == 0)

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -252,7 +252,7 @@ def test_add_energy_variables():
     energy_mean = np.mean([energy_min, energy_max], axis=0)
 
     # Call the function
-    add_energy_variables(dataset, particle, energy_min, energy_max)
+    dataset = add_energy_variables(dataset, particle, energy_min, energy_max)
 
     # Assertions
     assert f"{particle}_energy_delta_minus" in dataset.data_vars
@@ -325,7 +325,7 @@ def test_add_summed_particle_data_to_dataset(sample_dataset):
     ]
 
     # Call the function
-    add_summed_particle_data_to_dataset(
+    dataset_to_update = add_summed_particle_data_to_dataset(
         dataset_to_update, source_dataset, particle, energy_ranges
     )
 
@@ -367,7 +367,9 @@ def test_initialize_particle_data_arrays():
     epoch_size = 10
 
     # Call the function
-    initialize_particle_data_arrays(dataset, particle, num_energy_ranges, epoch_size)
+    dataset = initialize_particle_data_arrays(
+        dataset, particle, num_energy_ranges, epoch_size
+    )
 
     # Assertions
     assert f"{particle}" in dataset.data_vars


### PR DESCRIPTION
This PR removes duplicate code by refactoring L1B and L2 processing to use supporting functions in hit utils that handle summing particle data and adding energy variables that use a geometric mean.  The geometric mean replaces the energy index that was initially used, but didn't conform with mission requirements.

Closes #1552 

## Updated Files
- hit_utils.py
   - Add function to sum particle data and add results to the dataset. Used for both L1B and L2 products
- constants.py
   - Rename dictionary for clarity
- hit_l2.py
   - Update processing to use a function in hit utils that handles summing particle data and adding it to the dataset
   - Remove duplicate code
- hit_l1b.py
   - Update processing to use functions in hit utils that handles summing particle data and adding it to the dataset
   - Remove duplicate code
   - Add function to calculate rates for L1B products

## Testing
Corresponding test files were updated to reflect above changes.
