### PR TITLE
Covert exposure times from units of clock-ticks to seconds

### DIFF
--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -520,6 +520,9 @@ def pset_exposure(
         )[0]
         exposure_var["exposure_times"].values[:, i_esa] += new_exposure_times
 
+    # Convert exposure clock ticks to seconds
+    exposure_var["exposure_times"].values *= DE_CLOCK_TICK_S
+
     return exposure_var
 
 

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -243,7 +243,7 @@ def test_pset_exposure(
     # All the setup is done, call the pset_exposure function
     exposure_dict = hi_l1c.pset_exposure(empty_pset.coords, l1b_dataset)
 
-    # Based on the spin phase and clock_tick mocks, the expected output is:
+    # Based on the spin phase and clock_tick mocks, the expected clock ticks are:
     # - Repeated values of 3, 1 for the first half of the spin bins
     # - Repeated values of 3, 2 for the second half of the spin bins
     expected_values = np.stack(
@@ -251,8 +251,14 @@ def test_pset_exposure(
             np.tile([3, 1], hi_l1c.N_SPIN_BINS // 2),
             np.tile([6, 2], hi_l1c.N_SPIN_BINS // 2),
         ]
-    )[None, :, :]
-    np.testing.assert_array_equal(exposure_dict["exposure_times"].data, expected_values)
+    ).astype(float)[None, :, :]
+    # Convert expected clock ticks to seconds
+    expected_values *= DE_CLOCK_TICK_S
+    np.testing.assert_allclose(
+        exposure_dict["exposure_times"].data,
+        expected_values,
+        atol=DE_CLOCK_TICK_S / 100,
+    )
 
 
 def test_find_second_de_packet_data():


### PR DESCRIPTION
# Change Summary

## Overview
This was an oversight when I implemented the Hi exposure time algorithm. I forgot to do the last step of converting from clock-tick to seconds.

Closes: #1599 
