### PR TITLE
remove repointing attr

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -488,7 +488,8 @@ class ProcessInstrument(ABC):
         products = []
         for ds in datasets:
             ds.attrs["Data_version"] = self.version
-            ds.attrs["Repointing"] = self.repointing
+            if self.repointing is not None:
+                ds.attrs["Repointing"] = self.repointing
             ds.attrs["Start_date"] = self.start_date
             ds.attrs["Parents"] = parent_files
             products.append(write_cdf(ds))


### PR DESCRIPTION
# Change Summary
Change the repointing attribute so that it is not included in the global attributes if it is not passed through the CLI.

