### PR TITLE
I-ALiRT - Script for binary data

### DIFF
--- a/imap_processing/ialirt/l0/generate_binary.py
+++ b/imap_processing/ialirt/l0/generate_binary.py
@@ -24,10 +24,10 @@ def generate_binary(
     -------
     binary_blob_data : list
         Binary blob data for each packet.
-    time_data : list
+    met_data : list
         SCLK time in seconds.
     """
-    time_data = []
+    met_data = []
     binary_blob_data = []
 
     # Set up the parser from the input packet definition
@@ -40,11 +40,11 @@ def generate_binary(
             binary_blob = packet.raw_data
             # Subsecond time conversion specified in 7516-9054 GSW-FSW ICD.
             # Value of SCLK subseconds, unsigned, (LSB = 1/256 sec)
-            time = (
+            met = (
                 packet.user_data["SC_SCLK_SEC"]
                 + packet.user_data["SC_SCLK_SUB_SEC"] * 256
             )
             binary_blob_data.append(binary_blob)
-            time_data.append(time)
+            met_data.append(met)
 
-    return binary_blob_data, time_data
+    return binary_blob_data, met_data

--- a/imap_processing/ialirt/l0/generate_binary.py
+++ b/imap_processing/ialirt/l0/generate_binary.py
@@ -38,10 +38,7 @@ def generate_binary(
         for packet in packet_generator:
             # Subsecond time conversion specified in 7516-9054 GSW-FSW ICD.
             # Value of SCLK subseconds, unsigned, (LSB = 1/256 sec)
-            met = (
-                packet.user_data["SC_SCLK_SEC"]
-                + packet.user_data["SC_SCLK_SUB_SEC"] * 256
-            )
+            met = packet["SC_SCLK_SEC"] + packet["SC_SCLK_SUB_SEC"] / 256
             ingest_data.append(
                 {
                     "apid": 478,

--- a/imap_processing/ialirt/l0/generate_binary.py
+++ b/imap_processing/ialirt/l0/generate_binary.py
@@ -1,5 +1,6 @@
 """I-ALiRT data to populate binary blob database."""
 
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Union
 
@@ -9,7 +10,7 @@ from space_packet_parser import definitions
 def generate_binary(
     packet_file: Union[str, Path],
     xtce_packet_definition: Union[str, Path],
-) -> tuple[list, list]:
+) -> list[dict]:
     """
     Generate binary blob and SCLK data for each packet.
 
@@ -22,13 +23,11 @@ def generate_binary(
 
     Returns
     -------
-    binary_blob_data : list
-        Binary blob data for each packet.
-    met_data : list
-        SCLK time in seconds.
+    ingest_data : list[dict]
+        Dictionary final data product.
     """
-    met_data = []
-    binary_blob_data = []
+    now = datetime.now(timezone.utc)
+    ingest_data = []
 
     # Set up the parser from the input packet definition
     packet_definition = definitions.XtcePacketDefinition(xtce_packet_definition)
@@ -37,14 +36,19 @@ def generate_binary(
 
         # Iterate over the packets and access the raw binary data
         for packet in packet_generator:
-            binary_blob = packet.raw_data
             # Subsecond time conversion specified in 7516-9054 GSW-FSW ICD.
             # Value of SCLK subseconds, unsigned, (LSB = 1/256 sec)
             met = (
                 packet.user_data["SC_SCLK_SEC"]
                 + packet.user_data["SC_SCLK_SUB_SEC"] * 256
             )
-            binary_blob_data.append(binary_blob)
-            met_data.append(met)
+            ingest_data.append(
+                {
+                    "apid": 478,
+                    "met": met,
+                    "ingest_time": now,
+                    "packet_blob": packet.raw_data,
+                }
+            )
 
-    return binary_blob_data, met_data
+    return ingest_data

--- a/imap_processing/ialirt/l0/generate_binary.py
+++ b/imap_processing/ialirt/l0/generate_binary.py
@@ -1,0 +1,50 @@
+"""I-ALiRT data to populate binary blob database."""
+
+from pathlib import Path
+from typing import Union
+
+from space_packet_parser import definitions
+
+
+def generate_binary(
+    packet_file: Union[str, Path],
+    xtce_packet_definition: Union[str, Path],
+) -> tuple[list, list]:
+    """
+    Generate binary blob and SCLK data for each packet.
+
+    Parameters
+    ----------
+    packet_file : str
+        Path to data packet path with filename.
+    xtce_packet_definition : str
+        Path to XTCE file with filename.
+
+    Returns
+    -------
+    binary_blob_data : list
+        Binary blob data for each packet.
+    time_data : list
+        SCLK time in seconds.
+    """
+    time_data = []
+    binary_blob_data = []
+
+    # Set up the parser from the input packet definition
+    packet_definition = definitions.XtcePacketDefinition(xtce_packet_definition)
+    with packet_file.open("rb") as binary_data:
+        packet_generator = packet_definition.packet_generator(binary_data)
+
+        # Iterate over the packets and access the raw binary data
+        for packet in packet_generator:
+            binary_blob = packet.raw_data
+            # Subsecond time conversion specified in 7516-9054 GSW-FSW ICD.
+            # Value of SCLK subseconds, unsigned, (LSB = 1/256 sec)
+            time = (
+                packet.user_data["SC_SCLK_SEC"]
+                + packet.user_data["SC_SCLK_SUB_SEC"] * 256
+            )
+            binary_blob_data.append(binary_blob)
+            time_data.append(time)
+
+    return binary_blob_data, time_data

--- a/imap_processing/tests/ialirt/unit/test_generate_binary.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_binary.py
@@ -1,0 +1,15 @@
+from imap_processing import imap_module_directory
+from imap_processing.ialirt.l0.generate_binary import generate_binary
+
+
+def test_generate_binary():
+    """
+    Test test_generate_binary function.
+    """
+    test_file = "tests/ialirt/data/l0/apid_478.bin"
+    packet_files = imap_module_directory / test_file
+    packet_definition = imap_module_directory / "ialirt/packet_definitions/ialirt.xml"
+    binary_blob_data, time_data = generate_binary(packet_files, packet_definition)
+    assert len(binary_blob_data) == 44429
+    assert len(time_data) == 44429
+    assert time_data[0] == 482934903 + 62976

--- a/imap_processing/tests/ialirt/unit/test_generate_binary.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_binary.py
@@ -10,6 +10,5 @@ def test_generate_binary():
     packet_files = imap_module_directory / test_file
     packet_definition = imap_module_directory / "ialirt/packet_definitions/ialirt.xml"
     ingest_data = generate_binary(packet_files, packet_definition)
-    print("h")
     assert len(ingest_data) == 44429
     assert ingest_data[0]["met"] == 482934903 + 62976

--- a/imap_processing/tests/ialirt/unit/test_generate_binary.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_binary.py
@@ -1,7 +1,10 @@
+import pytest
+
 from imap_processing import imap_module_directory
 from imap_processing.ialirt.l0.generate_binary import generate_binary
 
 
+@pytest.mark.external_test_data
 def test_generate_binary():
     """
     Test test_generate_binary function.

--- a/imap_processing/tests/ialirt/unit/test_generate_binary.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_binary.py
@@ -11,4 +11,4 @@ def test_generate_binary():
     packet_definition = imap_module_directory / "ialirt/packet_definitions/ialirt.xml"
     ingest_data = generate_binary(packet_files, packet_definition)
     assert len(ingest_data) == 44429
-    assert ingest_data[0]["met"] == 482934903 + 62976
+    assert ingest_data[0]["met"] == 482934903 + 0.9609375

--- a/imap_processing/tests/ialirt/unit/test_generate_binary.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_binary.py
@@ -9,7 +9,7 @@ def test_generate_binary():
     test_file = "tests/ialirt/data/l0/apid_478.bin"
     packet_files = imap_module_directory / test_file
     packet_definition = imap_module_directory / "ialirt/packet_definitions/ialirt.xml"
-    binary_blob_data, time_data = generate_binary(packet_files, packet_definition)
-    assert len(binary_blob_data) == 44429
-    assert len(time_data) == 44429
-    assert time_data[0] == 482934903 + 62976
+    ingest_data = generate_binary(packet_files, packet_definition)
+    print("h")
+    assert len(ingest_data) == 44429
+    assert ingest_data[0]["met"] == 482934903 + 62976


### PR DESCRIPTION
# Change Summary

## Overview
Create the script for generating the binary blob from each packet. This will be imported into the lambda in sds-data-manager.

## New Files
- generate_binary.py
   - Generate the binary blob data.

## Testing
- test_generate_binary.py
   - Test generate_binary.py

Note: PR tests will fail until I-ALiRT - SC packet check #1665 is merged in.