### PR TITLE
Fix build_solid_angle_map for 6 degree spacing

### DIFF
--- a/imap_processing/ena_maps/utils/spatial_utils.py
+++ b/imap_processing/ena_maps/utils/spatial_utils.py
@@ -85,7 +85,9 @@ def build_solid_angle_map(
     if not np.isclose(proposed_number_of_lat_bins, number_of_lat_bins):
         raise ValueError("Spacing must divide evenly into pi radians.")
 
-    latitudes = np.linspace(-np.pi / 2, np.pi / 2, num=number_of_lat_bins+1, endpoint=True)
+    latitudes = np.linspace(
+        -np.pi / 2, np.pi / 2, num=number_of_lat_bins + 1, endpoint=True
+    )
     sine_latitudes = np.sin(latitudes)
     delta_sine_latitudes = np.diff(sine_latitudes)
     solid_angle_by_latitude = np.abs(spacing * delta_sine_latitudes)

--- a/imap_processing/ena_maps/utils/spatial_utils.py
+++ b/imap_processing/ena_maps/utils/spatial_utils.py
@@ -79,17 +79,20 @@ def build_solid_angle_map(
     if spacing <= 0:
         raise ValueError("Spacing must be positive valued, non-zero.")
 
-    if not np.isclose((np.pi / spacing) % 1, 0):
+    proposed_number_of_lat_bins = 180 / spacing_deg
+    number_of_lat_bins = round(180 / spacing_deg)
+    number_of_lon_bins = 2 * number_of_lat_bins
+    if not np.isclose(proposed_number_of_lat_bins, number_of_lat_bins):
         raise ValueError("Spacing must divide evenly into pi radians.")
 
-    latitudes = np.arange(-np.pi / 2, np.pi / 2 + spacing, step=spacing)
+    latitudes = np.linspace(-np.pi / 2, np.pi / 2, num=number_of_lat_bins+1, endpoint=True)
     sine_latitudes = np.sin(latitudes)
     delta_sine_latitudes = np.diff(sine_latitudes)
     solid_angle_by_latitude = np.abs(spacing * delta_sine_latitudes)
 
     # Order ensures agreement with build_az_el_grid's order of tiling az/el grid.
     solid_angle_grid = np.repeat(
-        solid_angle_by_latitude[np.newaxis, :], (2 * np.pi) / spacing, axis=0
+        solid_angle_by_latitude[np.newaxis, :], number_of_lon_bins, axis=0
     )
 
     return solid_angle_grid

--- a/imap_processing/ena_maps/utils/spatial_utils.py
+++ b/imap_processing/ena_maps/utils/spatial_utils.py
@@ -85,11 +85,11 @@ def build_solid_angle_map(
     if not np.isclose(proposed_number_of_lat_bins, number_of_lat_bins):
         raise ValueError("Spacing must divide evenly into pi radians.")
 
-    latitudes = np.linspace(
+    latitude_edges = np.linspace(
         -np.pi / 2, np.pi / 2, num=number_of_lat_bins + 1, endpoint=True
     )
-    sine_latitudes = np.sin(latitudes)
-    delta_sine_latitudes = np.diff(sine_latitudes)
+    sine_latitude_edges = np.sin(latitude_edges)
+    delta_sine_latitudes = np.diff(sine_latitude_edges)
     solid_angle_by_latitude = np.abs(spacing * delta_sine_latitudes)
 
     # Order ensures agreement with build_az_el_grid's order of tiling az/el grid.

--- a/imap_processing/tests/ena_maps/test_spatial_utils.py
+++ b/imap_processing/tests/ena_maps/test_spatial_utils.py
@@ -7,7 +7,7 @@ import pytest
 from imap_processing.ena_maps.utils import spatial_utils
 
 # Parameterize with spacings (degrees here):
-valid_spacings = [0.25, 0.5, 1, 5, 10, 20]
+valid_spacings = [0.25, 0.5, 1, 5, 6, 6.666666666666667, 10, 20]
 invalid_spacings = [0, -1, 11]
 invalid_spacings_match_str = [
     "Spacing must be positive valued, non-zero.",


### PR DESCRIPTION
# Change Summary

## Overview
When represented as a float, 6 degrees in radians is slightly greater than pi/30, making (pi / 6 degrees) % 1 = 0.999... This made the "divide evenly" check fail.

Change the behavior to compute an integer number of bins rather than relying on rounding details.

Fixes #1606.

## New Dependencies
N/A

## New Files
N/A

## Deleted Files
N/A

## Updated Files
- spatial_utils.py
  - Calculate the integer number of bins

## Testing
- Add 6 and 6.666666666666667 degrees (corresponding to 30 and 27 latitude bins) as valid options for tests to check. 