### PR TITLE
Lo L1B: Direct Event Pointing Bins

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -661,7 +661,6 @@ def set_pointing_direction(l1b_de: xr.Dataset) -> xr.Dataset:
     et = ttj2000ns_to_et(l1b_de["epoch"])
 
     direction = instrument_pointing(et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_DPS)
-
     # TODO: Need to ask Lo what to do if a latitude is outside of the
     # +/-2 degree range. Is that possible?
     l1b_de["direction_lon"] = xr.DataArray(

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -14,7 +14,8 @@ from imap_processing.lo.l1b.tof_conversions import (
     TOF2_CONV,
     TOF3_CONV,
 )
-from imap_processing.spice.time import met_to_ttj2000ns
+from imap_processing.spice.geometry import SpiceFrame, instrument_pointing
+from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_et
 
 
 def lo_l1b(dependencies: dict) -> list[Path]:
@@ -76,7 +77,11 @@ def lo_l1b(dependencies: dict) -> list[Path]:
         l1b_de = identify_species(l1b_de)
         # set the badtimes
         l1b_de = set_bad_times(l1b_de)
-        # TODO: set the direction for each direct event
+        # set the pointing direction for each direct event
+        l1b_de = set_pointing_direction(l1b_de)
+        # calculate and set the pointing bin based on the spin phase
+        # pointing bin is 3600 x 40 bins
+        l1b_de = set_pointing_bin(l1b_de)
 
     return [l1b_de]
 
@@ -629,6 +634,100 @@ def set_bad_times(l1b_de: xr.Dataset) -> xr.Dataset:
         dims=["epoch"],
         # TODO: Add to yaml
         # attrs=attr_mgr.get_variable_attributes("bad_times"),
+    )
+
+    return l1b_de
+
+
+def set_pointing_direction(l1b_de: xr.Dataset) -> xr.Dataset:
+    """
+    Set the pointing direction for each direct event.
+
+    The pointing direction is determined using the SPICE instrument pointing
+    function. The pointing direction are two 1D vectors in units of degrees
+    for longitude and latitude sharing the same epoch dimension.
+
+    Parameters
+    ----------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset.
+
+    Returns
+    -------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset with the pointing direction added.
+    """
+    # Get the pointing bin for each DE
+    et = ttj2000ns_to_et(l1b_de["epoch"])
+
+    direction = instrument_pointing(et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_DPS)
+
+    # TODO: Need to ask Lo what to do if a latitude is outside of the
+    # +/-2 degree range. Is that possible?
+    l1b_de["direction_lon"] = xr.DataArray(
+        direction[:, 0],
+        dims=["epoch"],
+        # TODO: Add direction_lon to YAML file
+        # attrs=attr_mgr.get_variable_attributes("direction_lon"),
+    )
+
+    l1b_de["direction_lat"] = xr.DataArray(
+        direction[:, 1],
+        dims=["epoch"],
+        # TODO: Add direction_lat to YAML file
+        # attrs=attr_mgr.get_variable_attributes("direction_lat"),
+    )
+
+    return l1b_de
+
+
+def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
+    """
+    Set the pointing bin for each direct event.
+
+    The pointing bins are defined as 3600 bins for longitude and 40 bins for latitude.
+    Each bin is 0.1 degrees. The bins are defined as follows:
+    Longitude bins: -180 to 180 degrees
+    Latitude bins: -2 to 2 degrees
+
+    Parameters
+    ----------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset.
+
+    Returns
+    -------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset with the pointing bins added.
+    """
+    # First column: latitudes
+    lats = l1b_de["direction_lat"]
+    # Second column: longitudes
+    lons = l1b_de["direction_lon"]
+
+    # Define bin edges
+    # 3600 bins, 0.1° each
+    lon_bins = np.linspace(-180, 180, 3601)
+    # 40 bins, 0.1° each
+    lat_bins = np.linspace(-2, 2, 41)
+
+    # put the lons and lats into bins
+    # shift to 0-based index
+    lon_bins = np.digitize(lons, lon_bins) - 1
+    lat_bins = np.digitize(lats, lat_bins) - 1
+
+    l1b_de["pointing_bin_lon"] = xr.DataArray(
+        lon_bins,
+        dims=["epoch"],
+        # TODO: Add pointing_bin_lon to YAML file
+        # attrs=attr_mgr.get_variable_attributes("pointing_bin_lon"),
+    )
+
+    l1b_de["pointing_bin_lat"] = xr.DataArray(
+        lat_bins,
+        dims=["epoch"],
+        # TODO: Add point_bin_lat to YAML file
+        # attrs=attr_mgr.get_variable_attributes("pointing_bin_lat"),
     )
 
     return l1b_de

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -63,7 +63,7 @@ class SpiceFrame(IntEnum):
 
 
 BORESIGHT_LOOKUP = {
-    SpiceFrame.IMAP_LO: np.array([0, -1, 0]),
+    SpiceFrame.IMAP_LO_BASE: np.array([0, -1, 0]),
     SpiceFrame.IMAP_HI_45: np.array([0, 1, 0]),
     SpiceFrame.IMAP_HI_90: np.array([0, 1, 0]),
     SpiceFrame.IMAP_ULTRA_45: np.array([0, 0, 1]),
@@ -136,7 +136,7 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
     """
     # TODO: Implement retrieval from SPICE?
     offset_lookup = {
-        SpiceFrame.IMAP_LO: 330 / 360,
+        SpiceFrame.IMAP_LO_BASE: 330 / 360,
         SpiceFrame.IMAP_HI_45: 255 / 360,
         SpiceFrame.IMAP_HI_90: 285 / 360,
         SpiceFrame.IMAP_ULTRA_45: 33 / 360,
@@ -325,7 +325,7 @@ def instrument_pointing(
     """
     Compute the instrument pointing at the specified times.
 
-    By default, the coordinates returned are Latitude/Longitude coordinates in
+    By default, the coordinates returned are (Longitude, Latitude) coordinates in
     the reference frame `to_frame`. Cartesian coordinates can be returned if
     desired by setting `cartesian=True`.
 

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -62,8 +62,6 @@ def attr_mgr_l1a():
 
 
 @patch("imap_processing.lo.l1b.lo_l1b.instrument_pointing")
-@pytest.mark.external_kernel
-@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 def test_lo_l1b(mock_instrument_pointing):
     # Arrange
     de_file = (

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -522,18 +522,23 @@ def test_set_direction():
         {},
         coords={
             "epoch": [
-                7.9794907049e17,
-                7.9794907153e17,
                 7.9794907254e17,
+                # + 1 second. Should be 24deg diff from
+                # previous epoch
+                7.9794907254e17 + 1e9,
+                # + 7.5 seconds. Should be 180deg diff from
+                # first epoch
+                7.9794907254e17 + 7.5e9,
+                # + 15 seconds. Should be 360deg diff from
+                # previous epoch
+                7.9794907254e17 + 15e9,
             ],
         },
     )
-    # Need to better verify these values. Latitudes are likely to
-    # be 0, but not sure what values to expect from Longitudes.
-    # The expected values are based on what I'm getting from the
-    # SPICE tools.
-    expected_direction_lat = np.array([0, 0, 0])
-    expected_direction_lon = np.array([91.3, 116.3, 140.5])
+    # latitudes are -90 to 90
+    expected_direction_lat = np.array([0, 0, 0, 0])
+    # longitude are -180 to 180
+    expected_direction_lon = np.array([140.5, 164.5, -39.5, 140.5])
 
     # Act
     l1b_de = set_pointing_direction(l1b_de)
@@ -555,20 +560,22 @@ def test_pointing_bins():
     # Arrange
     l1b_de = xr.Dataset(
         {
-            "direction_lat": ("epoch", [0, 0, 0]),
-            "direction_lon": ("epoch", [91.3, 116.3, 140.5]),
+            "direction_lat": ("epoch", [0, 0, 0, 0, 0]),
+            "direction_lon": ("epoch", [-180, 91.3, 116.3, 140.5, 180]),
         },
         coords={
             "epoch": [
                 7.9794907049e17,
                 7.9794907153e17,
                 7.9794907254e17,
+                7.9794907354e17,
+                7.9794907454e17,
             ],
         },
     )
 
-    expected_pointing_lats = np.array([20, 20, 20])
-    expected_pointing_lons = np.array([2712, 2962, 3205])
+    expected_pointing_lats = np.array([20, 20, 20, 20, 20])
+    expected_pointing_lons = np.array([0, 2712, 2962, 3205, 3600])
 
     # Act
     l1b_de = set_pointing_bin(l1b_de)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -22,6 +22,8 @@ from imap_processing.lo.l1b.lo_l1b import (
     set_coincidence_type,
     set_each_event_epoch,
     set_event_met,
+    set_pointing_bin,
+    set_pointing_direction,
     set_spin_bin,
     set_spin_cycle,
 )
@@ -79,6 +81,8 @@ def test_lo_l1b():
     assert expected_logical_source == output_file[0].attrs["Logical_source"]
 
 
+# @pytest.mark.external_kernel
+# @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 def test_create_datasets():
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="lo")
@@ -503,3 +507,67 @@ def test_set_bad_times():
 
     # Assert
     np.testing.assert_array_equal(l1b_de["badtimes"], expected_bad_times)
+
+
+@pytest.mark.external_kernel
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+def test_set_direction():
+    # Arrange
+    l1b_de = xr.Dataset(
+        {},
+        coords={
+            "epoch": [
+                7.9794907049e17,
+                7.9794907153e17,
+                7.9794907254e17,
+            ],
+        },
+    )
+    # Need to better verify these values. Latitudes are likely to
+    # be 0, but not sure what values to expect from Longitudes.
+    # The expected values are based on what I'm getting from the
+    # SPICE tools.
+    expected_direction_lat = np.array([0, 0, 0])
+    expected_direction_lon = np.array([91.3, 116.3, 140.5])
+
+    # Act
+    l1b_de = set_pointing_direction(l1b_de)
+
+    # Assert
+    np.testing.assert_allclose(
+        l1b_de["direction_lat"].values,
+        expected_direction_lat,
+        atol=1e-1,
+    )
+    np.testing.assert_allclose(
+        l1b_de["direction_lon"].values,
+        expected_direction_lon,
+        atol=1e-1,
+    )
+
+
+def test_pointing_bins():
+    # Arrange
+    l1b_de = xr.Dataset(
+        {
+            "direction_lat": ("epoch", [0, 0, 0]),
+            "direction_lon": ("epoch", [91.3, 116.3, 140.5]),
+        },
+        coords={
+            "epoch": [
+                7.9794907049e17,
+                7.9794907153e17,
+                7.9794907254e17,
+            ],
+        },
+    )
+
+    expected_pointing_lats = np.array([20, 20, 20])
+    expected_pointing_lons = np.array([2712, 2962, 3205])
+
+    # Act
+    l1b_de = set_pointing_bin(l1b_de)
+
+    # Assert
+    np.testing.assert_array_equal(l1b_de["pointing_bin_lat"], expected_pointing_lats)
+    np.testing.assert_array_equal(l1b_de["pointing_bin_lon"], expected_pointing_lons)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -60,7 +61,10 @@ def attr_mgr_l1a():
     return attr_mgr
 
 
-def test_lo_l1b():
+@patch("imap_processing.lo.l1b.lo_l1b.instrument_pointing")
+@pytest.mark.external_kernel
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+def test_lo_l1b(mock_instrument_pointing):
     # Arrange
     de_file = (
         imap_module_directory / "tests/lo/test_cdfs/imap_lo_l1a_de_20241022_v002.cdf"
@@ -74,6 +78,7 @@ def test_lo_l1b():
         data[dataset.attrs["Logical_source"]] = dataset
 
     expected_logical_source = "imap_lo_l1b_de"
+    mock_instrument_pointing.return_value = np.zeros((2000, 2))
     # Act
     output_file = lo_l1b(data)
 

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -51,7 +51,7 @@ def test_imap_state_ecliptic():
 @pytest.mark.parametrize(
     "instrument, expected_offset",
     [
-        (SpiceFrame.IMAP_LO, 330 / 360),
+        (SpiceFrame.IMAP_LO_BASE, 330 / 360),
         (SpiceFrame.IMAP_HI_45, 255 / 360),
         (SpiceFrame.IMAP_HI_90, 285 / 360),
         (SpiceFrame.IMAP_ULTRA_45, 33 / 360),

--- a/imap_processing/tests/spice/test_spin.py
+++ b/imap_processing/tests/spice/test_spin.py
@@ -199,7 +199,7 @@ def test_get_spin_data(use_fake_spin_data_for_time):
 @pytest.mark.parametrize(
     "instrument",
     [
-        SpiceFrame.IMAP_LO,
+        SpiceFrame.IMAP_LO_BASE,
         SpiceFrame.IMAP_HI_45,
         SpiceFrame.IMAP_HI_90,
         SpiceFrame.IMAP_ULTRA_45,


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds the pointing direction and pointing bin fields to the Lo L1B Direct Events product. These are the final two fields needed for this product before moving on to L1C Pointing Sets.

I also updated the SPICE code to workaround a Lo related bug and updated the docstring to the `instrument_pointing` function so it's clearer what order the coordinates are returned.

## Updated Files
- imap_processing/lo/l1b/lo_l1b.py
   - added function to set the pointing direction
   - added function to set the pointing bin
- imap_processing/spice/geometry.py
   - Change IMAP_LO enums ot IMAP_LO_BASE as workaround for Lo bug in SPICE kernel
   - Updated docstring so it's more clear what order the coordinates are returned in `instrument_pointing`

## Testing
Added two unit tests

Closes #1519