### PR TITLE
TST: Add pytest-xdist to run tests in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,9 @@ jobs:
         run: |
           # Ignore the network marks from the remote test environment
           if [ "$USE_EXTERNAL_DATA" = "true" ]; then
-            poetry run pytest --color=yes --cov --cov-report=xml
+            poetry run pytest -n auto --color=yes --cov --cov-report=xml
           else
-            poetry run pytest --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"
+            poetry run pytest -n auto --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"
           fi
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           if [ "$USE_EXTERNAL_DATA" = "true" ]; then
             # Running across multiple processes causes errors due to large downloads not
             # finishing before the tests get hit in test_codice_l1a
-            poetry run pytest -n auto --dist loadscope --color=yes --cov --cov-report=xml
+            poetry run pytest -n auto --color=yes --cov --cov-report=xml
           else
             poetry run pytest -n auto --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,9 @@ jobs:
         run: |
           # Ignore the network marks from the remote test environment
           if [ "$USE_EXTERNAL_DATA" = "true" ]; then
-            poetry run pytest -n auto --color=yes --cov --cov-report=xml
+            # Running across multiple processes causes errors due to large downloads not
+            # finishing before the tests get hit in test_codice_l1a
+            poetry run pytest --color=yes --cov --cov-report=xml
           else
             poetry run pytest -n auto --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           if [ "$USE_EXTERNAL_DATA" = "true" ]; then
             # Running across multiple processes causes errors due to large downloads not
             # finishing before the tests get hit in test_codice_l1a
-            poetry run pytest --color=yes --cov --cov-report=xml
+            poetry run pytest -n auto --dist loadscope --color=yes --cov --cov-report=xml
           else
             poetry run pytest -n auto --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,6 @@ jobs:
         run: |
           # Ignore the network marks from the remote test environment
           if [ "$USE_EXTERNAL_DATA" = "true" ]; then
-            # Running across multiple processes causes errors due to large downloads not
-            # finishing before the tests get hit in test_codice_l1a
             poetry run pytest -n auto --color=yes --cov --cov-report=xml
           else
             poetry run pytest -n auto --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -9,13 +9,14 @@ import xarray as xr
 from imap_processing.cdf.utils import load_cdf, write_cdf
 from imap_processing.codice import constants
 from imap_processing.codice.codice_l1a import process_codice_l1a
-from imap_processing.tests.conftest import _download_test_data
+from imap_processing.tests.conftest import _download_external_data, _test_data_paths
 
 from .conftest import TEST_L0_FILE, VALIDATION_DATA
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+pytestmark = pytest.mark.external_test_data
 
 DESCRIPTORS = [
     "hi-ialirt",
@@ -115,7 +116,7 @@ def test_l1a_data() -> xr.Dataset:
     # Make sure we have the data available here. This test collection gets
     # skipped at the module level if the mark isn't present. We can't decorate
     # a fixture, so add the needed call directly here instead.
-    _download_test_data()
+    _download_external_data(_test_data_paths())
     processed_datasets = process_codice_l1a(file_path=TEST_L0_FILE)
 
     return processed_datasets

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -9,13 +9,13 @@ import xarray as xr
 from imap_processing.cdf.utils import load_cdf, write_cdf
 from imap_processing.codice import constants
 from imap_processing.codice.codice_l1a import process_codice_l1a
+from imap_processing.tests.conftest import _download_test_data
 
 from .conftest import TEST_L0_FILE, VALIDATION_DATA
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-pytestmark = pytest.mark.external_test_data
 
 DESCRIPTORS = [
     "hi-ialirt",
@@ -112,7 +112,10 @@ def test_l1a_data() -> xr.Dataset:
     processed_datasets : list[xarray.Dataset]
         A list of ``xarray`` datasets containing the test data
     """
-
+    # Make sure we have the data available here. This test collection gets
+    # skipped at the module level if the mark isn't present. We can't decorate
+    # a fixture, so add the needed call directly here instead.
+    _download_test_data()
     processed_datasets = process_codice_l1a(file_path=TEST_L0_FILE)
 
     return processed_datasets

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -94,7 +94,7 @@ def _download_external_kernels(spice_test_data_path):
 
 @pytest.fixture(scope="session")
 def _download_test_data():
-    _download_external_data(test_data_paths())
+    _download_external_data(_test_data_paths())
 
 
 def _download_external_data(test_data_path_list):
@@ -125,7 +125,7 @@ def _download_external_data(test_data_path_list):
             logger.info(f"File already exists: {destination}")
 
 
-def test_data_paths():
+def _test_data_paths():
     """Defines a list of test data files to download from the AWS S3 bucket
     and the corresponding location in which to store the downloaded file"""
     test_data_path_list = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -521,6 +521,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 description = "A platform independent file lock."
@@ -1406,6 +1420,26 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2145,10 +2179,10 @@ viz = ["cartopy", "matplotlib", "nc-time-axis", "seaborn"]
 dev = ["mypy", "pre-commit", "ruff"]
 doc = ["numpydoc", "pydata-sphinx-theme", "sphinx", "sphinxcontrib-openapi"]
 map-visualization = ["healpy"]
-test = ["netcdf4", "openpyxl", "pytest", "pytest-cov", "requests"]
+test = ["netcdf4", "openpyxl", "pytest", "pytest-cov", "pytest-xdist", "requests"]
 tools = ["openpyxl", "pandas"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "bcd02b173b1105a23edcefa5c4b8fc15fbe627062a79ba1565ceea88ffd3de54"
+content-hash = "797bab33ebc52d61b95fd234612fe9364d43426f79d9f6e1c312f2dcae7e1ef6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ pre-commit = {version="^3.3.3", optional=true}
 pydata-sphinx-theme = {version="*", optional=true}
 pytest = {version=">=6.2.5", optional=true}
 pytest-cov = {version="^4.0.0", optional=true}
+pytest-xdist = {version="^3.2", optional=true}
 ruff = {version="==0.2.1", optional=true}
 sphinx = {version="*", optional=true}
 sphinxcontrib-openapi = {version="^0.8.3", optional=true}
@@ -60,7 +61,7 @@ netcdf4 = {version ="^1.7.2",  optional = true}
 [tool.poetry.extras]
 dev = ["pre-commit", "ruff", "mypy"]
 doc = ["numpydoc", "pydata-sphinx-theme", "sphinx", "sphinxcontrib-openapi"]
-test = ["openpyxl", "pytest", "pytest-cov", "requests", "netcdf4"]
+test = ["openpyxl", "pytest", "pytest-cov", "pytest-xdist", "requests", "netcdf4"]
 tools = ["openpyxl", "pandas"]
 map_visualization = ["healpy"]
 


### PR DESCRIPTION
Our test suite is getting pretty long to run, so lets try and add some parallelization to see if we can speed things up.

Make it opt-in but run the tests in parallel on the CI systems at least and allow users to locally use more processors.

I run with `pytest -n auto` locally and it started spinning the CPU fans but finished in under a minute.