### PR TITLE
TST/CI: Add pre-download utility and cache mechanism for data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,19 @@ jobs:
           poetry self add "poetry-dynamic-versioning[plugin]"
           poetry install --extras "test"
 
+      - name: Cache data directories
+        uses: actions/cache@v4
+        # We only download data on this runner, so only cache data from this run
+        # so we don't get an empty cache on other runners overriding that data
+        if: ${{ contains(matrix.os, 'ubuntu') && matrix.python-version == '3.10' }}
+        with:
+          path: |
+            **/data/
+            **/test_data/
+          key: cdf-data-${{ hashFiles('**/data/*', '**/test_data/*') }}
+          restore-keys: |
+            cdf-data-
+
       - name: Testing
         id: test
         env:
@@ -47,6 +60,9 @@ jobs:
         run: |
           # Ignore the network marks from the remote test environment
           if [ "$USE_EXTERNAL_DATA" = "true" ]; then
+            # Download external data before we run our tests so that
+            # we don't try to download them in parallel
+            poetry run python imap_processing/tests/conftest.py
             poetry run pytest -n auto --color=yes --cov --cov-report=xml
           else
             poetry run pytest -n auto --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -678,3 +678,9 @@ def use_fake_repoint_data_for_time(use_test_repoint_data_csv, tmpdir):
         use_test_repoint_data_csv(repoint_csv_file_path)
 
     return wrapped_repoint_data_filepath
+
+
+if __name__ == "__main__":
+    # This is to enable downloading files easier by letting us
+    # run this file directly
+    _download_external_data(_test_data_paths())


### PR DESCRIPTION
# Change Summary

## Overview

We are running into race conditions for downloading the tests while using pytest-xdist across multiple processes. This adds a command line option to pre-fetch the data in a single process before running the tests, which will then see the files already exist and not download them.

Additionally, add a cache so that the GitHub Actions can just restore the data files directly rather than needing to go and download them from our servers all the time.
