### PR TITLE
BUG: Update write_cdf to handle parent_files

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -135,8 +135,7 @@ def write_cdf(
     if parent_files:
         # Include the current files if there are any and include just the filename
         # [file1.txt, file2.cdf, ...]
-        dataset.attrs["Parents"] = dataset.attrs.get("Parents", [])
-        dataset.attrs["Parents"].extend(parent_files)
+        dataset.attrs["Parents"] = parent_files
 
     # Convert the xarray object to a CDF
     if "l1" in data_level:

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -103,9 +103,20 @@ def test_parents_injection(test_dataset):
     test_dataset : xarray.Dataset
         An ``xarray`` dataset object to test with
     """
+    # Deep copy the dataset to ensure that the original is not modified
+    test_ds1 = test_dataset.copy(deep=True)
+    test_ds1.attrs["Data_version"] = "v001"
     parent_paths = ["test_parent1.cdf", "test_parent2.cdf"]
-    new_dataset = load_cdf(write_cdf(test_dataset, parent_files=parent_paths))
+    new_dataset = load_cdf(write_cdf(test_ds1, parent_files=parent_paths))
     assert new_dataset.attrs["Parents"] == parent_paths
+
+    # Second write (with different version to force different filename)
+    test_ds2 = test_dataset.copy(deep=True)
+    test_ds2.attrs["Data_version"] = "v002"
+    one_parent_path = ["test_parent1.cdf"]
+    second_ds = load_cdf(write_cdf(test_ds2, parent_files=one_parent_path))
+    # cdflib returns str if one parent file
+    assert second_ds.attrs["Parents"] == "test_parent1.cdf"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Change Summary
closes #1569 

## Overview
This came during testing dependency updates. This issue is changing how we carry files used to produced a data file. Before, we were carry previous file's parent files but now we are only carry immediate files used to a data file.

## Updated Files
- imap_processing/cdf/utils.py
   - update to resolved above


## Testing
- imap_processing/tests/cdf/test_utils.py
