### PR TITLE
Pass start_date and repointing into write_cdf from CLI

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -108,6 +108,7 @@ def _parse_args() -> argparse.Namespace:
         '--data-level "l1a" '
         '--descriptor "all" '
         ' --start-date "20231212" '
+        '--repointing "repoint12345" '
         '--version "v001" '
         '--dependency "['
         "    {"
@@ -195,16 +196,24 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--start-date",
         type=str,
-        required=True,
-        help="Start time for the output data. Format: YYYYMMDD or repoint#####",
+        required=False,
+        help="Start time for the output data. Format: YYYYMMDD",
     )
 
     parser.add_argument(
         "--end-date",
         type=str,
         required=False,
-        help="End time for the output data. If not provided, start_time will be used "
+        help="DEPRECATED: Do not use this."
+        "End time for the output data. If not provided, start_time will be used "
         "for end_time. Format: YYYYMMDD",
+    )
+    parser.add_argument(
+        "--repointing",
+        type=str,
+        required=False,
+        help="Repointing time for output data. Replaces start_time if both are "
+        "provided. Format: repoint#####",
     )
 
     parser.add_argument(
@@ -250,6 +259,30 @@ def _validate_args(args: argparse.Namespace) -> None:
             f"{args.data_level} is not a supported data level for the {args.instrument}"
             " instrument, valid levels are: "
             f"{imap_processing.PROCESSING_LEVELS[args.instrument]}"
+        )
+    if args.start_date is None and args.repointing is None:
+        raise ValueError(
+            "Either start_date or repointing must be provided. "
+            "Run 'imap_cli -h' for more information."
+        )
+
+    if (
+        args.start_date is not None
+        and not imap_data_access.ScienceFilePath.is_valid_date(args.start_date)
+    ):
+        raise ValueError(f"{args.start_date} is not a valid date, use format YYYYMMDD.")
+
+    if (
+        args.repointing is not None
+        and not imap_data_access.ScienceFilePath.is_valid_repointing(args.repointing)
+    ):
+        raise ValueError(
+            f"{args.repointing} is not a valid repointing, use format repoint#####."
+        )
+
+    if args.end_date is not None:
+        logger.warning(
+            "The end_date argument is deprecated and will be ignored. Do not use."
         )
 
 
@@ -298,8 +331,8 @@ class ProcessInstrument(ABC):
         This is what ProcessingInputCollection.serialize() outputs.
     start_date : str
         The start date for the output data in YYYYMMDD format.
-    end_date : str
-        The end date for the output data in YYYYMMDD format.
+    repointing : str
+        The repointing for the output data in the format 'repoint#####'.
     version : str
         The version of the data in vXXX format.
     upload_to_sdc : bool
@@ -312,7 +345,7 @@ class ProcessInstrument(ABC):
         data_descriptor: str,
         dependency_str: str,
         start_date: str,
-        end_date: str,
+        repointing: str,
         version: str,
         upload_to_sdc: bool,
     ) -> None:
@@ -322,9 +355,7 @@ class ProcessInstrument(ABC):
         self.dependency_str = dependency_str
 
         self.start_date = start_date
-        self.end_date = end_date
-        if not end_date:
-            self.end_date = start_date
+        self.repointing = repointing
 
         self.version = version
         self.upload_to_sdc = upload_to_sdc
@@ -451,19 +482,13 @@ class ProcessInstrument(ABC):
         # start_date.
         # If it is start_date, skip repointing in the output filename.
 
-        start_date = None
-        if imap_data_access.ScienceFilePath.is_valid_date(self.start_date):
-            start_date = self.start_date
-
-        repointing = None
-        if imap_data_access.ScienceFilePath.is_valid_repointing(self.start_date):
-            repointing = self.start_date
-
         products = []
         for ds in datasets:
             ds.attrs["Data_version"] = self.version
             ds.attrs["Parents"] = parent_files
-            products.append(write_cdf(ds, start_date=start_date, repointing=repointing))
+            products.append(
+                write_cdf(ds, start_date=self.start_date, repointing=self.repointing)
+            )
 
         self.upload_products(products)
 
@@ -1123,7 +1148,7 @@ def main() -> None:
         args.descriptor,
         args.dependency,
         args.start_date,
-        args.end_date,
+        args.repointing,
         args.version,
         args.upload_to_sdc,
     )

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -10,6 +10,8 @@ Examples
     imap_cli --instrument <instrument> --level <data_level>
 """
 
+from __future__ import annotations
+
 import argparse
 import logging
 import re
@@ -280,7 +282,7 @@ def _validate_args(args: argparse.Namespace) -> None:
             f"{args.repointing} is not a valid repointing, use format repoint#####."
         )
 
-    if args.end_date is not None:
+    if getattr(args, "end_date", None) is not None:
         logger.warning(
             "The end_date argument is deprecated and will be ignored. Do not use."
         )
@@ -344,8 +346,8 @@ class ProcessInstrument(ABC):
         data_level: str,
         data_descriptor: str,
         dependency_str: str,
-        start_date: str,
-        repointing: str,
+        start_date: str | None,
+        repointing: str | None,
         version: str,
         upload_to_sdc: bool,
     ) -> None:
@@ -449,8 +451,9 @@ class ProcessInstrument(ABC):
         Child classes can override this method to customize the
         post-processing actions.
 
-        If start_date is used to generate the output file name by default, and can
-        either be a date in the form YYYYMMDD or a repointing in the form repoint#####.
+        The values from start_date and/or repointing are used to generate the output
+        file name if supplied. All other filename fields are derived from the
+        dataset attributes.
 
         Parameters
         ----------

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -196,7 +196,7 @@ def _parse_args() -> argparse.Namespace:
         "--start-date",
         type=str,
         required=True,
-        help="Start time for the output data. Format: YYYYMMDD",
+        help="Start time for the output data. Format: YYYYMMDD or repoint#####",
     )
 
     parser.add_argument(
@@ -206,7 +206,6 @@ def _parse_args() -> argparse.Namespace:
         help="End time for the output data. If not provided, start_time will be used "
         "for end_time. Format: YYYYMMDD",
     )
-    # TODO: Will need to add some way of including pointing numbers
 
     parser.add_argument(
         "--version",
@@ -419,6 +418,9 @@ class ProcessInstrument(ABC):
         Child classes can override this method to customize the
         post-processing actions.
 
+        If start_date is used to generate the output file name by default, and can
+        either be a date in the form YYYYMMDD or a repointing in the form repoint#####.
+
         Parameters
         ----------
         datasets : list[xarray.Dataset]
@@ -444,11 +446,24 @@ class ProcessInstrument(ABC):
         if not isinstance(self.version, str) or r.match(self.version) is None:
             self.version = f"v{int(self.version):03d}"  # vXXX
 
+        # Start date is either the start date or the repointing.
+        # if it is the repointing, default to using the first epoch in the file as
+        # start_date.
+        # If it is start_date, skip repointing in the output filename.
+
+        start_date = None
+        if imap_data_access.ScienceFilePath.is_valid_date(self.start_date):
+            start_date = self.start_date
+
+        repointing = None
+        if imap_data_access.ScienceFilePath.is_valid_repointing(self.start_date):
+            repointing = self.start_date
+
         products = []
         for ds in datasets:
             ds.attrs["Data_version"] = self.version
             ds.attrs["Parents"] = parent_files
-            products.append(write_cdf(ds))
+            products.append(write_cdf(ds, start_date=start_date, repointing=repointing))
 
         self.upload_products(products)
 

--- a/imap_processing/glows/l1a/glows_l1a.py
+++ b/imap_processing/glows/l1a/glows_l1a.py
@@ -440,9 +440,6 @@ def generate_histogram_dataset(
     )
 
     attrs = glows_cdf_attributes.get_global_attributes("imap_glows_l1a_hist")
-    if obs_day:
-        # this needs to be 5 digits, so truncate it from the temporary obs day
-        attrs["Repointing"] = int(str(obs_day)[-5:])
 
     output = xr.Dataset(
         coords={"epoch": epoch_time, "bins": bins, "bins_label": bin_label},

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -95,6 +95,19 @@ def test_written_and_loaded_dataset(test_dataset):
     assert str(test_dataset) == str(new_dataset)
 
 
+def test_repoint_start_date(test_dataset):
+    output_file_path = write_cdf(test_dataset)
+    assert "imap_swe_l1a_sci_20100101_v001.cdf" in output_file_path.name
+    output_file_path = write_cdf(test_dataset, start_date="20001212")
+    assert "imap_swe_l1a_sci_20001212_v001.cdf" in output_file_path.name
+    output_file_path = write_cdf(test_dataset, repointing="repoint12345")
+    assert "imap_swe_l1a_sci_20100101-repoint12345_v001.cdf" in output_file_path.name
+    output_file_path = write_cdf(
+        test_dataset, start_date="20001212", repointing="12345"
+    )
+    assert "imap_swe_l1a_sci_20001212-repoint12345_v001.cdf" in output_file_path.name
+
+
 @pytest.mark.parametrize(
     "test_str, compare_dict",
     [


### PR DESCRIPTION
# Change Summary
This wires up the CLI, repointing, and write_cdf methods. This ensures the output file uses the input start_date value from the CLI rather than computing from the epoch. It also allows us to pass a repointing number into the CLI instead of a date, and have that passed through to create a filename. 

This is the first step to fixing the repointing issues we saw in MSIM, although it does require updates to batch_starter to properly pass through the repointing number (but isn't a breaking change for anything)

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
- Added the ability to pass repointing 
- Added keyword arguments to write_cdf for start_date and repointing that replace the calculated values
- Deprecated end_date and removed it from the processing class
- Made start_date optional

This does NOT introduce any breaking changes to the CLI. 