### PR TITLE
Ultra l1c SIT4 Prep

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -119,13 +119,13 @@ imap_ultra_l1c_90sensor-spacecraftpset:
 imap_ultra_l1c_45sensor-heliopset:
     <<: *instrument_base
     Data_type: L1C_45Sensor-PSET>Level-1C Pointing Set Grid for Ultra45
-    Logical_source: imap_ultra_l1c_45sensor-spacecraftpset
+    Logical_source: imap_ultra_l1c_45sensor-heliopset
     Logical_source_description: IMAP-Ultra Instrument Level-1C Heliosphere Pointing Set Grid.
 
 imap_ultra_l1c_90sensor-heliopset:
     <<: *instrument_base
     Data_type: L1C_90Sensor-PSET>Level-1C Pointing Set Grid for Ultra90
-    Logical_source: imap_ultra_l1c_90sensor-spacecraftpset
+    Logical_source: imap_ultra_l1c_90sensor-heliopset
     Logical_source_description: IMAP-Ultra Instrument Level-1C Heliosphere Pointing Set Grid.
 
 imap_ultra_l1c_45sensor-histogram:

--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -107,14 +107,26 @@ imap_ultra_l1b_90sensor-badtimes:
 imap_ultra_l1c_45sensor-spacecraftpset:
     <<: *instrument_base
     Data_type: L1C_45Sensor-PSET>Level-1C Pointing Set Grid for Ultra45
-    Logical_source: imap_ultra_l1c_45sensor-pset
-    Logical_source_description: IMAP-Ultra Instrument Level-1C Pointing Set Grid Exposure Data.
+    Logical_source: imap_ultra_l1c_45sensor-spacecraftpset
+    Logical_source_description: IMAP-Ultra Instrument Level-1C Spacecraft Pointing Set Grid.
 
 imap_ultra_l1c_90sensor-spacecraftpset:
     <<: *instrument_base
     Data_type: L1C_90Sensor-PSET>Level-1C Pointing Set Grid for Ultra90
-    Logical_source: imap_ultra_l1c_90sensor-pset
-    Logical_source_description: IMAP-Ultra Instrument Level-1C Pointing Set Grid Exposure Data.
+    Logical_source: imap_ultra_l1c_90sensor-spacecraftpset
+    Logical_source_description: IMAP-Ultra Instrument Level-1C Spacecraft Pointing Set Grid.
+
+imap_ultra_l1c_45sensor-heliopset:
+    <<: *instrument_base
+    Data_type: L1C_45Sensor-PSET>Level-1C Pointing Set Grid for Ultra45
+    Logical_source: imap_ultra_l1c_45sensor-spacecraftpset
+    Logical_source_description: IMAP-Ultra Instrument Level-1C Heliosphere Pointing Set Grid.
+
+imap_ultra_l1c_90sensor-heliopset:
+    <<: *instrument_base
+    Data_type: L1C_90Sensor-PSET>Level-1C Pointing Set Grid for Ultra90
+    Logical_source: imap_ultra_l1c_90sensor-spacecraftpset
+    Logical_source_description: IMAP-Ultra Instrument Level-1C Heliosphere Pointing Set Grid.
 
 imap_ultra_l1c_45sensor-histogram:
     <<: *instrument_base

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -200,7 +200,7 @@ def _test_data_paths():
             / "ultra"
             / "data"
             / "l1"
-            / "IMAP-Ultra45_r1_L1_V0.csv",
+            / "IMAP-Ultra45_r1_L1_V0_shortened.csv",
         ),
         (
             "imap_ultra_l1b_45sensor-de_20240207_v999.cdf",

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -194,6 +194,15 @@ def _test_data_paths():
             / "idex_l1b_validation_file.h5",
         ),
         (
+            "IMAP-Ultra45_r1_L1_V0.csv",
+            imap_module_directory
+            / "tests"
+            / "ultra"
+            / "data"
+            / "l1"
+            / "IMAP-Ultra45_r1_L1_V0.csv",
+        ),
+        (
             "imap_ultra_l1b_45sensor-de_20240207_v999.cdf",
             imap_module_directory
             / "tests"

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -194,15 +194,6 @@ def _test_data_paths():
             / "idex_l1b_validation_file.h5",
         ),
         (
-            "IMAP-Ultra45_r1_L1_V0.csv",
-            imap_module_directory
-            / "tests"
-            / "ultra"
-            / "data"
-            / "l1"
-            / "IMAP-Ultra45_r1_L1_V0.csv",
-        ),
-        (
             "imap_ultra_l1b_45sensor-de_20240207_v999.cdf",
             imap_module_directory
             / "tests"

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -194,6 +194,15 @@ def _test_data_paths():
             / "idex_l1b_validation_file.h5",
         ),
         (
+            "IMAP-Ultra45_r1_L1_V0_shortened.csv",
+            imap_module_directory
+            / "tests"
+            / "ultra"
+            / "data"
+            / "l1"
+            / "IMAP-Ultra45_r1_L1_V0.csv",
+        ),
+        (
             "imap_ultra_l1b_45sensor-de_20240207_v999.cdf",
             imap_module_directory
             / "tests"

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -88,48 +88,48 @@ def test_calculate_spacecraft_pset_with_cdf():
 
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0.csv")
 
-    # Select a single pointing number
-    pointing = 0
-    df_subset = df[df["pointing_number"] == pointing].copy()
+    # Loop over all unique pointing numbers
+    for pointing in df["pointing_number"].unique():
+        df_subset = df[df["pointing_number"] == pointing].copy()
 
-    de_dict = {}
+        de_dict = {}
 
-    de_dict["epoch"] = df_subset["epoch"].values
-    species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
+        de_dict["epoch"] = df_subset["epoch"].values
+        species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
 
-    start_type = np.where(df_subset["PosYSlit"].values, 2, 1)
-    d, yf = get_front_y_position(start_type, df_subset["StopY"].values)
-    v, vhat, r = get_de_velocity(
-        (df_subset["StartX"].values, yf),
-        (df_subset["StopX"].values, df_subset["StopY"].values),
-        d,
-        df_subset["TOF"].values,
-    )
-    de_dict["direct_event_velocity"] = v.astype(np.float32)
+        start_type = np.where(df_subset["PosYSlit"].values, 2, 1)
+        d, yf = get_front_y_position(start_type, df_subset["StopY"].values)
+        v, vhat, r = get_de_velocity(
+            (df_subset["StartX"].values, yf),
+            (df_subset["StopX"].values, df_subset["StopY"].values),
+            d,
+            df_subset["TOF"].values,
+        )
+        de_dict["direct_event_velocity"] = v.astype(np.float32)
 
-    ultra_frame = SpiceFrame.IMAP_ULTRA_45
-    _, sc_dps_velocity, _ = get_annotated_particle_velocity(
-        df_subset["tdb"].values,
-        de_dict["direct_event_velocity"],
-        ultra_frame,
-        SpiceFrame.IMAP_DPS,
-        SpiceFrame.IMAP_SPACECRAFT,
-    )
+        ultra_frame = SpiceFrame.IMAP_ULTRA_45
+        _, sc_dps_velocity, _ = get_annotated_particle_velocity(
+            df_subset["tdb"].values,
+            de_dict["direct_event_velocity"],
+            ultra_frame,
+            SpiceFrame.IMAP_DPS,
+            SpiceFrame.IMAP_SPACECRAFT,
+        )
 
-    de_dict["velocity_dps_sc"] = sc_dps_velocity
-    de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
+        de_dict["velocity_dps_sc"] = sc_dps_velocity
+        de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
 
-    name = "imap_ultra_l1b_45sensor-de"
-    dataset = create_dataset(de_dict, name, "l1b")
+        name = "imap_ultra_l1b_45sensor-de"
+        dataset = create_dataset(de_dict, name, "l1b")
 
-    spacecraft_pset = calculate_spacecraft_pset(
-        dataset,
-        xr.Dataset(),  # placeholder for extendedspin_dataset
-        xr.Dataset(),  # placeholder for cullingmask_dataset
-        "imap_ultra_l1c_45sensor-spacecraftpset",
-    )
-    # TODO: validate with output histogram data once we have it in healpix.
-    assert (
-        spacecraft_pset.attrs["Logical_source"]
-        == "imap_ultra_l1c_45sensor-spacecraftpset"
-    )
+        spacecraft_pset = calculate_spacecraft_pset(
+            dataset,
+            xr.Dataset(),  # placeholder for extendedspin_dataset
+            xr.Dataset(),  # placeholder for cullingmask_dataset
+            "imap_ultra_l1c_45sensor-spacecraftpset",
+        )
+        # TODO: validate with output histogram data once we have it in healpix.
+        assert (
+            spacecraft_pset.attrs["Logical_source"]
+            == "imap_ultra_l1c_45sensor-spacecraftpset"
+        )

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -79,7 +79,7 @@ def test_calculate_spacecraft_pset():
     assert "energy_bin_geometric_mean" in spacecraft_pset.coords
 
 
-@pytest.mark.external_test_data
+@pytest.mark.xfail(reason="IMAP-Ultra45_r1_L1_V0.csv too large to download.")
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -97,7 +97,9 @@ def test_calculate_spacecraft_pset_with_cdf():
         de_dict["epoch"] = df_subset["epoch"].values
         species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
 
-        start_type = np.where(df_subset["PosYSlit"].values, 2, 1)
+        # PosYSlit is True for left (start_type = 1)
+        # PosYSlit is False for right (start_type = 2)
+        start_type = np.where(df_subset["PosYSlit"].values, 1, 2)
         d, yf = get_front_y_position(start_type, df_subset["StopY"].values)
         v, vhat, r = get_de_velocity(
             (df_subset["StartX"].values, yf),

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -79,14 +79,14 @@ def test_calculate_spacecraft_pset():
     assert "energy_bin_geometric_mean" in spacecraft_pset.coords
 
 
-@pytest.mark.xfail(reason="IMAP-Ultra45_r1_L1_V0.csv too large to download.")
+@pytest.mark.external_test_data
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 def test_calculate_spacecraft_pset_with_cdf():
     """Tests calculate_spacecraft_pset function with imported test data."""
-    # pragma: no cover
-    df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0.csv")
+
+    df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
 
     # Loop over all unique pointing numbers
     for pointing in df["pointing_number"].unique():

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -100,12 +100,14 @@ def test_calculate_spacecraft_pset_with_cdf():
         # PosYSlit is True for left (start_type = 1)
         # PosYSlit is False for right (start_type = 2)
         start_type = np.where(df_subset["PosYSlit"].values, 1, 2)
-        d, yf = get_front_y_position(start_type, df_subset["StopY"].values)
-        v, vhat, r = get_de_velocity(
-            (df_subset["StartX"].values, yf),
-            (df_subset["StopX"].values, df_subset["StopY"].values),
+        # Convert StartX, StopX, StopY to hundredths of mm.
+        d, yf = get_front_y_position(start_type, df_subset["StopY"].values * 100)
+        tof_tenths_ns = df_subset["TOF"].values * 10000
+        v, _, _ = get_de_velocity(
+            (df_subset["StartX"].values * 100, yf),
+            (df_subset["StopX"].values * 100, df_subset["StopY"].values * 100),
             d,
-            df_subset["TOF"].values,
+            tof_tenths_ns,
         )
         de_dict["direct_event_velocity"] = v.astype(np.float32)
 

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -15,8 +15,10 @@ from imap_processing.ultra.l1b.ultra_l1b_annotated import (
 from imap_processing.ultra.l1b.ultra_l1b_extended import (
     get_de_energy_kev,
     get_de_velocity,
+    get_front_y_position,
 )
 from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
+from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
@@ -25,8 +27,8 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-def test_pset():
-    """Tests calculate_pset function."""
+def test_calculate_spacecraft_pset():
+    """Tests calculate_spacecraft_pset function."""
     # This is just setting up the data so that it is in the format of l1b_de_dataset.
     test_path = TEST_PATH / "ultra-90_raw_event_data_shortened.csv"
     df = pd.read_csv(test_path)
@@ -75,3 +77,59 @@ def test_pset():
     assert "healpix" in spacecraft_pset.coords
     assert "epoch" in spacecraft_pset.coords
     assert "energy_bin_geometric_mean" in spacecraft_pset.coords
+
+
+@pytest.mark.external_test_data
+@pytest.mark.external_kernel
+@ensure_spice
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+def test_calculate_spacecraft_pset_with_cdf():
+    """Tests calculate_spacecraft_pset function with imported test data."""
+
+    df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0.csv")
+
+    # Select a single pointing number
+    pointing = 0
+    df_subset = df[df["pointing_number"] == pointing].copy()
+
+    de_dict = {}
+
+    de_dict["epoch"] = df_subset["epoch"].values
+    species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
+
+    start_type = np.where(df_subset["PosYSlit"].values, 2, 1)
+    d, yf = get_front_y_position(start_type, df_subset["StopY"].values)
+    v, vhat, r = get_de_velocity(
+        (df_subset["StartX"].values, yf),
+        (df_subset["StopX"].values, df_subset["StopY"].values),
+        d,
+        df_subset["TOF"].values,
+    )
+    de_dict["direct_event_velocity"] = v.astype(np.float32)
+
+    ultra_frame = SpiceFrame.IMAP_ULTRA_45
+    _, sc_dps_velocity, _ = get_annotated_particle_velocity(
+        df_subset["tdb"].values,
+        de_dict["direct_event_velocity"],
+        ultra_frame,
+        SpiceFrame.IMAP_DPS,
+        SpiceFrame.IMAP_SPACECRAFT,
+    )
+
+    de_dict["velocity_dps_sc"] = sc_dps_velocity
+    de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
+
+    name = "imap_ultra_l1b_45sensor-de"
+    dataset = create_dataset(de_dict, name, "l1b")
+
+    spacecraft_pset = calculate_spacecraft_pset(
+        dataset,
+        xr.Dataset(),  # placeholder for extendedspin_dataset
+        xr.Dataset(),  # placeholder for cullingmask_dataset
+        "imap_ultra_l1c_45sensor-spacecraftpset",
+    )
+    # TODO: validate with output histogram data once we have it in healpix.
+    assert (
+        spacecraft_pset.attrs["Logical_source"]
+        == "imap_ultra_l1c_45sensor-spacecraftpset"
+    )

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -74,7 +74,7 @@ def test_calculate_spacecraft_pset():
         test_l1b_de_dataset,  # placeholder for cullingmask_dataset
         "imap_ultra_l1c_45sensor-spacecraftpset",
     )
-    assert "healpix" in spacecraft_pset.coords
+    assert "pixel_index" in spacecraft_pset.coords
     assert "epoch" in spacecraft_pset.coords
     assert "energy_bin_geometric_mean" in spacecraft_pset.coords
 

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -85,7 +85,7 @@ def test_calculate_spacecraft_pset():
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 def test_calculate_spacecraft_pset_with_cdf():
     """Tests calculate_spacecraft_pset function with imported test data."""
-
+    # pragma: no cover
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0.csv")
 
     # Loop over all unique pointing numbers

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -75,7 +75,10 @@ def test_cdf_aux(ccsds_path_theta_0):
     test_data_path = write_cdf(test_data[0], istp=True)
 
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1a_45sensor-aux_20240207_v999.cdf"
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1a_45sensor-aux_20240207-repoint99999_v999.cdf"
+    )
 
 
 def test_cdf_rates(ccsds_path_theta_0):
@@ -86,7 +89,10 @@ def test_cdf_rates(ccsds_path_theta_0):
     test_data_path = write_cdf(test_data[0], istp=False)
 
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1a_45sensor-rates_20240207_v999.cdf"
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1a_45sensor-rates_20240207-repoint99999_v999.cdf"
+    )
 
 
 def test_cdf_tof(ccsds_path_theta_0):
@@ -97,8 +103,8 @@ def test_cdf_tof(ccsds_path_theta_0):
     test_data_path = write_cdf(test_data[0], istp=True)
     assert test_data_path.exists()
     assert (
-        test_data_path.name
-        == "imap_ultra_l1a_45sensor-histogram-ena-phxtof-hi-ang_20240207_v999.cdf"
+        test_data_path.name == "imap_ultra_l1a_45sensor-histogram-ena-phxtof-hi-ang_"
+        "20240207-repoint99999_v999.cdf"
     )
 
 
@@ -110,7 +116,10 @@ def test_cdf_events(ccsds_path_theta_0):
     test_data_path = write_cdf(test_data[0], istp=True)
 
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1a_45sensor-de_20240207_v999.cdf"
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1a_45sensor-de_20240207-repoint99999_v999.cdf"
+    )
 
 
 def test_cdf_hk(ccsds_path_theta_0):
@@ -122,7 +131,10 @@ def test_cdf_hk(ccsds_path_theta_0):
     test_data_path = write_cdf(data, istp=True)
 
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1a_45sensor-status_20240207_v999.cdf"
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1a_45sensor-status_20240207-repoint99999_v999.cdf"
+    )
 
 
 def test_get_event_id():

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -71,6 +71,7 @@ def test_cdf_aux(ccsds_path_theta_0):
 
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_AUX.apid[0])
     test_data[0].attrs["Data_version"] = "v999"
+    test_data[0].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(test_data[0], istp=True)
 
     assert test_data_path.exists()
@@ -81,6 +82,7 @@ def test_cdf_rates(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_RATES.apid[0])
     test_data[0].attrs["Data_version"] = "v999"
+    test_data[0].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(test_data[0], istp=False)
 
     assert test_data_path.exists()
@@ -91,6 +93,7 @@ def test_cdf_tof(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_TOF.apid[0])
     test_data[0].attrs["Data_version"] = "v999"
+    test_data[0].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(test_data[0], istp=True)
     assert test_data_path.exists()
     assert (
@@ -103,6 +106,7 @@ def test_cdf_events(ccsds_path_theta_0):
     """Tests that CDF file can be created."""
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_EVENTS.apid[0])
     test_data[0].attrs["Data_version"] = "v999"
+    test_data[0].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(test_data[0], istp=True)
 
     assert test_data_path.exists()
@@ -114,6 +118,7 @@ def test_cdf_hk(ccsds_path_theta_0):
     test_data = ultra_l1a(ccsds_path_theta_0, apid_input=869)
     data = test_data[0]
     data.attrs["Data_version"] = "v999"
+    data.attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(data, istp=True)
 
     assert test_data_path.exists()

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -136,9 +136,13 @@ def test_cdf_de(
     )
 
     l1b_de_dataset[0].attrs["Data_version"] = "v999"
+    l1b_de_dataset[0].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(l1b_de_dataset[0], istp=True)
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf"
+    )
 
 
 @pytest.mark.external_test_data
@@ -197,10 +201,12 @@ def test_cdf_extendedspin(use_fake_spin_data_for_time, faux_aux_dataset, rates_d
     l1b_extendedspin_dataset = ultra_l1b(data_dict)
     """Tests that CDF file is created and contains same attributes as xarray."""
     l1b_extendedspin_dataset[0].attrs["Data_version"] = "v999"
+    l1b_extendedspin_dataset[0].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[0], istp=True)
     assert test_data_path.exists()
     assert (
-        test_data_path.name == "imap_ultra_l1b_45sensor-extendedspin_20240207_v999.cdf"
+        test_data_path.name
+        == "imap_ultra_l1b_45sensor-extendedspin_20240207-repoint99999_v999.cdf"
     )
 
 
@@ -224,10 +230,12 @@ def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_da
 
     l1b_extendedspin_dataset = ultra_l1b(data_dict)
     l1b_extendedspin_dataset[1].attrs["Data_version"] = "v999"
+    l1b_extendedspin_dataset[1].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[1], istp=True)
     assert test_data_path.exists()
     assert (
-        test_data_path.name == "imap_ultra_l1b_45sensor-cullingmask_20240207_v999.cdf"
+        test_data_path.name
+        == "imap_ultra_l1b_45sensor-cullingmask_20240207-repoint99999_v999.cdf"
     )
 
 
@@ -251,9 +259,13 @@ def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_datas
 
     l1b_extendedspin_dataset = ultra_l1b(data_dict)
     l1b_extendedspin_dataset[2].attrs["Data_version"] = "v999"
+    l1b_extendedspin_dataset[2].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[2], istp=True)
     assert test_data_path.exists()
-    assert test_data_path.name == "imap_ultra_l1b_45sensor-badtimes_20240207_v999.cdf"
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1b_45sensor-badtimes_20240207-repoint99999_v999.cdf"
+    )
 
 
 def test_ultra_l1b_error(mock_data_l1a_rates_dict):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -125,7 +125,7 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 def test_calculate_spacecraft_pset_with_cdf():
     """Tests ultra_l1c function with imported test data."""
-
+    # pragma: no cover
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0.csv")
 
     # Select a single pointing number

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -119,7 +119,7 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
         ultra_l1c(mock_data_l1b_dict)
 
 
-@pytest.mark.external_test_data
+@pytest.mark.xfail(reason="IMAP-Ultra45_r1_L1_V0.csv too large to download.")
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -119,14 +119,14 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
         ultra_l1c(mock_data_l1b_dict)
 
 
-@pytest.mark.xfail(reason="IMAP-Ultra45_r1_L1_V0.csv too large to download.")
+@pytest.mark.external_test_data
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 def test_calculate_spacecraft_pset_with_cdf():
     """Tests ultra_l1c function with imported test data."""
     # pragma: no cover
-    df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0.csv")
+    df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
 
     # Select a single pointing number
     pointing = 0

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -176,5 +176,5 @@ def test_calculate_spacecraft_pset_with_cdf():
     assert test_data_path.exists()
     assert (
         test_data_path.name
-        == "imap_ultra_l1c_45sensor-pset_20250415-repoint00001_v999.cdf"
+        == "imap_ultra_l1c_45sensor-spacecraftpset_20250415-repoint00001_v999.cdf"
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -137,7 +137,9 @@ def test_calculate_spacecraft_pset_with_cdf():
     de_dict["epoch"] = df_subset["epoch"].values
     species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
 
-    start_type = np.where(df_subset["PosYSlit"].values, 2, 1)
+    # PosYSlit is True for left (start_type = 1)
+    # PosYSlit is False for right (start_type = 2)
+    start_type = np.where(df_subset["PosYSlit"].values, 1, 2)
     d, yf = get_front_y_position(start_type, df_subset["StopY"].values)
     v, vhat, r = get_de_velocity(
         (df_subset["StartX"].values, yf),

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -1,9 +1,24 @@
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 
+from imap_processing import imap_module_directory
+from imap_processing.cdf.utils import write_cdf
+from imap_processing.spice.geometry import SpiceFrame
+from imap_processing.spice.kernels import ensure_spice
+from imap_processing.ultra.l1b.ultra_l1b_annotated import (
+    get_annotated_particle_velocity,
+)
+from imap_processing.ultra.l1b.ultra_l1b_extended import (
+    get_de_energy_kev,
+    get_de_velocity,
+    get_front_y_position,
+)
 from imap_processing.ultra.l1c.ultra_l1c import ultra_l1c
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
+
+TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 
 @pytest.fixture
@@ -102,3 +117,64 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
         ValueError, match="Data dictionary does not contain the expected keys."
     ):
         ultra_l1c(mock_data_l1b_dict)
+
+
+@pytest.mark.external_test_data
+@pytest.mark.external_kernel
+@ensure_spice
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+def test_calculate_spacecraft_pset_with_cdf():
+    """Tests ultra_l1c function with imported test data."""
+
+    df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0.csv")
+
+    # Select a single pointing number
+    pointing = 0
+    df_subset = df[df["pointing_number"] == pointing].copy()
+
+    de_dict = {}
+
+    de_dict["epoch"] = df_subset["epoch"].values
+    species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
+
+    start_type = np.where(df_subset["PosYSlit"].values, 2, 1)
+    d, yf = get_front_y_position(start_type, df_subset["StopY"].values)
+    v, vhat, r = get_de_velocity(
+        (df_subset["StartX"].values, yf),
+        (df_subset["StopX"].values, df_subset["StopY"].values),
+        d,
+        df_subset["TOF"].values,
+    )
+    de_dict["direct_event_velocity"] = v.astype(np.float32)
+
+    ultra_frame = SpiceFrame.IMAP_ULTRA_45
+    _, sc_dps_velocity, _ = get_annotated_particle_velocity(
+        df_subset["tdb"].values,
+        de_dict["direct_event_velocity"],
+        ultra_frame,
+        SpiceFrame.IMAP_DPS,
+        SpiceFrame.IMAP_SPACECRAFT,
+    )
+
+    de_dict["velocity_dps_sc"] = sc_dps_velocity
+    de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
+
+    name = "imap_ultra_l1b_45sensor-de"
+    dataset = create_dataset(de_dict, name, "l1b")
+
+    data_dict = {
+        "imap_ultra_l1b_45sensor-de": dataset,
+        "imap_ultra_l1b_45sensor-extendedspin": xr.Dataset(),  # placeholder
+        "imap_ultra_l1b_45sensor-cullingmask": xr.Dataset(),  # placeholder
+    }
+
+    output_datasets = ultra_l1c(data_dict)
+    output_datasets[0].attrs["Data_version"] = "v999"
+    output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
+    test_data_path = write_cdf(output_datasets[0], istp=True)
+
+    assert test_data_path.exists()
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1c_45sensor-pset_20250415-repoint00001_v999.cdf"
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -140,12 +140,13 @@ def test_calculate_spacecraft_pset_with_cdf():
     # PosYSlit is True for left (start_type = 1)
     # PosYSlit is False for right (start_type = 2)
     start_type = np.where(df_subset["PosYSlit"].values, 1, 2)
-    d, yf = get_front_y_position(start_type, df_subset["StopY"].values)
-    v, vhat, r = get_de_velocity(
-        (df_subset["StartX"].values, yf),
-        (df_subset["StopX"].values, df_subset["StopY"].values),
+    d, yf = get_front_y_position(start_type, df_subset["StopY"].values * 100)
+    tof_tenths_ns = df_subset["TOF"].values * 10000
+    v, _, _ = get_de_velocity(
+        (df_subset["StartX"].values * 100, yf),
+        (df_subset["StopX"].values * 100, df_subset["StopY"].values * 100),
         d,
-        df_subset["TOF"].values,
+        tof_tenths_ns,
     )
     de_dict["direct_event_velocity"] = v.astype(np.float32)
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -125,7 +125,7 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 def test_calculate_spacecraft_pset_with_cdf():
     """Tests ultra_l1c function with imported test data."""
-    # pragma: no cover
+
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
 
     # Select a single pointing number

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -69,7 +69,7 @@ def calculate_spacecraft_pset(
     exposure_pointing = get_spacecraft_exposure_times(df_exposure)
 
     # For ISTP, epoch should be the center of the time bin.
-    pset_dict["epoch"] = de_dataset.epoch.data[0].astype(np.int64)
+    pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)
     pset_dict["counts"] = counts
     pset_dict["latitude"] = latitude
     pset_dict["longitude"] = longitude

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -76,7 +76,7 @@ def calculate_spacecraft_pset(
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
     pset_dict["background_rates"] = background_rates
     pset_dict["exposure_factor"] = exposure_pointing
-    pset_dict["healpix"] = healpix
+    pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()
 
     dataset = create_dataset(pset_dict, name, "l1c")

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -41,13 +41,13 @@ def create_dataset(
         }
         default_dimension = "spin_number"
     # L1c pset data products
-    elif "healpix" in data_dict:
+    elif "pixel_index" in data_dict:
         coords = {
-            "healpix": data_dict["healpix"],
+            "pixel_index": data_dict["pixel_index"],
             "energy_bin_geometric_mean": data_dict["energy_bin_geometric_mean"],
             "epoch": data_dict["epoch"],
         }
-        default_dimension = "healpix"
+        default_dimension = "pixel_index"
     # L1b de data product
     else:
         epoch_time = xr.DataArray(
@@ -89,7 +89,7 @@ def create_dataset(
 
     for key, data in data_dict.items():
         # Skip keys that are coordinates.
-        if key in ["epoch", "spin_number", "energy_bin_geometric_mean", "healpix"]:
+        if key in ["epoch", "spin_number", "energy_bin_geometric_mean", "pixel_index"]:
             continue
         elif key in velocity_keys:
             dataset[key] = xr.DataArray(
@@ -112,7 +112,7 @@ def create_dataset(
         elif key == "counts":
             dataset[key] = xr.DataArray(
                 data,
-                dims=["energy_bin_geometric_mean", "healpix"],
+                dims=["energy_bin_geometric_mean", "pixel_index"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         else:


### PR DESCRIPTION
# Change Summary

## Overview
Setting up for creating l1c pset cdfs in the spacecraft frame.

## Updated Files
- imap_ultra_global_cdf_attrs.yaml
- spacecraft_pset.py
   - Small change in data structure so that cdf creation wouldn't throw an error

## Testing
- conftest.py
   - Added external file with l1a 1/2 data that also contains the epoch and pointing number columns added.
- test_spacecraft_pset.py
   - Created place where l1c spacecraft psets will be tested once we have the histogram data in healpix form.
- test_ultra_l1a.py
   - Added pointing numbers to attributes.
- test_ultra_l1b.py
   - Added pointing numbers to attributes.
- test_ultra_l1c.py
   - Checked that cdf was able to be created.

## Notes
A dataframe was created from Ultra test data in the following branch:
ultra_l1c_put_cdf_in_s3

This resulted in a .csv with combined pointings, epoch calculated, and pointing numbers assigned.