### PR TITLE
HIT L2 - add total uncertainties

### DIFF
--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 # TODO:
 #  - review logging levels to use (debug vs. info)
 #  - determine where to pull ancillary data. Storing it locally for now
-#  - add function to calculate combined uncertainty and add this to L2 datasets
 
 
 def hit_l2(dependency: xr.Dataset) -> list[xr.Dataset]:
@@ -576,16 +575,20 @@ def process_summed_intensity_data(l1b_summed_rates_dataset: xr.Dataset) -> xr.Da
         L2_SUMMED_ANCILLARY_PATH_PREFIX,
     )
 
-    # Add systematic uncertainties to the dataset. These will not
-    # have the intensity calculation applied to them
+    # Calculate the intensity for each species
+    l2_summed_intensity_dataset = calculate_intensities_for_all_species(
+        l2_summed_intensity_dataset, ancillary_data_frames, VALID_SPECIES
+    )
+
+    # Add total and systematic uncertainties to the dataset
     for var in l2_summed_intensity_dataset.data_vars:
         if var in VALID_SPECIES:
             l2_summed_intensity_dataset = add_systematic_uncertainties(
                 l2_summed_intensity_dataset, var
             )
-    l2_summed_intensity_dataset = calculate_intensities_for_all_species(
-        l2_summed_intensity_dataset, ancillary_data_frames, VALID_SPECIES
-    )
+            l2_summed_intensity_dataset = add_total_uncertainties(
+                l2_summed_intensity_dataset, var
+            )
 
     return l2_summed_intensity_dataset
 
@@ -652,18 +655,16 @@ def process_standard_intensity_data(
             particle,
             energy_ranges,
         )
-        # Add systematic uncertainties to the dataset. These will not have the intensity
-        # calculation applied to them and values will be zeros
-        l2_standard_intensity_dataset = add_systematic_uncertainties(
-            l2_standard_intensity_dataset, particle
-        )
 
     l2_standard_intensity_dataset = calculate_intensities_for_all_species(
         l2_standard_intensity_dataset, ancillary_data_frames, VALID_SPECIES
     )
 
-    # Add total uncertainties to the dataset
+    # Add total and systematic uncertainties to the dataset
     for particle in STANDARD_PARTICLE_ENERGY_RANGE_MAPPING.keys():
+        l2_standard_intensity_dataset = add_systematic_uncertainties(
+            l2_standard_intensity_dataset, particle
+        )
         l2_standard_intensity_dataset = add_total_uncertainties(
             l2_standard_intensity_dataset, particle
         )
@@ -704,16 +705,20 @@ def process_sectored_intensity_data(
         L2_SECTORED_ANCILLARY_PATH_PREFIX,
     )
 
-    # Add systematic uncertainties to the dataset. These will not
-    # have the intensity calculation applied to them
+    # Calculate the intensity for each species
+    l2_sectored_intensity_dataset = calculate_intensities_for_all_species(
+        l2_sectored_intensity_dataset, ancillary_data_frames, VALID_SECTORED_SPECIES
+    )
+
+    # Add total and systematic uncertainties to the dataset
     for var in l2_sectored_intensity_dataset.data_vars:
         if var in VALID_SECTORED_SPECIES:
             l2_sectored_intensity_dataset = add_systematic_uncertainties(
                 l2_sectored_intensity_dataset, var
             )
-    l2_sectored_intensity_dataset = calculate_intensities_for_all_species(
-        l2_sectored_intensity_dataset, ancillary_data_frames, VALID_SECTORED_SPECIES
-    )
+            l2_sectored_intensity_dataset = add_total_uncertainties(
+                l2_sectored_intensity_dataset, var
+            )
 
     return l2_sectored_intensity_dataset
 
@@ -722,7 +727,7 @@ if __name__ == "__main__":
     from imap_processing import imap_module_directory
     from imap_processing.hit.l1a.hit_l1a import hit_l1a
     from imap_processing.hit.l1b.hit_l1b import (
-        process_standard_rates_data,
+        process_sectored_rates_data,
     )
 
     # L0 file path
@@ -734,17 +739,17 @@ if __name__ == "__main__":
     # Calculate livetime from the livetime counter
     livetime = counts["livetime_counter"] / 270
 
-    # # Process L2 Sectored
-    # sectored_rates = process_sectored_rates_data(counts, livetime)
-    # l2_sectored_intensity_dataset = process_sectored_intensity_data(sectored_rates)
-    # print(l2_sectored_intensity_dataset)
-    # print(l2_sectored_intensity_dataset["h"][0])
+    # Process L2 Sectored
+    sectored_rates = process_sectored_rates_data(counts, livetime)
+    l2_sectored_intensity_dataset = process_sectored_intensity_data(sectored_rates)
+    print(l2_sectored_intensity_dataset)
+    print(l2_sectored_intensity_dataset["h"][0])
 
-    # Process L2 Standard
-    standard_rates = process_standard_rates_data(counts, livetime)
-    l2_standard_flux_dataset = process_standard_intensity_data(standard_rates)
-    print(l2_standard_flux_dataset["h"][1])
-    print(l2_standard_flux_dataset.data_vars)
+    # # Process L2 Standard
+    # standard_rates = process_standard_rates_data(counts, livetime)
+    # l2_standard_flux_dataset = process_standard_intensity_data(standard_rates)
+    # print(l2_standard_flux_dataset["h"][1])
+    # print(l2_standard_flux_dataset.data_vars)
 
     # # Process L2 Summed
     # summed_rates = process_summed_rates_data(counts, livetime)

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -387,9 +387,7 @@ def calculate_intensities_for_all_species(
     return updated_ds
 
 
-def add_systematic_uncertainties(
-    dataset: xr.Dataset, particle: str, energy_bins: int
-) -> xr.Dataset:
+def add_systematic_uncertainties(dataset: xr.Dataset, particle: str) -> xr.Dataset:
     """
     Add systematic uncertainties to the dataset.
 
@@ -399,11 +397,10 @@ def add_systematic_uncertainties(
     Parameters
     ----------
     dataset : xr.Dataset
-        The dataset to add the systematic uncertainties to.
+        The dataset to add the systematic uncertainties to
+        which contain the particle data variables.
     particle : str
         The particle name.
-    energy_bins : int
-        Number of energy bins for the particle.
 
     Returns
     -------
@@ -413,14 +410,62 @@ def add_systematic_uncertainties(
     updated_ds = dataset.copy()
 
     updated_ds[f"{particle}_sys_err_minus"] = xr.DataArray(
-        data=np.zeros(energy_bins, dtype=np.float32),
-        dims=[f"{particle}_energy_mean"],
+        data=np.zeros(updated_ds[particle].shape, dtype=np.float32),
+        dims=updated_ds[particle].dims,
         name=f"{particle}_sys_err_minus",
     )
     updated_ds[f"{particle}_sys_err_plus"] = xr.DataArray(
-        data=np.zeros(energy_bins, dtype=np.float32),
-        dims=[f"{particle}_energy_mean"],
+        data=np.zeros(updated_ds[particle].shape, dtype=np.float32),
+        dims=updated_ds[particle].dims,
         name=f"{particle}_sys_err_plus",
+    )
+
+    return updated_ds
+
+
+def add_total_uncertainties(dataset: xr.Dataset, particle: str) -> xr.Dataset:
+    """
+    Add total uncertainties to the dataset.
+
+    This function calculates the total uncertainties for a given particle
+    by combining the statistical uncertainties and systematic uncertainties.
+
+    The total uncertainties are calculated as the square root of the sum
+    of the squares of the statistical and systematic uncertainties.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The dataset to add the total uncertainties to.
+    particle : str
+        The particle name.
+
+    Returns
+    -------
+    updated_ds : xr.Dataset
+        The dataset with the total uncertainties added.
+    """
+    updated_ds = dataset.copy()
+
+    # Calculate the total uncertainties
+    total_minus = np.sqrt(
+        np.square(updated_ds[f"{particle}_stat_uncert_minus"])
+        + np.square(updated_ds[f"{particle}_sys_err_minus"])
+    )
+    total_plus = np.sqrt(
+        np.square(updated_ds[f"{particle}_stat_uncert_plus"])
+        + np.square(updated_ds[f"{particle}_sys_err_plus"])
+    )
+
+    updated_ds[f"{particle}_total_uncert_minus"] = xr.DataArray(
+        data=total_minus.astype(np.float32),
+        dims=updated_ds[particle].dims,
+        name=f"{particle}_total_uncert_minus",
+    )
+    updated_ds[f"{particle}_total_uncert_plus"] = xr.DataArray(
+        data=total_plus.astype(np.float32),
+        dims=updated_ds[particle].dims,
+        name=f"{particle}_total_uncert_plus",
     )
 
     return updated_ds
@@ -536,9 +581,7 @@ def process_summed_intensity_data(l1b_summed_rates_dataset: xr.Dataset) -> xr.Da
     for var in l2_summed_intensity_dataset.data_vars:
         if var in VALID_SPECIES:
             l2_summed_intensity_dataset = add_systematic_uncertainties(
-                l2_summed_intensity_dataset,
-                var,
-                l2_summed_intensity_dataset[var].shape[1],
+                l2_summed_intensity_dataset, var
             )
     l2_summed_intensity_dataset = calculate_intensities_for_all_species(
         l2_summed_intensity_dataset, ancillary_data_frames, VALID_SPECIES
@@ -600,14 +643,8 @@ def process_standard_intensity_data(
         L2_STANDARD_ANCILLARY_PATH_PREFIX,
     )
 
-    # Process each particle type and energy range and add rates and uncertainties
-    # to the dataset
+    # Process each particle type and add rates and uncertainties to the dataset
     for particle, energy_ranges in STANDARD_PARTICLE_ENERGY_RANGE_MAPPING.items():
-        # Add systematic uncertainties to the dataset. These will not have the intensity
-        # calculation applied to them and values will be zeros
-        l2_standard_intensity_dataset = add_systematic_uncertainties(
-            l2_standard_intensity_dataset, particle, len(energy_ranges)
-        )
         # Add standard particle rates and statistical uncertainties to the dataset
         l2_standard_intensity_dataset = add_summed_particle_data_to_dataset(
             l2_standard_intensity_dataset,
@@ -615,9 +652,21 @@ def process_standard_intensity_data(
             particle,
             energy_ranges,
         )
+        # Add systematic uncertainties to the dataset. These will not have the intensity
+        # calculation applied to them and values will be zeros
+        l2_standard_intensity_dataset = add_systematic_uncertainties(
+            l2_standard_intensity_dataset, particle
+        )
+
     l2_standard_intensity_dataset = calculate_intensities_for_all_species(
         l2_standard_intensity_dataset, ancillary_data_frames, VALID_SPECIES
     )
+
+    # Add total uncertainties to the dataset
+    for particle in STANDARD_PARTICLE_ENERGY_RANGE_MAPPING.keys():
+        l2_standard_intensity_dataset = add_total_uncertainties(
+            l2_standard_intensity_dataset, particle
+        )
 
     return l2_standard_intensity_dataset
 
@@ -660,12 +709,45 @@ def process_sectored_intensity_data(
     for var in l2_sectored_intensity_dataset.data_vars:
         if var in VALID_SECTORED_SPECIES:
             l2_sectored_intensity_dataset = add_systematic_uncertainties(
-                l2_sectored_intensity_dataset,
-                var,
-                l2_sectored_intensity_dataset[var].shape[1],
+                l2_sectored_intensity_dataset, var
             )
     l2_sectored_intensity_dataset = calculate_intensities_for_all_species(
         l2_sectored_intensity_dataset, ancillary_data_frames, VALID_SECTORED_SPECIES
     )
 
     return l2_sectored_intensity_dataset
+
+
+if __name__ == "__main__":
+    from imap_processing import imap_module_directory
+    from imap_processing.hit.l1a.hit_l1a import hit_l1a
+    from imap_processing.hit.l1b.hit_l1b import (
+        process_standard_rates_data,
+    )
+
+    # L0 file path
+    packet_file = imap_module_directory / "tests/hit/test_data/sci_sample.ccsds"
+
+    datasets = hit_l1a(packet_file)
+    counts = datasets[0]
+
+    # Calculate livetime from the livetime counter
+    livetime = counts["livetime_counter"] / 270
+
+    # # Process L2 Sectored
+    # sectored_rates = process_sectored_rates_data(counts, livetime)
+    # l2_sectored_intensity_dataset = process_sectored_intensity_data(sectored_rates)
+    # print(l2_sectored_intensity_dataset)
+    # print(l2_sectored_intensity_dataset["h"][0])
+
+    # Process L2 Standard
+    standard_rates = process_standard_rates_data(counts, livetime)
+    l2_standard_flux_dataset = process_standard_intensity_data(standard_rates)
+    print(l2_standard_flux_dataset["h"][1])
+    print(l2_standard_flux_dataset.data_vars)
+
+    # # Process L2 Summed
+    # summed_rates = process_summed_rates_data(counts, livetime)
+    # l2_summed_intensity_dataset = process_summed_intensity_data(summed_rates)
+    # print(l2_summed_intensity_dataset)
+    # print(l2_summed_intensity_dataset["h"][0])

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -721,38 +721,3 @@ def process_sectored_intensity_data(
             )
 
     return l2_sectored_intensity_dataset
-
-
-if __name__ == "__main__":
-    from imap_processing import imap_module_directory
-    from imap_processing.hit.l1a.hit_l1a import hit_l1a
-    from imap_processing.hit.l1b.hit_l1b import (
-        process_sectored_rates_data,
-    )
-
-    # L0 file path
-    packet_file = imap_module_directory / "tests/hit/test_data/sci_sample.ccsds"
-
-    datasets = hit_l1a(packet_file)
-    counts = datasets[0]
-
-    # Calculate livetime from the livetime counter
-    livetime = counts["livetime_counter"] / 270
-
-    # Process L2 Sectored
-    sectored_rates = process_sectored_rates_data(counts, livetime)
-    l2_sectored_intensity_dataset = process_sectored_intensity_data(sectored_rates)
-    print(l2_sectored_intensity_dataset)
-    print(l2_sectored_intensity_dataset["h"][0])
-
-    # # Process L2 Standard
-    # standard_rates = process_standard_rates_data(counts, livetime)
-    # l2_standard_flux_dataset = process_standard_intensity_data(standard_rates)
-    # print(l2_standard_flux_dataset["h"][1])
-    # print(l2_standard_flux_dataset.data_vars)
-
-    # # Process L2 Summed
-    # summed_rates = process_summed_rates_data(counts, livetime)
-    # l2_summed_intensity_dataset = process_summed_intensity_data(summed_rates)
-    # print(l2_summed_intensity_dataset)
-    # print(l2_summed_intensity_dataset["h"][0])

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -17,6 +17,7 @@ from imap_processing.hit.l2.hit_l2 import (
     STANDARD_PARTICLE_ENERGY_RANGE_MAPPING,
     VALID_SECTORED_SPECIES,
     add_systematic_uncertainties,
+    add_total_uncertainties,
     build_ancillary_dataset,
     calculate_intensities,
     calculate_intensities_for_a_species,
@@ -28,6 +29,8 @@ from imap_processing.hit.l2.hit_l2 import (
     process_summed_intensity_data,
     reshape_for_sectored,
 )
+
+np.random.seed(42)  # Set a random seed for reproducibility
 
 
 @pytest.fixture(scope="module")
@@ -459,25 +462,86 @@ def test_calculate_intensities():
 
 def test_add_systematic_uncertainties():
     """Test the add_systematic_uncertainties function."""
+
     # Create sample function inputs
     particle = "h"
-    energy_ranges = [
-        {"energy_min": 1.8, "energy_max": 2.2, "R2": [1], "R3": [], "R4": []},
-        {"energy_min": 2.2, "energy_max": 2.7, "R2": [2], "R3": [], "R4": []},
-        {"energy_min": 2.7, "energy_max": 3.2, "R2": [3], "R3": [], "R4": []},
+    datasets = [
+        xr.Dataset(
+            {"h": (("epoch", "h_energy_mean"), np.random.rand(2, 3).astype("float32"))}
+        ),
+        xr.Dataset(
+            {
+                "h": (
+                    ("epoch", "h_energy_mean", "azimuth", "declination"),
+                    np.random.rand(2, 3, 15, 8).astype("float32"),
+                )
+            }
+        ),
     ]
-    dataset = xr.Dataset()
+
+    for dataset in datasets:
+        # Call the function
+        updated_dataset = add_systematic_uncertainties(dataset, particle)
+        # Assertions
+        assert f"{particle}_sys_err_minus" in updated_dataset.data_vars
+        assert f"{particle}_sys_err_plus" in updated_dataset.data_vars
+        assert (
+            updated_dataset[f"{particle}_sys_err_minus"].shape
+            == dataset[particle].shape
+        )
+        assert (
+            updated_dataset[f"{particle}_sys_err_plus"].shape == dataset[particle].shape
+        )
+        np.testing.assert_array_equal(
+            updated_dataset[f"{particle}_sys_err_minus"].values, 0
+        )
+        np.testing.assert_array_equal(
+            updated_dataset[f"{particle}_sys_err_plus"].values, 0
+        )
+
+
+def test_add_total_uncertainties():
+    # Create a sample dataset
+    data = np.random.rand(10, 5).astype(np.float32)
+    stat_uncert_minus = np.random.rand(10, 5).astype(np.float32)
+    stat_uncert_plus = np.random.rand(10, 5).astype(np.float32)
+    sys_err_minus = np.zeros(
+        (10, 5), dtype=np.float32
+    )  # zeros, unless changed during mission
+    sys_err_plus = np.zeros(
+        (10, 5), dtype=np.float32
+    )  # zeros, unless changed during mission
+
+    dataset = xr.Dataset(
+        {
+            "particle": (("dim_0", "dim_1"), data),
+            "particle_stat_uncert_minus": (("dim_0", "dim_1"), stat_uncert_minus),
+            "particle_stat_uncert_plus": (("dim_0", "dim_1"), stat_uncert_plus),
+            "particle_sys_err_minus": (("dim_0", "dim_1"), sys_err_minus),
+            "particle_sys_err_plus": (("dim_0", "dim_1"), sys_err_plus),
+        }
+    )
 
     # Call the function
-    dataset = add_systematic_uncertainties(dataset, particle, len(energy_ranges))
+    updated_dataset = add_total_uncertainties(dataset, "particle")
 
     # Assertions
-    assert f"{particle}_sys_err_minus" in dataset.data_vars
-    assert f"{particle}_sys_err_plus" in dataset.data_vars
-    np.testing.assert_array_equal(dataset[f"{particle}_sys_err_minus"].values, 0)
-    np.testing.assert_array_equal(dataset[f"{particle}_sys_err_plus"].values, 0)
-    assert dataset[f"{particle}_sys_err_minus"].shape == (len(energy_ranges),)
-    assert dataset[f"{particle}_sys_err_plus"].shape == (len(energy_ranges),)
+    np.testing.assert_array_almost_equal(
+        updated_dataset["particle_total_uncert_minus"].values,
+        np.sqrt(np.square(stat_uncert_minus) + np.square(sys_err_minus)),
+    )
+    np.testing.assert_array_almost_equal(
+        updated_dataset["particle_total_uncert_plus"].values,
+        np.sqrt(np.square(stat_uncert_plus) + np.square(sys_err_plus)),
+    )
+
+    # Check that the dimensions and attributes are preserved
+    assert (
+        updated_dataset["particle_total_uncert_minus"].dims == dataset["particle"].dims
+    )
+    assert (
+        updated_dataset["particle_total_uncert_plus"].dims == dataset["particle"].dims
+    )
 
 
 def test_process_sectored_intensity_data(l1b_sectored_rates_dataset):

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -30,8 +30,6 @@ from imap_processing.hit.l2.hit_l2 import (
     reshape_for_sectored,
 )
 
-np.random.seed(42)  # Set a random seed for reproducibility
-
 
 @pytest.fixture(scope="module")
 def sci_packet_filepath():
@@ -123,6 +121,7 @@ def test_build_ancillary_dataset_sectored():
     """
     Test the build_ancillary_dataset function for sectored data
     """
+    np.random.seed(42)  # Set a random seed for reproducibility
     epoch = np.array(["2025-01-01T00:00", "2025-01-01T00:01"], dtype="datetime64[m]")
     energy_mean = [1.8, 4, 6]
     declination = np.arange(8)
@@ -167,6 +166,7 @@ def test_build_ancillary_dataset_nonsectored():
     Non-sectored datasets are either L2 standard or L2 summed datasets
     They both have the same shape (epoch, energy_mean).
     """
+    np.random.seed(42)  # Set a random seed for reproducibility
     epoch = np.array(["2025-01-01T00:00", "2025-01-01T00:01"], dtype="datetime64[m]")
     energy_mean = [1.8, 4, 6]
 
@@ -252,6 +252,7 @@ def test_reshape_for_sectored():
     Test the reshape_for_sectored function.
     """
     # Mock input data: 3D array (epoch, energy, declination)
+    np.random.seed(42)  # Set a random seed for reproducibility
     epoch, energy, declination = 2, 3, 8
     input_array = np.random.rand(epoch, energy, declination)
 
@@ -462,8 +463,8 @@ def test_calculate_intensities():
 
 def test_add_systematic_uncertainties():
     """Test the add_systematic_uncertainties function."""
-
     # Create sample function inputs
+    np.random.seed(42)  # Set a random seed for reproducibility
     particle = "h"
     datasets = [
         xr.Dataset(
@@ -502,6 +503,7 @@ def test_add_systematic_uncertainties():
 
 def test_add_total_uncertainties():
     # Create a sample dataset
+    np.random.seed(42)  # Set a random seed for reproducibility
     data = np.random.rand(10, 5).astype(np.float32)
     stat_uncert_minus = np.random.rand(10, 5).astype(np.float32)
     stat_uncert_plus = np.random.rand(10, 5).astype(np.float32)


### PR DESCRIPTION
This PR adds total uncertainty variables to L2 datasets. It also fixes the shape of systematic uncertainties to match the data variables they reference.

Closes #1651 

## Updated Files
- hit_l2.py
   - Add new function to add total uncertainties to datasets
   - Fix shape of systematic uncertainties added to datasets
- test_hit_l2.py
   - Add test for new function
   - Update test for systematic uncertainties to reflect changes

