### PR TITLE
Version consolidation

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -100,10 +100,10 @@ def write_cdf(
     version = dataset.attrs.get("Data_version", None)
     if version is None:
         warnings.warn(
-            "No Data_version attribute found in dataset. Using default v001.",
+            "No Data_version attribute found in dataset. Using default v999.",
             stacklevel=2,
         )
-        version = "v001"
+        version = "v999"
     elif not re.match(r"v\d{3}", version):
         raise ValueError(
             f"The Data_version attribute {version} does not match expected format vXXX."

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import warnings
 from pathlib import Path
 
 import imap_data_access
@@ -96,15 +97,18 @@ def write_cdf(
     dt64 = TTJ2000_EPOCH + dataset["epoch"].values[0].astype("timedelta64[ns]")
     start_time = np.datetime_as_string(dt64, unit="D").replace("-", "")
 
-    # Will now accept vXXX or XXX formats, as batch starter sends versions as vXXX.
-    r = re.compile(r"v\d{3}")
-    if (
-        not isinstance(dataset.attrs["Data_version"], str)
-        or r.match(dataset.attrs["Data_version"]) is None
-    ):
-        version = f"v{int(dataset.attrs['Data_version']):03d}"  # vXXX
-    else:
-        version = dataset.attrs["Data_version"]
+    version = dataset.attrs.get("Data_version", None)
+    if version is None:
+        warnings.warn(
+            "No Data_version attribute found in dataset. Using default v001.",
+            stacklevel=2,
+        )
+        version = "v001"
+    elif not re.match(r"v\d{3}", version):
+        raise ValueError(
+            f"The Data_version attribute {version} does not match expected format vXXX."
+        )
+
     repointing = dataset.attrs.get("Repointing", None)
     science_file = imap_data_access.ScienceFilePath.generate_from_inputs(
         instrument=instrument,
@@ -174,7 +178,7 @@ def parse_filename_like(filename_like: str) -> re.Match:
         r"(?P<descriptor>[^_]+)"  # Required descriptor
         r"(_(?P<start_date>\d{8}))?"  # Optional start date
         r"(-repoint(?P<repointing>\d{5}))?"  # Optional repointing field
-        r"(?:_v(?P<version>\d{3}))?"  # Optional version
+        r"(?:_(?P<version>v\d{3}))?"  # Optional version
         r"(?:\.(?P<extension>cdf|pkts))?$"  # Optional extension
     )
     match = re.match(regex_str, filename_like)

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -431,6 +431,7 @@ class ProcessInstrument(ABC):
 
         logger.info("Writing products to local storage")
 
+        logger.info("Dataset version: %s", self.version)
         # Parent files used to create these datasets
         # https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html.
         parent_files = [p.name for p in dependencies.get_file_paths()]
@@ -438,6 +439,7 @@ class ProcessInstrument(ABC):
 
         products = []
         for ds in datasets:
+            ds.attrs["Data_version"] = self.version
             ds.attrs["Parents"] = parent_files
             products.append(write_cdf(ds))
 
@@ -475,7 +477,7 @@ class Codice(ProcessInstrument):
                 )
             # process data
             science_files = dependencies.get_file_paths(source="codice")
-            datasets = codice_l1a.process_codice_l1a(science_files[0], self.version)
+            datasets = codice_l1a.process_codice_l1a(science_files[0])
 
         if self.data_level == "l1b":
             if len(dependency_list) > 1:
@@ -486,7 +488,7 @@ class Codice(ProcessInstrument):
             # process data
             science_files = dependencies.get_file_paths(source="codice")
             dependency = load_cdf(science_files[0])
-            datasets = [codice_l1b.process_codice_l1b(dependency, self.version)]
+            datasets = [codice_l1b.process_codice_l1b(dependency)]
 
         return datasets
 
@@ -521,7 +523,7 @@ class Glows(ProcessInstrument):
                     f"{dependency_list}. Expected only one input dependency."
                 )
             science_files = dependencies.get_file_paths(source="glows")
-            datasets = glows_l1a(science_files[0], self.version)
+            datasets = glows_l1a(science_files[0])
 
         if self.data_level == "l1b":
             if len(dependency_list) > 1:
@@ -531,7 +533,7 @@ class Glows(ProcessInstrument):
                 )
             science_files = dependencies.get_file_paths(source="glows")
             input_dataset = load_cdf(science_files[0])
-            datasets = [glows_l1b(input_dataset, self.version)]
+            datasets = [glows_l1b(input_dataset)]
 
         if self.data_level == "l2":
             if len(dependency_list) > 1:
@@ -541,7 +543,7 @@ class Glows(ProcessInstrument):
                 )
             science_files = dependencies.get_file_paths(source="glows")
             input_dataset = load_cdf(science_files[0])
-            datasets = glows_l2(input_dataset, self.version)
+            datasets = glows_l2(input_dataset)
 
         return datasets
 
@@ -577,14 +579,14 @@ class Hi(ProcessInstrument):
                     f"{dependency_list}. Expected only one dependency."
                 )
             science_files = dependencies.get_file_paths(source="hi")
-            datasets = hi_l1a.hi_l1a(science_files[0], self.version)
+            datasets = hi_l1a.hi_l1a(science_files[0])
         elif self.data_level == "l1b":
             l0_files = dependencies.get_file_paths(source="hi", descriptor="raw")
             if l0_files:
-                datasets = hi_l1b.hi_l1b(l0_files[0], self.version)
+                datasets = hi_l1b.hi_l1b(l0_files[0])
             else:
                 l1a_files = dependencies.get_file_paths(source="hi")
-                datasets = hi_l1b.hi_l1b(load_cdf(l1a_files[0]), self.version)
+                datasets = hi_l1b.hi_l1b(load_cdf(l1a_files[0]))
         elif self.data_level == "l1c":
             # TODO: Add PSET calibration product config file dependency and remove
             #    below injected dependency
@@ -595,7 +597,7 @@ class Hi(ProcessInstrument):
                 / "imap_his_pset-calibration-prod-config_20240101_v001.csv"
             )
             hi_dependencies[0] = load_cdf(hi_dependencies[0])
-            datasets = hi_l1c.hi_l1c(hi_dependencies, self.version)
+            datasets = hi_l1c.hi_l1c(hi_dependencies)
         else:
             raise NotImplementedError(
                 f"Hi processing not implemented for level {self.data_level}"
@@ -634,7 +636,7 @@ class Hit(ProcessInstrument):
                 )
             # process data to L1A products
             science_files = dependencies.get_file_paths(source="hit")
-            datasets = hit_l1a(science_files[0], self.version)
+            datasets = hit_l1a(science_files[0])
 
         elif self.data_level == "l1b":
             if len(dependency_list) > 1:
@@ -654,7 +656,7 @@ class Hit(ProcessInstrument):
                 l1a_dataset = load_cdf(l1a_files[0])
                 data_dict[l1a_dataset.attrs["Logical_source"]] = l1a_dataset
             # process data to L1B products
-            datasets = hit_l1b(data_dict, self.version)
+            datasets = hit_l1b(data_dict)
         elif self.data_level == "l2":
             if len(dependency_list) > 1:
                 raise ValueError(
@@ -665,7 +667,7 @@ class Hit(ProcessInstrument):
             science_files = dependencies.get_file_paths(source="hit")
             l1b_dataset = load_cdf(science_files[0])
             # process data to L2 products
-            datasets = hit_l2(l1b_dataset, self.version)
+            datasets = hit_l2(l1b_dataset)
 
         return datasets
 
@@ -701,7 +703,7 @@ class Idex(ProcessInstrument):
                 )
             # get l0 file
             science_files = dependencies.get_file_paths(source="idex")
-            datasets = [PacketParser(science_files[0], self.version).data]
+            datasets = [PacketParser(science_files[0]).data]
         elif self.data_level == "l1b":
             if len(dependency_list) > 1:
                 raise ValueError(
@@ -712,7 +714,7 @@ class Idex(ProcessInstrument):
             science_files = dependencies.get_file_paths(source="idex")
             # process data
             dependency = load_cdf(science_files[0])
-            datasets = [idex_l1b(dependency, self.version)]
+            datasets = [idex_l1b(dependency)]
         return datasets
 
 
@@ -747,7 +749,7 @@ class Lo(ProcessInstrument):
                     f"{dependency_list}. Expected only one dependency."
                 )
             science_files = dependencies.get_file_paths(source="lo")
-            datasets = lo_l1a.lo_l1a(science_files[0], self.version)
+            datasets = lo_l1a.lo_l1a(science_files[0])
 
         elif self.data_level == "l1b":
             data_dict = {}
@@ -758,7 +760,7 @@ class Lo(ProcessInstrument):
                 )
                 dataset = load_cdf(science_files[0])
                 data_dict[dataset.attrs["Logical_source"]] = dataset
-            datasets = lo_l1b.lo_l1b(data_dict, self.version)
+            datasets = lo_l1b.lo_l1b(data_dict)
 
         elif self.data_level == "l1c":
             data_dict = {}
@@ -769,7 +771,7 @@ class Lo(ProcessInstrument):
                 dataset = load_cdf(science_files[0])
                 data_dict[dataset.attrs["Logical_source"]] = dataset
             # TODO: This is returning the wrong type
-            datasets = lo_l1c.lo_l1c(data_dict, self.version)
+            datasets = lo_l1c.lo_l1c(data_dict)
 
         return datasets
 
@@ -807,7 +809,7 @@ class Mag(ProcessInstrument):
                 )
             # TODO: Update this type
 
-            datasets = mag_l1a(science_files[0], self.version)
+            datasets = mag_l1a(science_files[0])
 
         if self.data_level == "l1b":
             if len(dependency_list) > 1:
@@ -816,15 +818,15 @@ class Mag(ProcessInstrument):
                     f"{dependency_list}. Expected only one dependency."
                 )
             input_data = load_cdf(science_files[0])
-            datasets = [mag_l1b(input_data, self.version)]
+            datasets = [mag_l1b(input_data)]
 
         if self.data_level == "l1c":
             input_data = [load_cdf(dep) for dep in science_files]
             # Input datasets can be in any order, and are validated within mag_l1c
             if len(input_data) == 1:
-                datasets = [mag_l1c(input_data[0], self.version)]
+                datasets = [mag_l1c(input_data[0])]
             elif len(input_data) == 2:
-                datasets = [mag_l1c(input_data[0], self.version, input_data[1])]
+                datasets = [mag_l1c(input_data[0], input_data[1])]
             else:
                 raise ValueError(
                     f"Invalid dependencies found for MAG L1C:"
@@ -845,9 +847,7 @@ class Mag(ProcessInstrument):
             )
             # TODO: Test data missing
             offset_dataset = xr.Dataset()
-            datasets = mag_l2(
-                calibration_dataset, offset_dataset, input_data, self.version
-            )
+            datasets = mag_l2(calibration_dataset, offset_dataset, input_data)
 
         return datasets
 
@@ -886,9 +886,6 @@ class Spacecraft(ProcessInstrument):
                 f"{input_files}. Expected only one dependency."
             )
         datasets = list(quaternions.process_quaternions(input_files[0]))
-        for ds in datasets:
-            ds.attrs["Data_version"] = self.version
-
         return datasets
 
 
@@ -940,7 +937,7 @@ class Swapi(ProcessInstrument):
                 dependent_files.append(hk_files[0])
 
             # process science or housekeeping data
-            datasets = swapi_l1(dependent_files, self.version)
+            datasets = swapi_l1(dependent_files)
         elif self.data_level == "l2":
             if len(dependency_list) > 1:
                 raise ValueError(
@@ -950,7 +947,7 @@ class Swapi(ProcessInstrument):
             # process data
             science_files = dependencies.get_file_paths(source="swapi")
             l1_dataset = load_cdf(science_files[0])
-            datasets = [swapi_l2(l1_dataset, self.version)]
+            datasets = [swapi_l2(l1_dataset)]
 
         return datasets
 
@@ -985,7 +982,7 @@ class Swe(ProcessInstrument):
                     f"{dependency_list}. Expected only one dependency."
                 )
             science_files = dependencies.get_file_paths(source="swe")
-            datasets = swe_l1a(str(science_files[0]), data_version=self.version)
+            datasets = swe_l1a(str(science_files[0]))
             # Right now, we only process science data. Therefore,
             # we expect only one dataset to be returned.
 
@@ -1010,7 +1007,7 @@ class Swe(ProcessInstrument):
             #     "swe", "l1b-in-flight-cal"
             # )[0]
             # TODO: read lookup table and in-flight calibration data here.
-            datasets = swe_l1b(l1a_dataset, self.version)
+            datasets = swe_l1b(l1a_dataset)
         else:
             print("Did not recognize data level. No processing done.")
 
@@ -1048,21 +1045,21 @@ class Ultra(ProcessInstrument):
                     f"{dependency_list}. Expected only one dependency."
                 )
             science_files = dependencies.get_file_paths(source="ultra")
-            datasets = ultra_l1a.ultra_l1a(science_files[0], self.version)
+            datasets = ultra_l1a.ultra_l1a(science_files[0])
 
         elif self.data_level == "l1b":
             data_dict = {}
             for dep in dependency_list:
                 dataset = load_cdf(dep.imap_file_paths[0])
                 data_dict[dataset.attrs["Logical_source"]] = dataset
-            datasets = ultra_l1b.ultra_l1b(data_dict, self.version)
+            datasets = ultra_l1b.ultra_l1b(data_dict)
 
         elif self.data_level == "l1c":
             data_dict = {}
             for dep in dependency_list:
                 dataset = load_cdf(dep.imap_file_paths[0])
                 data_dict[dataset.attrs["Logical_source"]] = dataset
-            datasets = ultra_l1c.ultra_l1c(data_dict, self.version)
+            datasets = ultra_l1c.ultra_l1c(data_dict)
 
         return datasets
 

--- a/imap_processing/codice/codice_l1b.py
+++ b/imap_processing/codice/codice_l1b.py
@@ -154,7 +154,7 @@ def create_science_dataset(
     return l1b_dataset
 
 
-def process_codice_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def process_codice_l1b(l1a_dataset: xr.Dataset) -> xr.Dataset:
     """
     Will process CoDICE l1a data to create l1b data products.
 
@@ -162,8 +162,6 @@ def process_codice_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset
     ----------
     l1a_dataset : xarray.Dataset
         CoDICE L1a dataset to process.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -176,7 +174,6 @@ def process_codice_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset
     cdf_attrs = ImapCdfAttributes()
     cdf_attrs.add_instrument_global_attrs("codice")
     cdf_attrs.add_instrument_variable_attrs("codice", "l1b")
-    cdf_attrs.add_global_attribute("Data_version", data_version)
 
     dataset_name = (
         l1a_dataset.attrs["Logical_source"].replace("-", "_").replace("l1a", "l1b")

--- a/imap_processing/glows/l1a/glows_l1a.py
+++ b/imap_processing/glows/l1a/glows_l1a.py
@@ -18,14 +18,9 @@ from imap_processing.spice.time import (
 )
 
 
-def create_glows_attr_obj(data_version: str) -> ImapCdfAttributes:
+def create_glows_attr_obj() -> ImapCdfAttributes:
     """
     Load in 1la CDF attributes for GLOWS instrument.
-
-    Parameters
-    ----------
-    data_version : str
-        Data version for CDF filename, in the format "vXXX".
 
     Returns
     -------
@@ -37,11 +32,10 @@ def create_glows_attr_obj(data_version: str) -> ImapCdfAttributes:
     # Load in files
     glows_attrs.add_instrument_global_attrs("glows")
     glows_attrs.add_instrument_variable_attrs("glows", "l1a")
-    glows_attrs.add_global_attribute("Data_version", data_version)
     return glows_attrs
 
 
-def glows_l1a(packet_filepath: Path, data_version: str) -> list[xr.Dataset]:
+def glows_l1a(packet_filepath: Path) -> list[xr.Dataset]:
     """
     Will process packets into GLOWS L1A CDF files.
 
@@ -52,8 +46,6 @@ def glows_l1a(packet_filepath: Path, data_version: str) -> list[xr.Dataset]:
     ----------
     packet_filepath : pathlib.Path
         Path to packet file for processing.
-    data_version : str
-        Data version for CDF filename, in the format "vXXX".
 
     Returns
     -------
@@ -61,9 +53,7 @@ def glows_l1a(packet_filepath: Path, data_version: str) -> list[xr.Dataset]:
         List of the L1A datasets.
     """
     # Create ImapCdfAttributes object for cdf attributes management
-    glows_attrs = create_glows_attr_obj(data_version)
-
-    # TODO: Data version inside file as well?
+    glows_attrs = create_glows_attr_obj()
 
     # Decompose packet file into histogram, and direct event data.
     hist_l0, de_l0 = decom_packets(packet_filepath)

--- a/imap_processing/glows/l1b/glows_l1b.py
+++ b/imap_processing/glows/l1b/glows_l1b.py
@@ -10,7 +10,7 @@ from imap_processing.glows import FLAG_LENGTH
 from imap_processing.glows.l1b.glows_l1b_data import DirectEventL1B, HistogramL1B
 
 
-def glows_l1b(input_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def glows_l1b(input_dataset: xr.Dataset) -> xr.Dataset:
     """
     Will process the GLOWS L1B data and format the output datasets.
 
@@ -18,8 +18,6 @@ def glows_l1b(input_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     input_dataset : xr.Dataset
         Dataset of input values.
-    data_version : str
-        Data version.
 
     Returns
     -------
@@ -29,7 +27,6 @@ def glows_l1b(input_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     cdf_attrs = ImapCdfAttributes()
     cdf_attrs.add_instrument_global_attrs("glows")
     cdf_attrs.add_instrument_variable_attrs("glows", "l1b")
-    cdf_attrs.add_global_attribute("Data_version", data_version)
 
     data_epoch = xr.DataArray(
         input_dataset["epoch"],

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -12,7 +12,7 @@ from imap_processing.glows.l1b.glows_l1b_data import HistogramL1B
 from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
 
 
-def glows_l2(input_dataset: xr.Dataset, data_version: str) -> list[xr.Dataset]:
+def glows_l2(input_dataset: xr.Dataset) -> list[xr.Dataset]:
     """
     Will process GLoWS L2 data from L1 data.
 
@@ -20,8 +20,6 @@ def glows_l2(input_dataset: xr.Dataset, data_version: str) -> list[xr.Dataset]:
     ----------
     input_dataset : xarray.Dataset
         Input L1B dataset.
-    data_version : str
-        Version for output.
 
     Returns
     -------
@@ -31,7 +29,6 @@ def glows_l2(input_dataset: xr.Dataset, data_version: str) -> list[xr.Dataset]:
     cdf_attrs = ImapCdfAttributes()
     cdf_attrs.add_instrument_global_attrs("glows")
     cdf_attrs.add_instrument_variable_attrs("glows", "l2")
-    cdf_attrs.add_global_attribute("Data_version", data_version)
 
     split_data = split_data_by_observational_day(input_dataset)
     l2_output = []

--- a/imap_processing/hi/l1a/hi_l1a.py
+++ b/imap_processing/hi/l1a/hi_l1a.py
@@ -16,7 +16,7 @@ from imap_processing.utils import packet_file_to_datasets
 logger = logging.getLogger(__name__)
 
 
-def hi_l1a(packet_file_path: Union[str, Path], data_version: str) -> list[xr.Dataset]:
+def hi_l1a(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
     """
     Will process IMAP raw data to l1a.
 
@@ -24,8 +24,6 @@ def hi_l1a(packet_file_path: Union[str, Path], data_version: str) -> list[xr.Dat
     ----------
     packet_file_path : str
         Data packet file path.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -61,9 +59,6 @@ def hi_l1a(packet_file_path: Union[str, Path], data_version: str) -> list[xr.Dat
         attr_mgr = ImapCdfAttributes()
         attr_mgr.add_instrument_global_attrs("hi")
         data.attrs.update(attr_mgr.get_global_attributes(gattr_key))
-
-        # TODO: revisit this
-        data.attrs["Data_version"] = data_version
 
         # set the sensor string in Logical_source
         sensor_str = apid_enum.sensor

--- a/imap_processing/hi/l1b/hi_l1b.py
+++ b/imap_processing/hi/l1b/hi_l1b.py
@@ -45,9 +45,7 @@ ATTR_MGR.add_instrument_global_attrs("hi")
 ATTR_MGR.add_instrument_variable_attrs(instrument="hi", level=None)
 
 
-def hi_l1b(
-    dependency: Union[str, Path, xr.Dataset], data_version: str
-) -> list[xr.Dataset]:
+def hi_l1b(dependency: Union[str, Path, xr.Dataset]) -> list[xr.Dataset]:
     """
     High level IMAP-HI L1B processing function.
 
@@ -55,8 +53,6 @@ def hi_l1b(
     ----------
     dependency : str or xarray.Dataset
         Path to L0 file or L1A dataset to process.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -91,9 +87,6 @@ def hi_l1b(
                 f"{l1a_dataset.attrs['Logical_source']}"
             )
 
-    # Update global attributes
-    for dataset in l1b_datasets:
-        dataset.attrs["Data_version"] = data_version
     return l1b_datasets
 
 

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -42,7 +42,7 @@ SPIN_PHASE_BIN_CENTERS = (SPIN_PHASE_BIN_EDGES[:-1] + SPIN_PHASE_BIN_EDGES[1:]) 
 logger = logging.getLogger(__name__)
 
 
-def hi_l1c(dependencies: list, data_version: str) -> list[xr.Dataset]:
+def hi_l1c(dependencies: list) -> list[xr.Dataset]:
     """
     High level IMAP-Hi l1c processing function.
 
@@ -55,10 +55,6 @@ def hi_l1c(dependencies: list, data_version: str) -> list[xr.Dataset]:
     ----------
     dependencies : list
         Input dependencies needed for l1c processing.
-
-    data_version : str
-        Data version to write to CDF files and the Data_version CDF attribute.
-        Should be in the format Vxxx.
 
     Returns
     -------
@@ -76,8 +72,6 @@ def hi_l1c(dependencies: list, data_version: str) -> list[xr.Dataset]:
             "Input dependencies not recognized for l1c pset processing."
         )
 
-    # TODO: revisit this
-    l1c_dataset.attrs["Data_version"] = data_version
     return [l1c_dataset]
 
 

--- a/imap_processing/hit/hit_utils.py
+++ b/imap_processing/hit/hit_utils.py
@@ -66,14 +66,12 @@ def get_datasets_by_apid(
     return datasets_by_apid
 
 
-def get_attribute_manager(data_version: str, level: str) -> ImapCdfAttributes:
+def get_attribute_manager(level: str) -> ImapCdfAttributes:
     """
     Create an attribute manager for the HIT data products.
 
     Parameters
     ----------
-    data_version : str
-        Version of the data product being created.
     level : str
         Data level of the product being created.
 
@@ -86,7 +84,6 @@ def get_attribute_manager(data_version: str, level: str) -> ImapCdfAttributes:
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="hit")
     attr_mgr.add_instrument_variable_attrs(instrument="hit", level=level)
-    attr_mgr.add_global_attribute("Data_version", data_version)
     return attr_mgr
 
 

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 fillval = -9223372036854775808
 
 
-def hit_l1a(packet_file: str, data_version: str) -> list[xr.Dataset]:
+def hit_l1a(packet_file: str) -> list[xr.Dataset]:
     """
     Will process HIT L0 data into L1A data products.
 
@@ -32,8 +32,6 @@ def hit_l1a(packet_file: str, data_version: str) -> list[xr.Dataset]:
     ----------
     packet_file : str
         Path to the CCSDS data packet file.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -44,7 +42,7 @@ def hit_l1a(packet_file: str, data_version: str) -> list[xr.Dataset]:
     datasets_by_apid = get_datasets_by_apid(packet_file)
 
     # Create the attribute manager for this data level
-    attr_mgr = get_attribute_manager(data_version, "l1a")
+    attr_mgr = get_attribute_manager("l1a")
 
     l1a_datasets = []
 

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 # TODO review logging levels to use (debug vs. info)
 
 
-def hit_l1b(dependencies: dict, data_version: str) -> list[xr.Dataset]:
+def hit_l1b(dependencies: dict) -> list[xr.Dataset]:
     """
     Will process HIT data to L1B.
 
@@ -37,8 +37,6 @@ def hit_l1b(dependencies: dict, data_version: str) -> list[xr.Dataset]:
         Dictionary of dependencies that are L1A xarray datasets
         for science data and a file path string to an L0 file
         for housekeeping data.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -46,7 +44,7 @@ def hit_l1b(dependencies: dict, data_version: str) -> list[xr.Dataset]:
         List of four L1B datasets.
     """
     # Create the attribute manager for this data level
-    attr_mgr = get_attribute_manager(data_version, "l1b")
+    attr_mgr = get_attribute_manager("l1b")
 
     # Create L1B datasets
     l1b_datasets: list = []

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 #  - add function to calculate combined uncertainty and add this to L2 datasets
 
 
-def hit_l2(dependency: xr.Dataset, data_version: str) -> list[xr.Dataset]:
+def hit_l2(dependency: xr.Dataset) -> list[xr.Dataset]:
     """
     Will process HIT data to L2.
 
@@ -37,8 +37,6 @@ def hit_l2(dependency: xr.Dataset, data_version: str) -> list[xr.Dataset]:
     dependency : xr.Dataset
         L1B xarray science dataset that is either summed rates
         standard rates or sector rates.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -47,7 +45,7 @@ def hit_l2(dependency: xr.Dataset, data_version: str) -> list[xr.Dataset]:
     """
     logger.info("Creating HIT L2 science datasets")
     # Create the attribute manager for this data level
-    attr_mgr = get_attribute_manager(data_version, "l2")
+    attr_mgr = get_attribute_manager("l2")
 
     # TODO: Write functions to process sectored rates dataset
     #       with logical source: "imap_hit_l2_macropixel-intensity"

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -9,8 +9,8 @@ Examples
     from imap_processing.idex.idex_l1b import idex_l1b
 
     l0_file = "imap_processing/tests/idex/imap_idex_l0_sci_20231214_v001.pkts"
-    l1a_data = PacketParser(l0_file, data_version)
-    l1b_data = idex_l1b(l1a_data, data_version)
+    l1a_data = PacketParser(l0_file)
+    l1b_data = idex_l1b(l1a_data)
     write_cdf(l1b_data)
 """
 
@@ -77,7 +77,7 @@ class TriggerMode(Enum):
         return f"{channel.upper()}{TriggerMode(mode).name}"
 
 
-def idex_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def idex_l1b(l1a_dataset: xr.Dataset) -> xr.Dataset:
     """
     Will process IDEX l1a data to create l1b data products.
 
@@ -85,8 +85,6 @@ def idex_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     l1a_dataset : xarray.Dataset
         IDEX L1a dataset to process.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -101,7 +99,6 @@ def idex_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     idex_attrs = ImapCdfAttributes()
     idex_attrs.add_instrument_global_attrs(instrument="idex")
     idex_attrs.add_instrument_variable_attrs(instrument="idex", level="l1b")
-    idex_attrs.add_global_attribute("Data_version", data_version)
 
     var_information_path = (
         f"{imap_module_directory}/idex/idex_variable_unpacking_and_eu_conversion.csv"

--- a/imap_processing/idex/idex_l2a.py
+++ b/imap_processing/idex/idex_l2a.py
@@ -10,9 +10,9 @@ Examples
     from imap_processing.idex.idex_l2a import idex_l2a
 
     l0_file = "imap_processing/tests/idex/imap_idex_l0_sci_20231214_v001.pkts"
-    l1a_data = PacketParser(l0_file, data_version)
-    l1b_data = idex_l1b(l1a_data, data_version)
-    l2a_data = idex_l2a(l1b_data, data_version)
+    l1a_data = PacketParser(l0_file)
+    l1b_data = idex_l1b(l1a_data)
+    l2a_data = idex_l2a(l1b_data)
     write_cdf(l2a_data)
 """
 
@@ -54,7 +54,7 @@ class BaselineNoiseTime(IntEnum):
     STOP = -5
 
 
-def idex_l2a(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def idex_l2a(l1b_dataset: xr.Dataset) -> xr.Dataset:
     """
     Will process IDEX l1b data to create l2a data products.
 
@@ -70,8 +70,6 @@ def idex_l2a(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     l1b_dataset : xarray.Dataset
         IDEX L1a dataset to process.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -165,7 +163,7 @@ def idex_l2a(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     l2a_dataset["tof_snr"] = xr.DataArray(snr, dims=["epoch"])
     l2a_dataset["mass"] = mass_scales_da
     # Update global attributes
-    idex_attrs = get_idex_attrs(data_version)
+    idex_attrs = get_idex_attrs()
     l2a_dataset.attrs = idex_attrs.get_global_attributes("imap_idex_l2a_sci")
 
     logger.info("IDEX L2A science data processing completed.")

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -11,10 +11,10 @@ Examples
     from imap_processing.idex.idex_l1b import idex_l2b
 
     l0_file = "imap_processing/tests/idex/imap_idex_l0_sci_20231214_v001.pkts"
-    l1a_data = PacketParser(l0_file, data_version)
-    l1b_data = idex_l1b(l1a_data, data_version)
-    l1a_data = idex_l2a(l1b_data, data_version)
-    l2b_data = idex_l2b(l2a_data, data_version)
+    l1a_data = PacketParser(l0_file)
+    l1b_data = idex_l1b(l1a_data)
+    l1a_data = idex_l2a(l1b_data)
+    l2b_data = idex_l2b(l2a_data)
     write_cdf(l2b_data)
 """
 
@@ -29,7 +29,7 @@ from imap_processing.spice.time import epoch_to_doy
 logger = logging.getLogger(__name__)
 
 
-def idex_l2b(l2a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def idex_l2b(l2a_dataset: xr.Dataset) -> xr.Dataset:
     """
     Will process IDEX l2a data to create l2b data products.
 
@@ -37,8 +37,6 @@ def idex_l2b(l2a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     l2a_dataset : xarray.Dataset
         IDEX L2a dataset to process.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -52,7 +50,6 @@ def idex_l2b(l2a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     # create the attribute manager for this data level
     idex_attrs = ImapCdfAttributes()
     idex_attrs.add_instrument_global_attrs(instrument="idex")
-    idex_attrs.add_global_attribute("Data_version", data_version)
 
     epoch_da = xr.DataArray(
         l2a_dataset["epoch"],

--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def lo_l1a(dependency: Path, data_version: str) -> list[xr.Dataset]:
+def lo_l1a(dependency: Path) -> list[xr.Dataset]:
     """
     Will process IMAP-Lo L0 data into L1A CDF data products.
 
@@ -30,8 +30,6 @@ def lo_l1a(dependency: Path, data_version: str) -> list[xr.Dataset]:
     dependency : Path
         Dependency file needed for data product creation.
         Should always be only one for L1A.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -51,7 +49,6 @@ def lo_l1a(dependency: Path, data_version: str) -> list[xr.Dataset]:
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="lo")
     attr_mgr.add_instrument_variable_attrs(instrument="lo", level="l1a")
-    attr_mgr.add_global_attribute("Data_version", data_version)
 
     if LoAPID.ILO_SPIN in datasets_by_apid:
         logger.info(

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -11,7 +11,7 @@ from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.spice.time import met_to_ttj2000ns
 
 
-def lo_l1b(dependencies: dict, data_version: str) -> list[Path]:
+def lo_l1b(dependencies: dict) -> list[Path]:
     """
     Will process IMAP-Lo L1A data into L1B CDF data products.
 
@@ -19,8 +19,6 @@ def lo_l1b(dependencies: dict, data_version: str) -> list[Path]:
     ----------
     dependencies : dict
         Dictionary of datasets needed for L1B data product creation in xarray Datasets.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -31,7 +29,6 @@ def lo_l1b(dependencies: dict, data_version: str) -> list[Path]:
     attr_mgr_l1b = ImapCdfAttributes()
     attr_mgr_l1b.add_instrument_global_attrs(instrument="lo")
     attr_mgr_l1b.add_instrument_variable_attrs(instrument="lo", level="l1b")
-    attr_mgr_l1b.add_global_attribute("Data_version", data_version)
     # create the attribute manager to access L1A fillval attributes
     attr_mgr_l1a = ImapCdfAttributes()
     attr_mgr_l1a.add_instrument_variable_attrs(instrument="lo", level="l1a")

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -11,7 +11,7 @@ from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.spice.time import met_to_ttj2000ns
 
 
-def lo_l1c(dependencies: dict, data_version: str) -> list[Path]:
+def lo_l1c(dependencies: dict) -> list[Path]:
     """
     Will process IMAP-Lo L1B data into L1C CDF data products.
 
@@ -19,8 +19,6 @@ def lo_l1c(dependencies: dict, data_version: str) -> list[Path]:
     ----------
     dependencies : dict
         Dictionary of datasets needed for L1C data product creation in xarray Datasets.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -31,7 +29,6 @@ def lo_l1c(dependencies: dict, data_version: str) -> list[Path]:
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="lo")
     attr_mgr.add_instrument_variable_attrs(instrument="lo", level="l1c")
-    attr_mgr.add_global_attribute("Data_version", data_version)
 
     # if the dependencies are used to create Annotated Direct Events
     if "imap_lo_l1b_de" in dependencies:

--- a/imap_processing/mag/l1a/mag_l1a.py
+++ b/imap_processing/mag/l1a/mag_l1a.py
@@ -24,7 +24,7 @@ from imap_processing.spice.time import (
 logger = logging.getLogger(__name__)
 
 
-def mag_l1a(packet_filepath: Path, data_version: str) -> list[xr.Dataset]:
+def mag_l1a(packet_filepath: Path) -> list[xr.Dataset]:
     """
     Will process MAG L0 data into L1A CDF files at cdf_filepath.
 
@@ -32,8 +32,6 @@ def mag_l1a(packet_filepath: Path, data_version: str) -> list[xr.Dataset]:
     ----------
     packet_filepath : pathlib.Path
         Packet files for processing.
-    data_version : str
-        Data version to write to CDF files.
 
     Returns
     -------
@@ -51,8 +49,6 @@ def mag_l1a(packet_filepath: Path, data_version: str) -> list[xr.Dataset]:
     attribute_manager = ImapCdfAttributes()
     attribute_manager.add_instrument_global_attrs("mag")
     attribute_manager.add_instrument_variable_attrs("mag", "l1a")
-
-    attribute_manager.add_global_attribute("Data_version", data_version)
     attribute_manager.add_global_attribute("Input_files", str(input_files))
     attribute_manager.add_global_attribute(
         "Generation_date",
@@ -179,7 +175,7 @@ def process_packets(
         # each sensor, we can calculate how much data is in this packet and where the
         # byte boundaries are.
         primary_vectors, secondary_vectors = MagL1a.process_vector_data(
-            mag_l0.VECTORS,  # type: ignore
+            mag_l0.VECTORS,
             primary_packet_properties.total_vectors,
             secondary_packet_data.total_vectors,
             mag_l0.COMPRESSION,

--- a/imap_processing/mag/l1a/mag_l1a_data.py
+++ b/imap_processing/mag/l1a/mag_l1a_data.py
@@ -368,7 +368,7 @@ class MagL1a:
 
     @staticmethod
     def process_vector_data(
-        vector_data: np.ndarray,
+        vector_data: np.ndarray | bytes,
         primary_count: int,
         secondary_count: int,
         compression: int,

--- a/imap_processing/mag/l1b/mag_l1b.py
+++ b/imap_processing/mag/l1b/mag_l1b.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def mag_l1b(
-    input_dataset: xr.Dataset, version: str, calibration_dataset: xr.Dataset = None
+    input_dataset: xr.Dataset, calibration_dataset: xr.Dataset = None
 ) -> Dataset:
     """
     Will process MAG L1B data from L1A data.
@@ -24,8 +24,6 @@ def mag_l1b(
     ----------
     input_dataset : xr.Dataset
         The input dataset to process.
-    version : str
-        The version of the output data.
     calibration_dataset : xr.Dataset
         The calibration dataset containing calibration matrices and timeshift values for
         mago and magi.
@@ -57,7 +55,6 @@ def mag_l1b(
     mag_attributes = ImapCdfAttributes()
     mag_attributes.add_instrument_global_attrs("mag")
     mag_attributes.add_instrument_variable_attrs("mag", "l1b")
-    mag_attributes.add_global_attribute("Data_version", version)
     source = source.replace("l1a", "l1b")
 
     output_dataset = mag_l1b_processing(

--- a/imap_processing/mag/l1c/mag_l1c.py
+++ b/imap_processing/mag/l1c/mag_l1c.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 def mag_l1c(
     first_input_dataset: xr.Dataset,
-    version: str,
     second_input_dataset: xr.Dataset = None,
 ) -> xr.Dataset:
     """
@@ -30,8 +29,6 @@ def mag_l1c(
     first_input_dataset : xr.Dataset
         The first input dataset to process. This can be either burst or norm data, for
         mago or magi.
-    version : str
-        The version of the output data.
     second_input_dataset : xr.Dataset, optional
         The second input dataset to process. This should be burst if first_input_dataset
         was norm, or norm if first_input_dataset was burst. It should match the
@@ -84,7 +81,6 @@ def mag_l1c(
 
     attribute_manager = ImapCdfAttributes()
     attribute_manager.add_instrument_global_attrs("mag")
-    attribute_manager.add_global_attribute("Data_version", version)
     attribute_manager.add_instrument_variable_attrs("mag", "l1c")
     compression = xr.DataArray(
         np.arange(2),

--- a/imap_processing/mag/l2/mag_l2.py
+++ b/imap_processing/mag/l2/mag_l2.py
@@ -12,7 +12,6 @@ def mag_l2(
     calibration_dataset: xr.Dataset,
     offset_dataset: xr.Dataset,
     input_data: xr.Dataset,
-    data_version: str,
 ) -> list[xr.Dataset]:
     """
     Complete MAG L2 processing.
@@ -28,8 +27,6 @@ def mag_l2(
         Offset ancillary file input.
     input_data : xr.Dataset
         Input data from MAG L1C or L1B.
-    data_version : str
-        Version of output file.
 
     Returns
     -------
@@ -43,7 +40,6 @@ def mag_l2(
         input_data["vectors"].data[:, :3],  # level 2 vectors don't include range
         input_data["epoch"].data,
         input_data["vectors"].data[:, 3],
-        {"Data_version": data_version},
         np.zeros(len(input_data["epoch"].data)),
         np.zeros(len(input_data["epoch"].data)),
         DataMode.NORM,

--- a/imap_processing/mag/l2/mag_l2.py
+++ b/imap_processing/mag/l2/mag_l2.py
@@ -40,6 +40,7 @@ def mag_l2(
         input_data["vectors"].data[:, :3],  # level 2 vectors don't include range
         input_data["epoch"].data,
         input_data["vectors"].data[:, 3],
+        {},
         np.zeros(len(input_data["epoch"].data)),
         np.zeros(len(input_data["epoch"].data)),
         DataMode.NORM,

--- a/imap_processing/spacecraft/quaternions.py
+++ b/imap_processing/spacecraft/quaternions.py
@@ -100,8 +100,6 @@ def process_quaternions(packet_file: Path | str) -> tuple[xr.Dataset, xr.Dataset
     # Update dataset global attributes
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs("spacecraft")
-    # TODO: Allow version to be passed in
-    attr_mgr.add_global_attribute("Data_version", 1)
     attr_mgr.add_instrument_variable_attrs(instrument="spacecraft", level=None)
 
     l1a_ds.attrs.update(

--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -425,7 +425,7 @@ def process_sweep_data(full_sweep_sci: xr.Dataset, cem_prefix: str) -> xr.Datase
 
 
 def process_swapi_science(
-    sci_dataset: xr.Dataset, hk_dataset: xr.Dataset, data_version: str
+    sci_dataset: xr.Dataset, hk_dataset: xr.Dataset
 ) -> xr.Dataset:
     """
     Will process SWAPI science data and create CDF file.
@@ -436,8 +436,6 @@ def process_swapi_science(
         L0 data.
     hk_dataset : xarray.Dataset
         Housekeeping data.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -585,8 +583,6 @@ def process_swapi_science(
     )
 
     # Add other global attributes
-    # TODO: add others like below once add_global_attribute is fixed
-    cdf_manager.add_global_attribute("Data_version", data_version)
     l1_global_attrs = cdf_manager.get_global_attributes("imap_swapi_l1_sci")
     l1_global_attrs["Apid"] = f"{sci_dataset['pkt_apid'].data[0]}"
 
@@ -702,7 +698,7 @@ def process_swapi_science(
     return dataset
 
 
-def swapi_l1(dependencies: list, data_version: str) -> xr.Dataset:
+def swapi_l1(dependencies: list) -> xr.Dataset:
     """
     Will process SWAPI level 0 data to level 1.
 
@@ -710,8 +706,6 @@ def swapi_l1(dependencies: list, data_version: str) -> xr.Dataset:
     ----------
     dependencies : list
         Input dependencies needed for L1 processing.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -743,7 +737,7 @@ def swapi_l1(dependencies: list, data_version: str) -> xr.Dataset:
     ):
         # process science data
         sci_dataset = process_swapi_science(
-            l0_unpacked_dict[SWAPIAPID.SWP_SCI], l1_hk_ds, data_version
+            l0_unpacked_dict[SWAPIAPID.SWP_SCI], l1_hk_ds
         )
         processed_data.append(sci_dataset)
 
@@ -752,7 +746,6 @@ def swapi_l1(dependencies: list, data_version: str) -> xr.Dataset:
         # Add HK datalevel attrs
         imap_attrs = ImapCdfAttributes()
         imap_attrs.add_instrument_global_attrs("swapi")
-        imap_attrs.add_global_attribute("Data_version", data_version)
         imap_attrs.add_instrument_variable_attrs(instrument="swapi", level=None)
         hk_ds.attrs.update(imap_attrs.get_global_attributes("imap_swapi_l1_hk"))
         hk_common_attrs = imap_attrs.get_variable_attributes("hk_attrs")

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 TIME_PER_BIN = 0.167  # seconds
 
 
-def swapi_l2(l1_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def swapi_l2(l1_dataset: xr.Dataset) -> xr.Dataset:
     """
     Produce science data to L2.
 
@@ -32,8 +32,6 @@ def swapi_l2(l1_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     l1_dataset : xarray.Dataset
         The L1 data input.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -60,7 +58,6 @@ def swapi_l2(l1_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     l2_dataset = l1_dataset[l1_data_keys]
 
     # Update L2 specific attributes
-    l2_dataset.attrs["Data_version"] = data_version
     l2_global_attrs = cdf_manager.get_global_attributes("imap_swapi_l2_sci")
     l2_dataset.attrs["Data_type"] = l2_global_attrs["Data_type"]
     l2_dataset.attrs["Logical_source"] = l2_global_attrs["Logical_source"]

--- a/imap_processing/swe/l1a/swe_l1a.py
+++ b/imap_processing/swe/l1a/swe_l1a.py
@@ -15,7 +15,7 @@ from imap_processing.utils import packet_file_to_datasets
 logger = logging.getLogger(__name__)
 
 
-def swe_l1a(packet_file: str, data_version: str) -> xr.Dataset:
+def swe_l1a(packet_file: str) -> xr.Dataset:
     """
     Will process SWE l0 data into l1a data.
 
@@ -27,9 +27,6 @@ def swe_l1a(packet_file: str, data_version: str) -> xr.Dataset:
     ----------
     packet_file : str
         Path where the raw packet file is stored.
-    data_version : str
-        Data version to write to CDF files and the Data_version CDF attribute.
-        Should be in the format Vxxx.
 
     Returns
     -------
@@ -48,17 +45,13 @@ def swe_l1a(packet_file: str, data_version: str) -> xr.Dataset:
     if SWEAPID.SWE_SCIENCE in datasets_by_apid:
         logger.info("Processing SWE science data.")
         processed_data.append(
-            swe_science(
-                l0_dataset=datasets_by_apid[SWEAPID.SWE_SCIENCE],
-                data_version=data_version,
-            )
+            swe_science(l0_dataset=datasets_by_apid[SWEAPID.SWE_SCIENCE])
         )
 
     # Process non-science data
     # Define minimal CDF attrs for the non science dataset
     imap_attrs = ImapCdfAttributes()
     imap_attrs.add_instrument_global_attrs("swe")
-    imap_attrs.add_global_attribute("Data_version", data_version)
     imap_attrs.add_instrument_variable_attrs("swe", "l1a")
     non_science_attrs = imap_attrs.get_variable_attributes("non_science_attrs")
     epoch_attrs = imap_attrs.get_variable_attributes("epoch", check_schema=False)

--- a/imap_processing/swe/l1a/swe_science.py
+++ b/imap_processing/swe/l1a/swe_science.py
@@ -64,7 +64,7 @@ def decompressed_counts(cem_count: int) -> int:
     )
 
 
-def swe_science(l0_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def swe_science(l0_dataset: xr.Dataset) -> xr.Dataset:
     """
     SWE L1a science processing.
 
@@ -96,10 +96,6 @@ def swe_science(l0_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     l0_dataset : xarray.Dataset
         Raw packet data from SWE stored as an xarray dataset.
-
-    data_version : str
-        Data version for the 'Data_version' CDF attribute. This is the version of the
-        output file.
 
     Returns
     -------
@@ -135,7 +131,6 @@ def swe_science(l0_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     cdf_attrs = ImapCdfAttributes()
     cdf_attrs.add_instrument_global_attrs("swe")
     cdf_attrs.add_instrument_variable_attrs("swe", "l1a")
-    cdf_attrs.add_global_attribute("Data_version", data_version)
 
     epoch_time = xr.DataArray(
         l0_dataset["epoch"],

--- a/imap_processing/swe/l1b/swe_l1b.py
+++ b/imap_processing/swe/l1b/swe_l1b.py
@@ -12,7 +12,7 @@ from imap_processing.utils import convert_raw_to_eu
 logger = logging.getLogger(__name__)
 
 
-def swe_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def swe_l1b(l1a_dataset: xr.Dataset) -> xr.Dataset:
     """
     Will process data to L1B.
 
@@ -20,8 +20,6 @@ def swe_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     l1a_dataset : xarray.Dataset
         The l1a data input.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -43,7 +41,7 @@ def swe_l1b(l1a_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
         conversion_table_path=conversion_table_path,
         packet_name=packet_name.name,
     )
-    data = swe_l1b_science(eu_data, data_version)
+    data = swe_l1b_science(eu_data)
     if data is None:
         logger.info("No data to write to CDF")
         return []

--- a/imap_processing/swe/l1b/swe_l1b_science.py
+++ b/imap_processing/swe/l1b/swe_l1b_science.py
@@ -466,7 +466,7 @@ def filter_full_cycle_data(
     return l1a_data
 
 
-def swe_l1b_science(l1a_data: xr.Dataset, data_version: str) -> xr.Dataset:
+def swe_l1b_science(l1a_data: xr.Dataset) -> xr.Dataset:
     """
     SWE l1b science processing.
 
@@ -474,8 +474,6 @@ def swe_l1b_science(l1a_data: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     l1a_data : xarray.Dataset
         Input data.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -552,7 +550,6 @@ def swe_l1b_science(l1a_data: xr.Dataset, data_version: str) -> xr.Dataset:
     cdf_attrs = ImapCdfAttributes()
     cdf_attrs.add_instrument_global_attrs("swe")
     cdf_attrs.add_instrument_variable_attrs("swe", "l1b")
-    cdf_attrs.add_global_attribute("Data_version", data_version)
 
     # One full cycle data combines four quarter cycles data.
     # Epoch will store center of each science meansurement using

--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -303,7 +303,7 @@ def find_angle_bin_indices(
     return spin_angle_bins_indices
 
 
-def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
+def swe_l2(l1b_dataset: xr.Dataset) -> xr.Dataset:
     """
     Will process data to L2.
 
@@ -311,8 +311,6 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     ----------
     l1b_dataset : xarray.Dataset
         The L1B dataset to process.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -322,7 +320,6 @@ def swe_l2(l1b_dataset: xr.Dataset, data_version: str) -> xr.Dataset:
     cdf_attributes = ImapCdfAttributes()
     cdf_attributes.add_instrument_global_attrs("swe")
     cdf_attributes.add_instrument_variable_attrs("swe", "l2")
-    cdf_attributes.add_global_attribute("Data_version", data_version)
 
     # Energy values in eV.
     energy_xr = xr.DataArray(

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -26,7 +26,7 @@ def test_dataset():
     # Load the CDF attrs
     swe_attrs = ImapCdfAttributes()
     swe_attrs.add_instrument_global_attrs("swe")
-    swe_attrs.add_global_attribute("Data_version", "001")
+    swe_attrs.add_global_attribute("Data_version", "v001")
 
     dataset = xr.Dataset(
         {
@@ -116,7 +116,7 @@ def test_written_and_loaded_dataset(test_dataset):
                 "data_level": "l1a",
                 "descriptor": "hist",
                 "start_date": "20250415",
-                "version": "001",
+                "version": "v001",
             },
         ),
         (
@@ -129,7 +129,7 @@ def test_written_and_loaded_dataset(test_dataset):
                 "descriptor": "pset",
                 "start_date": "20250415",
                 "repointing": "12345",
-                "version": "001",
+                "version": "v001",
                 "extension": "cdf",
             },
         ),

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -113,7 +113,7 @@ def test_l1a_data() -> xr.Dataset:
         A list of ``xarray`` datasets containing the test data
     """
 
-    processed_datasets = process_codice_l1a(file_path=TEST_L0_FILE, data_version="001")
+    processed_datasets = process_codice_l1a(file_path=TEST_L0_FILE)
 
     return processed_datasets
 
@@ -356,7 +356,7 @@ def test_l1a_validate_support_variables(test_l1a_data, index):
 def test_l1a_multiple_packets():
     """Tests that an input L0 file containing multiple APIDs can be processed."""
 
-    processed_datasets = process_codice_l1a(file_path=TEST_L0_FILE, data_version="001")
+    processed_datasets = process_codice_l1a(file_path=TEST_L0_FILE)
 
     # TODO: Could add some more checks here?
     assert len(processed_datasets) == 18

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -35,7 +35,7 @@ def test_l1b_data(request) -> xr.Dataset:
         A ``xarray`` dataset containing the test data
     """
     input_dataset = load_cdf(request.param)
-    dataset = process_codice_l1b(input_dataset, data_version="001")
+    dataset = process_codice_l1b(input_dataset)
     return dataset
 
 

--- a/imap_processing/tests/glows/conftest.py
+++ b/imap_processing/tests/glows/conftest.py
@@ -41,14 +41,14 @@ def l1a_test_data(decom_test_data):
 
 @pytest.fixture
 def l1a_dataset(packet_path):
-    return glows_l1a(packet_path, "v001")
+    return glows_l1a(packet_path)
 
 
 @pytest.fixture
 def l1b_hist_dataset(l1a_dataset):
-    return glows_l1b(l1a_dataset[1], "v001")
+    return glows_l1b(l1a_dataset[1])
 
 
 @pytest.fixture
 def l2_hist_dataset(l1b_datasets):
-    return glows_l2(l1b_datasets, "v001")
+    return glows_l2(l1b_datasets)

--- a/imap_processing/tests/glows/test_glows_l1a_cdf.py
+++ b/imap_processing/tests/glows/test_glows_l1a_cdf.py
@@ -33,7 +33,7 @@ def l1a_data(packet_path):
 
 def test_generate_histogram_dataset(l1a_data):
     histogram_l1a, _ = l1a_data
-    glows_attrs = create_glows_attr_obj("v001")
+    glows_attrs = create_glows_attr_obj()
     dataset = generate_histogram_dataset(histogram_l1a, glows_attrs)
 
     assert (dataset["histogram"].data[0] == histogram_l1a[0].histogram).all()
@@ -64,7 +64,7 @@ def test_generate_histogram_dataset(l1a_data):
 
 def test_generate_de_dataset(l1a_data):
     _, de_l1a = l1a_data
-    glows_attrs = create_glows_attr_obj("v001")
+    glows_attrs = create_glows_attr_obj()
     dataset = generate_de_dataset(de_l1a, glows_attrs)
     assert len(dataset["epoch"].values) == len(de_l1a)
 

--- a/imap_processing/tests/glows/test_glows_l1a_data.py
+++ b/imap_processing/tests/glows/test_glows_l1a_data.py
@@ -41,7 +41,7 @@ def test_histogram_list(histogram_test_data, decom_test_data):
 
 
 def test_histogram_obs_day(packet_path):
-    l1a = glows_l1a(packet_path, "v001")
+    l1a = glows_l1a(packet_path)
 
     assert len(l1a) == 3
 

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -289,7 +289,7 @@ def test_process_de(de_dataset, ancillary_dict):
 
 
 def test_glows_l1b(de_dataset, hist_dataset):
-    hist_output = glows_l1b(hist_dataset, "V001")
+    hist_output = glows_l1b(hist_dataset)
 
     assert hist_output["histogram"].dims == ("epoch", "bins")
     assert hist_output["histogram"].shape == (20, 3600)
@@ -341,7 +341,7 @@ def test_glows_l1b(de_dataset, hist_dataset):
     for key in expected_hist_data:
         assert key in hist_output
 
-    de_output = glows_l1b(de_dataset, "V001")
+    de_output = glows_l1b(de_dataset)
 
     # From table 15 in the algorithm document
     expected_de_data = [
@@ -364,14 +364,14 @@ def test_glows_l1b(de_dataset, hist_dataset):
 
 
 def test_generate_histogram_dataset(hist_dataset):
-    l1b_data = glows_l1b(hist_dataset, "v001")
+    l1b_data = glows_l1b(hist_dataset)
     output_path = write_cdf(l1b_data)
 
     assert Path.exists(output_path)
 
 
 def test_generate_de_dataset(de_dataset):
-    l1b_data = glows_l1b(de_dataset, "v001")
+    l1b_data = glows_l1b(de_dataset)
 
     output_path = write_cdf(l1b_data)
 

--- a/imap_processing/tests/glows/test_glows_l1b_data.py
+++ b/imap_processing/tests/glows/test_glows_l1b_data.py
@@ -80,7 +80,7 @@ def test_glows_l1b_de():
 
 
 def test_validation_data_histogram(l1a_dataset):
-    l1b = [glows_l1b(l1a_dataset[0], "v001"), glows_l1b(l1a_dataset[1], "v001")]
+    l1b = [glows_l1b(l1a_dataset[0]), glows_l1b(l1a_dataset[1])]
     end_time = l1b[0]["epoch"].data[-1]
 
     validation_data = (
@@ -149,7 +149,7 @@ def test_validation_data_histogram(l1a_dataset):
 def test_validation_data_de(l1a_dataset):
     de_data = l1a_dataset[2]
 
-    l1b = glows_l1b(de_data, "v001")
+    l1b = glows_l1b(de_data)
     validation_data = (
         Path(__file__).parent / "validation_data" / "imap_glows_l1b_de_output.json"
     )

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -29,7 +29,7 @@ def l1b_hists():
 
 
 def test_glows_l2(l1b_hist_dataset):
-    l2 = glows_l2(l1b_hist_dataset, "v001")[0]
+    l2 = glows_l2(l1b_hist_dataset)[0]
     assert l2.attrs["Logical_source"] == "imap_glows_l2_hist"
 
     assert np.allclose(l2["filter_temperature_average"].values, [57.6], rtol=0.1)

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -23,9 +23,8 @@ def test_hi_l1b_hk(hi_l0_test_data_path):
     housekeeping L1A as input"""
     # TODO: once things are more stable, check in an L1A HK file as test data
     bin_data_path = hi_l0_test_data_path / "H90_NHK_20241104.bin"
-    data_version = "001"
 
-    l1b_datasets = hi_l1b(bin_data_path, data_version=data_version)
+    l1b_datasets = hi_l1b(bin_data_path)
     assert len(l1b_datasets) == 1
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_90sensor-hk"
 
@@ -44,10 +43,9 @@ def test_hi_l1b_de(
         hi_l1_test_data_path / "imap_hi_l1a_45sensor-de_20250415_v999.cdf"
     )
     # Process using test data
-    data_version = "001"
     l1a_dataset = load_cdf(l1a_test_file_path)
 
-    l1b_datasets = hi_l1b(l1a_dataset, data_version=data_version)
+    l1b_datasets = hi_l1b(l1a_dataset)
     assert len(l1b_datasets) == 1
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_45sensor-de"
     assert len(l1b_datasets[0].data_vars) == 15

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -27,17 +27,16 @@ def hi_test_cal_prod_config_path(hi_l1_test_data_path):
 @mock.patch("imap_processing.hi.l1c.hi_l1c.generate_pset_dataset")
 def test_hi_l1c(mock_generate_pset_dataset, hi_test_cal_prod_config_path):
     """Test coverage for hi_l1c function"""
-    mock_generate_pset_dataset.return_value = xr.Dataset(attrs={"Data_version": None})
-    pset = hi_l1c.hi_l1c(
-        [xr.Dataset(), hi_test_cal_prod_config_path], data_version="99"
-    )[0]
-    assert pset.attrs["Data_version"] == "99"
+    mock_generate_pset_dataset.return_value = xr.Dataset()
+    pset = hi_l1c.hi_l1c([xr.Dataset(), hi_test_cal_prod_config_path])[0]
+    # Empty attributes, global values get added in post-processing
+    assert pset.attrs == {}
 
 
 def test_hi_l1c_not_implemented():
     """Test coverage for hi_l1c function with unrecognized dependencies"""
     with pytest.raises(NotImplementedError):
-        hi_l1c.hi_l1c([None, None], "0")
+        hi_l1c.hi_l1c([None, None])
 
 
 @pytest.mark.external_test_data
@@ -70,7 +69,6 @@ def test_generate_pset_dataset(
         np.testing.assert_array_equal(l1c_dataset[var].data.shape, (1, 9, 2, 3600))
 
     # Test ISTP compliance by writing CDF
-    l1c_dataset.attrs["Data_version"] = 1
     write_cdf(l1c_dataset)
 
 

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -11,10 +11,9 @@ def test_sci_de_decom(hi_l0_test_data_path):
     """Test science direct event data"""
 
     bin_data_path = hi_l0_test_data_path / "H90_sci_de_20241104.bin"
-    processed_data = hi_l1a(bin_data_path, data_version="001")
+    processed_data = hi_l1a(bin_data_path)
 
     assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_90sensor-de"
-    assert processed_data[0].attrs["Data_version"] == "001"
 
     # TODO: Verify correct unpacking of sample data. Issue: #1186
 
@@ -27,7 +26,7 @@ def test_sci_de_decom(hi_l0_test_data_path):
 def test_diag_fee_decom(hi_l0_test_data_path):
     """Test diag_fee data"""
     bin_data_path = hi_l0_test_data_path / "H45_diag_fee_20250208.bin"
-    processed_data = hi_l1a(packet_file_path=bin_data_path, data_version="001")
+    processed_data = hi_l1a(packet_file_path=bin_data_path)
     dataset = processed_data[0]
     cdf_filepath = write_cdf(processed_data[0], istp=False)
     assert cdf_filepath.name == "imap_hi_l1a_45sensor-diagfee_20250208_v001.cdf"
@@ -58,11 +57,10 @@ def test_app_nhk_decom(hi_l0_test_data_path):
 
     # Unpack housekeeping data
     bin_data_path = hi_l0_test_data_path / "H90_NHK_20241104.bin"
-    processed_data = hi_l1a(packet_file_path=bin_data_path, data_version="001")
+    processed_data = hi_l1a(packet_file_path=bin_data_path)
 
     assert np.unique(processed_data[0]["pkt_apid"].values) == HIAPID.H90_APP_NHK.value
     assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_90sensor-hk"
-    assert processed_data[0].attrs["Data_version"] == "001"
     # TODO: compare with validation data once we have it. Issue: #1184
 
     # Write CDF
@@ -76,7 +74,7 @@ def test_app_nhk_decom(hi_l0_test_data_path):
 def test_app_hist_decom(hi_l0_test_data_path):
     """Test histogram (SCI_CNT) data"""
     bin_data_path = hi_l0_test_data_path / "H90_sci_cnt_20241104.bin"
-    processed_data = hi_l1a(packet_file_path=bin_data_path, data_version="001")
+    processed_data = hi_l1a(packet_file_path=bin_data_path)
 
     assert processed_data[0].attrs["Logical_source"] == "imap_hi_l1a_90sensor-hist"
     # TODO: compare with validation data once we have it. Issue: #1185

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -18,7 +18,7 @@ def test_sci_de_decom(hi_l0_test_data_path):
     # TODO: Verify correct unpacking of sample data. Issue: #1186
 
     # Write to CDF
-    cdf_filename = "imap_hi_l1a_90sensor-de_20241105_v001.cdf"
+    cdf_filename = "imap_hi_l1a_90sensor-de_20241105_v999.cdf"
     cdf_filepath = write_cdf(processed_data[0])
     assert cdf_filepath.name == cdf_filename
 
@@ -29,7 +29,7 @@ def test_diag_fee_decom(hi_l0_test_data_path):
     processed_data = hi_l1a(packet_file_path=bin_data_path)
     dataset = processed_data[0]
     cdf_filepath = write_cdf(processed_data[0], istp=False)
-    assert cdf_filepath.name == "imap_hi_l1a_45sensor-diagfee_20250208_v001.cdf"
+    assert cdf_filepath.name == "imap_hi_l1a_45sensor-diagfee_20250208_v999.cdf"
 
     assert np.unique(processed_data[0]["pkt_apid"].values) == HIAPID.H45_DIAG_FEE.value
 
@@ -68,7 +68,7 @@ def test_app_nhk_decom(hi_l0_test_data_path):
 
     # TODO: ask Vivek about this date mismatch between the file name
     # and the data. May get resolved when we have good sample data.
-    assert cem_raw_cdf_filepath.name == "imap_hi_l1a_90sensor-hk_20241105_v001.cdf"
+    assert cem_raw_cdf_filepath.name == "imap_hi_l1a_90sensor-hk_20241105_v999.cdf"
 
 
 def test_app_hist_decom(hi_l0_test_data_path):

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -137,7 +137,7 @@ def test_validate_l1a_housekeeping_data(hk_packet_filepath):
     hk_packet_filepath : str
         File path to housekeeping ccsds file
     """
-    datasets = hit_l1a(hk_packet_filepath, "001")
+    datasets = hit_l1a(hk_packet_filepath)
     hk_dataset = None
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1a_hk":
@@ -223,7 +223,7 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
     """
 
     # Process the sample data
-    processed_datasets = hit_l1a(sci_packet_filepath, "001")
+    processed_datasets = hit_l1a(sci_packet_filepath)
     l1a_counts_data = processed_datasets[0]
 
     # Prepare validation data for comparison with processed data
@@ -260,7 +260,7 @@ def test_hit_l1a(hk_packet_filepath, sci_packet_filepath):
         Path to ccsds file for science data
     """
     for packet_filepath in [hk_packet_filepath, sci_packet_filepath]:
-        processed_datasets = hit_l1a(packet_filepath, "001")
+        processed_datasets = hit_l1a(packet_filepath)
         assert isinstance(processed_datasets, list)
         assert all(isinstance(ds, xr.Dataset) for ds in processed_datasets)
         if packet_filepath == hk_packet_filepath:

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -46,9 +46,9 @@ def dependencies(packet_filepath, sci_packet_filepath):
     # Create dictionary of dependencies and add CCSDS packet file
     data_dict = {"imap_hit_l0_raw": packet_filepath}
     # Add L1A datasets
-    l1a_datasets = hit_l1a.hit_l1a(packet_filepath, "001")
+    l1a_datasets = hit_l1a.hit_l1a(packet_filepath)
     # TODO: Remove this when HIT provides a packet file with all apids.
-    l1a_datasets.extend(hit_l1a.hit_l1a(sci_packet_filepath, "001"))
+    l1a_datasets.extend(hit_l1a.hit_l1a(sci_packet_filepath))
     for dataset in l1a_datasets:
         data_dict[dataset.attrs["Logical_source"]] = dataset
     return data_dict
@@ -57,7 +57,7 @@ def dependencies(packet_filepath, sci_packet_filepath):
 @pytest.fixture
 def l1b_hk_dataset(dependencies):
     """Get the housekeeping dataset"""
-    datasets = hit_l1b(dependencies, "001")
+    datasets = hit_l1b(dependencies)
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_hk":
             return dataset
@@ -66,7 +66,7 @@ def l1b_hk_dataset(dependencies):
 @pytest.fixture
 def l1b_standard_rates_dataset(dependencies):
     """Get the standard rates dataset"""
-    datasets = hit_l1b(dependencies, "001")
+    datasets = hit_l1b(dependencies)
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_standard-rates":
             return dataset
@@ -75,7 +75,7 @@ def l1b_standard_rates_dataset(dependencies):
 @pytest.fixture
 def l1a_counts_dataset(sci_packet_filepath):
     """Get L1A counts dataset to test l1b processing functions"""
-    l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath, "001")
+    l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath)
     for dataset in l1a_datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1a_counts":
             return dataset
@@ -545,7 +545,7 @@ def test_hit_l1b_missing_apid(sci_packet_filepath):
     # Create a dependency dictionary with a science CCSDS packet file
     # excluding the housekeeping apid
     dependency = {"imap_hit_l0_raw": sci_packet_filepath}
-    datasets = hit_l1b(dependency, "001")
+    datasets = hit_l1b(dependency)
     assert len(datasets) == 0
 
 
@@ -559,7 +559,8 @@ def test_hit_l1b(dependencies):
     dependencies : dict
         Dictionary of L1A datasets and CCSDS packet file path
     """
-    datasets = hit_l1b(dependencies, "001")
+    # TODO: update assertions after science data processing is completed
+    datasets = hit_l1b(dependencies)
 
     assert len(datasets) == 4
     for dataset in datasets:

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -35,12 +35,12 @@ def dependencies(sci_packet_filepath):
     """Get dependencies for L2 processing"""
     # Create dictionary of dependencies
     data_dict = {}
-    l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath, "001")
+    l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath)
     for l1a_dataset in l1a_datasets:
         l1a_data_dict = {}
         if l1a_dataset.attrs["Logical_source"] == "imap_hit_l1a_counts":
             l1a_data_dict["imap_hit_l1a_counts"] = l1a_dataset
-            l1b_datasets = hit_l1b(l1a_data_dict, "001")
+            l1b_datasets = hit_l1b(l1a_data_dict)
             for l1b_dataset in l1b_datasets:
                 data_dict[l1b_dataset.attrs["Logical_source"]] = l1b_dataset
     return data_dict
@@ -447,10 +447,10 @@ def test_hit_l2(dependencies):
         Dictionary of L1B datasets
     """
     # TODO: update assertions after science data processing is completed
-    l2_datasets = hit_l2(dependencies["imap_hit_l1b_summed-rates"], "001")
+    l2_datasets = hit_l2(dependencies["imap_hit_l1b_summed-rates"])
     assert len(l2_datasets) == 1
     assert l2_datasets[0].attrs["Logical_source"] == "imap_hit_l2_summed-intensity"
 
-    l2_datasets = hit_l2(dependencies["imap_hit_l1b_standard-rates"], "001")
+    l2_datasets = hit_l2(dependencies["imap_hit_l1b_standard-rates"])
     assert len(l2_datasets) == 1
     assert l2_datasets[0].attrs["Logical_source"] == "imap_hit_l2_standard-intensity"

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -30,9 +30,8 @@ def packet_filepath():
 @pytest.fixture(scope="module")
 def attribute_manager():
     """Create the attribute manager"""
-    data_version = "001"
     level = "l1a"
-    attr_mgr = get_attribute_manager(data_version, level)
+    attr_mgr = get_attribute_manager(level)
     return attr_mgr
 
 
@@ -70,9 +69,8 @@ def test_get_datasets_by_apid(packet_filepath):
 
 
 def test_get_attribute_manager():
-    data_version = "001"
     level = "l1a"
-    attr_mgr = get_attribute_manager(data_version, level)
+    attr_mgr = get_attribute_manager(level)
 
     assert isinstance(attr_mgr, ImapCdfAttributes)
 
@@ -197,7 +195,7 @@ def test_process_housekeeping(housekeeping_dataset, attribute_manager):
         "Investigator, Prof. David J. McComas of Princeton "
         "University.\n",
         "Data_type": "L1A_HK>Level-1A Housekeeping",
-        "Data_version": "001",
+        "Data_version": None,
         "Descriptor": "HIT>IMAP High-energy Ion Telescope",
         "Discipline": "Solar Physics>Heliospheric Physics",
         "File_naming_convention": "source_descriptor_datatype_yyyyMMdd_vNNN",

--- a/imap_processing/tests/idex/conftest.py
+++ b/imap_processing/tests/idex/conftest.py
@@ -40,7 +40,7 @@ def decom_test_data() -> xr.Dataset:
     dataset : xarray.Dataset
         A ``xarray`` dataset containing the test data
     """
-    return PacketParser(TEST_L0_FILE, "001").data
+    return PacketParser(TEST_L0_FILE).data
 
 
 @pytest.fixture(scope="session")
@@ -72,9 +72,7 @@ def l2a_dataset(decom_test_data: xr.Dataset) -> xr.Dataset:
         "imap_processing.idex.idex_l1b.get_spice_data",
         return_value={"spin_phase": spin_phase_angles},
     ):
-        dataset = idex_l2a(
-            idex_l1b(decom_test_data, data_version="001"), data_version="001"
-        )
+        dataset = idex_l2a(idex_l1b(decom_test_data))
     return dataset
 
 

--- a/imap_processing/tests/idex/test_idex_l1a.py
+++ b/imap_processing/tests/idex/test_idex_l1a.py
@@ -25,7 +25,7 @@ def test_idex_cdf_file(decom_test_data: xr.Dataset):
     file_name = write_cdf(decom_test_data)
 
     assert file_name.exists()
-    assert file_name.name == "imap_idex_l1a_sci-1week_20231218_v001.cdf"
+    assert file_name.name == "imap_idex_l1a_sci-1week_20231218_v999.cdf"
 
 
 def test_bad_cdf_attributes(decom_test_data: xr.Dataset):

--- a/imap_processing/tests/idex/test_idex_l1a.py
+++ b/imap_processing/tests/idex/test_idex_l1a.py
@@ -158,8 +158,8 @@ def test_compressed_packet():
     compressed = Path(f"{test_data_dir}/compressed_2023_102_14_24_55.pkts")
     non_compressed = Path(f"{test_data_dir}/non_compressed_2023_102_14_22_26.pkts")
 
-    decompressed = PacketParser(compressed, "001").data
-    expected = PacketParser(non_compressed, "001").data
+    decompressed = PacketParser(compressed).data
+    expected = PacketParser(non_compressed).data
 
     waveforms = [
         "TOF_High",

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -80,7 +80,7 @@ def test_idex_cdf_file(l1b_dataset: xr.Dataset):
     file_name = write_cdf(l1b_dataset)
 
     assert file_name.exists()
-    assert file_name.name == "imap_idex_l1b_sci-1week_20231218_v001.cdf"
+    assert file_name.name == "imap_idex_l1b_sci-1week_20231218_v999.cdf"
 
 
 def test_idex_waveform_units(l1b_dataset: xr.Dataset):

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -32,7 +32,7 @@ def l1b_dataset(mock_get_spice_data, decom_test_data: xr.Dataset) -> xr.Dataset:
     """
 
     mock_get_spice_data.side_effect = get_spice_data_side_effect_func
-    dataset = idex_l1b(decom_test_data, data_version="001")
+    dataset = idex_l1b(decom_test_data)
     return dataset
 
 

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -17,7 +17,7 @@ def l2b_dataset(l2a_dataset: xr.Dataset) -> xr.Dataset:
     dataset : xr.Dataset
         A ``xarray`` dataset containing the test data
     """
-    dataset = idex_l2b(l2a_dataset, data_version="001")
+    dataset = idex_l2b(l2a_dataset)
     return dataset
 
 

--- a/imap_processing/tests/lo/test_lo_l1a.py
+++ b/imap_processing/tests/lo/test_lo_l1a.py
@@ -15,7 +15,7 @@ def test_lo_l1a():
         "imap_lo_l1a_histogram",
         "imap_lo_l1a_de",
     ]
-    output_dataset = lo_l1a(dependency, "001")
+    output_dataset = lo_l1a(dependency)
 
     # Assert
     for dataset, logical_source in zip(output_dataset, expected_logical_source):
@@ -56,7 +56,7 @@ def test_lo_l1a_dataset():
     hist_fields_lower = [field.lower() for field in histogram_fields]
 
     # Act
-    output_datasets = lo_l1a(dependency, "001")
+    output_datasets = lo_l1a(dependency)
 
     # Assert
     np.testing.assert_array_equal(hist_fields_lower, output_datasets[1].data_vars)
@@ -108,7 +108,7 @@ def test_validate_spin_data():
             validation_data = validation_data.drop(matching_columns, axis=1)
 
     # Act
-    output_dataset = lo_l1a(dependency, "001")
+    output_dataset = lo_l1a(dependency)
 
     # Assert
     for field in spin_fields:

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -38,7 +38,6 @@ def attr_mgr_l1b():
     attr_mgr_l1b = ImapCdfAttributes()
     attr_mgr_l1b.add_instrument_global_attrs(instrument="lo")
     attr_mgr_l1b.add_instrument_variable_attrs(instrument="lo", level="l1b")
-    attr_mgr_l1b.add_global_attribute("Data_version", "000")
     return attr_mgr_l1b
 
 
@@ -57,7 +56,7 @@ def test_lo_l1b():
 
     expected_logical_source = "imap_lo_l1b_de"
     # Act
-    output_file = lo_l1b(data, "001")
+    output_file = lo_l1b(data)
 
     # Assert
     assert expected_logical_source == output_file[0].attrs["Logical_source"]

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -19,7 +19,7 @@ def test_lo_l1c():
 
     expected_logical_source = "imap_lo_l1c_pset"
     # Act
-    output_dataset = lo_l1c(data, "001")
+    output_dataset = lo_l1c(data)
 
     # Assert
     assert expected_logical_source == output_dataset.attrs["Logical_source"]

--- a/imap_processing/tests/lo/test_lo_science.py
+++ b/imap_processing/tests/lo/test_lo_science.py
@@ -153,7 +153,6 @@ def attr_mgr():
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="lo")
     attr_mgr.add_instrument_variable_attrs(instrument="lo", level="l1a")
-    attr_mgr.add_global_attribute("Data_version", "v000")
     return attr_mgr
 
 

--- a/imap_processing/tests/mag/conftest.py
+++ b/imap_processing/tests/mag/conftest.py
@@ -17,7 +17,7 @@ def validation_l1a():
     current_directory = Path(__file__).parent
     test_file = current_directory / "validation" / "mag_l1_test_data.pkts"
     # Test file contains only normal packets
-    l1a = mag_l1a(test_file, "v000")
+    l1a = mag_l1a(test_file)
     return l1a
 
 

--- a/imap_processing/tests/mag/test_mag_decom.py
+++ b/imap_processing/tests/mag/test_mag_decom.py
@@ -14,6 +14,7 @@ def cdf_attrs():
     test_attrs = ImapCdfAttributes()
     test_attrs.add_instrument_global_attrs("mag")
     test_attrs.add_instrument_variable_attrs("mag", "l1a")
+    # Default v001 expected when writing to file and re-loading
     test_attrs.add_global_attribute("Data_version", "v001")
     return test_attrs
 
@@ -75,7 +76,7 @@ def test_mag_raw_xarray(cdf_attrs):
         [
             item is not None
             for key, item in norm_data.attrs.items()
-            if key != "Logical_file_id"
+            if key not in ("Logical_file_id", "Data_version")
         ]
     )
 
@@ -83,7 +84,7 @@ def test_mag_raw_xarray(cdf_attrs):
         [
             item is not None
             for key, item in burst_data.attrs.items()
-            if key != "Logical_file_id"
+            if key not in ("Logical_file_id", "Data_version")
         ]
     )
 

--- a/imap_processing/tests/mag/test_mag_l1a.py
+++ b/imap_processing/tests/mag/test_mag_l1a.py
@@ -883,7 +883,7 @@ def test_mag_l1a():
     current_directory = Path(__file__).parent
     test_file = current_directory / "validation" / "mag_l1_test_data.pkts"
 
-    output_data = mag_l1a(test_file, "v001")
+    output_data = mag_l1a(test_file)
 
     # Test data is one day's worth of NORM data, so it should return one raw, one MAGO
     # and one MAGI dataset
@@ -896,9 +896,6 @@ def test_mag_l1a():
 
     for data_type in [data.attrs["Logical_source"] for data in output_data]:
         assert data_type in expected_logical_source
-
-    for data in output_data:
-        assert data.attrs["Data_version"] == "v001"
 
     assert "vectors" in output_data[-1].variables.keys()
     assert "compression_flags" in output_data[-1].variables.keys()

--- a/imap_processing/tests/mag/test_mag_l1b.py
+++ b/imap_processing/tests/mag/test_mag_l1b.py
@@ -67,12 +67,12 @@ def test_mag_attributes():
 
     mag_l1a_dataset.attrs["Logical_source"] = ["imap_mag_l1a_norm-mago"]
 
-    output = mag_l1b(mag_l1a_dataset, "v001")
+    output = mag_l1b(mag_l1a_dataset)
     assert output.attrs["Logical_source"] == "imap_mag_l1b_norm-mago"
 
     mag_l1a_dataset.attrs["Logical_source"] = ["imap_mag_l1a_burst-magi"]
 
-    output = mag_l1b(mag_l1a_dataset, "v001")
+    output = mag_l1b(mag_l1a_dataset)
     assert output.attrs["Logical_source"] == "imap_mag_l1b_burst-magi"
 
 
@@ -82,7 +82,7 @@ def test_cdf_output():
         / "validation"
         / "imap_mag_l1a_norm-magi_20251017_v001.cdf"
     )
-    l1b_dataset = mag_l1b(l1a_cdf, "v001")
+    l1b_dataset = mag_l1b(l1a_cdf)
 
     output_path = write_cdf(l1b_dataset)
 
@@ -110,7 +110,7 @@ def test_mag_compression_scale():
     mag_l1a_dataset["compression_flags"][3, :] = np.array([1, 14], dtype=np.int8)
 
     mag_l1a_dataset.attrs["Logical_source"] = ["imap_mag_l1a_norm-mago"]
-    output = mag_l1b(mag_l1a_dataset, "v001")
+    output = mag_l1b(mag_l1a_dataset)
 
     calibrated_vectors = np.matmul(test_calibration, np.array([1, 1, 1]))
     # 16 bit width is the standard
@@ -187,9 +187,9 @@ def test_calibrate_vector():
 def test_l1a_to_l1b(validation_l1a):
     # Convert l1a input validation packet file to l1b
     with pytest.raises(ValueError, match="Raw L1A"):
-        mag_l1b(validation_l1a[0], "v000")
+        mag_l1b(validation_l1a[0])
 
-    l1b = [mag_l1b(i, "v000") for i in validation_l1a[1:]]
+    l1b = [mag_l1b(i) for i in validation_l1a[1:]]
 
     assert len(l1b) == len(validation_l1a) - 1
 

--- a/imap_processing/tests/mag/test_mag_l1c.py
+++ b/imap_processing/tests/mag/test_mag_l1c.py
@@ -223,7 +223,7 @@ def test_interpolate_gaps(norm_dataset, mag_l1b_dataset):
 
 
 def test_mag_l1c(norm_dataset, burst_dataset):
-    l1c = mag_l1c(burst_dataset, "v001", norm_dataset)
+    l1c = mag_l1c(burst_dataset, norm_dataset)
     assert l1c["vector_magnitude"].shape == (len(l1c["epoch"].data),)
     assert l1c["vector_magnitude"].data[0] == np.linalg.norm(l1c["vectors"].data[0][:4])
     assert l1c["vector_magnitude"].data[-1] == np.linalg.norm(
@@ -242,7 +242,7 @@ def test_mag_l1c(norm_dataset, burst_dataset):
 
 
 def test_mag_attributes(norm_dataset, burst_dataset):
-    output = mag_l1c(norm_dataset, "v001", burst_dataset)
+    output = mag_l1c(norm_dataset, burst_dataset)
     assert output.attrs["Logical_source"] == "imap_mag_l1c_norm-mago"
 
     expected_attrs = ["missing_sequences", "interpolation_method"]
@@ -252,7 +252,7 @@ def test_mag_attributes(norm_dataset, burst_dataset):
 
 def test_missing_burst_file(norm_dataset, burst_dataset):
     # Should run with only normal mode data or only burst mode data.
-    output = mag_l1c(norm_dataset, "v001", None)
+    output = mag_l1c(norm_dataset, None)
     assert output.attrs["Logical_source"] == "imap_mag_l1c_norm-mago"
 
     # Should pass through normal mode data only
@@ -264,7 +264,7 @@ def test_missing_burst_file(norm_dataset, burst_dataset):
 def test_missing_norm_file(norm_dataset, burst_dataset):
     # Should run with only normal mode data or only burst mode data.
     burst_dataset.attrs["Logical_source"] = "imap_mag_l1b_burst-magi"
-    output = mag_l1c(burst_dataset, "v001", None)
+    output = mag_l1c(burst_dataset, None)
 
     assert output.attrs["Logical_source"] == "imap_mag_l1c_norm-magi"
     # TODO: test that the output is downsampled

--- a/imap_processing/tests/mag/test_mag_validation.py
+++ b/imap_processing/tests/mag/test_mag_validation.py
@@ -70,7 +70,7 @@ def test_mag_l1a_validation(test_number):
     input_file = source_directory / f"mag-l0-l1a-t{test_number}-in.bin"
     expected_output_file = source_directory / f"mag-l0-l1a-t{test_number}-out.csv"
 
-    mag_l1a_out = mag_l1a(input_file, "v000")
+    mag_l1a_out = mag_l1a(input_file)
     expected_output = pd.read_csv(expected_output_file)
 
     raw = mag_l1a_out[0]
@@ -198,8 +198,8 @@ def test_mag_l1b_validation(test_number):
     mag_l1a_mago["compression_flags"].data = compression_flags
     mag_l1a_magi["compression_flags"].data = compression_flags
 
-    mago = mag_l1b(mag_l1a_mago, "v000", calibration_input)
-    magi = mag_l1b(mag_l1a_magi, "v000", calibration_input)
+    mago = mag_l1b(mag_l1a_mago, calibration_input)
+    magi = mag_l1b(mag_l1a_magi, calibration_input)
 
     expected_mago = pd.read_csv(
         source_directory / f"mag-l1a-l1b-t{test_number}-mago-out.csv"
@@ -308,7 +308,7 @@ def test_mag_l1c_validation(test_number, sensor):
 
     burst.attrs["vectors_per_second"] = get_vecsec(test_number, sensor, "burst")
 
-    l1c = mag_l1c(norm, "v000", burst)
+    l1c = mag_l1c(norm, burst)
     expected_output = pd.read_csv(
         source_directory / f"mag-l1b-l1c-t{test_number}-{sensor}-normal-out.csv"
     )

--- a/imap_processing/tests/swapi/test_swapi_l1.py
+++ b/imap_processing/tests/swapi/test_swapi_l1.py
@@ -144,7 +144,7 @@ def test_process_swapi_science(decom_test_data):
     assert hk_ds["epoch"].shape == (17,)
     hk_duplicate_ds = xr.concat([hk_ds, hk_ds], dim="epoch")
     assert hk_duplicate_ds["epoch"].shape == (34,)
-    processed_data = process_swapi_science(ds_data, hk_duplicate_ds, data_version="001")
+    processed_data = process_swapi_science(ds_data, hk_duplicate_ds)
 
     # Test dataset dimensions
     assert processed_data.sizes == {
@@ -162,9 +162,7 @@ def test_process_swapi_science(decom_test_data):
 
     # make PLAN_ID data incorrect. Now processed data should have less sweeps
     ds_data["plan_id"].data[:24] = np.arange(24)
-    processed_data = process_swapi_science(
-        ds_data, decom_test_data[SWAPIAPID.SWP_HK], data_version="001"
-    )
+    processed_data = process_swapi_science(ds_data, decom_test_data[SWAPIAPID.SWP_HK])
     assert processed_data.sizes == {
         "epoch": 10,
         "energy": 72,
@@ -180,14 +178,14 @@ def test_process_swapi_science(decom_test_data):
 def test_swapi_l1_cdf(swapi_l0_test_data_path):
     """Test housekeeping processing and CDF file creation"""
     test_packet_file = swapi_l0_test_data_path / "imap_swapi_l0_raw_20240924_v001.pkts"
-    processed_data = swapi_l1([test_packet_file], data_version="v001")
+    processed_data = swapi_l1([test_packet_file])
     # hk cdf file
     hk_cdf_filename = "imap_swapi_l1_hk_20240924_v001.cdf"
     # TODO: how to add ignore ISTP checks for HK data to cli.py
     hk_cdf_path = write_cdf(processed_data[0])
     assert hk_cdf_path.name == hk_cdf_filename
 
-    processed_data = swapi_l1([test_packet_file, hk_cdf_path], data_version="v001")
+    processed_data = swapi_l1([test_packet_file, hk_cdf_path])
 
     assert processed_data[0].attrs["Apid"] == f"{SWAPIAPID.SWP_SCI}"
 

--- a/imap_processing/tests/swapi/test_swapi_l1.py
+++ b/imap_processing/tests/swapi/test_swapi_l1.py
@@ -170,7 +170,7 @@ def test_process_swapi_science(decom_test_data):
     }
 
     # Test CDF File
-    cdf_filename = "imap_swapi_l1_sci_20240924_v001.cdf"
+    cdf_filename = "imap_swapi_l1_sci_20240924_v999.cdf"
     cdf_path = write_cdf(processed_data)
     assert cdf_path.name == cdf_filename
 
@@ -180,7 +180,7 @@ def test_swapi_l1_cdf(swapi_l0_test_data_path):
     test_packet_file = swapi_l0_test_data_path / "imap_swapi_l0_raw_20240924_v001.pkts"
     processed_data = swapi_l1([test_packet_file])
     # hk cdf file
-    hk_cdf_filename = "imap_swapi_l1_hk_20240924_v001.cdf"
+    hk_cdf_filename = "imap_swapi_l1_hk_20240924_v999.cdf"
     # TODO: how to add ignore ISTP checks for HK data to cli.py
     hk_cdf_path = write_cdf(processed_data[0])
     assert hk_cdf_path.name == hk_cdf_filename
@@ -190,6 +190,6 @@ def test_swapi_l1_cdf(swapi_l0_test_data_path):
     assert processed_data[0].attrs["Apid"] == f"{SWAPIAPID.SWP_SCI}"
 
     # Test CDF File
-    cdf_filename = "imap_swapi_l1_sci_20240924_v001.cdf"
+    cdf_filename = "imap_swapi_l1_sci_20240924_v999.cdf"
     cdf_path = write_cdf(processed_data[0])
     assert cdf_path.name == cdf_filename

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -10,20 +10,20 @@ def test_swapi_l2_cdf(swapi_l0_test_data_path):
     test_packet_file = swapi_l0_test_data_path / "imap_swapi_l0_raw_20240924_v001.pkts"
     # Create HK CDF File
     processed_hk_data = swapi_l1([test_packet_file])
-    hk_cdf_filename = "imap_swapi_l1_hk_20240924_v001.cdf"
+    hk_cdf_filename = "imap_swapi_l1_hk_20240924_v999.cdf"
     hk_cdf_path = write_cdf(processed_hk_data[0])
     assert hk_cdf_path.name == hk_cdf_filename
 
     # Create L1 CDF File
     processed_sci_data = swapi_l1([test_packet_file, hk_cdf_path])
-    cdf_filename = "imap_swapi_l1_sci_20240924_v001.cdf"
+    cdf_filename = "imap_swapi_l1_sci_20240924_v999.cdf"
     cdf_path = write_cdf(processed_sci_data[0])
     assert cdf_path.name == cdf_filename
 
     l1_dataset = processed_sci_data[0]
     l2_dataset = swapi_l2(l1_dataset)
     l2_cdf = write_cdf(l2_dataset)
-    assert l2_cdf.name == "imap_swapi_l2_sci_20240924_v001.cdf"
+    assert l2_cdf.name == "imap_swapi_l2_sci_20240924_v999.cdf"
 
     # Test uncertainty variables are as expected
     np.testing.assert_array_equal(

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -9,19 +9,19 @@ def test_swapi_l2_cdf(swapi_l0_test_data_path):
     """Test housekeeping processing and CDF file creation"""
     test_packet_file = swapi_l0_test_data_path / "imap_swapi_l0_raw_20240924_v001.pkts"
     # Create HK CDF File
-    processed_hk_data = swapi_l1([test_packet_file], data_version="v001")
+    processed_hk_data = swapi_l1([test_packet_file])
     hk_cdf_filename = "imap_swapi_l1_hk_20240924_v001.cdf"
     hk_cdf_path = write_cdf(processed_hk_data[0])
     assert hk_cdf_path.name == hk_cdf_filename
 
     # Create L1 CDF File
-    processed_sci_data = swapi_l1([test_packet_file, hk_cdf_path], data_version="v001")
+    processed_sci_data = swapi_l1([test_packet_file, hk_cdf_path])
     cdf_filename = "imap_swapi_l1_sci_20240924_v001.cdf"
     cdf_path = write_cdf(processed_sci_data[0])
     assert cdf_path.name == cdf_filename
 
     l1_dataset = processed_sci_data[0]
-    l2_dataset = swapi_l2(l1_dataset, data_version="v001")
+    l2_dataset = swapi_l2(l1_dataset)
     l2_cdf = write_cdf(l2_dataset)
     assert l2_cdf.name == "imap_swapi_l2_sci_20240924_v001.cdf"
 

--- a/imap_processing/tests/swe/test_swe_l1a.py
+++ b/imap_processing/tests/swe/test_swe_l1a.py
@@ -5,7 +5,7 @@ from imap_processing.swe.l1a.swe_l1a import swe_l1a
 
 def test_cdf_creation():
     test_data_path = "tests/swe/l0_data/2024051010_SWE_SCIENCE_packet.bin"
-    processed_data = swe_l1a(imap_module_directory / test_data_path, "001")
+    processed_data = swe_l1a(imap_module_directory / test_data_path)
 
     cem_raw_cdf_filepath = write_cdf(processed_data[0])
 
@@ -14,7 +14,7 @@ def test_cdf_creation():
 
 def test_cdf_creation_hk():
     test_data_path = "tests/swe/l0_data/2024051010_SWE_HK_packet.bin"
-    processed_data = swe_l1a(imap_module_directory / test_data_path, "001")
+    processed_data = swe_l1a(imap_module_directory / test_data_path)
 
     hk_cdf_filepath = write_cdf(processed_data[0])
 
@@ -23,7 +23,7 @@ def test_cdf_creation_hk():
 
 def test_cdf_creation_cem_raw():
     test_data_path = "tests/swe/l0_data/2024051011_SWE_CEM_RAW_packet.bin"
-    processed_data = swe_l1a(imap_module_directory / test_data_path, "001")
+    processed_data = swe_l1a(imap_module_directory / test_data_path)
 
     cem_raw_cdf_filepath = write_cdf(processed_data[0])
 

--- a/imap_processing/tests/swe/test_swe_l1a.py
+++ b/imap_processing/tests/swe/test_swe_l1a.py
@@ -9,7 +9,7 @@ def test_cdf_creation():
 
     cem_raw_cdf_filepath = write_cdf(processed_data[0])
 
-    assert cem_raw_cdf_filepath.name == "imap_swe_l1a_sci_20240510_v001.cdf"
+    assert cem_raw_cdf_filepath.name == "imap_swe_l1a_sci_20240510_v999.cdf"
 
 
 def test_cdf_creation_hk():
@@ -18,7 +18,7 @@ def test_cdf_creation_hk():
 
     hk_cdf_filepath = write_cdf(processed_data[0])
 
-    assert hk_cdf_filepath.name == "imap_swe_l1a_hk_20240510_v001.cdf"
+    assert hk_cdf_filepath.name == "imap_swe_l1a_hk_20240510_v999.cdf"
 
 
 def test_cdf_creation_cem_raw():
@@ -27,4 +27,4 @@ def test_cdf_creation_cem_raw():
 
     cem_raw_cdf_filepath = write_cdf(processed_data[0])
 
-    assert cem_raw_cdf_filepath.name == "imap_swe_l1a_cem-raw_20240510_v001.cdf"
+    assert cem_raw_cdf_filepath.name == "imap_swe_l1a_cem-raw_20240510_v999.cdf"

--- a/imap_processing/tests/swe/test_swe_l1a_science.py
+++ b/imap_processing/tests/swe/test_swe_l1a_science.py
@@ -75,7 +75,7 @@ def test_data_order(decom_test_data):
     )
 
     # Get unpacked science data
-    processed_data = swe_science(decom_test_data, "001")
+    processed_data = swe_science(decom_test_data)
 
     quarter_cycle = processed_data["quarter_cycle"].isel(epoch=slice(0, 4))
     np.testing.assert_array_equal(quarter_cycle, [0, 1, 2, 3])
@@ -84,7 +84,7 @@ def test_data_order(decom_test_data):
 def test_swe_science_algorithm(decom_test_data):
     """Test general shape of return dataset from swe_science."""
     # Get unpacked science data
-    processed_data = swe_science(decom_test_data, "001")
+    processed_data = swe_science(decom_test_data)
 
     # science data should have this shape, 15x12x7.
     science_data = processed_data["science_data"].data[0]
@@ -101,7 +101,7 @@ def test_decompress_counts(decom_test_data, l1a_validation_df):
     raw_counts = l1a_validation_df.iloc[:, 1:8]
     decompressed_counts = l1a_validation_df.iloc[:, 8:15]
 
-    l1a_dataset = swe_science(decom_test_data, "001")
+    l1a_dataset = swe_science(decom_test_data)
 
     # compare raw counts
     assert np.all(

--- a/imap_processing/tests/swe/test_swe_l1b.py
+++ b/imap_processing/tests/swe/test_swe_l1b.py
@@ -22,7 +22,7 @@ def test_swe_l1b(decom_test_data_derived):
     decom_test_data_derived : xarray.dataset
         Dataset with derived values
     """
-    science_l1a_ds = swe_science(decom_test_data_derived, "001")
+    science_l1a_ds = swe_science(decom_test_data_derived)
 
     # read science validation data
     test_data_path = imap_module_directory / "tests/swe/l0_validation_data"
@@ -65,10 +65,12 @@ def test_swe_l1b(decom_test_data_derived):
 def test_cdf_creation(mock_read_in_flight_cal_data, l1b_validation_df):
     """Test that CDF file is created and has the correct name."""
     test_data_path = "tests/swe/l0_data/2024051010_SWE_SCIENCE_packet.bin"
-    l1a_datasets = swe_l1a(imap_module_directory / test_data_path, "002")
+    l1a_datasets = swe_l1a(imap_module_directory / test_data_path)
 
-    l1b_dataset = swe_l1b(l1a_datasets[0], "002")
-
+    l1b_dataset = swe_l1b(l1a_datasets[0])
+    # Injected during cli processing calls, not instrument functions,
+    # so set it manually here before writing
+    l1b_dataset[0].attrs["Data_version"] = "v002"
     sci_l1b_filepath = write_cdf(l1b_dataset[0])
 
     assert sci_l1b_filepath.name == "imap_swe_l1b_sci_20240510_v002.cdf"

--- a/imap_processing/tests/swe/test_swe_l1b_science.py
+++ b/imap_processing/tests/swe/test_swe_l1b_science.py
@@ -15,7 +15,7 @@ from imap_processing.swe.utils import swe_constants
 @pytest.fixture(scope="session")
 def l1a_test_data(decom_test_data):
     """Read test data from file and process to l1a"""
-    processed_data = swe_science(decom_test_data, "001")
+    processed_data = swe_science(decom_test_data)
     return processed_data
 
 

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -321,10 +321,10 @@ def test_swe_l2(mock_read_in_flight_cal_data, use_fake_spin_data_for_time):
     use_fake_spin_data_for_time(data_start_time, data_end_time)
 
     test_data_path = "tests/swe/l0_data/2024051010_SWE_SCIENCE_packet.bin"
-    l1a_datasets = swe_l1a(imap_module_directory / test_data_path, "002")
+    l1a_datasets = swe_l1a(imap_module_directory / test_data_path)
 
-    l1b_dataset = swe_l1b(l1a_datasets[0], "002")
-    l2_dataset = swe_l2(l1b_dataset[0], "002")
+    l1b_dataset = swe_l1b(l1a_datasets[0])
+    l2_dataset = swe_l2(l1b_dataset[0])
 
     assert isinstance(l2_dataset, xr.Dataset)
     assert l2_dataset["phase_space_density_spin_sector"].shape == (
@@ -346,5 +346,6 @@ def test_swe_l2(mock_read_in_flight_cal_data, use_fake_spin_data_for_time):
     )
 
     # Write L2 to CDF
+    l2_dataset.attrs["Data_version"] = "v002"
     l2_cdf_filepath = write_cdf(l2_dataset)
     assert l2_cdf_filepath.name == "imap_swe_l2_sci_20240510_v002.cdf"

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -163,27 +163,21 @@ def events_fsw_comparison_theta_0():
 @pytest.fixture
 def de_dataset(ccsds_path_theta_0, xtce_path):
     """L1A test data"""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_EVENTS.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_EVENTS.apid[0])
     return test_data[0]
 
 
 @pytest.fixture
 def rates_dataset(ccsds_path_theta_0):
     """L1A test data"""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_RATES.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_RATES.apid[0])
     return test_data[0]
 
 
 @pytest.fixture
 def aux_dataset(ccsds_path_theta_0):
     """L1A test data"""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_AUX.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_AUX.apid[0])
     return test_data[0]
 
 
@@ -247,7 +241,7 @@ def l1b_de_dataset(
 
     mock_get_annotated_particle_velocity.side_effect = side_effect_func
 
-    output_datasets = ultra_l1b(data_dict, data_version="001")
+    output_datasets = ultra_l1b(data_dict)
 
     return output_datasets
 
@@ -266,6 +260,6 @@ def l1b_extendedspin_dataset(
     data_dict["imap_ultra_l1a_45sensor-hk"] = faux_aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
 
-    output_datasets = ultra_l1b(data_dict, data_version="001")
+    output_datasets = ultra_l1b(data_dict)
 
     return output_datasets

--- a/imap_processing/tests/ultra/unit/test_badtimes.py
+++ b/imap_processing/tests/ultra/unit/test_badtimes.py
@@ -45,14 +45,11 @@ def test_calculate_badtimes():
         },
     )
 
-    culling_ds = calculate_cullingmask(
-        ds, name="imap_ultra_l1b_45sensor-badtimes", data_version="v1"
-    )
+    culling_ds = calculate_cullingmask(ds, name="imap_ultra_l1b_45sensor-badtimes")
     badtimes_ds = calculate_badtimes(
         ds,
         culling_ds["spin_number"].values,
         name="imap_ultra_l1b_45sensor-badtimes",
-        data_version="v1",
     )
 
     assert not np.any(

--- a/imap_processing/tests/ultra/unit/test_cullingmask.py
+++ b/imap_processing/tests/ultra/unit/test_cullingmask.py
@@ -38,9 +38,7 @@ def test_calculate_cullingmask_attitude():
         },
     )
 
-    result_ds = calculate_cullingmask(
-        ds, name="imap_ultra_l1b_45sensor-cullingmask", data_version="v1"
-    )
+    result_ds = calculate_cullingmask(ds, name="imap_ultra_l1b_45sensor-cullingmask")
 
     np.testing.assert_array_equal(result_ds["spin_number"].values, np.array([0]))
 
@@ -83,9 +81,7 @@ def test_calculate_cullingmask_rates():
         },
     )
 
-    result_ds = calculate_cullingmask(
-        ds, name="imap_ultra_l1b_45sensor-cullingmask", data_version="v1"
-    )
+    result_ds = calculate_cullingmask(ds, name="imap_ultra_l1b_45sensor-cullingmask")
 
     expected_spins = np.array([0, 1])
     np.testing.assert_array_equal(result_ds["spin_number"].values, expected_spins)

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -71,7 +71,6 @@ def test_pset():
         test_l1b_de_dataset,  # placeholder for extendedspin_dataset
         test_l1b_de_dataset,  # placeholder for cullingmask_dataset
         "imap_ultra_l1c_45sensor-spacecraftpset",
-        "001",
     )
     assert "healpix" in spacecraft_pset.coords
     assert "epoch" in spacecraft_pset.coords

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -62,7 +62,7 @@ def test_cdf_aux(ccsds_path_theta_0):
     test_data_path = write_cdf(test_data[0])
 
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1a_45sensor-aux_20240207_v001.cdf"
+    assert test_data_path.name == "imap_ultra_l1a_45sensor-aux_20240207_v999.cdf"
 
 
 def test_cdf_rates(ccsds_path_theta_0):
@@ -71,7 +71,7 @@ def test_cdf_rates(ccsds_path_theta_0):
     test_data_path = write_cdf(test_data[0], istp=False)
 
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1a_45sensor-rates_20240207_v001.cdf"
+    assert test_data_path.name == "imap_ultra_l1a_45sensor-rates_20240207_v999.cdf"
 
 
 def test_cdf_tof(ccsds_path_theta_0):
@@ -81,7 +81,7 @@ def test_cdf_tof(ccsds_path_theta_0):
     assert test_data_path.exists()
     assert (
         test_data_path.name
-        == "imap_ultra_l1a_45sensor-histogram-ena-phxtof-hi-ang_20240207_v001.cdf"
+        == "imap_ultra_l1a_45sensor-histogram-ena-phxtof-hi-ang_20240207_v999.cdf"
     )
 
 
@@ -91,7 +91,7 @@ def test_cdf_events(ccsds_path_theta_0):
     test_data_path = write_cdf(test_data[0], istp=False)
 
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1a_45sensor-de_20240207_v001.cdf"
+    assert test_data_path.name == "imap_ultra_l1a_45sensor-de_20240207_v999.cdf"
 
 
 def test_get_event_id():

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -16,9 +16,7 @@ from imap_processing.ultra.l1a.ultra_l1a import (
 def test_xarray_aux(ccsds_path_theta_0):
     """This function checks that a xarray was
     successfully created from the decom_ultra_aux data."""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_AUX.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_AUX.apid[0])
 
     # Spot check metadata data and attributes
     specific_epoch_data = test_data[0].sel(epoch=test_data[0].epoch[0])[
@@ -31,9 +29,7 @@ def test_xarray_aux(ccsds_path_theta_0):
 def test_xarray_rates(ccsds_path_theta_0):
     """This function checks that a xarray was
     successfully created from the decom_ultra_rates data."""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_RATES.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_RATES.apid[0])
     # Spot check metadata data and attributes
     specific_epoch_data = test_data[0].sel(epoch=test_data[0].epoch[0])["start_rf"]
     assert (specific_epoch_data == test_data[0]["start_rf"][0]).all()
@@ -42,9 +38,7 @@ def test_xarray_rates(ccsds_path_theta_0):
 def test_xarray_tof(ccsds_path_theta_0):
     """This function checks that a xarray was
     successfully created from the decom_ultra_tof data."""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_TOF.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_TOF.apid[0])
 
     # Spot check metadata data and attributes
     specific_epoch_data = test_data[0].sel(epoch=test_data[0].epoch[0], sid=0)[
@@ -56,9 +50,7 @@ def test_xarray_tof(ccsds_path_theta_0):
 def test_xarray_events(ccsds_path_theta_0):
     """This function checks that a xarray was
     successfully created from the decom_ultra_events data."""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_EVENTS.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_EVENTS.apid[0])
     specific_epoch_data = test_data[0].sel(epoch=test_data[0].epoch[0])["coin_type"]
     assert (specific_epoch_data == test_data[0]["coin_type"][0]).all()
 
@@ -66,9 +58,7 @@ def test_xarray_events(ccsds_path_theta_0):
 def test_cdf_aux(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
 
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_AUX.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_AUX.apid[0])
     test_data_path = write_cdf(test_data[0])
 
     assert test_data_path.exists()
@@ -77,9 +67,7 @@ def test_cdf_aux(ccsds_path_theta_0):
 
 def test_cdf_rates(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_RATES.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_RATES.apid[0])
     test_data_path = write_cdf(test_data[0], istp=False)
 
     assert test_data_path.exists()
@@ -88,9 +76,7 @@ def test_cdf_rates(ccsds_path_theta_0):
 
 def test_cdf_tof(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_TOF.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_TOF.apid[0])
     test_data_path = write_cdf(test_data[0])
     assert test_data_path.exists()
     assert (
@@ -101,9 +87,7 @@ def test_cdf_tof(ccsds_path_theta_0):
 
 def test_cdf_events(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
-    test_data = ultra_l1a(
-        ccsds_path_theta_0, data_version="001", apid=ULTRA_EVENTS.apid[0]
-    )
+    test_data = ultra_l1a(ccsds_path_theta_0, apid=ULTRA_EVENTS.apid[0])
     test_data_path = write_cdf(test_data[0], istp=False)
 
     assert test_data_path.exists()

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -67,7 +67,6 @@ def test_create_extendedspin_dataset(mock_data_l1b_extendedspin_dict):
         mock_data_l1b_extendedspin_dict,
         "imap_ultra_l1b_45sensor-extendedspin",
         "l1b",
-        "001",
     )
 
     assert "spin_number" in dataset.coords
@@ -82,9 +81,7 @@ def test_create_extendedspin_dataset(mock_data_l1b_extendedspin_dict):
 
 def test_create_de_dataset(mock_data_l1b_de_dict):
     """Tests that dataset is created as expected."""
-    dataset = create_dataset(
-        mock_data_l1b_de_dict, "imap_ultra_l1b_45sensor-de", "l1b", "001"
-    )
+    dataset = create_dataset(mock_data_l1b_de_dict, "imap_ultra_l1b_45sensor-de", "l1b")
 
     assert "epoch" in dataset.coords
     assert dataset.coords["epoch"].dtype == "datetime64[ns]"
@@ -145,4 +142,4 @@ def test_ultra_l1b_error(mock_data_l1a_rates_dict):
     with pytest.raises(
         ValueError, match="Data dictionary does not contain the expected keys."
     ):
-        ultra_l1b(mock_data_l1a_rates_dict, data_version="001")
+        ultra_l1b(mock_data_l1a_rates_dict)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -105,7 +105,7 @@ def test_cdf_de(l1b_de_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
     test_data_path = write_cdf(l1b_de_dataset[0], istp=False)
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1b_45sensor-de_20240207_v001.cdf"
+    assert test_data_path.name == "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
 
 
 def test_ultra_l1b_extendedspin(l1b_extendedspin_dataset):
@@ -130,7 +130,7 @@ def test_cdf_extendedspin(l1b_extendedspin_dataset):
     test_data_path = write_cdf(l1b_extendedspin_dataset[0], istp=False)
     assert test_data_path.exists()
     assert (
-        test_data_path.name == "imap_ultra_l1b_45sensor-extendedspin_20000101_v001.cdf"
+        test_data_path.name == "imap_ultra_l1b_45sensor-extendedspin_20000101_v999.cdf"
     )
 
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -68,7 +68,7 @@ def mock_data_l1c_dict():
 def test_create_dataset(mock_data_l1c_dict):
     """Tests that dataset is created as expected."""
     dataset = create_dataset(
-        mock_data_l1c_dict, "imap_ultra_l1c_45sensor-histogram", "l1c", "001"
+        mock_data_l1c_dict, "imap_ultra_l1c_45sensor-histogram", "l1c"
     )
 
     assert "epoch" in dataset.coords
@@ -80,7 +80,7 @@ def test_create_dataset(mock_data_l1c_dict):
 
 def test_ultra_l1c(mock_data_l1b_dict):
     """Tests that L1c data is created."""
-    output_datasets = ultra_l1c(mock_data_l1b_dict, data_version="001")
+    output_datasets = ultra_l1c(mock_data_l1b_dict)
 
     assert len(output_datasets) == 1
     assert (
@@ -101,4 +101,4 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
     with pytest.raises(
         ValueError, match="Data dictionary does not contain the expected keys."
     ):
-        ultra_l1c(mock_data_l1b_dict, data_version="001")
+        ultra_l1c(mock_data_l1b_dict)

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -23,9 +23,7 @@ from imap_processing.utils import packet_file_to_datasets
 logger = logging.getLogger(__name__)
 
 
-def ultra_l1a(
-    packet_file: str, data_version: str, apid: Optional[int] = None
-) -> list[xr.Dataset]:
+def ultra_l1a(packet_file: str, apid: Optional[int] = None) -> list[xr.Dataset]:
     """
     Will process ULTRA L0 data into L1A CDF files at output_filepath.
 
@@ -33,8 +31,6 @@ def ultra_l1a(
     ----------
     packet_file : str
         Path to the CCSDS data packet file.
-    data_version : str
-        Version of the data product being created.
     apid : Optional[int]
         Optional apid.
 
@@ -64,7 +60,6 @@ def ultra_l1a(
     # Update dataset global attributes
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs("ultra")
-    attr_mgr.add_global_attribute("Data_version", data_version)
     attr_mgr.add_instrument_variable_attrs("ultra", "l1a")
 
     for apid in apids:  # noqa PLR1704 redefined apid variable from outer scope

--- a/imap_processing/ultra/l1b/badtimes.py
+++ b/imap_processing/ultra/l1b/badtimes.py
@@ -11,7 +11,6 @@ def calculate_badtimes(
     extendedspin_dataset: xr.Dataset,
     cullingmask_spins: NDArray,
     name: str,
-    data_version: str,
 ) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Badtimes Data.
@@ -24,8 +23,6 @@ def calculate_badtimes(
         Dataset containing the culled data.
     name : str
         Name of the dataset.
-    data_version : str
-        Version of the data.
 
     Returns
     -------
@@ -38,6 +35,6 @@ def calculate_badtimes(
 
     filtered_dataset = extendedspin_dataset.sel(spin_number=culled_spins)
 
-    badtimes_dataset = create_dataset(filtered_dataset, name, "l1b", data_version)
+    badtimes_dataset = create_dataset(filtered_dataset, name, "l1b")
 
     return badtimes_dataset

--- a/imap_processing/ultra/l1b/cullingmask.py
+++ b/imap_processing/ultra/l1b/cullingmask.py
@@ -6,9 +6,7 @@ from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltra
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_cullingmask(
-    extendedspin_dataset: xr.Dataset, name: str, data_version: str
-) -> xr.Dataset:
+def calculate_cullingmask(extendedspin_dataset: xr.Dataset, name: str) -> xr.Dataset:
     """
     Create dataset with defined datatype for Culling Mask Data.
 
@@ -18,8 +16,6 @@ def calculate_cullingmask(
         Dataset containing the data.
     name : str
         Name of the dataset.
-    data_version : str
-        Version of the data.
 
     Returns
     -------
@@ -47,6 +43,6 @@ def calculate_cullingmask(
         spin_number=extendedspin_dataset["spin_number"][good_mask]
     )
 
-    cullingmask_dataset = create_dataset(filtered_dataset, name, "l1b", data_version)
+    cullingmask_dataset = create_dataset(filtered_dataset, name, "l1b")
 
     return cullingmask_dataset

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -29,7 +29,7 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_de(de_dataset: xr.Dataset, name: str, data_version: str) -> xr.Dataset:
+def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Direct Event Data.
 
@@ -39,8 +39,6 @@ def calculate_de(de_dataset: xr.Dataset, name: str, data_version: str) -> xr.Dat
         L1a dataset containing direct event data.
     name : str
         Name of the l1a dataset.
-    data_version : str
-        Version of the data.
 
     Returns
     -------
@@ -231,6 +229,6 @@ def calculate_de(de_dataset: xr.Dataset, name: str, data_version: str) -> xr.Dat
         len(de_dataset["epoch"]), np.nan, dtype=np.float32
     )
 
-    dataset = create_dataset(de_dict, name, "l1b", data_version)
+    dataset = create_dataset(de_dict, name, "l1b")
 
     return dataset

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -13,7 +13,6 @@ from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 def calculate_extendedspin(
     dict_datasets: dict[str, xr.Dataset],
     name: str,
-    data_version: str,
     instrument_id: int,
 ) -> xr.Dataset:
     """
@@ -25,8 +24,6 @@ def calculate_extendedspin(
         Dictionary containing all the datasets.
     name : str
         Name of the dataset.
-    data_version : str
-        Version of the data.
     instrument_id : int
         Instrument ID.
 
@@ -62,6 +59,6 @@ def calculate_extendedspin(
     extendedspin_dict["quality_attitude"] = attitude_qf
     extendedspin_dict["quality_ena_rates"] = rates_qf
 
-    extendedspin_dataset = create_dataset(extendedspin_dict, name, "l1b", data_version)
+    extendedspin_dataset = create_dataset(extendedspin_dict, name, "l1b")
 
     return extendedspin_dataset

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -8,7 +8,7 @@ from imap_processing.ultra.l1b.de import calculate_de
 from imap_processing.ultra.l1b.extendedspin import calculate_extendedspin
 
 
-def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
+def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A data into L1B CDF files at output_filepath.
 
@@ -16,8 +16,6 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
     ----------
     data_dict : dict
         The data itself and its dependent data.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -39,7 +37,6 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
         de_dataset = calculate_de(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
             f"imap_ultra_l1b_{instrument_id}sensor-de",
-            data_version,
         )
         output_datasets.append(de_dataset)
     # L1b extended data will be created if L1a hk, rates,
@@ -66,19 +63,16 @@ def ultra_l1b(data_dict: dict, data_version: str) -> list[xr.Dataset]:
                 ],
             },
             f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
-            data_version,
             instrument_id,
         )
         cullingmask_dataset = calculate_cullingmask(
             extendedspin_dataset,
             f"imap_ultra_l1b_{instrument_id}sensor-cullingmask",
-            data_version,
         )
         badtimes_dataset = calculate_badtimes(
             extendedspin_dataset,
             cullingmask_dataset["spin_number"].values,
             f"imap_ultra_l1b_{instrument_id}sensor-badtimes",
-            data_version,
         )
         output_datasets.extend(
             [extendedspin_dataset, cullingmask_dataset, badtimes_dataset]

--- a/imap_processing/ultra/l1c/histogram.py
+++ b/imap_processing/ultra/l1c/histogram.py
@@ -6,9 +6,7 @@ import xarray as xr
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
-def calculate_histogram(
-    histogram_dataset: xr.Dataset, name: str, data_version: str
-) -> xr.Dataset:
+def calculate_histogram(histogram_dataset: xr.Dataset, name: str) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Histogram Data.
 
@@ -18,8 +16,6 @@ def calculate_histogram(
         Dataset containing histogram data.
     name : str
         Name of dataset.
-    data_version : str
-        Version of the data.
 
     Returns
     -------
@@ -35,6 +31,6 @@ def calculate_histogram(
     histogram_dict["epoch"] = epoch
     histogram_dict["sid"] = np.zeros(len(epoch), dtype=np.uint8)
 
-    dataset = create_dataset(histogram_dict, name, "l1c", data_version)
+    dataset = create_dataset(histogram_dict, name, "l1c")
 
     return dataset

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -22,7 +22,6 @@ def calculate_spacecraft_pset(
     extendedspin_dataset: xr.Dataset,
     cullingmask_dataset: xr.Dataset,
     name: str,
-    data_version: str,
 ) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
@@ -37,8 +36,6 @@ def calculate_spacecraft_pset(
         Dataset containing cullingmask data.
     name : str
         Name of the dataset.
-    data_version : str
-        Version of the data.
 
     Returns
     -------
@@ -82,6 +79,6 @@ def calculate_spacecraft_pset(
     pset_dict["healpix"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()
 
-    dataset = create_dataset(pset_dict, name, "l1c", data_version)
+    dataset = create_dataset(pset_dict, name, "l1c")
 
     return dataset

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -6,7 +6,7 @@ from imap_processing.ultra.l1c.histogram import calculate_histogram
 from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
 
 
-def ultra_l1c(data_dict: dict, data_version: str) -> list[xr.Dataset]:
+def ultra_l1c(data_dict: dict) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A and L1B data into L1C CDF files at output_filepath.
 
@@ -14,8 +14,6 @@ def ultra_l1c(data_dict: dict, data_version: str) -> list[xr.Dataset]:
     ----------
     data_dict : dict
         The data itself and its dependent data.
-    data_version : str
-        Version of the data product being created.
 
     Returns
     -------
@@ -31,7 +29,6 @@ def ultra_l1c(data_dict: dict, data_version: str) -> list[xr.Dataset]:
         histogram_dataset = calculate_histogram(
             data_dict[f"imap_ultra_l1a_{instrument_id}sensor-histogram"],
             f"imap_ultra_l1c_{instrument_id}sensor-histogram",
-            data_version,
         )
         output_datasets = [histogram_dataset]
     elif (
@@ -44,7 +41,6 @@ def ultra_l1c(data_dict: dict, data_version: str) -> list[xr.Dataset]:
             data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
             data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"],
             f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset",
-            data_version,
         )
         # TODO: add calculate_helio_pset here
         output_datasets = [spacecraft_pset]

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -6,7 +6,9 @@ from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 
 
 def create_dataset(
-    data_dict: dict, name: str, level: str, data_version: str
+    data_dict: dict,
+    name: str,
+    level: str,
 ) -> xr.Dataset:
     """
     Create xarray for L1b data.
@@ -19,8 +21,6 @@ def create_dataset(
         Name of the dataset.
     level : str
         Level of the dataset.
-    data_version : str
-        Version of the data.
 
     Returns
     -------
@@ -30,7 +30,6 @@ def create_dataset(
     cdf_manager = ImapCdfAttributes()
     cdf_manager.add_instrument_global_attrs("ultra")
     cdf_manager.add_instrument_variable_attrs("ultra", level)
-    cdf_manager.add_global_attribute("Data_version", data_version)
 
     # L1b extended spin, badtimes, and cullingmask data products
     if "spin_number" in data_dict.keys():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ addopts = "-ra"
 filterwarnings = [
     "ignore:Converting non-nanosecond:UserWarning:cdflib",
     "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:cdflib",
+    # Ignore Data_version warnings during tests because we default to v001
+    "ignore:No Data_version attribute found:UserWarning:imap_processing",
 ]
 markers = [
     "external_kernel: marks tests as requiring external SPICE kernels (deselect with '-m \"not external_kernel\"')",


### PR DESCRIPTION
# Change Summary

## Overview

We are currently passing version around into every single instrument and requiring all instrument teams to inject the `Data_version` attribute on their own. This is handled in several different ways across instruments, and means that it is also a requirement to do instrument processing. An instrument processing step should only produce a data file, it doesn't need to know anything about which version it is (it may need to know other versions).

Our post-processing step should be injecting the necessary fields, so this pushes that logic into one common place in post-processing to do the global attribute injection.

This is mostly a find/remove job, with one addition being a UserWarning emitted when a default version of `v001` for a file is created (in testing this happens frequently, which I've suppressed as we don't care about it).

Sits on top of #1592 because that is needed to fix some cli mocks.