### PR TITLE
Add a query to check if the file exists pre-upload

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -22,6 +22,7 @@ from typing import final
 
 import imap_data_access
 import xarray as xr
+from imap_data_access import ScienceFilePath
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
 )
@@ -341,6 +342,11 @@ class ProcessInstrument(ABC):
         A flag indicating whether to upload the output file to the SDC.
     """
 
+    class ImapFileExistsError(Exception):
+        """Indicates a failure because the files already exist."""
+
+        pass
+
     def __init__(
         self,
         data_level: str,
@@ -372,6 +378,26 @@ class ProcessInstrument(ABC):
             A list of file paths to upload to the SDC.
         """
         if self.upload_to_sdc:
+            # Validate that the files don't already exist
+            for filename in products:
+                file_path = ScienceFilePath(filename)
+                existing_file = imap_data_access.query(
+                    instrument=file_path.instrument,
+                    data_level=file_path.data_level,
+                    descriptor=file_path.descriptor,
+                    start_date=file_path.start_date,
+                    end_date=file_path.start_date,
+                    repointing=file_path.repointing,
+                    version=file_path.version,
+                    extension="cdf",
+                )
+                if existing_file:
+                    raise ProcessInstrument.ImapFileExistsError(
+                        f"File {filename} already exists in the IMAP SDC. "
+                        "No files were uploaded."
+                        f"Generated files: {products}."
+                    )
+
             if len(products) == 0:
                 logger.info("No files to upload.")
             for filename in products:

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -251,12 +251,12 @@ def test_ultra_l1a(mock_ultra_l1a, mock_instrument_dependencies):
         '[{"type": "science","files": ["imap_ultra_l0_raw_20240207_v001.pkts"]}]'
     )
     instrument = Ultra(
-        "l1a", "raw", dependency_str, "20240207", "20240208", "v001", True
+        "l1a", "raw", dependency_str, "20240207", "20240208", "v001", False
     )
 
     instrument.process()
     assert mock_ultra_l1a.call_count == 1
-    assert mocks["mock_upload"].call_count == 2
+    assert mock_instrument_dependencies["mock_write_cdf"].call_count == 2
 
 
 @mock.patch("imap_processing.cli.ultra_l1b.ultra_l1b")

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -15,6 +15,7 @@ from imap_processing.cli import (
     Glows,
     Hi,
     Hit,
+    ProcessInstrument,
     Spacecraft,
     Swe,
     Ultra,
@@ -134,11 +135,12 @@ def test_codice(mock_codice_l1a, mock_instrument_dependencies):
         '[{"type": "science","files": ["imap_codice_l0_raw_20230822_v001.pkts"]}]'
     )
 
-    instrument = Codice("l1a", "hskp", dependency_str, "20230822", None, "v001", True)
+    instrument = Codice("l1a", "hskp", dependency_str, "20230822", None, "v001", False)
 
     instrument.process()
     assert mock_codice_l1a.call_count == 1
-    assert mocks["mock_upload"].call_count == 1
+    # Assert that write_cdf was called with the expected arguments
+    assert mock_instrument_dependencies["mock_write_cdf"].call_count == 1
 
 
 def test_repointing_file_creation(mock_instrument_dependencies):
@@ -198,12 +200,12 @@ def test_hi_l1(mock_instrument_dependencies, data_level, science_input, n_prods)
             '[{"type": "science","files": ["imap_hi_l0_raw_20231212_v001.pkts"]}]'
         )
         instrument = Hi(
-            data_level, "sci", dependency_str, "20231212", "20231213", "v005", True
+            data_level, "sci", dependency_str, "20231212", "20231213", "v005", False
         )
 
         instrument.process()
         assert mock_hi.call_count == 1
-        assert mocks["mock_upload"].call_count == n_prods
+        assert mock_instrument_dependencies["mock_write_cdf"].call_count == n_prods
 
 
 @mock.patch("imap_processing.cli.quaternions.process_quaternions", autospec=True)
@@ -226,12 +228,12 @@ def test_spacecraft(mock_spacecraft_l1a, mock_instrument_dependencies):
     )
 
     instrument = Spacecraft(
-        "l1a", "quaternions", dependency_str, "20230822", "20230822", "v001", True
+        "l1a", "quaternions", dependency_str, "20230822", "20230822", "v001", False
     )
 
     instrument.process()
     assert mock_spacecraft_l1a.call_count == 1
-    assert mocks["mock_upload"].call_count == 1
+    assert mock_instrument_dependencies["mock_write_cdf"].call_count == 1
 
 
 @mock.patch("imap_processing.cli.ultra_l1a.ultra_l1a")
@@ -269,12 +271,12 @@ def test_ultra_l1b(mock_ultra_l1b, mock_instrument_dependencies):
     )
     mocks["mock_pre_processing"].return_value = input_collection
 
-    instrument = Ultra("l1b", "de", "[]", "20240207", "20240208", "v001", True)
+    instrument = Ultra("l1b", "de", "[]", "20240207", "20240208", "v001", False)
 
     instrument.process()
     assert mocks["mock_download"].call_count == 0
     assert mock_ultra_l1b.call_count == 1
-    assert mocks["mock_upload"].call_count == 2
+    assert mock_instrument_dependencies["mock_write_cdf"].call_count == 2
 
 
 @mock.patch("imap_processing.cli.ultra_l1c.ultra_l1c")
@@ -288,11 +290,11 @@ def test_ultra_l1c(mock_ultra_l1c, mock_instrument_dependencies):
     )
     mocks["mock_pre_processing"].return_value = input_collection
 
-    instrument = Ultra("l1c", "pset", "[]", "20240207", "20240208", "v001", True)
+    instrument = Ultra("l1c", "pset", "[]", "20240207", "20240208", "v001", False)
 
     instrument.process()
     assert mock_ultra_l1c.call_count == 1
-    assert mocks["mock_upload"].call_count == 2
+    assert mock_instrument_dependencies["mock_write_cdf"].call_count == 2
 
 
 @mock.patch("imap_processing.cli.hit_l1a")
@@ -309,18 +311,43 @@ def test_hit_l1a(mock_hit_l1a, mock_instrument_dependencies):
     dependency_str = (
         '[{"type": "science","files": ["imap_hit_l0_raw_20100105_v001.pkts"]}]'
     )
-    instrument = Hit("l1a", "raw", dependency_str, "20100105", "20100101", "v001", True)
+    instrument = Hit(
+        "l1a", "raw", dependency_str, "20100105", "20100101", "v001", False
+    )
 
     instrument.process()
     assert mock_hit_l1a.call_count == 1
-    assert mocks["mock_upload"].call_count == 2
+    assert mock_instrument_dependencies["mock_write_cdf"].call_count == 2
 
 
 @mock.patch("imap_processing.cli.swe_l1a")
-def test_post_processing(mock_swe_l1a, mock_instrument_dependencies):
+@pytest.mark.parametrize(
+    "query_return, expected_error",
+    [
+        ([], None),
+        (
+            [
+                '{"file_path": '
+                '"/path/to/imap_swe_l1a_test_20100105_v001.cdf", "instrument": "swe"}'
+            ],
+            ProcessInstrument.ImapFileExistsError,
+        ),
+    ],
+)
+def test_post_processing(
+    mock_swe_l1a, mock_instrument_dependencies, query_return, expected_error
+):
     """Test coverage for post processing"""
     mocks = mock_instrument_dependencies
     mocks["mock_download"].return_value = "dependency0"
+    mocks["mock_write_cdf"].side_effect = [
+        "/path/to/imap_swe_l1a_test_20100105_v001.cdf"
+    ]
+    mocks[
+        "mock_write_cdf"
+    ].return_value = "/path/to/imap_swe_l1a_test_20100105_v001.cdf"
+    mocks["mock_query"].return_value = query_return
+
     test_ds = xr.Dataset()
     mock_swe_l1a.return_value = [test_ds]
     input_collection = ProcessingInputCollection(
@@ -333,12 +360,16 @@ def test_post_processing(mock_swe_l1a, mock_instrument_dependencies):
     )
     instrument = Swe("l1a", "raw", dependency_str, "20100105", None, "v001", True)
 
-    # This function calls both the instrument.do_processing() and
-    # instrument.post_processing()
-    instrument.process()
-    assert mock_swe_l1a.call_count == 1
-    # This test is testing that one file was uploaded
-    assert mocks["mock_upload"].call_count == 1
+    if expected_error:
+        with pytest.raises(expected_error):
+            instrument.process()
+    else:
+        # This function calls both the instrument.do_processing() and
+        # instrument.post_processing()
+        instrument.process()
+        assert mock_swe_l1a.call_count == 1
+        # This test is testing that one file was uploaded
+        assert mocks["mock_upload"].call_count == 1
 
     # Test parent injection
     assert test_ds.attrs["Parents"] == ["imap_swe_l0_raw_20100105_v001.pkts"]


### PR DESCRIPTION
# Change Summary
We were having infra errors all over the place with this bug. This makes it so if ANY of the files that are attempting upload already exist, we raise an error and don't upload ANY of them. This way we don't get partial file uploads with a failed processing job. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Add a check prior to upload to see if the file exists already.

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
All the unit tests mocked an upload and tested it. Instead, I tested that they call "write_cdf". now, test_post_processing is the only place where we check if the file is uploaded, and it checks either case. 