### PR TITLE
Lo L1B - Species Identification and Badtimes Initialization 

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -72,6 +72,11 @@ def lo_l1b(dependencies: dict) -> list[Path]:
         l1b_de = set_coincidence_type(l1a_de, l1b_de, attr_mgr_l1a)
         # convert the TOFs to engineering units
         l1b_de = convert_tofs_to_eu(l1a_de, l1b_de, attr_mgr_l1a, attr_mgr_l1b)
+        # set the species for each direct event
+        l1b_de = identify_species(l1b_de)
+        # set the badtimes
+        l1b_de = set_bad_times(l1b_de)
+        # TODO: set the direction for each direct event
 
     return [l1b_de]
 
@@ -546,6 +551,83 @@ def convert_tofs_to_eu(
             dims=["epoch"],
             attrs=attr_mgr_l1b.get_variable_attributes(tof),
         )
+
+    return l1b_de
+
+
+def identify_species(l1b_de: xr.Dataset) -> xr.Dataset:
+    """
+    Identify the species for each direct event.
+
+    The species are determined using the U_PAC 7-13kV range table with the TOF2 value.
+    Each event is set to "H" for Hydrogen, "O" for Oxygen, or "U" for Unknown.
+
+    See the species identification section in the Lo algorithm document for more
+    information on the ranges used to identify the species.
+
+    Parameters
+    ----------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset.
+
+    Returns
+    -------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset with the species identified.
+    """
+    # Define upper and lower ranges for Hydrogen and Oxygen
+    # Table defined in 9.3.4.4 of the Lo algorithm document
+    # UNH-IMAP-Lo-27850-6002-Data-Product-Algorithms-v9_&_IMAP-LoMappingAlgorithm
+    # The ranges are used for U_PAC voltages 7-12kV. Lo does not expect to use
+    # voltages outside of that range.
+    range_hydrogen = (13, 40)
+    range_oxygen = (75, 200)
+
+    # Initialize the species array with U for Unknown
+    species = np.full(len(l1b_de["epoch"]), "U")
+
+    tof2 = l1b_de["tof2"]
+    # Check for range Hydrogen using the TOF2 value
+    mask_h = (tof2 >= range_hydrogen[0]) & (tof2 <= range_hydrogen[1])
+    species[mask_h] = "H"
+
+    # Check for range Oxygen using the TOF2 value
+    mask_oxygen = (tof2 >= range_oxygen[0]) & (tof2 <= range_oxygen[1])
+    species[mask_oxygen] = "O"
+
+    # Add species to the dataset
+    l1b_de["species"] = xr.DataArray(
+        species,
+        dims=["epoch"],
+        # TODO: Add to yaml
+        # attrs=attr_mgr.get_variable_attributes("species"),
+    )
+
+    return l1b_de
+
+
+def set_bad_times(l1b_de: xr.Dataset) -> xr.Dataset:
+    """
+    Set the bad times for each direct event.
+
+    Parameters
+    ----------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset.
+
+    Returns
+    -------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset with the bad times added.
+    """
+    # Initialize all times as not bad for now
+    # 1 = badtime, 0 = not badtime
+    l1b_de["badtimes"] = xr.DataArray(
+        np.zeros(len(l1b_de["epoch"]), dtype=int),
+        dims=["epoch"],
+        # TODO: Add to yaml
+        # attrs=attr_mgr.get_variable_attributes("bad_times"),
+    )
 
     return l1b_de
 

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -621,6 +621,8 @@ def set_bad_times(l1b_de: xr.Dataset) -> xr.Dataset:
         The L1B DE dataset with the bad times added.
     """
     # Initialize all times as not bad for now
+    # TODO: Update to set badtimes based on criteria that
+    #  will be defined in the algorithm document
     # 1 = badtime, 0 = not badtime
     l1b_de["badtimes"] = xr.DataArray(
         np.zeros(len(l1b_de["epoch"]), dtype=int),

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -15,8 +15,10 @@ from imap_processing.lo.l1b.lo_l1b import (
     get_avg_spin_durations,
     get_spin_angle,
     get_spin_start_times,
+    identify_species,
     initialize_l1b_de,
     lo_l1b,
+    set_bad_times,
     set_coincidence_type,
     set_each_event_epoch,
     set_event_met,
@@ -465,3 +467,39 @@ def test_convert_tofs_to_eu(attr_mgr_l1b, attr_mgr_l1a):
             expected_tof,
             atol=1e-6,
         )
+
+
+def test_identify_species(attr_mgr_l1b):
+    # Arrange
+    fill_val = attr_mgr_l1b.get_variable_attributes("tof2")["FILLVAL"]
+    l1b_de = xr.Dataset(
+        {
+            "tof2": ("epoch", [14, 80, 500, fill_val]),
+        }
+    )
+
+    expected_species = np.array(["H", "O", "U", "U"])
+
+    # Act
+    l1b_de = identify_species(l1b_de)
+
+    # Assert
+    np.testing.assert_array_equal(l1b_de["species"], expected_species)
+
+
+def test_set_bad_times():
+    # Arrange
+    l1b_de = xr.Dataset(
+        {},
+        coords={
+            "epoch": [0, 1, 2],
+        },
+    )
+
+    expected_bad_times = np.array([0, 0, 0])
+
+    # Act
+    l1b_de = set_bad_times(l1b_de)
+
+    # Assert
+    np.testing.assert_array_equal(l1b_de["badtimes"], expected_bad_times)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -474,11 +474,11 @@ def test_identify_species(attr_mgr_l1b):
     fill_val = attr_mgr_l1b.get_variable_attributes("tof2")["FILLVAL"]
     l1b_de = xr.Dataset(
         {
-            "tof2": ("epoch", [14, 80, 500, fill_val]),
+            "tof2": ("epoch", [1, 14, 50, 80, 500, fill_val]),
         }
     )
 
-    expected_species = np.array(["H", "O", "U", "U"])
+    expected_species = np.array(["U", "H", "U", "O", "U", "U"])
 
     # Act
     l1b_de = identify_species(l1b_de)


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds code to identify the species of each Lo L1B Direct Event as either Hydrogen, Oxygen, or Unknown. The badtimes field is also initialized.

## Updated Files
- imap_processing/lo/l1b/lo_l1b.py
   - added function to identify the direct event species
   - added function to initialize badtimes (always not bad for now)

## Testing
Added two unit tests and ran CLI

Closes #1517