### PR TITLE
HIT L2 - Add attributes to L2 CDFs

### DIFF
--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -311,161 +311,315 @@ cno_energy_mean_label:
   FORMAT: A5
   VAR_TYPE: metadata
 
-# <=== Data Variables - Standard & Summed Datasets ===>
+# <=== Data Variables ===>
 
 dynamic_threshold_state:
   <<: *default_dns
 
-# Particle Intensity Variables
-h:
+# Standard Intensity Variables
+h_standard_intensity:
   <<: *default_particle
   DEPEND_1: h_energy_mean
-  CATDESC: H Intensity
+  CATDESC: H Standard Omnidirectional Intensity in 12 energy bins
   LABL_PTR_1: h_energy_mean_label
-  FIELDNAM: H Intensity
+  FIELDNAM: H Intensity Standard
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
 
-he3:
+he3_standard_intensity:
   <<: *default_particle
   DEPEND_1: he3_energy_mean
-  CATDESC: He3 Intensity
-  FIELDNAM: He3 Intensity
+  CATDESC: He3 Standard Omnidirectional Intensity in 11 energy bins
+  FIELDNAM: He3 Intensity Standard
   LABL_PTR_1: he3_energy_mean_label
   DELTA_MINUS: he3_total_uncert_plus
   DELTA_PLUS: he3_total_uncert_minus
 
-he4:
+he4_standard_intensity:
   <<: *default_particle
   DEPEND_1: he4_energy_mean
-  CATDESC: He4 Intensity
-  FIELDNAM: He4 Intensity
+  CATDESC: He4 Standard Omnidirectional Intensity in 12 energy bins
+  FIELDNAM: He4 Intensity Standard
   LABL_PTR_1: he4_energy_mean_label
   DELTA_MINUS: he4_total_uncert_plus
   DELTA_PLUS: he4_total_uncert_minus
 
-he:
+he_standard_intensity:
   <<: *default_particle
   DEPEND_1: he_energy_mean
-  CATDESC: He Intensity
-  FIELDNAM: He Intensity
+  CATDESC: He (total) Standard Omnidirectional Intensity in 11 energy bins
+  FIELDNAM: He Intensity Standard
   LABL_PTR_1: he_energy_mean_label
   DELTA_MINUS: he_total_uncert_plus
   DELTA_PLUS: he_total_uncert_minus
 
-c:
+c_standard_intensity:
   <<: *default_particle
   DEPEND_1: c_energy_mean
-  CATDESC: C Intensity
-  FIELDNAM: C Intensity
+  CATDESC: C Standard Omnidirectional Intensity in 12 energy bins
+  FIELDNAM: C Intensity Standard
   LABL_PTR_1: c_energy_mean_label
   DELTA_MINUS: c_total_uncert_plus
   DELTA_PLUS: c_total_uncert_minus
 
-o:
+o_standard_intensity:
   <<: *default_particle
   DEPEND_1: o_energy_mean
-  CATDESC: O Intensity
-  FIELDNAM: O Intensity
+  CATDESC: O Standard Omnidirectional Intensity in 12 energy bins
+  FIELDNAM: O Intensity Standard
   LABL_PTR_1: o_energy_mean_label
   DELTA_MINUS: o_total_uncert_plus
   DELTA_PLUS: o_total_uncert_minus
 
-n:
+n_standard_intensity:
   <<: *default_particle
   DEPEND_1: n_energy_mean
-  CATDESC: N Intensity
-  FIELDNAM: N Intensity
+  CATDESC: N Standard Omnidirectional Intensity in 12 energy bins
+  FIELDNAM: N Intensity Standard
   LABL_PTR_1: n_energy_mean_label
   DELTA_MINUS: n_total_uncert_plus
   DELTA_PLUS: n_total_uncert_minus
 
-ne:
+ne_standard_intensity:
   <<: *default_particle
   DEPEND_1: ne_energy_mean
-  CATDESC: Ne Intensity
-  FIELDNAM: Ne Intensity
+  CATDESC: Ne Standard Omnidirectional Intensity in 13 energy bins
+  FIELDNAM: Ne Intensity Standard
   LABL_PTR_1: ne_energy_mean_label
   DELTA_MINUS: ne_total_uncert_plus
   DELTA_PLUS: ne_total_uncert_minus
 
-na:
+na_standard_intensity:
   <<: *default_particle
   DEPEND_1: na_energy_mean
-  CATDESC: Na Intensity
-  FIELDNAM: Na Intensity
+  CATDESC: Na Standard Omnidirectional Intensity in 8 energy bins
+  FIELDNAM: Na Intensity Standard
   LABL_PTR_1: na_energy_mean_label
   DELTA_MINUS: na_total_uncert_plus
   DELTA_PLUS: na_total_uncert_minus
 
-mg:
+mg_standard_intensity:
   <<: *default_particle
   DEPEND_1: mg_energy_mean
-  CATDESC: Mg Intensity
-  FIELDNAM: Mg Intensity
+  CATDESC: Mg Standard Omnidirectional Intensity in 14 energy bins
+  FIELDNAM: Mg Intensity Standard
   LABL_PTR_1: mg_energy_mean_label
   DELTA_MINUS: mg_total_uncert_plus
   DELTA_PLUS: mg_total_uncert_minus
 
-al:
+al_standard_intensity:
   <<: *default_particle
   DEPEND_1: al_energy_mean
-  CATDESC: Al Intensity
-  FIELDNAM: Al Intensity
+  CATDESC: Al Standard Omnidirectional Intensity in 9 energy bins
+  FIELDNAM: Al Intensity Standard
   LABL_PTR_1: al_energy_mean_label
   DELTA_MINUS: al_total_uncert_plus
   DELTA_PLUS: al_total_uncert_minus
 
-si:
+si_standard_intensity:
   <<: *default_particle
   DEPEND_1: si_energy_mean
-  CATDESC: Si Intensity
-  FIELDNAM: Si Intensity
+  CATDESC: Si Standard Omnidirectional Intensity in 14 energy bins
+  FIELDNAM: Si Intensity Standard
   LABL_PTR_1: si_energy_mean_label
   DELTA_MINUS: si_total_uncert_plus
   DELTA_PLUS: si_total_uncert_minus
 
-s:
+s_standard_intensity:
   <<: *default_particle
   DEPEND_1: s_energy_mean
-  CATDESC: S Intensity
-  FIELDNAM: S Intensity
+  CATDESC: S Standard Omnidirectional Intensity in 13 energy bins
+  FIELDNAM: S Intensity Standard
   LABL_PTR_1: s_energy_mean_label
   DELTA_MINUS: s_total_uncert_plus
   DELTA_PLUS: s_total_uncert_minus
 
-ar:
+ar_standard_intensity:
   <<: *default_particle
   DEPEND_1: ar_energy_mean
-  CATDESC: Ar Intensity
-  FIELDNAM: Ar Intensity
+  CATDESC: Ar Standard Omnidirectional Intensity in 13 energy bins
+  FIELDNAM: Ar Intensity Standard
   LABL_PTR_1: ar_energy_mean_label
   DELTA_MINUS: ar_total_uncert_plus
   DELTA_PLUS: ar_total_uncert_minus
 
-ca:
+ca_standard_intensity:
   <<: *default_particle
   DEPEND_1: ca_energy_mean
-  CATDESC: Ca Intensity
-  FIELDNAM: Ca Intensity
+  CATDESC: Ca Standard Omnidirectional Intensity in 13 energy bins
+  FIELDNAM: Ca Intensity Standard
   LABL_PTR_1: ca_energy_mean_label
   DELTA_MINUS: ca_total_uncert_plus
   DELTA_PLUS: ca_total_uncert_minus
 
-fe:
+fe_standard_intensity:
   <<: *default_particle
   DEPEND_1: fe_energy_mean
-  CATDESC: Fe Intensity
-  FIELDNAM: Fe Intensity
+  CATDESC: Fe Standard Omnidirectional Intensity in 16 energy bins
+  FIELDNAM: Fe Intensity Standard
   LABL_PTR_1: fe_energy_mean_label
   DELTA_MINUS: fe_total_uncert_plus
   DELTA_PLUS: fe_total_uncert_minus
 
-ni:
+ni_standard_intensity:
   <<: *default_particle
   DEPEND_1: ni_energy_mean
-  CATDESC: Ni Intensity
-  FIELDNAM: Ni Intensity
+  CATDESC: Ni Standard Omnidirectional Intensity in 9 energy bins
+  FIELDNAM: Ni Intensity Standard
+  LABL_PTR_1: ni_energy_mean_label
+  DELTA_MINUS: ni_total_uncert_plus
+  DELTA_PLUS: ni_total_uncert_minus
+
+# Summed Intensity Variables
+h_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: h_energy_mean
+  CATDESC: H Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
+  LABL_PTR_1: h_energy_mean_label
+  FIELDNAM: H Intensity Summed
+  DELTA_MINUS: h_total_uncert_plus
+  DELTA_PLUS: h_total_uncert_minus
+
+he3_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: he3_energy_mean
+  CATDESC: He3 Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
+  FIELDNAM: He3 Intensity Summed
+  LABL_PTR_1: he3_energy_mean_label
+  DELTA_MINUS: he3_total_uncert_plus
+  DELTA_PLUS: he3_total_uncert_minus
+
+he4_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: he4_energy_mean
+  CATDESC: He4 Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
+  FIELDNAM: He4 Intensity Summed
+  LABL_PTR_1: he4_energy_mean_label
+  DELTA_MINUS: he4_total_uncert_plus
+  DELTA_PLUS: he4_total_uncert_minus
+
+he_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: he_energy_mean
+  CATDESC: He (total) Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
+  FIELDNAM: He Intensity Summed
+  LABL_PTR_1: he_energy_mean_label
+  DELTA_MINUS: he_total_uncert_plus
+  DELTA_PLUS: he_total_uncert_minus
+
+c_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: c_energy_mean
+  CATDESC: C Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
+  FIELDNAM: C Intensity Summed
+  LABL_PTR_1: c_energy_mean_label
+  DELTA_MINUS: c_total_uncert_plus
+  DELTA_PLUS: c_total_uncert_minus
+
+o_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: o_energy_mean
+  CATDESC: O Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
+  FIELDNAM: O Intensity Summed
+  LABL_PTR_1: o_energy_mean_label
+  DELTA_MINUS: o_total_uncert_plus
+  DELTA_PLUS: o_total_uncert_minus
+
+n_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: n_energy_mean
+  CATDESC: N Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
+  FIELDNAM: N Intensity Summed
+  LABL_PTR_1: n_energy_mean_label
+  DELTA_MINUS: n_total_uncert_plus
+  DELTA_PLUS: n_total_uncert_minus
+
+ne_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: ne_energy_mean
+  CATDESC: Ne Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
+  FIELDNAM: Ne Intensity Summed
+  LABL_PTR_1: ne_energy_mean_label
+  DELTA_MINUS: ne_total_uncert_plus
+  DELTA_PLUS: ne_total_uncert_minus
+
+na_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: na_energy_mean
+  CATDESC: Na Summed Omnidirectional Intensity in 2 energy bins (useful for quiet times)
+  FIELDNAM: Na Intensity Summed
+  LABL_PTR_1: na_energy_mean_label
+  DELTA_MINUS: na_total_uncert_plus
+  DELTA_PLUS: na_total_uncert_minus
+
+mg_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: mg_energy_mean
+  CATDESC: Mg Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
+  FIELDNAM: Mg Intensity Summed
+  LABL_PTR_1: mg_energy_mean_label
+  DELTA_MINUS: mg_total_uncert_plus
+  DELTA_PLUS: mg_total_uncert_minus
+
+al_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: al_energy_mean
+  CATDESC: Al Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
+  FIELDNAM: Al Intensity Summed
+  LABL_PTR_1: al_energy_mean_label
+  DELTA_MINUS: al_total_uncert_plus
+  DELTA_PLUS: al_total_uncert_minus
+
+si_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: si_energy_mean
+  CATDESC: Si Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
+  FIELDNAM: Si Intensity Summed
+  LABL_PTR_1: si_energy_mean_label
+  DELTA_MINUS: si_total_uncert_plus
+  DELTA_PLUS: si_total_uncert_minus
+
+s_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: s_energy_mean
+  CATDESC: S Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
+  FIELDNAM: S Intensity Summed
+  LABL_PTR_1: s_energy_mean_label
+  DELTA_MINUS: s_total_uncert_plus
+  DELTA_PLUS: s_total_uncert_minus
+
+ar_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: ar_energy_mean
+  CATDESC: Ar Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
+  FIELDNAM: Ar Intensity Summed
+  LABL_PTR_1: ar_energy_mean_label
+  DELTA_MINUS: ar_total_uncert_plus
+  DELTA_PLUS: ar_total_uncert_minus
+
+ca_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: ca_energy_mean
+  CATDESC: Ca Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
+  FIELDNAM: Ca Intensity Summed
+  LABL_PTR_1: ca_energy_mean_label
+  DELTA_MINUS: ca_total_uncert_plus
+  DELTA_PLUS: ca_total_uncert_minus
+
+fe_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: fe_energy_mean
+  CATDESC: Fe Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
+  FIELDNAM: Fe Intensity Summed
+  LABL_PTR_1: fe_energy_mean_label
+  DELTA_MINUS: fe_total_uncert_plus
+  DELTA_PLUS: fe_total_uncert_minus
+
+ni_summed_intensity:
+  <<: *default_particle
+  DEPEND_1: ni_energy_mean
+  CATDESC: Ni Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
+  FIELDNAM: Ni Intensity Summed
   LABL_PTR_1: ni_energy_mean_label
   DELTA_MINUS: ni_total_uncert_plus
   DELTA_PLUS: ni_total_uncert_minus
@@ -1430,7 +1584,7 @@ ni_total_uncert_minus:
 dynamic_threshold_state_macropixel:
   <<: *default_dns
 
-# Particle Intensity Variables
+# Macropixel Intensity Variables
 h_macropixel_intensity:
   <<: *default_particle
   CATDESC: H Macropixel Intensity
@@ -1556,7 +1710,7 @@ h_sys_err_plus_macropixel:
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
-  CATDESC: Plus systematic uncertainty for H
+  CATDESC: Plus systematic uncertainty for H Macropixel
   FIELDNAM: H Plus Systematic Uncertainty
 
 h_sys_err_minus_macropixel:
@@ -1567,7 +1721,7 @@ h_sys_err_minus_macropixel:
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
-  CATDESC: Minus systematic uncertainty for H
+  CATDESC: Minus systematic uncertainty for H Macropixel
   FIELDNAM: H Minus Systematic Uncertainty
 
 h_total_uncert_plus_macropixel:
@@ -1578,7 +1732,7 @@ h_total_uncert_plus_macropixel:
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
-  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H
+  CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H Macropixel
   FIELDNAM: H Plus Total Uncertainty
 
 h_total_uncert_minus_macropixel:
@@ -1589,7 +1743,7 @@ h_total_uncert_minus_macropixel:
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
-  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H
+  CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H Macropixel
   FIELDNAM: H Minus Total Uncertainty
 
 he4_stat_uncert_plus_macropixel:

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -64,7 +64,7 @@ default_dynamic_threshold_state_attrs: &default_dns
   LABLAXIS: Counts
   VALIDMIN: 0
   VALIDMAX: 3
-  FILLVAL: -9.22E+18
+  FILLVAL: -9223372036854775808
   DISPLAY_TYPE: time_series
   FORMAT: I1
   UNITS: " "
@@ -90,96 +90,115 @@ azimuth:
 
 h_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: h_energy_mean
   CATDESC: Geometric mean energy for H
   FIELDNAM: H Energy
 
 he3_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: he3_energy_mean
   CATDESC: Geometric mean energy for He3
   FIELDNAM: He3 Energy
 
 he4_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: he4_energy_mean
   CATDESC: Geometric mean energy for He4
   FIELDNAM: He4 Energy
 
 he_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: he_energy_mean
   CATDESC: Geometric mean energy for He
   FIELDNAM: He Energy
 
 c_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: c_energy_mean
   CATDESC: Geometric mean energy for C
   FIELDNAM: C Energy
 
 n_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: n_energy_mean
   CATDESC: Geometric mean energy for N
   FIELDNAM: N Energy
 
 o_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: o_energy_mean
   CATDESC: Geometric mean energy for O
   FIELDNAM: O Energy
 
 ne_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: ne_energy_mean
   CATDESC: Geometric mean energy for Ne
   FIELDNAM: Ne Energy
 
 na_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: na_energy_mean
   CATDESC: Geometric mean energy for Na
   FIELDNAM: Na Energy
 
 mg_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: mg_energy_mean
   CATDESC: Geometric mean energy for Mg
   FIELDNAM: Mg Energy
 
 si_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: si_energy_mean
   CATDESC: Geometric mean energy for Si
   FIELDNAM: Si Energy
 
 s_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: s_energy_mean
   CATDESC: Geometric mean energy for S
   FIELDNAM: S Energy
 
 al_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: al_energy_mean
   CATDESC: Geometric mean energy for Al
   FIELDNAM: Al Energy
 
 ar_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: ar_energy_mean
   CATDESC: Geometric mean energy for Ar
   FIELDNAM: Ar Energy
 
 ca_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: ca_energy_mean
   CATDESC: Geometric mean energy for Ca
   FIELDNAM: Ca Energy
 
 fe_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: fe_energy_mean
   CATDESC: Geometric mean energy for Fe
   FIELDNAM: Fe Energy
 
 ni_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: ni_energy_mean
   CATDESC: Geometric mean energy for Ni
   FIELDNAM: Ni Energy
 
 nemgsi_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: nemgsi_energy_mean
   CATDESC: Geometric mean energy for NeMgSi
   FIELDNAM: NeMgSi Energy
 
 cno_energy_mean:
   <<: *default_energy_mean
+  DEPEND_1: cno_energy_mean
   CATDESC: Geometric mean energy for CNO
   FIELDNAM: CNO Energy
 
@@ -627,238 +646,238 @@ ni_summed_intensity:
 # Energy Delta Variables
 h_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: h_energy_mean
+  DEPEND_1: h_energy_mean
   CATDESC: H energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: H energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 h_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: h_energy_mean
+  DEPEND_1: h_energy_mean
   CATDESC: H energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: H energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he3_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: he3_energy_mean
+  DEPEND_1: he3_energy_mean
   CATDESC: He3 energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He3 energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he3_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: he3_energy_mean
+  DEPEND_1: he3_energy_mean
   CATDESC: He3 energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He3 energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he4_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: he4_energy_mean
+  DEPEND_1: he4_energy_mean
   CATDESC: He4 energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He4 energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he4_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: he4_energy_mean
+  DEPEND_1: he4_energy_mean
   CATDESC: He4 energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He4 energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: he_energy_mean
+  DEPEND_1: he_energy_mean
   CATDESC: He energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: he_energy_mean
+  DEPEND_1: he_energy_mean
   CATDESC: He energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 c_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: c_energy_mean
+  DEPEND_1: c_energy_mean
   CATDESC: C energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: C energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 c_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: c_energy_mean
+  DEPEND_1: c_energy_mean
   CATDESC: C energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: C energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 o_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: o_energy_mean
+  DEPEND_1: o_energy_mean
   CATDESC: O energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: O energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 o_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: o_energy_mean
+  DEPEND_1: o_energy_mean
   CATDESC: O energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: O energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 n_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: n_energy_mean
+  DEPEND_1: n_energy_mean
   CATDESC: N energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: N energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 n_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: n_energy_mean
+  DEPEND_1: n_energy_mean
   CATDESC: N energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: N energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ne_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: ne_energy_mean
+  DEPEND_1: ne_energy_mean
   CATDESC: Ne energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ne energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ne_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: ne_energy_mean
+  DEPEND_1: ne_energy_mean
   CATDESC: Ne energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ne energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 na_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: na_energy_mean
+  DEPEND_1: na_energy_mean
   CATDESC: Na energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Na energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 na_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: na_energy_mean
+  DEPEND_1: na_energy_mean
   CATDESC: Na energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Na energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 mg_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: mg_energy_mean
+  DEPEND_1: mg_energy_mean
   CATDESC: Mg energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Mg energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 mg_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: mg_energy_mean
+  DEPEND_1: mg_energy_mean
   CATDESC: Mg energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Mg energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 al_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: al_energy_mean
+  DEPEND_1: al_energy_mean
   CATDESC: Al energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Al energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 al_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: al_energy_mean
+  DEPEND_1: al_energy_mean
   CATDESC: Al energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Al energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 si_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: si_energy_mean
+  DEPEND_1: si_energy_mean
   CATDESC: Si energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Si energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 si_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: si_energy_mean
+  DEPEND_1: si_energy_mean
   CATDESC: Si energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Si energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 s_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: s_energy_mean
+  DEPEND_1: s_energy_mean
   CATDESC: S energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: S energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 s_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: s_energy_mean
+  DEPEND_1: s_energy_mean
   CATDESC: S energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: S energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ar_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: ar_energy_mean
+  DEPEND_1: ar_energy_mean
   CATDESC: Ar energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ar energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ar_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: ar_energy_mean
+  DEPEND_1: ar_energy_mean
   CATDESC: Ar energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ar energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ca_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: ca_energy_mean
+  DEPEND_1: ca_energy_mean
   CATDESC: Ca energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ca energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ca_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: ca_energy_mean
+  DEPEND_1: ca_energy_mean
   CATDESC: Ca energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ca energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 fe_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: fe_energy_mean
+  DEPEND_1: fe_energy_mean
   CATDESC: Fe energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Fe energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 fe_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: fe_energy_mean
+  DEPEND_1: fe_energy_mean
   CATDESC: Fe energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Fe energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ni_energy_delta_plus:
   <<: *default_energy_delta
-  DEPEND_0: ni_energy_mean
+  DEPEND_1: ni_energy_mean
   CATDESC: Ni energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ni energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ni_energy_delta_minus:
   <<: *default_energy_delta
-  DEPEND_0: ni_energy_mean
+  DEPEND_1: ni_energy_mean
   CATDESC: Ni energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ni energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
@@ -881,15 +900,15 @@ h_stat_uncert_minus:
 h_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
-  CATDESC: Plus systematic uncertainty for H
-  FIELDNAM: H Plus Systematic uncertainty
+  CATDESC: Plus Systematic uncertainty for H
+  FIELDNAM: H Plus Systematic Uncertainty
   LABL_PTR_1: h_energy_mean_label
 
 h_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   CATDESC: Minus systematic uncertainty for H
-  FIELDNAM: H Minus Systematic uncertainty
+  FIELDNAM: H Minus Systematic Uncertainty
   LABL_PTR_1: h_energy_mean_label
 
 h_total_uncert_plus:
@@ -924,14 +943,14 @@ he3_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Plus systematic uncertainty for He3
-  FIELDNAM: He3 Plus Systematic uncertainty
+  FIELDNAM: He3 Plus Systematic Uncertainty
   LABL_PTR_1: he3_energy_mean_label
 
 he3_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he3_energy_mean
   CATDESC: Minus systematic uncertainty for He3
-  FIELDNAM: He3 Minus Systematic uncertainty
+  FIELDNAM: He3 Minus Systematic Uncertainty
   LABL_PTR_1: he3_energy_mean_label
 
 he3_total_uncert_plus:
@@ -966,14 +985,14 @@ he4_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   CATDESC: Plus systematic uncertainty for He4
-  FIELDNAM: He4 Plus Systematic uncertainty
+  FIELDNAM: He4 Plus Systematic Uncertainty
   LABL_PTR_1: he4_energy_mean_label
 
 he4_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   CATDESC: Minus systematic uncertainty for He4
-  FIELDNAM: He4 Minus Systematic uncertainty
+  FIELDNAM: He4 Minus Systematic Uncertainty
   LABL_PTR_1: he4_energy_mean_label
 
 he4_total_uncert_plus:
@@ -1008,14 +1027,14 @@ he_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
   CATDESC: Plus systematic uncertainty for He
-  FIELDNAM: He Plus Systematic uncertainty
+  FIELDNAM: He Plus Systematic Uncertainty
   LABL_PTR_1: he_energy_mean_label
 
 he_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: he_energy_mean
   CATDESC: Minus systematic uncertainty for He
-  FIELDNAM: He Minus Systematic uncertainty
+  FIELDNAM: He Minus Systematic Uncertainty
   LABL_PTR_1: he_energy_mean_label
 
 he_total_uncert_plus:
@@ -1050,14 +1069,14 @@ c_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
   CATDESC: Plus systematic uncertainty for C
-  FIELDNAM: C Plus Systematic uncertainty
+  FIELDNAM: C Plus Systematic Uncertainty
   LABL_PTR_1: c_energy_mean_label
 
 c_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: c_energy_mean
   CATDESC: Minus systematic uncertainty for C
-  FIELDNAM: C Minus Systematic uncertainty
+  FIELDNAM: C Minus Systematic Uncertainty
   LABL_PTR_1: c_energy_mean_label
 
 c_total_uncert_plus:
@@ -1092,14 +1111,14 @@ o_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
   CATDESC: Plus systematic uncertainty for O
-  FIELDNAM: O Plus Systematic uncertainty
+  FIELDNAM: O Plus Systematic Uncertainty
   LABL_PTR_1: o_energy_mean_label
 
 o_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: o_energy_mean
   CATDESC: Minus systematic uncertainty for O
-  FIELDNAM: O Minus Systematic uncertainty
+  FIELDNAM: O Minus Systematic Uncertainty
   LABL_PTR_1: o_energy_mean_label
 
 o_total_uncert_plus:
@@ -1134,14 +1153,14 @@ n_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
   CATDESC: Plus systematic uncertainty for N
-  FIELDNAM: N Plus Systematic uncertainty
+  FIELDNAM: N Plus Systematic Uncertainty
   LABL_PTR_1: n_energy_mean_label
 
 n_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: n_energy_mean
   CATDESC: Minus systematic uncertainty for N
-  FIELDNAM: N Minus Systematic uncertainty
+  FIELDNAM: N Minus Systematic Uncertainty
   LABL_PTR_1: n_energy_mean_label
 
 n_total_uncert_plus:
@@ -1176,14 +1195,14 @@ ne_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
   CATDESC: Plus systematic uncertainty for Ne
-  FIELDNAM: Ne Plus Systematic uncertainty
+  FIELDNAM: Ne Plus Systematic Uncertainty
   LABL_PTR_1: ne_energy_mean_label
 
 ne_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ne_energy_mean
   CATDESC: Minus systematic uncertainty for Ne
-  FIELDNAM: Ne Minus Systematic uncertainty
+  FIELDNAM: Ne Minus Systematic Uncertainty
   LABL_PTR_1: ne_energy_mean_label
 
 ne_total_uncert_plus:
@@ -1218,14 +1237,14 @@ na_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
   CATDESC: Plus systematic uncertainty for Na
-  FIELDNAM: Na Plus Systematic uncertainty
+  FIELDNAM: Na Plus Systematic Uncertainty
   LABL_PTR_1: na_energy_mean_label
 
 na_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: na_energy_mean
   CATDESC: Minus systematic uncertainty for Na
-  FIELDNAM: Na Minus Systematic uncertainty
+  FIELDNAM: Na Minus Systematic Uncertainty
   LABL_PTR_1: na_energy_mean_label
 
 na_total_uncert_plus:
@@ -1260,14 +1279,14 @@ mg_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
   CATDESC: Plus systematic uncertainty for Mg
-  FIELDNAM: Mg Plus Systematic uncertainty
+  FIELDNAM: Mg Plus Systematic Uncertainty
   LABL_PTR_1: mg_energy_mean_label
 
 mg_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: mg_energy_mean
   CATDESC: Minus systematic uncertainty for Mg
-  FIELDNAM: Mg Minus Systematic uncertainty
+  FIELDNAM: Mg Minus Systematic Uncertainty
   LABL_PTR_1: mg_energy_mean_label
 
 mg_total_uncert_plus:
@@ -1302,14 +1321,14 @@ al_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
   CATDESC: Plus systematic uncertainty for Al
-  FIELDNAM: Al Plus Systematic uncertainty
+  FIELDNAM: Al Plus Systematic Uncertainty
   LABL_PTR_1: al_energy_mean_label
 
 al_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: al_energy_mean
   CATDESC: Minus systematic uncertainty for Al
-  FIELDNAM: Al Minus Systematic uncertainty
+  FIELDNAM: Al Minus Systematic Uncertainty
   LABL_PTR_1: al_energy_mean_label
 
 al_total_uncert_plus:
@@ -1344,14 +1363,14 @@ si_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
   CATDESC: Plus systematic uncertainty for Si
-  FIELDNAM: Si Plus Systematic uncertainty
+  FIELDNAM: Si Plus Systematic Uncertainty
   LABL_PTR_1: si_energy_mean_label
 
 si_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: si_energy_mean
   CATDESC: Minus systematic uncertainty for Si
-  FIELDNAM: Si Minus Systematic uncertainty
+  FIELDNAM: Si Minus Systematic Uncertainty
   LABL_PTR_1: si_energy_mean_label
 
 si_total_uncert_plus:
@@ -1386,14 +1405,14 @@ s_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
   CATDESC: Plus systematic uncertainty for S
-  FIELDNAM: S Plus Systematic uncertainty
+  FIELDNAM: S Plus Systematic Uncertainty
   LABL_PTR_1: s_energy_mean_label
 
 s_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: s_energy_mean
   CATDESC: Minus systematic uncertainty for S
-  FIELDNAM: S Minus Systematic uncertainty
+  FIELDNAM: S Minus Systematic Uncertainty
   LABL_PTR_1: s_energy_mean_label
 
 s_total_uncert_plus:
@@ -1428,14 +1447,14 @@ ar_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
   CATDESC: Plus systematic uncertainty for Ar
-  FIELDNAM: Ar Plus Systematic uncertainty
+  FIELDNAM: Ar Plus Systematic Uncertainty
   LABL_PTR_1: ar_energy_mean_label
 
 ar_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ar_energy_mean
   CATDESC: Minus systematic uncertainty for Ar
-  FIELDNAM: Ar Minus Systematic uncertainty
+  FIELDNAM: Ar Minus Systematic Uncertainty
   LABL_PTR_1: ar_energy_mean_label
 
 ar_total_uncert_plus:
@@ -1470,14 +1489,14 @@ ca_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
   CATDESC: Plus systematic uncertainty for Ca
-  FIELDNAM: Ca Plus Systematic uncertainty
+  FIELDNAM: Ca Plus Systematic Uncertainty
   LABL_PTR_1: ca_energy_mean_label
 
 ca_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ca_energy_mean
   CATDESC: Minus systematic uncertainty for Ca
-  FIELDNAM: Ca Minus Systematic uncertainty
+  FIELDNAM: Ca Minus Systematic Uncertainty
   LABL_PTR_1: ca_energy_mean_label
 
 ca_total_uncert_plus:
@@ -1512,14 +1531,14 @@ fe_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   CATDESC: Plus systematic uncertainty for Fe
-  FIELDNAM: Fe Plus Systematic uncertainty
+  FIELDNAM: Fe Plus Systematic Uncertainty
   LABL_PTR_1: fe_energy_mean_label
 
 fe_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   CATDESC: Minus systematic uncertainty for Fe
-  FIELDNAM: Fe Minus Systematic uncertainty
+  FIELDNAM: Fe Minus Systematic Uncertainty
   LABL_PTR_1: fe_energy_mean_label
 
 fe_total_uncert_plus:
@@ -1554,14 +1573,14 @@ ni_sys_err_plus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
   CATDESC: Plus systematic uncertainty for Ni
-  FIELDNAM: Ni Plus Systematic uncertainty
+  FIELDNAM: Ni Plus Systematic Uncertainty
   LABL_PTR_1: ni_energy_mean_label
 
 ni_sys_err_minus:
   <<: *default_uncertainty
   DEPEND_1: ni_energy_mean
   CATDESC: Minus systematic uncertainty for Ni
-  FIELDNAM: Ni Minus Systematic uncertainty
+  FIELDNAM: Ni Minus Systematic Uncertainty
   LABL_PTR_1: ni_energy_mean_label
 
 ni_total_uncert_plus:
@@ -1614,10 +1633,10 @@ he4_macropixel_intensity:
 cno_macropixel_intensity:
   <<: *default_particle
   CATDESC: C, N, O Macropixel Intensity
-  DEPEND_1: c_energy_mean
+  DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
   DEPEND_3: declination
-  LABL_PTR_1: c_energy_mean_label
+  LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: declination_label
   FIELDNAM: CNO Intensity Macropixel

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -56,23 +56,6 @@ default_angle_attrs: &default_angle
   UNITS: Deg
   SCALE_TYP: linear
 
-default_dynamic_threshold_state_attrs: &default_dns
-  DEPEND_0: epoch
-  VAR_TYPE: data
-  CATDESC: Raw dynamic threshold state per integration
-  FIELDNAM: Dynamic threshold state
-  LABLAXIS: Counts
-  VALIDMIN: 0
-  VALIDMAX: 3
-  FILLVAL: -9223372036854775808
-  DISPLAY_TYPE: time_series
-  FORMAT: I1
-  UNITS: " "
-  SCALE_TYP: linear
-  SCALEMIN: 0.0001
-  SCALEMAX: 1000
-  DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
-
 # <=== Coordinates ===>
 declination:
   <<: *default_angle
@@ -333,7 +316,21 @@ cno_energy_mean_label:
 # <=== Data Variables ===>
 
 dynamic_threshold_state:
-  <<: *default_dns
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  CATDESC: Raw dynamic threshold state per integration
+  FIELDNAM: Dynamic threshold state
+  LABLAXIS: Counts
+  VALIDMIN: 0
+  VALIDMAX: 3
+  FILLVAL: -9223372036854775808
+  DISPLAY_TYPE: time_series
+  FORMAT: I1
+  UNITS: " "
+  SCALE_TYP: linear
+  SCALEMIN: 0.0001
+  SCALEMAX: 1000
+  DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
 
 # Standard Intensity Variables
 h_standard_intensity:
@@ -1599,9 +1596,6 @@ ni_total_uncert_minus:
 
 
 # <=== Data Variables - Macropixel Dataset ===>
-
-dynamic_threshold_state_macropixel:
-  <<: *default_dns
 
 # Macropixel Intensity Variables
 h_macropixel_intensity:

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -19,7 +19,7 @@ default_energy_mean_attrs: &default_energy_mean
   LABLAXIS: Energy
   FILLVAL: -1.00E+31
   VALIDMIN: 0
-  VALIDMAX: 1000
+  VALIDMAX: 100
   FORMAT: F5.1
   UNITS: MeV
   SCALE_TYP: log
@@ -30,7 +30,7 @@ default_energy_delta_attrs: &default_energy_delta
   LABLAXIS: Energy
   FILLVAL: -1.00E+31
   VALIDMIN: 0
-  VALIDMAX: 1000
+  VALIDMAX: 100
   FORMAT: F5.1
   UNITS: MeV
   SCALE_TYP: log
@@ -68,7 +68,7 @@ default_dynamic_threshold_state_attrs: &default_dns
   DISPLAY_TYPE: time_series
   FORMAT: I1
   UNITS: " "
-  SCALE_TYP: log
+  SCALE_TYP: linear
   SCALEMIN: 0.0001
   SCALEMAX: 1000
   DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
@@ -1431,7 +1431,7 @@ dynamic_threshold_state_macropixel:
   <<: *default_dns
 
 # Particle Intensity Variables
-h_macropixel:
+h_macropixel_intensity:
   <<: *default_particle
   CATDESC: H Macropixel Intensity
   DEPEND_1: h_energy_mean
@@ -1444,7 +1444,7 @@ h_macropixel:
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
 
-he4_macropixel:
+he4_macropixel_intensity:
   <<: *default_particle
   CATDESC: He4 Macropixel Intensity
   DEPEND_1: he4_energy_mean
@@ -1457,7 +1457,7 @@ he4_macropixel:
   DELTA_MINUS: he4_total_uncert_plus
   DELTA_PLUS: he4_total_uncert_minus
 
-cno_macropixel:
+cno_macropixel_intensity:
   <<: *default_particle
   CATDESC: C, N, O Macropixel Intensity
   DEPEND_1: c_energy_mean
@@ -1470,7 +1470,7 @@ cno_macropixel:
   DELTA_MINUS: c_total_uncert_plus
   DELTA_PLUS: c_total_uncert_minus
 
-nemgsi_macropixel:
+nemgsi_macropixel_intensity:
   <<: *default_particle
   CATDESC: NeMgSi Macropixel Intensity
   DEPEND_1: nemgsi_energy_mean
@@ -1483,7 +1483,7 @@ nemgsi_macropixel:
   DELTA_MINUS: nemgsi_total_uncert_plus
   DELTA_PLUS: nemgsi_total_uncert_minus
 
-fe_macropixel:
+fe_macropixel_intensity:
   <<: *default_particle
   CATDESC: Fe Macropixel Intensity
   DEPEND_1: fe_energy_mean
@@ -1497,28 +1497,28 @@ fe_macropixel:
   DELTA_PLUS: fe_total_uncert_minus
 
 # Energy Delta Variables
-cno_energy_delta_plus_macropixel:
+cno_energy_delta_plus:
   <<: *default_energy_delta
   DEPEND_0: cno_energy_mean
   CATDESC: C, N, O energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: CNO energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
-cno_energy_delta_minus_macropixel:
+cno_energy_delta_minus:
   <<: *default_energy_delta
   DEPEND_0: cno_energy_mean
   CATDESC: C, N, O energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: CNO energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
-nemgsi_energy_delta_plus_macropixel:
+nemgsi_energy_delta_plus:
     <<: *default_energy_delta
     DEPEND_0: nemgsi_energy_mean
     CATDESC: Ne, Mg, Si energy delta plus (maximum bin energy minus geometric mean)
     FIELDNAM: NeMgSi energy delta plus
     DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
-nemgsi_energy_delta_minus_macropixel:
+nemgsi_energy_delta_minus:
     <<: *default_energy_delta
     DEPEND_0: nemgsi_energy_mean
     CATDESC: Ne, Mg, Si energy delta minus (geometric mean minus minimum bin energy)

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -57,15 +57,15 @@ def hit_l2(dependency_sci: xr.Dataset, dependencies_anc: list) -> list[xr.Datase
 
     # Process science data to L2 datasets
     if "imap_hit_l1b_summed-rates" in dependency_sci.attrs["Logical_source"]:
-        l2_dataset = process_summed_intensity_data(dependency_sci, dependencies_anc)
+        l2_dataset = process_summed_intensity(dependency_sci, dependencies_anc)
         logical_source = "imap_hit_l2_summed-intensity"
 
     if "imap_hit_l1b_standard-rates" in dependency_sci.attrs["Logical_source"]:
-        l2_dataset = process_standard_intensity_data(dependency_sci, dependencies_anc)
+        l2_dataset = process_standard_intensity(dependency_sci, dependencies_anc)
         logical_source = "imap_hit_l2_standard-intensity"
 
     if "imap_hit_l1b_sectored-rates" in dependency_sci.attrs["Logical_source"]:
-        l2_dataset = process_sectored_intensity_data(dependency_sci, dependencies_anc)
+        l2_dataset = process_macropixel_intensity(dependency_sci, dependencies_anc)
         logical_source = "imap_hit_l2_macropixel-intensity"
 
     # Add attributes to dataset
@@ -158,7 +158,7 @@ def calculate_intensities(
     for all epochs.
 
         This function uses equation 9 and 12 from the HIT algorithm document:
-        ((Summed L1B Rates) / (Delta Time * Delta E * Geometry Factor * Efficiency)) - b
+        ((L1B Rates) / (Delta Time * Delta E * Geometry Factor * Efficiency)) - b
 
     Parameters
     ----------
@@ -584,11 +584,11 @@ def load_ancillary_data(dynamic_threshold_states: set, ancillary_files: list) ->
     return ancillary_data_frames
 
 
-def process_summed_intensity_data(
+def process_summed_intensity(
     l1b_summed_rates_dataset: xr.Dataset, ancillary_files: list
 ) -> xr.Dataset:
     """
-    Will process L2 HIT summed intensity data from L1B summed rates.
+    Will process L1B summed rates to L2 HIT summed intensity data.
 
     This function converts the L1B summed rates to L2 summed intensities
     using ancillary tables containing factors needed to calculate the
@@ -642,11 +642,11 @@ def process_summed_intensity_data(
     return summed_intensity_dataset
 
 
-def process_standard_intensity_data(
+def process_standard_intensity(
     l1b_standard_rates_dataset: xr.Dataset, ancillary_files: list
 ) -> xr.Dataset:
     """
-    Will process L2 standard intensity data from L1B standard rates data.
+    Will process L1B standard rates data to L2 standard intensity data.
 
     This function converts L1B standard rates to L2 standard intensities for each
     particle type and energy range using ancillary tables containing factors
@@ -728,21 +728,19 @@ def process_standard_intensity_data(
     return standard_intensity_dataset
 
 
-def process_sectored_intensity_data(
+def process_macropixel_intensity(
     l1b_sectored_rates_dataset: xr.Dataset, ancillary_files: list
 ) -> xr.Dataset:
     """
-    Will process L2 HIT sectored intensity data from L1B sectored rates data.
+    Will process L1B sectored rates data to L2 macropixel intensity data.
 
-    This function converts the L1B sectored rates to L2 sectored intensities
+    This function converts the L1B sectored rates to L2 macropixel intensities
     using ancillary tables containing factors needed to calculate the
     intensity (energy bin width, geometry factor, efficiency, and b).
 
     Equation 12 from the HIT algorithm document:
-    Sectored Intensity = (Summed L1B Sectored Rates) /
-                       (600 * Delta E * Geometry Factor * Efficiency) - b
-
-    Note: sectored is also known as macropixel at this data level
+    Macropixel Intensity = ((Summed L1B Sectored Rates) /
+                       (600 * Delta E * Geometry Factor * Efficiency)) - b
 
     Parameters
     ----------
@@ -755,35 +753,35 @@ def process_sectored_intensity_data(
     Returns
     -------
     xr.Dataset
-        The processed L2 sectored intensity dataset.
+        The processed L2 macropixel intensity dataset.
     """
-    # Create a new dataset to store the L2 sectored intensity data
-    sectored_intensity_dataset = l1b_sectored_rates_dataset.copy(deep=True)
+    # Create a new dataset to store the L2 macropixel intensity data
+    macropixel_intensity_dataset = l1b_sectored_rates_dataset.copy(deep=True)
 
     # Load ancillary data for each dynamic threshold state into a dictionary
     ancillary_data_frames = load_ancillary_data(
-        set(sectored_intensity_dataset["dynamic_threshold_state"].values),
+        set(macropixel_intensity_dataset["dynamic_threshold_state"].values),
         ancillary_files,
     )
 
     # Calculate the intensity for each species
-    sectored_intensity_dataset = calculate_intensities_for_all_species(
-        sectored_intensity_dataset, ancillary_data_frames, VALID_SECTORED_SPECIES
+    macropixel_intensity_dataset = calculate_intensities_for_all_species(
+        macropixel_intensity_dataset, ancillary_data_frames, VALID_SECTORED_SPECIES
     )
 
     # Add total and systematic uncertainties to the dataset
-    for var in sectored_intensity_dataset.data_vars:
+    for var in macropixel_intensity_dataset.data_vars:
         if var in VALID_SECTORED_SPECIES:
-            sectored_intensity_dataset = add_systematic_uncertainties(
-                sectored_intensity_dataset, var
+            macropixel_intensity_dataset = add_systematic_uncertainties(
+                macropixel_intensity_dataset, var
             )
-            sectored_intensity_dataset = add_total_uncertainties(
-                sectored_intensity_dataset, var
+            macropixel_intensity_dataset = add_total_uncertainties(
+                macropixel_intensity_dataset, var
             )
 
             # Expand the variable name to include macropixel intensity
-            sectored_intensity_dataset = sectored_intensity_dataset.rename(
+            macropixel_intensity_dataset = macropixel_intensity_dataset.rename(
                 {var: f"{var}_macropixel_intensity"}
             )
 
-    return sectored_intensity_dataset
+    return macropixel_intensity_dataset

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -86,6 +86,13 @@ def add_cdf_attributes(
     This function adds attributes to the dataset variables and dimensions.
     It also adds dimension labels to the dataset as coordinates.
 
+    The attributes are defined in a YAML file and retrieved by the attribute manager.
+    Many variables share attributes across datasets, but some differ due to dimension
+    variations. For example, macropixel uncertainty variables are 4D, while summed
+    and standard uncertainty variables are 2D. To handle this, macropixel uncertainty
+    variables have a "_macropixel" suffix in the YAML file, while summed and standard
+    variables do not (i.e. h_total_uncert_minus_macropixel vs. h_total_uncert_minus).
+
     Parameters
     ----------
     dataset : xr.Dataset
@@ -106,23 +113,19 @@ def add_cdf_attributes(
     # Assign attributes to each data variable in the Dataset
     for var in dataset.data_vars.keys():
         try:
-            if (
-                "macropixel" in logical_source
-                and "intensity" not in var
-                and "energy" not in var
-            ):
+            if "macropixel" in logical_source and ("uncert" in var or "sys_err" in var):
+                # Retrieve attributes specific to macropixel data.
                 dataset[var].attrs = attr_mgr.get_variable_attributes(
                     f"{var}_macropixel"
                 )
             else:
                 dataset[var].attrs = attr_mgr.get_variable_attributes(var)
             if "energy_delta" in var:
+                # skip schema check to avoid DEPEND_0 being added unnecessarily
                 dataset[var].attrs = attr_mgr.get_variable_attributes(
                     var, check_schema=False
                 )
         except KeyError:
-            # TODO: consider raising an error after L2 attributes are defined.
-            #  Until then, continue with processing and log warning
             logger.error(f"Field {var} not found in attribute manager.")
 
     # Assign attributes to dimensions and add dimension labels to dataset

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -672,48 +672,52 @@ def process_standard_intensity_data(
         The L2 standard intensity dataset.
     """
     # Create a new dataset to store the L2 standard intensity data
-    l2_standard_intensity_dataset = xr.Dataset()
+    standard_intensity_dataset = xr.Dataset()
 
     # Assign the epoch coordinate from the l1B dataset
-    l2_standard_intensity_dataset = l2_standard_intensity_dataset.assign_coords(
+    standard_intensity_dataset = standard_intensity_dataset.assign_coords(
         {"epoch": l1b_standard_rates_dataset.coords["epoch"]}
     )
 
     # Add dynamic threshold state to the dataset
-    l2_standard_intensity_dataset["dynamic_threshold_state"] = (
-        l1b_standard_rates_dataset["dynamic_threshold_state"]
-    )
+    standard_intensity_dataset["dynamic_threshold_state"] = l1b_standard_rates_dataset[
+        "dynamic_threshold_state"
+    ]
 
     # Load ancillary data for each dynamic threshold state into a dictionary
     ancillary_data_frames = load_ancillary_data(
-        set(l2_standard_intensity_dataset["dynamic_threshold_state"].values),
+        set(standard_intensity_dataset["dynamic_threshold_state"].values),
         ancillary_files,
     )
 
     # Process each particle type and add rates and uncertainties to the dataset
     for particle, energy_ranges in STANDARD_PARTICLE_ENERGY_RANGE_MAPPING.items():
         # Add standard particle rates and statistical uncertainties to the dataset
-        l2_standard_intensity_dataset = add_summed_particle_data_to_dataset(
-            l2_standard_intensity_dataset,
+        standard_intensity_dataset = add_summed_particle_data_to_dataset(
+            standard_intensity_dataset,
             l1b_standard_rates_dataset,
             particle,
             energy_ranges,
         )
 
-    l2_standard_intensity_dataset = calculate_intensities_for_all_species(
-        l2_standard_intensity_dataset, ancillary_data_frames, VALID_SPECIES
+    standard_intensity_dataset = calculate_intensities_for_all_species(
+        standard_intensity_dataset, ancillary_data_frames, VALID_SPECIES
     )
 
     # Add total and systematic uncertainties to the dataset
     for particle in STANDARD_PARTICLE_ENERGY_RANGE_MAPPING.keys():
-        l2_standard_intensity_dataset = add_systematic_uncertainties(
-            l2_standard_intensity_dataset, particle
+        standard_intensity_dataset = add_systematic_uncertainties(
+            standard_intensity_dataset, particle
         )
-        l2_standard_intensity_dataset = add_total_uncertainties(
-            l2_standard_intensity_dataset, particle
+        standard_intensity_dataset = add_total_uncertainties(
+            standard_intensity_dataset, particle
+        )
+        # Expand the variable name to include standard intensity
+        standard_intensity_dataset = standard_intensity_dataset.rename(
+            {particle: f"{particle}_standard_intensity"}
         )
 
-    return l2_standard_intensity_dataset
+    return standard_intensity_dataset
 
 
 def process_sectored_intensity_data(
@@ -848,4 +852,4 @@ if __name__ == "__main__":
     print(l2_standard_intensity_dataset[0]["h_standard_intensity"])
     print(l2_standard_intensity_dataset[0]["h_sys_err_plus"].attrs)
     print(l2_standard_intensity_dataset[0]["h_standard_intensity"].attrs)
-    print(l2_standard_intensity_dataset[0]["declination_label"])
+    print(l2_standard_intensity_dataset[0]["h_energy_mean_label"])

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -81,7 +81,7 @@ def add_cdf_attributes(
     dataset: xr.Dataset, logical_source: str, attr_mgr: ImapCdfAttributes
 ) -> xr.Dataset:
     """
-    Update attributes to the given dataset.
+    Add attributes to the given dataset.
 
     This function adds attributes to the dataset variables and dimensions.
     It also adds dimension labels to the dataset as coordinates.

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hit.hit_utils import (
     add_summed_particle_data_to_dataset,
     get_attribute_manager,
@@ -46,64 +47,100 @@ def hit_l2(dependency_sci: xr.Dataset, dependencies_anc: list) -> list[xr.Datase
     processed_data : list[xarray.Dataset]
         List of one L2 dataset.
     """
-    logger.info("Creating HIT L2 science datasets")
+    logger.info("Creating HIT L2 science dataset")
 
     # Create the attribute manager for this data level
     attr_mgr = get_attribute_manager("l2")
 
-    l2_datasets: dict = {}
+    logical_source = None
+    l2_dataset = None
 
     # Process science data to L2 datasets
     if "imap_hit_l1b_summed-rates" in dependency_sci.attrs["Logical_source"]:
-        l2_datasets["imap_hit_l2_summed-intensity"] = process_summed_intensity_data(
-            dependency_sci, dependencies_anc
-        )
-        logger.info("HIT L2 summed intensity dataset created")
+        l2_dataset = process_summed_intensity_data(dependency_sci, dependencies_anc)
+        logical_source = "imap_hit_l2_summed-intensity"
 
     if "imap_hit_l1b_standard-rates" in dependency_sci.attrs["Logical_source"]:
-        l2_datasets["imap_hit_l2_standard-intensity"] = process_standard_intensity_data(
-            dependency_sci, dependencies_anc
-        )
-        logger.info("HIT L2 standard intensity dataset created")
+        l2_dataset = process_standard_intensity_data(dependency_sci, dependencies_anc)
+        logical_source = "imap_hit_l2_standard-intensity"
 
     if "imap_hit_l1b_sectored-rates" in dependency_sci.attrs["Logical_source"]:
-        l2_datasets["imap_hit_l2_macropixel-intensity"] = (
-            process_sectored_intensity_data(dependency_sci, dependencies_anc)
-        )
-        logger.info("HIT L2 macropixel intensity dataset created")
+        l2_dataset = process_sectored_intensity_data(dependency_sci, dependencies_anc)
+        logical_source = "imap_hit_l2_macropixel-intensity"
 
-    # Update attributes and dimensions
-    for logical_source, dataset in l2_datasets.items():
-        dataset.attrs = attr_mgr.get_global_attributes(logical_source)
-
-        # TODO: Add CDF attributes to yaml once they're defined for L2 science data
-        #  consider moving attribute handling to hit_utils.py
-        # Assign attributes and dimensions to each data array in the Dataset
-        for field in dataset.data_vars.keys():
-            try:
-                # Create a dict of dimensions using the DEPEND_I keys in the
-                # attributes
-                dims = {
-                    key: value
-                    for key, value in attr_mgr.get_variable_attributes(field).items()
-                    if "DEPEND" in key
-                }
-                dataset[field].attrs = attr_mgr.get_variable_attributes(field)
-                dataset[field].assign_coords(dims)
-            except KeyError:
-                # TODO: consider raising an error after L2 attributes are defined.
-                #  Until then, continue with processing and log warning
-                logger.warning(f"Field {field} not found in attribute manager.")
-
-        # Skip schema check for epoch to prevent attr_mgr from adding the
-        # DEPEND_0 attribute which isn't required for epoch
-        dataset.epoch.attrs = attr_mgr.get_variable_attributes(
-            "epoch", check_schema=False
-        )
+    # Add attributes to dataset
+    if l2_dataset is not None and logical_source is not None:
+        l2_dataset = add_cdf_attributes(l2_dataset, logical_source, attr_mgr)
 
         logger.info(f"HIT L2 dataset created for {logical_source}")
 
-    return list(l2_datasets.values())
+    return [l2_dataset]
+
+
+def add_cdf_attributes(
+    dataset: xr.Dataset, logical_source: str, attr_mgr: ImapCdfAttributes
+) -> xr.Dataset:
+    """
+    Update attributes to the given dataset.
+
+    This function adds attributes to the dataset variables and dimensions.
+    It also adds dimension labels to the dataset as coordinates.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The dataset to update.
+    logical_source : str
+        The logical source of the dataset.
+    attr_mgr : AttributeManager
+        The attribute manager to retrieve attributes.
+
+    Returns
+    -------
+    xr.Dataset
+        The updated dataset with attributes and dimension labels.
+    """
+    # Update global attributes
+    dataset.attrs = attr_mgr.get_global_attributes(logical_source)
+
+    # Assign attributes to each data variable in the Dataset
+    for var in dataset.data_vars.keys():
+        try:
+            if (
+                "macropixel" in logical_source
+                and "intensity" not in var
+                and "energy" not in var
+            ):
+                dataset[var].attrs = attr_mgr.get_variable_attributes(
+                    f"{var}_macropixel"
+                )
+            else:
+                dataset[var].attrs = attr_mgr.get_variable_attributes(var)
+        except KeyError:
+            # TODO: consider raising an error after L2 attributes are defined.
+            #  Until then, continue with processing and log warning
+            logger.error(f"Field {var} not found in attribute manager.")
+
+    # Assign attributes to dimensions and add dimension labels to dataset
+    # check_schema=False to avoid attr_mgr adding stuff dimensions don't need
+    for dim in dataset.dims:
+        dataset[dim].attrs = attr_mgr.get_variable_attributes(dim, check_schema=False)
+        # TODO: should labels be added as coordinates? Check with SPDF
+        if dim != "epoch":
+            dataset = dataset.assign_coords(
+                {
+                    f"{dim}_label": xr.DataArray(
+                        dataset[dim].values.astype(str),
+                        name=f"{dim}_label",
+                        dims=[dim],
+                        attrs=attr_mgr.get_variable_attributes(
+                            f"{dim}_label", check_schema=False
+                        ),
+                    )
+                }
+            )
+
+    return dataset
 
 
 def calculate_intensities(
@@ -730,4 +767,85 @@ def process_sectored_intensity_data(
                 l2_sectored_intensity_dataset, var
             )
 
+            # Expand the variable name to include macropixel intensity
+            l2_sectored_intensity_dataset = l2_sectored_intensity_dataset.rename(
+                {var: f"{var}_macropixel_intensity"}
+            )
+
     return l2_sectored_intensity_dataset
+
+
+if __name__ == "__main__":
+    from imap_processing import imap_module_directory
+    from imap_processing.hit.l1a.hit_l1a import hit_l1a
+    from imap_processing.hit.l1b.hit_l1b import (
+        process_standard_rates_data,
+    )
+
+    # L0 file path
+    packet_file = imap_module_directory / "tests/hit/test_data/sci_sample.ccsds"
+
+    datasets = hit_l1a(packet_file)
+    counts = datasets[0]
+
+    # Calculate livetime from the livetime counter
+    livetime = counts["livetime_counter"] / 270
+
+    # # Process L2 Sectored
+    # sectored_rates = process_sectored_rates_data(counts, livetime)
+    # l2_sectored_intensity_dataset = process_sectored_intensity_data(sectored_rates)
+    # print(l2_sectored_intensity_dataset)
+    # print(l2_sectored_intensity_dataset["h"][0])
+    #
+    # # Process L2 Standard
+    # standard_rates = process_standard_rates_data(counts, livetime)
+    # l2_standard_flux_dataset = process_standard_intensity_data(standard_rates)
+    # print(l2_standard_flux_dataset["h"][1])
+    # print(l2_standard_flux_dataset.data_vars)
+    #
+    # # Process L2 Summed
+    # summed_rates = process_summed_rates_data(counts, livetime)
+    # l2_summed_intensity_dataset = process_summed_intensity_data(summed_rates)
+    # print(l2_summed_intensity_dataset)
+    # print(l2_summed_intensity_dataset["h"][0])
+    #
+    #
+    prefix = imap_module_directory / "tests/hit/test_data/ancillary"
+    ancillary = {
+        "macropixel": [
+            prefix / "imap_hit_sectored-dt0-factors_20250219_v002.csv",
+            prefix / "imap_hit_sectored-dt1-factors_20250219_v002.csv",
+            prefix / "imap_hit_sectored-dt2-factors_20250219_v002.csv",
+            prefix / "imap_hit_sectored-dt3-factors_20250219_v002.csv",
+        ],
+        "summed": [
+            prefix / "imap_hit_summed-dt0-factors_20250219_v002.csv",
+            prefix / "imap_hit_summed-dt1-factors_20250219_v002.csv",
+            prefix / "imap_hit_summed-dt2-factors_20250219_v002.csv",
+            prefix / "imap_hit_summed-dt3-factors_20250219_v002.csv",
+        ],
+        "standard": [
+            prefix / "imap_hit_standard-dt0-factors_20250219_v002.csv",
+            prefix / "imap_hit_standard-dt1-factors_20250219_v002.csv",
+            prefix / "imap_hit_standard-dt2-factors_20250219_v002.csv",
+            prefix / "imap_hit_standard-dt3-factors_20250219_v002.csv",
+        ],
+    }
+
+    # # Process L2 Sectored
+    # sectored_rates = process_sectored_rates_data(counts, livetime)
+    # sectored_rates.attrs["Logical_source"] = "imap_hit_l1b_sectored-rates"
+    # l2_sectored_intensity_dataset = hit_l2(sectored_rates, ancillary["macropixel"])
+    # print(l2_sectored_intensity_dataset[0]["h_macropixel_intensity"])
+    # print(l2_sectored_intensity_dataset[0]["h_sys_err_plus"].attrs)
+    # print(l2_sectored_intensity_dataset[0]["h_macropixel_intensity"].attrs)
+    # print(l2_sectored_intensity_dataset[0]["declination_label"])
+
+    # # Process L2 Standard
+    standard_rates = process_standard_rates_data(counts, livetime)
+    standard_rates.attrs["Logical_source"] = "imap_hit_l1b_standard-rates"
+    l2_standard_intensity_dataset = hit_l2(standard_rates, ancillary["standard"])
+    print(l2_standard_intensity_dataset[0]["h_standard_intensity"])
+    print(l2_standard_intensity_dataset[0]["h_sys_err_plus"].attrs)
+    print(l2_standard_intensity_dataset[0]["h_standard_intensity"].attrs)
+    print(l2_standard_intensity_dataset[0]["declination_label"])

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -608,30 +608,34 @@ def process_summed_intensity_data(
         The processed L2 summed intensity dataset.
     """
     # Create a new dataset to store the L2 summed intensity data
-    l2_summed_intensity_dataset = l1b_summed_rates_dataset.copy(deep=True)
+    summed_intensity_dataset = l1b_summed_rates_dataset.copy(deep=True)
 
     # Load ancillary data for each dynamic threshold state into a dictionary
     ancillary_data_frames = load_ancillary_data(
-        set(l2_summed_intensity_dataset["dynamic_threshold_state"].values),
+        set(summed_intensity_dataset["dynamic_threshold_state"].values),
         ancillary_files,
     )
 
     # Calculate the intensity for each species
-    l2_summed_intensity_dataset = calculate_intensities_for_all_species(
-        l2_summed_intensity_dataset, ancillary_data_frames, VALID_SPECIES
+    summed_intensity_dataset = calculate_intensities_for_all_species(
+        summed_intensity_dataset, ancillary_data_frames, VALID_SPECIES
     )
 
     # Add total and systematic uncertainties to the dataset
-    for var in l2_summed_intensity_dataset.data_vars:
+    for var in summed_intensity_dataset.data_vars:
         if var in VALID_SPECIES:
-            l2_summed_intensity_dataset = add_systematic_uncertainties(
-                l2_summed_intensity_dataset, var
+            summed_intensity_dataset = add_systematic_uncertainties(
+                summed_intensity_dataset, var
             )
-            l2_summed_intensity_dataset = add_total_uncertainties(
-                l2_summed_intensity_dataset, var
+            summed_intensity_dataset = add_total_uncertainties(
+                summed_intensity_dataset, var
+            )
+            # Expand the variable name to include standard intensity
+            summed_intensity_dataset = summed_intensity_dataset.rename(
+                {var: f"{var}_summed_intensity"}
             )
 
-    return l2_summed_intensity_dataset
+    return summed_intensity_dataset
 
 
 def process_standard_intensity_data(
@@ -783,37 +787,16 @@ if __name__ == "__main__":
     from imap_processing import imap_module_directory
     from imap_processing.hit.l1a.hit_l1a import hit_l1a
     from imap_processing.hit.l1b.hit_l1b import (
-        process_standard_rates_data,
+        process_summed_rates_data,
     )
 
     # L0 file path
     packet_file = imap_module_directory / "tests/hit/test_data/sci_sample.ccsds"
-
     datasets = hit_l1a(packet_file)
     counts = datasets[0]
-
     # Calculate livetime from the livetime counter
     livetime = counts["livetime_counter"] / 270
 
-    # # Process L2 Sectored
-    # sectored_rates = process_sectored_rates_data(counts, livetime)
-    # l2_sectored_intensity_dataset = process_sectored_intensity_data(sectored_rates)
-    # print(l2_sectored_intensity_dataset)
-    # print(l2_sectored_intensity_dataset["h"][0])
-    #
-    # # Process L2 Standard
-    # standard_rates = process_standard_rates_data(counts, livetime)
-    # l2_standard_flux_dataset = process_standard_intensity_data(standard_rates)
-    # print(l2_standard_flux_dataset["h"][1])
-    # print(l2_standard_flux_dataset.data_vars)
-    #
-    # # Process L2 Summed
-    # summed_rates = process_summed_rates_data(counts, livetime)
-    # l2_summed_intensity_dataset = process_summed_intensity_data(summed_rates)
-    # print(l2_summed_intensity_dataset)
-    # print(l2_summed_intensity_dataset["h"][0])
-    #
-    #
     prefix = imap_module_directory / "tests/hit/test_data/ancillary"
     ancillary = {
         "macropixel": [
@@ -845,11 +828,20 @@ if __name__ == "__main__":
     # print(l2_sectored_intensity_dataset[0]["h_macropixel_intensity"].attrs)
     # print(l2_sectored_intensity_dataset[0]["declination_label"])
 
-    # # Process L2 Standard
-    standard_rates = process_standard_rates_data(counts, livetime)
-    standard_rates.attrs["Logical_source"] = "imap_hit_l1b_standard-rates"
-    l2_standard_intensity_dataset = hit_l2(standard_rates, ancillary["standard"])
-    print(l2_standard_intensity_dataset[0]["h_standard_intensity"])
-    print(l2_standard_intensity_dataset[0]["h_sys_err_plus"].attrs)
-    print(l2_standard_intensity_dataset[0]["h_standard_intensity"].attrs)
-    print(l2_standard_intensity_dataset[0]["h_energy_mean_label"])
+    # # # Process L2 Standard
+    # standard_rates = process_standard_rates_data(counts, livetime)
+    # standard_rates.attrs["Logical_source"] = "imap_hit_l1b_standard-rates"
+    # l2_standard_intensity_dataset = hit_l2(standard_rates, ancillary["standard"])
+    # print(l2_standard_intensity_dataset[0]["h_standard_intensity"])
+    # print(l2_standard_intensity_dataset[0]["h_sys_err_plus"].attrs)
+    # print(l2_standard_intensity_dataset[0]["h_standard_intensity"].attrs)
+    # print(l2_standard_intensity_dataset[0]["h_energy_mean_label"])
+
+    # # Process L2 Summed
+    summed_rates = process_summed_rates_data(counts, livetime)
+    summed_rates.attrs["Logical_source"] = "imap_hit_l1b_summed-rates"
+    l2_summed_intensity_dataset = hit_l2(summed_rates, ancillary["summed"])
+    print(l2_summed_intensity_dataset[0]["h_summed_intensity"])
+    print(l2_summed_intensity_dataset[0]["h_sys_err_plus"].attrs)
+    print(l2_summed_intensity_dataset[0]["h_summed_intensity"].attrs)
+    print(l2_summed_intensity_dataset[0]["h_energy_mean_label"])

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -116,6 +116,10 @@ def add_cdf_attributes(
                 )
             else:
                 dataset[var].attrs = attr_mgr.get_variable_attributes(var)
+            if "energy_delta" in var:
+                dataset[var].attrs = attr_mgr.get_variable_attributes(
+                    var, check_schema=False
+                )
         except KeyError:
             # TODO: consider raising an error after L2 attributes are defined.
             #  Until then, continue with processing and log warning
@@ -738,6 +742,8 @@ def process_sectored_intensity_data(
     Sectored Intensity = (Summed L1B Sectored Rates) /
                        (600 * Delta E * Geometry Factor * Efficiency) - b
 
+    Note: sectored is also known as macropixel at this data level
+
     Parameters
     ----------
     l1b_sectored_rates_dataset : xr.Dataset
@@ -752,96 +758,32 @@ def process_sectored_intensity_data(
         The processed L2 sectored intensity dataset.
     """
     # Create a new dataset to store the L2 sectored intensity data
-    l2_sectored_intensity_dataset = l1b_sectored_rates_dataset.copy(deep=True)
+    sectored_intensity_dataset = l1b_sectored_rates_dataset.copy(deep=True)
 
     # Load ancillary data for each dynamic threshold state into a dictionary
     ancillary_data_frames = load_ancillary_data(
-        set(l2_sectored_intensity_dataset["dynamic_threshold_state"].values),
+        set(sectored_intensity_dataset["dynamic_threshold_state"].values),
         ancillary_files,
     )
 
     # Calculate the intensity for each species
-    l2_sectored_intensity_dataset = calculate_intensities_for_all_species(
-        l2_sectored_intensity_dataset, ancillary_data_frames, VALID_SECTORED_SPECIES
+    sectored_intensity_dataset = calculate_intensities_for_all_species(
+        sectored_intensity_dataset, ancillary_data_frames, VALID_SECTORED_SPECIES
     )
 
     # Add total and systematic uncertainties to the dataset
-    for var in l2_sectored_intensity_dataset.data_vars:
+    for var in sectored_intensity_dataset.data_vars:
         if var in VALID_SECTORED_SPECIES:
-            l2_sectored_intensity_dataset = add_systematic_uncertainties(
-                l2_sectored_intensity_dataset, var
+            sectored_intensity_dataset = add_systematic_uncertainties(
+                sectored_intensity_dataset, var
             )
-            l2_sectored_intensity_dataset = add_total_uncertainties(
-                l2_sectored_intensity_dataset, var
+            sectored_intensity_dataset = add_total_uncertainties(
+                sectored_intensity_dataset, var
             )
 
             # Expand the variable name to include macropixel intensity
-            l2_sectored_intensity_dataset = l2_sectored_intensity_dataset.rename(
+            sectored_intensity_dataset = sectored_intensity_dataset.rename(
                 {var: f"{var}_macropixel_intensity"}
             )
 
-    return l2_sectored_intensity_dataset
-
-
-if __name__ == "__main__":
-    from imap_processing import imap_module_directory
-    from imap_processing.hit.l1a.hit_l1a import hit_l1a
-    from imap_processing.hit.l1b.hit_l1b import (
-        process_summed_rates_data,
-    )
-
-    # L0 file path
-    packet_file = imap_module_directory / "tests/hit/test_data/sci_sample.ccsds"
-    datasets = hit_l1a(packet_file)
-    counts = datasets[0]
-    # Calculate livetime from the livetime counter
-    livetime = counts["livetime_counter"] / 270
-
-    prefix = imap_module_directory / "tests/hit/test_data/ancillary"
-    ancillary = {
-        "macropixel": [
-            prefix / "imap_hit_sectored-dt0-factors_20250219_v002.csv",
-            prefix / "imap_hit_sectored-dt1-factors_20250219_v002.csv",
-            prefix / "imap_hit_sectored-dt2-factors_20250219_v002.csv",
-            prefix / "imap_hit_sectored-dt3-factors_20250219_v002.csv",
-        ],
-        "summed": [
-            prefix / "imap_hit_summed-dt0-factors_20250219_v002.csv",
-            prefix / "imap_hit_summed-dt1-factors_20250219_v002.csv",
-            prefix / "imap_hit_summed-dt2-factors_20250219_v002.csv",
-            prefix / "imap_hit_summed-dt3-factors_20250219_v002.csv",
-        ],
-        "standard": [
-            prefix / "imap_hit_standard-dt0-factors_20250219_v002.csv",
-            prefix / "imap_hit_standard-dt1-factors_20250219_v002.csv",
-            prefix / "imap_hit_standard-dt2-factors_20250219_v002.csv",
-            prefix / "imap_hit_standard-dt3-factors_20250219_v002.csv",
-        ],
-    }
-
-    # # Process L2 Sectored
-    # sectored_rates = process_sectored_rates_data(counts, livetime)
-    # sectored_rates.attrs["Logical_source"] = "imap_hit_l1b_sectored-rates"
-    # l2_sectored_intensity_dataset = hit_l2(sectored_rates, ancillary["macropixel"])
-    # print(l2_sectored_intensity_dataset[0]["h_macropixel_intensity"])
-    # print(l2_sectored_intensity_dataset[0]["h_sys_err_plus"].attrs)
-    # print(l2_sectored_intensity_dataset[0]["h_macropixel_intensity"].attrs)
-    # print(l2_sectored_intensity_dataset[0]["declination_label"])
-
-    # # # Process L2 Standard
-    # standard_rates = process_standard_rates_data(counts, livetime)
-    # standard_rates.attrs["Logical_source"] = "imap_hit_l1b_standard-rates"
-    # l2_standard_intensity_dataset = hit_l2(standard_rates, ancillary["standard"])
-    # print(l2_standard_intensity_dataset[0]["h_standard_intensity"])
-    # print(l2_standard_intensity_dataset[0]["h_sys_err_plus"].attrs)
-    # print(l2_standard_intensity_dataset[0]["h_standard_intensity"].attrs)
-    # print(l2_standard_intensity_dataset[0]["h_energy_mean_label"])
-
-    # # Process L2 Summed
-    summed_rates = process_summed_rates_data(counts, livetime)
-    summed_rates.attrs["Logical_source"] = "imap_hit_l1b_summed-rates"
-    l2_summed_intensity_dataset = hit_l2(summed_rates, ancillary["summed"])
-    print(l2_summed_intensity_dataset[0]["h_summed_intensity"])
-    print(l2_summed_intensity_dataset[0]["h_sys_err_plus"].attrs)
-    print(l2_summed_intensity_dataset[0]["h_summed_intensity"].attrs)
-    print(l2_summed_intensity_dataset[0]["h_energy_mean_label"])
+    return sectored_intensity_dataset

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -27,9 +27,9 @@ from imap_processing.hit.l2.hit_l2 import (
     get_species_ancillary_data,
     hit_l2,
     load_ancillary_data,
-    process_sectored_intensity_data,
-    process_standard_intensity_data,
-    process_summed_intensity_data,
+    process_macropixel_intensity,
+    process_standard_intensity,
+    process_summed_intensity,
     reshape_for_sectored,
 )
 
@@ -617,12 +617,12 @@ def test_add_total_uncertainties():
     )
 
 
-def test_process_sectored_intensity_data(
+def test_process_macropixel_intensity(
     l1b_sectored_rates_dataset, ancillary_dependencies
 ):
     """Test the variables in the sectored intensity dataset"""
 
-    l2_sectored_intensity_dataset = process_sectored_intensity_data(
+    l2_sectored_intensity_dataset = process_macropixel_intensity(
         l1b_sectored_rates_dataset, ancillary_dependencies["macropixel"]
     )
 
@@ -663,12 +663,10 @@ def test_process_sectored_intensity_data(
         )
 
 
-def test_process_summed_intensity_data(
-    l1b_summed_rates_dataset, ancillary_dependencies
-):
+def test_process_summed_intensity(l1b_summed_rates_dataset, ancillary_dependencies):
     """Test the variables in the summed intensity dataset"""
 
-    l2_summed_intensity_dataset = process_summed_intensity_data(
+    l2_summed_intensity_dataset = process_summed_intensity(
         l1b_summed_rates_dataset, ancillary_dependencies["summed"]
     )
 
@@ -713,12 +711,10 @@ def test_process_summed_intensity_data(
         assert f"{particle}_energy_delta_plus" in l2_summed_intensity_dataset.data_vars
 
 
-def test_process_standard_intensity_data(
-    l1b_standard_rates_dataset, ancillary_dependencies
-):
+def test_process_standard_intensity(l1b_standard_rates_dataset, ancillary_dependencies):
     """Test the variables in the standard intensity dataset"""
 
-    l2_standard_intensity_dataset = process_standard_intensity_data(
+    l2_standard_intensity_dataset = process_standard_intensity(
         l1b_standard_rates_dataset, ancillary_dependencies["standard"]
     )
 

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -154,6 +154,8 @@ def test_add_cdf_attributes():
         {
             "intensity_var": (["dim1", "dim2"], np.ones((2, 2))),
             "other_var": (["dim1", "dim2"], np.ones((2, 2))),
+            "uncert_var": (["dim1", "dim2"], np.ones((2, 2))),
+            "sys_err_var": (["dim1", "dim2"], np.ones((2, 2))),
             "energy_var": (["dim1"], np.ones(2)),
             "energy_delta_var": (["dim1"], np.ones(2)),
         },
@@ -179,12 +181,14 @@ def test_add_cdf_attributes():
     assert result.attrs["Global_attr"] == "Test Dataset"
 
     # 2. Variable attributes
-    # 'other_var' should use macropixel logic
-    assert "other_var_macropixel_attr" in result["other_var"].attrs
+    # uncertainty vars should use macropixel logic
+    assert "uncert_var_macropixel_attr" in result["uncert_var"].attrs
+    assert "sys_err_var_macropixel_attr" in result["sys_err_var"].attrs
 
-    # 'intensity_var' and 'energy_var' should use regular logic
+    # 'intensity_var', 'energy_var', 'other_var' should use regular logic
     assert "intensity_var_attr" in result["intensity_var"].attrs
     assert "energy_var_attr" in result["energy_var"].attrs
+    assert "other_var_attr" in result["other_var"].attrs
 
     # 'energy_delta_var' should have check_schema=False
     assert "energy_delta_var_attr" in result["energy_delta_var"].attrs

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -148,13 +148,14 @@ def _check_ancillary_dataset(
 
 
 def test_add_cdf_attributes():
+    """Test the add_cdf_attributes function."""
     # Create a dataset with multiple variable name patterns
     dataset = xr.Dataset(
         {
             "intensity_var": (["dim1", "dim2"], np.ones((2, 2))),
-            "energy_var": (["dim1", "dim2"], np.ones((2, 2))),
-            "energy_delta_var": (["dim1", "dim2"], np.ones((2, 2))),
             "other_var": (["dim1", "dim2"], np.ones((2, 2))),
+            "energy_var": (["dim1"], np.ones(2)),
+            "energy_delta_var": (["dim1"], np.ones(2)),
         },
         coords={"dim1": [10, 20], "dim2": [1, 2]},
     )

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
@@ -18,6 +18,7 @@ from imap_processing.hit.l2.hit_l2 import (
     SECONDS_PER_MIN,
     STANDARD_PARTICLE_ENERGY_RANGE_MAPPING,
     VALID_SECTORED_SPECIES,
+    add_cdf_attributes,
     add_systematic_uncertainties,
     add_total_uncertainties,
     build_ancillary_dataset,
@@ -144,6 +145,56 @@ def _check_ancillary_dataset(
         np.testing.assert_array_equal(
             species_array.coords[coord], ancillary_ds.coords[coord]
         )
+
+
+def test_add_cdf_attributes():
+    # Create a dataset with multiple variable name patterns
+    dataset = xr.Dataset(
+        {
+            "intensity_var": (["dim1", "dim2"], np.ones((2, 2))),
+            "energy_var": (["dim1", "dim2"], np.ones((2, 2))),
+            "energy_delta_var": (["dim1", "dim2"], np.ones((2, 2))),
+            "other_var": (["dim1", "dim2"], np.ones((2, 2))),
+        },
+        coords={"dim1": [10, 20], "dim2": [1, 2]},
+    )
+
+    # Logical source to test macropixel logic
+    logical_source = "test_macropixel"
+
+    # Create a mock attribute manager
+    attr_mgr = Mock()
+    attr_mgr.get_global_attributes.return_value = {"Global_attr": "Test Dataset"}
+
+    def fake_get_variable_attributes(name, check_schema=True):
+        return {f"{name}_attr": "value", "check_schema": check_schema}
+
+    attr_mgr.get_variable_attributes.side_effect = fake_get_variable_attributes
+
+    # Run the function
+    result = add_cdf_attributes(dataset, logical_source, attr_mgr)
+
+    # 1. Global attributes
+    assert result.attrs["Global_attr"] == "Test Dataset"
+
+    # 2. Variable attributes
+    # 'other_var' should use macropixel logic
+    assert "other_var_macropixel_attr" in result["other_var"].attrs
+
+    # 'intensity_var' and 'energy_var' should use regular logic
+    assert "intensity_var_attr" in result["intensity_var"].attrs
+    assert "energy_var_attr" in result["energy_var"].attrs
+
+    # 'energy_delta_var' should have check_schema=False
+    assert "energy_delta_var_attr" in result["energy_delta_var"].attrs
+    assert result["energy_delta_var"].attrs["check_schema"] is False
+
+    # 3. Dimension attributes and labels
+    for dim in ["dim1", "dim2"]:
+        assert f"{dim}_attr" in result[dim].attrs
+        assert f"{dim}_label" in result.coords
+        assert f"{f'{dim}_label'}_attr" in result[f"{dim}_label"].attrs
+        assert list(result[f"{dim}_label"].dims) == [dim]
 
 
 def test_load_ancillary_data():
@@ -648,7 +699,10 @@ def test_process_macropixel_intensity(
     assert "dynamic_threshold_state" in l2_sectored_intensity_dataset.data_vars
 
     for particle in VALID_SECTORED_SPECIES:
-        assert f"{particle}" in l2_sectored_intensity_dataset.data_vars
+        assert (
+            f"{particle}_macropixel_intensity"
+            in l2_sectored_intensity_dataset.data_vars
+        )
         assert (
             f"{particle}_stat_uncert_minus" in l2_sectored_intensity_dataset.data_vars
         )
@@ -702,7 +756,7 @@ def test_process_summed_intensity(l1b_summed_rates_dataset, ancillary_dependenci
     assert "dynamic_threshold_state" in l1b_summed_rates_dataset.data_vars
 
     for particle in SUMMED_PARTICLE_ENERGY_RANGE_MAPPING.keys():
-        assert f"{particle}" in l2_summed_intensity_dataset.data_vars
+        assert f"{particle}_summed_intensity" in l2_summed_intensity_dataset.data_vars
         assert f"{particle}_stat_uncert_minus" in l2_summed_intensity_dataset.data_vars
         assert f"{particle}_stat_uncert_plus" in l2_summed_intensity_dataset.data_vars
         assert f"{particle}_sys_err_minus" in l2_summed_intensity_dataset.data_vars
@@ -750,7 +804,9 @@ def test_process_standard_intensity(l1b_standard_rates_dataset, ancillary_depend
     assert "dynamic_threshold_state" in l1b_standard_rates_dataset.data_vars
 
     for particle in STANDARD_PARTICLE_ENERGY_RANGE_MAPPING.keys():
-        assert f"{particle}" in l2_standard_intensity_dataset.data_vars
+        assert (
+            f"{particle}_standard_intensity" in l2_standard_intensity_dataset.data_vars
+        )
         assert (
             f"{particle}_stat_uncert_minus" in l2_standard_intensity_dataset.data_vars
         )


### PR DESCRIPTION
This PR updates L2 processing to add CDF attributes to datasets.

Closes #1076 
Closes #1077 
Closes #1078 

## Updated Files
- hit_l2.py
   - Added a function to add attributes to L2 datasets
   - Cleaned up function and variable names (i.e. rename sectored to macropixel, etc.)
- test_hit_l2.py
   - updated tests to reflect changes above
   - added a new test for adding cdf attributes
- imap_hit_l2_variable_attrs.yaml
   - updated attribute names to reflect changes to variable names requested by HIT
   - updated energy mean attrs to include DEPEND_1
   - expanded some CATDESC descriptions
   - other updates for ISTP compliance

