### PR TITLE
Lo L1B - Fixed CLI dependency loop

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -749,7 +749,7 @@ class Lo(ProcessInstrument):
         elif self.data_level == "l1b":
             data_dict = {}
             # TODO: Check this and update with new features as needed.
-            for input_type in dependencies:
+            for input_type in dependencies.processing_input:
                 science_files = dependencies.get_file_paths(
                     source="lo", descriptor=input_type.descriptor
                 )


### PR DESCRIPTION
# Change Summary

## Overview
Fixed the CLI dependency loop for Lo L1B. Needed to add `.processing_input` to fix this error:

`TypeError: 'ProcessingInputCollection' object is not iterable`

## Testing
Ran CLI and was able to produce an L1B DE CDF
