### PR TITLE
SWE L2 - use correct energy ordering for PSD

### DIFF
--- a/imap_processing/swe/l2/swe_l2.py
+++ b/imap_processing/swe/l2/swe_l2.py
@@ -96,9 +96,12 @@ def calculate_phase_space_density(l1b_dataset: xr.Dataset) -> xr.Dataset:
             for val in esa_table_nums
         ]
     )
+    # All sectors have same energy. Would be more rigorous to use the known sweep pattern
+    particle_energy_data.sort(axis=-1)
     particle_energy_data = particle_energy_data.reshape(
         -1, swe_constants.N_ESA_STEPS, swe_constants.N_ANGLE_SECTORS
     )
+    #assert not np.diff(particle_energy_data, axis=-1).any()
 
     # Calculate phase space density using formula:
     #   2 * (C/tau) / (G * 1.237e31 * eV^2)

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -345,6 +345,13 @@ def test_swe_l2(mock_read_in_flight_cal_data, use_fake_spin_data_for_time):
         swe_constants.N_ANGLE_SECTORS,
     )
 
+    rate = l1b_dataset[0].science_data.to_numpy()
+    psd = l2_dataset.phase_space_density_spin_sector.to_numpy()
+    rate = rate[2, :, :, 3]  # nonzero counts at all energy & spin
+    psd = psd[2, :, :, 3]
+    cal_factor = psd / rate  # same CEM, should be constant at a given energy
+    assert np.allclose(cal_factor, cal_factor[:, 0:1], rtol=1e-9, atol=0)
+
     # Write L2 to CDF
     l2_dataset.attrs["Data_version"] = "v002"
     l2_cdf_filepath = write_cdf(l2_dataset)


### PR DESCRIPTION
# Change Summary
Change the energy ordering in `swe_l2.calculate_phase_space_density` to account for the fact that `swe_l1b_science.populate_full_cycle_data` puts the output data in energy order, not scan order.

Since intensities are made from PSD, this fixed the intensities as well.

## Overview
We noticed in making fake L2 files from ACE that the calculated PSDs were pretty nonphysical. `calculate_phase_space_density` uses `get_particle_energy` to look up energies, which are returned in the "checkerboard" energy sweep order. But `populate_full_cycle_data` uses the actual energies to put data into an appropriate energy bin ordered by `swe_constants.ESA_VOLTAGE_ROW_INDEX_DICT`

This may conflict with #1620.

## Updated Files
- swe/l2/swe_l2.py
   - Sort the energies by energy, so that they're in the correct order. This doesn't exactly match what's being done in `populate_full_cycle_data`...to exactly match that, it should probably use values from `swe_constants.ESA_VOLTAGE_ROW_INDEX_DICT`, but that seems pretty fragile to LUT changes. Alternatively, this probably _should_ sort by the known energy sweep pattern and catch any problems after the fact, but we don't have that explicitly stored anywhere.
   - There's a commented-out assertion that all energies for a given sector are the same. It's really just for illustration and I'm guessing it'll be pulled out before merging, but may help the reviewer.
- tests/swe/test_swe_l2.py
   - Add a check to `test_swe_l2` (the functional) that the ratio of PSD to count rate is the same where the energy is the same. This is done for one particular time step and CEM where I've verified there are counts in all the angle and energy bins. This test fails with the code on `dev` and passes with the change.

## Testing
See updates to `test_swe_l2.py` above
