### PR TITLE
MNT: Bring parent file handling into the post-processing step

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -3,7 +3,6 @@
 import logging
 import re
 from pathlib import Path
-from typing import Optional
 
 import imap_data_access
 import numpy as np
@@ -64,7 +63,6 @@ def load_cdf(
 
 def write_cdf(
     dataset: xr.Dataset,
-    parent_files: Optional[list] = None,
     **extra_cdf_kwargs: dict,
 ) -> Path:
     """
@@ -81,10 +79,6 @@ def write_cdf(
     ----------
     dataset : xarray.Dataset
         The dataset object to convert to a CDF.
-    parent_files : List of filenames, optional
-        List of parent files that were used to make this file. These get added to
-        the ``Parents`` global attribute:
-        https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html.
     **extra_cdf_kwargs : dict
         Additional keyword arguments to pass to the ``xarray_to_cdf`` function.
 
@@ -131,11 +125,6 @@ def write_cdf(
     dataset.attrs["Logical_file_id"] = file_path.stem
     # Add the processing version to the dataset attributes
     dataset.attrs["ground_software_version"] = imap_processing._version.__version__
-    # Add any parent files to the dataset attributes
-    if parent_files:
-        # Include the current files if there are any and include just the filename
-        # [file1.txt, file2.cdf, ...]
-        dataset.attrs["Parents"] = parent_files
 
     # Convert the xarray object to a CDF
     if "l1" in data_level:

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -42,7 +42,7 @@ SPIN_PHASE_BIN_CENTERS = (SPIN_PHASE_BIN_EDGES[:-1] + SPIN_PHASE_BIN_EDGES[1:]) 
 logger = logging.getLogger(__name__)
 
 
-def hi_l1c(dependencies: list, data_version: str) -> xr.Dataset:
+def hi_l1c(dependencies: list, data_version: str) -> list[xr.Dataset]:
     """
     High level IMAP-Hi l1c processing function.
 
@@ -78,7 +78,7 @@ def hi_l1c(dependencies: list, data_version: str) -> xr.Dataset:
 
     # TODO: revisit this
     l1c_dataset.attrs["Data_version"] = data_version
-    return l1c_dataset
+    return [l1c_dataset]
 
 
 def generate_pset_dataset(

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -95,30 +95,6 @@ def test_written_and_loaded_dataset(test_dataset):
     assert str(test_dataset) == str(new_dataset)
 
 
-def test_parents_injection(test_dataset):
-    """Tests the ``write_cdf`` function for Parents attribute injection.
-
-    Parameters
-    ----------
-    test_dataset : xarray.Dataset
-        An ``xarray`` dataset object to test with
-    """
-    # Deep copy the dataset to ensure that the original is not modified
-    test_ds1 = test_dataset.copy(deep=True)
-    test_ds1.attrs["Data_version"] = "v001"
-    parent_paths = ["test_parent1.cdf", "test_parent2.cdf"]
-    new_dataset = load_cdf(write_cdf(test_ds1, parent_files=parent_paths))
-    assert new_dataset.attrs["Parents"] == parent_paths
-
-    # Second write (with different version to force different filename)
-    test_ds2 = test_dataset.copy(deep=True)
-    test_ds2.attrs["Data_version"] = "v002"
-    one_parent_path = ["test_parent1.cdf"]
-    second_ds = load_cdf(write_cdf(test_ds2, parent_files=one_parent_path))
-    # cdflib returns str if one parent file
-    assert second_ds.attrs["Parents"] == "test_parent1.cdf"
-
-
 @pytest.mark.parametrize(
     "test_str, compare_dict",
     [

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -30,7 +30,7 @@ def test_hi_l1c(mock_generate_pset_dataset, hi_test_cal_prod_config_path):
     mock_generate_pset_dataset.return_value = xr.Dataset(attrs={"Data_version": None})
     pset = hi_l1c.hi_l1c(
         [xr.Dataset(), hi_test_cal_prod_config_path], data_version="99"
-    )
+    )[0]
     assert pset.attrs["Data_version"] == "99"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ disable_error_code = ['import-not-found', # Unable to locate module or package s
                 'no-untyped-call', # Function calls are only made to functions that are fully typed
                 'type-arg', # Requires type arguments to be specified in list[] and dict[]
                 'union-attr', # Item "float" of "float | Any" has no attribute "reshape"
+                'no-any-return', # Returning Any from a function
               ]
 strict = true
 explicit_package_bases = true


### PR DESCRIPTION
# Change Summary

## Overview

These variables shouldn't just be injected upon writing the cdf, but rather anytime we create the datasets, so we should put it in post-processing instead. Granted, we do call `write_cdf()` after this, but it seems better to keep things contained within the processing steps rather than pass them through.