### PR TITLE
HIT L2 - Fix ISTP errors

### DIFF
--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -337,7 +337,7 @@ h_standard_intensity:
   <<: *default_particle
   DEPEND_1: h_energy_mean
   CATDESC: H Standard Omnidirectional Intensity in 12 energy bins
-  LABL_PTR_1: h_energy_mean_label
+  LABLAXIS: h_energy_mean_label
   FIELDNAM: H Intensity Standard
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
@@ -347,7 +347,7 @@ he3_standard_intensity:
   DEPEND_1: he3_energy_mean
   CATDESC: He3 Standard Omnidirectional Intensity in 11 energy bins
   FIELDNAM: He3 Intensity Standard
-  LABL_PTR_1: he3_energy_mean_label
+  LABLAXIS: he3_energy_mean_label
   DELTA_MINUS: he3_total_uncert_plus
   DELTA_PLUS: he3_total_uncert_minus
 
@@ -356,7 +356,7 @@ he4_standard_intensity:
   DEPEND_1: he4_energy_mean
   CATDESC: He4 Standard Omnidirectional Intensity in 12 energy bins
   FIELDNAM: He4 Intensity Standard
-  LABL_PTR_1: he4_energy_mean_label
+  LABLAXIS: he4_energy_mean_label
   DELTA_MINUS: he4_total_uncert_plus
   DELTA_PLUS: he4_total_uncert_minus
 
@@ -365,7 +365,7 @@ he_standard_intensity:
   DEPEND_1: he_energy_mean
   CATDESC: He (total) Standard Omnidirectional Intensity in 11 energy bins
   FIELDNAM: He Intensity Standard
-  LABL_PTR_1: he_energy_mean_label
+  LABLAXIS: he_energy_mean_label
   DELTA_MINUS: he_total_uncert_plus
   DELTA_PLUS: he_total_uncert_minus
 
@@ -374,7 +374,7 @@ c_standard_intensity:
   DEPEND_1: c_energy_mean
   CATDESC: C Standard Omnidirectional Intensity in 12 energy bins
   FIELDNAM: C Intensity Standard
-  LABL_PTR_1: c_energy_mean_label
+  LABLAXIS: c_energy_mean_label
   DELTA_MINUS: c_total_uncert_plus
   DELTA_PLUS: c_total_uncert_minus
 
@@ -383,7 +383,7 @@ o_standard_intensity:
   DEPEND_1: o_energy_mean
   CATDESC: O Standard Omnidirectional Intensity in 12 energy bins
   FIELDNAM: O Intensity Standard
-  LABL_PTR_1: o_energy_mean_label
+  LABLAXIS: o_energy_mean_label
   DELTA_MINUS: o_total_uncert_plus
   DELTA_PLUS: o_total_uncert_minus
 
@@ -392,7 +392,7 @@ n_standard_intensity:
   DEPEND_1: n_energy_mean
   CATDESC: N Standard Omnidirectional Intensity in 12 energy bins
   FIELDNAM: N Intensity Standard
-  LABL_PTR_1: n_energy_mean_label
+  LABLAXIS: n_energy_mean_label
   DELTA_MINUS: n_total_uncert_plus
   DELTA_PLUS: n_total_uncert_minus
 
@@ -401,7 +401,7 @@ ne_standard_intensity:
   DEPEND_1: ne_energy_mean
   CATDESC: Ne Standard Omnidirectional Intensity in 13 energy bins
   FIELDNAM: Ne Intensity Standard
-  LABL_PTR_1: ne_energy_mean_label
+  LABLAXIS: ne_energy_mean_label
   DELTA_MINUS: ne_total_uncert_plus
   DELTA_PLUS: ne_total_uncert_minus
 
@@ -410,7 +410,7 @@ na_standard_intensity:
   DEPEND_1: na_energy_mean
   CATDESC: Na Standard Omnidirectional Intensity in 8 energy bins
   FIELDNAM: Na Intensity Standard
-  LABL_PTR_1: na_energy_mean_label
+  LABLAXIS: na_energy_mean_label
   DELTA_MINUS: na_total_uncert_plus
   DELTA_PLUS: na_total_uncert_minus
 
@@ -419,7 +419,7 @@ mg_standard_intensity:
   DEPEND_1: mg_energy_mean
   CATDESC: Mg Standard Omnidirectional Intensity in 14 energy bins
   FIELDNAM: Mg Intensity Standard
-  LABL_PTR_1: mg_energy_mean_label
+  LABLAXIS: mg_energy_mean_label
   DELTA_MINUS: mg_total_uncert_plus
   DELTA_PLUS: mg_total_uncert_minus
 
@@ -428,7 +428,7 @@ al_standard_intensity:
   DEPEND_1: al_energy_mean
   CATDESC: Al Standard Omnidirectional Intensity in 9 energy bins
   FIELDNAM: Al Intensity Standard
-  LABL_PTR_1: al_energy_mean_label
+  LABLAXIS: al_energy_mean_label
   DELTA_MINUS: al_total_uncert_plus
   DELTA_PLUS: al_total_uncert_minus
 
@@ -437,7 +437,7 @@ si_standard_intensity:
   DEPEND_1: si_energy_mean
   CATDESC: Si Standard Omnidirectional Intensity in 14 energy bins
   FIELDNAM: Si Intensity Standard
-  LABL_PTR_1: si_energy_mean_label
+  LABLAXIS: si_energy_mean_label
   DELTA_MINUS: si_total_uncert_plus
   DELTA_PLUS: si_total_uncert_minus
 
@@ -446,7 +446,7 @@ s_standard_intensity:
   DEPEND_1: s_energy_mean
   CATDESC: S Standard Omnidirectional Intensity in 13 energy bins
   FIELDNAM: S Intensity Standard
-  LABL_PTR_1: s_energy_mean_label
+  LABLAXIS: s_energy_mean_label
   DELTA_MINUS: s_total_uncert_plus
   DELTA_PLUS: s_total_uncert_minus
 
@@ -455,7 +455,7 @@ ar_standard_intensity:
   DEPEND_1: ar_energy_mean
   CATDESC: Ar Standard Omnidirectional Intensity in 13 energy bins
   FIELDNAM: Ar Intensity Standard
-  LABL_PTR_1: ar_energy_mean_label
+  LABLAXIS: ar_energy_mean_label
   DELTA_MINUS: ar_total_uncert_plus
   DELTA_PLUS: ar_total_uncert_minus
 
@@ -464,7 +464,7 @@ ca_standard_intensity:
   DEPEND_1: ca_energy_mean
   CATDESC: Ca Standard Omnidirectional Intensity in 13 energy bins
   FIELDNAM: Ca Intensity Standard
-  LABL_PTR_1: ca_energy_mean_label
+  LABLAXIS: ca_energy_mean_label
   DELTA_MINUS: ca_total_uncert_plus
   DELTA_PLUS: ca_total_uncert_minus
 
@@ -473,7 +473,7 @@ fe_standard_intensity:
   DEPEND_1: fe_energy_mean
   CATDESC: Fe Standard Omnidirectional Intensity in 16 energy bins
   FIELDNAM: Fe Intensity Standard
-  LABL_PTR_1: fe_energy_mean_label
+  LABLAXIS: fe_energy_mean_label
   DELTA_MINUS: fe_total_uncert_plus
   DELTA_PLUS: fe_total_uncert_minus
 
@@ -482,7 +482,7 @@ ni_standard_intensity:
   DEPEND_1: ni_energy_mean
   CATDESC: Ni Standard Omnidirectional Intensity in 9 energy bins
   FIELDNAM: Ni Intensity Standard
-  LABL_PTR_1: ni_energy_mean_label
+  LABLAXIS: ni_energy_mean_label
   DELTA_MINUS: ni_total_uncert_plus
   DELTA_PLUS: ni_total_uncert_minus
 
@@ -491,7 +491,7 @@ h_summed_intensity:
   <<: *default_particle
   DEPEND_1: h_energy_mean
   CATDESC: H Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
-  LABL_PTR_1: h_energy_mean_label
+  LABLAXIS: h_energy_mean_label
   FIELDNAM: H Intensity Summed
   DELTA_MINUS: h_total_uncert_plus
   DELTA_PLUS: h_total_uncert_minus
@@ -501,7 +501,7 @@ he3_summed_intensity:
   DEPEND_1: he3_energy_mean
   CATDESC: He3 Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
   FIELDNAM: He3 Intensity Summed
-  LABL_PTR_1: he3_energy_mean_label
+  LABLAXIS: he3_energy_mean_label
   DELTA_MINUS: he3_total_uncert_plus
   DELTA_PLUS: he3_total_uncert_minus
 
@@ -510,7 +510,7 @@ he4_summed_intensity:
   DEPEND_1: he4_energy_mean
   CATDESC: He4 Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: He4 Intensity Summed
-  LABL_PTR_1: he4_energy_mean_label
+  LABLAXIS: he4_energy_mean_label
   DELTA_MINUS: he4_total_uncert_plus
   DELTA_PLUS: he4_total_uncert_minus
 
@@ -519,7 +519,7 @@ he_summed_intensity:
   DEPEND_1: he_energy_mean
   CATDESC: He (total) Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
   FIELDNAM: He Intensity Summed
-  LABL_PTR_1: he_energy_mean_label
+  LABLAXIS: he_energy_mean_label
   DELTA_MINUS: he_total_uncert_plus
   DELTA_PLUS: he_total_uncert_minus
 
@@ -528,7 +528,7 @@ c_summed_intensity:
   DEPEND_1: c_energy_mean
   CATDESC: C Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: C Intensity Summed
-  LABL_PTR_1: c_energy_mean_label
+  LABLAXIS: c_energy_mean_label
   DELTA_MINUS: c_total_uncert_plus
   DELTA_PLUS: c_total_uncert_minus
 
@@ -537,7 +537,7 @@ o_summed_intensity:
   DEPEND_1: o_energy_mean
   CATDESC: O Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: O Intensity Summed
-  LABL_PTR_1: o_energy_mean_label
+  LABLAXIS: o_energy_mean_label
   DELTA_MINUS: o_total_uncert_plus
   DELTA_PLUS: o_total_uncert_minus
 
@@ -546,7 +546,7 @@ n_summed_intensity:
   DEPEND_1: n_energy_mean
   CATDESC: N Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: N Intensity Summed
-  LABL_PTR_1: n_energy_mean_label
+  LABLAXIS: n_energy_mean_label
   DELTA_MINUS: n_total_uncert_plus
   DELTA_PLUS: n_total_uncert_minus
 
@@ -555,7 +555,7 @@ ne_summed_intensity:
   DEPEND_1: ne_energy_mean
   CATDESC: Ne Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: Ne Intensity Summed
-  LABL_PTR_1: ne_energy_mean_label
+  LABLAXIS: ne_energy_mean_label
   DELTA_MINUS: ne_total_uncert_plus
   DELTA_PLUS: ne_total_uncert_minus
 
@@ -564,7 +564,7 @@ na_summed_intensity:
   DEPEND_1: na_energy_mean
   CATDESC: Na Summed Omnidirectional Intensity in 2 energy bins (useful for quiet times)
   FIELDNAM: Na Intensity Summed
-  LABL_PTR_1: na_energy_mean_label
+  LABLAXIS: na_energy_mean_label
   DELTA_MINUS: na_total_uncert_plus
   DELTA_PLUS: na_total_uncert_minus
 
@@ -573,7 +573,7 @@ mg_summed_intensity:
   DEPEND_1: mg_energy_mean
   CATDESC: Mg Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: Mg Intensity Summed
-  LABL_PTR_1: mg_energy_mean_label
+  LABLAXIS: mg_energy_mean_label
   DELTA_MINUS: mg_total_uncert_plus
   DELTA_PLUS: mg_total_uncert_minus
 
@@ -582,7 +582,7 @@ al_summed_intensity:
   DEPEND_1: al_energy_mean
   CATDESC: Al Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
   FIELDNAM: Al Intensity Summed
-  LABL_PTR_1: al_energy_mean_label
+  LABLAXIS: al_energy_mean_label
   DELTA_MINUS: al_total_uncert_plus
   DELTA_PLUS: al_total_uncert_minus
 
@@ -591,7 +591,7 @@ si_summed_intensity:
   DEPEND_1: si_energy_mean
   CATDESC: Si Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: Si Intensity Summed
-  LABL_PTR_1: si_energy_mean_label
+  LABLAXIS: si_energy_mean_label
   DELTA_MINUS: si_total_uncert_plus
   DELTA_PLUS: si_total_uncert_minus
 
@@ -600,7 +600,7 @@ s_summed_intensity:
   DEPEND_1: s_energy_mean
   CATDESC: S Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: S Intensity Summed
-  LABL_PTR_1: s_energy_mean_label
+  LABLAXIS: s_energy_mean_label
   DELTA_MINUS: s_total_uncert_plus
   DELTA_PLUS: s_total_uncert_minus
 
@@ -609,7 +609,7 @@ ar_summed_intensity:
   DEPEND_1: ar_energy_mean
   CATDESC: Ar Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: Ar Intensity Summed
-  LABL_PTR_1: ar_energy_mean_label
+  LABLAXIS: ar_energy_mean_label
   DELTA_MINUS: ar_total_uncert_plus
   DELTA_PLUS: ar_total_uncert_minus
 
@@ -618,7 +618,7 @@ ca_summed_intensity:
   DEPEND_1: ca_energy_mean
   CATDESC: Ca Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: Ca Intensity Summed
-  LABL_PTR_1: ca_energy_mean_label
+  LABLAXIS: ca_energy_mean_label
   DELTA_MINUS: ca_total_uncert_plus
   DELTA_PLUS: ca_total_uncert_minus
 
@@ -627,7 +627,7 @@ fe_summed_intensity:
   DEPEND_1: fe_energy_mean
   CATDESC: Fe Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: Fe Intensity Summed
-  LABL_PTR_1: fe_energy_mean_label
+  LABLAXIS: fe_energy_mean_label
   DELTA_MINUS: fe_total_uncert_plus
   DELTA_PLUS: fe_total_uncert_minus
 
@@ -636,7 +636,7 @@ ni_summed_intensity:
   DEPEND_1: ni_energy_mean
   CATDESC: Ni Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
   FIELDNAM: Ni Intensity Summed
-  LABL_PTR_1: ni_energy_mean_label
+  LABLAXIS: ni_energy_mean_label
   DELTA_MINUS: ni_total_uncert_plus
   DELTA_PLUS: ni_total_uncert_minus
 

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -6,7 +6,7 @@ default_particle_attrs: &default_particle
   FILLVAL: -1.00E+31
   VALIDMIN: 0
   VALIDMAX: 10000000000
-  FORMAT: F9.3
+  FORMAT: F14.3
   UNITS: 1/(cm^2 s MeV/nuc sr)
   SCALE_TYP: log
   SCALEMIN: 0.0001
@@ -42,7 +42,7 @@ default_uncertainty_attrs: &default_uncertainty
   VALIDMIN: 0
   VALIDMAX: 10000000000
   FILLVAL: -1.00E+31
-  FORMAT: F9.3
+  FORMAT: F14.3
   UNITS: 1/(cm^2 s MeV/nuc sr)
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential_Uncertainty
 
@@ -52,7 +52,7 @@ default_angle_attrs: &default_angle
   FILLVAL: -1.00E+31
   VALIDMIN: 0
   VALIDMAX: 1000
-  FORMAT: F5.1
+  FORMAT: F12.2
   UNITS: Deg
   SCALE_TYP: linear
 

--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -13,18 +13,7 @@ default_particle_attrs: &default_particle
   SCALEMAX: 1000
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
-default_energy_mean_attrs: &default_energy_mean
-  VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
-  LABLAXIS: Energy
-  FILLVAL: -1.00E+31
-  VALIDMIN: 0
-  VALIDMAX: 100
-  FORMAT: F5.1
-  UNITS: MeV
-  SCALE_TYP: log
-
-default_energy_delta_attrs: &default_energy_delta
+default_energy_attrs: &default_energy
   VAR_TYPE: support_data
   DISPLAY_TYPE: no_plot
   LABLAXIS: Energy
@@ -72,115 +61,115 @@ azimuth:
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:ArrivalDirection,Qualifer:DirectionAngle.AzimuthAngle
 
 h_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: h_energy_mean
   CATDESC: Geometric mean energy for H
   FIELDNAM: H Energy
 
 he3_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: he3_energy_mean
   CATDESC: Geometric mean energy for He3
   FIELDNAM: He3 Energy
 
 he4_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: he4_energy_mean
   CATDESC: Geometric mean energy for He4
   FIELDNAM: He4 Energy
 
 he_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: he_energy_mean
   CATDESC: Geometric mean energy for He
   FIELDNAM: He Energy
 
 c_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: c_energy_mean
   CATDESC: Geometric mean energy for C
   FIELDNAM: C Energy
 
 n_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: n_energy_mean
   CATDESC: Geometric mean energy for N
   FIELDNAM: N Energy
 
 o_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: o_energy_mean
   CATDESC: Geometric mean energy for O
   FIELDNAM: O Energy
 
 ne_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: ne_energy_mean
   CATDESC: Geometric mean energy for Ne
   FIELDNAM: Ne Energy
 
 na_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: na_energy_mean
   CATDESC: Geometric mean energy for Na
   FIELDNAM: Na Energy
 
 mg_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: mg_energy_mean
   CATDESC: Geometric mean energy for Mg
   FIELDNAM: Mg Energy
 
 si_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: si_energy_mean
   CATDESC: Geometric mean energy for Si
   FIELDNAM: Si Energy
 
 s_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: s_energy_mean
   CATDESC: Geometric mean energy for S
   FIELDNAM: S Energy
 
 al_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: al_energy_mean
   CATDESC: Geometric mean energy for Al
   FIELDNAM: Al Energy
 
 ar_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: ar_energy_mean
   CATDESC: Geometric mean energy for Ar
   FIELDNAM: Ar Energy
 
 ca_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: ca_energy_mean
   CATDESC: Geometric mean energy for Ca
   FIELDNAM: Ca Energy
 
 fe_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: fe_energy_mean
   CATDESC: Geometric mean energy for Fe
   FIELDNAM: Fe Energy
 
 ni_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: ni_energy_mean
   CATDESC: Geometric mean energy for Ni
   FIELDNAM: Ni Energy
 
 nemgsi_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: nemgsi_energy_mean
   CATDESC: Geometric mean energy for NeMgSi
   FIELDNAM: NeMgSi Energy
 
 cno_energy_mean:
-  <<: *default_energy_mean
+  <<: *default_energy
   DEPEND_1: cno_energy_mean
   CATDESC: Geometric mean energy for CNO
   FIELDNAM: CNO Energy
@@ -642,238 +631,238 @@ ni_summed_intensity:
 
 # Energy Delta Variables
 h_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: h_energy_mean
   CATDESC: H energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: H energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 h_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: h_energy_mean
   CATDESC: H energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: H energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he3_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: he3_energy_mean
   CATDESC: He3 energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He3 energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he3_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: he3_energy_mean
   CATDESC: He3 energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He3 energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he4_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: he4_energy_mean
   CATDESC: He4 energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He4 energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he4_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: he4_energy_mean
   CATDESC: He4 energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He4 energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 he_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: he_energy_mean
   CATDESC: He energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: He energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 he_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: he_energy_mean
   CATDESC: He energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: He energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 c_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: c_energy_mean
   CATDESC: C energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: C energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 c_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: c_energy_mean
   CATDESC: C energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: C energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 o_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: o_energy_mean
   CATDESC: O energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: O energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 o_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: o_energy_mean
   CATDESC: O energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: O energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 n_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: n_energy_mean
   CATDESC: N energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: N energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 n_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: n_energy_mean
   CATDESC: N energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: N energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ne_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: ne_energy_mean
   CATDESC: Ne energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ne energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ne_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: ne_energy_mean
   CATDESC: Ne energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ne energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 na_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: na_energy_mean
   CATDESC: Na energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Na energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 na_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: na_energy_mean
   CATDESC: Na energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Na energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 mg_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: mg_energy_mean
   CATDESC: Mg energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Mg energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 mg_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: mg_energy_mean
   CATDESC: Mg energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Mg energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 al_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: al_energy_mean
   CATDESC: Al energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Al energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 al_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: al_energy_mean
   CATDESC: Al energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Al energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 si_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: si_energy_mean
   CATDESC: Si energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Si energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 si_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: si_energy_mean
   CATDESC: Si energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Si energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 s_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: s_energy_mean
   CATDESC: S energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: S energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 s_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: s_energy_mean
   CATDESC: S energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: S energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ar_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: ar_energy_mean
   CATDESC: Ar energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ar energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ar_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: ar_energy_mean
   CATDESC: Ar energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ar energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ca_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: ca_energy_mean
   CATDESC: Ca energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ca energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ca_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: ca_energy_mean
   CATDESC: Ca energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ca energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 fe_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: fe_energy_mean
   CATDESC: Fe energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Fe energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 fe_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: fe_energy_mean
   CATDESC: Fe energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Fe energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 ni_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: ni_energy_mean
   CATDESC: Ni energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: Ni energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 ni_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_1: ni_energy_mean
   CATDESC: Ni energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: Ni energy delta minus
@@ -1665,28 +1654,28 @@ fe_macropixel_intensity:
 
 # Energy Delta Variables
 cno_energy_delta_plus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_0: cno_energy_mean
   CATDESC: C, N, O energy delta plus (maximum bin energy minus geometric mean)
   FIELDNAM: CNO energy delta plus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 cno_energy_delta_minus:
-  <<: *default_energy_delta
+  <<: *default_energy
   DEPEND_0: cno_energy_mean
   CATDESC: C, N, O energy delta minus (geometric mean minus minimum bin energy)
   FIELDNAM: CNO energy delta minus
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Minimum
 
 nemgsi_energy_delta_plus:
-    <<: *default_energy_delta
+    <<: *default_energy
     DEPEND_0: nemgsi_energy_mean
     CATDESC: Ne, Mg, Si energy delta plus (maximum bin energy minus geometric mean)
     FIELDNAM: NeMgSi energy delta plus
     DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Maximum
 
 nemgsi_energy_delta_minus:
-    <<: *default_energy_delta
+    <<: *default_energy
     DEPEND_0: nemgsi_energy_mean
     CATDESC: Ne, Mg, Si energy delta minus (geometric mean minus minimum bin energy)
     FIELDNAM: NeMgSi energy delta minus


### PR DESCRIPTION
This PR addresses ISTP errors with L2 CDF files specifically related to the FORMAT and LABLAXIS attributes in preparation for SIT-4

-Increased FORMAT to F12.2 and F14.3 where needed
-Replaced LABL_PTR_1 with LABLAXIS for variables with dimensions no higher than DEPEND_1

Additionally, the energy mean and energy delta default attributes were combined into one set of energy default attributes since they share the same values.