### PR TITLE
HIT L2 - Add CDF attributes to yaml

### DIFF
--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -172,7 +172,7 @@ h:
   DEPEND_1: h_energy_mean
   LABL_PTR_1: h_energy_label
   FIELDNAM: H Standard Intensity
-  LABLAXIS: 'H Intensity'
+  LABLAXIS: H Intensity
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
 

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -1,4 +1,5 @@
 # TODO: add attributes for L2 variables
+# TODO: figure out how to handle duplicate names between products (i.e. h is used in all 3)
 
 # <=== Defaults ===>
 # Assumed values for all variable attrs unless overwritten
@@ -12,3 +13,128 @@ default_attrs: &default
   VAR_TYPE: data
   UNITS: ' '
   SCALETYP: linear
+
+default_standard_var_attrs: &default_standard
+  <<: *default
+  VAR_TYPE: data
+  DISPLAY_TYPE: spectrogram
+  FILLVAL: -1.00E+31
+  VALIDMIN: 0
+  VALIDMAX: 10000000000
+  FORMAT: F9.3
+  UNITS: '1/(cm^2 s MeV/nuc sr)'
+
+default_energy_mean_attrs: &default_energy_mean
+  <<: *default
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  LABLAXIS: Energy
+  FILLVAL: -1.00E+31
+  VALIDMIN: 0
+  VALIDMAX: 1000
+  FORMAT: F5.1
+  UNITS: 'MeV'
+
+# <=== Coordinates ===>
+
+# Standard intensity coordinates
+h_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for H Standard
+  FIELDNAM: H Energy
+
+he3_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for He3 Standard
+  FIELDNAM: He3 Energy
+
+he4_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for He4 Standard
+  FIELDNAM: He4 Energy
+
+he_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for He Standard
+  FIELDNAM: He Energy
+
+c_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for C Standard
+  FIELDNAM: C Energy
+
+n_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for N Standard
+  FIELDNAM: N Energy
+
+o_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for O Standard
+  FIELDNAM: O Energy
+
+ne_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Ne Standard
+  FIELDNAM: Ne Energy
+
+na_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Na Standard
+  FIELDNAM: Na Energy
+
+mg_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Mg Standard
+  FIELDNAM: Mg Energy
+
+si_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Si Standard
+  FIELDNAM: Si Energy
+
+s_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for S Standard
+  FIELDNAM: S Energy
+
+al_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Al Standard
+  FIELDNAM: Al Energy
+
+ar_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Ar Standard
+  FIELDNAM: Ar Energy
+
+ca_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Ca Standard
+  FIELDNAM: Ca Energy
+
+fe_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Fe Standard
+  FIELDNAM: Fe Energy
+
+ni_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Ni Standard
+  FIELDNAM: Ni Energy
+
+
+# <=== Label Attributes ===>
+
+# <=== Data Variable Attributes ===>
+
+# Standard intensity data variables
+h:
+  <<: *default_standard
+  CATDESC: H Standard intensity
+  DEPEND_0: epoch
+  DEPEND_1: h_energy_mean
+  LABL_PTR_1: h_energy_label
+  FIELDNAM: H Standard Intensity
+  LABLAXIS: 'H Intensity'   #TODO is lablaxis needed?
+

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -1,6 +1,6 @@
 # TODO: add attributes for L2 variables
 # TODO: figure out how to handle duplicate names between products (i.e. h is used in all 3)
-
+# TODO: keep default_attrs? It mostly changes
 # <=== Defaults ===>
 # Assumed values for all variable attrs unless overwritten
 default_attrs: &default
@@ -15,7 +15,7 @@ default_attrs: &default
   SCALETYP: linear
 
 default_standard_var_attrs: &default_standard
-  <<: *default
+  DEPEND_0: epoch
   VAR_TYPE: data
   DISPLAY_TYPE: spectrogram
   FILLVAL: -1.00E+31
@@ -23,9 +23,12 @@ default_standard_var_attrs: &default_standard
   VALIDMAX: 10000000000
   FORMAT: F9.3
   UNITS: '1/(cm^2 s MeV/nuc sr)'
+  SCALE_TYP: log
+  SCALEMIN: 0.0001
+  SCALEMAX: 1000
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 default_energy_mean_attrs: &default_energy_mean
-  <<: *default
   VAR_TYPE: support_data
   DISPLAY_TYPE: no_plot
   LABLAXIS: Energy
@@ -34,6 +37,29 @@ default_energy_mean_attrs: &default_energy_mean
   VALIDMAX: 1000
   FORMAT: F5.1
   UNITS: 'MeV'
+  SCALE_TYP: log
+
+default_energy_deltas_attrs: &default_energy_deltas
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  LABLAXIS: Energy
+  FILLVAL: -1.00E+31
+  VALIDMIN: 0
+  VALIDMAX: 1000
+  FORMAT: F5.1
+  UNITS: 'MeV'
+  SCALE_TYP: log
+
+default_uncertainty_attrs: &default_uncertainty
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: spectrogram
+  VALIDMIN: 0
+  VALIDMAX: 10000000000
+  FILLVAL: -1.00E+31
+  FORMAT: F9.3
+  UNITS: 1/(cm^2 s MeV/nuc sr)
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential_Uncertainty
+
 
 # <=== Coordinates ===>
 
@@ -129,12 +155,610 @@ ni_energy_mean:
 # <=== Data Variable Attributes ===>
 
 # Standard intensity data variables
+dynamic_threshold_state:
+  <<: *default_standard
+  CATDESC: Raw dynamic threshold state per integration
+  FIELDNAM: Dynamic threshold state
+  LABLAXIS: Counts   #TODO is lablaxis needed?
+  VALIDMIN: 0
+  VALIDMAX: 3
+  FILLVAL: -9.22E+18
+  DISPLAY_TYPE: time_series
+  DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
+
 h:
   <<: *default_standard
-  CATDESC: H Standard intensity
-  DEPEND_0: epoch
+  CATDESC: H Standard Intensity
   DEPEND_1: h_energy_mean
   LABL_PTR_1: h_energy_label
   FIELDNAM: H Standard Intensity
-  LABLAXIS: 'H Intensity'   #TODO is lablaxis needed?
+  LABLAXIS: 'H Intensity'
+  DELTA_MINUS: h_total_uncert_plus
+  DELTA_PLUS: h_total_uncert_minus
 
+he3:
+  <<: *default_standard
+  DEPEND_1: he3_energy_mean
+  CATDESC: He3 Standard Intensity
+  FIELDNAM: He3 Standard Intensity
+  LABL_PTR_1: he3_energy_label
+  LABLAXIS: He3 Intensity
+  DELTA_MINUS: he3_total_uncert_plus
+  DELTA_PLUS: he3_total_uncert_minus
+
+he4:
+  <<: *default_standard
+  DEPEND_1: he4_energy_mean
+  CATDESC: He4 Standard Intensity
+  FIELDNAM: He4 Standard Intensity
+  LABL_PTR_1: he4_energy_label
+  LABLAXIS: He4 Intensity
+  DELTA_MINUS: he4_total_uncert_plus
+  DELTA_PLUS: he4_total_uncert_minus
+
+he:
+  <<: *default_standard
+  DEPEND_1: he_energy_mean
+  CATDESC: He Standard Intensity
+  FIELDNAM: He Standard Intensity
+  LABL_PTR_1: he_energy_label
+  LABLAXIS: He Intensity
+  DELTA_MINUS: he_total_uncert_plus
+  DELTA_PLUS: he_total_uncert_minus
+
+c:
+  <<: *default_standard
+  DEPEND_1: c_energy_mean
+  CATDESC: C Standard Intensity
+  FIELDNAM: C Standard Intensity
+  LABL_PTR_1: c_energy_label
+  LABLAXIS: C Intensity
+  DELTA_MINUS: c_total_uncert_plus
+  DELTA_PLUS: c_total_uncert_minus
+
+o:
+  <<: *default_standard
+  DEPEND_1: o_energy_mean
+  CATDESC: O Standard Intensity
+  FIELDNAM: O Standard Intensity
+  LABL_PTR_1: o_energy_label
+  LABLAXIS: O Intensity
+  DELTA_MINUS: o_total_uncert_plus
+  DELTA_PLUS: o_total_uncert_minus
+
+n:
+  <<: *default_standard
+  DEPEND_1: n_energy_mean
+  CATDESC: N Standard Intensity
+  FIELDNAM: N Standard Intensity
+  LABL_PTR_1: n_energy_label
+  LABLAXIS: N Intensity
+  DELTA_MINUS: n_total_uncert_plus
+  DELTA_PLUS: n_total_uncert_minus
+
+ne:
+  <<: *default_standard
+  DEPEND_1: ne_energy_mean
+  CATDESC: Ne Standard Intensity
+  FIELDNAM: Ne Standard Intensity
+  LABL_PTR_1: ne_energy_label
+  LABLAXIS: Ne Intensity
+  DELTA_MINUS: ne_total_uncert_plus
+  DELTA_PLUS: ne_total_uncert_minus
+
+na:
+  <<: *default_standard
+  DEPEND_1: na_energy_mean
+  CATDESC: Na Standard Intensity
+  FIELDNAM: Na Standard Intensity
+  LABL_PTR_1: na_energy_label
+  LABLAXIS: Na Intensity
+  DELTA_MINUS: na_total_uncert_plus
+  DELTA_PLUS: na_total_uncert_minus
+
+mg:
+  <<: *default_standard
+  DEPEND_1: mg_energy_mean
+  CATDESC: Mg Standard Intensity
+  FIELDNAM: Mg Standard Intensity
+  LABL_PTR_1: mg_energy_label
+  LABLAXIS: Mg Intensity
+  DELTA_MINUS: mg_total_uncert_plus
+  DELTA_PLUS: mg_total_uncert_minus
+
+al:
+  <<: *default_standard
+  DEPEND_1: al_energy_mean
+  CATDESC: Al Standard Intensity
+  FIELDNAM: Al Standard Intensity
+  LABL_PTR_1: al_energy_label
+  LABLAXIS: Al Intensity
+  DELTA_MINUS: al_total_uncert_plus
+  DELTA_PLUS: al_total_uncert_minus
+
+si:
+  <<: *default_standard
+  DEPEND_1: si_energy_mean
+  CATDESC: Si Standard Intensity
+  FIELDNAM: Si Standard Intensity
+  LABL_PTR_1: si_energy_label
+  LABLAXIS: Si Intensity
+  DELTA_MINUS: si_total_uncert_plus
+  DELTA_PLUS: si_total_uncert_minus
+
+s:
+  <<: *default_standard
+  DEPEND_1: s_energy_mean
+  CATDESC: S Standard Intensity
+  FIELDNAM: S Standard Intensity
+  LABL_PTR_1: s_energy_label
+  LABLAXIS: S Intensity
+  DELTA_MINUS: s_total_uncert_plus
+  DELTA_PLUS: s_total_uncert_minus
+
+ar:
+  <<: *default_standard
+  DEPEND_1: ar_energy_mean
+  CATDESC: Ar Standard Intensity
+  FIELDNAM: Ar Standard Intensity
+  LABL_PTR_1: ar_energy_label
+  LABLAXIS: Ar Intensity
+  DELTA_MINUS: ar_total_uncert_plus
+  DELTA_PLUS: ar_total_uncert_minus
+
+ca:
+  <<: *default_standard
+  DEPEND_1: ca_energy_mean
+  CATDESC: Ca Standard Intensity
+  FIELDNAM: Ca Standard Intensity
+  LABL_PTR_1: ca_energy_label
+  LABLAXIS: Ca Intensity
+  DELTA_MINUS: ca_total_uncert_plus
+  DELTA_PLUS: ca_total_uncert_minus
+
+fe:
+  <<: *default_standard
+  DEPEND_1: fe_energy_mean
+  CATDESC: Fe Standard Intensity
+  FIELDNAM: Fe Standard Intensity
+  LABL_PTR_1: fe_energy_label
+  LABLAXIS: Fe Intensity
+  DELTA_MINUS: fe_total_uncert_plus
+  DELTA_PLUS: fe_total_uncert_minus
+
+ni:
+  <<: *default_standard
+  DEPEND_1: ni_energy_mean
+  CATDESC: Ni Standard Intensity
+  FIELDNAM: Ni Standard Intensity
+  LABL_PTR_1: ni_energy_label
+  LABLAXIS: Ni Intensity
+  DELTA_MINUS: ni_total_uncert_plus
+  DELTA_PLUS: ni_total_uncert_minus
+
+# <=== Energy Delta Variable Attributes ===>
+
+h_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: h_energy_mean
+  CATDESC: H energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: H energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+h_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: h_energy_mean
+  CATDESC: H energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: H energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+he3_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: he3_energy_mean
+  CATDESC: He3 energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: He3 energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+he3_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: he3_energy_mean
+  CATDESC: He3 energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: He3 energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+he4_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: he4_energy_mean
+  CATDESC: He4 energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: He4 energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+he4_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: he4_energy_mean
+  CATDESC: He4 energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: He4 energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+he_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: he_energy_mean
+  CATDESC: He energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: He energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+he_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: he_energy_mean
+  CATDESC: He energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: He energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+c_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: c_energy_mean
+  CATDESC: C energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: C energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+c_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: c_energy_mean
+  CATDESC: C energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: C energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+n_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: n_energy_mean
+  CATDESC: N energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: N energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+n_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: n_energy_mean
+  CATDESC: N energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: N energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+ne_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: ne_energy_mean
+  CATDESC: Ne energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Ne energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+ne_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: ne_energy_mean
+  CATDESC: Ne energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Ne energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+na_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: na_energy_mean
+  CATDESC: Na energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Na energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+na_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: na_energy_mean
+  CATDESC: Na energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Na energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+mg_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: mg_energy_mean
+  CATDESC: Mg energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Mg energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+mg_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: mg_energy_mean
+  CATDESC: Mg energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Mg energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+si_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: si_energy_mean
+  CATDESC: Si energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Si energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+si_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: si_energy_mean
+  CATDESC: Si energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Si energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+s_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: s_energy_mean
+  CATDESC: S energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: S energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+s_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: s_energy_mean
+  CATDESC: S energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: S energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+ar_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: ar_energy_mean
+  CATDESC: Ar energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Ar energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+ar_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: ar_energy_mean
+  CATDESC: Ar energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Ar energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+ca_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: ca_energy_mean
+  CATDESC: Ca energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Ca energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+ca_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: ca_energy_mean
+  CATDESC: Ca energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Ca energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+fe_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: fe_energy_mean
+  CATDESC: Fe energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Fe energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+fe_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: fe_energy_mean
+  CATDESC: Fe energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Fe energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+ni_energy_delta_plus:
+  <<: *default_energy_deltas
+  DEPEND_0: ni_energy_mean
+  CATDESC: Ni energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Ni energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+ni_energy_delta_minus:
+  <<: *default_energy_deltas
+  DEPEND_0: ni_energy_mean
+  CATDESC: Ni energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Ni energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+# <=== Uncertainty Variable Attributes ===>
+
+# Statistical uncertainty variables
+h_stat_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  CATDESC: Plus statistical uncertainty for H Standard
+  FIELDNAM: H Plus Statistical Uncertinty
+  LABLAXIS: H Flux
+
+h_stat_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  CATDESC: Minus statistical uncertainty for H Standard
+  FIELDNAM: H Minus Statistical Uncertinty
+  LABLAXIS: H Flux
+
+he3_stat_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: he3_energy_mean
+  CATDESC: Plus statistical uncertainty for He3 Standard
+  FIELDNAM: He3 Plus Statistical Uncertinty
+  LABLAXIS: He3 Flux
+
+he3_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: he3_energy_mean
+    CATDESC: Minus statistical uncertainty for He3 Standard
+    FIELDNAM: He3 Minus Statistical Uncertinty
+    LABLAXIS: He3 Flux
+
+he4_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: he4_energy_mean
+    CATDESC: Plus statistical uncertainty for He4 Standard
+    FIELDNAM: He4 Plus Statistical Uncertinty
+    LABLAXIS: He4 Flux
+
+he4_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: he4_energy_mean
+    CATDESC: Minus statistical uncertainty for He4 Standard
+    FIELDNAM: He4 Minus Statistical Uncertinty
+    LABLAXIS: He4 Flux
+
+he_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: he_energy_mean
+    CATDESC: Plus statistical uncertainty for He Standard
+    FIELDNAM: He Plus Statistical Uncertinty
+    LABLAXIS: He Flux
+
+he_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: he_energy_mean
+    CATDESC: Minus statistical uncertainty for He Standard
+    FIELDNAM: He Minus Statistical Uncertinty
+    LABLAXIS: He Flux
+
+c_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: c_energy_mean
+    CATDESC: Plus statistical uncertainty for C Standard
+    FIELDNAM: C Plus Statistical Uncertinty
+    LABLAXIS: C Flux
+
+c_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: c_energy_mean
+    CATDESC: Minus statistical uncertainty for C Standard
+    FIELDNAM: C Minus Statistical Uncertinty
+    LABLAXIS: C Flux
+
+n_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: n_energy_mean
+    CATDESC: Plus statistical uncertainty for N Standard
+    FIELDNAM: N Plus Statistical Uncertinty
+    LABLAXIS: N Flux
+
+n_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: n_energy_mean
+    CATDESC: Minus statistical uncertainty for N Standard
+    FIELDNAM: N Minus Statistical Uncertinty
+    LABLAXIS: N Flux
+
+ne_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: ne_energy_mean
+    CATDESC: Plus statistical uncertainty for Ne Standard
+    FIELDNAM: Ne Plus Statistical Uncertinty
+    LABLAXIS: Ne Flux
+
+ne_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: ne_energy_mean
+    CATDESC: Minus statistical uncertainty for Ne Standard
+    FIELDNAM: Ne Minus Statistical Uncertinty
+    LABLAXIS: Ne Flux
+
+na_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: na_energy_mean
+    CATDESC: Plus statistical uncertainty for Na Standard
+    FIELDNAM: Na Plus Statistical Uncertinty
+    LABLAXIS: Na Flux
+
+na_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: na_energy_mean
+    CATDESC: Minus statistical uncertainty for Na Standard
+    FIELDNAM: Na Minus Statistical Uncertinty
+    LABLAXIS: Na Flux
+
+mg_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: mg_energy_mean
+    CATDESC: Plus statistical uncertainty for Mg Standard
+    FIELDNAM: Mg Plus Statistical Uncertinty
+    LABLAXIS: Mg Flux
+
+mg_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: mg_energy_mean
+    CATDESC: Minus statistical uncertainty for Mg Standard
+    FIELDNAM: Mg Minus Statistical Uncertinty
+    LABLAXIS: Mg Flux
+
+si_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: si_energy_mean
+    CATDESC: Plus statistical uncertainty for Si Standard
+    FIELDNAM: Si Plus Statistical Uncertinty
+    LABLAXIS: Si Flux
+
+si_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: si_energy_mean
+    CATDESC: Minus statistical uncertainty for Si Standard
+    FIELDNAM: Si Minus Statistical Uncertinty
+    LABLAXIS: Si Flux
+
+s_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: s_energy_mean
+    CATDESC: Plus statistical uncertainty for S Standard
+    FIELDNAM: S Plus Statistical Uncertinty
+    LABLAXIS: S Flux
+
+s_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: s_energy_mean
+    CATDESC: Minus statistical uncertainty for S Standard
+    FIELDNAM: S Minus Statistical Uncertinty
+    LABLAXIS: S Flux
+
+ar_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: ar_energy_mean
+    CATDESC: Plus statistical uncertainty for Ar Standard
+    FIELDNAM: Ar Plus Statistical Uncertinty
+    LABLAXIS: Ar Flux
+
+ar_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: ar_energy_mean
+    CATDESC: Minus statistical uncertainty for Ar Standard
+    FIELDNAM: Ar Minus Statistical Uncertinty
+    LABLAXIS: Ar Flux
+
+ca_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: ca_energy_mean
+    CATDESC: Plus statistical uncertainty for Ca Standard
+    FIELDNAM: Ca Plus Statistical Uncertinty
+    LABLAXIS: Ca Flux
+
+ca_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: ca_energy_mean
+    CATDESC: Minus statistical uncertainty for Ca Standard
+    FIELDNAM: Ca Minus Statistical Uncertinty
+    LABLAXIS: Ca Flux
+
+fe_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: fe_energy_mean
+    CATDESC: Plus statistical uncertainty for Fe Standard
+    FIELDNAM: Fe Plus Statistical Uncertinty
+    LABLAXIS: Fe Flux
+
+fe_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: fe_energy_mean
+    CATDESC: Minus statistical uncertainty for Fe Standard
+    FIELDNAM: Fe Minus Statistical Uncertinty
+    LABLAXIS: Fe Flux
+
+ni_stat_uncert_plus:
+    <<: *default_uncertainty
+    DEPEND_1: ni_energy_mean
+    CATDESC: Plus statistical uncertainty for Ni Standard
+    FIELDNAM: Ni Plus Statistical Uncertinty
+    LABLAXIS: Ni Flux
+
+ni_stat_uncert_minus:
+    <<: *default_uncertainty
+    DEPEND_1: ni_energy_mean
+    CATDESC: Minus statistical uncertainty for Ni Standard
+    FIELDNAM: Ni Minus Statistical Uncertinty
+    LABLAXIS: Ni Flux
+
+# Systematic Uncertainty Variable Attributes

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -1,7 +1,3 @@
-# TODO: figure out how to handle duplicate names between products (i.e. h is used in all 3)
-# TODO: remove lablaxis where lablptr is used?
-# TODO: add attributes for labels
-
 # <=== Defaults ===>
 default_particle_attrs: &default_particle
   DEPEND_0: epoch
@@ -40,6 +36,7 @@ default_energy_delta_attrs: &default_energy_delta
   SCALE_TYP: log
 
 default_uncertainty_attrs: &default_uncertainty
+  DEPEND_0: epoch
   VAR_TYPE: support_data
   DISPLAY_TYPE: spectrogram
   VALIDMIN: 0
@@ -544,6 +541,20 @@ c_energy_delta_minus:
   FIELDNAM: C energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
+o_energy_delta_plus:
+  <<: *default_energy_delta
+  DEPEND_0: o_energy_mean
+  CATDESC: O energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: O energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+o_energy_delta_minus:
+  <<: *default_energy_delta
+  DEPEND_0: o_energy_mean
+  CATDESC: O energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: O energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
 n_energy_delta_plus:
   <<: *default_energy_delta
   DEPEND_0: n_energy_mean
@@ -598,6 +609,20 @@ mg_energy_delta_minus:
   DEPEND_0: mg_energy_mean
   CATDESC: Mg energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Mg energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+al_energy_delta_plus:
+  <<: *default_energy_delta
+  DEPEND_0: al_energy_mean
+  CATDESC: Al energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Al energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+al_energy_delta_minus:
+  <<: *default_energy_delta
+  DEPEND_0: al_energy_mean
+  CATDESC: Al energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Al energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 si_energy_delta_plus:

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -550,215 +550,718 @@ ni_energy_delta_minus:
 
 # <=== Uncertainty Variable Attributes ===>
 
-# Statistical uncertainty variables
 h_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   CATDESC: Plus statistical uncertainty for H Standard
-  FIELDNAM: H Plus Statistical Uncertinty
+  FIELDNAM: H Plus Statistical uncertainty
   LABLAXIS: H Flux
 
 h_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   CATDESC: Minus statistical uncertainty for H Standard
-  FIELDNAM: H Minus Statistical Uncertinty
+  FIELDNAM: H Minus Statistical uncertainty
+  LABLAXIS: H Flux
+
+h_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  CATDESC: Plus systematic uncertainty for H Standard
+  FIELDNAM: H Plus Systematic uncertainty
+  LABLAXIS: H Flux
+
+h_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  CATDESC: Minus systematic uncertainty for H Standard
+  FIELDNAM: H Minus Systematic uncertainty
+  LABLAXIS: H Flux
+
+h_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H Standard
+  FIELDNAM: H Total Uncertainty
+  LABLAXIS: H Flux
+
+h_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H Standard
+  FIELDNAM: H Total Uncertainty
   LABLAXIS: H Flux
 
 he3_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Plus statistical uncertainty for He3 Standard
-  FIELDNAM: He3 Plus Statistical Uncertinty
+  FIELDNAM: He3 Plus Statistical uncertainty
   LABLAXIS: He3 Flux
 
 he3_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: he3_energy_mean
-    CATDESC: Minus statistical uncertainty for He3 Standard
-    FIELDNAM: He3 Minus Statistical Uncertinty
-    LABLAXIS: He3 Flux
+  <<: *default_uncertainty
+  DEPEND_1: he3_energy_mean
+  CATDESC: Minus statistical uncertainty for He3 Standard
+  FIELDNAM: He3 Minus Statistical uncertainty
+  LABLAXIS: He3 Flux
+
+he3_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: he3_energy_mean
+  CATDESC: Plus systematic uncertainty for He3 Standard
+  FIELDNAM: He3 Plus Systematic uncertainty
+  LABLAXIS: He3 Flux
+
+he3_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: he3_energy_mean
+  CATDESC: Minus systematic uncertainty for He3 Standard
+  FIELDNAM: He3 Minus Systematic uncertainty
+  LABLAXIS: He3 Flux
+
+he3_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: he3_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He3 Standard
+  FIELDNAM: He3 Total Uncertainty
+  LABLAXIS: He3 Flux
+
+he3_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: he3_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He3 Standard
+  FIELDNAM: He3 Total Uncertainty
+  LABLAXIS: He3 Flux
 
 he4_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: he4_energy_mean
-    CATDESC: Plus statistical uncertainty for He4 Standard
-    FIELDNAM: He4 Plus Statistical Uncertinty
-    LABLAXIS: He4 Flux
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  CATDESC: Plus statistical uncertainty for He4 Standard
+  FIELDNAM: He4 Plus Statistical uncertainty
+  LABLAXIS: He4 Flux
 
 he4_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: he4_energy_mean
-    CATDESC: Minus statistical uncertainty for He4 Standard
-    FIELDNAM: He4 Minus Statistical Uncertinty
-    LABLAXIS: He4 Flux
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  CATDESC: Minus statistical uncertainty for He4 Standard
+  FIELDNAM: He4 Minus Statistical uncertainty
+  LABLAXIS: He4 Flux
+
+he4_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  CATDESC: Plus systematic uncertainty for He4 Standard
+  FIELDNAM: He4 Plus Systematic uncertainty
+  LABLAXIS: He4 Flux
+
+he4_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  CATDESC: Minus systematic uncertainty for He4 Standard
+  FIELDNAM: He4 Minus Systematic uncertainty
+  LABLAXIS: He4 Flux
+
+he4_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He4 Standard
+  FIELDNAM: He4 Total Uncertainty
+  LABLAXIS: He4 Flux
+
+he4_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He4 Standard
+  FIELDNAM: He4 Total Uncertainty
+  LABLAXIS: He4 Flux
 
 he_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: he_energy_mean
-    CATDESC: Plus statistical uncertainty for He Standard
-    FIELDNAM: He Plus Statistical Uncertinty
-    LABLAXIS: He Flux
+  <<: *default_uncertainty
+  DEPEND_1: he_energy_mean
+  CATDESC: Plus statistical uncertainty for He Standard
+  FIELDNAM: He Plus Statistical uncertainty
+  LABLAXIS: He Flux
 
 he_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: he_energy_mean
-    CATDESC: Minus statistical uncertainty for He Standard
-    FIELDNAM: He Minus Statistical Uncertinty
-    LABLAXIS: He Flux
+  <<: *default_uncertainty
+  DEPEND_1: he_energy_mean
+  CATDESC: Minus statistical uncertainty for He Standard
+  FIELDNAM: He Minus Statistical uncertainty
+  LABLAXIS: He Flux
+
+he_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: he_energy_mean
+  CATDESC: Plus systematic uncertainty for He Standard
+  FIELDNAM: He Plus Systematic uncertainty
+  LABLAXIS: He Flux
+
+he_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: he_energy_mean
+  CATDESC: Minus systematic uncertainty for He Standard
+  FIELDNAM: He Minus Systematic uncertainty
+  LABLAXIS: He Flux
+
+he_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: he_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He Standard
+  FIELDNAM: He Total Uncertainty
+  LABLAXIS: He Flux
+
+he_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: he_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He Standard
+  FIELDNAM: He Total Uncertainty
+  LABLAXIS: He Flux
 
 c_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: c_energy_mean
-    CATDESC: Plus statistical uncertainty for C Standard
-    FIELDNAM: C Plus Statistical Uncertinty
-    LABLAXIS: C Flux
+  <<: *default_uncertainty
+  DEPEND_1: c_energy_mean
+  CATDESC: Plus statistical uncertainty for C Standard
+  FIELDNAM: C Plus Statistical uncertainty
+  LABLAXIS: C Flux
 
 c_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: c_energy_mean
-    CATDESC: Minus statistical uncertainty for C Standard
-    FIELDNAM: C Minus Statistical Uncertinty
-    LABLAXIS: C Flux
+  <<: *default_uncertainty
+  DEPEND_1: c_energy_mean
+  CATDESC: Minus statistical uncertainty for C Standard
+  FIELDNAM: C Minus Statistical uncertainty
+  LABLAXIS: C Flux
+
+c_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: c_energy_mean
+  CATDESC: Plus systematic uncertainty for C Standard
+  FIELDNAM: C Plus Systematic uncertainty
+  LABLAXIS: C Flux
+
+c_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: c_energy_mean
+  CATDESC: Minus systematic uncertainty for C Standard
+  FIELDNAM: C Minus Systematic uncertainty
+  LABLAXIS: C Flux
+
+c_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: c_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for C Standard
+  FIELDNAM: C Total Uncertainty
+  LABLAXIS: C Flux
+
+c_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: c_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for C Standard
+  FIELDNAM: C Total Uncertainty
+  LABLAXIS: C Flux
+
+o_stat_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: o_energy_mean
+  CATDESC: Plus statistical uncertainty for O Standard
+  FIELDNAM: O Plus Statistical uncertainty
+  LABLAXIS: O Flux
+
+o_stat_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: o_energy_mean
+  CATDESC: Minus statistical uncertainty for O Standard
+  FIELDNAM: O Minus Statistical uncertainty
+  LABLAXIS: O Flux
+
+o_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: o_energy_mean
+  CATDESC: Plus systematic uncertainty for O Standard
+  FIELDNAM: O Plus Systematic uncertainty
+  LABLAXIS: O Flux
+
+o_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: o_energy_mean
+  CATDESC: Minus systematic uncertainty for O Standard
+  FIELDNAM: O Minus Systematic uncertainty
+  LABLAXIS: O Flux
+
+o_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: o_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for O Standard
+  FIELDNAM: O Total Uncertainty
+  LABLAXIS: O Flux
+
+o_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: o_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for O Standard
+  FIELDNAM: O Total Uncertainty
+  LABLAXIS: O Flux
 
 n_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: n_energy_mean
-    CATDESC: Plus statistical uncertainty for N Standard
-    FIELDNAM: N Plus Statistical Uncertinty
-    LABLAXIS: N Flux
+  <<: *default_uncertainty
+  DEPEND_1: n_energy_mean
+  CATDESC: Plus statistical uncertainty for N Standard
+  FIELDNAM: N Plus Statistical uncertainty
+  LABLAXIS: N Flux
 
 n_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: n_energy_mean
-    CATDESC: Minus statistical uncertainty for N Standard
-    FIELDNAM: N Minus Statistical Uncertinty
-    LABLAXIS: N Flux
+  <<: *default_uncertainty
+  DEPEND_1: n_energy_mean
+  CATDESC: Minus statistical uncertainty for N Standard
+  FIELDNAM: N Minus Statistical uncertainty
+  LABLAXIS: N Flux
+
+n_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: n_energy_mean
+  CATDESC: Plus systematic uncertainty for N Standard
+  FIELDNAM: N Plus Systematic uncertainty
+  LABLAXIS: N Flux
+
+n_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: n_energy_mean
+  CATDESC: Minus systematic uncertainty for N Standard
+  FIELDNAM: N Minus Systematic uncertainty
+  LABLAXIS: N Flux
+
+n_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: n_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for N Standard
+  FIELDNAM: N Total Uncertainty
+  LABLAXIS: N Flux
+
+n_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: n_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for N Standard
+  FIELDNAM: N Total Uncertainty
+  LABLAXIS: N Flux
 
 ne_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: ne_energy_mean
-    CATDESC: Plus statistical uncertainty for Ne Standard
-    FIELDNAM: Ne Plus Statistical Uncertinty
-    LABLAXIS: Ne Flux
+  <<: *default_uncertainty
+  DEPEND_1: ne_energy_mean
+  CATDESC: Plus statistical uncertainty for Ne Standard
+  FIELDNAM: Ne Plus Statistical uncertainty
+  LABLAXIS: Ne Flux
 
 ne_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: ne_energy_mean
-    CATDESC: Minus statistical uncertainty for Ne Standard
-    FIELDNAM: Ne Minus Statistical Uncertinty
-    LABLAXIS: Ne Flux
+  <<: *default_uncertainty
+  DEPEND_1: ne_energy_mean
+  CATDESC: Minus statistical uncertainty for Ne Standard
+  FIELDNAM: Ne Minus Statistical uncertainty
+  LABLAXIS: Ne Flux
+
+ne_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: ne_energy_mean
+  CATDESC: Plus systematic uncertainty for Ne Standard
+  FIELDNAM: Ne Plus Systematic uncertainty
+  LABLAXIS: Ne Flux
+
+ne_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: ne_energy_mean
+  CATDESC: Minus systematic uncertainty for Ne Standard
+  FIELDNAM: Ne Minus Systematic uncertainty
+  LABLAXIS: Ne Flux
+
+ne_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: ne_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ne Standard
+  FIELDNAM: Ne Total Uncertainty
+  LABLAXIS: Ne Flux
+
+ne_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: ne_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ne Standard
+  FIELDNAM: Ne Total Uncertainty
+  LABLAXIS: Ne Flux
 
 na_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: na_energy_mean
-    CATDESC: Plus statistical uncertainty for Na Standard
-    FIELDNAM: Na Plus Statistical Uncertinty
-    LABLAXIS: Na Flux
+  <<: *default_uncertainty
+  DEPEND_1: na_energy_mean
+  CATDESC: Plus statistical uncertainty for Na Standard
+  FIELDNAM: Na Plus Statistical uncertainty
+  LABLAXIS: Na Flux
 
 na_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: na_energy_mean
-    CATDESC: Minus statistical uncertainty for Na Standard
-    FIELDNAM: Na Minus Statistical Uncertinty
-    LABLAXIS: Na Flux
+  <<: *default_uncertainty
+  DEPEND_1: na_energy_mean
+  CATDESC: Minus statistical uncertainty for Na Standard
+  FIELDNAM: Na Minus Statistical uncertainty
+  LABLAXIS: Na Flux
+
+na_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: na_energy_mean
+  CATDESC: Plus systematic uncertainty for Na Standard
+  FIELDNAM: Na Plus Systematic uncertainty
+  LABLAXIS: Na Flux
+
+na_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: na_energy_mean
+  CATDESC: Minus systematic uncertainty for Na Standard
+  FIELDNAM: Na Minus Systematic uncertainty
+  LABLAXIS: Na Flux
+
+na_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: na_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Na Standard
+  FIELDNAM: Na Total Uncertainty
+  LABLAXIS: Na Flux
+
+na_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: na_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Na Standard
+  FIELDNAM: Na Total Uncertainty
+  LABLAXIS: Na Flux
 
 mg_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: mg_energy_mean
-    CATDESC: Plus statistical uncertainty for Mg Standard
-    FIELDNAM: Mg Plus Statistical Uncertinty
-    LABLAXIS: Mg Flux
+  <<: *default_uncertainty
+  DEPEND_1: mg_energy_mean
+  CATDESC: Plus statistical uncertainty for Mg Standard
+  FIELDNAM: Mg Plus Statistical uncertainty
+  LABLAXIS: Mg Flux
 
 mg_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: mg_energy_mean
-    CATDESC: Minus statistical uncertainty for Mg Standard
-    FIELDNAM: Mg Minus Statistical Uncertinty
-    LABLAXIS: Mg Flux
+  <<: *default_uncertainty
+  DEPEND_1: mg_energy_mean
+  CATDESC: Minus statistical uncertainty for Mg Standard
+  FIELDNAM: Mg Minus Statistical uncertainty
+  LABLAXIS: Mg Flux
+
+mg_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: mg_energy_mean
+  CATDESC: Plus systematic uncertainty for Mg Standard
+  FIELDNAM: Mg Plus Systematic uncertainty
+  LABLAXIS: Mg Flux
+
+mg_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: mg_energy_mean
+  CATDESC: Minus systematic uncertainty for Mg Standard
+  FIELDNAM: Mg Minus Systematic uncertainty
+  LABLAXIS: Mg Flux
+
+mg_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: mg_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Mg Standard
+  FIELDNAM: Mg Total Uncertainty
+  LABLAXIS: Mg Flux
+
+mg_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: mg_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Mg Standard
+  FIELDNAM: Mg Total Uncertainty
+  LABLAXIS: Mg Flux
+
+al_stat_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: al_energy_mean
+  CATDESC: Plus statistical uncertainty for Al Standard
+  FIELDNAM: Al Plus Statistical uncertainty
+  LABLAXIS: Al Flux
+
+al_stat_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: al_energy_mean
+  CATDESC: Minus statistical uncertainty for Al Standard
+  FIELDNAM: Al Minus Statistical uncertainty
+  LABLAXIS: Al Flux
+
+al_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: al_energy_mean
+  CATDESC: Plus systematic uncertainty for Al Standard
+  FIELDNAM: Al Plus Systematic uncertainty
+  LABLAXIS: Al Flux
+
+al_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: al_energy_mean
+  CATDESC: Minus systematic uncertainty for Al Standard
+  FIELDNAM: Al Minus Systematic uncertainty
+  LABLAXIS: Al Flux
+
+al_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: al_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Al Standard
+  FIELDNAM: Al Total Uncertainty
+  LABLAXIS: Al Flux
+
+al_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: al_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Al Standard
+  FIELDNAM: Al Total Uncertainty
+  LABLAXIS: Al Flux
 
 si_stat_uncert_plus:
     <<: *default_uncertainty
     DEPEND_1: si_energy_mean
     CATDESC: Plus statistical uncertainty for Si Standard
-    FIELDNAM: Si Plus Statistical Uncertinty
+    FIELDNAM: Si Plus Statistical uncertainty
     LABLAXIS: Si Flux
 
 si_stat_uncert_minus:
     <<: *default_uncertainty
     DEPEND_1: si_energy_mean
     CATDESC: Minus statistical uncertainty for Si Standard
-    FIELDNAM: Si Minus Statistical Uncertinty
+    FIELDNAM: Si Minus Statistical uncertainty
     LABLAXIS: Si Flux
 
+si_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: si_energy_mean
+  CATDESC: Plus systematic uncertainty for Si Standard
+  FIELDNAM: Si Plus Systematic uncertainty
+  LABLAXIS: Si Flux
+
+si_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: si_energy_mean
+  CATDESC: Minus systematic uncertainty for Si Standard
+  FIELDNAM: Si Minus Systematic uncertainty
+  LABLAXIS: Si Flux
+
+si_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: si_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Si Standard
+  FIELDNAM: Si Total Uncertainty
+  LABLAXIS: Si Flux
+
+si_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: si_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Si Standard
+  FIELDNAM: Si Total Uncertainty
+  LABLAXIS: Si Flux
+
 s_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: s_energy_mean
-    CATDESC: Plus statistical uncertainty for S Standard
-    FIELDNAM: S Plus Statistical Uncertinty
-    LABLAXIS: S Flux
+  <<: *default_uncertainty
+  DEPEND_1: s_energy_mean
+  CATDESC: Plus statistical uncertainty for S Standard
+  FIELDNAM: S Plus Statistical uncertainty
+  LABLAXIS: S Flux
 
 s_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: s_energy_mean
-    CATDESC: Minus statistical uncertainty for S Standard
-    FIELDNAM: S Minus Statistical Uncertinty
-    LABLAXIS: S Flux
+  <<: *default_uncertainty
+  DEPEND_1: s_energy_mean
+  CATDESC: Minus statistical uncertainty for S Standard
+  FIELDNAM: S Minus Statistical uncertainty
+  LABLAXIS: S Flux
+
+s_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: s_energy_mean
+  CATDESC: Plus systematic uncertainty for S Standard
+  FIELDNAM: S Plus Systematic uncertainty
+  LABLAXIS: S Flux
+
+s_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: s_energy_mean
+  CATDESC: Minus systematic uncertainty for S Standard
+  FIELDNAM: S Minus Systematic uncertainty
+  LABLAXIS: S Flux
+
+s_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: s_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for S Standard
+  FIELDNAM: S Total Uncertainty
+  LABLAXIS: S Flux
+
+s_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: s_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for S Standard
+  FIELDNAM: S Total Uncertainty
+  LABLAXIS: S Flux
 
 ar_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: ar_energy_mean
-    CATDESC: Plus statistical uncertainty for Ar Standard
-    FIELDNAM: Ar Plus Statistical Uncertinty
-    LABLAXIS: Ar Flux
+  <<: *default_uncertainty
+  DEPEND_1: ar_energy_mean
+  CATDESC: Plus statistical uncertainty for Ar Standard
+  FIELDNAM: Ar Plus Statistical uncertainty
+  LABLAXIS: Ar Flux
 
 ar_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: ar_energy_mean
-    CATDESC: Minus statistical uncertainty for Ar Standard
-    FIELDNAM: Ar Minus Statistical Uncertinty
-    LABLAXIS: Ar Flux
+  <<: *default_uncertainty
+  DEPEND_1: ar_energy_mean
+  CATDESC: Minus statistical uncertainty for Ar Standard
+  FIELDNAM: Ar Minus Statistical uncertainty
+  LABLAXIS: Ar Flux
+
+ar_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: ar_energy_mean
+  CATDESC: Plus systematic uncertainty for Ar Standard
+  FIELDNAM: Ar Plus Systematic uncertainty
+  LABLAXIS: Ar Flux
+
+ar_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: ar_energy_mean
+  CATDESC: Minus systematic uncertainty for Ar Standard
+  FIELDNAM: Ar Minus Systematic uncertainty
+  LABLAXIS: Ar Flux
+
+ar_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: ar_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ar Standard
+  FIELDNAM: Ar Total Uncertainty
+  LABLAXIS: Ar Flux
+
+ar_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: ar_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ar Standard
+  FIELDNAM: Ar Total Uncertainty
+  LABLAXIS: Ar Flux
 
 ca_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: ca_energy_mean
-    CATDESC: Plus statistical uncertainty for Ca Standard
-    FIELDNAM: Ca Plus Statistical Uncertinty
-    LABLAXIS: Ca Flux
+  <<: *default_uncertainty
+  DEPEND_1: ca_energy_mean
+  CATDESC: Plus statistical uncertainty for Ca Standard
+  FIELDNAM: Ca Plus Statistical uncertainty
+  LABLAXIS: Ca Flux
 
 ca_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: ca_energy_mean
-    CATDESC: Minus statistical uncertainty for Ca Standard
-    FIELDNAM: Ca Minus Statistical Uncertinty
-    LABLAXIS: Ca Flux
+  <<: *default_uncertainty
+  DEPEND_1: ca_energy_mean
+  CATDESC: Minus statistical uncertainty for Ca Standard
+  FIELDNAM: Ca Minus Statistical uncertainty
+  LABLAXIS: Ca Flux
+
+ca_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: ca_energy_mean
+  CATDESC: Plus systematic uncertainty for Ca Standard
+  FIELDNAM: Ca Plus Systematic uncertainty
+  LABLAXIS: Ca Flux
+
+ca_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: ca_energy_mean
+  CATDESC: Minus systematic uncertainty for Ca Standard
+  FIELDNAM: Ca Minus Systematic uncertainty
+  LABLAXIS: Ca Flux
+
+ca_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: ca_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ca Standard
+  FIELDNAM: Ca Total Uncertainty
+  LABLAXIS: Ca Flux
+
+ca_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: ca_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ca Standard
+  FIELDNAM: Ca Total Uncertainty
+  LABLAXIS: Ca Flux
 
 fe_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: fe_energy_mean
-    CATDESC: Plus statistical uncertainty for Fe Standard
-    FIELDNAM: Fe Plus Statistical Uncertinty
-    LABLAXIS: Fe Flux
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  CATDESC: Plus statistical uncertainty for Fe Standard
+  FIELDNAM: Fe Plus Statistical uncertainty
+  LABLAXIS: Fe Flux
 
 fe_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: fe_energy_mean
-    CATDESC: Minus statistical uncertainty for Fe Standard
-    FIELDNAM: Fe Minus Statistical Uncertinty
-    LABLAXIS: Fe Flux
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  CATDESC: Minus statistical uncertainty for Fe Standard
+  FIELDNAM: Fe Minus Statistical uncertainty
+  LABLAXIS: Fe Flux
+
+fe_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  CATDESC: Plus systematic uncertainty for Fe Standard
+  FIELDNAM: Fe Plus Systematic uncertainty
+  LABLAXIS: Fe Flux
+
+fe_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  CATDESC: Minus systematic uncertainty for Fe Standard
+  FIELDNAM: Fe Minus Systematic uncertainty
+  LABLAXIS: Fe Flux
+
+fe_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Fe Standard
+  FIELDNAM: Fe Total Uncertainty
+  LABLAXIS: Fe Flux
+
+fe_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Fe Standard
+  FIELDNAM: Fe Total Uncertainty
+  LABLAXIS: Fe Flux
 
 ni_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: ni_energy_mean
-    CATDESC: Plus statistical uncertainty for Ni Standard
-    FIELDNAM: Ni Plus Statistical Uncertinty
-    LABLAXIS: Ni Flux
+  <<: *default_uncertainty
+  DEPEND_1: ni_energy_mean
+  CATDESC: Plus statistical uncertainty for Ni Standard
+  FIELDNAM: Ni Plus Statistical uncertainty
+  LABLAXIS: Ni Flux
 
 ni_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: ni_energy_mean
-    CATDESC: Minus statistical uncertainty for Ni Standard
-    FIELDNAM: Ni Minus Statistical Uncertinty
-    LABLAXIS: Ni Flux
+  <<: *default_uncertainty
+  DEPEND_1: ni_energy_mean
+  CATDESC: Minus statistical uncertainty for Ni Standard
+  FIELDNAM: Ni Minus Statistical uncertainty
+  LABLAXIS: Ni Flux
 
-# Systematic Uncertainty Variable Attributes
+ni_sys_err_plus:
+  <<: *default_uncertainty
+  DEPEND_1: ni_energy_mean
+  CATDESC: Plus systematic uncertainty for Ni Standard
+  FIELDNAM: Ni Plus Systematic uncertainty
+  LABLAXIS: Ni Flux
+
+ni_sys_err_minus:
+  <<: *default_uncertainty
+  DEPEND_1: ni_energy_mean
+  CATDESC: Minus systematic uncertainty for Ni Standard
+  FIELDNAM: Ni Minus Systematic uncertainty
+  LABLAXIS: Ni Flux
+
+ni_total_uncert_plus:
+  <<: *default_uncertainty
+  DEPEND_1: ni_energy_mean
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ni Standard
+  FIELDNAM: Ni Total Uncertainty
+  LABLAXIS: Ni Flux
+
+ni_total_uncert_minus:
+  <<: *default_uncertainty
+  DEPEND_1: ni_energy_mean
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ni Standard
+  FIELDNAM: Ni Total Uncertainty
+  LABLAXIS: Ni Flux
+
+

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -1,20 +1,9 @@
-# TODO: add attributes for L2 variables
 # TODO: figure out how to handle duplicate names between products (i.e. h is used in all 3)
-# TODO: keep default_attrs? It mostly changes
-# <=== Defaults ===>
-# Assumed values for all variable attrs unless overwritten
-default_attrs: &default
-  DEPEND_0: epoch
-  DISPLAY_TYPE: time_series
-  FILLVAL: -9223372036854775808
-  FORMAT: I12
-  VALIDMIN: 0
-  VALIDMAX: 9223372036854775807
-  VAR_TYPE: data
-  UNITS: ' '
-  SCALETYP: linear
+# TODO: remove lablaxis where lablptr is used?
+# TODO: add attributes for labels
 
-default_standard_var_attrs: &default_standard
+# <=== Defaults ===>
+default_particle_attrs: &default_particle
   DEPEND_0: epoch
   VAR_TYPE: data
   DISPLAY_TYPE: spectrogram
@@ -22,7 +11,7 @@ default_standard_var_attrs: &default_standard
   VALIDMIN: 0
   VALIDMAX: 10000000000
   FORMAT: F9.3
-  UNITS: '1/(cm^2 s MeV/nuc sr)'
+  UNITS: 1/(cm^2 s MeV/nuc sr)
   SCALE_TYP: log
   SCALEMIN: 0.0001
   SCALEMAX: 1000
@@ -36,10 +25,10 @@ default_energy_mean_attrs: &default_energy_mean
   VALIDMIN: 0
   VALIDMAX: 1000
   FORMAT: F5.1
-  UNITS: 'MeV'
+  UNITS: MeV
   SCALE_TYP: log
 
-default_energy_deltas_attrs: &default_energy_deltas
+default_energy_delta_attrs: &default_energy_delta
   VAR_TYPE: support_data
   DISPLAY_TYPE: no_plot
   LABLAXIS: Energy
@@ -47,7 +36,7 @@ default_energy_deltas_attrs: &default_energy_deltas
   VALIDMIN: 0
   VALIDMAX: 1000
   FORMAT: F5.1
-  UNITS: 'MeV'
+  UNITS: MeV
   SCALE_TYP: log
 
 default_uncertainty_attrs: &default_uncertainty
@@ -60,1208 +49,1716 @@ default_uncertainty_attrs: &default_uncertainty
   UNITS: 1/(cm^2 s MeV/nuc sr)
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential_Uncertainty
 
+default_angle_attrs: &default_angle
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  FILLVAL: -1.00E+31
+  VALIDMIN: 0
+  VALIDMAX: 1000
+  FORMAT: F5.1
+  UNITS: Deg
+  SCALE_TYP: linear
 
-# <=== Coordinates ===>
-
-# Standard intensity coordinates
-h_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for H Standard
-  FIELDNAM: H Energy
-
-he3_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for He3 Standard
-  FIELDNAM: He3 Energy
-
-he4_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for He4 Standard
-  FIELDNAM: He4 Energy
-
-he_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for He Standard
-  FIELDNAM: He Energy
-
-c_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for C Standard
-  FIELDNAM: C Energy
-
-n_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for N Standard
-  FIELDNAM: N Energy
-
-o_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for O Standard
-  FIELDNAM: O Energy
-
-ne_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Ne Standard
-  FIELDNAM: Ne Energy
-
-na_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Na Standard
-  FIELDNAM: Na Energy
-
-mg_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Mg Standard
-  FIELDNAM: Mg Energy
-
-si_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Si Standard
-  FIELDNAM: Si Energy
-
-s_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for S Standard
-  FIELDNAM: S Energy
-
-al_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Al Standard
-  FIELDNAM: Al Energy
-
-ar_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Ar Standard
-  FIELDNAM: Ar Energy
-
-ca_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Ca Standard
-  FIELDNAM: Ca Energy
-
-fe_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Fe Standard
-  FIELDNAM: Fe Energy
-
-ni_energy_mean:
-  <<: *default_energy_mean
-  CATDESC: Geometric mean energy for Ni Standard
-  FIELDNAM: Ni Energy
-
-
-# <=== Label Attributes ===>
-
-# <=== Data Variable Attributes ===>
-
-# Standard intensity data variables
-dynamic_threshold_state:
-  <<: *default_standard
+default_dynamic_threshold_state_attrs: &default_dns
+  DEPEND_0: epoch
+  VAR_TYPE: data
   CATDESC: Raw dynamic threshold state per integration
   FIELDNAM: Dynamic threshold state
-  LABLAXIS: Counts   #TODO is lablaxis needed?
+  LABLAXIS: Counts
   VALIDMIN: 0
   VALIDMAX: 3
   FILLVAL: -9.22E+18
   DISPLAY_TYPE: time_series
+  FORMAT: I1
+  UNITS: " "
+  SCALE_TYP: log
+  SCALEMIN: 0.0001
+  SCALEMAX: 1000
   DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
 
+# <=== Coordinates ===>
+declination:
+  <<: *default_angle
+  CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
+  FIELDNAM: Declination
+  LABLAXIS: Declination
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:ArrivalDirection,Qualifer:DirectionAngle.PolarAngle
+
+azimuth:
+  <<: *default_angle
+  CATDESC: Spin angle in 15 bins (0 deg. is zero of spin phase)
+  FIELDNAM: Azimuth
+  LABLAXIS: Azimuth
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:ArrivalDirection,Qualifer:DirectionAngle.AzimuthAngle
+
+h_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for H
+  FIELDNAM: H Energy
+
+he3_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for He3
+  FIELDNAM: He3 Energy
+
+he4_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for He4
+  FIELDNAM: He4 Energy
+
+he_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for He
+  FIELDNAM: He Energy
+
+c_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for C
+  FIELDNAM: C Energy
+
+n_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for N
+  FIELDNAM: N Energy
+
+o_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for O
+  FIELDNAM: O Energy
+
+ne_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Ne
+  FIELDNAM: Ne Energy
+
+na_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Na
+  FIELDNAM: Na Energy
+
+mg_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Mg
+  FIELDNAM: Mg Energy
+
+si_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Si
+  FIELDNAM: Si Energy
+
+s_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for S
+  FIELDNAM: S Energy
+
+al_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Al
+  FIELDNAM: Al Energy
+
+ar_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Ar
+  FIELDNAM: Ar Energy
+
+ca_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Ca
+  FIELDNAM: Ca Energy
+
+fe_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Fe
+  FIELDNAM: Fe Energy
+
+ni_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for Ni
+  FIELDNAM: Ni Energy
+
+nemgsi_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for NeMgSi
+  FIELDNAM: NeMgSi Energy
+
+cno_energy_mean:
+  <<: *default_energy_mean
+  CATDESC: Geometric mean energy for CNO
+  FIELDNAM: CNO Energy
+
+
+# <=== Labels ===>
+#TODO: add labels
+
+# <=== Data Variables - Standard & Summed Datasets ===>
+
+dynamic_threshold_state:
+  <<: *default_dns
+
+# Particle Intensity Variables
 h:
-  <<: *default_standard
-  CATDESC: H Standard Intensity
+  <<: *default_particle
   DEPEND_1: h_energy_mean
+  CATDESC: H Intensity
   LABL_PTR_1: h_energy_label
-  FIELDNAM: H Standard Intensity
+  FIELDNAM: H Intensity
   LABLAXIS: H Intensity
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
 
 he3:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: he3_energy_mean
-  CATDESC: He3 Standard Intensity
-  FIELDNAM: He3 Standard Intensity
+  CATDESC: He3 Intensity
+  FIELDNAM: He3 Intensity
   LABL_PTR_1: he3_energy_label
   LABLAXIS: He3 Intensity
   DELTA_MINUS: he3_total_uncert_plus
   DELTA_PLUS: he3_total_uncert_minus
 
 he4:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: he4_energy_mean
-  CATDESC: He4 Standard Intensity
-  FIELDNAM: He4 Standard Intensity
+  CATDESC: He4 Intensity
+  FIELDNAM: He4 Intensity
   LABL_PTR_1: he4_energy_label
   LABLAXIS: He4 Intensity
   DELTA_MINUS: he4_total_uncert_plus
   DELTA_PLUS: he4_total_uncert_minus
 
 he:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: he_energy_mean
-  CATDESC: He Standard Intensity
-  FIELDNAM: He Standard Intensity
+  CATDESC: He Intensity
+  FIELDNAM: He Intensity
   LABL_PTR_1: he_energy_label
   LABLAXIS: He Intensity
   DELTA_MINUS: he_total_uncert_plus
   DELTA_PLUS: he_total_uncert_minus
 
 c:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: c_energy_mean
-  CATDESC: C Standard Intensity
-  FIELDNAM: C Standard Intensity
+  CATDESC: C Intensity
+  FIELDNAM: C Intensity
   LABL_PTR_1: c_energy_label
   LABLAXIS: C Intensity
   DELTA_MINUS: c_total_uncert_plus
   DELTA_PLUS: c_total_uncert_minus
 
 o:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: o_energy_mean
-  CATDESC: O Standard Intensity
-  FIELDNAM: O Standard Intensity
+  CATDESC: O Intensity
+  FIELDNAM: O Intensity
   LABL_PTR_1: o_energy_label
   LABLAXIS: O Intensity
   DELTA_MINUS: o_total_uncert_plus
   DELTA_PLUS: o_total_uncert_minus
 
 n:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: n_energy_mean
-  CATDESC: N Standard Intensity
-  FIELDNAM: N Standard Intensity
+  CATDESC: N Intensity
+  FIELDNAM: N Intensity
   LABL_PTR_1: n_energy_label
   LABLAXIS: N Intensity
   DELTA_MINUS: n_total_uncert_plus
   DELTA_PLUS: n_total_uncert_minus
 
 ne:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: ne_energy_mean
-  CATDESC: Ne Standard Intensity
-  FIELDNAM: Ne Standard Intensity
+  CATDESC: Ne Intensity
+  FIELDNAM: Ne Intensity
   LABL_PTR_1: ne_energy_label
   LABLAXIS: Ne Intensity
   DELTA_MINUS: ne_total_uncert_plus
   DELTA_PLUS: ne_total_uncert_minus
 
 na:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: na_energy_mean
-  CATDESC: Na Standard Intensity
-  FIELDNAM: Na Standard Intensity
+  CATDESC: Na Intensity
+  FIELDNAM: Na Intensity
   LABL_PTR_1: na_energy_label
   LABLAXIS: Na Intensity
   DELTA_MINUS: na_total_uncert_plus
   DELTA_PLUS: na_total_uncert_minus
 
 mg:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: mg_energy_mean
-  CATDESC: Mg Standard Intensity
-  FIELDNAM: Mg Standard Intensity
+  CATDESC: Mg Intensity
+  FIELDNAM: Mg Intensity
   LABL_PTR_1: mg_energy_label
   LABLAXIS: Mg Intensity
   DELTA_MINUS: mg_total_uncert_plus
   DELTA_PLUS: mg_total_uncert_minus
 
 al:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: al_energy_mean
-  CATDESC: Al Standard Intensity
-  FIELDNAM: Al Standard Intensity
+  CATDESC: Al Intensity
+  FIELDNAM: Al Intensity
   LABL_PTR_1: al_energy_label
   LABLAXIS: Al Intensity
   DELTA_MINUS: al_total_uncert_plus
   DELTA_PLUS: al_total_uncert_minus
 
 si:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: si_energy_mean
-  CATDESC: Si Standard Intensity
-  FIELDNAM: Si Standard Intensity
+  CATDESC: Si Intensity
+  FIELDNAM: Si Intensity
   LABL_PTR_1: si_energy_label
   LABLAXIS: Si Intensity
   DELTA_MINUS: si_total_uncert_plus
   DELTA_PLUS: si_total_uncert_minus
 
 s:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: s_energy_mean
-  CATDESC: S Standard Intensity
-  FIELDNAM: S Standard Intensity
+  CATDESC: S Intensity
+  FIELDNAM: S Intensity
   LABL_PTR_1: s_energy_label
   LABLAXIS: S Intensity
   DELTA_MINUS: s_total_uncert_plus
   DELTA_PLUS: s_total_uncert_minus
 
 ar:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: ar_energy_mean
-  CATDESC: Ar Standard Intensity
-  FIELDNAM: Ar Standard Intensity
+  CATDESC: Ar Intensity
+  FIELDNAM: Ar Intensity
   LABL_PTR_1: ar_energy_label
   LABLAXIS: Ar Intensity
   DELTA_MINUS: ar_total_uncert_plus
   DELTA_PLUS: ar_total_uncert_minus
 
 ca:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: ca_energy_mean
-  CATDESC: Ca Standard Intensity
-  FIELDNAM: Ca Standard Intensity
+  CATDESC: Ca Intensity
+  FIELDNAM: Ca Intensity
   LABL_PTR_1: ca_energy_label
   LABLAXIS: Ca Intensity
   DELTA_MINUS: ca_total_uncert_plus
   DELTA_PLUS: ca_total_uncert_minus
 
 fe:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: fe_energy_mean
-  CATDESC: Fe Standard Intensity
-  FIELDNAM: Fe Standard Intensity
+  CATDESC: Fe Intensity
+  FIELDNAM: Fe Intensity
   LABL_PTR_1: fe_energy_label
   LABLAXIS: Fe Intensity
   DELTA_MINUS: fe_total_uncert_plus
   DELTA_PLUS: fe_total_uncert_minus
 
 ni:
-  <<: *default_standard
+  <<: *default_particle
   DEPEND_1: ni_energy_mean
-  CATDESC: Ni Standard Intensity
-  FIELDNAM: Ni Standard Intensity
+  CATDESC: Ni Intensity
+  FIELDNAM: Ni Intensity
   LABL_PTR_1: ni_energy_label
   LABLAXIS: Ni Intensity
   DELTA_MINUS: ni_total_uncert_plus
   DELTA_PLUS: ni_total_uncert_minus
 
-# <=== Energy Delta Variable Attributes ===>
-
+# Energy Delta Variables
 h_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: h_energy_mean
   CATDESC: H energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: H energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 h_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: h_energy_mean
   CATDESC: H energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: H energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he3_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: he3_energy_mean
   CATDESC: He3 energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He3 energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he3_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: he3_energy_mean
   CATDESC: He3 energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He3 energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he4_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: he4_energy_mean
   CATDESC: He4 energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He4 energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he4_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: he4_energy_mean
   CATDESC: He4 energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He4 energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: he_energy_mean
   CATDESC: He energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: he_energy_mean
   CATDESC: He energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 c_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: c_energy_mean
   CATDESC: C energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: C energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 c_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: c_energy_mean
   CATDESC: C energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: C energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 n_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: n_energy_mean
   CATDESC: N energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: N energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 n_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: n_energy_mean
   CATDESC: N energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: N energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ne_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: ne_energy_mean
   CATDESC: Ne energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ne energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ne_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: ne_energy_mean
   CATDESC: Ne energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ne energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 na_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: na_energy_mean
   CATDESC: Na energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Na energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 na_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: na_energy_mean
   CATDESC: Na energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Na energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 mg_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: mg_energy_mean
   CATDESC: Mg energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Mg energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 mg_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: mg_energy_mean
   CATDESC: Mg energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Mg energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 si_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: si_energy_mean
   CATDESC: Si energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Si energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 si_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: si_energy_mean
   CATDESC: Si energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Si energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 s_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: s_energy_mean
   CATDESC: S energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: S energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 s_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: s_energy_mean
   CATDESC: S energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: S energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ar_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: ar_energy_mean
   CATDESC: Ar energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ar energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ar_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: ar_energy_mean
   CATDESC: Ar energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ar energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ca_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: ca_energy_mean
   CATDESC: Ca energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ca energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ca_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: ca_energy_mean
   CATDESC: Ca energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ca energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 fe_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: fe_energy_mean
   CATDESC: Fe energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Fe energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 fe_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: fe_energy_mean
   CATDESC: Fe energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Fe energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ni_energy_delta_plus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: ni_energy_mean
   CATDESC: Ni energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ni energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ni_energy_delta_minus:
-  <<: *default_energy_deltas
+  <<: *default_energy_delta
   DEPEND_0: ni_energy_mean
   CATDESC: Ni energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ni energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
-# <=== Uncertainty Variable Attributes ===>
-
+# Uncertainty Variables (statistical, systematic, and total)
 h_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
-  CATDESC: Plus statistical uncertainty for H Standard
+  CATDESC: Plus statistical uncertainty for H
   FIELDNAM: H Plus Statistical uncertainty
   LABLAXIS: H Flux
 
 h_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
-  CATDESC: Minus statistical uncertainty for H Standard
+  CATDESC: Minus statistical uncertainty for H
   FIELDNAM: H Minus Statistical uncertainty
   LABLAXIS: H Flux
 
 h_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
-  CATDESC: Plus systematic uncertainty for H Standard
+  CATDESC: Plus systematic uncertainty for H
   FIELDNAM: H Plus Systematic uncertainty
   LABLAXIS: H Flux
 
 h_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
-  CATDESC: Minus systematic uncertainty for H Standard
+  CATDESC: Minus systematic uncertainty for H
   FIELDNAM: H Minus Systematic uncertainty
   LABLAXIS: H Flux
 
 h_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H Standard
-  FIELDNAM: H Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H
+  FIELDNAM: H Plus Total Uncertainty
   LABLAXIS: H Flux
 
 h_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H Standard
-  FIELDNAM: H Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H
+  FIELDNAM: H Minus Total Uncertainty
   LABLAXIS: H Flux
 
 he3_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
-  CATDESC: Plus statistical uncertainty for He3 Standard
+  CATDESC: Plus statistical uncertainty for He3
   FIELDNAM: He3 Plus Statistical uncertainty
   LABLAXIS: He3 Flux
 
 he3_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
-  CATDESC: Minus statistical uncertainty for He3 Standard
+  CATDESC: Minus statistical uncertainty for He3
   FIELDNAM: He3 Minus Statistical uncertainty
   LABLAXIS: He3 Flux
 
 he3_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
-  CATDESC: Plus systematic uncertainty for He3 Standard
+  CATDESC: Plus systematic uncertainty for He3
   FIELDNAM: He3 Plus Systematic uncertainty
   LABLAXIS: He3 Flux
 
 he3_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
-  CATDESC: Minus systematic uncertainty for He3 Standard
+  CATDESC: Minus systematic uncertainty for He3
   FIELDNAM: He3 Minus Systematic uncertainty
   LABLAXIS: He3 Flux
 
 he3_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He3 Standard
-  FIELDNAM: He3 Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He3
+  FIELDNAM: He3 Plus Total Uncertainty
   LABLAXIS: He3 Flux
 
 he3_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He3 Standard
-  FIELDNAM: He3 Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He3
+  FIELDNAM: He3 Minus Total Uncertainty
   LABLAXIS: He3 Flux
 
 he4_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
-  CATDESC: Plus statistical uncertainty for He4 Standard
+  CATDESC: Plus statistical uncertainty for He4
   FIELDNAM: He4 Plus Statistical uncertainty
   LABLAXIS: He4 Flux
 
 he4_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
-  CATDESC: Minus statistical uncertainty for He4 Standard
+  CATDESC: Minus statistical uncertainty for He4
   FIELDNAM: He4 Minus Statistical uncertainty
   LABLAXIS: He4 Flux
 
 he4_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
-  CATDESC: Plus systematic uncertainty for He4 Standard
+  CATDESC: Plus systematic uncertainty for He4
   FIELDNAM: He4 Plus Systematic uncertainty
   LABLAXIS: He4 Flux
 
 he4_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
-  CATDESC: Minus systematic uncertainty for He4 Standard
+  CATDESC: Minus systematic uncertainty for He4
   FIELDNAM: He4 Minus Systematic uncertainty
   LABLAXIS: He4 Flux
 
 he4_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He4 Standard
-  FIELDNAM: He4 Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He4
+  FIELDNAM: He4 Plus Total Uncertainty
   LABLAXIS: He4 Flux
 
 he4_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He4 Standard
-  FIELDNAM: He4 Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He4
+  FIELDNAM: He4 Minus Total Uncertainty
   LABLAXIS: He4 Flux
 
 he_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
-  CATDESC: Plus statistical uncertainty for He Standard
+  CATDESC: Plus statistical uncertainty for He
   FIELDNAM: He Plus Statistical uncertainty
   LABLAXIS: He Flux
 
 he_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
-  CATDESC: Minus statistical uncertainty for He Standard
+  CATDESC: Minus statistical uncertainty for He
   FIELDNAM: He Minus Statistical uncertainty
   LABLAXIS: He Flux
 
 he_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
-  CATDESC: Plus systematic uncertainty for He Standard
+  CATDESC: Plus systematic uncertainty for He
   FIELDNAM: He Plus Systematic uncertainty
   LABLAXIS: He Flux
 
 he_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
-  CATDESC: Minus systematic uncertainty for He Standard
+  CATDESC: Minus systematic uncertainty for He
   FIELDNAM: He Minus Systematic uncertainty
   LABLAXIS: He Flux
 
 he_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He Standard
-  FIELDNAM: He Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He
+  FIELDNAM: He Plus Total Uncertainty
   LABLAXIS: He Flux
 
 he_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He Standard
-  FIELDNAM: He Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He
+  FIELDNAM: He Minus Total Uncertainty
   LABLAXIS: He Flux
 
 c_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
-  CATDESC: Plus statistical uncertainty for C Standard
+  CATDESC: Plus statistical uncertainty for C
   FIELDNAM: C Plus Statistical uncertainty
   LABLAXIS: C Flux
 
 c_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
-  CATDESC: Minus statistical uncertainty for C Standard
+  CATDESC: Minus statistical uncertainty for C
   FIELDNAM: C Minus Statistical uncertainty
   LABLAXIS: C Flux
 
 c_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
-  CATDESC: Plus systematic uncertainty for C Standard
+  CATDESC: Plus systematic uncertainty for C
   FIELDNAM: C Plus Systematic uncertainty
   LABLAXIS: C Flux
 
 c_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
-  CATDESC: Minus systematic uncertainty for C Standard
+  CATDESC: Minus systematic uncertainty for C
   FIELDNAM: C Minus Systematic uncertainty
   LABLAXIS: C Flux
 
 c_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for C Standard
-  FIELDNAM: C Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for C
+  FIELDNAM: C Plus Total Uncertainty
   LABLAXIS: C Flux
 
 c_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for C Standard
-  FIELDNAM: C Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for C
+  FIELDNAM: C Minus Total Uncertainty
   LABLAXIS: C Flux
 
 o_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
-  CATDESC: Plus statistical uncertainty for O Standard
+  CATDESC: Plus statistical uncertainty for O
   FIELDNAM: O Plus Statistical uncertainty
   LABLAXIS: O Flux
 
 o_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
-  CATDESC: Minus statistical uncertainty for O Standard
+  CATDESC: Minus statistical uncertainty for O
   FIELDNAM: O Minus Statistical uncertainty
   LABLAXIS: O Flux
 
 o_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
-  CATDESC: Plus systematic uncertainty for O Standard
+  CATDESC: Plus systematic uncertainty for O
   FIELDNAM: O Plus Systematic uncertainty
   LABLAXIS: O Flux
 
 o_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
-  CATDESC: Minus systematic uncertainty for O Standard
+  CATDESC: Minus systematic uncertainty for O
   FIELDNAM: O Minus Systematic uncertainty
   LABLAXIS: O Flux
 
 o_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for O Standard
-  FIELDNAM: O Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for O
+  FIELDNAM: O Plus Total Uncertainty
   LABLAXIS: O Flux
 
 o_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for O Standard
-  FIELDNAM: O Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for O
+  FIELDNAM: O Minus Total Uncertainty
   LABLAXIS: O Flux
 
 n_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
-  CATDESC: Plus statistical uncertainty for N Standard
+  CATDESC: Plus statistical uncertainty for N
   FIELDNAM: N Plus Statistical uncertainty
   LABLAXIS: N Flux
 
 n_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
-  CATDESC: Minus statistical uncertainty for N Standard
+  CATDESC: Minus statistical uncertainty for N
   FIELDNAM: N Minus Statistical uncertainty
   LABLAXIS: N Flux
 
 n_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
-  CATDESC: Plus systematic uncertainty for N Standard
+  CATDESC: Plus systematic uncertainty for N
   FIELDNAM: N Plus Systematic uncertainty
   LABLAXIS: N Flux
 
 n_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
-  CATDESC: Minus systematic uncertainty for N Standard
+  CATDESC: Minus systematic uncertainty for N
   FIELDNAM: N Minus Systematic uncertainty
   LABLAXIS: N Flux
 
 n_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for N Standard
-  FIELDNAM: N Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for N
+  FIELDNAM: N Plus Total Uncertainty
   LABLAXIS: N Flux
 
 n_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for N Standard
-  FIELDNAM: N Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for N
+  FIELDNAM: N Minus Total Uncertainty
   LABLAXIS: N Flux
 
 ne_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
-  CATDESC: Plus statistical uncertainty for Ne Standard
+  CATDESC: Plus statistical uncertainty for Ne
   FIELDNAM: Ne Plus Statistical uncertainty
   LABLAXIS: Ne Flux
 
 ne_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
-  CATDESC: Minus statistical uncertainty for Ne Standard
+  CATDESC: Minus statistical uncertainty for Ne
   FIELDNAM: Ne Minus Statistical uncertainty
   LABLAXIS: Ne Flux
 
 ne_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
-  CATDESC: Plus systematic uncertainty for Ne Standard
+  CATDESC: Plus systematic uncertainty for Ne
   FIELDNAM: Ne Plus Systematic uncertainty
   LABLAXIS: Ne Flux
 
 ne_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
-  CATDESC: Minus systematic uncertainty for Ne Standard
+  CATDESC: Minus systematic uncertainty for Ne
   FIELDNAM: Ne Minus Systematic uncertainty
   LABLAXIS: Ne Flux
 
 ne_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ne Standard
-  FIELDNAM: Ne Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ne
+  FIELDNAM: Ne Plus Total Uncertainty
   LABLAXIS: Ne Flux
 
 ne_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ne Standard
-  FIELDNAM: Ne Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ne
+  FIELDNAM: Ne Minus Total Uncertainty
   LABLAXIS: Ne Flux
 
 na_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
-  CATDESC: Plus statistical uncertainty for Na Standard
+  CATDESC: Plus statistical uncertainty for Na
   FIELDNAM: Na Plus Statistical uncertainty
   LABLAXIS: Na Flux
 
 na_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
-  CATDESC: Minus statistical uncertainty for Na Standard
+  CATDESC: Minus statistical uncertainty for Na
   FIELDNAM: Na Minus Statistical uncertainty
   LABLAXIS: Na Flux
 
 na_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
-  CATDESC: Plus systematic uncertainty for Na Standard
+  CATDESC: Plus systematic uncertainty for Na
   FIELDNAM: Na Plus Systematic uncertainty
   LABLAXIS: Na Flux
 
 na_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
-  CATDESC: Minus systematic uncertainty for Na Standard
+  CATDESC: Minus systematic uncertainty for Na
   FIELDNAM: Na Minus Systematic uncertainty
   LABLAXIS: Na Flux
 
 na_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Na Standard
-  FIELDNAM: Na Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Na
+  FIELDNAM: Na Plus Total Uncertainty
   LABLAXIS: Na Flux
 
 na_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Na Standard
-  FIELDNAM: Na Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Na
+  FIELDNAM: Na Minus Total Uncertainty
   LABLAXIS: Na Flux
 
 mg_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
-  CATDESC: Plus statistical uncertainty for Mg Standard
+  CATDESC: Plus statistical uncertainty for Mg
   FIELDNAM: Mg Plus Statistical uncertainty
   LABLAXIS: Mg Flux
 
 mg_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
-  CATDESC: Minus statistical uncertainty for Mg Standard
+  CATDESC: Minus statistical uncertainty for Mg
   FIELDNAM: Mg Minus Statistical uncertainty
   LABLAXIS: Mg Flux
 
 mg_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
-  CATDESC: Plus systematic uncertainty for Mg Standard
+  CATDESC: Plus systematic uncertainty for Mg
   FIELDNAM: Mg Plus Systematic uncertainty
   LABLAXIS: Mg Flux
 
 mg_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
-  CATDESC: Minus systematic uncertainty for Mg Standard
+  CATDESC: Minus systematic uncertainty for Mg
   FIELDNAM: Mg Minus Systematic uncertainty
   LABLAXIS: Mg Flux
 
 mg_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Mg Standard
-  FIELDNAM: Mg Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Mg
+  FIELDNAM: Mg Plus Total Uncertainty
   LABLAXIS: Mg Flux
 
 mg_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Mg Standard
-  FIELDNAM: Mg Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Mg
+  FIELDNAM: Mg Minus Total Uncertainty
   LABLAXIS: Mg Flux
 
 al_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
-  CATDESC: Plus statistical uncertainty for Al Standard
+  CATDESC: Plus statistical uncertainty for Al
   FIELDNAM: Al Plus Statistical uncertainty
   LABLAXIS: Al Flux
 
 al_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
-  CATDESC: Minus statistical uncertainty for Al Standard
+  CATDESC: Minus statistical uncertainty for Al
   FIELDNAM: Al Minus Statistical uncertainty
   LABLAXIS: Al Flux
 
 al_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
-  CATDESC: Plus systematic uncertainty for Al Standard
+  CATDESC: Plus systematic uncertainty for Al
   FIELDNAM: Al Plus Systematic uncertainty
   LABLAXIS: Al Flux
 
 al_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
-  CATDESC: Minus systematic uncertainty for Al Standard
+  CATDESC: Minus systematic uncertainty for Al
   FIELDNAM: Al Minus Systematic uncertainty
   LABLAXIS: Al Flux
 
 al_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Al Standard
-  FIELDNAM: Al Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Al
+  FIELDNAM: Al Plus Total Uncertainty
   LABLAXIS: Al Flux
 
 al_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Al Standard
-  FIELDNAM: Al Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Al
+  FIELDNAM: Al Minus Total Uncertainty
   LABLAXIS: Al Flux
 
 si_stat_uncert_plus:
     <<: *default_uncertainty
     DEPEND_1: si_energy_mean
-    CATDESC: Plus statistical uncertainty for Si Standard
+    CATDESC: Plus statistical uncertainty for Si
     FIELDNAM: Si Plus Statistical uncertainty
     LABLAXIS: Si Flux
 
 si_stat_uncert_minus:
     <<: *default_uncertainty
     DEPEND_1: si_energy_mean
-    CATDESC: Minus statistical uncertainty for Si Standard
+    CATDESC: Minus statistical uncertainty for Si
     FIELDNAM: Si Minus Statistical uncertainty
     LABLAXIS: Si Flux
 
 si_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
-  CATDESC: Plus systematic uncertainty for Si Standard
+  CATDESC: Plus systematic uncertainty for Si
   FIELDNAM: Si Plus Systematic uncertainty
   LABLAXIS: Si Flux
 
 si_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
-  CATDESC: Minus systematic uncertainty for Si Standard
+  CATDESC: Minus systematic uncertainty for Si
   FIELDNAM: Si Minus Systematic uncertainty
   LABLAXIS: Si Flux
 
 si_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Si Standard
-  FIELDNAM: Si Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Si
+  FIELDNAM: Si Plus Total Uncertainty
   LABLAXIS: Si Flux
 
 si_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Si Standard
-  FIELDNAM: Si Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Si
+  FIELDNAM: Si Minus Total Uncertainty
   LABLAXIS: Si Flux
 
 s_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
-  CATDESC: Plus statistical uncertainty for S Standard
+  CATDESC: Plus statistical uncertainty for S
   FIELDNAM: S Plus Statistical uncertainty
   LABLAXIS: S Flux
 
 s_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
-  CATDESC: Minus statistical uncertainty for S Standard
+  CATDESC: Minus statistical uncertainty for S
   FIELDNAM: S Minus Statistical uncertainty
   LABLAXIS: S Flux
 
 s_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
-  CATDESC: Plus systematic uncertainty for S Standard
+  CATDESC: Plus systematic uncertainty for S
   FIELDNAM: S Plus Systematic uncertainty
   LABLAXIS: S Flux
 
 s_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
-  CATDESC: Minus systematic uncertainty for S Standard
+  CATDESC: Minus systematic uncertainty for S
   FIELDNAM: S Minus Systematic uncertainty
   LABLAXIS: S Flux
 
 s_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for S Standard
-  FIELDNAM: S Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for S
+  FIELDNAM: S Plus Total Uncertainty
   LABLAXIS: S Flux
 
 s_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for S Standard
-  FIELDNAM: S Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for S
+  FIELDNAM: S Minus Total Uncertainty
   LABLAXIS: S Flux
 
 ar_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
-  CATDESC: Plus statistical uncertainty for Ar Standard
+  CATDESC: Plus statistical uncertainty for Ar
   FIELDNAM: Ar Plus Statistical uncertainty
   LABLAXIS: Ar Flux
 
 ar_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
-  CATDESC: Minus statistical uncertainty for Ar Standard
+  CATDESC: Minus statistical uncertainty for Ar
   FIELDNAM: Ar Minus Statistical uncertainty
   LABLAXIS: Ar Flux
 
 ar_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
-  CATDESC: Plus systematic uncertainty for Ar Standard
+  CATDESC: Plus systematic uncertainty for Ar
   FIELDNAM: Ar Plus Systematic uncertainty
   LABLAXIS: Ar Flux
 
 ar_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
-  CATDESC: Minus systematic uncertainty for Ar Standard
+  CATDESC: Minus systematic uncertainty for Ar
   FIELDNAM: Ar Minus Systematic uncertainty
   LABLAXIS: Ar Flux
 
 ar_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ar Standard
-  FIELDNAM: Ar Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ar
+  FIELDNAM: Ar Plus Total Uncertainty
   LABLAXIS: Ar Flux
 
 ar_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ar Standard
-  FIELDNAM: Ar Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ar
+  FIELDNAM: Ar Minus Total Uncertainty
   LABLAXIS: Ar Flux
 
 ca_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
-  CATDESC: Plus statistical uncertainty for Ca Standard
+  CATDESC: Plus statistical uncertainty for Ca
   FIELDNAM: Ca Plus Statistical uncertainty
   LABLAXIS: Ca Flux
 
 ca_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
-  CATDESC: Minus statistical uncertainty for Ca Standard
+  CATDESC: Minus statistical uncertainty for Ca
   FIELDNAM: Ca Minus Statistical uncertainty
   LABLAXIS: Ca Flux
 
 ca_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
-  CATDESC: Plus systematic uncertainty for Ca Standard
+  CATDESC: Plus systematic uncertainty for Ca
   FIELDNAM: Ca Plus Systematic uncertainty
   LABLAXIS: Ca Flux
 
 ca_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
-  CATDESC: Minus systematic uncertainty for Ca Standard
+  CATDESC: Minus systematic uncertainty for Ca
   FIELDNAM: Ca Minus Systematic uncertainty
   LABLAXIS: Ca Flux
 
 ca_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ca Standard
-  FIELDNAM: Ca Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ca
+  FIELDNAM: Ca Plus Total Uncertainty
   LABLAXIS: Ca Flux
 
 ca_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ca Standard
-  FIELDNAM: Ca Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ca
+  FIELDNAM: Ca Minus Total Uncertainty
   LABLAXIS: Ca Flux
 
 fe_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
-  CATDESC: Plus statistical uncertainty for Fe Standard
+  CATDESC: Plus statistical uncertainty for Fe
   FIELDNAM: Fe Plus Statistical uncertainty
   LABLAXIS: Fe Flux
 
 fe_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
-  CATDESC: Minus statistical uncertainty for Fe Standard
+  CATDESC: Minus statistical uncertainty for Fe
   FIELDNAM: Fe Minus Statistical uncertainty
   LABLAXIS: Fe Flux
 
 fe_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
-  CATDESC: Plus systematic uncertainty for Fe Standard
+  CATDESC: Plus systematic uncertainty for Fe
   FIELDNAM: Fe Plus Systematic uncertainty
   LABLAXIS: Fe Flux
 
 fe_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
-  CATDESC: Minus systematic uncertainty for Fe Standard
+  CATDESC: Minus systematic uncertainty for Fe
   FIELDNAM: Fe Minus Systematic uncertainty
   LABLAXIS: Fe Flux
 
 fe_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Fe Standard
-  FIELDNAM: Fe Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Fe
+  FIELDNAM: Fe Plus Total Uncertainty
   LABLAXIS: Fe Flux
 
 fe_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Fe Standard
-  FIELDNAM: Fe Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Fe
+  FIELDNAM: Fe Minus Total Uncertainty
   LABLAXIS: Fe Flux
 
 ni_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
-  CATDESC: Plus statistical uncertainty for Ni Standard
+  CATDESC: Plus statistical uncertainty for Ni
   FIELDNAM: Ni Plus Statistical uncertainty
   LABLAXIS: Ni Flux
 
 ni_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
-  CATDESC: Minus statistical uncertainty for Ni Standard
+  CATDESC: Minus statistical uncertainty for Ni
   FIELDNAM: Ni Minus Statistical uncertainty
   LABLAXIS: Ni Flux
 
 ni_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
-  CATDESC: Plus systematic uncertainty for Ni Standard
+  CATDESC: Plus systematic uncertainty for Ni
   FIELDNAM: Ni Plus Systematic uncertainty
   LABLAXIS: Ni Flux
 
 ni_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
-  CATDESC: Minus systematic uncertainty for Ni Standard
+  CATDESC: Minus systematic uncertainty for Ni
   FIELDNAM: Ni Minus Systematic uncertainty
   LABLAXIS: Ni Flux
 
 ni_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ni Standard
-  FIELDNAM: Ni Total Uncertainty
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ni
+  FIELDNAM: Ni Plus Total Uncertainty
   LABLAXIS: Ni Flux
 
 ni_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ni Standard
-  FIELDNAM: Ni Total Uncertainty
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ni
+  FIELDNAM: Ni Minus Total Uncertainty
   LABLAXIS: Ni Flux
+
+
+# <=== Data Variables - Macropixel Dataset ===>
+
+dynamic_threshold_state_macropixel:
+  <<: *default_dns
+
+# Particle Intensity Variables
+h_macropixel:
+  <<: *default_particle
+  CATDESC: H Macropixel Intensity
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: h_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  FIELDNAM: H Intensity Macropixel
+  LABLAXIS: H Intensity
+  DELTA_MINUS: h_total_uncert_plus
+  DELTA_PLUS: h_total_uncert_minus
+
+he4_macropixel:
+  <<: *default_particle
+  CATDESC: He4 Macropixel Intensity
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: he4_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  FIELDNAM: He4 Intensity Macropixel
+  LABLAXIS: He4 Intensity
+  DELTA_MINUS: he4_total_uncert_plus
+  DELTA_PLUS: he4_total_uncert_minus
+
+cno_macropixel:
+  <<: *default_particle
+  CATDESC: C, N, O Macropixel Intensity
+  DEPEND_1: c_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: c_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  FIELDNAM: CNO Intensity Macropixel
+  LABLAXIS: CNO Intensity
+  DELTA_MINUS: c_total_uncert_plus
+  DELTA_PLUS: c_total_uncert_minus
+
+nemgsi_macropixel:
+  <<: *default_particle
+  CATDESC: NeMgSi Macropixel Intensity
+  DEPEND_1: ne_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: ne_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  FIELDNAM: NeMgSi Intensity Macropixel
+  LABLAXIS: NeMgSi Intensity
+  DELTA_MINUS: ne_total_uncert_plus
+  DELTA_PLUS: ne_total_uncert_minus
+
+fe_macropixel:
+  <<: *default_particle
+  CATDESC: Fe Macropixel Intensity
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: fe_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  FIELDNAM: Fe Intensity Macropixel
+  LABLAXIS: Fe Intensity
+  DELTA_MINUS: fe_total_uncert_plus
+  DELTA_PLUS: fe_total_uncert_minus
+
+# Energy Delta Variables
+cno_energy_delta_plus_macropixel:
+  <<: *default_energy_delta
+  DEPEND_0: cno_energy_mean
+  CATDESC: C, N, O energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: CNO energy delta plus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+cno_energy_delta_minus_macropixel:
+  <<: *default_energy_delta
+  DEPEND_0: cno_energy_mean
+  CATDESC: C, N, O energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: CNO energy delta minus
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+nemgsi_energy_delta_plus_macropixel:
+    <<: *default_energy_delta
+    DEPEND_0: nemgsi_energy_mean
+    CATDESC: Ne, Mg, Si energy delta plus (maximum bin energy minus geometric mean)
+    FIELDNAM: NeMgSi energy delta plus
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
+
+nemgsi_energy_delta_minus_macropixel:
+    <<: *default_energy_delta
+    DEPEND_0: nemgsi_energy_mean
+    CATDESC: Ne, Mg, Si energy delta minus (geometric mean minus minimum bin energy)
+    FIELDNAM: NeMgSi energy delta minus
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
+
+# Uncertainty Variables (statistical, systematic, and total)
+h_stat_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: h_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus statistical uncertainty for H Macropixel
+  FIELDNAM: H plus statistical uncertainty
+  LABLAXIS: H Flux
+
+h_stat_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: h_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus statistical uncertainty for H Macropixel
+  FIELDNAM: H Minus Statistical Uncertainty
+  LABLAXIS: H Flux
+
+h_sys_err_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: h_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus systematic uncertainty for H
+  FIELDNAM: H Plus Systematic Uncertainty
+  LABLAXIS: H Flux
+
+h_sys_err_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: h_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus systematic uncertainty for H
+  FIELDNAM: H Minus Systematic Uncertainty
+  LABLAXIS: H Flux
+
+h_total_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: h_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H
+  FIELDNAM: H Plus Total Uncertainty
+  LABLAXIS: H Flux
+
+h_total_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: h_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H
+  FIELDNAM: H Minus Total Uncertainty
+  LABLAXIS: H Flux
+
+he4_stat_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: he4_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus statistical uncertainty for He4 Macropixel
+  FIELDNAM: He4 Plus Statistical Uncertainty
+  LABLAXIS: He4 Flux
+
+he4_stat_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: he4_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus statistical uncertainty for He4 Macropixel
+  FIELDNAM: He4 Minus Statistical Uncertainty
+  LABLAXIS: He4 Flux
+
+he4_sys_err_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: he4_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus systematic uncertainty for He4 Macropixel
+  FIELDNAM: He4 Plus Systematic Uncertainty
+  LABLAXIS: He4 Flux
+
+he4_sys_err_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: he4_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus systematic uncertainty for He4 Macropixel
+  FIELDNAM: He4 Minus Systematic Uncertainty
+  LABLAXIS: He4 Flux
+
+he4_total_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: he4_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He4 Macropixel
+  FIELDNAM: He4 Plus Total Uncertainty
+  LABLAXIS: He4 Flux
+
+he4_total_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: he4_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He4 Macropixel
+  FIELDNAM: He4 Minus Total Uncertainty
+  LABLAXIS: He4 Flux
+
+cno_stat_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: cno_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: cno_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus statistical uncertainty for C, N, O Macropixel
+  FIELDNAM: CNO Plus Statistical Uncertainty
+  LABLAXIS: CNO Flux
+
+cno_stat_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: cno_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: cno_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus statistical uncertainty for C, N, O Macropixel
+  FIELDNAM: CNO Minus Statistical Uncertainty
+  LABLAXIS: CNO Flux
+
+cno_sys_err_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: cno_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: cno_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus systematic uncertainty for C, N, O Macropixel
+  FIELDNAM: CNO Plus Systematic Uncertainty
+  LABLAXIS: CNO Flux
+
+cno_sys_err_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: cno_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: cno_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus systematic uncertainty for C, N, O Macropixel
+  FIELDNAM: CNO Minus Systematic Uncertainty
+  LABLAXIS: CNO Flux
+
+cno_total_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: cno_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: cno_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for C, N, O Macropixel
+  FIELDNAM: CNO Plus Total Uncertainty
+  LABLAXIS: CNO Flux
+
+cno_total_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: cno_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: cno_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for C, N, O Macropixel
+  FIELDNAM: CNO Minus Total Uncertainty
+  LABLAXIS: CNO Flux
+
+nemgsi_stat_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: nemgsi_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus statistical uncertainty for Ne, Mg, Si Macropixel
+  FIELDNAM: NeMgSi Plus Statistical Uncertainty
+  LABLAXIS: NeMgSi Flux
+
+nemgsi_stat_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: nemgsi_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus statistical uncertainty for Ne, Mg, Si Macropixel
+  FIELDNAM: NeMgSi Minus Statistical Uncertainty
+  LABLAXIS: NeMgSi Flux
+
+nemgsi_sys_err_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: nemgsi_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus systematic uncertainty for Ne, Mg, Si Macropixel
+  FIELDNAM: NeMgSi Plus Systematic Uncertainty
+  LABLAXIS: NeMgSi Flux
+
+nemgsi_sys_err_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: nemgsi_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus systematic uncertainty for Ne, Mg, Si Macropixel
+  FIELDNAM: NeMgSi Minus Systematic Uncertainty
+  LABLAXIS: NeMgSi Flux
+
+nemgsi_total_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: nemgsi_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ne, Mg, Si Macropixel
+  FIELDNAM: NeMgSi Plus Total Uncertainty
+  LABLAXIS: NeMgSi Flux
+
+nemgsi_total_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: nemgsi_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ne, Mg, Si Macropixel
+  FIELDNAM: NeMgSi Minus Total Uncertainty
+  LABLAXIS: NeMgSi Flux
+
+fe_stat_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: fe_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus statistical uncertainty for Fe Macropixel
+  FIELDNAM: Fe Plus Statistical Uncertainty
+  LABLAXIS: Fe Flux
+
+fe_stat_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: fe_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus statistical uncertainty for Fe Macropixel
+  FIELDNAM: Fe Minus Statistical Uncertainty
+  LABLAXIS: Fe Flux
+
+fe_sys_err_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: fe_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus systematic uncertainty for Fe Macropixel
+  FIELDNAM: Fe Plus Systematic Uncertainty
+  LABLAXIS: Fe Flux
+
+fe_sys_err_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: fe_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus systematic uncertainty for Fe Macropixel
+  FIELDNAM: Fe Minus Systematic Uncertainty
+  LABLAXIS: Fe Flux
+
+fe_total_uncert_plus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: fe_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Fe Macropixel
+  FIELDNAM: Fe Plus Total Uncertainty
+  LABLAXIS: Fe Flux
+
+fe_total_uncert_minus_macropixel:
+  <<: *default_uncertainty
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: declination
+  LABL_PTR_1: fe_energy_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: declination_label
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Fe Macropixel
+  FIELDNAM: Fe Minus Total Uncertainty
+  LABLAXIS: Fe Flux
+
+
 
 

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -188,7 +188,131 @@ cno_energy_mean:
 
 
 # <=== Labels ===>
-#TODO: add labels
+declination_label:
+  CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
+  FIELDNAM: Declination Angle
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+azimuth_label:
+  CATDESC: Spin angle in 15 bins (0 deg. is zero of spin phase)
+  FIELDNAM: Azimuth Angle
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+h_energy_mean_label:
+  CATDESC: Geometric mean energy for H
+  FIELDNAM: H Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+he3_energy_mean_label:
+  CATDESC: Geometric mean energy for He3
+  FIELDNAM: He3 Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+he4_energy_mean_label:
+  CATDESC: Geometric mean energy for He4
+  FIELDNAM: He4 Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+he_energy_mean_label:
+  CATDESC: Geometric mean energy for He
+  FIELDNAM: He Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+c_energy_mean_label:
+  CATDESC: Geometric mean energy for C
+  FIELDNAM: C Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+n_energy_mean_label:
+  CATDESC: Geometric mean energy for N
+  FIELDNAM: N Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+o_energy_mean_label:
+  CATDESC: Geometric mean energy for O
+  FIELDNAM: O Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+ne_energy_mean_label:
+  CATDESC: Geometric mean energy for Ne
+  FIELDNAM: Ne Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+na_energy_mean_label:
+  CATDESC: Geometric mean energy for Na
+  FIELDNAM: Na Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+mg_energy_mean_label:
+  CATDESC: Geometric mean energy for Mg
+  FIELDNAM: Mg Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+si_energy_mean_label:
+  CATDESC: Geometric mean energy for Si
+  FIELDNAM: Si Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+s_energy_mean_label:
+  CATDESC: Geometric mean energy for S
+  FIELDNAM: S Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+al_energy_mean_label:
+  CATDESC: Geometric mean energy for Al
+  FIELDNAM: Al Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+ar_energy_mean_label:
+  CATDESC: Geometric mean energy for Ar
+  FIELDNAM: Ar Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+ca_energy_mean_label:
+  CATDESC: Geometric mean energy for Ca
+  FIELDNAM: Ca Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+fe_energy_mean_label:
+  CATDESC: Geometric mean energy for Fe
+  FIELDNAM: Fe Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+ni_energy_mean_label:
+  CATDESC: Geometric mean energy for Ni
+  FIELDNAM: Ni Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+nemgsi_energy_mean_label:
+  CATDESC: Geometric mean energy for NeMgSi
+  FIELDNAM: NeMgSi Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+cno_energy_mean_label:
+  CATDESC: Geometric mean energy for CNO
+  FIELDNAM: CNO Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
 
 # <=== Data Variables - Standard & Summed Datasets ===>
 
@@ -200,9 +324,8 @@ h:
   <<: *default_particle
   DEPEND_1: h_energy_mean
   CATDESC: H Intensity
-  LABL_PTR_1: h_energy_label
+  LABL_PTR_1: h_energy_mean_label
   FIELDNAM: H Intensity
-  LABLAXIS: H Intensity
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
 
@@ -211,8 +334,7 @@ he3:
   DEPEND_1: he3_energy_mean
   CATDESC: He3 Intensity
   FIELDNAM: He3 Intensity
-  LABL_PTR_1: he3_energy_label
-  LABLAXIS: He3 Intensity
+  LABL_PTR_1: he3_energy_mean_label
   DELTA_MINUS: he3_total_uncert_plus
   DELTA_PLUS: he3_total_uncert_minus
 
@@ -221,8 +343,7 @@ he4:
   DEPEND_1: he4_energy_mean
   CATDESC: He4 Intensity
   FIELDNAM: He4 Intensity
-  LABL_PTR_1: he4_energy_label
-  LABLAXIS: He4 Intensity
+  LABL_PTR_1: he4_energy_mean_label
   DELTA_MINUS: he4_total_uncert_plus
   DELTA_PLUS: he4_total_uncert_minus
 
@@ -231,8 +352,7 @@ he:
   DEPEND_1: he_energy_mean
   CATDESC: He Intensity
   FIELDNAM: He Intensity
-  LABL_PTR_1: he_energy_label
-  LABLAXIS: He Intensity
+  LABL_PTR_1: he_energy_mean_label
   DELTA_MINUS: he_total_uncert_plus
   DELTA_PLUS: he_total_uncert_minus
 
@@ -241,8 +361,7 @@ c:
   DEPEND_1: c_energy_mean
   CATDESC: C Intensity
   FIELDNAM: C Intensity
-  LABL_PTR_1: c_energy_label
-  LABLAXIS: C Intensity
+  LABL_PTR_1: c_energy_mean_label
   DELTA_MINUS: c_total_uncert_plus
   DELTA_PLUS: c_total_uncert_minus
 
@@ -251,8 +370,7 @@ o:
   DEPEND_1: o_energy_mean
   CATDESC: O Intensity
   FIELDNAM: O Intensity
-  LABL_PTR_1: o_energy_label
-  LABLAXIS: O Intensity
+  LABL_PTR_1: o_energy_mean_label
   DELTA_MINUS: o_total_uncert_plus
   DELTA_PLUS: o_total_uncert_minus
 
@@ -261,8 +379,7 @@ n:
   DEPEND_1: n_energy_mean
   CATDESC: N Intensity
   FIELDNAM: N Intensity
-  LABL_PTR_1: n_energy_label
-  LABLAXIS: N Intensity
+  LABL_PTR_1: n_energy_mean_label
   DELTA_MINUS: n_total_uncert_plus
   DELTA_PLUS: n_total_uncert_minus
 
@@ -271,8 +388,7 @@ ne:
   DEPEND_1: ne_energy_mean
   CATDESC: Ne Intensity
   FIELDNAM: Ne Intensity
-  LABL_PTR_1: ne_energy_label
-  LABLAXIS: Ne Intensity
+  LABL_PTR_1: ne_energy_mean_label
   DELTA_MINUS: ne_total_uncert_plus
   DELTA_PLUS: ne_total_uncert_minus
 
@@ -281,8 +397,7 @@ na:
   DEPEND_1: na_energy_mean
   CATDESC: Na Intensity
   FIELDNAM: Na Intensity
-  LABL_PTR_1: na_energy_label
-  LABLAXIS: Na Intensity
+  LABL_PTR_1: na_energy_mean_label
   DELTA_MINUS: na_total_uncert_plus
   DELTA_PLUS: na_total_uncert_minus
 
@@ -291,8 +406,7 @@ mg:
   DEPEND_1: mg_energy_mean
   CATDESC: Mg Intensity
   FIELDNAM: Mg Intensity
-  LABL_PTR_1: mg_energy_label
-  LABLAXIS: Mg Intensity
+  LABL_PTR_1: mg_energy_mean_label
   DELTA_MINUS: mg_total_uncert_plus
   DELTA_PLUS: mg_total_uncert_minus
 
@@ -301,8 +415,7 @@ al:
   DEPEND_1: al_energy_mean
   CATDESC: Al Intensity
   FIELDNAM: Al Intensity
-  LABL_PTR_1: al_energy_label
-  LABLAXIS: Al Intensity
+  LABL_PTR_1: al_energy_mean_label
   DELTA_MINUS: al_total_uncert_plus
   DELTA_PLUS: al_total_uncert_minus
 
@@ -311,8 +424,7 @@ si:
   DEPEND_1: si_energy_mean
   CATDESC: Si Intensity
   FIELDNAM: Si Intensity
-  LABL_PTR_1: si_energy_label
-  LABLAXIS: Si Intensity
+  LABL_PTR_1: si_energy_mean_label
   DELTA_MINUS: si_total_uncert_plus
   DELTA_PLUS: si_total_uncert_minus
 
@@ -321,8 +433,7 @@ s:
   DEPEND_1: s_energy_mean
   CATDESC: S Intensity
   FIELDNAM: S Intensity
-  LABL_PTR_1: s_energy_label
-  LABLAXIS: S Intensity
+  LABL_PTR_1: s_energy_mean_label
   DELTA_MINUS: s_total_uncert_plus
   DELTA_PLUS: s_total_uncert_minus
 
@@ -331,8 +442,7 @@ ar:
   DEPEND_1: ar_energy_mean
   CATDESC: Ar Intensity
   FIELDNAM: Ar Intensity
-  LABL_PTR_1: ar_energy_label
-  LABLAXIS: Ar Intensity
+  LABL_PTR_1: ar_energy_mean_label
   DELTA_MINUS: ar_total_uncert_plus
   DELTA_PLUS: ar_total_uncert_minus
 
@@ -341,8 +451,7 @@ ca:
   DEPEND_1: ca_energy_mean
   CATDESC: Ca Intensity
   FIELDNAM: Ca Intensity
-  LABL_PTR_1: ca_energy_label
-  LABLAXIS: Ca Intensity
+  LABL_PTR_1: ca_energy_mean_label
   DELTA_MINUS: ca_total_uncert_plus
   DELTA_PLUS: ca_total_uncert_minus
 
@@ -351,8 +460,7 @@ fe:
   DEPEND_1: fe_energy_mean
   CATDESC: Fe Intensity
   FIELDNAM: Fe Intensity
-  LABL_PTR_1: fe_energy_label
-  LABLAXIS: Fe Intensity
+  LABL_PTR_1: fe_energy_mean_label
   DELTA_MINUS: fe_total_uncert_plus
   DELTA_PLUS: fe_total_uncert_minus
 
@@ -361,8 +469,7 @@ ni:
   DEPEND_1: ni_energy_mean
   CATDESC: Ni Intensity
   FIELDNAM: Ni Intensity
-  LABL_PTR_1: ni_energy_label
-  LABLAXIS: Ni Intensity
+  LABL_PTR_1: ni_energy_mean_label
   DELTA_MINUS: ni_total_uncert_plus
   DELTA_PLUS: ni_total_uncert_minus
 
@@ -583,714 +690,714 @@ h_stat_uncert_plus:
   DEPEND_1: h_energy_mean
   CATDESC: Plus statistical uncertainty for H
   FIELDNAM: H Plus Statistical uncertainty
-  LABLAXIS: H Flux
+  LABL_PTR_1: h_energy_mean_label
 
 h_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   CATDESC: Minus statistical uncertainty for H
   FIELDNAM: H Minus Statistical uncertainty
-  LABLAXIS: H Flux
+  LABL_PTR_1: h_energy_mean_label
 
 h_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   CATDESC: Plus systematic uncertainty for H
   FIELDNAM: H Plus Systematic uncertainty
-  LABLAXIS: H Flux
+  LABL_PTR_1: h_energy_mean_label
 
 h_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   CATDESC: Minus systematic uncertainty for H
   FIELDNAM: H Minus Systematic uncertainty
-  LABLAXIS: H Flux
+  LABL_PTR_1: h_energy_mean_label
 
 h_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H
   FIELDNAM: H Plus Total Uncertainty
-  LABLAXIS: H Flux
+  LABL_PTR_1: h_energy_mean_label
 
 h_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H
   FIELDNAM: H Minus Total Uncertainty
-  LABLAXIS: H Flux
+  LABL_PTR_1: h_energy_mean_label
 
 he3_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Plus statistical uncertainty for He3
   FIELDNAM: He3 Plus Statistical uncertainty
-  LABLAXIS: He3 Flux
+  LABL_PTR_1: he3_energy_mean_label
 
 he3_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Minus statistical uncertainty for He3
   FIELDNAM: He3 Minus Statistical uncertainty
-  LABLAXIS: He3 Flux
+  LABL_PTR_1: he3_energy_mean_label
 
 he3_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Plus systematic uncertainty for He3
   FIELDNAM: He3 Plus Systematic uncertainty
-  LABLAXIS: He3 Flux
+  LABL_PTR_1: he3_energy_mean_label
 
 he3_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Minus systematic uncertainty for He3
   FIELDNAM: He3 Minus Systematic uncertainty
-  LABLAXIS: He3 Flux
+  LABL_PTR_1: he3_energy_mean_label
 
 he3_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He3
   FIELDNAM: He3 Plus Total Uncertainty
-  LABLAXIS: He3 Flux
+  LABL_PTR_1: he3_energy_mean_label
 
 he3_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He3
   FIELDNAM: He3 Minus Total Uncertainty
-  LABLAXIS: He3 Flux
+  LABL_PTR_1: he3_energy_mean_label
 
 he4_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   CATDESC: Plus statistical uncertainty for He4
   FIELDNAM: He4 Plus Statistical uncertainty
-  LABLAXIS: He4 Flux
+  LABL_PTR_1: he4_energy_mean_label
 
 he4_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   CATDESC: Minus statistical uncertainty for He4
   FIELDNAM: He4 Minus Statistical uncertainty
-  LABLAXIS: He4 Flux
+  LABL_PTR_1: he4_energy_mean_label
 
 he4_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   CATDESC: Plus systematic uncertainty for He4
   FIELDNAM: He4 Plus Systematic uncertainty
-  LABLAXIS: He4 Flux
+  LABL_PTR_1: he4_energy_mean_label
 
 he4_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   CATDESC: Minus systematic uncertainty for He4
   FIELDNAM: He4 Minus Systematic uncertainty
-  LABLAXIS: He4 Flux
+  LABL_PTR_1: he4_energy_mean_label
 
 he4_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He4
   FIELDNAM: He4 Plus Total Uncertainty
-  LABLAXIS: He4 Flux
+  LABL_PTR_1: he4_energy_mean_label
 
 he4_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He4
   FIELDNAM: He4 Minus Total Uncertainty
-  LABLAXIS: He4 Flux
+  LABL_PTR_1: he4_energy_mean_label
 
 he_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
   CATDESC: Plus statistical uncertainty for He
   FIELDNAM: He Plus Statistical uncertainty
-  LABLAXIS: He Flux
+  LABL_PTR_1: he_energy_mean_label
 
 he_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
   CATDESC: Minus statistical uncertainty for He
   FIELDNAM: He Minus Statistical uncertainty
-  LABLAXIS: He Flux
+  LABL_PTR_1: he_energy_mean_label
 
 he_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
   CATDESC: Plus systematic uncertainty for He
   FIELDNAM: He Plus Systematic uncertainty
-  LABLAXIS: He Flux
+  LABL_PTR_1: he_energy_mean_label
 
 he_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
   CATDESC: Minus systematic uncertainty for He
   FIELDNAM: He Minus Systematic uncertainty
-  LABLAXIS: He Flux
+  LABL_PTR_1: he_energy_mean_label
 
 he_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He
   FIELDNAM: He Plus Total Uncertainty
-  LABLAXIS: He Flux
+  LABL_PTR_1: he_energy_mean_label
 
 he_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He
   FIELDNAM: He Minus Total Uncertainty
-  LABLAXIS: He Flux
+  LABL_PTR_1: he_energy_mean_label
 
 c_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
   CATDESC: Plus statistical uncertainty for C
   FIELDNAM: C Plus Statistical uncertainty
-  LABLAXIS: C Flux
+  LABL_PTR_1: c_energy_mean_label
 
 c_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
   CATDESC: Minus statistical uncertainty for C
   FIELDNAM: C Minus Statistical uncertainty
-  LABLAXIS: C Flux
+  LABL_PTR_1: c_energy_mean_label
 
 c_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
   CATDESC: Plus systematic uncertainty for C
   FIELDNAM: C Plus Systematic uncertainty
-  LABLAXIS: C Flux
+  LABL_PTR_1: c_energy_mean_label
 
 c_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
   CATDESC: Minus systematic uncertainty for C
   FIELDNAM: C Minus Systematic uncertainty
-  LABLAXIS: C Flux
+  LABL_PTR_1: c_energy_mean_label
 
 c_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for C
   FIELDNAM: C Plus Total Uncertainty
-  LABLAXIS: C Flux
+  LABL_PTR_1: c_energy_mean_label
 
 c_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for C
   FIELDNAM: C Minus Total Uncertainty
-  LABLAXIS: C Flux
+  LABL_PTR_1: c_energy_mean_label
 
 o_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
   CATDESC: Plus statistical uncertainty for O
   FIELDNAM: O Plus Statistical uncertainty
-  LABLAXIS: O Flux
+  LABL_PTR_1: o_energy_mean_label
 
 o_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
   CATDESC: Minus statistical uncertainty for O
   FIELDNAM: O Minus Statistical uncertainty
-  LABLAXIS: O Flux
+  LABL_PTR_1: o_energy_mean_label
 
 o_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
   CATDESC: Plus systematic uncertainty for O
   FIELDNAM: O Plus Systematic uncertainty
-  LABLAXIS: O Flux
+  LABL_PTR_1: o_energy_mean_label
 
 o_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
   CATDESC: Minus systematic uncertainty for O
   FIELDNAM: O Minus Systematic uncertainty
-  LABLAXIS: O Flux
+  LABL_PTR_1: o_energy_mean_label
 
 o_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for O
   FIELDNAM: O Plus Total Uncertainty
-  LABLAXIS: O Flux
+  LABL_PTR_1: o_energy_mean_label
 
 o_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for O
   FIELDNAM: O Minus Total Uncertainty
-  LABLAXIS: O Flux
+  LABL_PTR_1: o_energy_mean_label
 
 n_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
   CATDESC: Plus statistical uncertainty for N
   FIELDNAM: N Plus Statistical uncertainty
-  LABLAXIS: N Flux
+  LABL_PTR_1: n_energy_mean_label
 
 n_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
   CATDESC: Minus statistical uncertainty for N
   FIELDNAM: N Minus Statistical uncertainty
-  LABLAXIS: N Flux
+  LABL_PTR_1: n_energy_mean_label
 
 n_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
   CATDESC: Plus systematic uncertainty for N
   FIELDNAM: N Plus Systematic uncertainty
-  LABLAXIS: N Flux
+  LABL_PTR_1: n_energy_mean_label
 
 n_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
   CATDESC: Minus systematic uncertainty for N
   FIELDNAM: N Minus Systematic uncertainty
-  LABLAXIS: N Flux
+  LABL_PTR_1: n_energy_mean_label
 
 n_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for N
   FIELDNAM: N Plus Total Uncertainty
-  LABLAXIS: N Flux
+  LABL_PTR_1: n_energy_mean_label
 
 n_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for N
   FIELDNAM: N Minus Total Uncertainty
-  LABLAXIS: N Flux
+  LABL_PTR_1: n_energy_mean_label
 
 ne_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
   CATDESC: Plus statistical uncertainty for Ne
   FIELDNAM: Ne Plus Statistical uncertainty
-  LABLAXIS: Ne Flux
+  LABL_PTR_1: ne_energy_mean_label
 
 ne_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
   CATDESC: Minus statistical uncertainty for Ne
   FIELDNAM: Ne Minus Statistical uncertainty
-  LABLAXIS: Ne Flux
+  LABL_PTR_1: ne_energy_mean_label
 
 ne_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
   CATDESC: Plus systematic uncertainty for Ne
   FIELDNAM: Ne Plus Systematic uncertainty
-  LABLAXIS: Ne Flux
+  LABL_PTR_1: ne_energy_mean_label
 
 ne_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
   CATDESC: Minus systematic uncertainty for Ne
   FIELDNAM: Ne Minus Systematic uncertainty
-  LABLAXIS: Ne Flux
+  LABL_PTR_1: ne_energy_mean_label
 
 ne_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ne
   FIELDNAM: Ne Plus Total Uncertainty
-  LABLAXIS: Ne Flux
+  LABL_PTR_1: ne_energy_mean_label
 
 ne_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ne
   FIELDNAM: Ne Minus Total Uncertainty
-  LABLAXIS: Ne Flux
+  LABL_PTR_1: ne_energy_mean_label
 
 na_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
   CATDESC: Plus statistical uncertainty for Na
   FIELDNAM: Na Plus Statistical uncertainty
-  LABLAXIS: Na Flux
+  LABL_PTR_1: na_energy_mean_label
 
 na_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
   CATDESC: Minus statistical uncertainty for Na
   FIELDNAM: Na Minus Statistical uncertainty
-  LABLAXIS: Na Flux
+  LABL_PTR_1: na_energy_mean_label
 
 na_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
   CATDESC: Plus systematic uncertainty for Na
   FIELDNAM: Na Plus Systematic uncertainty
-  LABLAXIS: Na Flux
+  LABL_PTR_1: na_energy_mean_label
 
 na_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
   CATDESC: Minus systematic uncertainty for Na
   FIELDNAM: Na Minus Systematic uncertainty
-  LABLAXIS: Na Flux
+  LABL_PTR_1: na_energy_mean_label
 
 na_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Na
   FIELDNAM: Na Plus Total Uncertainty
-  LABLAXIS: Na Flux
+  LABL_PTR_1: na_energy_mean_label
 
 na_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Na
   FIELDNAM: Na Minus Total Uncertainty
-  LABLAXIS: Na Flux
+  LABL_PTR_1: na_energy_mean_label
 
 mg_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
   CATDESC: Plus statistical uncertainty for Mg
   FIELDNAM: Mg Plus Statistical uncertainty
-  LABLAXIS: Mg Flux
+  LABL_PTR_1: mg_energy_mean_label
 
 mg_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
   CATDESC: Minus statistical uncertainty for Mg
   FIELDNAM: Mg Minus Statistical uncertainty
-  LABLAXIS: Mg Flux
+  LABL_PTR_1: mg_energy_mean_label
 
 mg_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
   CATDESC: Plus systematic uncertainty for Mg
   FIELDNAM: Mg Plus Systematic uncertainty
-  LABLAXIS: Mg Flux
+  LABL_PTR_1: mg_energy_mean_label
 
 mg_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
   CATDESC: Minus systematic uncertainty for Mg
   FIELDNAM: Mg Minus Systematic uncertainty
-  LABLAXIS: Mg Flux
+  LABL_PTR_1: mg_energy_mean_label
 
 mg_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Mg
   FIELDNAM: Mg Plus Total Uncertainty
-  LABLAXIS: Mg Flux
+  LABL_PTR_1: mg_energy_mean_label
 
 mg_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Mg
   FIELDNAM: Mg Minus Total Uncertainty
-  LABLAXIS: Mg Flux
+  LABL_PTR_1: mg_energy_mean_label
 
 al_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
   CATDESC: Plus statistical uncertainty for Al
   FIELDNAM: Al Plus Statistical uncertainty
-  LABLAXIS: Al Flux
+  LABL_PTR_1: al_energy_mean_label
 
 al_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
   CATDESC: Minus statistical uncertainty for Al
   FIELDNAM: Al Minus Statistical uncertainty
-  LABLAXIS: Al Flux
+  LABL_PTR_1: al_energy_mean_label
 
 al_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
   CATDESC: Plus systematic uncertainty for Al
   FIELDNAM: Al Plus Systematic uncertainty
-  LABLAXIS: Al Flux
+  LABL_PTR_1: al_energy_mean_label
 
 al_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
   CATDESC: Minus systematic uncertainty for Al
   FIELDNAM: Al Minus Systematic uncertainty
-  LABLAXIS: Al Flux
+  LABL_PTR_1: al_energy_mean_label
 
 al_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Al
   FIELDNAM: Al Plus Total Uncertainty
-  LABLAXIS: Al Flux
+  LABL_PTR_1: al_energy_mean_label
 
 al_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Al
   FIELDNAM: Al Minus Total Uncertainty
-  LABLAXIS: Al Flux
+  LABL_PTR_1: al_energy_mean_label
 
 si_stat_uncert_plus:
-    <<: *default_uncertainty
-    DEPEND_1: si_energy_mean
-    CATDESC: Plus statistical uncertainty for Si
-    FIELDNAM: Si Plus Statistical uncertainty
-    LABLAXIS: Si Flux
+  <<: *default_uncertainty
+  DEPEND_1: si_energy_mean
+  CATDESC: Plus statistical uncertainty for Si
+  FIELDNAM: Si Plus Statistical uncertainty
+  LABL_PTR_1: si_energy_mean_label
 
 si_stat_uncert_minus:
-    <<: *default_uncertainty
-    DEPEND_1: si_energy_mean
-    CATDESC: Minus statistical uncertainty for Si
-    FIELDNAM: Si Minus Statistical uncertainty
-    LABLAXIS: Si Flux
+  <<: *default_uncertainty
+  DEPEND_1: si_energy_mean
+  CATDESC: Minus statistical uncertainty for Si
+  FIELDNAM: Si Minus Statistical uncertainty
+  LABL_PTR_1: si_energy_mean_label
 
 si_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
   CATDESC: Plus systematic uncertainty for Si
   FIELDNAM: Si Plus Systematic uncertainty
-  LABLAXIS: Si Flux
+  LABL_PTR_1: si_energy_mean_label
 
 si_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
   CATDESC: Minus systematic uncertainty for Si
   FIELDNAM: Si Minus Systematic uncertainty
-  LABLAXIS: Si Flux
+  LABL_PTR_1: si_energy_mean_label
 
 si_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Si
   FIELDNAM: Si Plus Total Uncertainty
-  LABLAXIS: Si Flux
+  LABL_PTR_1: si_energy_mean_label
 
 si_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Si
   FIELDNAM: Si Minus Total Uncertainty
-  LABLAXIS: Si Flux
+  LABL_PTR_1: si_energy_mean_label
 
 s_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
   CATDESC: Plus statistical uncertainty for S
   FIELDNAM: S Plus Statistical uncertainty
-  LABLAXIS: S Flux
+  LABL_PTR_1: s_energy_mean_label
 
 s_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
   CATDESC: Minus statistical uncertainty for S
   FIELDNAM: S Minus Statistical uncertainty
-  LABLAXIS: S Flux
+  LABL_PTR_1: s_energy_mean_label
 
 s_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
   CATDESC: Plus systematic uncertainty for S
   FIELDNAM: S Plus Systematic uncertainty
-  LABLAXIS: S Flux
+  LABL_PTR_1: s_energy_mean_label
 
 s_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
   CATDESC: Minus systematic uncertainty for S
   FIELDNAM: S Minus Systematic uncertainty
-  LABLAXIS: S Flux
+  LABL_PTR_1: s_energy_mean_label
 
 s_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for S
   FIELDNAM: S Plus Total Uncertainty
-  LABLAXIS: S Flux
+  LABL_PTR_1: s_energy_mean_label
 
 s_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for S
   FIELDNAM: S Minus Total Uncertainty
-  LABLAXIS: S Flux
+  LABL_PTR_1: s_energy_mean_label
 
 ar_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
   CATDESC: Plus statistical uncertainty for Ar
   FIELDNAM: Ar Plus Statistical uncertainty
-  LABLAXIS: Ar Flux
+  LABL_PTR_1: ar_energy_mean_label
 
 ar_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
   CATDESC: Minus statistical uncertainty for Ar
   FIELDNAM: Ar Minus Statistical uncertainty
-  LABLAXIS: Ar Flux
+  LABL_PTR_1: ar_energy_mean_label
 
 ar_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
   CATDESC: Plus systematic uncertainty for Ar
   FIELDNAM: Ar Plus Systematic uncertainty
-  LABLAXIS: Ar Flux
+  LABL_PTR_1: ar_energy_mean_label
 
 ar_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
   CATDESC: Minus systematic uncertainty for Ar
   FIELDNAM: Ar Minus Systematic uncertainty
-  LABLAXIS: Ar Flux
+  LABL_PTR_1: ar_energy_mean_label
 
 ar_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ar
   FIELDNAM: Ar Plus Total Uncertainty
-  LABLAXIS: Ar Flux
+  LABL_PTR_1: ar_energy_mean_label
 
 ar_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ar
   FIELDNAM: Ar Minus Total Uncertainty
-  LABLAXIS: Ar Flux
+  LABL_PTR_1: ar_energy_mean_label
 
 ca_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
   CATDESC: Plus statistical uncertainty for Ca
   FIELDNAM: Ca Plus Statistical uncertainty
-  LABLAXIS: Ca Flux
+  LABL_PTR_1: ca_energy_mean_label
 
 ca_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
   CATDESC: Minus statistical uncertainty for Ca
   FIELDNAM: Ca Minus Statistical uncertainty
-  LABLAXIS: Ca Flux
+  LABL_PTR_1: ca_energy_mean_label
 
 ca_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
   CATDESC: Plus systematic uncertainty for Ca
   FIELDNAM: Ca Plus Systematic uncertainty
-  LABLAXIS: Ca Flux
+  LABL_PTR_1: ca_energy_mean_label
 
 ca_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
   CATDESC: Minus systematic uncertainty for Ca
   FIELDNAM: Ca Minus Systematic uncertainty
-  LABLAXIS: Ca Flux
+  LABL_PTR_1: ca_energy_mean_label
 
 ca_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ca
   FIELDNAM: Ca Plus Total Uncertainty
-  LABLAXIS: Ca Flux
+  LABL_PTR_1: ca_energy_mean_label
 
 ca_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ca
   FIELDNAM: Ca Minus Total Uncertainty
-  LABLAXIS: Ca Flux
+  LABL_PTR_1: ca_energy_mean_label
 
 fe_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   CATDESC: Plus statistical uncertainty for Fe
   FIELDNAM: Fe Plus Statistical uncertainty
-  LABLAXIS: Fe Flux
+  LABL_PTR_1: fe_energy_mean_label
 
 fe_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   CATDESC: Minus statistical uncertainty for Fe
   FIELDNAM: Fe Minus Statistical uncertainty
-  LABLAXIS: Fe Flux
+  LABL_PTR_1: fe_energy_mean_label
 
 fe_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   CATDESC: Plus systematic uncertainty for Fe
   FIELDNAM: Fe Plus Systematic uncertainty
-  LABLAXIS: Fe Flux
+  LABL_PTR_1: fe_energy_mean_label
 
 fe_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   CATDESC: Minus systematic uncertainty for Fe
   FIELDNAM: Fe Minus Systematic uncertainty
-  LABLAXIS: Fe Flux
+  LABL_PTR_1: fe_energy_mean_label
 
 fe_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Fe
   FIELDNAM: Fe Plus Total Uncertainty
-  LABLAXIS: Fe Flux
+  LABL_PTR_1: fe_energy_mean_label
 
 fe_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Fe
   FIELDNAM: Fe Minus Total Uncertainty
-  LABLAXIS: Fe Flux
+  LABL_PTR_1: fe_energy_mean_label
 
 ni_stat_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
   CATDESC: Plus statistical uncertainty for Ni
   FIELDNAM: Ni Plus Statistical uncertainty
-  LABLAXIS: Ni Flux
+  LABL_PTR_1: ni_energy_mean_label
 
 ni_stat_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
   CATDESC: Minus statistical uncertainty for Ni
   FIELDNAM: Ni Minus Statistical uncertainty
-  LABLAXIS: Ni Flux
+  LABL_PTR_1: ni_energy_mean_label
 
 ni_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
   CATDESC: Plus systematic uncertainty for Ni
   FIELDNAM: Ni Plus Systematic uncertainty
-  LABLAXIS: Ni Flux
+  LABL_PTR_1: ni_energy_mean_label
 
 ni_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
   CATDESC: Minus systematic uncertainty for Ni
   FIELDNAM: Ni Minus Systematic uncertainty
-  LABLAXIS: Ni Flux
+  LABL_PTR_1: ni_energy_mean_label
 
 ni_total_uncert_plus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ni
   FIELDNAM: Ni Plus Total Uncertainty
-  LABLAXIS: Ni Flux
+  LABL_PTR_1: ni_energy_mean_label
 
 ni_total_uncert_minus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ni
   FIELDNAM: Ni Minus Total Uncertainty
-  LABLAXIS: Ni Flux
+  LABL_PTR_1: ni_energy_mean_label
 
 
 # <=== Data Variables - Macropixel Dataset ===>
@@ -1305,11 +1412,10 @@ h_macropixel:
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: h_energy_label
+  LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   FIELDNAM: H Intensity Macropixel
-  LABLAXIS: H Intensity
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
 
@@ -1319,11 +1425,10 @@ he4_macropixel:
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: he4_energy_label
+  LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   FIELDNAM: He4 Intensity Macropixel
-  LABLAXIS: He4 Intensity
   DELTA_MINUS: he4_total_uncert_plus
   DELTA_PLUS: he4_total_uncert_minus
 
@@ -1333,27 +1438,25 @@ cno_macropixel:
   DEPEND_1: c_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: c_energy_label
+  LABL_PTR_1: c_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   FIELDNAM: CNO Intensity Macropixel
-  LABLAXIS: CNO Intensity
   DELTA_MINUS: c_total_uncert_plus
   DELTA_PLUS: c_total_uncert_minus
 
 nemgsi_macropixel:
   <<: *default_particle
   CATDESC: NeMgSi Macropixel Intensity
-  DEPEND_1: ne_energy_mean
+  DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: ne_energy_label
+  LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   FIELDNAM: NeMgSi Intensity Macropixel
-  LABLAXIS: NeMgSi Intensity
-  DELTA_MINUS: ne_total_uncert_plus
-  DELTA_PLUS: ne_total_uncert_minus
+  DELTA_MINUS: nemgsi_total_uncert_plus
+  DELTA_PLUS: nemgsi_total_uncert_minus
 
 fe_macropixel:
   <<: *default_particle
@@ -1361,11 +1464,10 @@ fe_macropixel:
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: fe_energy_label
+  LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   FIELDNAM: Fe Intensity Macropixel
-  LABLAXIS: Fe Intensity
   DELTA_MINUS: fe_total_uncert_plus
   DELTA_PLUS: fe_total_uncert_minus
 
@@ -1404,360 +1506,330 @@ h_stat_uncert_plus_macropixel:
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: h_energy_label
+  LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus statistical uncertainty for H Macropixel
   FIELDNAM: H plus statistical uncertainty
-  LABLAXIS: H Flux
 
 h_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: h_energy_label
+  LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus statistical uncertainty for H Macropixel
   FIELDNAM: H Minus Statistical Uncertainty
-  LABLAXIS: H Flux
 
 h_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: h_energy_label
+  LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus systematic uncertainty for H
   FIELDNAM: H Plus Systematic Uncertainty
-  LABLAXIS: H Flux
 
 h_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: h_energy_label
+  LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus systematic uncertainty for H
   FIELDNAM: H Minus Systematic Uncertainty
-  LABLAXIS: H Flux
 
 h_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: h_energy_label
+  LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H
   FIELDNAM: H Plus Total Uncertainty
-  LABLAXIS: H Flux
 
 h_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: h_energy_label
+  LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H
   FIELDNAM: H Minus Total Uncertainty
-  LABLAXIS: H Flux
 
 he4_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: he4_energy_label
+  LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus statistical uncertainty for He4 Macropixel
   FIELDNAM: He4 Plus Statistical Uncertainty
-  LABLAXIS: He4 Flux
 
 he4_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: he4_energy_label
+  LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus statistical uncertainty for He4 Macropixel
   FIELDNAM: He4 Minus Statistical Uncertainty
-  LABLAXIS: He4 Flux
 
 he4_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: he4_energy_label
+  LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus systematic uncertainty for He4 Macropixel
   FIELDNAM: He4 Plus Systematic Uncertainty
-  LABLAXIS: He4 Flux
 
 he4_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: he4_energy_label
+  LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus systematic uncertainty for He4 Macropixel
   FIELDNAM: He4 Minus Systematic Uncertainty
-  LABLAXIS: He4 Flux
 
 he4_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: he4_energy_label
+  LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He4 Macropixel
   FIELDNAM: He4 Plus Total Uncertainty
-  LABLAXIS: He4 Flux
 
 he4_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: he4_energy_label
+  LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He4 Macropixel
   FIELDNAM: He4 Minus Total Uncertainty
-  LABLAXIS: He4 Flux
 
 cno_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: cno_energy_label
+  LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus statistical uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Plus Statistical Uncertainty
-  LABLAXIS: CNO Flux
 
 cno_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: cno_energy_label
+  LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus statistical uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Minus Statistical Uncertainty
-  LABLAXIS: CNO Flux
 
 cno_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: cno_energy_label
+  LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus systematic uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Plus Systematic Uncertainty
-  LABLAXIS: CNO Flux
 
 cno_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: cno_energy_label
+  LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus systematic uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Minus Systematic Uncertainty
-  LABLAXIS: CNO Flux
 
 cno_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: cno_energy_label
+  LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Plus Total Uncertainty
-  LABLAXIS: CNO Flux
 
 cno_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: cno_energy_label
+  LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Minus Total Uncertainty
-  LABLAXIS: CNO Flux
 
 nemgsi_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus statistical uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Plus Statistical Uncertainty
-  LABLAXIS: NeMgSi Flux
 
 nemgsi_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus statistical uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Minus Statistical Uncertainty
-  LABLAXIS: NeMgSi Flux
 
 nemgsi_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus systematic uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Plus Systematic Uncertainty
-  LABLAXIS: NeMgSi Flux
 
 nemgsi_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus systematic uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Minus Systematic Uncertainty
-  LABLAXIS: NeMgSi Flux
 
 nemgsi_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Plus Total Uncertainty
-  LABLAXIS: NeMgSi Flux
 
 nemgsi_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: nemgsi_energy_label
+  LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Minus Total Uncertainty
-  LABLAXIS: NeMgSi Flux
 
 fe_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: fe_energy_label
+  LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus statistical uncertainty for Fe Macropixel
   FIELDNAM: Fe Plus Statistical Uncertainty
-  LABLAXIS: Fe Flux
 
 fe_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: fe_energy_label
+  LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus statistical uncertainty for Fe Macropixel
   FIELDNAM: Fe Minus Statistical Uncertainty
-  LABLAXIS: Fe Flux
 
 fe_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: fe_energy_label
+  LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus systematic uncertainty for Fe Macropixel
   FIELDNAM: Fe Plus Systematic Uncertainty
-  LABLAXIS: Fe Flux
 
 fe_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: fe_energy_label
+  LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus systematic uncertainty for Fe Macropixel
   FIELDNAM: Fe Minus Systematic Uncertainty
-  LABLAXIS: Fe Flux
 
 fe_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: fe_energy_label
+  LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Fe Macropixel
   FIELDNAM: Fe Plus Total Uncertainty
-  LABLAXIS: Fe Flux
 
 fe_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: fe_energy_label
+  LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Fe Macropixel
   FIELDNAM: Fe Minus Total Uncertainty
-  LABLAXIS: Fe Flux
 
 
 


### PR DESCRIPTION
This PR adds CDF attributes for all three L2 products to a yaml file. There are many data variables in these products so I created default attributes where possible to avoid repetition while balancing readability.

Closes #1075 
