### PR TITLE
Optionally energy-dependent `exposure_factor`

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -103,16 +103,6 @@ latitude:
 # Define Data variables, but not their pixel-level DEPENDs
 # (e.g. pixel_index for HEALPix maps, longitude/latitude for rectangular maps).
 # Those are defined in the tiling specific YAML files.
-exposure_factor:
-  <<: *default_float32
-  CATDESC: Exact or approximate exposure time over which counts in a pixel are accumulated.  Used as a weighting factor for combining data quantities sensibly.
-  FIELDNAM: Exposure Times
-  DEPEND_0: epoch
-  UNITS: s
-  VAR_TYPE: data
-  LABLAXIS: Exposure
-  DISPLAY_TYPE: no_plot
-
 ena_intensity:
   <<: *default_float32
   CATDESC: Mono-energetic ENA intensity.
@@ -145,7 +135,17 @@ sensitivity:
   LABLAXIS: sensitivity
   DISPLAY_TYPE: image
 
-obs_date:
+exposure_factor: &exposure_factor_energy_independent
+  <<: *default_float32
+  CATDESC: Exact or approximate exposure time over which counts in a pixel are accumulated.  Used as a weighting factor for combining data quantities sensibly.
+  FIELDNAM: Exposure Times
+  DEPEND_0: epoch
+  UNITS: s
+  VAR_TYPE: data
+  LABLAXIS: Exposure
+  DISPLAY_TYPE: no_plot
+
+obs_date: &obs_date_energy_independent
   <<: *default_int64
   datatype: int64
   CATDESC: Exposure time weighted mean collection date of data in a pixel.
@@ -155,3 +155,12 @@ obs_date:
   VAR_TYPE: data
   LABLAXIS: epoch
   DISPLAY_TYPE: image
+
+# These copied metadata vars will allow for variables
+# to be either energy-dependent or independent.
+# The tiling-specific YAML files will override the DEPENDs and LABL_PTRs.
+exposure_factor_energy_dependent:
+  <<: *exposure_factor_energy_independent
+
+obs_date_energy_dependent:
+  <<: *obs_date_energy_independent

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -137,7 +137,7 @@ sensitivity:
 
 exposure_factor: &exposure_factor_energy_independent
   <<: *default_float32
-  CATDESC: Exact or approximate exposure time over which counts in a pixel are accumulated.  Used as a weighting factor for combining data quantities sensibly.
+  CATDESC: Exact or approximate time over which counts are accumulated.
   FIELDNAM: Exposure Times
   DEPEND_0: epoch
   UNITS: s

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -68,6 +68,7 @@ sensitivity:
 
 # These data variables will have an extra (energy) dimension
 # only if the energy dimension is present in the L1C data.
+# The default is energy-independent.
 exposure_factor:
   DEPEND_1: pixel_index
   LABL_PTR_1: pixel_index_label

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -47,11 +47,6 @@ latitude:
   LABL_PTR_1: pixel_index_label
 
 # Define Data variables
-exposure_factor:
-  # TODO: add in energy dimension, at least for Heliosphereic frame
-  DEPEND_1: pixel_index
-  LABL_PTR_1: pixel_index_label
-
 ena_intensity:
   DEPEND_1: energy
   DEPEND_2: pixel_index
@@ -71,6 +66,24 @@ sensitivity:
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
 
+# These data variables will have an extra (energy) dimension
+# only if the energy dimension is present in the L1C data.
+exposure_factor:
+  DEPEND_1: pixel_index
+  LABL_PTR_1: pixel_index_label
+
 obs_date:
   DEPEND_1: pixel_index
   LABL_PTR_1: pixel_index_label
+
+exposure_factor_energy_dependent:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
+
+obs_date_energy_dependent:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -55,13 +55,6 @@ latitude:
   SCALE_TYP: linear
 
 # Define Data variables
-exposure_factor:
-  # TODO: add in energy dimension, at least for Heliosphereic frame
-  DEPEND_1: longitude
-  DEPEND_2: latitude
-  LABL_PTR_1: longitude_label
-  LABL_PTR_2: latitude_label
-
 ena_intensity:
   DEPEND_1: energy
   DEPEND_2: longitude
@@ -86,8 +79,32 @@ sensitivity:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
+# These data variables will have an extra (energy) dimension
+# only if the energy dimension is present in the L1C data.
+exposure_factor:
+  DEPEND_1: longitude
+  DEPEND_2: latitude
+  LABL_PTR_1: longitude_label
+  LABL_PTR_2: latitude_label
+
 obs_date:
   DEPEND_1: longitude
   DEPEND_2: latitude
   LABL_PTR_1: longitude_label
   LABL_PTR_2: latitude_label
+
+exposure_factor_energy_dependent:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+obs_date_energy_dependent:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -81,6 +81,7 @@ sensitivity:
 
 # These data variables will have an extra (energy) dimension
 # only if the energy dimension is present in the L1C data.
+# The default is energy-independent.
 exposure_factor:
   DEPEND_1: longitude
   DEPEND_2: latitude

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -66,6 +66,62 @@ VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION = [
     "corrected_count_rate",
 ]
 
+# These variables may or may not be energy dependent, depending on the
+# input data. They must be handled slightly differently when it comes to adding
+# metadata to the map dataset.
+INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES = ["obs_date", "exposure_factor"]
+
+
+def get_variable_attributes_optional_energy_dependence(
+    cdf_attrs: ImapCdfAttributes,
+    variable_array: xr.DataArray,
+    *,
+    check_schema: bool = True,
+) -> dict:
+    """
+    Wrap `get_variable_attributes` to handle optionally energy-dependent vars.
+
+    Several variables are only energy dependent in some cases (input PSET dependent).
+    The metadata on those variables must be handled differently in such cases.
+
+    Parameters
+    ----------
+    cdf_attrs : ImapCdfAttributes
+        The CDF attributes object to use for getting variable attributes.
+    variable_array : xr.DataArray
+        The xarray DataArray containing the variable data and dims.
+        Must have a name attribute.
+    check_schema : bool
+        Flag to bypass schema validation.
+
+    Returns
+    -------
+    dict
+        The attributes for the variable.
+    """
+    variable_name = variable_array.name
+    variable_dims = variable_array.dims
+
+    # Even if we will override with the energy-dependent metadata, begin by
+    # getting the metadata for the energy-independent variable.
+    metadata = cdf_attrs.get_variable_attributes(
+        variable_name=variable_name,
+        check_schema=check_schema,
+    )
+    if (variable_name in INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES) and (
+        "energy" in variable_dims
+    ):
+        # These are overrides which only affect the latter DEPEND_N and LABL_PTR_N
+        # They do not cover all the metadata values so we will not
+        # use the schema validation.
+        metadata.update(
+            cdf_attrs.get_variable_attributes(
+                variable_name=f"{variable_name}_energy_dependent",
+                check_schema=False,
+            )
+        )
+    return metadata
+
 
 def generate_ultra_healpix_skymap(
     ultra_l1c_psets: list[str | xr.Dataset],
@@ -153,9 +209,13 @@ def generate_ultra_healpix_skymap(
             np.ones(pointing_set.num_points, dtype=int),
             dims=(CoordNames.HEALPIX_INDEX.value),
         )
-        pointing_set.data["obs_date"] = xr.DataArray(
-            np.full((1, pointing_set.num_points), pointing_set.epoch),
-            dims=(CoordNames.TIME.value, CoordNames.HEALPIX_INDEX.value),
+
+        # The obs_date is the same for all pixels in a pointing set, and the same
+        # dimension as the exposure_factor.
+        pointing_set.data["obs_date"] = xr.full_like(
+            pointing_set.data["exposure_factor"],
+            fill_value=pointing_set.epoch,
+            dtype=np.int64,
         )
         # Add solid_angle * exposure of pointing set as data_var
         # so this quantity is projected to map pixels for use in weighted averaging
@@ -405,8 +465,9 @@ def ultra_l2(
         # The longitude and latitude variables will be present only in Healpix tiled
         # map, and, as support_data, should not have schema validation
         map_dataset[variable].attrs.update(
-            cdf_attrs.get_variable_attributes(
-                variable_name=variable,
+            get_variable_attributes_optional_energy_dependence(
+                cdf_attrs=cdf_attrs,
+                variable_array=map_dataset[variable],
                 check_schema=variable
                 not in ["longitude", "latitude", "longitude_delta", "latitude_delta"],
             )

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -102,24 +102,18 @@ def get_variable_attributes_optional_energy_dependence(
     variable_name = variable_array.name
     variable_dims = variable_array.dims
 
-    # Even if we will override with the energy-dependent metadata, begin by
-    # getting the metadata for the energy-independent variable.
+    # These variables must get metadata with a different key if they are energy
+    # dependent.
+    if (variable_name in INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES) and (
+        (CoordNames.ENERGY_L2.value in variable_dims)
+        or (CoordNames.ENERGY_ULTRA_L1C.value in variable_dims)
+    ):
+        variable_name = f"{variable_name}_energy_dependent"
+
     metadata = cdf_attrs.get_variable_attributes(
         variable_name=variable_name,
         check_schema=check_schema,
     )
-    if (variable_name in INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES) and (
-        "energy" in variable_dims
-    ):
-        # These are overrides which only affect the latter DEPEND_N and LABL_PTR_N
-        # They do not cover all the metadata values so we will not
-        # use the schema validation.
-        metadata.update(
-            cdf_attrs.get_variable_attributes(
-                variable_name=f"{variable_name}_energy_dependent",
-                check_schema=False,
-            )
-        )
     return metadata
 
 


### PR DESCRIPTION
# Change Summary

Adapt Ultra L2 metadata and observation date calculation to handle exposure_factor with and without an energy dimension. 

Closes #1691

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

In the case of the heliosphere frame PSETs, the "exposure_factor" variable will have dims=("epoch", **"energy_..."**,"pixel_index") while the spacecraft frame is not energy dependent, and will have dims=("epoch","pixel_index"). This needs to be handled properly in Ultra L2, especially by handling the metadata differently between the two cases.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
-  imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
-  imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
   - Add overwrites for `exposure_factor_energy_dependent` and `obs_date_energy_dependent`'s LABL_PTRs and DEPENDs
-  imap_processing/ultra/l2/ultra_l2.py
   - Add wrapper function to get metadata on vars with optional energy dependence. 
     - These variables must take in the energy independent metadata, and overwrite their DEPENDs and LABL_PTRs
-  imap_processing/tests/ultra/mock_data.py
   - Mock the exposure_factor either with/out energy dependence. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Test new function. 