### PR TITLE
IDEX housekeeping - Recalculate epoch time with respect to fine grained time

### DIFF
--- a/imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml
@@ -33,6 +33,18 @@ imap_idex_l1b_sci:
   Logical_source: imap_idex_l1b_sci-1week
   Logical_source_description: IMAP Mission IDEX Instrument Level-1B Data.
 
+imap_idex_l1b_evt:
+   <<: *instrument_base
+   Data_type: L1B_EVT>Level-1B Event Message Data
+   Logical_source: imap_idex_l1b_evt
+   Logical_source_description: IMAP Mission IDEX Instrument Level-1B Event Message Data.
+
+imap_idex_l1b_catlst:
+  <<: *instrument_base
+  Data_type: L1B_CATLST>Level-1B Packet Catalog Summary Data
+  Logical_source: imap_idex_l1b_catlst
+  Logical_source_description: IMAP Mission IDEX Instrument Level-1B Packet Catalog Summary Data.
+
 imap_idex_l2a_sci:
   <<: *instrument_base
   Data_type: L2A_SCI>Level-2A Science Data

--- a/imap_processing/idex/idex_l0.py
+++ b/imap_processing/idex/idex_l0.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def decom_packets(
     packet_file: Union[str, Path],
-) -> tuple[list[Any], dict[int, Dataset]]:
+) -> tuple[list[Any], dict[int, Dataset], dict[int, Dataset]]:
     """
     Decom IDEX data packets using IDEX packet definition.
 
@@ -27,7 +27,7 @@ def decom_packets(
     -------
     Tuple[list, dict]
         Returns a list of all unpacked science data and a dictionary of datasets
-        indexed by their APIDs.
+        indexed by their APIDs, one for raw and derived values.
 
     Notes
     -----
@@ -40,8 +40,15 @@ def decom_packets(
     hk_xtce_file = f"{xtce_base_path}/idex_housekeeping_packet_definition.xml"
 
     science_decom_packet_list = decom.decom_packets(packet_file, science_xtce_file)
-    datasets_by_apid = packet_file_to_datasets(
+    raw_datasets_by_apid = packet_file_to_datasets(
+        packet_file, hk_xtce_file, use_derived_value=False
+    )
+    derived_datasets_by_apid = packet_file_to_datasets(
         packet_file, hk_xtce_file, use_derived_value=True
     )
 
-    return list(science_decom_packet_list), datasets_by_apid
+    return (
+        list(science_decom_packet_list),
+        raw_datasets_by_apid,
+        derived_datasets_by_apid,
+    )

--- a/imap_processing/idex/idex_l0.py
+++ b/imap_processing/idex/idex_l0.py
@@ -40,6 +40,8 @@ def decom_packets(
     hk_xtce_file = f"{xtce_base_path}/idex_housekeeping_packet_definition.xml"
 
     science_decom_packet_list = decom.decom_packets(packet_file, science_xtce_file)
-    datasets_by_apid = packet_file_to_datasets(packet_file, hk_xtce_file)
+    datasets_by_apid = packet_file_to_datasets(
+        packet_file, hk_xtce_file, use_derived_value=True
+    )
 
     return list(science_decom_packet_list), datasets_by_apid

--- a/imap_processing/idex/idex_l1a.py
+++ b/imap_processing/idex/idex_l1a.py
@@ -89,6 +89,7 @@ class PacketParser:
             logger.info("Processing IDEX L1A Event Message data.")
             data = datset_by_apid[IDEXAPID.IDEX_EVT]
             data.attrs = self.idex_attrs.get_global_attributes("imap_idex_l1a_evt")
+            data["epoch"] = calculate_idex_epoch_time(data["shcoarse"], data["shfine"])
             data["epoch"].attrs = epoch_attrs
             self.data.append(data)
 
@@ -96,6 +97,7 @@ class PacketParser:
             logger.info("Processing IDEX L1A Catalog List Summary data.")
             data = datset_by_apid[IDEXAPID.IDEX_CATLST]
             data.attrs = self.idex_attrs.get_global_attributes("imap_idex_l1a_catlst")
+            data["epoch"] = calculate_idex_epoch_time(data["shcoarse"], data["shfine"])
             data["epoch"].attrs = epoch_attrs
             self.data.append(data)
 
@@ -228,6 +230,39 @@ def _read_waveform_bits(waveform_raw: str, high_sample: bool = True) -> list[int
     return ints
 
 
+def calculate_idex_epoch_time(
+    shcoarse_time: Union[float, np.ndarray], shfine_time: Union[float, np.ndarray]
+) -> npt.NDArray[np.int64]:
+    """
+    Calculate the epoch time from the FPGA header time variables.
+
+    We are given the MET seconds, we need to convert it to nanoseconds in j2000. IDEX
+    epoch is calculated with shcoarse and shfine time values. The shcoarse time counts
+    the number of whole seconds elapsed since the epoch (Jan 1st 2010), while shfine
+    time counts the number of additional 20-microsecond intervals beyond the whole
+    seconds. Together, these time measurements establish when a dust event took place.
+
+    Parameters
+    ----------
+    shcoarse_time : float, numpy.ndarray
+        The coarse time value from the FPGA header. Number of seconds since epoch.
+    shfine_time : float, numpy.ndarray
+        The fine time value from the FPGA header. Number of 20 microsecond "ticks" since
+         the last second.
+
+    Returns
+    -------
+    numpy.ndarray[numpy.int64]
+        The mission elapsed time converted to nanoseconds since the J2000 epoch
+        in the terrestrial time (TT) timescale.
+    """
+    # Number of microseconds since the last second
+    microseconds_since_last_second = 20 * shfine_time
+    # Get met time in seconds including shfine
+    met = shcoarse_time + microseconds_since_last_second * 1e-6
+    return met_to_ttj2000ns(met)
+
+
 class RawDustEvent:
     """
     Encapsulate IDEX Raw Dust Event.
@@ -259,8 +294,6 @@ class RawDustEvent:
     -------
     _append_raw_data(scitype, bits)
         Append data to the appropriate bit string.
-    _set_impact_time(packet)
-        Calculate the datetime64 from the FPGA header information.
     _set_sample_trigger_times(packet)
         Calculate the actual sample trigger time.
     _parse_high_sample_waveform(waveform_raw)
@@ -308,7 +341,9 @@ class RawDustEvent:
         """
         # Calculate the impact time in seconds since epoch
         self.impact_time = 0
-        self._set_impact_time(header_packet)
+        self.impact_time = calculate_idex_epoch_time(
+            header_packet["SHCOARSE"], header_packet["SHFINE"]
+        )
 
         # The actual trigger time for the low and high sample rate in
         # microseconds since the impact time
@@ -366,35 +401,6 @@ class RawDustEvent:
             self.Ion_Grid_bits += bits
         else:
             logger.warning("Unknown science type received: [%s]", scitype)
-
-    def _set_impact_time(self, packet: space_packet_parser.packets.CCSDSPacket) -> None:
-        """
-        Calculate the impact time from the FPGA header information.
-
-        We are given the MET seconds, we need convert it to UTC in type
-        ``np.datetime64``.
-
-        Parameters
-        ----------
-        packet : space_packet_parser.packets.CCSDSPacket
-            The IDEX FPGA header packet.
-
-        Notes
-        -----
-        TODO: This conversion is temporary for now, and will need SPICE in the
-              future. IDEX has set the time launch to Jan 1 2012 for calibration
-              testing.
-        """
-        # Number of seconds since epoch (nominally the launch time)
-        seconds_since_launch = packet["SHCOARSE"]
-        # Number of 20 microsecond "ticks" since the last second
-        num_of_20_microsecond_increments = packet["SHFINE"]
-        # Number of microseconds since the last second
-        microseconds_since_last_second = 20 * num_of_20_microsecond_increments
-        # Get the datetime of Jan 1 2012 as the start date
-        met = seconds_since_launch + microseconds_since_last_second * 1e-6
-
-        self.impact_time = met_to_ttj2000ns(met)
 
     def _set_sample_trigger_times(
         self, packet: space_packet_parser.packets.CCSDSPacket

--- a/imap_processing/idex/idex_l1a.py
+++ b/imap_processing/idex/idex_l1a.py
@@ -79,27 +79,39 @@ class PacketParser:
             "epoch", check_schema=False
         )
 
-        science_packets, datset_by_apid = decom_packets(packet_file)
+        science_packets, raw_datset_by_apid, derived_datasets_by_apid = decom_packets(
+            packet_file
+        )
 
         if science_packets:
             logger.info("Processing IDEX L1A Science data.")
             self.data.append(self._create_science_dataset(science_packets))
 
-        if IDEXAPID.IDEX_EVT in datset_by_apid:
-            logger.info("Processing IDEX L1A Event Message data.")
-            data = datset_by_apid[IDEXAPID.IDEX_EVT]
-            data.attrs = self.idex_attrs.get_global_attributes("imap_idex_l1a_evt")
-            data["epoch"] = calculate_idex_epoch_time(data["shcoarse"], data["shfine"])
-            data["epoch"].attrs = epoch_attrs
-            self.data.append(data)
+        datasets_by_level = {"l1a": raw_datset_by_apid, "l1b": derived_datasets_by_apid}
+        for level, dataset in datasets_by_level.items():
+            if IDEXAPID.IDEX_EVT in dataset:
+                logger.info(f"Processing IDEX {level} Event Message data")
+                data = dataset[IDEXAPID.IDEX_EVT]
+                data.attrs = self.idex_attrs.get_global_attributes(
+                    f"imap_idex_{level}_evt"
+                )
+                data["epoch"] = calculate_idex_epoch_time(
+                    data["shcoarse"], data["shfine"]
+                )
+                data["epoch"].attrs = epoch_attrs
+                self.data.append(data)
 
-        if IDEXAPID.IDEX_CATLST in datset_by_apid:
-            logger.info("Processing IDEX L1A Catalog List Summary data.")
-            data = datset_by_apid[IDEXAPID.IDEX_CATLST]
-            data.attrs = self.idex_attrs.get_global_attributes("imap_idex_l1a_catlst")
-            data["epoch"] = calculate_idex_epoch_time(data["shcoarse"], data["shfine"])
-            data["epoch"].attrs = epoch_attrs
-            self.data.append(data)
+            if IDEXAPID.IDEX_CATLST in dataset:
+                logger.info(f"Processing IDEX {level} Catalog List Summary data.")
+                data = dataset[IDEXAPID.IDEX_CATLST]
+                data.attrs = self.idex_attrs.get_global_attributes(
+                    f"imap_idex_{level}_catlst"
+                )
+                data["epoch"] = calculate_idex_epoch_time(
+                    data["shcoarse"], data["shfine"]
+                )
+                data["epoch"].attrs = epoch_attrs
+                self.data.append(data)
 
         logger.info("IDEX L1A data processing completed.")
 

--- a/imap_processing/idex/idex_l1a.py
+++ b/imap_processing/idex/idex_l1a.py
@@ -256,10 +256,8 @@ def calculate_idex_epoch_time(
         The mission elapsed time converted to nanoseconds since the J2000 epoch
         in the terrestrial time (TT) timescale.
     """
-    # Number of microseconds since the last second
-    microseconds_since_last_second = 20 * shfine_time
-    # Get met time in seconds including shfine
-    met = shcoarse_time + microseconds_since_last_second * 1e-6
+    # Get met time in seconds including shfine (number of 20 microsecond ticks)
+    met = shcoarse_time + shfine_time * 20e-6
     return met_to_ttj2000ns(met)
 
 

--- a/imap_processing/tests/idex/conftest.py
+++ b/imap_processing/tests/idex/conftest.py
@@ -48,26 +48,26 @@ def decom_test_data_sci() -> xr.Dataset:
 
 @pytest.fixture
 def decom_test_data_catlst() -> xr.Dataset:
-    """Return a ``xarray`` dataset containing the catalog list summary data.
+    """List of ``xarray`` datasets containing the raw and derived catalog list data.
 
     Returns
     -------
-    dataset : xarray.Dataset
-        A ``xarray`` dataset containing the catalog list summary data.
+    dataset : list[xarray.Dataset]
+        A list of ``xarray`` dataset containing the catalog list summary datasets.
     """
-    return PacketParser(TEST_L0_FILE_CATLST).data[0]
+    return PacketParser(TEST_L0_FILE_CATLST).data
 
 
 @pytest.fixture
 def decom_test_data_evt() -> xr.Dataset:
-    """Return a ``xarray`` dataset containing the event log data.
+    """List of ``xarray`` datasets containing the raw and derived event log data.
 
     Returns
     -------
-    dataset : xarray.Dataset
-        A ``xarray`` dataset containing the event log data.
+    dataset : list[xarray.Dataset]
+        A list of ``xarray`` datasets containing the event log datasets.
     """
-    return PacketParser(TEST_L0_FILE_EVT).data[0]
+    return PacketParser(TEST_L0_FILE_EVT).data
 
 
 @pytest.fixture

--- a/imap_processing/tests/idex/test_idex_l0.py
+++ b/imap_processing/tests/idex/test_idex_l0.py
@@ -48,23 +48,26 @@ def test_idex_tof_high_data(decom_test_data_sci: xr.Dataset):
     assert (decom_test_data_sci["TOF_High"][13].data == data).all()
 
 
-def test_catlst_event_num(decom_test_data_catlst: xr.Dataset):
+def test_catlst_event_num(decom_test_data_catlst: list[xr.Dataset]):
     """Verify that a sample of the data is correct.
 
     Parameters
     ----------
-    decom_test_data_catlst : xarray.Dataset
-        The dataset to test with
+    decom_test_data_catlst : list[xarray.Dataset]
+        The raw and derived (l1a and l1b) datasets to test with.
     """
-    assert len(decom_test_data_catlst["epoch"]) == 1
+    # test both l1a and l1b datasets
+    for ds in decom_test_data_catlst:
+        assert len(ds["epoch"]) == 1
 
 
-def test_evt_event_num(decom_test_data_evt: xr.Dataset):
+def test_evt_event_num(decom_test_data_evt: list[xr.Dataset]):
     """Verify that a sample of the data is correct.
 
     Parameters
     ----------
-    decom_test_data_evt : xarray.Dataset
-        The dataset to test with
+    decom_test_data_evt : list[xarray.Dataset]
+        The raw and derived (l1a and l1b) datasets to test with.
     """
-    assert len(decom_test_data_evt["epoch"]) == 28
+    for ds in decom_test_data_evt:
+        assert len(ds["epoch"]) == 28

--- a/imap_processing/tests/idex/test_idex_l1a.py
+++ b/imap_processing/tests/idex/test_idex_l1a.py
@@ -293,44 +293,47 @@ def test_decode_sub_frame_psel_3():
     assert ints == [1, 2, 4, 1, 5]
 
 
-def test_catlst_dataset(decom_test_data_catlst: xr.Dataset):
+def test_catlst_dataset(decom_test_data_catlst: list[xr.Dataset]):
     """Verify that the dataset contains what we expect and can be written to a cdf.
 
     Parameters
     ----------
-    decom_test_data_catlst : xarray.Dataset
-        The dataset to test with
+    decom_test_data_catlst : list[xarray.Dataset]
+        The raw and derived (l1a and l1b) datasets to test with.
     """
-    assert "shcoarse" in decom_test_data_catlst
-    assert "shfine" in decom_test_data_catlst
-    # Assert epoch is calculated using fine grained clock ticks
-    expected_epoch = met_to_ttj2000ns(
-        decom_test_data_catlst["shcoarse"] + decom_test_data_catlst["shfine"] * 20e-6
-    )
-    np.testing.assert_array_equal(decom_test_data_catlst.epoch, expected_epoch)
+    for ds in decom_test_data_catlst:
+        assert "shcoarse" in ds
+        assert "shfine" in ds
+        # Assert epoch is calculated using fine-grained clock ticks
+        expected_epoch = met_to_ttj2000ns(ds["shcoarse"] + ds["shfine"] * 20e-6)
+        np.testing.assert_array_equal(ds.epoch, expected_epoch)
     # Assert that the dataset can be written to a CDF file
-    filename = write_cdf(decom_test_data_catlst)
+    filename_l1a = write_cdf(decom_test_data_catlst[0])
+    assert filename_l1a.name == "imap_idex_l1a_catlst_20241206_v999.cdf"
 
-    assert filename.name == "imap_idex_l1a_catlst_20241206_v999.cdf"
+    filename_l1b = write_cdf(decom_test_data_catlst[1])
+    assert filename_l1b.name == "imap_idex_l1b_catlst_20241206_v999.cdf"
 
 
-def test_evt_dataset(decom_test_data_evt: xr.Dataset):
+def test_evt_dataset(decom_test_data_evt: list[xr.Dataset]):
     """Verify that the dataset contains what we expect and can be written to a cdf.
 
     Parameters
     ----------
-    decom_test_data_evt : xarray.Dataset
-        The dataset to test with
+    decom_test_data_evt : list[xarray.Dataset]
+        The raw and derived (l1a and l1b) datasets to test with.
     """
-    assert "elid_evtpkt" in decom_test_data_evt
-    assert "shcoarse" in decom_test_data_evt
-    assert "shfine" in decom_test_data_evt
-    # Assert epoch is calculated using fine grained clock ticks
-    expected_epoch = met_to_ttj2000ns(
-        decom_test_data_evt["shcoarse"] + decom_test_data_evt["shfine"] * 20e-6
-    )
-    np.testing.assert_array_equal(decom_test_data_evt.epoch, expected_epoch)
+    for ds in decom_test_data_evt:
+        assert "shcoarse" in ds
+        assert "shfine" in ds
+        # Assert epoch is calculated using fine grained clock ticks
+        expected_epoch = met_to_ttj2000ns(ds["shcoarse"] + ds["shfine"] * 20e-6)
+        np.testing.assert_array_equal(ds.epoch, expected_epoch)
+    assert decom_test_data_evt[0]["elid_evtpkt"][9] == 192
+    assert decom_test_data_evt[1]["elid_evtpkt"][9] == "SCI_STE"
     # Assert that the dataset can be written to a CDF file
-    filename = write_cdf(decom_test_data_evt)
+    filename_l1a = write_cdf(decom_test_data_evt[0])
+    assert filename_l1a.name == "imap_idex_l1a_evt_20250108_v999.cdf"
 
-    assert filename.name == "imap_idex_l1a_evt_20250108_v999.cdf"
+    filename_l1b = write_cdf(decom_test_data_evt[1])
+    assert filename_l1b.name == "imap_idex_l1b_evt_20250108_v999.cdf"

--- a/imap_processing/tests/idex/test_idex_l1a.py
+++ b/imap_processing/tests/idex/test_idex_l1a.py
@@ -12,6 +12,7 @@ from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import load_cdf, write_cdf
 from imap_processing.idex.decode import _decode_sub_frame, read_bits, rice_decode
 from imap_processing.idex.idex_l1a import PacketParser
+from imap_processing.spice.time import met_to_ttj2000ns
 
 
 def test_idex_cdf_file(decom_test_data_sci: xr.Dataset):
@@ -302,6 +303,11 @@ def test_catlst_dataset(decom_test_data_catlst: xr.Dataset):
     """
     assert "shcoarse" in decom_test_data_catlst
     assert "shfine" in decom_test_data_catlst
+    # Assert epoch is calculated using fine grained clock ticks
+    expected_epoch = met_to_ttj2000ns(
+        decom_test_data_catlst["shcoarse"] + decom_test_data_catlst["shfine"] * 20e-6
+    )
+    np.testing.assert_array_equal(decom_test_data_catlst.epoch, expected_epoch)
     # Assert that the dataset can be written to a CDF file
     filename = write_cdf(decom_test_data_catlst)
 
@@ -319,7 +325,11 @@ def test_evt_dataset(decom_test_data_evt: xr.Dataset):
     assert "elid_evtpkt" in decom_test_data_evt
     assert "shcoarse" in decom_test_data_evt
     assert "shfine" in decom_test_data_evt
-
+    # Assert epoch is calculated using fine grained clock ticks
+    expected_epoch = met_to_ttj2000ns(
+        decom_test_data_evt["shcoarse"] + decom_test_data_evt["shfine"] * 20e-6
+    )
+    np.testing.assert_array_equal(decom_test_data_evt.epoch, expected_epoch)
     # Assert that the dataset can be written to a CDF file
     filename = write_cdf(decom_test_data_evt)
 

--- a/imap_processing/tests/idex/test_idex_l1a.py
+++ b/imap_processing/tests/idex/test_idex_l1a.py
@@ -292,27 +292,35 @@ def test_decode_sub_frame_psel_3():
     assert ints == [1, 2, 4, 1, 5]
 
 
-def test_cdf_creation_catlst(decom_test_data_catlst: xr.Dataset):
-    """Verify that a sample of the data can be written to a cdf without errors.
+def test_catlst_dataset(decom_test_data_catlst: xr.Dataset):
+    """Verify that the dataset contains what we expect and can be written to a cdf.
 
     Parameters
     ----------
     decom_test_data_catlst : xarray.Dataset
         The dataset to test with
     """
+    assert "shcoarse" in decom_test_data_catlst
+    assert "shfine" in decom_test_data_catlst
+    # Assert that the dataset can be written to a CDF file
     filename = write_cdf(decom_test_data_catlst)
 
     assert filename.name == "imap_idex_l1a_catlst_20241206_v999.cdf"
 
 
-def test_cdf_creation_evt(decom_test_data_evt: xr.Dataset):
-    """Verify that a sample of the data can be written to a cdf without errors.
+def test_evt_dataset(decom_test_data_evt: xr.Dataset):
+    """Verify that the dataset contains what we expect and can be written to a cdf.
 
     Parameters
     ----------
     decom_test_data_evt : xarray.Dataset
         The dataset to test with
     """
+    assert "elid_evtpkt" in decom_test_data_evt
+    assert "shcoarse" in decom_test_data_evt
+    assert "shfine" in decom_test_data_evt
+
+    # Assert that the dataset can be written to a CDF file
     filename = write_cdf(decom_test_data_evt)
 
     assert filename.name == "imap_idex_l1a_evt_20250108_v999.cdf"


### PR DESCRIPTION
# Change Summary

## Overview
IDEX epochs are calculated with shcoarse and shfine time values. Fix housekeeping to calculate epoch by using both. 

## Updated Files
- imap_processing/idex/idex_l0.py
   - Use derived values for housekeeping. 
- imap_processing/idex/idex_l1a.py
   - move epoch calculation out of DustEventClass as it now needed for housekeeping as well. 

## Testing
Add checks for specific variables needed in housekeeping
