### PR TITLE
Ultra L2: Minor projection changes

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1279,7 +1279,8 @@ class HealpixSkyMap(AbstractSkyMap):
         smaller and smaller subpixels, then calculates the solid-angle weighted mean
         of the healpix map's value at this pixel, until the difference
         between the mean values of two consecutive subdivisions is within the
-        specified tolerances. The function returns the mean value at the final level
+        specified tolerances at all values in that pixel (e.g., all energy bins).
+        The function returns the mean value at the final level
         of subdivision and the depth of recursion.
 
         Parameters
@@ -1321,8 +1322,15 @@ class HealpixSkyMap(AbstractSkyMap):
                 )
             )
 
-            # Determine if tolerance is met
-            # (skip on the 0th iteration, as there's no delta)
+            # Determine if tolerance is met,
+            # (skip on the 0th iteration, as there's no delta to compare).
+
+            # Note:  Using allclose() means that, while we calculate the mean pixel
+            # value(s) over  all the subdivided subpixels, this mean may have multiple
+            # values (e.g., different energy bins), so we check if
+            # all of them are within the tolerances. This can result in
+            # over-subdividing some energy bins, where there is little spatial gradient,
+            # but where another energy bin has a large gradient.
             if depth > 0:
                 if np.allclose(
                     mean_pixel_value,

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1324,11 +1324,9 @@ class HealpixSkyMap(AbstractSkyMap):
             # Determine if tolerance is met
             # (skip on the 0th iteration, as there's no delta)
             if depth > 0:
-                # TODO: Ask Nick/Ultra Instrument team if we need to compare each value
-                # in the pixel's array, or just the mean value.
-                if np.isclose(
-                    mean_pixel_value.mean(),
-                    previous_mean_pixel_value.mean(),
+                if np.allclose(
+                    mean_pixel_value,
+                    previous_mean_pixel_value,
                     rtol=rtol,
                     atol=atol,
                 ):

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -97,11 +97,11 @@ class TestUltraL2:
                         "spice_reference_frame": map_frame,
                         "values_to_push_project": [
                             "counts",
-                            "sensitivity",
-                            "background_rates",
                         ],
                         "values_to_pull_project": [
                             "exposure_factor",
+                            "sensitivity",
+                            "background_rates",
                         ],
                         "nside": 32,
                         "nested": False,
@@ -165,11 +165,11 @@ class TestUltraL2:
                             "spice_reference_frame": "ECLIPJ2000",
                             "values_to_push_project": [
                                 "counts",
-                                "sensitivity",
-                                "background_rates",
                             ],
                             "values_to_pull_project": [
                                 "exposure_factor",
+                                "sensitivity",
+                                "background_rates",
                             ],
                             "spacing_deg": 2.0,
                         }
@@ -219,10 +219,10 @@ class TestUltraL2:
                 "spice_reference_frame": "ECLIPJ2000",
                 "values_to_push_project": [
                     "counts",
-                    "sensitivity",
                 ],
                 "values_to_pull_project": [
                     "exposure_factor",
+                    "sensitivity",
                 ],
                 "nside": 16,
                 "nested": True,

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -23,11 +23,11 @@ DEFAULT_ULTRA_L2_MAP_STRUCTURE: ena_maps.RectangularSkyMap | ena_maps.HealpixSky
             "spice_reference_frame": "ECLIPJ2000",
             "values_to_push_project": [
                 "counts",
-                "sensitivity",
-                "background_rates",
             ],
             "values_to_pull_project": [
                 "exposure_factor",
+                "sensitivity",
+                "background_rates",
             ],
             "nside": 32,
             "nested": False,
@@ -45,12 +45,12 @@ DEFAULT_L2_HEALPIX_NESTED = False
 # These variables must always be present in each L1C dataset
 REQUIRED_L1C_VARIABLES_PUSH = [
     "counts",
-    "sensitivity",
-    "background_rates",
-    "obs_date",
 ]
 REQUIRED_L1C_VARIABLES_PULL = [
     "exposure_factor",
+    "sensitivity",
+    "background_rates",
+    "obs_date",
 ]
 
 # These variables are projected to the map as the mean of pointing set pixels value,
@@ -190,9 +190,13 @@ def generate_ultra_healpix_skymap(
     # Add additional data variables to the map
     output_map_structure.values_to_push_project.extend(
         [
+            "num_pointing_set_pixel_members",
+        ]
+    )
+    output_map_structure.values_to_pull_project.extend(
+        [
             "obs_date",
             "pointing_set_exposure_times_solid_angle",
-            "num_pointing_set_pixel_members",
         ]
     )
 
@@ -270,8 +274,8 @@ def generate_ultra_healpix_skymap(
         skymap.data_1d["pointing_set_exposure_times_solid_angle"]
     )
 
-    # TODO: Ask Ultra team about background rates - I think they should increase when
-    # binned to larger pixels, as I've done here, but that was never explicitly stated
+    # Background rates must be scaled by the ratio of the solid angles of the
+    # map pixel / pointing set pixel
     skymap.data_1d["background_rates"] *= skymap.solid_angle / pointing_set.solid_angle
 
     # Get the energy bin widths from a PointingSet (they will all be the same)


### PR DESCRIPTION
# Change Summary

2 Small changes after talking with Nick and Bob on the Instrument team. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

1. In the `Healpix-->Rectangular` subdivision code, Use `allclose()` to compare all values (e.g., different energy bins) of the mean pixel, rather than `isclose()` to check the mean over all those energy bins. Closes #1718
2. In the Ultra L2 code, Pull sensitivity and background_rates, rather than push them. They remain projected as their means weighted by `exposure_factor * solid_angle`. `background_rates` is confirmed to be scaled by the ratio of solid angles. Closes #1717 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
-  imap_processing/ena_maps/ena_maps.py
   - allclose
-  imap_processing/ultra/l2/ultra_l2.py
   - pull sensitivity, bkg

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
- Update tests on the above