### PR TITLE
IDEX l1b - modify copy of test dataset

### DIFF
--- a/imap_processing/tests/idex/conftest.py
+++ b/imap_processing/tests/idex/conftest.py
@@ -46,6 +46,7 @@ def decom_test_data_sci() -> xr.Dataset:
     return PacketParser(TEST_L0_FILE_SCI).data[0]
 
 
+@pytest.fixture
 def decom_test_data_catlst() -> xr.Dataset:
     """Return a ``xarray`` dataset containing the catalog list summary data.
 
@@ -57,6 +58,7 @@ def decom_test_data_catlst() -> xr.Dataset:
     return PacketParser(TEST_L0_FILE_CATLST).data[0]
 
 
+@pytest.fixture
 def decom_test_data_evt() -> xr.Dataset:
     """Return a ``xarray`` dataset containing the event log data.
 

--- a/imap_processing/tests/idex/conftest.py
+++ b/imap_processing/tests/idex/conftest.py
@@ -34,7 +34,7 @@ SPICE_ARRAYS = [
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def decom_test_data_sci() -> xr.Dataset:
     """Return a ``xarray`` dataset containing test data.
 
@@ -46,7 +46,6 @@ def decom_test_data_sci() -> xr.Dataset:
     return PacketParser(TEST_L0_FILE_SCI).data[0]
 
 
-@pytest.fixture(scope="module")
 def decom_test_data_catlst() -> xr.Dataset:
     """Return a ``xarray`` dataset containing the catalog list summary data.
 
@@ -58,7 +57,6 @@ def decom_test_data_catlst() -> xr.Dataset:
     return PacketParser(TEST_L0_FILE_CATLST).data[0]
 
 
-@pytest.fixture(scope="module")
 def decom_test_data_evt() -> xr.Dataset:
     """Return a ``xarray`` dataset containing the event log data.
 
@@ -70,7 +68,7 @@ def decom_test_data_evt() -> xr.Dataset:
     return PacketParser(TEST_L0_FILE_EVT).data[0]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def l1a_example_data(_download_test_data):
     """
     Pytest fixture to load example L1A data (produced by the IDEX team) for testing.
@@ -83,7 +81,7 @@ def l1a_example_data(_download_test_data):
     return load_hdf_file(L1A_EXAMPLE_FILE)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def l2a_dataset(decom_test_data_sci: xr.Dataset) -> xr.Dataset:
     """Return a ``xarray`` dataset containing test data.
 
@@ -103,7 +101,7 @@ def l2a_dataset(decom_test_data_sci: xr.Dataset) -> xr.Dataset:
     return dataset
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def l1b_example_data(_download_test_data):
     """
     Pytest fixture to load example L1B data (produced by the IDEX team) for testing.

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -20,7 +20,7 @@ from imap_processing.tests.idex import conftest
 from imap_processing.tests.idex.conftest import get_spice_data_side_effect_func
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 @mock.patch("imap_processing.idex.idex_l1b.get_spice_data")
 def l1b_dataset(mock_get_spice_data, decom_test_data_sci: xr.Dataset) -> xr.Dataset:
     """Return a ``xarray`` dataset containing test data.

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -195,7 +195,7 @@ def test_get_trigger_settings_failure(decom_test_data_sci):
 
     Parameters
     ----------
-    decom_test_data : xarray.Dataset
+    decom_test_data_sci : xarray.Dataset
         L1a dataset
     """
     decom_test_data_sci["idx__txhdrhgtrigmode"][0] = 1

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal
 from imap_processing.idex.idex_l2b import idex_l2b, round_spin_phases
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def l2b_dataset(l2a_dataset: xr.Dataset) -> xr.Dataset:
     """Return a ``xarray`` dataset containing test data.
 


### PR DESCRIPTION
# Change Summary

## Overview
IDEX l1b validation test uses an l1b dataset fixture that has a "module" scope. I _think_ recent changes in the way we run our github tests have caused this fixture to be rerun after the l1a dataset was modified for another test. That other test modifies the dataset in a way that is supposed to cause an error. This then causes an error in the set up of the l1b validation test. 

This update should fix this by decoupling the l1a and l1b datasets. 

## Updated Files
- imap_processing/tests/idex/test_idex_l1b.py 
   - Use a copy of the l1a dataset in the l1b fixture 
