### PR TITLE
1657 mapping   pointingset class should use abstractproperty

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -19,14 +19,14 @@ logger = logging.getLogger(__name__)
 
 
 def load_cdf(
-    file_path: Path, remove_xarray_attrs: bool = True, **kwargs: dict
+    file_path: Path | str, remove_xarray_attrs: bool = True, **kwargs: dict
 ) -> xr.Dataset:
     """
     Load the contents of a CDF file into an ``xarray`` dataset.
 
     Parameters
     ----------
-    file_path : Path or ImapFilePath
+    file_path : Path or ImapFilePath or str
         The path to the CDF file or ImapFilePath object.
     remove_xarray_attrs : bool
         Whether to remove the xarray attributes that get injected by the

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import pathlib
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
@@ -220,14 +219,40 @@ class PointingSet(ABC):
         The reference Spice frame of the pointing set.
     """
 
+    # Attributes that are set in the ABC __init__ method
+    data: xr.Dataset
+    spice_reference_frame: geometry.SpiceFrame
+    # Attributes required to be set in a subclass
+    az_el_points: np.ndarray
+    num_points: int
+    spatial_coords: tuple[str, ...]
+
     @abstractmethod
-    def __init__(self, dataset: xr.Dataset, spice_reference_frame: geometry.SpiceFrame):
+    def __init__(
+        self,
+        dataset: xr.Dataset,
+        spice_reference_frame: geometry.SpiceFrame = geometry.SpiceFrame.IMAP_DPS,
+    ):
         """Abstract method to initialize the pointing set object."""
         self.spice_reference_frame = spice_reference_frame
-        self.num_points = 0
-        self.az_el_points = np.zeros((self.num_points, 2))
-        self.data = xr.Dataset()
-        self.spatial_coords: tuple[str, ...] = ()
+        self.data = dataset
+
+    @classmethod
+    def from_cdf(cls, cdf_path: Path) -> PointingSet:
+        """
+        Generate a PointingSet object from a CDF file.
+
+        Parameters
+        ----------
+        cdf_path : str | Path
+            Location of Pointing Set CDF file.
+
+        Returns
+        -------
+        pointing_set : PointingSet
+            Input CDF file data loaded into PointingSet.
+        """
+        return cls(load_cdf(cdf_path))
 
     @property
     def unwrapped_dims_dict(self) -> dict[str, tuple[str, ...]]:
@@ -292,8 +317,8 @@ class RectangularPointingSet(PointingSet):
 
     Parameters
     ----------
-    l1c_dataset : xr.Dataset | pathlib.Path | str
-        L1c xarray dataset containing the pointing set data or the path to the dataset.
+    dataset : xr.Dataset
+        L1c xarray dataset containing the pointing set data.
         Currently, the dataset is expected to be tiled in a rectangular grid,
         with data_vars indexed along the coordinates:
             - 'epoch' : time value (1 value per PSET)
@@ -313,17 +338,10 @@ class RectangularPointingSet(PointingSet):
 
     def __init__(
         self,
-        l1c_dataset: xr.Dataset | pathlib.Path | str,
+        dataset: xr.Dataset,
         spice_reference_frame: geometry.SpiceFrame = geometry.SpiceFrame.IMAP_DPS,
     ):
-        # Store the reference frame of the pointing set
-        self.spice_reference_frame = spice_reference_frame
-
-        # Read in the data and store the xarray dataset as data attr
-        if isinstance(l1c_dataset, (str, pathlib.Path)):
-            self.data = load_cdf(pathlib.Path(l1c_dataset))
-        elif isinstance(l1c_dataset, xr.Dataset):
-            self.data = l1c_dataset
+        super().__init__(dataset, spice_reference_frame)
 
         # A PSET must have a single epoch
         self.epoch = self.data["epoch"].values
@@ -398,8 +416,8 @@ class UltraPointingSet(PointingSet):
 
     Parameters
     ----------
-    l1c_dataset : xr.Dataset | pathlib.Path | str
-        L1c xarray dataset containing the pointing set data or the path to the dataset.
+    dataset : xr.Dataset
+        L1c xarray dataset containing the pointing set data.
         Currently, the dataset is expected to be tiled in a HEALPix tessellation,
         with data_vars indexed along the coordinates:
             - 'epoch' : time value (1 value per PSET, from the mean of the PSET)
@@ -420,17 +438,10 @@ class UltraPointingSet(PointingSet):
 
     def __init__(
         self,
-        l1c_dataset: xr.Dataset | pathlib.Path | str,
+        dataset: xr.Dataset,
         spice_reference_frame: geometry.SpiceFrame = geometry.SpiceFrame.IMAP_DPS,
     ):
-        # Store the reference frame of the pointing set
-        self.spice_reference_frame = spice_reference_frame
-
-        # Read in the data and store the xarray dataset as data attr
-        if isinstance(l1c_dataset, (str, pathlib.Path)):
-            self.data = load_cdf(pathlib.Path(l1c_dataset))
-        elif isinstance(l1c_dataset, xr.Dataset):
-            self.data = l1c_dataset
+        super().__init__(dataset, spice_reference_frame)
 
         # A PSET must have a single epoch
         self.epoch = self.data["epoch"].values
@@ -485,48 +496,6 @@ class UltraPointingSet(PointingSet):
         self.az_el_points = np.column_stack(
             (self.azimuth_pixel_center, self.elevation_pixel_center)
         )
-
-    @classmethod
-    def from_path_or_dataset(
-        cls,
-        input_data: xr.Dataset | str | pathlib.Path,
-    ) -> UltraPointingSet:
-        """
-        Read a path or Dataset into an UltraPointingSet.
-
-        Parameters
-        ----------
-        input_data : xr.Dataset | str | pathlib.Path
-            Path to the CDF file or xarray Dataset containing the L1C dataset.
-            If a dataset is provided, it will be copied to avoid modifying the original.
-
-        Returns
-        -------
-        UltraPointingSet
-            An UltraPointingSet object containing the L1C dataset.
-
-        Raises
-        ------
-        ValueError
-            If input_data is neither an xarray Dataset nor a path to a CDF file.
-        """
-        # Allow for passing in EITHER xarray Datasets (preferable for testing)
-        if isinstance(input_data, xr.Dataset):
-            # Copy to avoid modifying the original dataset in place
-            input_data = input_data.copy(deep=True)
-            ultra_pointing_set = UltraPointingSet(l1c_dataset=input_data)
-        # OR paths to CDF files (preferable for projecting many PointingSets)
-        elif isinstance(input_data, str | pathlib.Path):
-            if isinstance(input_data, str):
-                input_data = pathlib.Path(input_data)
-            ultra_pointing_set = UltraPointingSet(l1c_dataset=load_cdf(input_data))
-        else:
-            raise ValueError(
-                f"Input data must be either an xarray Dataset or a path to a CDF file "
-                "containing the L1C dataset.\n"
-                f"Found {type(input_data)} instead."
-            )
-        return ultra_pointing_set
 
     def __repr__(self) -> str:
         """

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -138,9 +138,9 @@ def match_coords_to_indices(
     # which must be converted to ephemeris time (ET) for SPICE.
     if event_et is None:
         if isinstance(input_object, PointingSet):
-            event_et = ttj2000ns_to_et(input_object.data["epoch"].values)
+            event_et = ttj2000ns_to_et(input_object.epoch)
         elif isinstance(output_object, PointingSet):
-            event_et = ttj2000ns_to_et(output_object.data["epoch"].values)
+            event_et = ttj2000ns_to_et(output_object.epoch)
         else:
             raise ValueError(
                 "Event time must be specified if both objects are SkyMaps."
@@ -219,8 +219,8 @@ class PointingSet(ABC):
 
     Parameters
     ----------
-    dataset : xr.Dataset
-        Dataset containing the pointing set data.
+    dataset : xr.Dataset | str | Path
+        Dataset or path to CDF file containing the pointing set data.
     spice_reference_frame : geometry.SpiceFrame
         The reference Spice frame of the pointing set.
     """
@@ -230,6 +230,7 @@ class PointingSet(ABC):
 
     # Attributes that are set in the ABC __init__ method
     data: xr.Dataset
+    epoch: np.ndarray
     spice_reference_frame: geometry.SpiceFrame
     # Attributes required to be set in a subclass
     az_el_points: np.ndarray
@@ -239,29 +240,20 @@ class PointingSet(ABC):
     @abstractmethod
     def __init__(
         self,
-        dataset: xr.Dataset,
+        dataset: xr.Dataset | str | Path,
         spice_reference_frame: geometry.SpiceFrame = geometry.SpiceFrame.IMAP_DPS,
     ):
         """Abstract method to initialize the pointing set object."""
         self.spice_reference_frame = spice_reference_frame
+
+        if isinstance(dataset, (str, Path)):
+            dataset = load_cdf(dataset)
         self.data = dataset
 
-    @classmethod
-    def from_cdf(cls: type[T], cdf_path: Path) -> T:
-        """
-        Generate a PointingSet object from a CDF file.
-
-        Parameters
-        ----------
-        cdf_path : str | Path
-            Location of Pointing Set CDF file.
-
-        Returns
-        -------
-        pointing_set : PointingSet
-            Input CDF file data loaded into PointingSet.
-        """
-        return cls(load_cdf(cdf_path))
+        # A PSET must have a single epoch
+        if len(np.unique(self.data["epoch"].values)) > 1:
+            raise ValueError("Multiple epochs found in the dataset.")
+        self.epoch = self.data["epoch"].values[0]
 
     @property
     def unwrapped_dims_dict(self) -> dict[str, tuple[str, ...]]:
@@ -326,8 +318,8 @@ class RectangularPointingSet(PointingSet):
 
     Parameters
     ----------
-    dataset : xr.Dataset
-        L1c xarray dataset containing the pointing set data.
+    dataset : xr.Dataset | str | Path
+        Dataset or path to CDF file containing the pointing set data.
         Currently, the dataset is expected to be tiled in a rectangular grid,
         with data_vars indexed along the coordinates:
             - 'epoch' : time value (1 value per PSET)
@@ -353,15 +345,10 @@ class RectangularPointingSet(PointingSet):
 
     def __init__(
         self,
-        dataset: xr.Dataset,
+        dataset: xr.Dataset | str | Path,
         spice_reference_frame: geometry.SpiceFrame = geometry.SpiceFrame.IMAP_DPS,
     ):
         super().__init__(dataset, spice_reference_frame)
-
-        # A PSET must have a single epoch
-        self.epoch = self.data["epoch"].values
-        if len(np.unique(self.epoch)) > 1:
-            raise ValueError("Multiple epochs found in the dataset.")
 
         self.spatial_coords = (
             CoordNames.AZIMUTH_L1C.value,
@@ -424,8 +411,8 @@ class UltraPointingSet(PointingSet):
 
     Parameters
     ----------
-    dataset : xr.Dataset
-        L1c xarray dataset containing the pointing set data.
+    dataset : xr.Dataset | str | Path
+        Dataset or path to CDF file containing the pointing set data.
         Currently, the dataset is expected to be tiled in a HEALPix tessellation,
         with data_vars indexed along the coordinates:
             - 'epoch' : time value (1 value per PSET, from the mean of the PSET)
@@ -453,15 +440,10 @@ class UltraPointingSet(PointingSet):
 
     def __init__(
         self,
-        dataset: xr.Dataset,
+        dataset: xr.Dataset | str | Path,
         spice_reference_frame: geometry.SpiceFrame = geometry.SpiceFrame.IMAP_DPS,
     ):
         super().__init__(dataset, spice_reference_frame)
-
-        # A PSET must have a single epoch
-        self.epoch = self.data["epoch"].values
-        if len(np.unique(self.epoch)) > 1:
-            raise ValueError("Multiple epochs found in the dataset.")
 
         # Set the spatial coordinates and number of points
         self.spatial_coords = (CoordNames.HEALPIX_INDEX.value,)

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -7,6 +7,7 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
+from typing import TypeVar
 
 import astropy_healpix.healpy as hp
 import numpy as np
@@ -203,6 +204,11 @@ def match_coords_to_indices(
     return flat_indices_input_grid_output_frame
 
 
+# Define a TypeVar type to dynamically hint the return type of the base PointingSet
+# class classmethod
+T = TypeVar("T", bound="PointingSet")
+
+
 # Define the pointing set classes
 class PointingSet(ABC):
     """
@@ -241,7 +247,7 @@ class PointingSet(ABC):
         self.data = dataset
 
     @classmethod
-    def from_cdf(cls, cdf_path: Path) -> PointingSet:
+    def from_cdf(cls: type[T], cdf_path: Path) -> T:
         """
         Generate a PointingSet object from a CDF file.
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -230,7 +230,6 @@ class PointingSet(ABC):
 
     # Attributes that are set in the ABC __init__ method
     data: xr.Dataset
-    epoch: np.ndarray
     spice_reference_frame: geometry.SpiceFrame
     # Attributes required to be set in a subclass
     az_el_points: np.ndarray
@@ -253,7 +252,18 @@ class PointingSet(ABC):
         # A PSET must have a single epoch
         if len(np.unique(self.data["epoch"].values)) > 1:
             raise ValueError("Multiple epochs found in the dataset.")
-        self.epoch = self.data["epoch"].values[0]
+
+    @property
+    def epoch(self) -> float:
+        """
+        The singular epoch value from the xarray.Dataset.
+
+        Returns
+        -------
+        epoch: float
+            The epoch value [J2000 TT ns] of the pointing set.
+        """
+        return self.data["epoch"].values[0]
 
     @property
     def unwrapped_dims_dict(self) -> dict[str, tuple[str, ...]]:

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -254,13 +254,13 @@ class PointingSet(ABC):
             raise ValueError("Multiple epochs found in the dataset.")
 
     @property
-    def epoch(self) -> float:
+    def epoch(self) -> int:
         """
         The singular epoch value from the xarray.Dataset.
 
         Returns
         -------
-        epoch: float
+        epoch: int
             The epoch value [J2000 TT ns] of the pointing set.
         """
         return self.data["epoch"].values[0]

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -219,6 +219,9 @@ class PointingSet(ABC):
         The reference Spice frame of the pointing set.
     """
 
+    # The minimum set of class attributes for any PointingSet to function with
+    # a SkyMap using only the PUSH method of projecting are defined here.
+
     # Attributes that are set in the ABC __init__ method
     data: xr.Dataset
     spice_reference_frame: geometry.SpiceFrame
@@ -336,6 +339,12 @@ class RectangularPointingSet(PointingSet):
         If multiple epochs are found in the dataset.
     """
 
+    # In addition to the required attributes defined in the base PointingSet
+    # class, the following attributes are required for a RectangularPointingSet
+    # to be projected using the PULL method.
+    tiling_type: SkyTilingType = SkyTilingType.RECTANGULAR
+    sky_grid: spatial_utils.AzElSkyGrid
+
     def __init__(
         self,
         dataset: xr.Dataset,
@@ -348,7 +357,6 @@ class RectangularPointingSet(PointingSet):
         if len(np.unique(self.epoch)) > 1:
             raise ValueError("Multiple epochs found in the dataset.")
 
-        self.tiling_type = SkyTilingType.RECTANGULAR
         self.spatial_coords = (
             CoordNames.AZIMUTH_L1C.value,
             CoordNames.ELEVATION_L1C.value,
@@ -367,12 +375,12 @@ class RectangularPointingSet(PointingSet):
                 "Azimuth and elevation bin spacing do not match: "
                 f"az {az_bin_delta[0]} != el {el_bin_delta[0]}."
             )
-        self.spacing_deg = az_bin_delta[0]
+        spacing_deg = az_bin_delta[0]
 
         # Build the az/azimuth and el/elevation grids with an AzElSkyGrid object
         # and check that the 1D axes match the dataset's az and el.
         self.sky_grid = spatial_utils.AzElSkyGrid(
-            spacing_deg=self.spacing_deg,
+            spacing_deg=spacing_deg,
         )
 
         for dim, constructed_bins in zip(
@@ -403,12 +411,6 @@ class RectangularPointingSet(PointingSet):
         )
         self.num_points = self.az_el_points.shape[0]
 
-        # Also store the bin edges for the pointing set to allow for "pull" method
-        # of index matching (not yet implemented).
-        # These are 1D arrays of different lengths and cannot be stacked.
-        self.az_bin_edges = self.sky_grid.az_bin_edges
-        self.el_bin_edges = self.sky_grid.el_bin_edges
-
 
 class UltraPointingSet(PointingSet):
     """
@@ -436,6 +438,13 @@ class UltraPointingSet(PointingSet):
         If multiple epochs are found in the dataset.
     """
 
+    # In addition to the required attributes defined in the base PointingSet
+    # class, the following attributes are required for a UltraPointingSet
+    # to be projected using the PULL method.
+    tiling_type: SkyTilingType = SkyTilingType.HEALPIX
+    nside: int
+    nested: bool
+
     def __init__(
         self,
         dataset: xr.Dataset,
@@ -448,8 +457,7 @@ class UltraPointingSet(PointingSet):
         if len(np.unique(self.epoch)) > 1:
             raise ValueError("Multiple epochs found in the dataset.")
 
-        # Set the tiling type and number of points
-        self.tiling_type = SkyTilingType.HEALPIX
+        # Set the spatial coordinates and number of points
         self.spatial_coords = (CoordNames.HEALPIX_INDEX.value,)
         self.num_points = self.data[CoordNames.HEALPIX_INDEX.value].size
         self.nside = hp.npix_to_nside(self.num_points)
@@ -463,7 +471,7 @@ class UltraPointingSet(PointingSet):
         )
 
         # Get the azimuth and elevation coordinates of the healpix pixel centers (deg)
-        self.azimuth_pixel_center, self.elevation_pixel_center = hp.pix2ang(
+        azimuth_pixel_center, elevation_pixel_center = hp.pix2ang(
             nside=self.nside,
             ipix=np.arange(self.num_points),
             nest=self.nested,
@@ -476,7 +484,7 @@ class UltraPointingSet(PointingSet):
         # (e.g. "longitude"/"latitude" vs "azimuth"/"elevation").
         for dim, constructed_bins in zip(
             [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
-            [self.azimuth_pixel_center, self.elevation_pixel_center],
+            [azimuth_pixel_center, elevation_pixel_center],
         ):
             if not np.allclose(
                 self.data[dim],
@@ -494,7 +502,7 @@ class UltraPointingSet(PointingSet):
         # of shape (num_points, 2) where column 0 is the lon/az
         # and column 1 is the lat/el.
         self.az_el_points = np.column_stack(
-            (self.azimuth_pixel_center, self.elevation_pixel_center)
+            (azimuth_pixel_center, elevation_pixel_center)
         )
 
     def __repr__(self) -> str:

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -56,8 +56,8 @@ class TestUltraPointingSet:
         """Test instantiation of UltraPointingSet"""
         ultra_psets = [
             ena_maps.UltraPointingSet(
+                l1c_product,
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=l1c_product,
             )
             for l1c_product in self.l1c_pset_products
         ]
@@ -92,26 +92,18 @@ class TestUltraPointingSet:
             )
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
-    def test_from_path_or_dataset(
+    def test_from_cdf(
         self,
     ):
         ultra_pset = self.l1c_pset_products[0]
 
         cdf_filepath = write_cdf(ultra_pset, istp=False)
 
-        ultra_pset_from_dataset = ena_maps.UltraPointingSet.from_path_or_dataset(
-            ultra_pset
-        )
-        ultra_pset_from_dataset_copy = ena_maps.UltraPointingSet.from_path_or_dataset(
-            ultra_pset
-        )
+        ultra_pset_from_dataset = ena_maps.UltraPointingSet.from_cdf(ultra_pset)
+        ultra_pset_from_dataset_copy = ena_maps.UltraPointingSet.from_cdf(ultra_pset)
 
-        ultra_pset_from_str = ena_maps.UltraPointingSet.from_path_or_dataset(
-            cdf_filepath
-        )
-        ultra_pset_from_path = ena_maps.UltraPointingSet.from_path_or_dataset(
-            Path(cdf_filepath)
-        )
+        ultra_pset_from_str = ena_maps.UltraPointingSet.from_cdf(cdf_filepath)
+        ultra_pset_from_path = ena_maps.UltraPointingSet.from_cdf(Path(cdf_filepath))
 
         np.testing.assert_allclose(
             ultra_pset_from_dataset.data["counts"].values,
@@ -155,8 +147,8 @@ class TestUltraPointingSet:
 
         with pytest.raises(ValueError, match="do not match"):
             ena_maps.UltraPointingSet(
+                ultra_pset_ds,
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=ultra_pset_ds,
             )
 
 
@@ -170,8 +162,8 @@ class TestRectangularSkyMap:
         )
         self.ultra_psets = [
             ena_maps.UltraPointingSet(
+                l1c_product,
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=l1c_product,
             )
             for l1c_product in self.ultra_l1c_pset_products
         ]
@@ -185,8 +177,8 @@ class TestRectangularSkyMap:
         )
         self.rectangular_psets = [
             ena_maps.RectangularPointingSet(
+                l1c_product,
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=l1c_product,
             )
             for l1c_product in self.rectangular_l1c_pset_products
         ]
@@ -462,8 +454,8 @@ class TestHealpixSkyMap:
         )
         self.ultra_psets = [
             ena_maps.UltraPointingSet(
+                l1c_product,
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=l1c_product,
             )
             for l1c_product in self.ultra_l1c_pset_products
         ]
@@ -477,8 +469,8 @@ class TestHealpixSkyMap:
         )
         self.rectangular_psets = [
             ena_maps.RectangularPointingSet(
+                l1c_product,
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=l1c_product,
             )
             for l1c_product in self.rectangular_l1c_pset_products
         ]
@@ -550,7 +542,7 @@ class TestHealpixSkyMap:
 
         # Create a PointingSet with a bright spot
         mock_pset_input_frame = ena_maps.UltraPointingSet(
-            l1c_dataset=self.ultra_l1c_pset_products[0],
+            self.ultra_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         mock_pset_input_frame.data["counts"].values = np.zeros_like(
@@ -632,7 +624,7 @@ class TestHealpixSkyMap:
 
         # Create a PointingSet with a bright spot
         mock_pset_input_frame = ena_maps.RectangularPointingSet(
-            l1c_dataset=self.rectangular_l1c_pset_products[0],
+            self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         mock_pset_input_frame.data["counts"].values = np.zeros_like(
@@ -923,8 +915,8 @@ class TestIndexMatching:
         )
         self.rectangular_psets = [
             ena_maps.RectangularPointingSet(
+                l1c_product,
                 spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
-                l1c_dataset=l1c_product,
             )
             for l1c_product in self.rectangular_l1c_pset_products
         ]
@@ -944,7 +936,7 @@ class TestIndexMatching:
 
         # Mock a PSET, overriding the az/el points
         mock_pset_input_frame = ena_maps.RectangularPointingSet(
-            l1c_dataset=self.rectangular_l1c_pset_products[0],
+            self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         manual_az_el_coords = np.array(
@@ -1022,7 +1014,7 @@ class TestIndexMatching:
 
         # Make a PointingSet
         mock_pset_input_frame = ena_maps.RectangularPointingSet(
-            l1c_dataset=self.rectangular_l1c_pset_products[0],
+            self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
 
@@ -1061,7 +1053,7 @@ class TestIndexMatching:
         self,
     ):
         mock_pset_input_frame = ena_maps.RectangularPointingSet(
-            l1c_dataset=self.rectangular_l1c_pset_products[0],
+            self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.ECLIPJ2000,
         )
         # Until implemented, just change the tiling on a RectangularSkyMap
@@ -1077,11 +1069,11 @@ class TestIndexMatching:
 
     def test_match_coords_to_indices_pset_to_pset_error(self):
         mock_pset_input_frame = ena_maps.RectangularPointingSet(
-            l1c_dataset=self.rectangular_l1c_pset_products[0],
+            self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         mock_pset_output_frame = ena_maps.RectangularPointingSet(
-            l1c_dataset=self.rectangular_l1c_pset_products[1],
+            self.rectangular_l1c_pset_products[1],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         with pytest.raises(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -99,8 +99,7 @@ class TestUltraPointingSet:
 
         cdf_filepath = write_cdf(ultra_pset, istp=False)
 
-        ultra_pset_from_dataset = ena_maps.UltraPointingSet.from_cdf(ultra_pset)
-        ultra_pset_from_dataset_copy = ena_maps.UltraPointingSet.from_cdf(ultra_pset)
+        ultra_pset_from_dataset = ena_maps.UltraPointingSet(ultra_pset)
 
         ultra_pset_from_str = ena_maps.UltraPointingSet.from_cdf(cdf_filepath)
         ultra_pset_from_path = ena_maps.UltraPointingSet.from_cdf(Path(cdf_filepath))
@@ -114,23 +113,6 @@ class TestUltraPointingSet:
         np.testing.assert_allclose(
             ultra_pset_from_dataset.data["counts"].values,
             ultra_pset_from_path.data["counts"].values,
-            rtol=1e-6,
-        )
-
-        # delete cdf_filepath once we're done with it
-        Path(cdf_filepath).unlink()
-
-        # The two datasets should should start as equal, but not the same object
-        # So if we modify one, the other should not change
-        np.testing.assert_allclose(
-            ultra_pset_from_dataset.data["counts"].values,
-            ultra_pset_from_dataset_copy.data["counts"].values,
-            rtol=1e-6,
-        )
-        ultra_pset_from_dataset.data["counts"].values[0] += int(1e8)
-        assert not np.allclose(
-            ultra_pset_from_dataset.data["counts"].values,
-            ultra_pset_from_dataset_copy.data["counts"].values,
             rtol=1e-6,
         )
 
@@ -284,7 +266,7 @@ class TestRectangularSkyMap:
         """
         index_matching_method = ena_maps.IndexMatchMethod.PUSH
 
-        pset_spacing_deg = self.rectangular_psets[0].spacing_deg
+        pset_spacing_deg = self.rectangular_psets[0].sky_grid.spacing_deg
 
         # Mock frame_transform to return the az and el unchanged
         mock_frame_transform_az_el.side_effect = (
@@ -635,10 +617,13 @@ class TestHealpixSkyMap:
         mock_pset_input_frame.data["counts"].values[
             :,
             :,
-            int(input_bright_pixel_az_el_deg[0] // mock_pset_input_frame.spacing_deg),
+            int(
+                input_bright_pixel_az_el_deg[0]
+                // mock_pset_input_frame.sky_grid.spacing_deg
+            ),
             int(
                 (90 + input_bright_pixel_az_el_deg[1])
-                // mock_pset_input_frame.spacing_deg
+                // mock_pset_input_frame.sky_grid.spacing_deg
             ),
         ] = 1
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -92,7 +92,7 @@ class TestUltraPointingSet:
             )
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
-    def test_from_cdf(
+    def test_init_cdf(
         self,
     ):
         ultra_pset = self.l1c_pset_products[0]
@@ -101,8 +101,8 @@ class TestUltraPointingSet:
 
         ultra_pset_from_dataset = ena_maps.UltraPointingSet(ultra_pset)
 
-        ultra_pset_from_str = ena_maps.UltraPointingSet.from_cdf(cdf_filepath)
-        ultra_pset_from_path = ena_maps.UltraPointingSet.from_cdf(Path(cdf_filepath))
+        ultra_pset_from_str = ena_maps.UltraPointingSet(cdf_filepath)
+        ultra_pset_from_path = ena_maps.UltraPointingSet(Path(cdf_filepath))
 
         np.testing.assert_allclose(
             ultra_pset_from_dataset.data["counts"].values,

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 import numpy as np
 import xarray as xr
@@ -140,10 +139,7 @@ def generate_ultra_healpix_skymap(
     )
 
     for ultra_l1c_pset in ultra_l1c_psets:
-        if isinstance(ultra_l1c_pset, str):
-            pointing_set = ena_maps.UltraPointingSet.from_cdf(Path(ultra_l1c_pset))
-        else:
-            pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
+        pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
         logger.info(
             f"Projecting a PointingSet with {pointing_set.num_points} pixels "
             f"at epoch:{pointing_set.epoch}\n"

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import numpy as np
 import xarray as xr
@@ -139,7 +140,10 @@ def generate_ultra_healpix_skymap(
     )
 
     for ultra_l1c_pset in ultra_l1c_psets:
-        pointing_set = ena_maps.UltraPointingSet.from_path_or_dataset(ultra_l1c_pset)
+        if isinstance(ultra_l1c_pset, xr.Dataset):
+            pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
+        else:
+            pointing_set = ena_maps.UltraPointingSet.from_cdf(Path(ultra_l1c_pset))
         logger.info(
             f"Projecting a PointingSet with {pointing_set.num_points} pixels "
             f"at epoch:{pointing_set.epoch}\n"

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -140,10 +140,10 @@ def generate_ultra_healpix_skymap(
     )
 
     for ultra_l1c_pset in ultra_l1c_psets:
-        if isinstance(ultra_l1c_pset, xr.Dataset):
-            pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
-        else:
+        if isinstance(ultra_l1c_pset, str):
             pointing_set = ena_maps.UltraPointingSet.from_cdf(Path(ultra_l1c_pset))
+        else:
+            pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
         logger.info(
             f"Projecting a PointingSet with {pointing_set.num_points} pixels "
             f"at epoch:{pointing_set.epoch}\n"


### PR DESCRIPTION
# Change Summary

## Overview
I experimented with making some abstractmethod properties in the PointingSet base class, but what we really want are required instance variables. I settled on defining what I think is the minimum set of attributes into class body with type-hints only. I also identified some common code amongst the base class and child classes and moved that into the base class `__init__` method. 

## Updated Files
- imap_processing/ena_maps/ena_maps.py
   - Move required attributes into Class body
   - Move common code into ABC class `__init__` method and call `super().__init__()` in subclasses.
   - Unify `__init__()` method signatures across classes.
   - Remove some unused/duplicate class variables.
   - Create common `from_cdf()` method in the base class.
   - Remove `from_path_or_dataset()` method from UltraPointingSet
- imap_processing/tests/ena_maps/test_ena_maps.py
   - Remove portion of test from `test_from_cdf` that checked that dataset mutation did not occur.
   - Update instantiation calls to match common `__init__` signature.
- imap_processing/ultra/l2/ultra_l2.py
   - Update ultra_l2 code to call different method when instantiating UltraPointingSet from str or xr.Dataset

Closes: #1657 
