### PR TITLE
Fixing ultra L2 test

### DIFF
--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -317,12 +317,12 @@ def test_ultra_l2(mock_ultra_l2, mock_instrument_dependencies):
         "20240207",
         "20240207",
         "v001",
-        True,
+        False,
     )
 
     instrument.process()
     assert mock_ultra_l2.call_count == 1
-    assert mocks["mock_upload"].call_count == 1
+    assert mock_instrument_dependencies["mock_write_cdf"].call_count == 1
 
 
 @mock.patch("imap_processing.cli.hit_l1a")


### PR DESCRIPTION
# Change Summary
This test started failing due to some merge conflicts because of a change I made to the CLI. This fixes it. 

(rather than testing that upload succeeds through our mock API, this checks that a CDF file is created through a mock call to write_cdf. The upload stuff is tested separately.)
