### PR TITLE
ENA Maps: Convert HealpixSkyMap to RectangularSkyMap

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1203,7 +1203,7 @@ class HealpixSkyMap(AbstractSkyMap):
 
     # Allow for 5 arguments, and self to be passed.
     # ruff: noqa: PLR0913
-    def get_pixel_value_recursive_subdivs(
+    def get_rect_pixel_value_recursive_subdivs(
         self,
         rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
         rect_pix_spacing_deg: float,
@@ -1339,7 +1339,7 @@ class HealpixSkyMap(AbstractSkyMap):
             # for each value key.
             healpix_values_array = self.data_1d[value_key]
             best_value_and_recursion_depth_by_pixel = [
-                self.get_pixel_value_recursive_subdivs(
+                self.get_rect_pixel_value_recursive_subdivs(
                     rect_pix_center_lon_lat=lon_lat,
                     rect_pix_spacing_deg=rect_map.spacing_deg,
                     value_key=value_key,

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1090,7 +1090,7 @@ class HealpixSkyMap(AbstractSkyMap):
         self,
         rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
         rect_pix_spacing_deg: float,
-        value_key: str,
+        value_array: xr.DataArray,
         num_subdivisions: int,
     ) -> np.typing.NDArray:
         """
@@ -1106,8 +1106,8 @@ class HealpixSkyMap(AbstractSkyMap):
             The center longitude and latitude of the rectangular pixel.
         rect_pix_spacing_deg : float
             The spacing of the rectangular pixel in degrees.
-        value_key : str
-            The name of the value to interpolate from the healpix map.
+        value_array : xr.DataArray
+            The data array containing the healpix map values.
         num_subdivisions : int
             The number of subdivisions to create for the rectangular pixel.
             The more subdivisions, the more accurate the interpolation, but also
@@ -1118,9 +1118,8 @@ class HealpixSkyMap(AbstractSkyMap):
         np.typing.NDArray
             The mean value of the healpix map at the subpixel centers.
 
-            If the array associated with the key value_key has a single value
-            at each pixel, the output will be a single value,
-            but if there are other dimensions,
+            If value_array has a single value at each pixel, the output
+            will be a single value, but if there are other dimensions,
             (e.g., if self.data_1d['flux'].sizes =
             {"epoch": 1, "energy": 24, "pixel": 16200}),
             the output will be an array with the same dims except the pixel dimension
@@ -1186,9 +1185,7 @@ class HealpixSkyMap(AbstractSkyMap):
             lonlat=True,
         )
         # Get the healpix values at the rectangular subpixel centers
-        hp_vals_at_rect_pix_ctrs = self.data_1d[value_key].values[
-            ..., hp_pix_at_rect_subpix_ctrs
-        ]
+        hp_vals_at_rect_pix_ctrs = value_array.values[..., hp_pix_at_rect_subpix_ctrs]
 
         # Weighted mean (weighted by solid angle) of these values over the pixel axis,
         # which is the last axis of this array
@@ -1196,8 +1193,7 @@ class HealpixSkyMap(AbstractSkyMap):
             hp_vals_at_rect_pix_ctrs * rect_subpix_solid_angle_by_lat
         )
         mean_pixel_value = (
-            weighted_hp_vals_at_rect_pix_ctrs.sum(axis=(-1))
-            / full_rect_pixel_solid_angle
+            weighted_hp_vals_at_rect_pix_ctrs.sum(axis=-1) / full_rect_pixel_solid_angle
         )
         return mean_pixel_value
 
@@ -1205,7 +1201,7 @@ class HealpixSkyMap(AbstractSkyMap):
         self,
         rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
         rect_pix_spacing_deg: float,
-        value_key: str,
+        value_array: xr.DataArray,
         *,
         rtol: float = 1e-3,
         atol: float = 1e-12,
@@ -1227,8 +1223,8 @@ class HealpixSkyMap(AbstractSkyMap):
             The center longitude and latitude of the rectangular pixel.
         rect_pix_spacing_deg : float
             The spacing of the rectangular pixel in degrees.
-        value_key : str
-            The name of the value to interpolate from the healpix map.
+        value_array : xr.DataArray
+            The data array containing the healpix map values to interpolate from.
         rtol : float, optional
             The relative tolerance for convergence, by default 1e-3.
         atol : float, optional
@@ -1255,7 +1251,7 @@ class HealpixSkyMap(AbstractSkyMap):
                 self.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
                     rect_pix_center_lon_lat=rect_pix_center_lon_lat,
                     rect_pix_spacing_deg=rect_pix_spacing_deg,
-                    value_key=value_key,
+                    value_array=value_array,
                     num_subdivisions=depth,
                 )
             )
@@ -1263,6 +1259,8 @@ class HealpixSkyMap(AbstractSkyMap):
             # Determine if tolerance is met
             # (skip on the 0th iteration, as there's no delta)
             if depth > 0:
+                # TODO: Ask Nick/Ultra Instrument team if we need to compare each value
+                # in the pixel's array, or just the mean value.
                 if np.isclose(
                     mean_pixel_value.mean(),
                     previous_mean_pixel_value.mean(),
@@ -1328,8 +1326,6 @@ class HealpixSkyMap(AbstractSkyMap):
         # Dict to hold the subdivision depth by pixel for each value key
         subdiv_depth_dict = {}
         for value_key in value_keys:
-            self.data_1d[value_key]
-
             # For each of the values, calculate each pixel's value with
             # recursive subdivision. Unfortunately, this must be done independently
             # for each value key.
@@ -1338,7 +1334,7 @@ class HealpixSkyMap(AbstractSkyMap):
                 self.get_rect_pixel_value_recursive_subdivs(
                     rect_pix_center_lon_lat=lon_lat,
                     rect_pix_spacing_deg=rect_map.spacing_deg,
-                    value_key=value_key,
+                    value_array=healpix_values_array,
                     max_subdivision_depth=max_subdivision_depth,
                 )
                 for lon_lat in rect_map.az_el_points

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1085,6 +1085,7 @@ class HealpixSkyMap(AbstractSkyMap):
             }
         )
 
+    # Define methods for converting a Healpix map to a Rectangular map:
     def calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
         self,
         rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
@@ -1093,10 +1094,11 @@ class HealpixSkyMap(AbstractSkyMap):
         num_subdivisions: int,
     ) -> np.typing.NDArray:
         """
-        Interpolate the value of a rectangular pixel from a healpix map w/ subdivisions.
+        Interpolate the value of 1 rectangular pixel from a healpix map w/ subdivisions.
 
-        This function splits a rectangular pixel into smaller subpixels
-        and calculates the mean value of the healpix map at those subpixel centers.
+        This function splits a single rectangular pixel into smaller subpixels
+        and calculates the solid angle weighted mean value of
+        the healpix map at all of the subpixel centers.
 
         Parameters
         ----------
@@ -1115,10 +1117,12 @@ class HealpixSkyMap(AbstractSkyMap):
         -------
         np.typing.NDArray
             The mean value of the healpix map at the subpixel centers.
+
             If the array associated with the key value_key has a single value
             at each pixel, the output will be a single value,
-            but if there are other dimensions, (e.g., if
-            self.data_1d['flux'].sizes = {"epoch": 1, "energy": 24, "pixel": 16200}),
+            but if there are other dimensions,
+            (e.g., if self.data_1d['flux'].sizes =
+            {"epoch": 1, "energy": 24, "pixel": 16200}),
             the output will be an array with the same dims except the pixel dimension
             (e.g., (1, 24)).
         """
@@ -1230,30 +1234,12 @@ class HealpixSkyMap(AbstractSkyMap):
         """
         relative_tolerance, absolute_tolerance = tolerances
 
-        # Calculate mean value at the 0th level of recursion (no subdivision of the pix)
-        # TODO: I think we can put this in the 0th level of recursion and
-        # skip calculating the delta and comparing it to the tolerance
-        depth = 0
-        rect_pix_center_lon_lat = np.reshape(rect_pix_center_lon_lat, (-1, 2))
-        hp_pix_at_rect_subpix_ctr = hp.ang2pix(
-            nside=self.nside,
-            nest=self.nested,
-            theta=rect_pix_center_lon_lat[:, 0],
-            phi=rect_pix_center_lon_lat[:, 1],
-            lonlat=True,
-        )
-        hp_vals_at_rect_pix_ctrs = self.data_1d[value_key].values[
-            ..., hp_pix_at_rect_subpix_ctr
-        ]
-        mean_pixel_value_at_level = [
-            hp_vals_at_rect_pix_ctrs.mean(axis=(-1)),
-        ]
-
         # Recursively subdivide a pixel and calculate its mean value until either the
         # difference between consecutive levels is within the specified tolerances
         # or the maximum recursion depth is reached
+        depth = 0
+        mean_pixel_value_at_level = []
         while depth < MAX_RECURSION_DEPTH:
-            depth += 1
             mean_pixel_value = (
                 self.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
                     rect_pix_center_lon_lat=rect_pix_center_lon_lat,
@@ -1265,21 +1251,22 @@ class HealpixSkyMap(AbstractSkyMap):
             mean_pixel_value_at_level.append(mean_pixel_value)
 
             # Determine if tolerance is met
-            abs_delta = np.abs(
-                mean_pixel_value_at_level[-1].mean()
-                - mean_pixel_value_at_level[-2].mean()
-            )
-            total_abs_tolerance = (
-                relative_tolerance * np.abs(mean_pixel_value_at_level[-1].mean())
-                + absolute_tolerance
-            )
-            if abs_delta < total_abs_tolerance:
-                break
+            if depth > 0:
+                abs_delta = np.abs(
+                    mean_pixel_value_at_level[-1].mean()
+                    - mean_pixel_value_at_level[-2].mean()
+                )
+                total_abs_tolerance = (
+                    relative_tolerance * np.abs(mean_pixel_value_at_level[-1].mean())
+                    + absolute_tolerance
+                )
+                if abs_delta < total_abs_tolerance:
+                    break
+            depth += 1
 
         # Only keep the last (best) mean pixel value
         return mean_pixel_value_at_level[-1], depth
 
-    # Define methods for converting a Healpix map to a Rectangular map
     def to_rectangular_skymap_with_recusive_subdivision(
         self,
         rect_spacing_deg: float,

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -26,7 +26,7 @@ from imap_processing.spice.time import ttj2000ns_to_et
 logger = logging.getLogger(__name__)
 
 # Set the maximum recursion depth for the conversion from Healpix to rectangular SkyMap.
-MAX_RECURSION_DEPTH = 8
+MAX_SUBDIV_RECURSION_DEPTH = 8
 
 
 class SkyTilingType(Enum):
@@ -1085,7 +1085,7 @@ class HealpixSkyMap(AbstractSkyMap):
             }
         )
 
-    # Define methods for converting a Healpix map to a Rectangular map:
+    # Define several methods for converting a Healpix map to a Rectangular map:
     def calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
         self,
         rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
@@ -1094,7 +1094,7 @@ class HealpixSkyMap(AbstractSkyMap):
         num_subdivisions: int,
     ) -> np.typing.NDArray:
         """
-        Interpolate the value of 1 rectangular pixel from a healpix map w/ subdivisions.
+        Interpolate the value of a rectangular pixel from a healpix map w/ subdivisions.
 
         This function splits a single rectangular pixel into smaller subpixels
         and calculates the solid angle weighted mean value of
@@ -1127,7 +1127,8 @@ class HealpixSkyMap(AbstractSkyMap):
             (e.g., (1, 24)).
         """
         # Assumes that you already checked the pixel doesn't fall entirely in an HP pix
-        # TODO: Add this here? It shouldn't really be necessary, as the next function
+        # TODO: Ask Nick if we need to add this here to mimic his code.
+        # It shouldn't really be necessary, as the next function
         # get_pixel_value_recursive_subdivs will finish at 1 subdivision
 
         # Ensure input contains lon in the first column and lat in the second column
@@ -1200,18 +1201,23 @@ class HealpixSkyMap(AbstractSkyMap):
         )
         return mean_pixel_value
 
+    # Allow for 5 arguments, and self to be passed.
+    # ruff: noqa: PLR0913
     def get_pixel_value_recursive_subdivs(
         self,
         rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
         rect_pix_spacing_deg: float,
         value_key: str,
         tolerances: tuple[float, float] = (1e-3, 1e-12),
+        max_subdivision_depth: int = MAX_SUBDIV_RECURSION_DEPTH,
     ) -> tuple[list[np.typing.NDArray], int]:
         """
         Recursively subdivide a rectangular pixel to get a mean value within tolerances.
 
-        Recursively subdivide a rectangular pixel into smaller subpixels until the
-        difference between the mean values of two consecutive subdivisions is within the
+        Takes a rectangular pixel, and recursively breaks it up into
+        smaller and smaller subpixels, then calculates the solid-angle weighted mean
+        of the healpix map's value at this pixel, until the difference
+        between the mean values of two consecutive subdivisions is within the
         specified tolerances. The function returns the mean value at the final level
         of subdivision and the depth of recursion.
 
@@ -1226,6 +1232,12 @@ class HealpixSkyMap(AbstractSkyMap):
         tolerances : tuple[float, float], optional
             The relative and absolute tolerances for convergence,
             by default (1e-3, 1e-12).
+        max_subdivision_depth : int, optional
+            The maximum depth of recursion for subdivision,
+            by default MAX_SUBDIV_RECURSION_DEPTH.
+            Computation grows exponentially with depth, but only where the value
+            has a significant gradient between adjacent healpix pixels.
+            If the value is smooth, the recursion depth will be low.
 
         Returns
         -------
@@ -1239,7 +1251,7 @@ class HealpixSkyMap(AbstractSkyMap):
         # or the maximum recursion depth is reached
         depth = 0
         mean_pixel_value_at_level = []
-        while depth < MAX_RECURSION_DEPTH:
+        while depth < max_subdivision_depth:
             mean_pixel_value = (
                 self.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
                     rect_pix_center_lon_lat=rect_pix_center_lon_lat,
@@ -1251,6 +1263,7 @@ class HealpixSkyMap(AbstractSkyMap):
             mean_pixel_value_at_level.append(mean_pixel_value)
 
             # Determine if tolerance is met
+            # (skip on the 0th iteration, as there's no delta)
             if depth > 0:
                 abs_delta = np.abs(
                     mean_pixel_value_at_level[-1].mean()
@@ -1281,6 +1294,8 @@ class HealpixSkyMap(AbstractSkyMap):
             The spacing of the rectangular map in degrees.
         value_keys : list[str]
             The names of the values to interpolate from the healpix map.
+            Each must be independently interpolated because the subdivision depth
+            depends on the gradient of the value between adjacent healpix pixels.
 
         Returns
         -------
@@ -1295,13 +1310,30 @@ class HealpixSkyMap(AbstractSkyMap):
             spice_frame=self.spice_reference_frame,
         )
 
+        # Depending on the maximum recursion depth, the number of pixels in the
+        # RectangularSkyMap, and the number of value keys, and especially on the
+        # gradients of the values, the number of operations can be very large, so
+        # log key information about the expected number of operations.
+        approx_max_operations = (
+            (4**MAX_SUBDIV_RECURSION_DEPTH) * self.num_points * len(value_keys)
+        )
+        logger.info(
+            f"Converting from a HealpixSkyMap(nside={self.nside}) to a "
+            f"RectangularSkyMap(spacing_deg={rect_spacing_deg}) with recursive "
+            "subdivision.\n The maximum recursion depth is "
+            f"{MAX_SUBDIV_RECURSION_DEPTH}, yielding a maximum number of healpix calls"
+            f" of {approx_max_operations:.3e}."
+        )
+
         # Dict to hold the subdivision depth by pixel for each value key
         subdiv_depth_dict = {}
         for value_key in value_keys:
             self.data_1d[value_key]
 
+            # For each of the values, calculate each pixel's value with
+            # recursive subdivision. Unfortunately, this must be done independently
+            # for each value key.
             healpix_values_array = self.data_1d[value_key]
-
             best_value_and_recursion_depth_by_pixel = [
                 self.get_pixel_value_recursive_subdivs(
                     rect_pix_center_lon_lat=lon_lat,
@@ -1311,14 +1343,18 @@ class HealpixSkyMap(AbstractSkyMap):
                 for lon_lat in rect_map.az_el_points
             ]
 
+            # Store the best value(s) of each pixel in the rectangular map with the
+            # leading coordinates of the healpix map, and the pixel coordinate last
             rect_map.data_1d[value_key] = xr.DataArray(
                 np.moveaxis(
                     [r[0] for r in best_value_and_recursion_depth_by_pixel], 0, -1
                 ),
                 dims=(*healpix_values_array.dims[:-1], CoordNames.GENERIC_PIXEL.value),
             )
+
             # Update the coordinates of the rectangular map with any new coordinates
-            # except the pixel coord, which will be different between
+            # from the healpix map except the pixel coord,
+            # which will be different in the rectangular map.
             for coord in healpix_values_array.coords:
                 if coord not in (
                     CoordNames.GENERIC_PIXEL.value,
@@ -1327,6 +1363,7 @@ class HealpixSkyMap(AbstractSkyMap):
                     rect_map.data_1d.coords[coord] = healpix_values_array.coords[coord]
 
             # Add the subdivision depth by pixel of this value_key to the dictionary
+            # This may be necessary for uncertainty estimation
             subdiv_depth_dict[value_key] = np.array(
                 [r[1] for r in best_value_and_recursion_depth_by_pixel]
             )

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1348,12 +1348,20 @@ class HealpixSkyMap(AbstractSkyMap):
                 for lon_lat in rect_map.az_el_points
             ]
 
+            interpolated_data_by_rect_pixel = np.moveaxis(
+                [r[0] for r in best_value_and_recursion_depth_by_pixel], 0, -1
+            )
+            # This can introduce an extra dim as the last dim of the array
+            # to values with only one dimension
+            if len(healpix_values_array.dims) == 1:
+                interpolated_data_by_rect_pixel = np.squeeze(
+                    interpolated_data_by_rect_pixel,
+                )
+
             # Store the best value(s) of each pixel in the rectangular map with the
             # leading coordinates of the healpix map, and the pixel coordinate last
             rect_map.data_1d[value_key] = xr.DataArray(
-                np.moveaxis(
-                    [r[0] for r in best_value_and_recursion_depth_by_pixel], 0, -1
-                ),
+                data=interpolated_data_by_rect_pixel,
                 dims=(*healpix_values_array.dims[:-1], CoordNames.GENERIC_PIXEL.value),
             )
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -25,6 +25,9 @@ from imap_processing.spice.time import ttj2000ns_to_et
 
 logger = logging.getLogger(__name__)
 
+# Set the maximum recursion depth for the conversion from Healpix to rectangular SkyMap.
+MAX_RECURSION_DEPTH = 8
+
 
 class SkyTilingType(Enum):
     """Enumeration of the types of tiling used in the ENA maps."""
@@ -1081,6 +1084,267 @@ class HealpixSkyMap(AbstractSkyMap):
                 CoordNames.GENERIC_PIXEL.value: np.arange(self.num_points),
             }
         )
+
+    def calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
+        self,
+        rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
+        rect_pix_spacing_deg: float,
+        value_key: str,
+        num_subdivisions: int,
+    ) -> np.typing.NDArray:
+        """
+        Interpolate the value of a rectangular pixel from a healpix map w/ subdivisions.
+
+        This function splits a rectangular pixel into smaller subpixels
+        and calculates the mean value of the healpix map at those subpixel centers.
+
+        Parameters
+        ----------
+        rect_pix_center_lon_lat : np.typing.NDArray | tuple[float, float]
+            The center longitude and latitude of the rectangular pixel.
+        rect_pix_spacing_deg : float
+            The spacing of the rectangular pixel in degrees.
+        value_key : str
+            The name of the value to interpolate from the healpix map.
+        num_subdivisions : int
+            The number of subdivisions to create for the rectangular pixel.
+            The more subdivisions, the more accurate the interpolation, but also
+            the more computationally expensive it is.
+
+        Returns
+        -------
+        np.typing.NDArray
+            The mean value of the healpix map at the subpixel centers.
+            If the array associated with the key value_key has a single value
+            at each pixel, the output will be a single value,
+            but if there are other dimensions, (e.g., if
+            self.data_1d['flux'].sizes = {"epoch": 1, "energy": 24, "pixel": 16200}),
+            the output will be an array with the same dims except the pixel dimension
+            (e.g., (1, 24)).
+        """
+        # Assumes that you already checked the pixel doesn't fall entirely in an HP pix
+        # TODO: Add this here? It shouldn't really be necessary, as the next function
+        # get_pixel_value_recursive_subdivs will finish at 1 subdivision
+
+        # Ensure input contains lon in the first column and lat in the second column
+        rect_pix_center_lon_lat = np.array(rect_pix_center_lon_lat).reshape(-1, 2)
+
+        # Calculate the number of subdivisions and the spacing of the subpixels
+        # Then calculate the subpixel centers
+        n_subpix_side = 2**num_subdivisions
+        subpix_spacing = rect_pix_spacing_deg / n_subpix_side
+        left_edge_lon = rect_pix_center_lon_lat[:, 0] - rect_pix_spacing_deg / 2
+        bottom_edge_lat = rect_pix_center_lon_lat[:, 1] - rect_pix_spacing_deg / 2
+
+        rect_subpix_lon_ctrs = (
+            left_edge_lon
+            + subpix_spacing * np.arange(n_subpix_side)
+            + subpix_spacing / 2
+        )
+        rect_subpix_lat_ctrs = (
+            bottom_edge_lat
+            + subpix_spacing * np.arange(n_subpix_side)
+            + subpix_spacing / 2
+        )
+
+        # We must weight by solid angle, which is not exactly equal for all subpixels
+        # Calculate the solid angle of the full rectangular pixel (sterad)
+        full_rect_pixel_solid_angle = np.deg2rad(rect_pix_spacing_deg) * (
+            np.sin(np.deg2rad(bottom_edge_lat + rect_pix_spacing_deg))
+            - np.sin(np.deg2rad(bottom_edge_lat))
+        )
+
+        # Calculate solid angle of each subpix from the rect_subpix_lat_ctrs (sterad)
+        all_edges_lat = bottom_edge_lat + np.arange(n_subpix_side + 1) * subpix_spacing
+        sine_all_edges_lat = np.sin(np.deg2rad(all_edges_lat))
+        rect_subpix_solid_angle_by_lat = np.diff(sine_all_edges_lat) * np.deg2rad(
+            subpix_spacing
+        )
+        rect_subpix_solid_angle_by_lat = np.repeat(
+            rect_subpix_solid_angle_by_lat[np.newaxis, :], n_subpix_side, axis=0
+        ).reshape(-1)
+
+        rect_subpix_ctrs = (
+            np.array(
+                np.meshgrid(rect_subpix_lon_ctrs, rect_subpix_lat_ctrs, indexing="ij")
+            )
+            .reshape(2, -1)
+            .T
+        )
+
+        # Get the healpix pixel indices at the rectangular subpixel centers
+        hp_pix_at_rect_subpix_ctrs = hp.ang2pix(
+            nside=self.nside,
+            nest=self.nested,
+            theta=rect_subpix_ctrs[:, 0],
+            phi=rect_subpix_ctrs[:, 1],
+            lonlat=True,
+        )
+        # Get the healpix values at the rectangular subpixel centers
+        hp_vals_at_rect_pix_ctrs = self.data_1d[value_key].values[
+            ..., hp_pix_at_rect_subpix_ctrs
+        ]
+
+        # Weighted mean (weighted by solid angle) of these values over the pixel axis,
+        # which is the last axis of this array
+        weighted_hp_vals_at_rect_pix_ctrs = (
+            hp_vals_at_rect_pix_ctrs * rect_subpix_solid_angle_by_lat
+        )
+        mean_pixel_value = (
+            weighted_hp_vals_at_rect_pix_ctrs.sum(axis=(-1))
+            / full_rect_pixel_solid_angle
+        )
+        return mean_pixel_value
+
+    def get_pixel_value_recursive_subdivs(
+        self,
+        rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
+        rect_pix_spacing_deg: float,
+        value_key: str,
+        tolerances: tuple[float, float] = (1e-3, 1e-12),
+    ) -> tuple[list[np.typing.NDArray], int]:
+        """
+        Recursively subdivide a rectangular pixel to get a mean value within tolerances.
+
+        Recursively subdivide a rectangular pixel into smaller subpixels until the
+        difference between the mean values of two consecutive subdivisions is within the
+        specified tolerances. The function returns the mean value at the final level
+        of subdivision and the depth of recursion.
+
+        Parameters
+        ----------
+        rect_pix_center_lon_lat : np.typing.NDArray | tuple[float, float]
+            The center longitude and latitude of the rectangular pixel.
+        rect_pix_spacing_deg : float
+            The spacing of the rectangular pixel in degrees.
+        value_key : str
+            The name of the value to interpolate from the healpix map.
+        tolerances : tuple[float, float], optional
+            The relative and absolute tolerances for convergence,
+            by default (1e-3, 1e-12).
+
+        Returns
+        -------
+        tuple[list[float], int]
+            The mean value at the final level of subdivision and the depth of recursion.
+        """
+        relative_tolerance, absolute_tolerance = tolerances
+
+        # Calculate mean value at the 0th level of recursion (no subdivision of the pix)
+        # TODO: I think we can put this in the 0th level of recursion and
+        # skip calculating the delta and comparing it to the tolerance
+        depth = 0
+        rect_pix_center_lon_lat = np.reshape(rect_pix_center_lon_lat, (-1, 2))
+        hp_pix_at_rect_subpix_ctr = hp.ang2pix(
+            nside=self.nside,
+            nest=self.nested,
+            theta=rect_pix_center_lon_lat[:, 0],
+            phi=rect_pix_center_lon_lat[:, 1],
+            lonlat=True,
+        )
+        hp_vals_at_rect_pix_ctrs = self.data_1d[value_key].values[
+            ..., hp_pix_at_rect_subpix_ctr
+        ]
+        mean_pixel_value_at_level = [
+            hp_vals_at_rect_pix_ctrs.mean(axis=(-1)),
+        ]
+
+        # Recursively subdivide a pixel and calculate its mean value until either the
+        # difference between consecutive levels is within the specified tolerances
+        # or the maximum recursion depth is reached
+        while depth < MAX_RECURSION_DEPTH:
+            depth += 1
+            mean_pixel_value = (
+                self.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
+                    rect_pix_center_lon_lat=rect_pix_center_lon_lat,
+                    rect_pix_spacing_deg=rect_pix_spacing_deg,
+                    value_key=value_key,
+                    num_subdivisions=depth,
+                )
+            )
+            mean_pixel_value_at_level.append(mean_pixel_value)
+
+            # Determine if tolerance is met
+            abs_delta = np.abs(
+                mean_pixel_value_at_level[-1].mean()
+                - mean_pixel_value_at_level[-2].mean()
+            )
+            total_abs_tolerance = (
+                relative_tolerance * np.abs(mean_pixel_value_at_level[-1].mean())
+                + absolute_tolerance
+            )
+            if abs_delta < total_abs_tolerance:
+                break
+
+        # Only keep the last (best) mean pixel value
+        return mean_pixel_value_at_level[-1], depth
+
+    # Define methods for converting a Healpix map to a Rectangular map
+    def to_rectangular_skymap_with_recusive_subdivision(
+        self,
+        rect_spacing_deg: float,
+        value_keys: list[str],
+    ) -> tuple[RectangularSkyMap, dict[str, np.typing.NDArray]]:
+        """
+        Interpolate a healpix map to a rectangular map using recursive subdivision.
+
+        Parameters
+        ----------
+        rect_spacing_deg : float
+            The spacing of the rectangular map in degrees.
+        value_keys : list[str]
+            The names of the values to interpolate from the healpix map.
+
+        Returns
+        -------
+        tuple[RectangularSkyMap, dict[str, np.typing.NDArray]]
+            A RectangularSkyMap containing the interpolated values, and a dictionary of
+            each value and its corresponding subdivision depth by pixel.
+        """
+        # Begin by defining the rectangular map we want to create, which must be
+        # in the same spice reference frame as the healpix map
+        rect_map = RectangularSkyMap(
+            spacing_deg=rect_spacing_deg,
+            spice_frame=self.spice_reference_frame,
+        )
+
+        # Dict to hold the subdivision depth by pixel for each value key
+        subdiv_depth_dict = {}
+        for value_key in value_keys:
+            self.data_1d[value_key]
+
+            healpix_values_array = self.data_1d[value_key]
+
+            best_value_and_recursion_depth_by_pixel = [
+                self.get_pixel_value_recursive_subdivs(
+                    rect_pix_center_lon_lat=lon_lat,
+                    rect_pix_spacing_deg=rect_map.spacing_deg,
+                    value_key=value_key,
+                )
+                for lon_lat in rect_map.az_el_points
+            ]
+
+            rect_map.data_1d[value_key] = xr.DataArray(
+                np.moveaxis(
+                    [r[0] for r in best_value_and_recursion_depth_by_pixel], 0, -1
+                ),
+                dims=(*healpix_values_array.dims[:-1], CoordNames.GENERIC_PIXEL.value),
+            )
+            # Update the coordinates of the rectangular map with any new coordinates
+            # except the pixel coord, which will be different between
+            for coord in healpix_values_array.coords:
+                if coord not in (
+                    CoordNames.GENERIC_PIXEL.value,
+                    CoordNames.HEALPIX_INDEX.value,
+                ):
+                    rect_map.data_1d.coords[coord] = healpix_values_array.coords[coord]
+
+            # Add the subdivision depth by pixel of this value_key to the dictionary
+            subdiv_depth_dict[value_key] = np.array(
+                [r[1] for r in best_value_and_recursion_depth_by_pixel]
+            )
+
+        return rect_map, subdiv_depth_dict
 
     def __repr__(self) -> str:
         """

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1339,6 +1339,8 @@ class HealpixSkyMap(AbstractSkyMap):
             # For each of the values, calculate each pixel's value with
             # recursive subdivision. Unfortunately, this must be done independently
             # for each value key.
+
+            # Yields a list of tuple (mean_value, depth) for each pixel in the map
             healpix_values_array = self.data_1d[value_key]
             best_value_and_recursion_depth_by_pixel = [
                 self.get_rect_pixel_value_recursive_subdivs(
@@ -1350,9 +1352,17 @@ class HealpixSkyMap(AbstractSkyMap):
                 for lon_lat in rect_map.az_el_points
             ]
 
-            interpolated_data_by_rect_pixel = np.moveaxis(
-                [r[0] for r in best_value_and_recursion_depth_by_pixel], 0, -1
+            # Separate the best value and the recursion depth for each pixel
+            # into two lists, then convert both to numpy arrays
+            # and move the pixel dim to the last dim of values
+            interpolated_data_by_rect_pixel, subdiv_depth_of_value_by_pixel = zip(
+                *best_value_and_recursion_depth_by_pixel
             )
+            interpolated_data_by_rect_pixel = np.moveaxis(
+                np.array(interpolated_data_by_rect_pixel), 0, -1
+            )
+            subdiv_depth_of_value_by_pixel = np.array(subdiv_depth_of_value_by_pixel)
+
             # This can introduce an extra dim as the last dim of the array
             # to values with only one dimension
             if len(healpix_values_array.dims) == 1:
@@ -1379,9 +1389,6 @@ class HealpixSkyMap(AbstractSkyMap):
 
             # Add the subdivision depth by pixel of this value_key to the dictionary
             # This may be necessary for uncertainty estimation
-            subdiv_depth_of_value_by_pixel = np.array(
-                [r[1] for r in best_value_and_recursion_depth_by_pixel]
-            )
             subdiv_depth_dict[value_key] = subdiv_depth_of_value_by_pixel
             logger.info(
                 f"Summary of subdivision depth for {value_key}:\n"

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1280,10 +1280,11 @@ class HealpixSkyMap(AbstractSkyMap):
         # Only keep the last (best) mean pixel value
         return mean_pixel_value_at_level[-1], depth
 
-    def to_rectangular_skymap_with_recusive_subdivision(
+    def to_rectangular_skymap(
         self,
         rect_spacing_deg: float,
         value_keys: list[str],
+        max_subdivision_depth: int = MAX_SUBDIV_RECURSION_DEPTH,
     ) -> tuple[RectangularSkyMap, dict[str, np.typing.NDArray]]:
         """
         Interpolate a healpix map to a rectangular map using recursive subdivision.
@@ -1296,6 +1297,9 @@ class HealpixSkyMap(AbstractSkyMap):
             The names of the values to interpolate from the healpix map.
             Each must be independently interpolated because the subdivision depth
             depends on the gradient of the value between adjacent healpix pixels.
+        max_subdivision_depth : int, optional
+            The maximum depth of recursion for subdivision,
+            by default MAX_SUBDIV_RECURSION_DEPTH.
 
         Returns
         -------
@@ -1315,13 +1319,13 @@ class HealpixSkyMap(AbstractSkyMap):
         # gradients of the values, the number of operations can be very large, so
         # log key information about the expected number of operations.
         approx_max_operations = (
-            (4**MAX_SUBDIV_RECURSION_DEPTH) * self.num_points * len(value_keys)
+            (4**max_subdivision_depth) * self.num_points * len(value_keys)
         )
         logger.info(
             f"Converting from a HealpixSkyMap(nside={self.nside}) to a "
             f"RectangularSkyMap(spacing_deg={rect_spacing_deg}) with recursive "
             "subdivision.\n The maximum recursion depth is "
-            f"{MAX_SUBDIV_RECURSION_DEPTH}, yielding a maximum number of healpix calls"
+            f"{max_subdivision_depth}, yielding a maximum number of healpix calls"
             f" of {approx_max_operations:.3e}."
         )
 
@@ -1339,6 +1343,7 @@ class HealpixSkyMap(AbstractSkyMap):
                     rect_pix_center_lon_lat=lon_lat,
                     rect_pix_spacing_deg=rect_map.spacing_deg,
                     value_key=value_key,
+                    max_subdivision_depth=max_subdivision_depth,
                 )
                 for lon_lat in rect_map.az_el_points
             ]

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1201,15 +1201,12 @@ class HealpixSkyMap(AbstractSkyMap):
         )
         return mean_pixel_value
 
-    # Allow for 5 arguments, and self to be passed.
-    # ruff: noqa: PLR0913
     def get_rect_pixel_value_recursive_subdivs(
         self,
         rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
         rect_pix_spacing_deg: float,
         value_key: str,
-        tolerances: tuple[float, float] = (1e-3, 1e-12),
-        max_subdivision_depth: int = MAX_SUBDIV_RECURSION_DEPTH,
+        **kwargs: float | int,
     ) -> tuple[np.typing.NDArray, int]:
         """
         Recursively subdivide a rectangular pixel to get a mean value within tolerances.
@@ -1229,28 +1226,36 @@ class HealpixSkyMap(AbstractSkyMap):
             The spacing of the rectangular pixel in degrees.
         value_key : str
             The name of the value to interpolate from the healpix map.
-        tolerances : tuple[float, float], optional
-            The relative and absolute tolerances for convergence,
-            by default (1e-3, 1e-12).
-        max_subdivision_depth : int, optional
-            The maximum depth of recursion for subdivision,
-            by default MAX_SUBDIV_RECURSION_DEPTH.
-            Computation grows exponentially with depth, but only where the value
-            has a significant gradient between adjacent healpix pixels.
-            If the value is smooth, the recursion depth will be low.
+        **kwargs
+            Overrides to the default values for the following
+            rtol : float, optional
+                The relative tolerance for convergence, by default 1e-3.
+            atol : float, optional
+                The absolute tolerance for convergence, by default 1e-12.
+            max_subdivision_depth : int, optional
+                The maximum depth of recursion for subdivision,
+                by default MAX_SUBDIV_RECURSION_DEPTH.
+                Computation grows exponentially with depth, but only where the value
+                has a significant gradient between adjacent healpix pixels.
+                If the value is smooth, the recursion depth will be low.
 
         Returns
         -------
         tuple[list[float], int]
             The mean value at the final level of subdivision and the depth of recursion.
         """
-        relative_tolerance, absolute_tolerance = tolerances
+        # Get relative/absolute tolerances and max depth from kwargs, or use defaults
+        relative_tolerance = kwargs.get("rtol", 1e-3)
+        absolute_tolerance = kwargs.get("atol", 1e-12)
+        max_subdivision_depth = kwargs.get(
+            "max_subdivision_depth", MAX_SUBDIV_RECURSION_DEPTH
+        )
 
         # Recursively subdivide a pixel and calculate its mean value until either the
         # difference between consecutive levels is within the specified tolerances
         # or the maximum recursion depth is reached
         depth = 0
-        mean_pixel_value_at_level = []
+        previous_mean_pixel_value: NDArray = np.full((1,), np.nan)
         while depth < max_subdivision_depth:
             mean_pixel_value = (
                 self.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
@@ -1260,25 +1265,22 @@ class HealpixSkyMap(AbstractSkyMap):
                     num_subdivisions=depth,
                 )
             )
-            mean_pixel_value_at_level.append(mean_pixel_value)
 
             # Determine if tolerance is met
             # (skip on the 0th iteration, as there's no delta)
             if depth > 0:
-                abs_delta = np.abs(
-                    mean_pixel_value_at_level[-1].mean()
-                    - mean_pixel_value_at_level[-2].mean()
-                )
-                total_abs_tolerance = (
-                    relative_tolerance * np.abs(mean_pixel_value_at_level[-1].mean())
-                    + absolute_tolerance
-                )
-                if abs_delta < total_abs_tolerance:
+                if np.isclose(
+                    mean_pixel_value.mean(),
+                    previous_mean_pixel_value.mean(),
+                    rtol=relative_tolerance,
+                    atol=absolute_tolerance,
+                ):
                     break
             depth += 1
+            previous_mean_pixel_value = mean_pixel_value
 
         # Only keep the last (best) mean pixel value
-        return mean_pixel_value_at_level[-1], depth
+        return mean_pixel_value, depth
 
     def to_rectangular_skymap(
         self,

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1195,6 +1195,11 @@ class HealpixSkyMap(AbstractSkyMap):
         mean_pixel_value = (
             weighted_hp_vals_at_rect_pix_ctrs.sum(axis=-1) / full_rect_pixel_solid_angle
         )
+        # Log the mean pixel value and the number of subdivisions for debugging
+        logger.debug(
+            f"    Mean pixel value at Number of subdivisions: {num_subdivisions}: "
+            f"array of shape {mean_pixel_value.shape}: {mean_pixel_value}"
+        )
         return mean_pixel_value
 
     def get_rect_pixel_value_recursive_subdivs(  # noqa: PLR0913
@@ -1271,6 +1276,11 @@ class HealpixSkyMap(AbstractSkyMap):
             depth += 1
             previous_mean_pixel_value = mean_pixel_value
 
+        logger.debug(
+            f"Pixel at ({rect_pix_center_lon_lat} deg size={rect_pix_spacing_deg} deg,)"
+            f" converged to {mean_pixel_value.mean()} in {depth} subdivisions."
+            f" Previous mean was {previous_mean_pixel_value.mean()}."
+        )
         # Only keep the last (best) mean pixel value
         return mean_pixel_value, depth
 
@@ -1369,8 +1379,20 @@ class HealpixSkyMap(AbstractSkyMap):
 
             # Add the subdivision depth by pixel of this value_key to the dictionary
             # This may be necessary for uncertainty estimation
-            subdiv_depth_dict[value_key] = np.array(
+            subdiv_depth_of_value_by_pixel = np.array(
                 [r[1] for r in best_value_and_recursion_depth_by_pixel]
+            )
+            subdiv_depth_dict[value_key] = subdiv_depth_of_value_by_pixel
+            logger.info(
+                f"Summary of subdivision depth for {value_key}:\n"
+                "Mean +/- std number of subdivisions for the "
+                f"{rect_map.num_points} pixels of {value_key} is:\n"
+                f"    {np.mean(subdiv_depth_of_value_by_pixel):.6f}."
+                f" +/- {np.std(subdiv_depth_of_value_by_pixel):.6f}.\n"
+                "Min / Max number of subdivisions: \n"
+                f"    {np.min(subdiv_depth_of_value_by_pixel):.6f} / "
+                f"{np.max(subdiv_depth_of_value_by_pixel):.6f}.\n"
+                f"The maximum allowed depth is {max_subdivision_depth}."
             )
 
         return rect_map, subdiv_depth_dict

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1201,12 +1201,15 @@ class HealpixSkyMap(AbstractSkyMap):
         )
         return mean_pixel_value
 
-    def get_rect_pixel_value_recursive_subdivs(
+    def get_rect_pixel_value_recursive_subdivs(  # noqa: PLR0913
         self,
         rect_pix_center_lon_lat: np.typing.NDArray | tuple[float, float],
         rect_pix_spacing_deg: float,
         value_key: str,
-        **kwargs: float | int,
+        *,
+        rtol: float = 1e-3,
+        atol: float = 1e-12,
+        max_subdivision_depth: int = MAX_SUBDIV_RECURSION_DEPTH,
     ) -> tuple[np.typing.NDArray, int]:
         """
         Recursively subdivide a rectangular pixel to get a mean value within tolerances.
@@ -1226,31 +1229,22 @@ class HealpixSkyMap(AbstractSkyMap):
             The spacing of the rectangular pixel in degrees.
         value_key : str
             The name of the value to interpolate from the healpix map.
-        **kwargs
-            Overrides to the default values for the following
-            rtol : float, optional
-                The relative tolerance for convergence, by default 1e-3.
-            atol : float, optional
-                The absolute tolerance for convergence, by default 1e-12.
-            max_subdivision_depth : int, optional
-                The maximum depth of recursion for subdivision,
-                by default MAX_SUBDIV_RECURSION_DEPTH.
-                Computation grows exponentially with depth, but only where the value
-                has a significant gradient between adjacent healpix pixels.
-                If the value is smooth, the recursion depth will be low.
+        rtol : float, optional
+            The relative tolerance for convergence, by default 1e-3.
+        atol : float, optional
+            The absolute tolerance for convergence, by default 1e-12.
+        max_subdivision_depth : int, optional
+            The maximum depth of recursion for subdivision,
+            by default MAX_SUBDIV_RECURSION_DEPTH.
+            Computation grows exponentially with depth, but only where the value
+            has a significant gradient between adjacent healpix pixels.
+            If the value is smooth, the recursion depth will be low.
 
         Returns
         -------
         tuple[list[float], int]
             The mean value at the final level of subdivision and the depth of recursion.
         """
-        # Get relative/absolute tolerances and max depth from kwargs, or use defaults
-        relative_tolerance = kwargs.get("rtol", 1e-3)
-        absolute_tolerance = kwargs.get("atol", 1e-12)
-        max_subdivision_depth = kwargs.get(
-            "max_subdivision_depth", MAX_SUBDIV_RECURSION_DEPTH
-        )
-
         # Recursively subdivide a pixel and calculate its mean value until either the
         # difference between consecutive levels is within the specified tolerances
         # or the maximum recursion depth is reached
@@ -1272,8 +1266,8 @@ class HealpixSkyMap(AbstractSkyMap):
                 if np.isclose(
                     mean_pixel_value.mean(),
                     previous_mean_pixel_value.mean(),
-                    rtol=relative_tolerance,
-                    atol=absolute_tolerance,
+                    rtol=rtol,
+                    atol=atol,
                 ):
                     break
             depth += 1

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1210,7 +1210,7 @@ class HealpixSkyMap(AbstractSkyMap):
         value_key: str,
         tolerances: tuple[float, float] = (1e-3, 1e-12),
         max_subdivision_depth: int = MAX_SUBDIV_RECURSION_DEPTH,
-    ) -> tuple[list[np.typing.NDArray], int]:
+    ) -> tuple[np.typing.NDArray, int]:
         """
         Recursively subdivide a rectangular pixel to get a mean value within tolerances.
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -804,6 +804,7 @@ class TestHealpixSkyMap:
             4: 107.5,  # 0.5/107.5 = 0.00465116 change
             5: 107.51,  # 0.01/107.51 = 0.00009301 change
             6: 107.5099,  # 0.0001/107.5099 = 0.00000093 change
+            7: 120,  # Big change - but will stop because of MAX SUBDIVS
         }
         required_rtols = [
             0.1,
@@ -812,6 +813,7 @@ class TestHealpixSkyMap:
             0.005,
             0.0001,
             0.000001,
+            1e-12,
         ]
 
         mock_calculate_rect_pixel_value_from_healpix_map_n_subdivisions.side_effect = (
@@ -834,12 +836,71 @@ class TestHealpixSkyMap:
                 rect_pix_spacing_deg=4,
                 value_key="counts",
                 tolerances=(required_rtols[expected_subdiv_level - 1], 0),
+                max_subdivision_depth=7,
             )
             assert depth == expected_subdiv_level
             np.testing.assert_equal(
                 mean,
                 value_by_subdivisions[expected_subdiv_level],
                 err_msg=f"Failed for expected_subdiv_level: {expected_subdiv_level}",
+            )
+
+    def test_to_rectangular_skymap_with_recusive_subdivision(
+        self,
+    ):
+        hp_map = ena_maps.HealpixSkyMap(
+            nside=64,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+
+        hp_map.data_1d["counts"] = xr.DataArray(
+            data=np.fromfunction(
+                lambda time, energy, pixel: 1000 + pixel * (10 * (energy + 1)),
+                shape=(1, 10, hp_map.num_points),
+                dtype=np.float32,
+            ),
+            dims=["epoch", "energy", "pixel"],
+        )
+        hp_map.data_1d["exposure_factor"] = xr.DataArray(
+            data=np.ones((10, hp_map.num_points)),
+            dims=["energy", "pixel"],
+        )
+
+        rect_map, subdiv_depth_dict = (
+            hp_map.to_rectangular_skymap_with_recusive_subdivision(
+                rect_spacing_deg=2,
+                value_keys=["counts", "exposure_factor"],
+            )
+        )
+
+        for value_key, subdiv_depth in subdiv_depth_dict.items():
+            # subdiv depth should always be between 1 and
+            # ena_maps.MAX_SUBDIV_RECURSION_DEPTH
+            np.testing.assert_array_less(
+                0,
+                subdiv_depth,
+                err_msg=f"subdiv <1 for: {value_key}",
+            )
+            np.testing.assert_array_less(
+                subdiv_depth,
+                ena_maps.MAX_SUBDIV_RECURSION_DEPTH + 1,
+                err_msg=f"subdiv >MAX for: {value_key}",
+            )
+
+            # The min and max values of the rect and healpix maps should be close
+            # The min will have a larger relative tolerance because the variation
+            # in the test data is larger in comparison to the min value than to the max
+            np.testing.assert_allclose(
+                rect_map.data_1d[value_key].min(),
+                hp_map.data_1d[value_key].min(),
+                rtol=5e-2,
+                err_msg=f"Min values of {value_key} do not match",
+            )
+            np.testing.assert_allclose(
+                rect_map.data_1d[value_key].max(),
+                hp_map.data_1d[value_key].max(),
+                rtol=1e-3,
+                err_msg=f"Max values of {value_key} do not match",
             )
 
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -789,7 +789,7 @@ class TestHealpixSkyMap:
     @mock.patch(
         "imap_processing.ena_maps.ena_maps.HealpixSkyMap.calculate_rect_pixel_value_from_healpix_map_n_subdivisions"
     )
-    def test_get_pixel_value_recursive_subdivs(
+    def test_get_rect_pixel_value_recursive_subdivs(
         self,
         mock_calculate_rect_pixel_value_from_healpix_map_n_subdivisions,
     ):
@@ -831,7 +831,7 @@ class TestHealpixSkyMap:
         # Test the recursive subdivision by setting different tolerances to get the
         # expected number of subdivisions and resultant mean value.
         for expected_subdiv_level in range(1, len(required_rtols)):
-            mean, depth = hp_map.get_pixel_value_recursive_subdivs(
+            mean, depth = hp_map.get_rect_pixel_value_recursive_subdivs(
                 rect_pix_center_lon_lat=(180, 0),
                 rect_pix_spacing_deg=4,
                 value_key="counts",
@@ -845,7 +845,7 @@ class TestHealpixSkyMap:
                 err_msg=f"Failed for expected_subdiv_level: {expected_subdiv_level}",
             )
 
-    def test_to_rectangular_skymap_with_recusive_subdivision(
+    def test_to_rectangular_skymap(
         self,
     ):
         hp_map = ena_maps.HealpixSkyMap(
@@ -866,11 +866,9 @@ class TestHealpixSkyMap:
             dims=["energy", "pixel"],
         )
 
-        rect_map, subdiv_depth_dict = (
-            hp_map.to_rectangular_skymap_with_recusive_subdivision(
-                rect_spacing_deg=2,
-                value_keys=["counts", "exposure_factor"],
-            )
+        rect_map, subdiv_depth_dict = hp_map.to_rectangular_skymap(
+            rect_spacing_deg=2,
+            value_keys=["counts", "exposure_factor"],
         )
 
         for value_key, subdiv_depth in subdiv_depth_dict.items():
@@ -901,6 +899,13 @@ class TestHealpixSkyMap:
                 hp_map.data_1d[value_key].max(),
                 rtol=1e-3,
                 err_msg=f"Max values of {value_key} do not match",
+            )
+
+            # The dims of the rect map should be the same as the healpix map,
+            # except for the final pixel dimension
+            assert (
+                rect_map.data_1d[value_key].dims[:-1]
+                == hp_map.data_1d[value_key].dims[:-1]
             )
 
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -835,7 +835,7 @@ class TestHealpixSkyMap:
                 rect_pix_center_lon_lat=(180, 0),
                 rect_pix_spacing_deg=4,
                 value_key="counts",
-                tolerances=(required_rtols[expected_subdiv_level - 1], 0),
+                rtol=required_rtols[expected_subdiv_level - 1],
                 max_subdivision_depth=7,
             )
             assert depth == expected_subdiv_level

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -697,6 +697,151 @@ class TestHealpixSkyMap:
             hp_map.data_1d["counts"].values,
         )
 
+    @mock.patch("astropy_healpix.healpy.ang2pix")
+    def test_calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
+        self,
+        mock_ang2pix,
+    ):
+        """Test getting rectangular pixel values from HealpixSkyMap via subdivision."""
+
+        # Mock ang2pix to return fixed values based on a dict
+        pixel_dict = {
+            # 0 subdiv - just 1 pixel
+            (180, 0): 0,
+            # 1 subdiv - all subpix have same solid angle because centered on equator
+            (179, -1): 1,
+            (179, 1): 2,
+            (181, -1): 3,
+            (181, 1): 4,
+            # 2 subdiv - 'Inner' subpix have larger solid angle than 'outer' subpix
+            (178.5, -1.5): 5,
+            (178.5, -0.5): 6,
+            (178.5, 0.5): 7,
+            (178.5, 1.5): 8,
+            (179.5, -1.5): 9,
+            (179.5, -0.5): 10,
+            (179.5, 0.5): 11,
+            (179.5, 1.5): 12,
+            (180.5, -1.5): 12,
+            (180.5, -0.5): 14,
+            (180.5, 0.5): 15,
+            (180.5, 1.5): 16,
+            (181.5, -1.5): 17,
+            (181.5, -0.5): 18,
+            (181.5, 0.5): 19,
+            (181.5, 1.5): 20,
+        }
+        expected_mean_0_subdivisions = 0
+        expected_mean_1_subdivisions = 2.5
+        expected_mean_2_subdivisions = 12.5
+
+        def mock_ang2pix_fn(nside, theta, phi, nest=True, lonlat=False):
+            vals = []
+            for pix_num in range(len(theta)):
+                key = (theta[pix_num], phi[pix_num])
+                vals.append(pixel_dict.get(key, 0))
+            return np.array(vals)
+
+        hp_map = ena_maps.HealpixSkyMap(
+            nside=16,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+            nested=True,
+        )
+        hp_map.data_1d["counts"] = xr.DataArray(
+            data=[
+                np.arange(hp_map.num_points),
+            ],
+            dims=["epoch", "pixel"],
+        )
+
+        for num_subdiv, (expected_value, atol) in enumerate(
+            [
+                # The first subdivs have all the same solid angle
+                (expected_mean_0_subdivisions, 1e-9),
+                (expected_mean_1_subdivisions, 1e-9),
+                # Slight difference from not taking into account asym solid angle
+                (expected_mean_2_subdivisions, 0.1),
+            ]
+        ):
+            mock_ang2pix.reset_mock()
+            mock_ang2pix.side_effect = mock_ang2pix_fn
+            mean_value = (
+                hp_map.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
+                    rect_pix_center_lon_lat=(180, 0),
+                    rect_pix_spacing_deg=4,
+                    value_key="counts",
+                    num_subdivisions=num_subdiv,
+                )
+            )
+            np.testing.assert_allclose(
+                mean_value,
+                expected_value,
+                atol=atol,
+                err_msg=f"Failed for num_subdivisions: {num_subdiv}",
+            )
+        hp_map.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
+            rect_pix_center_lon_lat=(180, 0),
+            rect_pix_spacing_deg=2,
+            value_key="counts",
+            num_subdivisions=0,
+        )
+
+    @mock.patch(
+        "imap_processing.ena_maps.ena_maps.HealpixSkyMap.calculate_rect_pixel_value_from_healpix_map_n_subdivisions"
+    )
+    def test_get_pixel_value_recursive_subdivs(
+        self,
+        mock_calculate_rect_pixel_value_from_healpix_map_n_subdivisions,
+    ):
+        """Test that the recursive subdivision works as expected with different rtol."""
+
+        # Mock the function to return a fixed value for a number of subdivisions
+        value_by_subdivisions = {
+            0: 100.0,
+            1: 110.0,  # 10/110 = 0.09090909 change
+            2: 105.0,  # 5/105 = 0.04761905 change
+            3: 107.0,  # 2/107 = 0.01869159 change
+            4: 107.5,  # 0.5/107.5 = 0.00465116 change
+            5: 107.51,  # 0.01/107.51 = 0.00009301 change
+            6: 107.5099,  # 0.0001/107.5099 = 0.00000093 change
+        }
+        required_rtols = [
+            0.1,
+            0.05,
+            0.02,
+            0.005,
+            0.0001,
+            0.000001,
+        ]
+
+        mock_calculate_rect_pixel_value_from_healpix_map_n_subdivisions.side_effect = (
+            lambda *args, **kwargs: np.array(
+                [
+                    value_by_subdivisions[kwargs["num_subdivisions"]],
+                ]
+            )
+        )
+        hp_map = ena_maps.HealpixSkyMap(
+            nside=16,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+
+        # Test the recursive subdivision by setting different tolerances to get the
+        # expected number of subdivisions and resultant mean value.
+        for expected_subdiv_level in range(1, len(required_rtols)):
+            mean, depth = hp_map.get_pixel_value_recursive_subdivs(
+                rect_pix_center_lon_lat=(180, 0),
+                rect_pix_spacing_deg=4,
+                value_key="counts",
+                tolerances=(required_rtols[expected_subdiv_level - 1], 0),
+            )
+            assert depth == expected_subdiv_level
+            np.testing.assert_equal(
+                mean,
+                value_by_subdivisions[expected_subdiv_level],
+                err_msg=f"Failed for expected_subdiv_level: {expected_subdiv_level}",
+            )
+
 
 class TestIndexMatching:
     @pytest.fixture(autouse=True)

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -769,7 +769,7 @@ class TestHealpixSkyMap:
                 hp_map.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
                     rect_pix_center_lon_lat=(180, 0),
                     rect_pix_spacing_deg=4,
-                    value_key="counts",
+                    value_array=hp_map.data_1d["counts"],
                     num_subdivisions=num_subdiv,
                 )
             )
@@ -782,7 +782,7 @@ class TestHealpixSkyMap:
         hp_map.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
             rect_pix_center_lon_lat=(180, 0),
             rect_pix_spacing_deg=2,
-            value_key="counts",
+            value_array=hp_map.data_1d["counts"],
             num_subdivisions=0,
         )
 
@@ -834,7 +834,7 @@ class TestHealpixSkyMap:
             mean, depth = hp_map.get_rect_pixel_value_recursive_subdivs(
                 rect_pix_center_lon_lat=(180, 0),
                 rect_pix_spacing_deg=4,
-                value_key="counts",
+                value_array=[],
                 rtol=required_rtols[expected_subdiv_level - 1],
                 max_subdivision_depth=7,
             )

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -865,10 +865,14 @@ class TestHealpixSkyMap:
             data=np.ones((10, hp_map.num_points)),
             dims=["energy", "pixel"],
         )
+        hp_map.data_1d["observation_date"] = xr.DataArray(
+            data=np.ones(hp_map.num_points),
+            dims=["pixel"],
+        )
 
         rect_map, subdiv_depth_dict = hp_map.to_rectangular_skymap(
             rect_spacing_deg=2,
-            value_keys=["counts", "exposure_factor"],
+            value_keys=["counts", "exposure_factor", "observation_date"],
         )
 
         for value_key, subdiv_depth in subdiv_depth_dict.items():


### PR DESCRIPTION
# Change Summary

Converts a HealpixSkyMap to RectangularSkyMap using recursive subdivision of each rectangular pixel.

Closes #1398 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

To get the value of a Rectangular Sky Map pixel, you can approximate it as the value of the Healpix Sky Map pixel into which the rectangular pixel's center falls. If the rectangular pixel overlaps multiple Healpix pixels, this will be less accurate, especially if the gradient between those Healpix pixel values is large. You can increase the accuracy by subdividing the rectangular pixel into 4 equal area subpixels, and taking the mean of their center values. Weight this mean by their solid angles, which change by latitude. You can do this recursively until you get a value which doesn't change significantly between subsequent subdivisions. 

This is a somewhat computationally expensive process (running locally, it can take ~5 seconds to interpolate each variable on medium gradients), but will be quite rare operation, only run at the end of some map-making. I've tried to parallelize it, but I've been so far unable to make it significantly faster, and it doesn't seem like a high priority. 

The best way I can explain this process is through [this diagram - see the current version on Galaxy confluence](https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/256936180/Ultra+L2+Diagrams#UltraL2Diagrams-ConversionfromHealpix%E2%86%92RectangularConceptualDiagram). 

![image](https://github.com/user-attachments/assets/0f5b58b6-0486-4fcd-9a35-f64376e55771)


Figures:
1. Original Healpix Sky Map (nside=32) Flux
![image](https://github.com/user-attachments/assets/88d8771f-f080-4d05-b44e-8b7d60617ef1)
2. Interpolated Rectangular Sky Map (2˚) Flux ![image](https://github.com/user-attachments/assets/5547bc3e-3841-430f-968e-78a33ebce197)
3. The number of subdivisions necessary at each pixel. Note how this is very low except around high gradients. ![newplot](https://github.com/user-attachments/assets/9a8a0298-e1cb-479b-b1d2-5a8506a4460a)
# New Dependencies
<!--List any new dependencies introduced by these changes-->


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/ena_maps/ena_maps.py
   - Add methods to `HealpixSkyMap` to: 
     - calculate a rectangular pixel's mean value at a given number of subdivisions
     - calculate a rectangular pixel's mean value recursively using more and more subdivisions until the tolerance is met
     - Build a `RectangularSkyMap` by interpolating each pixel's value. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Tests for the 3 new methods