### PR TITLE
Ultra L2: define `delta_minus`/`delta_plus` for energy bins WRT geometric mean

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -10,6 +10,7 @@ from imap_processing.ultra.l1c import ultra_l1c_pset_bins
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_background_rates,
+    get_energy_delta_plus_minus,
     get_helio_exposure_times,
     get_helio_histogram,
     get_spacecraft_exposure_times,
@@ -56,6 +57,28 @@ def test_build_energy_bins():
     np.testing.assert_allclose(
         energy_bin_geometric_means, expected_geometric_means, atol=1e-4
     )
+
+
+def test_get_energy_delta_plus_minus(monkeypatch):
+    """Tests get_energy_delta_plus_minus function."""
+    # Mock fixed values for the energy bins - these are not the actual geometric means
+    mock_intervals = [(0, 1), (1, 5), (5, 20), (20, 1234)]
+    mock_midpoints = None
+    mock_geometric_means = np.array([0, 2, 7, 100])
+
+    expected_bins_energy_delta_plus = np.array([1, 3, 13, 1134])
+    expected_bins_energy_delta_minus = np.array([0, 1, 2, 80])
+
+    def mock_build_energy_bins():
+        return mock_intervals, mock_midpoints, mock_geometric_means
+
+    monkeypatch.setattr(
+        ultra_l1c_pset_bins, "build_energy_bins", mock_build_energy_bins
+    )
+
+    bins_energy_delta_plus, bins_energy_delta_minus = get_energy_delta_plus_minus()
+    assert np.array_equal(bins_energy_delta_plus, expected_bins_energy_delta_plus)
+    assert np.array_equal(bins_energy_delta_minus, expected_bins_energy_delta_minus)
 
 
 def test_get_spacecraft_histogram(test_data):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -10,7 +10,7 @@ from imap_processing.ultra.l1c import ultra_l1c_pset_bins
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_background_rates,
-    get_energy_delta_plus_minus,
+    get_energy_delta_minus_plus,
     get_helio_exposure_times,
     get_helio_histogram,
     get_spacecraft_exposure_times,
@@ -59,8 +59,8 @@ def test_build_energy_bins():
     )
 
 
-def test_get_energy_delta_plus_minus(monkeypatch):
-    """Tests get_energy_delta_plus_minus function."""
+def test_get_energy_delta_minus_plus(monkeypatch):
+    """Tests get_energy_delta_minus_plus function."""
     # Mock fixed values for the energy bins - these are not the actual geometric means
     mock_intervals = [(0, 1), (1, 5), (5, 20), (20, 1234)]
     mock_midpoints = None
@@ -76,7 +76,7 @@ def test_get_energy_delta_plus_minus(monkeypatch):
         ultra_l1c_pset_bins, "build_energy_bins", mock_build_energy_bins
     )
 
-    bins_energy_delta_plus, bins_energy_delta_minus = get_energy_delta_plus_minus()
+    bins_energy_delta_minus, bins_energy_delta_plus = get_energy_delta_minus_plus()
     assert np.array_equal(bins_energy_delta_plus, expected_bins_energy_delta_plus)
     assert np.array_equal(bins_energy_delta_minus, expected_bins_energy_delta_minus)
 

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -50,6 +50,33 @@ def build_energy_bins() -> tuple[list[tuple[float, float]], np.ndarray, np.ndarr
     return intervals, energy_midpoints, energy_bin_geometric_means
 
 
+def get_energy_delta_plus_minus() -> tuple[NDArray, NDArray]:
+    """
+    Calculate the energy_delta_plus and energy_delta_minus for use in the CDF.
+
+    Returns
+    -------
+    bins_energy_delta_plus : np.ndarray
+        Array of energy delta plus values.
+    bins_energy_delta_minus : np.ndarray
+        Array of energy delta minus values.
+
+    Notes
+    -----
+    Calculates as the following:
+    energy_delta_plus=abs(bin_upper - bin_geom_mean)
+    energy_delta_minus=abs(bin_geom_mean - bin_lower)
+    where bin_upper and bin_lower are the upper and lower bounds of the energy bins
+    and bin_geom_mean is the geometric mean of the energy bin.
+    """
+    bins, _, bin_geom_means = build_energy_bins()
+    bins_energy_delta_plus, bins_energy_delta_minus = [], []
+    for bin_edges, bin_geom_mean in zip(bins, bin_geom_means):
+        bins_energy_delta_plus.append(bin_edges[1] - bin_geom_mean)
+        bins_energy_delta_minus.append(bin_geom_mean - bin_edges[0])
+    return abs(np.array(bins_energy_delta_plus)), abs(np.array(bins_energy_delta_minus))
+
+
 def get_spacecraft_histogram(
     vhat: tuple[np.ndarray, np.ndarray, np.ndarray],
     energy: np.ndarray,

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -50,22 +50,22 @@ def build_energy_bins() -> tuple[list[tuple[float, float]], np.ndarray, np.ndarr
     return intervals, energy_midpoints, energy_bin_geometric_means
 
 
-def get_energy_delta_plus_minus() -> tuple[NDArray, NDArray]:
+def get_energy_delta_minus_plus() -> tuple[NDArray, NDArray]:
     """
-    Calculate the energy_delta_plus and energy_delta_minus for use in the CDF.
+    Calculate the energy_delta_minus and energy_delta_plus for use in the CDF.
 
     Returns
     -------
-    bins_energy_delta_plus : np.ndarray
-        Array of energy delta plus values.
     bins_energy_delta_minus : np.ndarray
-        Array of energy delta minus values.
+        Array of energy_delta_minus values.
+    bins_energy_delta_plus : np.ndarray
+        Array of energy_delta_plus values.
 
     Notes
     -----
     Calculates as the following:
-    energy_delta_plus=abs(bin_upper - bin_geom_mean)
     energy_delta_minus=abs(bin_geom_mean - bin_lower)
+    energy_delta_plus=abs(bin_upper - bin_geom_mean)
     where bin_upper and bin_lower are the upper and lower bounds of the energy bins
     and bin_geom_mean is the geometric mean of the energy bin.
     """
@@ -74,7 +74,7 @@ def get_energy_delta_plus_minus() -> tuple[NDArray, NDArray]:
     for bin_edges, bin_geom_mean in zip(bins, bin_geom_means):
         bins_energy_delta_plus.append(bin_edges[1] - bin_geom_mean)
         bins_energy_delta_minus.append(bin_geom_mean - bin_edges[0])
-    return abs(np.array(bins_energy_delta_plus)), abs(np.array(bins_energy_delta_minus))
+    return abs(np.array(bins_energy_delta_minus)), abs(np.array(bins_energy_delta_plus))
 
 
 def get_spacecraft_histogram(

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -11,6 +11,7 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.ena_maps import ena_maps
 from imap_processing.ena_maps.utils.coordinates import CoordNames
+from imap_processing.ultra.l1c.ultra_l1c_pset_bins import get_energy_delta_minus_plus
 
 logger = logging.getLogger(__name__)
 logger.info("Importing ultra_l2 module")
@@ -466,14 +467,14 @@ def ultra_l2(
             )
 
     # Add the energy delta plus/minus to the map dataset
-    # TODO: Update these placeholders on energy deltas (our mean is the geometric mean,
-    # so it should have asymmetric deltas).
+    energy_delta_minus, energy_delta_plus = get_energy_delta_minus_plus()
     map_dataset.coords["energy_delta_minus"] = xr.DataArray(
-        (l1c_products[0]["energy_bin_delta"].values / 2),
+        energy_delta_minus,
         dims=(CoordNames.ENERGY_L2.value,),
     )
-    map_dataset.coords["energy_delta_plus"] = map_dataset["energy_delta_minus"].copy(
-        deep=True
+    map_dataset.coords["energy_delta_plus"] = xr.DataArray(
+        energy_delta_plus,
+        dims=(CoordNames.ENERGY_L2.value,),
     )
 
     # Add variable specific attributes to the map's data_vars and coords


### PR DESCRIPTION
# Change Summary

Calculate the asymmetric `delta_minus`/`delta_plus` of Ultra's energy bins.

Closes #1697 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Ultra uses a geometric mean of energy bin the energy bin:

$E_{\mu,geom} = \sqrt{E_{min} \times E_{max}}$

So we need to calculate the asymmetric `delta_minus`/`delta_plus` of Ultra's energy bins

$\Delta_- = | E_{\mu,geom} - E_{min}| $
$\Delta_+ = | E_{max} - E_{\mu,geom}| $

This is probably retrievable from the geometric mean energy and the total energy range of the energy bin, but it's far simpler to just define a function which calls `build_energy_bins()` and does the arithmetic above. Because `build_energy_bins` is set to provide a constant output, this should be safe. 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
   - Define `get_energy_delta_minus_plus()` function
- imap_processing/ultra/l2/ultra_l2.py
   - Use the new function to get the energy deltas

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
- Test the function using mocked outputs of `build_energy_bins()`