### PR TITLE
Ultra l1c - cdf updates

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -64,6 +64,14 @@ default_float32_attrs: &default_float32
   VALIDMAX: 3.4028235e+38
   dtype: float32
 
+default_float64_attrs: &default_float64
+  <<: *default
+  FILLVAL: -1.0e31
+  FORMAT: F10.2
+  VALIDMIN: -1.7976931348623157e+308
+  VALIDMAX: 1.7976931348623157e+308
+  dtype: float64
+
 x_front:
   <<: *default_float32
   CATDESC: x front position

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -185,6 +185,15 @@ def _test_data_paths():
             / "idex_l1b_validation_file.h5",
         ),
         (
+            "imap_ultra_l1b_45sensor-de_20240207_v999.cdf",
+            imap_module_directory
+            / "tests"
+            / "ultra"
+            / "data"
+            / "l1"
+            / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf",
+        ),
+        (
             "ultra-90_raw_event_data_shortened.csv",
             imap_module_directory
             / "tests"

--- a/imap_processing/tests/ultra/unit/test_badtimes.py
+++ b/imap_processing/tests/ultra/unit/test_badtimes.py
@@ -56,3 +56,51 @@ def test_calculate_badtimes():
     assert not np.any(
         np.isin(culling_ds["spin_number"].values, badtimes_ds["spin_number"].values)
     )
+
+
+def test_calculate_badtimes_empty():
+    """Test calculate_badtimes when all spins are culled (empty case)."""
+
+    spin_numbers = np.array([0, 1, 2])
+    energy_bins = np.array([10, 20, 30])
+    spin_start_time = np.array([0, 1, 2])
+
+    quality_attitude = np.full(
+        spin_numbers.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
+    )
+
+    quality_ena_rates = np.full(
+        (len(energy_bins), len(spin_numbers)),
+        ImapRatesUltraFlags.ZEROCOUNTS.value | ImapRatesUltraFlags.HIGHRATES.value,
+        dtype=np.uint16,
+    )
+
+    ds = xr.Dataset(
+        {
+            "epoch": np.array([0, 1, 2], dtype="datetime64[ns]"),
+            "quality_attitude": (("spin_number",), quality_attitude),
+            "quality_ena_rates": (
+                ("energy_bin_geometric_mean", "spin_number"),
+                quality_ena_rates,
+            ),
+            "spin_start_time": (("spin_number",), spin_start_time),
+        },
+        coords={
+            "spin_number": spin_numbers,
+            "energy_bin_geometric_mean": energy_bins,
+        },
+    )
+
+    badtimes_ds = calculate_badtimes(
+        ds,
+        spin_numbers,
+        name="imap_ultra_l1b_45sensor-badtimes",
+    )
+
+    assert badtimes_ds["spin_number"].values[0] == 4294967295
+    assert badtimes_ds["spin_start_time"].values[0] == -1.0e31
+    assert badtimes_ds["spin_period"].values[0] == -1.0e31
+    assert badtimes_ds["spin_rate"].values[0] == -1.0e31
+    assert badtimes_ds["quality_attitude"].values[0] == 65535
+    assert np.all(badtimes_ds["ena_rates"].values == -1.0e31)
+    assert np.all(badtimes_ds["quality_ena_rates"].values == 65535)

--- a/imap_processing/tests/ultra/unit/test_cullingmask.py
+++ b/imap_processing/tests/ultra/unit/test_cullingmask.py
@@ -87,3 +87,50 @@ def test_calculate_cullingmask_rates():
 
     expected_spins = np.array([0, 1])
     np.testing.assert_array_equal(result_ds["spin_number"].values, expected_spins)
+
+
+def test_calculate_cullingmask_empty():
+    """Test calculate_cullingmask when all spins are culled (empty case)."""
+
+    spin_numbers = np.array([0, 1, 2])
+    energy_bins = np.array([10, 20, 30])
+    spin_start_time = np.array([0, 1, 2])
+
+    quality_attitude = np.full(
+        spin_numbers.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
+    )
+
+    quality_ena_rates = np.full(
+        (len(energy_bins), len(spin_numbers)),
+        ImapRatesUltraFlags.ZEROCOUNTS.value | ImapRatesUltraFlags.HIGHRATES.value,
+        dtype=np.uint16,
+    )
+
+    ds = xr.Dataset(
+        {
+            "epoch": np.array([0, 1, 2], dtype="datetime64[ns]"),
+            "quality_attitude": (("spin_number",), quality_attitude),
+            "quality_ena_rates": (
+                ("energy_bin_geometric_mean", "spin_number"),
+                quality_ena_rates,
+            ),
+            "spin_start_time": (("spin_number",), spin_start_time),
+        },
+        coords={
+            "spin_number": spin_numbers,
+            "energy_bin_geometric_mean": energy_bins,
+        },
+    )
+
+    cullingmask_ds = calculate_cullingmask(
+        ds,
+        name="imap_ultra_l1b_45sensor-cullingmask",
+    )
+
+    assert cullingmask_ds["spin_number"].values[0] == 4294967295
+    assert cullingmask_ds["spin_start_time"].values[0] == -1.0e31
+    assert cullingmask_ds["spin_period"].values[0] == -1.0e31
+    assert cullingmask_ds["spin_rate"].values[0] == -1.0e31
+    assert cullingmask_ds["quality_attitude"].values[0] == 65535
+    assert np.all(cullingmask_ds["ena_rates"].values == -1.0e31)
+    assert np.all(cullingmask_ds["quality_ena_rates"].values == 65535)

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -4,9 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from imap_processing.ultra.constants import UltraConstants
-from imap_processing.cdf.utils import load_cdf
 from imap_processing import imap_module_directory
+from imap_processing.cdf.utils import load_cdf
+from imap_processing.ultra.constants import UltraConstants
 
 TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -5,6 +5,10 @@ import pandas as pd
 import pytest
 
 from imap_processing.ultra.constants import UltraConstants
+from imap_processing.cdf.utils import load_cdf
+from imap_processing import imap_module_directory
+
+TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 
 @pytest.fixture
@@ -17,10 +21,12 @@ def df_filt(de_dataset, events_fsw_comparison_theta_0):
     return df_filt
 
 
-def test_calculate_de(l1b_de_dataset, df_filt):
+@pytest.mark.external_test_data
+def test_calculate_de(df_filt):
     """Tests calculate_de function."""
 
-    l1b_de_dataset = l1b_de_dataset[0]
+    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset = load_cdf(l1b_de_dataset_path)
     l1b_de_dataset = l1b_de_dataset.where(
         l1b_de_dataset["start_type"] != 255, drop=True
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -70,7 +70,8 @@ def test_cdf_aux(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
 
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_AUX.apid[0])
-    test_data_path = write_cdf(test_data[0])
+    test_data[0].attrs["Data_version"] = "v999"
+    test_data_path = write_cdf(test_data[0], istp=True)
 
     assert test_data_path.exists()
     assert test_data_path.name == "imap_ultra_l1a_45sensor-aux_20240207_v999.cdf"
@@ -79,6 +80,7 @@ def test_cdf_aux(ccsds_path_theta_0):
 def test_cdf_rates(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_RATES.apid[0])
+    test_data[0].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(test_data[0], istp=False)
 
     assert test_data_path.exists()
@@ -88,7 +90,8 @@ def test_cdf_rates(ccsds_path_theta_0):
 def test_cdf_tof(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_TOF.apid[0])
-    test_data_path = write_cdf(test_data[0])
+    test_data[0].attrs["Data_version"] = "v999"
+    test_data_path = write_cdf(test_data[0], istp=True)
     assert test_data_path.exists()
     assert (
         test_data_path.name
@@ -99,7 +102,8 @@ def test_cdf_tof(ccsds_path_theta_0):
 def test_cdf_events(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_EVENTS.apid[0])
-    test_data_path = write_cdf(test_data[0], istp=False)
+    test_data[0].attrs["Data_version"] = "v999"
+    test_data_path = write_cdf(test_data[0], istp=True)
 
     assert test_data_path.exists()
     assert test_data_path.name == "imap_ultra_l1a_45sensor-de_20240207_v999.cdf"

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -108,6 +108,7 @@ def test_ultra_l1b(l1b_de_dataset):
 
 def test_cdf_de(l1b_de_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
+    l1b_de_dataset[0].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(l1b_de_dataset[0], istp=True)
     assert test_data_path.exists()
     assert test_data_path.name == "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
@@ -132,6 +133,7 @@ def test_ultra_l1b_extendedspin(l1b_extendedspin_dataset):
 
 def test_cdf_extendedspin(l1b_extendedspin_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
+    l1b_extendedspin_dataset[0].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[0], istp=True)
     assert test_data_path.exists()
     assert (
@@ -141,6 +143,7 @@ def test_cdf_extendedspin(l1b_extendedspin_dataset):
 
 def test_cdf_cullingmask(l1b_extendedspin_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
+    l1b_extendedspin_dataset[1].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[1], istp=True)
     assert test_data_path.exists()
     assert (
@@ -150,6 +153,7 @@ def test_cdf_cullingmask(l1b_extendedspin_dataset):
 
 def test_cdf_badtimes(l1b_extendedspin_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
+    l1b_extendedspin_dataset[2].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[2], istp=True)
     assert test_data_path.exists()
     assert test_data_path.name == "imap_ultra_l1b_45sensor-badtimes_20240207_v999.cdf"

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -204,6 +204,7 @@ def test_cdf_extendedspin(use_fake_spin_data_for_time, faux_aux_dataset, rates_d
     )
 
 
+@pytest.mark.external_test_data
 def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
     use_fake_spin_data_for_time(0, 141 * 15)
@@ -230,6 +231,7 @@ def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_da
     )
 
 
+@pytest.mark.external_test_data
 def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
     use_fake_spin_data_for_time(0, 141 * 15)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -1,10 +1,15 @@
+from unittest import mock
+
 import numpy as np
 import pytest
 import xarray as xr
 
-from imap_processing.cdf.utils import write_cdf
+from imap_processing import imap_module_directory
+from imap_processing.cdf.utils import load_cdf, write_cdf
 from imap_processing.ultra.l1b.ultra_l1b import ultra_l1b
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
+
+TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 
 @pytest.fixture
@@ -95,27 +100,68 @@ def test_create_de_dataset(mock_data_l1b_de_dict):
     np.testing.assert_array_equal(dataset["x_front"], np.zeros(3))
 
 
-def test_ultra_l1b(l1b_de_dataset):
-    """Tests that L1b data is created."""
+@pytest.mark.external_test_data
+@mock.patch("imap_processing.ultra.l1b.de.get_annotated_particle_velocity")
+def test_cdf_de(
+    mock_get_annotated_particle_velocity, de_dataset, use_fake_spin_data_for_time
+):
+    """Tests that CDF file is created and contains same attributes as xarray."""
 
-    assert len(l1b_de_dataset) == 1
+    data_dict = {}
+    data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
+    # Create a spin table that cover spin 0-141
+    use_fake_spin_data_for_time(0, 141 * 15)
+
+    # Mock get_annotated_particle_velocity to avoid needing kernels
+    def side_effect_func(event_times, position, ultra_frame, dps_frame, sc_frame):
+        """
+        Mock behavior of get_annotated_particle_velocity.
+
+        Returns NaN-filled arrays matching the expected output shape.
+        """
+        num_events = event_times.size
+        return (
+            np.full((num_events, 3), np.nan),  # sc_velocity
+            np.full((num_events, 3), np.nan),  # sc_dps_velocity
+            np.full((num_events, 3), np.nan),  # helio_velocity
+        )
+
+    mock_get_annotated_particle_velocity.side_effect = side_effect_func
+
+    l1b_de_dataset = ultra_l1b(data_dict)
 
     assert (
         l1b_de_dataset[0].attrs["Logical_source_description"]
         == "IMAP-Ultra Instrument Level-1B Direct Event Data."
     )
 
-
-def test_cdf_de(l1b_de_dataset):
-    """Tests that CDF file is created and contains same attributes as xarray."""
     l1b_de_dataset[0].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(l1b_de_dataset[0], istp=True)
     assert test_data_path.exists()
     assert test_data_path.name == "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
 
 
-def test_ultra_l1b_extendedspin(l1b_extendedspin_dataset):
+@pytest.mark.external_test_data
+def test_ultra_l1b_extendedspin(
+    use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset
+):
     """Tests that L1b data is created."""
+    use_fake_spin_data_for_time(0, 141 * 15)
+    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset = load_cdf(l1b_de_dataset_path)
+
+    data_dict = {
+        key: l1b_de_dataset
+        for key in [
+            "imap_ultra_l1b_45sensor-de",
+            "imap_ultra_l1a_45sensor-hk",
+            "imap_ultra_l1a_45sensor-params",
+        ]
+    }
+    data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+
+    l1b_extendedspin_dataset = ultra_l1b(data_dict)
 
     assert len(l1b_extendedspin_dataset) == 3
 
@@ -131,7 +177,24 @@ def test_ultra_l1b_extendedspin(l1b_extendedspin_dataset):
         )
 
 
-def test_cdf_extendedspin(l1b_extendedspin_dataset):
+@pytest.mark.external_test_data
+def test_cdf_extendedspin(use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset):
+    use_fake_spin_data_for_time(0, 141 * 15)
+    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset = load_cdf(l1b_de_dataset_path)
+
+    data_dict = {
+        key: l1b_de_dataset
+        for key in [
+            "imap_ultra_l1b_45sensor-de",
+            "imap_ultra_l1a_45sensor-hk",
+            "imap_ultra_l1a_45sensor-params",
+        ]
+    }
+    data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+
+    l1b_extendedspin_dataset = ultra_l1b(data_dict)
     """Tests that CDF file is created and contains same attributes as xarray."""
     l1b_extendedspin_dataset[0].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[0], istp=True)
@@ -141,8 +204,24 @@ def test_cdf_extendedspin(l1b_extendedspin_dataset):
     )
 
 
-def test_cdf_cullingmask(l1b_extendedspin_dataset):
+def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
+    use_fake_spin_data_for_time(0, 141 * 15)
+    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset = load_cdf(l1b_de_dataset_path)
+
+    data_dict = {
+        key: l1b_de_dataset
+        for key in [
+            "imap_ultra_l1b_45sensor-de",
+            "imap_ultra_l1a_45sensor-hk",
+            "imap_ultra_l1a_45sensor-params",
+        ]
+    }
+    data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+
+    l1b_extendedspin_dataset = ultra_l1b(data_dict)
     l1b_extendedspin_dataset[1].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[1], istp=True)
     assert test_data_path.exists()
@@ -151,8 +230,24 @@ def test_cdf_cullingmask(l1b_extendedspin_dataset):
     )
 
 
-def test_cdf_badtimes(l1b_extendedspin_dataset):
+def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
+    use_fake_spin_data_for_time(0, 141 * 15)
+    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset = load_cdf(l1b_de_dataset_path)
+
+    data_dict = {
+        key: l1b_de_dataset
+        for key in [
+            "imap_ultra_l1b_45sensor-de",
+            "imap_ultra_l1a_45sensor-hk",
+            "imap_ultra_l1a_45sensor-params",
+        ]
+    }
+    data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
+    data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+
+    l1b_extendedspin_dataset = ultra_l1b(data_dict)
     l1b_extendedspin_dataset[2].attrs["Data_version"] = "v999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[2], istp=True)
     assert test_data_path.exists()

--- a/imap_processing/ultra/l1b/badtimes.py
+++ b/imap_processing/ultra/l1b/badtimes.py
@@ -6,6 +6,10 @@ from numpy.typing import NDArray
 
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
+FILLVAL_UINT16 = 65535
+FILLVAL_FLOAT64 = -1.0e31
+FILLVAL_UINT32 = 4294967295
+
 
 def calculate_badtimes(
     extendedspin_dataset: xr.Dataset,
@@ -36,5 +40,25 @@ def calculate_badtimes(
     filtered_dataset = extendedspin_dataset.sel(spin_number=culled_spins)
 
     badtimes_dataset = create_dataset(filtered_dataset, name, "l1b")
+
+    if badtimes_dataset["spin_number"].size == 0:
+        badtimes_dataset = badtimes_dataset.drop_dims("spin_number")
+        badtimes_dataset = badtimes_dataset.expand_dims(spin_number=[FILLVAL_UINT32])
+        badtimes_dataset["spin_start_time"] = np.array(
+            [FILLVAL_FLOAT64], dtype="float64"
+        )
+        badtimes_dataset["spin_period"] = np.array([FILLVAL_FLOAT64], dtype="float64")
+        badtimes_dataset["spin_rate"] = np.array([FILLVAL_FLOAT64], dtype="float64")
+        badtimes_dataset["quality_attitude"] = np.array(
+            [FILLVAL_UINT16], dtype="uint16"
+        )
+        badtimes_dataset["quality_ena_rates"] = (
+            ("energy_bin_geometric_mean", "spin_number"),
+            np.full((3, 1), FILLVAL_UINT16, dtype="uint16"),
+        )
+        badtimes_dataset["ena_rates"] = (
+            ("energy_bin_geometric_mean", "spin_number"),
+            np.full((3, 1), FILLVAL_FLOAT64, dtype="float64"),
+        )
 
     return badtimes_dataset

--- a/imap_processing/ultra/l1b/cullingmask.py
+++ b/imap_processing/ultra/l1b/cullingmask.py
@@ -1,9 +1,14 @@
 """Calculate Culling Mask."""
 
+import numpy as np
 import xarray as xr
 
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
+
+FILLVAL_UINT16 = 65535
+FILLVAL_FLOAT64 = -1.0e31
+FILLVAL_UINT32 = 4294967295
 
 
 def calculate_cullingmask(extendedspin_dataset: xr.Dataset, name: str) -> xr.Dataset:
@@ -44,5 +49,29 @@ def calculate_cullingmask(extendedspin_dataset: xr.Dataset, name: str) -> xr.Dat
     )
 
     cullingmask_dataset = create_dataset(filtered_dataset, name, "l1b")
+
+    if cullingmask_dataset["spin_number"].size == 0:
+        cullingmask_dataset = cullingmask_dataset.drop_dims("spin_number")
+        cullingmask_dataset = cullingmask_dataset.expand_dims(
+            spin_number=[FILLVAL_UINT32]
+        )
+        cullingmask_dataset["spin_start_time"] = np.array(
+            [FILLVAL_FLOAT64], dtype="float64"
+        )
+        cullingmask_dataset["spin_period"] = np.array(
+            [FILLVAL_FLOAT64], dtype="float64"
+        )
+        cullingmask_dataset["spin_rate"] = np.array([FILLVAL_FLOAT64], dtype="float64")
+        cullingmask_dataset["quality_attitude"] = np.array(
+            [FILLVAL_UINT16], dtype="uint16"
+        )
+        cullingmask_dataset["quality_ena_rates"] = (
+            ("energy_bin_geometric_mean", "spin_number"),
+            np.full((3, 1), FILLVAL_UINT16, dtype="uint16"),
+        )
+        cullingmask_dataset["ena_rates"] = (
+            ("energy_bin_geometric_mean", "spin_number"),
+            np.full((3, 1), FILLVAL_FLOAT64, dtype="float64"),
+        )
 
     return cullingmask_dataset

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -15,6 +15,7 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
     get_ctof,
     get_de_energy_kev,
     get_de_velocity,
+    get_efficiency,
     get_energy_pulse_height,
     get_energy_ssd,
     get_eventtimes,
@@ -241,6 +242,11 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
     de_dict["phi_fwhm"], de_dict["theta_fwhm"] = get_fwhm(
         start_type,
         f"ultra{sensor}",
+        de_dict["tof_energy"],
+        de_dict["phi"],
+        de_dict["theta"],
+    )
+    de_dict["event_efficiency"] = get_efficiency(
         de_dict["tof_energy"],
         de_dict["phi"],
         de_dict["theta"],

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -95,31 +95,31 @@ def create_dataset(
             dataset[key] = xr.DataArray(
                 data,
                 dims=["epoch", "component"],
-                attrs=cdf_manager.get_variable_attributes(key),
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in ("ena_rates_threshold", "energy_bin_delta"):
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean"],
-                attrs=cdf_manager.get_variable_attributes(key),
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in rates_keys:
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean", "spin_number"],
-                attrs=cdf_manager.get_variable_attributes(key),
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key == "counts":
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean", "healpix"],
-                attrs=cdf_manager.get_variable_attributes(key),
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         else:
             dataset[key] = xr.DataArray(
                 data,
                 dims=[default_dimension],
-                attrs=cdf_manager.get_variable_attributes(key),
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
 
     return dataset


### PR DESCRIPTION
# Change Summary

## Overview
Tying up some loose ends. Adding l1b de cdf as external download file. Adding "Data_version" to the test to be able to populate global attributes. Creating a single FILL value in badtimes.py and cullingmask.py since an empty cdf was causing problems.

## Updated Files
- badtimes.py
   - Nick was having problems with this cdf because it was empty. Added an if statement that populates the cdf with a single FILL value if it is empty.
- cullingmask.py
   - Same as what was done with badtimes.py.
- de.py
   - Adding the event efficiency in.
- imap_ultra_l1b_variable_attrs.yaml
   - Added default float 64 so I would have a proper FILL value for the cullingmask.py and badtimes.py
- ultra_l1_utils.py
   - From Tenzin: we need to make check_schema=False to properly populate the attributes

## Testing
- test_ultra_l1a.py
   - Added a “Data_version” to the attributes here since global attributes do not get added if this value is none. And also set ISTP=True
- test_ultra_l1b.py
   - Added a “Data_version” to the attributes here since global attributes do not get added if this value is none. 
- conftest.py
   - Added the l1b de cdf to the files available to download from s3.
- test_de.py
   - download l1b_de cdf instead of relying on data generated in conftest.py
- test_badtimes.py
   - Test for empty dataset issue
- test_culingmask.py
   - Test for empty dataset issue
