### PR TITLE
Remove obs day calculation from glows l1a

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -129,9 +129,12 @@ def write_cdf(
             f"The Data_version attribute {version} does not match expected format vXXX."
         )
 
-    # TODO: Do we need to retrieve this from the dataset?
-    if repointing is None:
-        repointing = dataset.attrs.get("Repointing", None)
+    if "repointing" in dataset.attrs:
+        # If provided, assume that we want to override the passed-in value
+        repointing = dataset.attrs["repointing"]
+    elif repointing is not None:
+        dataset.attrs["repointing"] = repointing
+
     repointing_int = int(repointing[-5:]) if repointing else None
     science_file = imap_data_access.ScienceFilePath.generate_from_inputs(
         instrument=instrument,

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -66,9 +66,6 @@ def load_cdf(
 
 def write_cdf(
     dataset: xr.Dataset,
-    *,
-    start_date: str | None = None,
-    repointing: str | None = None,
     **extra_cdf_kwargs: dict,
 ) -> Path:
     """
@@ -81,22 +78,16 @@ def write_cdf(
     determined by the "Logical_source" attribute.  The version is determined from
     "Data_version".
 
-    The start_date and repointing parameters are used to override the computed values.
+    The start_date and repointing attributes in the dataset are used to override the
+    computed values.
+
     If these are not included, start_date is generated from the first epoch in the
-    dataset and repointing is retrieved from the dataset attributes (or not included if
-    the attribute is not present).
+    dataset and repointing is not included if the attribute is not present or None.
 
     Parameters
     ----------
     dataset : xarray.Dataset
         The dataset object to convert to a CDF.
-    start_date : str
-        In the output filename, this is the start_date. If not provided or None,
-        the first epoch in the dataset is used.
-    repointing : str
-        The repointing number to use in the output filename. If not provided or None,
-        the repointing number is retrieved from the dataset attributes. If none are
-        provided, it is excluded from the filename.
     **extra_cdf_kwargs : dict
         Additional keyword arguments to pass to the ``xarray_to_cdf`` function.
 
@@ -112,6 +103,8 @@ def write_cdf(
     # TODO: This implementation of epoch to time string results in an error of
     #       5 seconds due to 5 leap-second occurrences since the J2000 epoch.
     # TODO: Create a ttj2000_to_datetime function to handle this conversion
+    start_date = dataset.attrs.get("Start_date", None)
+
     if start_date is None:
         # If no start time is included, then use the first epoch in the dataset
         dt64 = TTJ2000_EPOCH + dataset["epoch"].values[0].astype("timedelta64[ns]")
@@ -129,11 +122,7 @@ def write_cdf(
             f"The Data_version attribute {version} does not match expected format vXXX."
         )
 
-    if repointing is None and "Repointing" in dataset.attrs:
-        # If nothing is provided, attempt to retrieve from the dataset attrs
-        repointing = dataset.attrs["Repointing"]
-    elif repointing is not None:
-        dataset.attrs["Repointing"] = repointing
+    repointing = dataset.attrs.get("Repointing", None)
 
     repointing_int = int(repointing[-5:]) if repointing else None
     science_file = imap_data_access.ScienceFilePath.generate_from_inputs(

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -129,11 +129,11 @@ def write_cdf(
             f"The Data_version attribute {version} does not match expected format vXXX."
         )
 
-    if "repointing" in dataset.attrs:
-        # If provided, assume that we want to override the passed-in value
-        repointing = dataset.attrs["repointing"]
+    if repointing is None and "Repointing" in dataset.attrs:
+        # If nothing is provided, attempt to retrieve from the dataset attrs
+        repointing = dataset.attrs["Repointing"]
     elif repointing is not None:
-        dataset.attrs["repointing"] = repointing
+        dataset.attrs["Repointing"] = repointing
 
     repointing_int = int(repointing[-5:]) if repointing else None
     science_file = imap_data_access.ScienceFilePath.generate_from_inputs(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -488,10 +488,10 @@ class ProcessInstrument(ABC):
         products = []
         for ds in datasets:
             ds.attrs["Data_version"] = self.version
+            ds.attrs["Repointing"] = self.repointing
+            ds.attrs["Start_date"] = self.start_date
             ds.attrs["Parents"] = parent_files
-            products.append(
-                write_cdf(ds, start_date=self.start_date, repointing=self.repointing)
-            )
+            products.append(write_cdf(ds))
 
         self.upload_products(products)
 

--- a/imap_processing/glows/l1a/glows_l1a_data.py
+++ b/imap_processing/glows/l1a/glows_l1a_data.py
@@ -326,7 +326,7 @@ class DirectEventL1A:
 
     Methods
     -------
-    append
+    merge_de_packets
         Add another Level0 instance.
     """
 

--- a/imap_processing/glows/l1a/glows_l1a_data.py
+++ b/imap_processing/glows/l1a/glows_l1a_data.py
@@ -346,7 +346,7 @@ class DirectEventL1A:
         if level0.LEN == 1:
             self._process_de_data()
 
-    def append(self, second_l0: DirectEventL0) -> None:
+    def merge_de_packets(self, second_l0: DirectEventL0) -> None:
         """
         Merge an additional direct event packet to this DirectEventL1A class.
 

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -98,13 +98,13 @@ def test_written_and_loaded_dataset(test_dataset):
 def test_repoint_start_date(test_dataset):
     output_file_path = write_cdf(test_dataset)
     assert "imap_swe_l1a_sci_20100101_v001.cdf" in output_file_path.name
-    output_file_path = write_cdf(test_dataset, start_date="20001212")
+    test_dataset.attrs["Start_date"] = "20001212"
+
+    output_file_path = write_cdf(test_dataset)
     assert "imap_swe_l1a_sci_20001212_v001.cdf" in output_file_path.name
-    output_file_path = write_cdf(test_dataset, repointing="repoint12345")
-    assert "imap_swe_l1a_sci_20100101-repoint12345_v001.cdf" in output_file_path.name
-    output_file_path = write_cdf(
-        test_dataset, start_date="20001212", repointing="12345"
-    )
+
+    test_dataset.attrs["Repointing"] = "12345"
+    output_file_path = write_cdf(test_dataset)
     assert "imap_swe_l1a_sci_20001212-repoint12345_v001.cdf" in output_file_path.name
 
 

--- a/imap_processing/tests/glows/conftest.py
+++ b/imap_processing/tests/glows/conftest.py
@@ -1,4 +1,3 @@
-from functools import reduce
 from pathlib import Path
 
 import pytest
@@ -31,10 +30,7 @@ def l1a_test_data(decom_test_data):
     for hist in decom_test_data[0]:
         hist_l1a.append(HistogramL1A(hist))
 
-    de_l1a_dict = process_de_l0(decom_test_data[1])
-
-    # Flatten the dictionary to one list of DE values
-    de_l1a = reduce(list.__add__, [value for value in de_l1a_dict.values()])
+    de_l1a = process_de_l0(decom_test_data[1])
 
     return hist_l1a, de_l1a
 
@@ -46,7 +42,7 @@ def l1a_dataset(packet_path):
 
 @pytest.fixture
 def l1b_hist_dataset(l1a_dataset):
-    return glows_l1b(l1a_dataset[1])
+    return glows_l1b(l1a_dataset[0])
 
 
 @pytest.fixture

--- a/imap_processing/tests/glows/test_glows_l1a_cdf.py
+++ b/imap_processing/tests/glows/test_glows_l1a_cdf.py
@@ -1,38 +1,17 @@
 import dataclasses
-from functools import reduce
 
 import numpy as np
-import pytest
 
-from imap_processing.glows.l0 import decom_glows
 from imap_processing.glows.l1a.glows_l1a import (
     create_glows_attr_obj,
     generate_de_dataset,
     generate_histogram_dataset,
-    process_de_l0,
 )
-from imap_processing.glows.l1a.glows_l1a_data import HistogramL1A
 from imap_processing.glows.utils.constants import TimeTuple
 
 
-@pytest.fixture
-def l1a_data(packet_path):
-    """Read test data from file"""
-
-    histogram_l0, de_l0 = decom_glows.decom_packets(packet_path)
-
-    histogram_l1a = [HistogramL1A(hist) for hist in histogram_l0]
-
-    de_l1a_dict = process_de_l0(de_l0)
-
-    # Flatten the dictionary to one list of DE values
-    de_l1a = reduce(list.__add__, [value for value in de_l1a_dict.values()])
-
-    return (histogram_l1a, de_l1a)
-
-
-def test_generate_histogram_dataset(l1a_data):
-    histogram_l1a, _ = l1a_data
+def test_generate_histogram_dataset(l1a_test_data):
+    histogram_l1a, _ = l1a_test_data
     glows_attrs = create_glows_attr_obj()
     dataset = generate_histogram_dataset(histogram_l1a, glows_attrs)
 
@@ -62,8 +41,8 @@ def test_generate_histogram_dataset(l1a_data):
         assert (dataset["histogram"].data[i] == histogram_l1a[i].histogram).all()
 
 
-def test_generate_de_dataset(l1a_data):
-    _, de_l1a = l1a_data
+def test_generate_de_dataset(l1a_test_data):
+    _, de_l1a = l1a_test_data
     glows_attrs = create_glows_attr_obj()
     dataset = generate_de_dataset(de_l1a, glows_attrs)
     assert len(dataset["epoch"].values) == len(de_l1a)

--- a/imap_processing/tests/glows/test_glows_l1a_data.py
+++ b/imap_processing/tests/glows/test_glows_l1a_data.py
@@ -43,17 +43,15 @@ def test_histogram_list(histogram_test_data, decom_test_data):
 def test_histogram_obs_day(packet_path):
     l1a = glows_l1a(packet_path)
 
-    assert len(l1a) == 3
+    assert len(l1a) == 2
 
     assert "hist" in l1a[0].attrs["Logical_source"]
-    assert "hist" in l1a[1].attrs["Logical_source"]
 
     # Numbers pulled from the validation data.
     # this test assumes that the "is_night" flag switching from true to false is the
     # start of the observation day.
 
     assert np.array_equal(l1a[0]["imap_start_time"].data[0], 54232215.0)
-    assert np.array_equal(l1a[1]["imap_start_time"].data[0], 54232455.0)
 
 
 def test_histogram_attributes(histogram_test_data):
@@ -270,7 +268,7 @@ def test_combine_direct_events(decom_test_data):
     de1 = DirectEventL1A(de0_first)
     assert not de1.direct_events
     if not de1.direct_events:
-        de1.append(de0_second)
+        de1.merge_de_packets(de0_second)
 
     assert de1.direct_events
 
@@ -293,7 +291,7 @@ def test_combine_direct_events_with_missing(decom_test_data):
     de1 = DirectEventL1A(de0_first)
     assert not de1.direct_events
     if not de1.direct_events:
-        de1.append(de0_second)
+        de1.merge_de_packets(de0_second)
 
     assert de1.direct_events
     # Missing one value

--- a/imap_processing/tests/glows/test_glows_l1b_data.py
+++ b/imap_processing/tests/glows/test_glows_l1b_data.py
@@ -147,7 +147,7 @@ def test_validation_data_histogram(l1a_dataset):
 
 
 def test_validation_data_de(l1a_dataset):
-    de_data = l1a_dataset[2]
+    de_data = l1a_dataset[1]
 
     l1b = glows_l1b(de_data)
     validation_data = (

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -35,12 +35,6 @@ def test_glows_l2(l1b_hist_dataset):
     assert np.allclose(l2["filter_temperature_average"].values, [57.6], rtol=0.1)
 
 
-@pytest.mark.skip(reason="Spin table not yet complete")
-def test_split_by_observational_day(l1b_hist_dataset):
-    # TODO: Complete test when spin table is complete
-    raise NotImplementedError
-
-
 def test_filter_good_times():
     active_flags = np.ones((17,))
     active_flags[16] = 0

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -162,12 +162,10 @@ def test_repointing_file_creation(mock_instrument_dependencies):
     # Assert that write_cdf was called with the expected arguments
     assert mock_instrument_dependencies["mock_write_cdf"].call_count == 1
     assert (
-        mock_instrument_dependencies["mock_write_cdf"].call_args[1]["repointing"]
+        mock_instrument_dependencies["mock_write_cdf"]
+        .call_args[0][0]
+        .attrs.get("Repointing", None)
         == "repoint00002"
-    )
-    assert (
-        mock_instrument_dependencies["mock_write_cdf"].call_args[1]["start_date"]
-        is None
     )
 
 


### PR DESCRIPTION
# Change Summary
Remove all the estimation work of observational day/repointing number from glows since we can now get it from the L0 file. 

Generally deleting, one small change in the repointing CDF piece per conversation with @greglucas .
