### PR TITLE
Ultra l1c pset - add energy interval

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -236,20 +236,6 @@ path_length:
   LABLAXIS: path_length
   UNITS: mm / 100
 
-azimuth:
-  <<: *default_float32
-  CATDESC: Azimuth.
-  FIELDNAM: azimuth
-  LABLAXIS: azimuth
-  UNITS: radians
-
-elevation:
-  <<: *default_float32
-  CATDESC: Elevation.
-  FIELDNAM: elevation
-  LABLAXIS: elevation
-  UNITS: radians
-
 phi:
   <<: *default_float32
   CATDESC: Ultra instrument frame event phi (azimuth with range -90 -> 90).

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -138,6 +138,7 @@ packetdata:
 energy_bin_delta:
   <<: *default_float32
   CATDESC: Difference between the energy bin edges.
+  DEPEND_0: energy_bin_geometric_mean
   FIELDNAM: energy_bin_delta
   LABLAXIS: energy bin delta
   UNITS: keV

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -134,3 +134,10 @@ packetdata:
   LABLAXIS: packet data
   # TODO: come back to format
   UNITS: " "
+
+energy_bin_delta:
+  <<: *default_float32
+  CATDESC: Difference between the energy bin edges.
+  FIELDNAM: energy_bin_delta
+  LABLAXIS: energy bin delta
+  UNITS: keV

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -80,4 +80,4 @@ class UltraConstants:
     CULLING_RPM_MAX = 6.0
 
     # Thresholds for culling based on counts.
-    CULLING_ENERGY_BIN_EDGES: ClassVar[list] = [-1e5, 0, 10, 20, 1e5]
+    CULLING_ENERGY_BIN_EDGES: ClassVar[list] = [0, 10, 20, 1e5]

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -80,6 +80,7 @@ def calculate_spacecraft_pset(
     pset_dict["background_rates"] = background_rates
     pset_dict["exposure_factor"] = exposure_pointing
     pset_dict["healpix"] = healpix
+    pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()
 
     dataset = create_dataset(pset_dict, name, "l1c", data_version)
 

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -96,7 +96,7 @@ def create_dataset(
                 dims=["epoch", "component"],
                 attrs=cdf_manager.get_variable_attributes(key),
             )
-        elif key == "ena_rates_threshold":
+        elif key in ("ena_rates_threshold", "energy_bin_delta"):
             dataset[key] = xr.DataArray(
                 data_dict[key],
                 dims=["energy_bin_geometric_mean"],


### PR DESCRIPTION
# Change Summary

## Overview
Added energy interval for l1c pset and made minor changes based on feedback from the instrument team.

## Updated Files
- imap_ultra_l1b_variable_attrs.yaml
   - Removed unused variable attributes
- imap_ultra_l1c_variable_attrs.yaml
   - Added l1c pset attribute for energy interval
- constants.py
   - Changed range based on Nick Dutton feedback (which made sense)
- spacecraft_pset.py
   - Added energy interval
- ultra_l1_utils.py
   - Modified dataset creation for energy interval

## Testing
- Tests ran as expected
