### PR TITLE
Ultra - L1b Cleanup

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1a_variable_attrs.yaml
@@ -1,3 +1,4 @@
+# Source: https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FILLVAL
 default_attrs: &default
   # Assumed values for all variable attrs unless overwritten
   DEPEND_0: epoch
@@ -51,7 +52,7 @@ default_int32_attrs: &default_int32
 
 default_float32_attrs: &default_float32
   <<: *default
-  FILLVAL: .NAN
+  FILLVAL: -1.0e31
   FORMAT: F10.2
   VALIDMIN: -3.4028235e+38
   VALIDMAX: 3.4028235e+38
@@ -59,7 +60,7 @@ default_float32_attrs: &default_float32
 
 default_float64_attrs: &default_float64
   <<: *default
-  FILLVAL: .NAN
+  FILLVAL: -1.0e31
   FORMAT: F10.2
   VALIDMIN: -1.7976931348623157e+308
   VALIDMAX: 1.7976931348623157e+308

--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -213,13 +213,11 @@ energy_heliosphere:
   UNITS: keV
 
 species:
-  <<: *default
+  <<: *default_uint8
   DISPLAY_TYPE: no_plot
   CATDESC: Label species type.
   FIELDNAM: Label species type.
-  FILLVAL: "UNKNOWN"
-  FORMAT: A8
-  dtype: str
+  LABLAXIS: species
   UNITS: " "
 
 front_back_distance:

--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -58,7 +58,7 @@ default_int32_attrs: &default_int32
 
 default_float32_attrs: &default_float32
   <<: *default
-  FILLVAL: .NAN
+  FILLVAL: -1.0e31
   FORMAT: F12.6
   VALIDMIN: -3.4028235e+38
   VALIDMAX: 3.4028235e+38

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -11,7 +11,7 @@ default_attrs: &default
 
 default_float32_attrs: &default_float32
   <<: *default
-  FILLVAL: .NAN
+  FILLVAL: -1.0e31
   FORMAT: F12.6
   VALIDMIN: -3.4028235e+38
   VALIDMAX: 3.4028235e+38

--- a/imap_processing/tests/ultra/unit/test_badtimes.py
+++ b/imap_processing/tests/ultra/unit/test_badtimes.py
@@ -32,6 +32,7 @@ def test_calculate_badtimes():
 
     ds = xr.Dataset(
         {
+            "epoch": np.array([0, 1, 2, 3], dtype="datetime64[ns]"),
             "quality_attitude": (("spin_number",), quality_attitude),
             "quality_ena_rates": (
                 ("energy_bin_geometric_mean", "spin_number"),

--- a/imap_processing/tests/ultra/unit/test_cullingmask.py
+++ b/imap_processing/tests/ultra/unit/test_cullingmask.py
@@ -25,6 +25,7 @@ def test_calculate_cullingmask_attitude():
 
     ds = xr.Dataset(
         {
+            "epoch": np.array([0, 1, 2, 3], dtype="datetime64[ns]"),
             "quality_attitude": (("spin_number",), quality_attitude),
             "quality_ena_rates": (
                 ("energy_bin_geometric_mean", "spin_number"),
@@ -76,6 +77,7 @@ def test_calculate_cullingmask_rates():
             "spin_start_time": (("spin_number",), spin_start_time),
         },
         coords={
+            "epoch": np.array([0, 1, 2, 3], dtype="datetime64[ns]"),
             "spin_number": spin_numbers,
             "energy_bin_geometric_mean": energy_bins,
         },

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -22,7 +22,7 @@ def test_calculate_de(l1b_de_dataset, df_filt):
 
     l1b_de_dataset = l1b_de_dataset[0]
     l1b_de_dataset = l1b_de_dataset.where(
-        l1b_de_dataset["start_type"] != np.iinfo(np.int64).min, drop=True
+        l1b_de_dataset["start_type"] != 255, drop=True
     )
     # Front and back positions
     assert np.allclose(l1b_de_dataset["x_front"].data, df_filt["Xf"].astype("float"))

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -63,7 +63,7 @@ def test_calculate_de(l1b_de_dataset, df_filt):
             & (l1b_de_dataset["tof_corrected"] < UltraConstants.CTOF_SPECIES_MAX)
         )[0]
     ]
-    assert np.all(species_array == "H")
+    assert np.all(species_array == 1)
 
     # Velocities in various frames
     test_tof = l1b_de_dataset["tof_start_stop"]

--- a/imap_processing/tests/ultra/unit/test_decom_apid_896.py
+++ b/imap_processing/tests/ultra/unit/test_decom_apid_896.py
@@ -27,6 +27,8 @@ def test_image_raw_events_decom(
 
     df = pd.read_csv(events_test_path, index_col="MET")
 
+    # # Check all values of each column are as expected,
+    # except for those set to fill value
     np.testing.assert_array_equal(
         df["SID"].values[df["SID"].values != -1],
         decom_ultra["sid"].values[df["SID"].values != -1],
@@ -126,6 +128,8 @@ def test_image_raw_events_decom_flags(decom_test_data, events_test_path):
     """This function reads validation data and checks that decom data
     matches validation data for image rate packet"""
 
+    # # Check all values of each column are as expected,
+    # except for those set to fill value
     decom_ultra = decom_test_data
     df = pd.read_csv(events_test_path, index_col="MET")
 

--- a/imap_processing/tests/ultra/unit/test_decom_apid_896.py
+++ b/imap_processing/tests/ultra/unit/test_decom_apid_896.py
@@ -26,30 +26,87 @@ def test_image_raw_events_decom(
     decom_ultra = decom_test_data
 
     df = pd.read_csv(events_test_path, index_col="MET")
-    df.replace(-1, np.iinfo(np.int64).min, inplace=True)
 
-    np.testing.assert_array_equal(df.SID, decom_ultra["sid"])
-    np.testing.assert_array_equal(df["Spin"], decom_ultra["spin"])
-    np.testing.assert_array_equal(df["AbortFlag"], decom_ultra["abortflag"])
-    np.testing.assert_array_equal(df["StartDelay"], decom_ultra["startdelay"])
-    np.testing.assert_array_equal(df["Count"], decom_ultra["count"])
-    np.testing.assert_array_equal(df["CoinType"], decom_ultra["coin_type"])
-    np.testing.assert_array_equal(df["StartType"], decom_ultra["start_type"])
-    np.testing.assert_array_equal(df["StopType"], decom_ultra["stop_type"])
-    np.testing.assert_array_equal(df["StartPosTDC"], decom_ultra["start_pos_tdc"])
-    np.testing.assert_array_equal(df["StopNorthTDC"], decom_ultra["stop_north_tdc"])
-    np.testing.assert_array_equal(df["StopEastTDC"], decom_ultra["stop_east_tdc"])
-    np.testing.assert_array_equal(df["StopSouthTDC"], decom_ultra["stop_south_tdc"])
-    np.testing.assert_array_equal(df["StopWestTDC"], decom_ultra["stop_west_tdc"])
-    np.testing.assert_array_equal(df["CoinNorthTDC"], decom_ultra["coin_north_tdc"])
-    np.testing.assert_array_equal(df["CoinSouthTDC"], decom_ultra["coin_south_tdc"])
     np.testing.assert_array_equal(
-        df["CoinDiscreteTDC"], decom_ultra["coin_discrete_tdc"]
+        df["SID"].values[df["SID"].values != -1],
+        decom_ultra["sid"].values[df["SID"].values != -1],
     )
-    np.testing.assert_array_equal(df["EnergyOrPH"], decom_ultra["energy_ph"])
-    np.testing.assert_array_equal(df["PulseWidth"], decom_ultra["pulse_width"])
-    np.testing.assert_array_equal(df["PhaseAngle"], decom_ultra["phase_angle"])
-    np.testing.assert_array_equal(df["Bin"], decom_ultra["bin"])
+    np.testing.assert_array_equal(
+        df["Spin"].values[df["Spin"].values != -1],
+        decom_ultra["spin"].values[df["Spin"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["AbortFlag"].values[df["AbortFlag"].values != -1],
+        decom_ultra["abortflag"].values[df["AbortFlag"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["StartDelay"].values[df["StartDelay"].values != -1],
+        decom_ultra["startdelay"].values[df["StartDelay"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["Count"].values[df["Count"].values != -1],
+        decom_ultra["count"].values[df["Count"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CoinType"].values[df["CoinType"].values != -1],
+        decom_ultra["coin_type"].values[df["CoinType"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["StartType"].values[df["StartType"].values != -1],
+        decom_ultra["start_type"].values[df["StartType"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["StopType"].values[df["StopType"].values != -1],
+        decom_ultra["stop_type"].values[df["StopType"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["StartPosTDC"].values[df["StartPosTDC"].values != -1],
+        decom_ultra["start_pos_tdc"].values[df["StartPosTDC"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["StopNorthTDC"].values[df["StopNorthTDC"].values != -1],
+        decom_ultra["stop_north_tdc"].values[df["StopNorthTDC"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["StopEastTDC"].values[df["StopEastTDC"].values != -1],
+        decom_ultra["stop_east_tdc"].values[df["StopEastTDC"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["StopSouthTDC"].values[df["StopSouthTDC"].values != -1],
+        decom_ultra["stop_south_tdc"].values[df["StopSouthTDC"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["StopWestTDC"].values[df["StopWestTDC"].values != -1],
+        decom_ultra["stop_west_tdc"].values[df["StopWestTDC"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CoinNorthTDC"].values[df["CoinNorthTDC"].values != -1],
+        decom_ultra["coin_north_tdc"].values[df["CoinNorthTDC"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CoinSouthTDC"].values[df["CoinSouthTDC"].values != -1],
+        decom_ultra["coin_south_tdc"].values[df["CoinSouthTDC"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CoinDiscreteTDC"].values[df["CoinDiscreteTDC"].values != -1],
+        decom_ultra["coin_discrete_tdc"].values[df["CoinDiscreteTDC"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["EnergyOrPH"].values[df["EnergyOrPH"].values != -1],
+        decom_ultra["energy_ph"].values[df["EnergyOrPH"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["PulseWidth"].values[df["PulseWidth"].values != -1],
+        decom_ultra["pulse_width"].values[df["PulseWidth"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["PhaseAngle"].values[df["PhaseAngle"].values != -1],
+        decom_ultra["phase_angle"].values[df["PhaseAngle"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["Bin"].values[df["Bin"].values != -1],
+        decom_ultra["bin"].values[df["Bin"].values != -1],
+    )
 
 
 @pytest.mark.parametrize(
@@ -71,34 +128,120 @@ def test_image_raw_events_decom_flags(decom_test_data, events_test_path):
 
     decom_ultra = decom_test_data
     df = pd.read_csv(events_test_path, index_col="MET")
-    df.replace(-1, np.iinfo(np.int64).min, inplace=True)
 
-    np.testing.assert_array_equal(df["CnT"], decom_ultra["event_flag_cnt"])
-    np.testing.assert_array_equal(df["PHCmpSL"], decom_ultra["event_flag_phcmpsl"])
-    np.testing.assert_array_equal(df["PHCmpSR"], decom_ultra["event_flag_phcmpsr"])
-    np.testing.assert_array_equal(df["PHCmpCD"], decom_ultra["event_flag_phcmpcd"])
-    np.testing.assert_array_equal(df["SSDS7"], decom_ultra["ssd_flag_7"])
-    np.testing.assert_array_equal(df["SSDS6"], decom_ultra["ssd_flag_6"])
-    np.testing.assert_array_equal(df["SSDS5"], decom_ultra["ssd_flag_5"])
-    np.testing.assert_array_equal(df["SSDS4"], decom_ultra["ssd_flag_4"])
-    np.testing.assert_array_equal(df["SSDS3"], decom_ultra["ssd_flag_3"])
-    np.testing.assert_array_equal(df["SSDS2"], decom_ultra["ssd_flag_2"])
-    np.testing.assert_array_equal(df["SSDS1"], decom_ultra["ssd_flag_1"])
-    np.testing.assert_array_equal(df["SSDS0"], decom_ultra["ssd_flag_0"])
-    np.testing.assert_array_equal(df["CFDCoinTN"], decom_ultra["cfd_flag_cointn"])
-    np.testing.assert_array_equal(df["CFDCoinBN"], decom_ultra["cfd_flag_coinbn"])
-    np.testing.assert_array_equal(df["CFDCoinTS"], decom_ultra["cfd_flag_coints"])
-    np.testing.assert_array_equal(df["CFDCoinBS"], decom_ultra["cfd_flag_coinbs"])
-    np.testing.assert_array_equal(df["CFDCoinD"], decom_ultra["cfd_flag_coind"])
-    np.testing.assert_array_equal(df["CFDStartRF"], decom_ultra["cfd_flag_startrf"])
-    np.testing.assert_array_equal(df["CFDStartLF"], decom_ultra["cfd_flag_startlf"])
-    np.testing.assert_array_equal(df["CFDStartRP"], decom_ultra["cfd_flag_startrp"])
-    np.testing.assert_array_equal(df["CFDStartLP"], decom_ultra["cfd_flag_startlp"])
-    np.testing.assert_array_equal(df["CFDStopTN"], decom_ultra["cfd_flag_stoptn"])
-    np.testing.assert_array_equal(df["CFDStopBN"], decom_ultra["cfd_flag_stopbn"])
-    np.testing.assert_array_equal(df["CFDStopTE"], decom_ultra["cfd_flag_stopte"])
-    np.testing.assert_array_equal(df["CFDStopBE"], decom_ultra["cfd_flag_stopbe"])
-    np.testing.assert_array_equal(df["CFDStopTS"], decom_ultra["cfd_flag_stopts"])
-    np.testing.assert_array_equal(df["CFDStopBS"], decom_ultra["cfd_flag_stopbs"])
-    np.testing.assert_array_equal(df["CFDStopTW"], decom_ultra["cfd_flag_stoptw"])
-    np.testing.assert_array_equal(df["CFDStopBW"], decom_ultra["cfd_flag_stopbw"])
+    np.testing.assert_array_equal(
+        df["CnT"].values[df["CnT"].values != -1],
+        decom_ultra["event_flag_cnt"].values[df["CnT"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["PHCmpSL"].values[df["PHCmpSL"].values != -1],
+        decom_ultra["event_flag_phcmpsl"].values[df["PHCmpSL"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["PHCmpSR"].values[df["PHCmpSR"].values != -1],
+        decom_ultra["event_flag_phcmpsr"].values[df["PHCmpSR"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["PHCmpCD"].values[df["PHCmpCD"].values != -1],
+        decom_ultra["event_flag_phcmpcd"].values[df["PHCmpCD"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["SSDS7"].values[df["SSDS7"].values != -1],
+        decom_ultra["ssd_flag_7"].values[df["SSDS7"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["SSDS6"].values[df["SSDS6"].values != -1],
+        decom_ultra["ssd_flag_6"].values[df["SSDS6"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["SSDS5"].values[df["SSDS5"].values != -1],
+        decom_ultra["ssd_flag_5"].values[df["SSDS5"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["SSDS4"].values[df["SSDS4"].values != -1],
+        decom_ultra["ssd_flag_4"].values[df["SSDS4"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["SSDS3"].values[df["SSDS3"].values != -1],
+        decom_ultra["ssd_flag_3"].values[df["SSDS3"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["SSDS2"].values[df["SSDS2"].values != -1],
+        decom_ultra["ssd_flag_2"].values[df["SSDS2"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["SSDS1"].values[df["SSDS1"].values != -1],
+        decom_ultra["ssd_flag_1"].values[df["SSDS1"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["SSDS0"].values[df["SSDS0"].values != -1],
+        decom_ultra["ssd_flag_0"].values[df["SSDS0"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDCoinTN"].values[df["CFDCoinTN"].values != -1],
+        decom_ultra["cfd_flag_cointn"].values[df["CFDCoinTN"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDCoinBN"].values[df["CFDCoinBN"].values != -1],
+        decom_ultra["cfd_flag_coinbn"].values[df["CFDCoinBN"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDCoinTS"].values[df["CFDCoinTS"].values != -1],
+        decom_ultra["cfd_flag_coints"].values[df["CFDCoinTS"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDCoinBS"].values[df["CFDCoinBS"].values != -1],
+        decom_ultra["cfd_flag_coinbs"].values[df["CFDCoinBS"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDCoinD"].values[df["CFDCoinD"].values != -1],
+        decom_ultra["cfd_flag_coind"].values[df["CFDCoinD"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStartRF"].values[df["CFDStartRF"].values != -1],
+        decom_ultra["cfd_flag_startrf"].values[df["CFDStartRF"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStartLF"].values[df["CFDStartLF"].values != -1],
+        decom_ultra["cfd_flag_startlf"].values[df["CFDStartLF"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStartRP"].values[df["CFDStartRP"].values != -1],
+        decom_ultra["cfd_flag_startrp"].values[df["CFDStartRP"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStartLP"].values[df["CFDStartLP"].values != -1],
+        decom_ultra["cfd_flag_startlp"].values[df["CFDStartLP"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStopTN"].values[df["CFDStopTN"].values != -1],
+        decom_ultra["cfd_flag_stoptn"].values[df["CFDStopTN"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStopBN"].values[df["CFDStopBN"].values != -1],
+        decom_ultra["cfd_flag_stopbn"].values[df["CFDStopBN"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStopTE"].values[df["CFDStopTE"].values != -1],
+        decom_ultra["cfd_flag_stopte"].values[df["CFDStopTE"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStopBE"].values[df["CFDStopBE"].values != -1],
+        decom_ultra["cfd_flag_stopbe"].values[df["CFDStopBE"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStopTS"].values[df["CFDStopTS"].values != -1],
+        decom_ultra["cfd_flag_stopts"].values[df["CFDStopTS"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStopBS"].values[df["CFDStopBS"].values != -1],
+        decom_ultra["cfd_flag_stopbs"].values[df["CFDStopBS"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStopTW"].values[df["CFDStopTW"].values != -1],
+        decom_ultra["cfd_flag_stoptw"].values[df["CFDStopTW"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["CFDStopBW"].values[df["CFDStopBW"].values != -1],
+        decom_ultra["cfd_flag_stopbw"].values[df["CFDStopBW"].values != -1],
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -103,7 +103,7 @@ def test_ultra_l1b(l1b_de_dataset):
 
 def test_cdf_de(l1b_de_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
-    test_data_path = write_cdf(l1b_de_dataset[0], istp=False)
+    test_data_path = write_cdf(l1b_de_dataset[0], istp=True)
     assert test_data_path.exists()
     assert test_data_path.name == "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
 
@@ -127,10 +127,10 @@ def test_ultra_l1b_extendedspin(l1b_extendedspin_dataset):
 
 def test_cdf_extendedspin(l1b_extendedspin_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
-    test_data_path = write_cdf(l1b_extendedspin_dataset[0], istp=False)
+    test_data_path = write_cdf(l1b_extendedspin_dataset[0], istp=True)
     assert test_data_path.exists()
     assert (
-        test_data_path.name == "imap_ultra_l1b_45sensor-extendedspin_20000101_v999.cdf"
+        test_data_path.name == "imap_ultra_l1b_45sensor-extendedspin_20240207_v999.cdf"
     )
 
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -134,6 +134,22 @@ def test_cdf_extendedspin(l1b_extendedspin_dataset):
     )
 
 
+def test_cdf_cullingmask(l1b_extendedspin_dataset):
+    """Tests that CDF file is created and contains same attributes as xarray."""
+    test_data_path = write_cdf(l1b_extendedspin_dataset[1], istp=True)
+    assert test_data_path.exists()
+    assert (
+        test_data_path.name == "imap_ultra_l1b_45sensor-cullingmask_20240207_v999.cdf"
+    )
+
+
+def test_cdf_badtimes(l1b_extendedspin_dataset):
+    """Tests that CDF file is created and contains same attributes as xarray."""
+    test_data_path = write_cdf(l1b_extendedspin_dataset[2], istp=True)
+    assert test_data_path.exists()
+    assert test_data_path.name == "imap_ultra_l1b_45sensor-badtimes_20240207_v999.cdf"
+
+
 def test_ultra_l1b_error(mock_data_l1a_rates_dict):
     """Tests that L1a data throws an error."""
     mock_data_l1a_rates_dict["bad_key"] = mock_data_l1a_rates_dict.pop(

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -42,6 +42,10 @@ def mock_data_l1b_de_dict():
 
 @pytest.fixture
 def mock_data_l1b_extendedspin_dict():
+    epoch = np.array(
+        [760591786368000000, 760591787368000000, 760591788368000000],
+        dtype="datetime64[ns]",
+    )
     spin = np.array(
         [0, 1, 2],
         dtype="uint32",
@@ -53,6 +57,7 @@ def mock_data_l1b_extendedspin_dict():
     spin_start_time = np.array([0, 1, 2], dtype="uint64")
     quality = np.zeros((2, 3), dtype="uint16")
     data_dict = {
+        "epoch": epoch,
         "spin_number": spin,
         "energy_bin_geometric_mean": energy,
         "spin_start_time": spin_start_time,

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -1,8 +1,10 @@
 """Tests Culling for ULTRA L1b."""
 
 import numpy as np
+import pandas as pd
 import pytest
 
+from imap_processing import imap_module_directory
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
@@ -13,6 +15,8 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
     get_n_sigma,
     get_spin_data,
 )
+
+TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 
 @pytest.fixture
@@ -108,3 +112,50 @@ def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time, faux_aux_datas
     expected = np.array([False] * 14 + [True])
 
     assert np.all(result == expected)
+
+
+def test_with_data():
+    import re
+
+    data = TEST_PATH / "IMAP-Ultra90_20.65_mod.txt"
+
+    with open(data) as f:
+        lines = f.readlines()
+
+    # Remove lines starting with ###
+    lines = [line for line in lines if not line.strip().startswith("###")]
+
+    # Replace multiple spaces/tabs with a single comma
+    lines = [re.sub(r"[\t ]+", ",", line.strip()) for line in lines]
+
+    # Now read it as a CSV from the cleaned lines
+    from io import StringIO
+
+    clean_text = "\n".join(lines)
+    df = pd.read_csv(StringIO(clean_text), header=None)
+
+    # Set your correct column names
+    df.columns = [
+        "tdb",
+        "StartX",
+        "PosYSlit",
+        "StopX",
+        "StopY",
+        "Energy",
+        "Type",
+        "PH",
+        "SpinPhase",
+        "TOF",
+    ]
+    import matplotlib
+
+    matplotlib.use("TkAgg")  # Or 'QtAgg' if you have PyQt installed
+    import matplotlib.pyplot as plt
+
+    plt.plot(df["tdb"])
+    plt.xlabel("Index")  # X-axis label (just the row number for now)
+    plt.ylabel("tdb")  # Y-axis label
+    plt.title("TDB Values")
+    plt.grid(True)
+    plt.show()
+    print("hi")

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -1,7 +1,6 @@
 """Tests Culling for ULTRA L1b."""
 
 import numpy as np
-import pandas as pd
 import pytest
 
 from imap_processing import imap_module_directory
@@ -112,50 +111,3 @@ def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time, faux_aux_datas
     expected = np.array([False] * 14 + [True])
 
     assert np.all(result == expected)
-
-
-def test_with_data():
-    import re
-
-    data = TEST_PATH / "IMAP-Ultra90_20.65_mod.txt"
-
-    with open(data) as f:
-        lines = f.readlines()
-
-    # Remove lines starting with ###
-    lines = [line for line in lines if not line.strip().startswith("###")]
-
-    # Replace multiple spaces/tabs with a single comma
-    lines = [re.sub(r"[\t ]+", ",", line.strip()) for line in lines]
-
-    # Now read it as a CSV from the cleaned lines
-    from io import StringIO
-
-    clean_text = "\n".join(lines)
-    df = pd.read_csv(StringIO(clean_text), header=None)
-
-    # Set your correct column names
-    df.columns = [
-        "tdb",
-        "StartX",
-        "PosYSlit",
-        "StopX",
-        "StopY",
-        "Energy",
-        "Type",
-        "PH",
-        "SpinPhase",
-        "TOF",
-    ]
-    import matplotlib
-
-    matplotlib.use("TkAgg")  # Or 'QtAgg' if you have PyQt installed
-    import matplotlib.pyplot as plt
-
-    plt.plot(df["tdb"])
-    plt.xlabel("Index")  # X-axis label (just the row number for now)
-    plt.ylabel("tdb")  # Y-axis label
-    plt.title("TDB Values")
-    plt.grid(True)
-    plt.show()
-    print("hi")

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -40,9 +40,7 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 def test_fixture(de_dataset, events_fsw_comparison_theta_0):
     """Fixture to compute and return yf and related data."""
     # Remove start_type with fill values
-    de_dataset = de_dataset.where(
-        de_dataset["start_type"] != np.iinfo(np.int64).min, drop=True
-    )
+    de_dataset = de_dataset.where(de_dataset["start_type"] != 255, drop=True)
 
     df = pd.read_csv(events_fsw_comparison_theta_0)
     df_filt = df[df["StartType"] != -1]

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -341,7 +341,7 @@ def test_get_de_energy_kev(test_fixture):
     )
 
     energy = get_de_energy_kev(v, species_bin_ph)
-    index_hydrogen = np.where(species_bin_ph == "H")
+    index_hydrogen = np.where(species_bin_ph == 1)
     actual_energy = energy[index_hydrogen[0]]
     expected_energy = df_ph["energy_revised"].astype("float")
 
@@ -434,13 +434,13 @@ def test_determine_species(test_fixture):
         "SSD",
     )
 
-    h_indices_ph = np.where(species_bin_ph == "H")[0]
+    h_indices_ph = np.where(species_bin_ph == 1)[0]
     ctof_indices_ph = np.where(
         (df_ph["cTOF"].astype("float") > UltraConstants.CTOF_SPECIES_MIN)
         & (df_ph["cTOF"].astype("float") < UltraConstants.CTOF_SPECIES_MAX)
     )[0]
 
-    h_indices_ssd = np.where(species_bin_ssd == "H")[0]
+    h_indices_ssd = np.where(species_bin_ssd == 1)[0]
     ctof_indices_ssd = np.where(
         (df_ssd["cTOF"].astype("float") > UltraConstants.CTOF_SPECIES_MIN)
         & (df_ssd["cTOF"].astype("float") < UltraConstants.CTOF_SPECIES_MAX)

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -6,8 +6,10 @@ from typing import cast
 
 import numpy as np
 import xarray as xr
+import yaml
 from numpy.typing import NDArray
 
+from imap_processing import imap_module_directory
 from imap_processing.ultra.l0.decom_tools import (
     decompress_binary,
     decompress_image,
@@ -151,7 +153,17 @@ def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
     """
     all_events = []
     all_indices = []
-    empty_event = {field: np.iinfo(np.int64).min for field in EVENT_FIELD_RANGES}
+
+    with open(
+        imap_module_directory / "cdf" / "config" / "imap_ultra_l1a_variable_attrs.yaml"
+    ) as f:
+        field_metadata = yaml.safe_load(f)
+
+    empty_event = {
+        field: field_metadata.get(field, {}).get("FILLVAL", np.iinfo(np.int64).min)
+        for field in EVENT_FIELD_RANGES
+    }
+
     counts = ds["count"].values
     eventdata_array = ds["eventdata"].values
 

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -6,10 +6,9 @@ from typing import cast
 
 import numpy as np
 import xarray as xr
-import yaml
 from numpy.typing import NDArray
 
-from imap_processing import imap_module_directory
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.ultra.l0.decom_tools import (
     decompress_binary,
     decompress_image,
@@ -154,13 +153,13 @@ def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
     all_events = []
     all_indices = []
 
-    with open(
-        imap_module_directory / "cdf" / "config" / "imap_ultra_l1a_variable_attrs.yaml"
-    ) as f:
-        field_metadata = yaml.safe_load(f)
+    attrs = ImapCdfAttributes()
+    attrs.add_instrument_variable_attrs("ultra", level="l1a")
 
     empty_event = {
-        field: field_metadata.get(field, {}).get("FILLVAL", np.iinfo(np.int64).min)
+        field: attrs.get_variable_attributes(field).get(
+            "FILLVAL", np.iinfo(np.int64).min
+        )
         for field in EVENT_FIELD_RANGES
     }
 

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -101,7 +101,7 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
     ctof = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
     magnitude_v = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
     energy = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    species_bin = np.full(len(de_dataset["epoch"]), "UNKNOWN", dtype="U10")
+    species_bin = np.full(len(de_dataset["epoch"]), 255, dtype=np.uint8)
     t2 = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
     event_times = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
     spin_starts = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -75,7 +75,7 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
         {key: de_dataset[dataset_key] for key, dataset_key in zip(keys, dataset_keys)}
     )
 
-    valid_mask = de_dataset["start_type"].data != np.iinfo(np.int64).min
+    valid_mask = de_dataset["start_type"].data != 255
     ph_mask = np.isin(
         de_dataset["stop_type"].data, [StopType.Top.value, StopType.Bottom.value]
     )
@@ -86,26 +86,27 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
     ssd_indices = np.nonzero(valid_mask & ssd_mask)[0]
 
     # Instantiate arrays
-    xf = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    yf = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    xb = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    yb = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    xc = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    d = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float64)
-    r = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    phi = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    theta = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    tof = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    etof = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    ctof = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    magnitude_v = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    energy = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
+    # Note that -1.0e31 and 255 are FILL values.
+    xf = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    yf = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    xb = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    yb = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    xc = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    d = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
+    r = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    phi = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    theta = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    tof = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    etof = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    ctof = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    magnitude_v = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    energy = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
     species_bin = np.full(len(de_dataset["epoch"]), "UNKNOWN", dtype="U10")
-    t2 = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float32)
-    event_times = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float64)
-    spin_starts = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float64)
-    spin_period_sec = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.float64)
-    start_type = np.full(len(de_dataset["epoch"]), np.nan, dtype=np.uint8)
+    t2 = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
+    event_times = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
+    spin_starts = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
+    spin_period_sec = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
+    start_type = np.full(len(de_dataset["epoch"]), 255, dtype=np.uint8)
 
     xf[valid_indices] = get_front_x_position(
         de_dataset["start_type"].data[valid_indices],

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -29,6 +29,9 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
 )
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
+FILLVAL_UINT8 = 255
+FILLVAL_FLOAT32 = -1.0e31
+
 
 def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
     """
@@ -75,7 +78,7 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
         {key: de_dataset[dataset_key] for key, dataset_key in zip(keys, dataset_keys)}
     )
 
-    valid_mask = de_dataset["start_type"].data != 255
+    valid_mask = de_dataset["start_type"].data != FILLVAL_UINT8
     ph_mask = np.isin(
         de_dataset["stop_type"].data, [StopType.Top.value, StopType.Bottom.value]
     )
@@ -86,27 +89,28 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
     ssd_indices = np.nonzero(valid_mask & ssd_mask)[0]
 
     # Instantiate arrays
-    # Note that -1.0e31 and 255 are FILL values.
-    xf = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    yf = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    xb = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    yb = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    xc = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    d = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
-    r = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    phi = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    theta = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    tof = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    etof = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    ctof = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    magnitude_v = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    energy = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    species_bin = np.full(len(de_dataset["epoch"]), 255, dtype=np.uint8)
-    t2 = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float32)
-    event_times = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
-    spin_starts = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
-    spin_period_sec = np.full(len(de_dataset["epoch"]), -1.0e31, dtype=np.float64)
-    start_type = np.full(len(de_dataset["epoch"]), 255, dtype=np.uint8)
+    xf = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    yf = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    xb = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    yb = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    xc = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    d = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float64)
+    r = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    phi = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    theta = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    tof = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    etof = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    ctof = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    magnitude_v = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    energy = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    species_bin = np.full(len(de_dataset["epoch"]), FILLVAL_UINT8, dtype=np.uint8)
+    t2 = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    event_times = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float64)
+    spin_starts = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float64)
+    spin_period_sec = np.full(
+        len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float64
+    )
+    start_type = np.full(len(de_dataset["epoch"]), FILLVAL_UINT8, dtype=np.uint8)
 
     xf[valid_indices] = get_front_x_position(
         de_dataset["start_type"].data[valid_indices],

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -1,5 +1,6 @@
 """Calculate Extended Spin."""
 
+import numpy as np
 import xarray as xr
 
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
@@ -46,8 +47,14 @@ def calculate_extendedspin(
     attitude_qf, spin_rates, spin_period, spin_starttime = flag_attitude(
         de_dataset["spin"].values, aux_dataset
     )
+    # Get the first epoch for each spin.
+    mask = xr.DataArray(np.isin(de_dataset["spin"], spin), dims="epoch")
+    filtered_dataset = de_dataset.where(mask, drop=True)
+    _, first_indices = np.unique(filtered_dataset["spin"].values, return_index=True)
+    first_epochs = filtered_dataset["epoch"].values[first_indices]
 
     # These will be the coordinates.
+    extendedspin_dict["epoch"] = first_epochs
     extendedspin_dict["spin_number"] = spin
     extendedspin_dict["energy_bin_geometric_mean"] = energy_midpoints
 

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -670,7 +670,7 @@ def get_energy_ssd(de_dataset: xarray.Dataset, ssd: np.ndarray) -> NDArray[np.fl
     energy_norm : np.ndarray
         Energy measured using the SSD.
     """
-    ssd_indices = np.where(de_dataset["stop_type"].data >= 8)[0]
+    ssd_indices = np.nonzero(np.isin(de_dataset["stop_type"], StopType.SSD.value))[0]
     energy = de_dataset["energy_ph"].data[ssd_indices]
 
     composite_energy = np.empty(len(energy), dtype=np.float64)

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -572,7 +572,7 @@ def get_de_energy_kev(v: np.ndarray, species: np.ndarray) -> NDArray:
     # Compute the sum of squares.
     v2 = np.sum(vv**2, axis=1)
 
-    index_hydrogen = np.where(species == "H")
+    index_hydrogen = np.where(species == 1)
     energy = np.full_like(v2, np.nan)
 
     # 1/2 mv^2 in Joules, convert to keV

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -761,13 +761,13 @@ def determine_species(tof: np.ndarray, path_length: np.ndarray, type: str) -> ND
     # Event TOF normalization to Z axis
     ctof, _ = get_ctof(tof, path_length, type)
     # Initialize bin array
-    species_bin = np.full(len(ctof), "UNKNOWN", dtype="U10")
+    species_bin = np.full(len(ctof), 255, dtype=np.uint8)
 
-    # Assign "H" to bins where cTOF is within the specified range
+    # Assign Species 1 ("H") to bins where cTOF is within the specified range
     species_bin[
         (ctof > UltraConstants.CTOF_SPECIES_MIN)
         & (ctof < UltraConstants.CTOF_SPECIES_MAX)
-    ] = "H"
+    ] = 1
 
     return species_bin
 

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -722,9 +722,11 @@ def get_ctof(
 
     # Multiply times 100 to convert to hundredths of a millimeter.
     ctof = tof * dmin_ctof * 100 / path_length
+    magnitude_v = np.full(len(ctof), -1.0e31, dtype=np.float32)
 
-    # Convert from mm/0.1ns to km/s.
-    magnitude_v = dmin_ctof / np.abs(ctof) * 1e4
+    # Convert from mm/0.1ns to km/s for valid ctof values
+    valid_mask = ctof >= 0
+    magnitude_v[valid_mask] = dmin_ctof / ctof[valid_mask] * 1e4
 
     return ctof, magnitude_v
 

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -37,7 +37,7 @@ def create_dataset(
             "spin_number": data_dict["spin_number"],
             "energy_bin_geometric_mean": data_dict["energy_bin_geometric_mean"],
             # Start time aligns with the universal spin table
-            "epoch": data_dict["spin_start_time"],
+            "epoch": data_dict["epoch"],
         }
         default_dimension = "spin_number"
     # L1c pset data products


### PR DESCRIPTION
# Change Summary

## Overview
Cleanup including making FILL values individualized based on data type, filing vmagnitude with FILL values if ctof is negative, adding epoch to extendedspin, cullingmask, and badtimes so that file naming would work well, making certain that ISTP=True.

## Updated Files
- imap_ultra_l1a_variable_attrs.yaml
   - Update FILL values to ISTP standards
- imap_ultra_l1b_variable_attrs.yaml
   - Update attributes
- imap_ultra_l1c_variable_attrs.yaml
   - Update FILL values to ISTP standards
- decom_ultra.py
   - Individualized FILL values to match data type
- ultra_l1b_extended.py
   - vmag -> nans where ctof = neg
   - Changed species bin to type uint8
- ultra_l1_utils.py
   - Added “epoch” instead of spin start time as a coordinate. This was necessary for filenaming of extendedspin, cullingmask, and badtimes data products.
- extendedspin.py
   - Added “epoch” instead of spin start time as a coordinate. This was necessary for filenaming of extendedspin, cullingmask, and badtimes data products.
- de.py
   - Added individualized FILL values

## Testing
- test_de.py
- test_decom_apid_896.py
- test_ultra_l1b.py
- test_ultra_l1b_extended.py
- test_cullingmask.py
- test_badtimes.py