### PR TITLE
1625 hi pset   epoch value should be start time

### DIFF
--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -143,7 +143,7 @@ def empty_pset_dataset(
     Parameters
     ----------
     epoch_val : int
-        The starting epoch for data in the PSET.
+        The starting epoch in J2000 TT nanoseconds for data in the PSET.
     l1b_energy_steps : np.ndarray
         The array of esa_energy_step data from the L1B DE product.
     n_cal_prods : int

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -102,13 +102,10 @@ def generate_pset_dataset(
     config_df = CalibrationProductConfig.from_csv(calibration_prod_config_path)
 
     pset_dataset = empty_pset_dataset(
+        de_dataset.epoch.data[0],
         de_dataset.esa_energy_step.data,
         config_df.cal_prod_config.number_of_products,
         logical_source_parts["sensor"],
-    )
-    # For ISTP, epoch should be the center of the time bin.
-    pset_dataset.epoch.data[0] = np.mean(de_dataset.epoch.data[[0, -1]]).astype(
-        np.int64
     )
     pset_et = ttj2000ns_to_et(pset_dataset.epoch.data[0])
     # Calculate and add despun_z, hae_latitude, and hae_longitude variables to
@@ -138,13 +135,15 @@ def generate_pset_dataset(
 
 
 def empty_pset_dataset(
-    l1b_energy_steps: np.ndarray, n_cal_prods: int, sensor_str: str
+    epoch_val: int, l1b_energy_steps: np.ndarray, n_cal_prods: int, sensor_str: str
 ) -> xr.Dataset:
     """
     Allocate an empty xarray.Dataset with appropriate pset coordinates.
 
     Parameters
     ----------
+    epoch_val : int
+        The starting epoch for data in the PSET.
     l1b_energy_steps : np.ndarray
         The array of esa_energy_step data from the L1B DE product.
     n_cal_prods : int
@@ -164,12 +163,12 @@ def empty_pset_dataset(
     # preallocate coordinates xr.DataArrays
     coords = dict()
     # epoch coordinate has only 1 entry for pointing set
-    epoch_attrs = attr_mgr.get_variable_attributes("epoch")
+    epoch_attrs = attr_mgr.get_variable_attributes("epoch", check_schema=False)
     epoch_attrs.update(
         attr_mgr.get_variable_attributes("hi_pset_epoch", check_schema=False)
     )
     coords["epoch"] = xr.DataArray(
-        np.empty(1, dtype=np.int64),  # TODO: get dtype from cdf attrs?
+        np.array([epoch_val], dtype=np.int64),  # TODO: get dtype from cdf attrs?
         name="epoch",
         dims=["epoch"],
         attrs=epoch_attrs,

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -77,7 +77,7 @@ def test_empty_pset_dataset():
     n_calibration_prods = 5
     sensor_str = HIAPID.H90_SCI_DE.sensor
     dataset = hi_l1c.empty_pset_dataset(
-        l1b_esa_energy_steps, n_calibration_prods, sensor_str
+        100, l1b_esa_energy_steps, n_calibration_prods, sensor_str
     )
 
     assert dataset.epoch.size == 1
@@ -143,6 +143,7 @@ def test_pset_counts(hi_l1_test_data_path, hi_test_cal_prod_config_path):
         hi_test_cal_prod_config_path
     )
     empty_pset = hi_l1c.empty_pset_dataset(
+        100,
         l1b_dataset.esa_energy_step.data,
         cal_config_df.cal_prod_config.number_of_products,
         HIAPID.H90_SCI_DE.sensor,
@@ -209,7 +210,7 @@ def test_pset_exposure(
 ):
     """Test coverage for pset_exposure function"""
     empty_pset = hi_l1c.empty_pset_dataset(
-        np.arange(2) + 1, 2, HIAPID.H90_SCI_DE.sensor
+        100, np.arange(2) + 1, 2, HIAPID.H90_SCI_DE.sensor
     )
     # Set the mock of find_second_de_packet_data to return a xr.Dataset
     # with some dummy data. ESA 1 will get binned data once, ESA 2 will get

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -53,9 +53,7 @@ def test_generate_pset_dataset(
         l1b_dataset, hi_test_cal_prod_config_path
     )
 
-    assert l1c_dataset.epoch.data[0] == np.mean(l1b_dataset.epoch.data[[0, -1]]).astype(
-        np.int64
-    )
+    assert l1c_dataset.epoch.data[0] == l1b_dataset.epoch.data[0].astype(np.int64)
 
     np.testing.assert_array_equal(l1c_dataset.despun_z.data.shape, (1, 3))
     np.testing.assert_array_equal(l1c_dataset.hae_latitude.data.shape, (1, 3600))


### PR DESCRIPTION
# Change Summary

## Overview
After feedback from SPDF, the PSET epoch value should be the start date of data in the file rather than the mean. Also, this fixes a bug discovered when I set up a pipeline for processing simulated data in Jupyter. See: #1624 

## Updated Files
- imap_processing/hi/l1c/hi_l1c.py
   - Set PSET epoch to start time of data in the file
   - Create the empty dataset with the correct epoch value
- imap_processing/tests/hi/test_hi_l1c.py
   - Update to test for start epoch value in PSET dataset
   - Update tests that use `empty_pset_dataset`

Closes: #1625 #1624 