### PR TITLE
MNT: Add network marks to IDEX test files to avoid downloading

### DIFF
--- a/imap_processing/tests/idex/test_idex_l1a.py
+++ b/imap_processing/tests/idex/test_idex_l1a.py
@@ -103,6 +103,7 @@ def test_idex_tof_high_data_from_cdf(decom_test_data: xr.Dataset):
     assert (l1_data["TOF_High"][13].data == data).all()
 
 
+@pytest.mark.external_test_data()
 def test_validate_l1a_idex_data_variables(
     decom_test_data: xr.Dataset, l1a_example_data: xr.Dataset
 ):

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -247,6 +247,7 @@ def test_get_spice_data(
         assert len(spice_data[array]) == len(decom_test_data["epoch"])
 
 
+@pytest.mark.external_test_data()
 def test_validate_l1b_idex_data_variables(
     l1b_dataset: xr.Dataset, l1b_example_data: xr.Dataset
 ):


### PR DESCRIPTION
I noticed that these two tests were failing when the tests should be skipped on the 3.12 runners.
https://github.com/IMAP-Science-Operations-Center/imap_processing/actions/runs/14248070127/job/39933951656#step:6:1463

This adds in a network mark to avoid downloading the data and skip these tests on the other runners.