### PR TITLE
PULL exposure_factor rather than PUSH

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -166,8 +166,10 @@ class TestUltraL2:
                             "values_to_push_project": [
                                 "counts",
                                 "sensitivity",
-                                "exposure_factor",
                                 "background_rates",
+                            ],
+                            "values_to_pull_project": [
+                                "exposure_factor",
                             ],
                             "spacing_deg": 2.0,
                         }
@@ -215,7 +217,13 @@ class TestUltraL2:
             {
                 "sky_tiling_type": "HEALPIX",
                 "spice_reference_frame": "ECLIPJ2000",
-                "values_to_push_project": ["counts", "sensitivity", "exposure_factor"],
+                "values_to_push_project": [
+                    "counts",
+                    "sensitivity",
+                ],
+                "values_to_pull_project": [
+                    "exposure_factor",
+                ],
                 "nside": 16,
                 "nested": True,
             }
@@ -425,29 +433,24 @@ class TestUltraL2:
             )
 
     @pytest.mark.usefixtures("_setup_spice_kernels_list")
-    def test_ultra_l2_warning_for_push_and_pull(
+    def test_ultra_l2_error_for_push_and_pull(
         self, mock_data_dict, furnish_kernels, caplog
     ):
         map_structure = ena_maps.AbstractSkyMap.from_dict(
             {
                 "sky_tiling_type": "HEALPIX",
                 "spice_reference_frame": "ECLIPJ2000",
-                "values_to_push_project": ["counts", "sensitivity"],
-                "values_to_pull_project": ["sensitivity", "exposure_factor"],
+                "values_to_push_project": ["counts", "exposure_factor"],
+                "values_to_pull_project": ["exposure_factor", "sensitivity"],
                 "nside": 16,
                 "nested": True,
             }
         )
-        # A warning should be raised, since sensitivity is in both PUSH and PULL
+        # An error is expected when the same variable is in both the push/pull lists
         with furnish_kernels(self.required_kernel_names):
-            [
-                map_dataset,
-            ] = ultra_l2.ultra_l2(
-                data_dict=mock_data_dict,
-                data_version="001",
-                output_map_structure=map_structure,
-            )
-        assert (
-            "variables are present in both the PUSH and PULL projection lists"
-            in caplog.text
-        )
+            with pytest.raises(ValueError, match="Some variables are present in both"):
+                ultra_l2.ultra_l2(
+                    data_dict=mock_data_dict,
+                    data_version="001",
+                    output_map_structure=map_structure,
+                )

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -95,14 +95,14 @@ class TestUltraL2:
                     {
                         "sky_tiling_type": "HEALPIX",
                         "spice_reference_frame": map_frame,
-                        "projection_method_and_values": {
-                            "PUSH": [
-                                "counts",
-                                "exposure_factor",
-                                "sensitivity",
-                                "background_rates",
-                            ],
-                        },
+                        "values_to_push_project": [
+                            "counts",
+                            "sensitivity",
+                            "background_rates",
+                        ],
+                        "values_to_pull_project": [
+                            "exposure_factor",
+                        ],
                         "nside": 32,
                         "nested": False,
                     }
@@ -163,14 +163,12 @@ class TestUltraL2:
                         {
                             "sky_tiling_type": "RECTANGULAR",
                             "spice_reference_frame": "ECLIPJ2000",
-                            "projection_method_and_values": {
-                                "PUSH": [
-                                    "counts",
-                                    "exposure_factor",
-                                    "sensitivity",
-                                    "background_rates",
-                                ],
-                            },
+                            "values_to_push_project": [
+                                "counts",
+                                "sensitivity",
+                                "exposure_factor",
+                                "background_rates",
+                            ],
                             "spacing_deg": 2.0,
                         }
                     ),
@@ -189,7 +187,8 @@ class TestUltraL2:
         # The map should contain the following variables,
         # because we did not drop any variables
         expected_vars = (
-            ultra_l2.REQUIRED_L1C_VARIABLES
+            ultra_l2.REQUIRED_L1C_VARIABLES_PUSH
+            + ultra_l2.REQUIRED_L1C_VARIABLES_PULL
             + ultra_l2.VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION
             + ["ena_intensity", "ena_intensity_stat_unc"]
         )
@@ -216,9 +215,7 @@ class TestUltraL2:
             {
                 "sky_tiling_type": "HEALPIX",
                 "spice_reference_frame": "ECLIPJ2000",
-                "projection_method_and_values": {
-                    "PUSH": ["counts", "exposure_factor", "sensitivity"],
-                },
+                "values_to_push_project": ["counts", "sensitivity", "exposure_factor"],
                 "nside": 16,
                 "nested": True,
             }
@@ -426,3 +423,31 @@ class TestUltraL2:
                 attrs_with_energy_dependent_exposure["DEPEND_3"]
                 == CoordNames.ELEVATION_L2.value
             )
+
+    @pytest.mark.usefixtures("_setup_spice_kernels_list")
+    def test_ultra_l2_warning_for_push_and_pull(
+        self, mock_data_dict, furnish_kernels, caplog
+    ):
+        map_structure = ena_maps.AbstractSkyMap.from_dict(
+            {
+                "sky_tiling_type": "HEALPIX",
+                "spice_reference_frame": "ECLIPJ2000",
+                "values_to_push_project": ["counts", "sensitivity"],
+                "values_to_pull_project": ["sensitivity", "exposure_factor"],
+                "nside": 16,
+                "nested": True,
+            }
+        )
+        # A warning should be raised, since sensitivity is in both PUSH and PULL
+        with furnish_kernels(self.required_kernel_names):
+            [
+                map_dataset,
+            ] = ultra_l2.ultra_l2(
+                data_dict=mock_data_dict,
+                data_version="001",
+                output_map_structure=map_structure,
+            )
+        assert (
+            "variables are present in both the PUSH and PULL projection lists"
+            in caplog.text
+        )

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -246,7 +246,11 @@ class TestUltraL2:
                 "sky_tiling_type": "RECTANGULAR",
                 "spice_reference_frame": "ECLIPJ2000",
                 "projection_method_and_values": {
-                    "PUSH": ["counts", "exposure_factor", "sensitivity"],
+                    "values_to_push_project": [
+                        "counts",
+                        "exposure_factor",
+                        "sensitivity",
+                    ],
                 },
                 "spacing_deg": 10,  # Larger spacing for faster test
             }
@@ -256,7 +260,11 @@ class TestUltraL2:
                 "sky_tiling_type": "HEALPIX",
                 "spice_reference_frame": "ECLIPJ2000",
                 "projection_method_and_values": {
-                    "PUSH": ["counts", "exposure_factor", "sensitivity"],
+                    "values_to_push_project": [
+                        "counts",
+                        "exposure_factor",
+                        "sensitivity",
+                    ],
                 },
                 "nside": 16,
                 "nested": True,
@@ -451,6 +459,5 @@ class TestUltraL2:
             with pytest.raises(ValueError, match="Some variables are present in both"):
                 ultra_l2.ultra_l2(
                     data_dict=mock_data_dict,
-                    data_version="001",
                     output_map_structure=map_structure,
                 )

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -46,7 +46,7 @@ REQUIRED_L1C_VARIABLES_PUSH = [
     "counts",
     "sensitivity",
     "background_rates",
-    "observation_time",
+    "obs_date",
 ]
 REQUIRED_L1C_VARIABLES_PULL = [
     "exposure_factor",

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -22,9 +22,11 @@ DEFAULT_ULTRA_L2_MAP_STRUCTURE: ena_maps.RectangularSkyMap | ena_maps.HealpixSky
             "spice_reference_frame": "ECLIPJ2000",
             "values_to_push_project": [
                 "counts",
-                "exposure_factor",
                 "sensitivity",
                 "background_rates",
+            ],
+            "values_to_pull_project": [
+                "exposure_factor",
             ],
             "nside": 32,
             "nested": False,
@@ -40,11 +42,14 @@ DEFAULT_L2_HEALPIX_NESTED = False
 
 
 # These variables must always be present in each L1C dataset
-REQUIRED_L1C_VARIABLES = [
+REQUIRED_L1C_VARIABLES_PUSH = [
     "counts",
-    "exposure_factor",
     "sensitivity",
     "background_rates",
+    "observation_time",
+]
+REQUIRED_L1C_VARIABLES_PULL = [
+    "exposure_factor",
 ]
 
 # These variables are projected to the map as the mean of pointing set pixels value,
@@ -153,7 +158,7 @@ def generate_ultra_healpix_skymap(
     2. Iterate over the input pointing sets and read them into UltraPointingSet objects.
     3. For each pointing set, weight certain variables by exposure and solid angle of
     the pointing set pixels.
-    4. Project the pointing set values to the map using the push method.
+    4. Project the pointing set values to the map using the push/pull methods.
     5. Perform subsequent processing for weighted quantities at the SkyMap level
     (e.g., divide weighted quantities by their summed weights to
     get their weighted mean)
@@ -188,15 +193,28 @@ def generate_ultra_healpix_skymap(
     # Get full list of variables to push to the map: all requested variables plus
     # any which are required for L2 processing
     value_keys_to_push_project = list(
-        set(output_map_structure.values_to_push_project + REQUIRED_L1C_VARIABLES)
+        set(output_map_structure.values_to_push_project + REQUIRED_L1C_VARIABLES_PUSH)
     )
+    value_keys_to_pull_project = list(
+        set(output_map_structure.values_to_pull_project + REQUIRED_L1C_VARIABLES_PULL)
+    )
+    # If there are overlapping variable names, issue a warning
+    if set(value_keys_to_push_project).intersection(set(value_keys_to_pull_project)):
+        logger.warning(
+            "Some variables are present in both the PUSH and PULL projection lists."
+            "They will be projected in both ways (PUSH then PULL), which is likely "
+            "not the intended behavior. Please check the projection lists."
+            f"PUSH Variables: {value_keys_to_push_project} \n"
+            f"PULL Variables: {value_keys_to_pull_project}"
+        )
 
     for ultra_l1c_pset in ultra_l1c_psets:
         pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
         logger.info(
             f"Projecting a PointingSet with {pointing_set.num_points} pixels "
             f"at epoch:{pointing_set.epoch}\n"
-            f"These values will be projected: {value_keys_to_push_project}"
+            f"These values will be push projected: {value_keys_to_push_project}"
+            f"\nThese values will be pull projected: {value_keys_to_pull_project}",
         )
 
         pointing_set.data["num_pointing_set_pixel_members"] = xr.DataArray(
@@ -223,25 +241,24 @@ def generate_ultra_healpix_skymap(
             VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE
         ] *= pointing_set.data["pointing_set_exposure_times_solid_angle"]
 
+        # Project values such as counts via the PUSH method
         skymap.project_pset_values_to_map(
             pointing_set=pointing_set,
             value_keys=value_keys_to_push_project,
             index_match_method=ena_maps.IndexMatchMethod.PUSH,
         )
 
+        # Project values such as exposure_factor via the PULL method
+        skymap.project_pset_values_to_map(
+            pointing_set=pointing_set,
+            value_keys=value_keys_to_pull_project,
+            index_match_method=ena_maps.IndexMatchMethod.PULL,
+        )
+
     # Subsequent processing for weighted quantities at SkyMap level
     skymap.data_1d[VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE] /= (
         skymap.data_1d["pointing_set_exposure_times_solid_angle"]
     )
-
-    # TODO: Ask Ultra team about this - I think this is a decent
-    # but imperfect approximation for meaning the exposure:
-    # (dividing by the 1/(number of PSETs)) to fix the exposure being mean-ed over
-    # all pixels in all PSETs which feed into a map superpixel,
-    # rather than being mean-ed over pixels in a PSET and summed over PSETs
-    skymap.data_1d["exposure_factor"] /= skymap.data_1d[
-        "num_pointing_set_pixel_members"
-    ] / len(ultra_l1c_psets)
 
     # TODO: Ask Ultra team about background rates - I think they should increase when
     # binned to larger pixels, as I've done here, but that was never explicitly stated

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -151,6 +151,11 @@ def generate_ultra_healpix_skymap(
         HealpixSkyMap object containing the combined data from all pointing sets,
         with calculated ena_intensity and its statistical uncertainty values.
 
+    Raises
+    ------
+    ValueError
+        If there are overlapping variable names in the push and pull projection lists.
+
     Notes
     -----
     The structure of this function goes as follows:
@@ -198,9 +203,9 @@ def generate_ultra_healpix_skymap(
     value_keys_to_pull_project = list(
         set(output_map_structure.values_to_pull_project + REQUIRED_L1C_VARIABLES_PULL)
     )
-    # If there are overlapping variable names, issue a warning
+    # If there are overlapping variable names, raise an error
     if set(value_keys_to_push_project).intersection(set(value_keys_to_pull_project)):
-        logger.warning(
+        raise ValueError(
             "Some variables are present in both the PUSH and PULL projection lists. "
             "They will be projected in both ways (PUSH then PULL), which is likely "
             "not the intended behavior. Please check the projection lists."

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -197,20 +197,22 @@ def generate_ultra_healpix_skymap(
 
     # Get full list of variables to push to the map: all requested variables plus
     # any which are required for L2 processing
-    value_keys_to_push_project = list(
+    output_map_structure.values_to_push_project = list(
         set(output_map_structure.values_to_push_project + REQUIRED_L1C_VARIABLES_PUSH)
     )
-    value_keys_to_pull_project = list(
+    output_map_structure.values_to_pull_project = list(
         set(output_map_structure.values_to_pull_project + REQUIRED_L1C_VARIABLES_PULL)
     )
     # If there are overlapping variable names, raise an error
-    if set(value_keys_to_push_project).intersection(set(value_keys_to_pull_project)):
+    if set(output_map_structure.values_to_push_project).intersection(
+        set(output_map_structure.values_to_pull_project)
+    ):
         raise ValueError(
             "Some variables are present in both the PUSH and PULL projection lists. "
             "They will be projected in both ways (PUSH then PULL), which is likely "
             "not the intended behavior. Please check the projection lists."
-            f"PUSH Variables: {value_keys_to_push_project} \n"
-            f"PULL Variables: {value_keys_to_pull_project}"
+            f"PUSH Variables: {output_map_structure.values_to_push_project} \n"
+            f"PULL Variables: {output_map_structure.values_to_pull_project}"
         )
 
     for ultra_l1c_pset in ultra_l1c_psets:
@@ -218,8 +220,10 @@ def generate_ultra_healpix_skymap(
         logger.info(
             f"Projecting a PointingSet with {pointing_set.num_points} pixels "
             f"at epoch:{pointing_set.epoch}\n"
-            f"These values will be push projected: {value_keys_to_push_project}"
-            f"\nThese values will be pull projected: {value_keys_to_pull_project}",
+            "These values will be push projected: "
+            f">> {output_map_structure.values_to_push_project}"
+            "\nThese values will be pull projected: "
+            f">> {output_map_structure.values_to_pull_project}",
         )
 
         pointing_set.data["num_pointing_set_pixel_members"] = xr.DataArray(
@@ -249,14 +253,14 @@ def generate_ultra_healpix_skymap(
         # Project values such as counts via the PUSH method
         skymap.project_pset_values_to_map(
             pointing_set=pointing_set,
-            value_keys=value_keys_to_push_project,
+            value_keys=output_map_structure.values_to_push_project,
             index_match_method=ena_maps.IndexMatchMethod.PUSH,
         )
 
         # Project values such as exposure_factor via the PULL method
         skymap.project_pset_values_to_map(
             pointing_set=pointing_set,
-            value_keys=value_keys_to_pull_project,
+            value_keys=output_map_structure.values_to_pull_project,
             index_match_method=ena_maps.IndexMatchMethod.PULL,
         )
 

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -201,7 +201,7 @@ def generate_ultra_healpix_skymap(
     # If there are overlapping variable names, issue a warning
     if set(value_keys_to_push_project).intersection(set(value_keys_to_pull_project)):
         logger.warning(
-            "Some variables are present in both the PUSH and PULL projection lists."
+            "Some variables are present in both the PUSH and PULL projection lists. "
             "They will be projected in both ways (PUSH then PULL), which is likely "
             "not the intended behavior. Please check the projection lists."
             f"PUSH Variables: {value_keys_to_push_project} \n"


### PR DESCRIPTION
# Change Summary

Small PR to PULL `exposure_factor` data from PSETs, rather than pushing it. 

Closes #1675

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

Ultra L2: 
1. Add category of variables to PULL project, which must always include "exposure_factor"
2. Remove temporary, imperfect approximation for meaning the exposure. This is no longer necessary with PULL approach

- ultra_l2.py
  - Switch exposure to pull projection and remove old approximation for meaning exposure. 