### PR TITLE
add kernel furnishing to InstrumentProcessing.pre_processing

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -21,9 +21,11 @@ from pathlib import Path
 from typing import final
 
 import imap_data_access
+import spiceypy
 import xarray as xr
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
+    SPICESource,
 )
 
 import imap_processing
@@ -404,7 +406,8 @@ class ProcessInstrument(ABC):
         Complete pre-processing.
 
         For this baseclass, pre-processing consists of downloading dependencies
-        for processing. Child classes can override this method to customize the
+        for processing and furnishing any spice kernels in the input
+        dependencies. Child classes can override this method to customize the
         pre-processing actions.
 
         Returns
@@ -415,6 +418,12 @@ class ProcessInstrument(ABC):
         dependencies = ProcessingInputCollection()
         dependencies.deserialize(self.dependency_str)
         dependencies.download_all_files()
+
+        # Furnish spice kernels
+        kernel_paths = dependencies.get_file_paths(source=SPICESource.SPICE.value)
+        logger.info(f"Furnishing kernels: {kernel_paths}")
+        spiceypy.furnsh([str(kernel_path) for kernel_path in kernel_paths])
+
         return dependencies
 
     @abstractmethod

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -422,7 +422,7 @@ class ProcessInstrument(ABC):
         # Furnish spice kernels
         kernel_paths = dependencies.get_file_paths(source=SPICESource.SPICE.value)
         logger.info(f"Furnishing kernels: {kernel_paths}")
-        spiceypy.furnsh([str(kernel_path) for kernel_path in kernel_paths])
+        spiceypy.furnsh([str(kernel_path.resolve()) for kernel_path in kernel_paths])
 
         return dependencies
 
@@ -503,6 +503,9 @@ class ProcessInstrument(ABC):
             products.append(write_cdf(ds))
 
         self.upload_products(products)
+
+        logger.info("Clearing furnished SPICE kernels")
+        spiceypy.kclear()
 
 
 class Codice(ProcessInstrument):

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests coverage for imap_processing.cli."""
 
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -321,16 +322,15 @@ def test_hit_l1a(mock_hit_l1a, mock_instrument_dependencies):
 
 
 @pytest.mark.usefixtures("_unset_metakernel_path")
-def test_pre_processing(spice_test_data_path):
+def test_spice_kernel_handling(spice_test_data_path):
     """Test coverage for ProcessInstrument.pre_processing method()."""
     kernels_to_furnish = ["naif0012.tls", "imap_sclk_0000.tsc"]
-    dependency_str = (
-        "["
-        '{"type": "science","files": ["imap_hi_l2a_sensor45-de_20100105_v001.cdf"]},'
-        + f'{{"type":"spice","files": {kernels_to_furnish}}},'.replace("'", '"')
-        + '{"type": "spice","files": ["imap_2010_104_01.repoint.csv"]}'
-        "]"
-    )
+    dependency_obj = [
+        {"type": "science", "files": ["imap_hi_l2a_sensor45-de_20100105_v001.cdf"]},
+        {"type": "spice", "files": kernels_to_furnish},
+        {"type": "spice", "files": ["imap_2010_104_01.repoint.csv"]},
+    ]
+    dependency_str = json.dumps(dependency_obj)
 
     def download_side_effect(path: Path):
         """Copy kernels from spice_test_data_path to expected DATA_DIR location."""
@@ -355,7 +355,9 @@ def test_pre_processing(spice_test_data_path):
         mock.patch("imap_data_access.processing_input.download") as mock_download,
         mock.patch("imap_processing.cli.load_cdf"),
         mock.patch("imap_processing.cli.Hi.do_processing") as mock_do_processing,
-        mock.patch("imap_processing.cli.ProcessInstrument.post_processing"),
+        # mock.patch("imap_processing.cli.ProcessInstrument.post_processing"),
+        mock.patch("imap_processing.cli.write_cdf"),
+        mock.patch("imap_processing.cli.ProcessInstrument.upload_products"),
     ):
         mock_download.side_effect = download_side_effect
         mock_do_processing.side_effect = do_processing_side_effect
@@ -365,7 +367,11 @@ def test_pre_processing(spice_test_data_path):
         )
         # Verify no kernels are furnished prior to calling process
         assert spiceypy.ktotal("ALL") == 0
+        # Verification that the expected kernels get furnished is done in the
+        # mocked do_processing function
         instrument.process()
+        # Verify that the furnished kernels get cleared in the post_processing method
+        assert spiceypy.ktotal("ALL") == 0
 
 
 @mock.patch("imap_processing.cli.swe_l1a")

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -327,8 +327,8 @@ def test_pre_processing(spice_test_data_path):
     dependency_str = (
         "["
         '{"type": "science","files": ["imap_hi_l2a_sensor45-de_20100105_v001.cdf"]},'
-        f'{{"type":"spice","files": ["{'", "'.join(kernels_to_furnish)}"]}},'
-        '{"type": "spice","files": ["imap_2010_104_01.repoint.csv"]}'
+        + f'{{"type":"spice","files": {kernels_to_furnish}}},'.replace("'", '"')
+        + '{"type": "spice","files": ["imap_2010_104_01.repoint.csv"]}'
         "]"
     )
 

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -1,9 +1,13 @@
 """Tests coverage for imap_processing.cli."""
 
+import shutil
 import sys
+from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pytest
+import spiceypy
 import xarray as xr
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
@@ -314,6 +318,54 @@ def test_hit_l1a(mock_hit_l1a, mock_instrument_dependencies):
     instrument.process()
     assert mock_hit_l1a.call_count == 1
     assert mocks["mock_upload"].call_count == 2
+
+
+@pytest.mark.usefixtures("_unset_metakernel_path")
+def test_pre_processing(spice_test_data_path):
+    """Test coverage for ProcessInstrument.pre_processing method()."""
+    kernels_to_furnish = ["naif0012.tls", "imap_sclk_0000.tsc"]
+    dependency_str = (
+        "["
+        '{"type": "science","files": ["imap_hi_l2a_sensor45-de_20100105_v001.cdf"]},'
+        f'{{"type":"spice","files": ["{'", "'.join(kernels_to_furnish)}"]}},'
+        '{"type": "spice","files": ["imap_2010_104_01.repoint.csv"]}'
+        "]"
+    )
+
+    def download_side_effect(path: Path):
+        """Copy kernels from spice_test_data_path to expected DATA_DIR location."""
+        if (spice_test_data_path / path.name).exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(spice_test_data_path / path.name, path)
+
+    # Test that the expected kernels are furnished within the function that
+    # gets substituted in for the processing function.
+    def do_processing_side_effect(*args, **kwargs):
+        """Check that the expected kernels are furnished"""
+        kernel_count = spiceypy.ktotal("ALL")
+        furnished_kernels = [
+            Path(spiceypy.kdata(i, "ALL")[0]).name for i in range(kernel_count)
+        ]
+        np.testing.assert_array_equal(
+            sorted(furnished_kernels), sorted(kernels_to_furnish)
+        )
+        return [xr.Dataset()]
+
+    with (
+        mock.patch("imap_data_access.processing_input.download") as mock_download,
+        mock.patch("imap_processing.cli.load_cdf"),
+        mock.patch("imap_processing.cli.Hi.do_processing") as mock_do_processing,
+        mock.patch("imap_processing.cli.ProcessInstrument.post_processing"),
+    ):
+        mock_download.side_effect = download_side_effect
+        mock_do_processing.side_effect = do_processing_side_effect
+
+        instrument = Hi(
+            "l1b", "sensor45-de", dependency_str, "20100105", None, "v001", True
+        )
+        # Verify no kernels are furnished prior to calling process
+        assert spiceypy.ktotal("ALL") == 0
+        instrument.process()
 
 
 @mock.patch("imap_processing.cli.swe_l1a")


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds the automatic furnishing of spice files in the `pre_processing` step that come in as dependencies. The changes in `cli.py` are straightforward, but the added test in `test_cli.py` is not. See change description below.

## Updated Files
- imap_processing/cli.py
   - Log the files that will be furnished
   - Furnish the files listed as source='spice'
- imap_processing/tests/test_cli.py
   - The test has lots of mocks in order to get the right coverage and test what I wanted to test.
   - The imap_data_access.processing_input.download is mocked to copy files from the `tests/spice/test_data` path to the expected `DATA_DIR/spice` path.
   - The `do_processing` step is mocked to check that the expected kernels are furnished at the time that instrument processing is done.
   - `load_cdf` and `post_processing` are mocked so that they do nothing.

Closes: #1683 
