### PR TITLE
HIT - Rename 'declination' to 'zenith'

### DIFF
--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -57,11 +57,11 @@ default_angle_attrs: &default_angle
   SCALE_TYP: linear
 
 # <=== Coordinates ===>
-declination:
+zenith:
   <<: *default_angle
   CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
-  FIELDNAM: Declination
-  LABLAXIS: Declination
+  FIELDNAM: Zenith
+  LABLAXIS: Zenith
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:ArrivalDirection,Qualifer:DirectionAngle.PolarAngle
 
 azimuth:
@@ -187,9 +187,9 @@ cno_energy_mean:
 
 
 # <=== Labels ===>
-declination_label:
+zenith_label:
   CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
-  FIELDNAM: Declination Angle
+  FIELDNAM: Zenith Angle
   FORMAT: A6
   VAR_TYPE: metadata
 
@@ -1603,10 +1603,10 @@ h_macropixel_intensity:
   CATDESC: H Macropixel Intensity
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   FIELDNAM: H Intensity Macropixel
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
@@ -1616,10 +1616,10 @@ he4_macropixel_intensity:
   CATDESC: He4 Macropixel Intensity
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   FIELDNAM: He4 Intensity Macropixel
   DELTA_MINUS: he4_total_uncert_plus
   DELTA_PLUS: he4_total_uncert_minus
@@ -1629,10 +1629,10 @@ cno_macropixel_intensity:
   CATDESC: C, N, O Macropixel Intensity
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   FIELDNAM: CNO Intensity Macropixel
   DELTA_MINUS: c_total_uncert_plus
   DELTA_PLUS: c_total_uncert_minus
@@ -1642,10 +1642,10 @@ nemgsi_macropixel_intensity:
   CATDESC: NeMgSi Macropixel Intensity
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   FIELDNAM: NeMgSi Intensity Macropixel
   DELTA_MINUS: nemgsi_total_uncert_plus
   DELTA_PLUS: nemgsi_total_uncert_minus
@@ -1655,10 +1655,10 @@ fe_macropixel_intensity:
   CATDESC: Fe Macropixel Intensity
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   FIELDNAM: Fe Intensity Macropixel
   DELTA_MINUS: fe_total_uncert_plus
   DELTA_PLUS: fe_total_uncert_minus
@@ -1697,10 +1697,10 @@ h_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus statistical uncertainty for H Macropixel
   FIELDNAM: H plus statistical uncertainty
 
@@ -1708,10 +1708,10 @@ h_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus statistical uncertainty for H Macropixel
   FIELDNAM: H Minus Statistical Uncertainty
 
@@ -1719,10 +1719,10 @@ h_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus systematic uncertainty for H Macropixel
   FIELDNAM: H Plus Systematic Uncertainty
 
@@ -1730,10 +1730,10 @@ h_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus systematic uncertainty for H Macropixel
   FIELDNAM: H Minus Systematic Uncertainty
 
@@ -1741,10 +1741,10 @@ h_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for H Macropixel
   FIELDNAM: H Plus Total Uncertainty
 
@@ -1752,10 +1752,10 @@ h_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: h_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: h_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for H Macropixel
   FIELDNAM: H Minus Total Uncertainty
 
@@ -1763,10 +1763,10 @@ he4_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus statistical uncertainty for He4 Macropixel
   FIELDNAM: He4 Plus Statistical Uncertainty
 
@@ -1774,10 +1774,10 @@ he4_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus statistical uncertainty for He4 Macropixel
   FIELDNAM: He4 Minus Statistical Uncertainty
 
@@ -1785,10 +1785,10 @@ he4_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus systematic uncertainty for He4 Macropixel
   FIELDNAM: He4 Plus Systematic Uncertainty
 
@@ -1796,10 +1796,10 @@ he4_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus systematic uncertainty for He4 Macropixel
   FIELDNAM: He4 Minus Systematic Uncertainty
 
@@ -1807,10 +1807,10 @@ he4_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for He4 Macropixel
   FIELDNAM: He4 Plus Total Uncertainty
 
@@ -1818,10 +1818,10 @@ he4_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: he4_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: he4_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for He4 Macropixel
   FIELDNAM: He4 Minus Total Uncertainty
 
@@ -1829,10 +1829,10 @@ cno_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus statistical uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Plus Statistical Uncertainty
 
@@ -1840,10 +1840,10 @@ cno_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus statistical uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Minus Statistical Uncertainty
 
@@ -1851,10 +1851,10 @@ cno_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus systematic uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Plus Systematic Uncertainty
 
@@ -1862,10 +1862,10 @@ cno_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus systematic uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Minus Systematic Uncertainty
 
@@ -1873,10 +1873,10 @@ cno_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Plus Total Uncertainty
 
@@ -1884,10 +1884,10 @@ cno_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: cno_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: cno_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for C, N, O Macropixel
   FIELDNAM: CNO Minus Total Uncertainty
 
@@ -1895,10 +1895,10 @@ nemgsi_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus statistical uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Plus Statistical Uncertainty
 
@@ -1906,10 +1906,10 @@ nemgsi_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus statistical uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Minus Statistical Uncertainty
 
@@ -1917,10 +1917,10 @@ nemgsi_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus systematic uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Plus Systematic Uncertainty
 
@@ -1928,10 +1928,10 @@ nemgsi_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus systematic uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Minus Systematic Uncertainty
 
@@ -1939,10 +1939,10 @@ nemgsi_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Plus Total Uncertainty
 
@@ -1950,10 +1950,10 @@ nemgsi_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: nemgsi_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: nemgsi_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Ne, Mg, Si Macropixel
   FIELDNAM: NeMgSi Minus Total Uncertainty
 
@@ -1961,10 +1961,10 @@ fe_stat_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus statistical uncertainty for Fe Macropixel
   FIELDNAM: Fe Plus Statistical Uncertainty
 
@@ -1972,10 +1972,10 @@ fe_stat_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus statistical uncertainty for Fe Macropixel
   FIELDNAM: Fe Minus Statistical Uncertainty
 
@@ -1983,10 +1983,10 @@ fe_sys_err_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus systematic uncertainty for Fe Macropixel
   FIELDNAM: Fe Plus Systematic Uncertainty
 
@@ -1994,10 +1994,10 @@ fe_sys_err_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus systematic uncertainty for Fe Macropixel
   FIELDNAM: Fe Minus Systematic Uncertainty
 
@@ -2005,10 +2005,10 @@ fe_total_uncert_plus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Plus total (statistical and systematic added in quadrature) uncertainty for Fe Macropixel
   FIELDNAM: Fe Plus Total Uncertainty
 
@@ -2016,10 +2016,10 @@ fe_total_uncert_minus_macropixel:
   <<: *default_uncertainty
   DEPEND_1: fe_energy_mean
   DEPEND_2: azimuth
-  DEPEND_3: declination
+  DEPEND_3: zenith
   LABL_PTR_1: fe_energy_mean_label
   LABL_PTR_2: azimuth_label
-  LABL_PTR_3: declination_label
+  LABL_PTR_3: zenith_label
   CATDESC: Minus total (statistical and systematic added in quadrature) uncertainty for Fe Macropixel
   FIELDNAM: Fe Minus Total Uncertainty
 

--- a/imap_processing/hit/l0/constants.py
+++ b/imap_processing/hit/l0/constants.py
@@ -118,7 +118,7 @@ MANTISSA_BITS = 12
 EXPONENT_BITS = 4
 
 # Define sectorate angles
-DECLINATION_ANGLES = np.array(
+ZENITH_ANGLES = np.array(
     [11.25, 33.75, 56.25, 78.75, 101.25, 123.75, 146.25, 168.75], dtype=np.float32
 )
 AZIMUTH_ANGLES = np.array(

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -6,11 +6,11 @@ import xarray as xr
 from imap_processing.hit.l0.constants import (
     AZIMUTH_ANGLES,
     COUNTS_DATA_STRUCTURE,
-    DECLINATION_ANGLES,
     EXPONENT_BITS,
     FLAG_PATTERN,
     FRAME_SIZE,
     MANTISSA_BITS,
+    ZENITH_ANGLES,
 )
 from imap_processing.utils import convert_to_binary_string
 
@@ -92,14 +92,14 @@ def parse_count_rates(sci_dataset: xr.Dataset) -> None:
         # Get dims for data variables (yaml file not created yet)
         if len(field_meta.shape) > 1:
             if "sectorates" in field:
-                # Reshape data to 15x8 for azimuth and declination look directions
+                # Reshape data to 15x8 for azimuth and zenith look directions
                 parsed_data = np.array(parsed_data).reshape((-1, *field_meta.shape))
-                dims = ["epoch", "azimuth", "declination"]
+                dims = ["epoch", "azimuth", "zenith"]
                 # Add angle values to coordinates
-                sci_dataset.coords["declination"] = xr.DataArray(
-                    data=DECLINATION_ANGLES,
-                    dims=["declination"],
-                    name="declination",
+                sci_dataset.coords["zenith"] = xr.DataArray(
+                    data=ZENITH_ANGLES,
+                    dims=["zenith"],
+                    name="zenith",
                 )
                 sci_dataset.coords["azimuth"] = xr.DataArray(
                     data=AZIMUTH_ANGLES,

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -83,7 +83,7 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
 
     The data is added to the dataset as new data fields named
     according to their species. They have 4 dimensions: epoch
-    energy mean, azimuth, and declination. The energy mean
+    energy mean, azimuth, and zenith. The energy mean
     dimension is used to distinguish between the different energy
     ranges the data belongs to. The energy deltas for each species
     are also added to the dataset as new data fields.
@@ -136,14 +136,14 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
 
     # Add sectored rates by species to the dataset
     for species, data in data_by_species.items():
-        # Rates data has shape: energy_mean, epoch, azimuth, declination
+        # Rates data has shape: energy_mean, epoch, azimuth, zenith
         # Convert rates to numpy array and transpose axes to get
-        # shape: epoch, energy_mean, azimuth, declination
+        # shape: epoch, energy_mean, azimuth, zenith
         rates_data = np.transpose(np.array(data["counts"]), axes=(1, 0, 2, 3))
 
         updated_dataset[f"{species}_sectored_counts"] = xr.DataArray(
             data=rates_data,
-            dims=["epoch", f"{species}_energy_mean", "azimuth", "declination"],
+            dims=["epoch", f"{species}_energy_mean", "azimuth", "zenith"],
             name=f"{species}_counts_sectored",
         )
 

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -469,7 +469,7 @@ def process_sectored_rates_data(
         l1a_counts_dataset,
         coords=[
             "epoch",
-            "declination",
+            "zenith",
             "azimuth",
             "h_energy_mean",
             "he4_energy_mean",

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -197,8 +197,8 @@ def reshape_for_sectored(arr: np.ndarray) -> np.ndarray:
     """
     Reshape the ancillary data for sectored rates.
 
-    Reshape the 3D arrays (epoch, energy, declination) to 4D arrays
-    (epoch, energy, azimuth, declination) by repeating the data
+    Reshape the 3D arrays (epoch, energy, zenith) to 4D arrays
+    (epoch, energy, azimuth, zenith) by repeating the data
     along the azimuth dimension. This is done to match the dimensions
     of the sectored rates data to allow for proper calculation of
     intensities.
@@ -255,10 +255,8 @@ def build_ancillary_dataset(
     """
     data_vars = {}
 
-    # Check if this is sectored data (i.e., has azimuth and declination dims)
-    is_sectored = (
-        "declination" in species_array.dims or "declination" in species_array.coords
-    )
+    # Check if this is sectored data (i.e., has azimuth and zenith dims)
+    is_sectored = "zenith" in species_array.dims or "zenith" in species_array.coords
 
     # Build variables
     data_vars["delta_e"] = (species_array.dims, delta_e)
@@ -355,7 +353,7 @@ def calculate_intensities_for_a_species(
     )
 
     # Reshape parameters for sectored rates to 4D arrays
-    if "declination" in updated_ds[species_variable].dims:
+    if "zenith" in updated_ds[species_variable].dims:
         delta_e = reshape_for_sectored(delta_e)
         geometry_factors = reshape_for_sectored(geometry_factors)
         efficiencies = reshape_for_sectored(efficiencies)

--- a/imap_processing/tests/hit/helpers/l1_validation.py
+++ b/imap_processing/tests/hit/helpers/l1_validation.py
@@ -349,7 +349,7 @@ def compare_data(
                     # which are only present in the validation data. In the actual
                     # data, sectored rates are organized by species in 4D arrays.
                     #    i.e. h_sectored_counts has shape
-                    #         (epoch, h_energy_index, azimuth, declination).
+                    #         (epoch, h_energy_index, azimuth, zenith).
                     # species and energy index are used to find the correct
                     # array of sectored rate data from the actual data for comparison.
                     species = expected_data[field][frame]

--- a/imap_processing/tests/hit/test_decom_hit.py
+++ b/imap_processing/tests/hit/test_decom_hit.py
@@ -7,7 +7,7 @@ from imap_processing import imap_module_directory
 from imap_processing.hit.hit_utils import (
     HitAPID,
 )
-from imap_processing.hit.l0.constants import AZIMUTH_ANGLES, DECLINATION_ANGLES
+from imap_processing.hit.l0.constants import AZIMUTH_ANGLES, ZENITH_ANGLES
 from imap_processing.hit.l0.decom_hit import (
     assemble_science_frames,
     decom_hit,
@@ -123,7 +123,7 @@ def test_parse_count_rates(sci_dataset):
     if count_rate_vars in list(sci_dataset.keys()):
         assert True
 
-    assert np.allclose(sci_dataset["declination"].values, DECLINATION_ANGLES)
+    assert np.allclose(sci_dataset["zenith"].values, ZENITH_ANGLES)
     assert np.allclose(sci_dataset["azimuth"].values, AZIMUTH_ANGLES)
 
 

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -303,7 +303,7 @@ def test_process_sectored_rates_data(l1a_counts_dataset, livetime):
 
     valid_coords = {
         "epoch",
-        "declination",
+        "zenith",
         "azimuth",
         "h_energy_mean",
         "he4_energy_mean",

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -251,16 +251,16 @@ def test_build_ancillary_dataset_sectored():
     np.random.seed(42)  # Set a random seed for reproducibility
     epoch = np.array(["2025-01-01T00:00", "2025-01-01T00:01"], dtype="datetime64[m]")
     energy_mean = [1.8, 4, 6]
-    declination = np.arange(8)
+    zenith = np.arange(8)
     azimuth = np.arange(15)
 
     species_array = xr.DataArray(
-        data=np.random.rand(2, 3, 15, 8),  # (epoch, energy_mean, azimuth, declination)
-        dims=("epoch", "energy_mean", "azimuth", "declination"),
+        data=np.random.rand(2, 3, 15, 8),  # (epoch, energy_mean, azimuth, zenith)
+        dims=("epoch", "energy_mean", "azimuth", "zenith"),
         coords={
             "epoch": epoch,
             "energy_mean": energy_mean,
-            "declination": declination,
+            "zenith": zenith,
             "azimuth": azimuth,
         },
         name="h",
@@ -378,13 +378,13 @@ def test_reshape_for_sectored():
     """
     Test the reshape_for_sectored function.
     """
-    # Mock input data: 3D array (epoch, energy, declination)
+    # Mock input data: 3D array (epoch, energy, zenith)
     np.random.seed(42)  # Set a random seed for reproducibility
-    epoch, energy, declination = 2, 3, 8
-    input_array = np.random.rand(epoch, energy, declination)
+    epoch, energy, zenith = 2, 3, 8
+    input_array = np.random.rand(epoch, energy, zenith)
 
-    # Expected output shape: 4D array (epoch, energy, azimuth, declination)
-    expected_shape = (epoch, energy, N_AZIMUTH, declination)
+    # Expected output shape: 4D array (epoch, energy, azimuth, zenith)
+    expected_shape = (epoch, energy, N_AZIMUTH, zenith)
 
     # Call the function
     reshaped_array = reshape_for_sectored(input_array)
@@ -600,7 +600,7 @@ def test_add_systematic_uncertainties():
         xr.Dataset(
             {
                 "h": (
-                    ("epoch", "h_energy_mean", "azimuth", "declination"),
+                    ("epoch", "h_energy_mean", "azimuth", "zenith"),
                     np.random.rand(2, 3, 15, 8).astype("float32"),
                 )
             }
@@ -688,7 +688,7 @@ def test_process_macropixel_intensity(
     valid_coords = {
         "epoch",
         "azimuth",
-        "declination",
+        "zenith",
         "h_energy_mean",
         "he4_energy_mean",
         "cno_energy_mean",


### PR DESCRIPTION
This PR updates the 'declination' angle dimension to 'zenith' and all references to it in the HIT processing code. This change is the result of project leadership's interest in refining variable names in mission datasets. The HIT instrument team determined that zenith is a preferable name to use than declination or other existing nomenclature options for angles.

Closes #1348 
