### PR TITLE
MNT: Add too many arguments to list of rules to ignore

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ruff: noqa: PLR0913
 """
 Run the processing for a specific instrument & data level.
 

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -1,4 +1,3 @@
-# ruff: noqa: PLR0913
 """Module for GLOWS L1B data products."""
 
 import dataclasses

--- a/imap_processing/idex/idex_l2a.py
+++ b/imap_processing/idex/idex_l2a.py
@@ -16,7 +16,6 @@ Examples
     write_cdf(l2a_data)
 """
 
-# ruff: noqa: PLR0913
 import logging
 from enum import IntEnum
 

--- a/imap_processing/mag/l1a/mag_l1a_data.py
+++ b/imap_processing/mag/l1a/mag_l1a_data.py
@@ -791,7 +791,7 @@ class MagL1a:
         return primary_vectors, secondary_vectors
 
     @staticmethod
-    def _process_vector_section(  # noqa: PLR0913
+    def _process_vector_section(
         vector_bits: np.ndarray,
         split_bits: list,
         last_index: int,

--- a/imap_processing/tests/ultra/data/mock_data.py
+++ b/imap_processing/tests/ultra/data/mock_data.py
@@ -14,7 +14,7 @@ DEFAULT_RECT_SPACING_DEG_L1C = 0.5
 DEFAULT_HEALPIX_NSIDE_L1C = 128
 
 
-def mock_l1c_pset_product_rectangular(  # noqa: PLR0913
+def mock_l1c_pset_product_rectangular(
     spacing_deg: float = DEFAULT_RECT_SPACING_DEG_L1C,
     stripe_center_lat: int = 0,
     width_scale: float = 10.0,
@@ -192,7 +192,7 @@ def mock_l1c_pset_product_rectangular(  # noqa: PLR0913
     return pset_product
 
 
-def mock_l1c_pset_product_healpix(  # noqa: PLR0913
+def mock_l1c_pset_product_healpix(
     nside: int = DEFAULT_HEALPIX_NSIDE_L1C,
     stripe_center_lat: int = 0,
     width_scale: float = 10.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,12 +90,15 @@ markers = [
 [tool.ruff]
 target-version = "py39"
 lint.select = ["B", "D", "E", "F", "I", "N", "S", "W", "PL", "PT", "UP", "RUF"]
-# D104: Missing docstring in public package
-# PLR2004: Magic value in comparison
-# RUF200: pyproject missing field (poetry doesn't follow the spec)
-# PLR0915: too-many-statements error
-# RUF002: `−` (MINUS SIGN). Did you mean `-` (HYPHEN-MINUS) error
-lint.ignore = ["D104", "PLR2004", "RUF200", "S311", "PLR0915", "RUF002"]
+lint.ignore = [
+  "D104",  # Missing docstring in public package
+  "PLR0913",  # too-many-args error
+  "PLR0915",  # too-many-statements error
+  "PLR2004",  # Magic value in comparison
+  "RUF002",  # `−` (MINUS SIGN). Did you mean `-` (HYPHEN-MINUS) error
+  "RUF200",  # pyproject missing field (poetry doesn't follow the spec)
+  "S311",  # suspicious-non-cryptographic-random-usage
+]
 
 [tool.ruff.lint.per-file-ignores]
 # S603 unchecked input in subprocess call is fine in our tests


### PR DESCRIPTION
# Change Summary

## Overview

This rule has been causing more headache than it is worth. We shouldn't be changing good-enough code to satisfy the linter.