### PR TITLE
1730 ena skymap inheritance improvements

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -681,8 +681,8 @@ class AbstractSkyMap(ABC):
         """
         raise NotImplementedError("AbstractSkyMap.to_dataset() not implemented.")
 
-    @abstractmethod
     @property
+    @abstractmethod
     def binning_grid_shape(self) -> tuple[int]:
         """
         Shape of the binning grid.
@@ -923,6 +923,7 @@ class AbstractSkyMap(ABC):
         skymap.values_to_pull_project = properties.get("values_to_pull_project", [])
         return skymap
 
+    @abstractmethod
     def to_dict(self) -> dict:
         """
         Convert the SkyMap object to a dictionary of properties.
@@ -932,32 +933,7 @@ class AbstractSkyMap(ABC):
         dict
             Dictionary containing the map properties.
         """
-        if isinstance(self, HealpixSkyMap):
-            map_properties_dict = {
-                "sky_tiling_type": "HEALPIX",
-                "spice_reference_frame": self.spice_reference_frame.name,
-                "nside": self.nside,
-                "nested": self.nested,
-            }
-        elif isinstance(self, RectangularSkyMap):
-            map_properties_dict = {
-                "sky_tiling_type": "RECTANGULAR",
-                "spice_reference_frame": self.spice_reference_frame.name,
-                "spacing_deg": self.spacing_deg,
-            }
-        else:
-            raise ValueError(
-                f"Unknown SkyMap type: {self.__class__.__name__}. "
-                f"Must be one of: {AbstractSkyMap.__subclasses__()}"
-            )
-
-        map_properties_dict["values_to_push_project"] = (
-            self.values_to_push_project if self.values_to_push_project else []
-        )
-        map_properties_dict["values_to_pull_project"] = (
-            self.values_to_pull_project if self.values_to_pull_project else []
-        )
-        return map_properties_dict
+        raise NotImplementedError("to_dict must be implemented in a subclass.")
 
     def to_json(self, json_path: str | Path) -> None:
         """
@@ -1144,6 +1120,28 @@ class RectangularSkyMap(AbstractSkyMap):
             rewrapped_data,
             coords={**self.non_spatial_coords, **self.spatial_coords},
         )
+
+    def to_dict(self) -> dict:
+        """
+        Convert the RectangularSkyMap object to a dictionary of properties.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the map properties.
+        """
+        map_properties_dict = {
+            "sky_tiling_type": "RECTANGULAR",
+            "spice_reference_frame": self.spice_reference_frame.name,
+            "spacing_deg": self.spacing_deg,
+            "values_to_push_project": (
+                self.values_to_push_project if self.values_to_push_project else []
+            ),
+            "values_to_pull_project": (
+                self.values_to_pull_project if self.values_to_pull_project else []
+            ),
+        }
+        return map_properties_dict
 
     def __repr__(self) -> str:
         """
@@ -1580,6 +1578,29 @@ class HealpixSkyMap(AbstractSkyMap):
             )
 
         return rect_map, subdiv_depth_dict
+
+    def to_dict(self) -> dict:
+        """
+        Convert the HealpixSkyMap object to a dictionary of properties.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the map properties.
+        """
+        map_properties_dict = {
+            "sky_tiling_type": "HEALPIX",
+            "spice_reference_frame": self.spice_reference_frame.name,
+            "nside": self.nside,
+            "nested": self.nested,
+            "values_to_push_project": (
+                self.values_to_push_project if self.values_to_push_project else []
+            ),
+            "values_to_pull_project": (
+                self.values_to_pull_project if self.values_to_pull_project else []
+            ),
+        }
+        return map_properties_dict
 
     def __repr__(self) -> str:
         """

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -820,7 +820,9 @@ class AbstractSkyMap(ABC):
             self.data_1d[value_key] += pointing_projected_values
 
     @classmethod
-    def from_json(cls, json_path: str | Path) -> RectangularSkyMap | HealpixSkyMap:
+    def from_properties_json(
+        cls, json_path: str | Path
+    ) -> RectangularSkyMap | HealpixSkyMap:
         """
         Create a SkyMap object from a JSON configuration file.
 
@@ -836,10 +838,12 @@ class AbstractSkyMap(ABC):
         """
         with open(json_path) as f:
             properties = json.load(f)
-        return cls.from_dict(properties)
+        return cls.from_properties_dict(properties)
 
     @classmethod
-    def from_dict(cls, properties: dict) -> RectangularSkyMap | HealpixSkyMap:
+    def from_properties_dict(
+        cls, properties: dict
+    ) -> RectangularSkyMap | HealpixSkyMap:
         """
         Create a SkyMap object from a dictionary of properties.
 
@@ -924,7 +928,7 @@ class AbstractSkyMap(ABC):
         return skymap
 
     @abstractmethod
-    def to_dict(self) -> dict:
+    def to_properties_dict(self) -> dict:
         """
         Convert the SkyMap object to a dictionary of properties.
 
@@ -935,7 +939,7 @@ class AbstractSkyMap(ABC):
         """
         raise NotImplementedError("to_dict must be implemented in a subclass.")
 
-    def to_json(self, json_path: str | Path) -> None:
+    def to_properties_json(self, json_path: str | Path) -> None:
         """
         Save the SkyMap object to a JSON configuration file.
 
@@ -945,7 +949,7 @@ class AbstractSkyMap(ABC):
             Path to the JSON file where the properties will be saved.
         """
         with open(json_path, "w") as f:
-            json.dump(self.to_dict(), f, indent=4)
+            json.dump(self.to_properties_dict(), f, indent=4)
 
 
 class RectangularSkyMap(AbstractSkyMap):
@@ -1124,7 +1128,7 @@ class RectangularSkyMap(AbstractSkyMap):
             coords={**self.non_spatial_coords, **self.spatial_coords},
         )
 
-    def to_dict(self) -> dict:
+    def to_properties_dict(self) -> dict:
         """
         Convert the RectangularSkyMap object to a dictionary of properties.
 
@@ -1137,12 +1141,8 @@ class RectangularSkyMap(AbstractSkyMap):
             "sky_tiling_type": "RECTANGULAR",
             "spice_reference_frame": self.spice_reference_frame.name,
             "spacing_deg": self.spacing_deg,
-            "values_to_push_project": (
-                self.values_to_push_project if self.values_to_push_project else []
-            ),
-            "values_to_pull_project": (
-                self.values_to_pull_project if self.values_to_pull_project else []
-            ),
+            "values_to_push_project": self.values_to_push_project,
+            "values_to_pull_project": self.values_to_pull_project,
         }
         return map_properties_dict
 
@@ -1234,7 +1234,7 @@ class HealpixSkyMap(AbstractSkyMap):
         Returns
         -------
         binning_grid_shape : tuple[int]
-            Shape of the AzElSkyGrid (num_az_bins, num_el_bins).
+            Shape of the HealpixSkyGrid (num_points,).
         """
         return (self.num_points,)
 
@@ -1588,7 +1588,7 @@ class HealpixSkyMap(AbstractSkyMap):
 
         return rect_map, subdiv_depth_dict
 
-    def to_dict(self) -> dict:
+    def to_properties_dict(self) -> dict:
         """
         Convert the HealpixSkyMap object to a dictionary of properties.
 
@@ -1602,12 +1602,8 @@ class HealpixSkyMap(AbstractSkyMap):
             "spice_reference_frame": self.spice_reference_frame.name,
             "nside": self.nside,
             "nested": self.nested,
-            "values_to_push_project": (
-                self.values_to_push_project if self.values_to_push_project else []
-            ),
-            "values_to_pull_project": (
-                self.values_to_pull_project if self.values_to_pull_project else []
-            ),
+            "values_to_push_project": self.values_to_push_project,
+            "values_to_pull_project": self.values_to_pull_project,
         }
         return map_properties_dict
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -999,7 +999,10 @@ class RectangularSkyMap(AbstractSkyMap):
     """
 
     tiling_type = SkyTilingType.RECTANGULAR  # Type of tiling of the sky
+
+    # ======== Attributes unique to RectangularSkyMap ========
     sky_grid: spatial_utils.AzElSkyGrid
+    solid_angle_grid: np.ndarray
 
     def __init__(
         self,
@@ -1174,6 +1177,12 @@ class HealpixSkyMap(AbstractSkyMap):
     """
 
     tiling_type = SkyTilingType.HEALPIX
+
+    # ======== Attributes unique to HealpixSkyMap ========
+    nside: int
+    nested: bool
+    approx_resolution: float
+    solid_angle: float
 
     def __init__(
         self, nside: int, spice_frame: geometry.SpiceFrame, nested: bool = False

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -679,16 +679,7 @@ class AbstractSkyMap(ABC):
             If the SkyMap is Healpix, the data is unchanged from the data_1d, but
             the pixel coordinate is renamed to CoordNames.HEALPIX_INDEX.value.
         """
-        if len(self.data_1d.data_vars) == 0:
-            # If the map is empty, return an empty xarray Dataset,
-            # with the unaltered spatial coords of the map
-            return xr.Dataset(
-                {},
-                coords={**self.spatial_coords},
-            )
-        raise NotImplementedError(
-            "AbstractSkyMap.to_dataset() not implemented for no-empty objects."
-        )
+        raise NotImplementedError("AbstractSkyMap.to_dataset() not implemented.")
 
     @abstractmethod
     @property
@@ -1120,7 +1111,10 @@ class RectangularSkyMap(AbstractSkyMap):
         if len(self.data_1d.data_vars) == 0:
             # If the map is empty, return an empty xarray Dataset,
             # with the unaltered spatial coords of the map
-            return super().to_dataset()
+            return xr.Dataset(
+                {},
+                coords={**self.spatial_coords},
+            )
         # Rewrap each data array in the data_1d to the original 2D grid shape
         rewrapped_data = {}
         for key in self.data_1d.data_vars:
@@ -1252,7 +1246,10 @@ class HealpixSkyMap(AbstractSkyMap):
         if len(self.data_1d.data_vars) == 0:
             # If the map is empty, return an empty xarray Dataset,
             # with the unaltered spatial coords of the map
-            return super().to_dataset()
+            return xr.Dataset(
+                {},
+                coords={**self.spatial_coords},
+            )
         # return the data_1d as is, but with the pixel coordinate
         # renamed to CoordNames.HEALPIX_INDEX.value
         return self.data_1d.rename(

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -627,22 +627,44 @@ class AbstractSkyMap(ABC):
     The data can be also accessed via the to_dataset method, which rewraps the data to
     a 2D grid shape if the map is rectangular and formats the data as an xarray
     Dataset with the correct dims and coords.
+
+    Parameters
+    ----------
+    spice_frame : geometry.SpiceFrame
+        The reference Spice frame of the map.
     """
 
+    # ======== Attributes that are set in the ABC __init__ method ========
+    # The spice frame that the az_el_points are expressed in
+    spice_frame: geometry.SpiceFrame
+    # Lists of variables to project using push and pull methods
+    values_to_push_project: list[str]
+    values_to_pull_project: list[str]
+
+    # ======== Attributes required to be set in a subclass ========
+    # Azimuth and elevation coordinates of each spatial pixel. The ndarray should
+    # have the shape (n, 2) where n is the number of spatial pixels
+    az_el_points: np.ndarray
+    # Type of sky tiling
+    tiling_type: SkyTilingType
+    # Dictionary of xr.DataArray objects for each non-spatial coordinate in the SkyMap
+    non_spatial_coords: dict[str, xr.DataArray | NDArray]
+    # Dictionary of xr.DataArray objects for each spatial coordinate in the SkyMap
+    spatial_coords: dict[str, xr.DataArray | NDArray]
+    # 1D Array of spatial pixel solid angles
+    solid_angle_points: np.ndarray
+    # Dataset to store map data projected from PointingSet objects
+    data_1d: xr.Dataset
+
     @abstractmethod
-    def __init__(self) -> None:
-        self.tiling_type: SkyTilingType
-        self.sky_grid: spatial_utils.AzElSkyGrid
-        self.num_points: int
-        self.non_spatial_coords: dict[str, xr.DataArray | NDArray]
-        self.spatial_coords: dict[str, xr.DataArray | NDArray]
-        self.binning_grid_shape: tuple[int, ...]
-        self.data_1d: xr.Dataset
+    def __init__(self, spice_frame: geometry.SpiceFrame) -> None:
+        self.spice_reference_frame = spice_frame
 
         # Initialize values to be used by the instrument code to push/pull
-        self.values_to_push_project: list[str] = []
-        self.values_to_pull_project: list[str] = []
+        self.values_to_push_project = []
+        self.values_to_pull_project = []
 
+    @abstractmethod
     def to_dataset(self) -> xr.Dataset:
         """
         Get the SkyMap data as a formatted xarray Dataset.
@@ -664,43 +686,34 @@ class AbstractSkyMap(ABC):
                 {},
                 coords={**self.spatial_coords},
             )
+        raise NotImplementedError(
+            "AbstractSkyMap.to_dataset() not implemented for no-empty objects."
+        )
 
-        if self.tiling_type is SkyTilingType.HEALPIX:
-            # return the data_1d as is, but with the pixel coordinate
-            # renamed to CoordNames.HEALPIX_INDEX.value
-            return self.data_1d.rename(
-                {CoordNames.GENERIC_PIXEL.value: CoordNames.HEALPIX_INDEX.value}
-            )
-        elif self.tiling_type is SkyTilingType.RECTANGULAR:
-            # Rewrap each data array in the data_1d to the original 2D grid shape
-            rewrapped_data = {}
-            for key in self.data_1d.data_vars:
-                # drop pixel dim from the end, and add the spatial coords as dims
-                rewrapped_dims = [
-                    dim
-                    for dim in self.data_1d[key].dims
-                    if dim != CoordNames.GENERIC_PIXEL.value
-                ]
-                rewrapped_dims.extend(self.spatial_coords.keys())
-                rewrapped_data[key] = xr.DataArray(
-                    spatial_utils.rewrap_even_spaced_az_el_grid(
-                        self.data_1d[key].values,
-                        self.binning_grid_shape,
-                    ),
-                    dims=rewrapped_dims,
-                )
-                # Add the output coordinates to the rewrapped data, excluding the pixel
-                self.non_spatial_coords.update(
-                    {
-                        coord: self.data_1d[key].coords[coord]
-                        for coord in self.data_1d[key].coords
-                        if coord != CoordNames.GENERIC_PIXEL.value
-                    }
-                )
-            return xr.Dataset(
-                rewrapped_data,
-                coords={**self.non_spatial_coords, **self.spatial_coords},
-            )
+    @abstractmethod
+    @property
+    def binning_grid_shape(self) -> tuple[int]:
+        """
+        Shape of the binning grid.
+
+        Returns
+        -------
+        binning_grid_shape : tuple[int]
+            Shape of the binning grid.
+        """
+        raise NotImplementedError("binning_grid_shape property method not implemented.")
+
+    @property
+    def num_points(self) -> int:
+        """
+        The number of spatial pixels in the SkyMap.
+
+        Returns
+        -------
+        num_points: int
+            The number of spatial pixels in the pointing set.
+        """
+        return self.az_el_points.shape[0]
 
     def project_pset_values_to_map(
         self,
@@ -1018,28 +1031,21 @@ class RectangularSkyMap(AbstractSkyMap):
     increases in pixel index, elevation increments first, then azimuth.
     """
 
+    tiling_type = SkyTilingType.RECTANGULAR  # Type of tiling of the sky
+    sky_grid: spatial_utils.AzElSkyGrid
+
     def __init__(
         self,
         spacing_deg: float,
         spice_frame: geometry.SpiceFrame,
     ):
         # Define the core properties of the map:
-        self.tiling_type = SkyTilingType.RECTANGULAR  # Type of tiling of the sky
-
-        # The reference Spice frame of the map, in which angles are defined
-        self.spice_reference_frame = spice_frame
-
-        # Initialize values to be used by the instrument code to push/pull
-        self.values_to_push_project: list[str] = []
-        self.values_to_pull_project: list[str] = []
+        super().__init__(spice_frame)
 
         # Angular spacing of the map grid (degrees) defines the number, size of pixels.
-        self.spacing_deg = spacing_deg
         self.sky_grid = spatial_utils.AzElSkyGrid(
-            spacing_deg=self.spacing_deg,
+            spacing_deg=spacing_deg,
         )
-        # The shape of the map (num_az_bins, num_el_bins) is used to bin the data
-        self.binning_grid_shape = self.sky_grid.grid_shape
 
         self.non_spatial_coords = {}
         self.spatial_coords = {
@@ -1061,7 +1067,6 @@ class RectangularSkyMap(AbstractSkyMap):
 
         # Stack so axis 0 is different pixels, and axis 1 is (az, el) of the pixel
         self.az_el_points = np.column_stack((az_points, el_points))
-        self.num_points = self.az_el_points.shape[0]
 
         # Calculate solid angles of each pixel in the map grid in units of steradians
         self.solid_angle_grid = spatial_utils.build_solid_angle_map(
@@ -1074,6 +1079,76 @@ class RectangularSkyMap(AbstractSkyMap):
             coords={
                 CoordNames.GENERIC_PIXEL.value: np.arange(self.num_points),
             }
+        )
+
+    @property
+    def spacing_deg(self) -> float:
+        """
+        Pixel spacing angle in degrees.
+
+        Returns
+        -------
+        spacing_deg : float
+            Spacing angle in degrees.
+        """
+        return self.sky_grid.spacing_deg
+
+    @property
+    def binning_grid_shape(self) -> tuple[int]:
+        """
+        Shape of the AzElSkyGrid.
+
+        Returns
+        -------
+        binning_grid_shape : tuple[int]
+            Shape of the AzElSkyGrid (num_az_bins, num_el_bins).
+        """
+        return self.sky_grid.grid_shape
+
+    def to_dataset(self) -> xr.Dataset:
+        """
+        Get the SkyMap data as a formatted xarray.Dataset.
+
+        Returns
+        -------
+        xr.Dataset
+            The SkyMap data as a formatted xarray Dataset with dims and coords.
+            If the SkyMap is empty, an empty xarray Dataset is returned.
+            The 1D data used for projecting is rewrapped to a 2D grid of
+            lon/lat (AKA az/el) coordinates.
+        """
+        if len(self.data_1d.data_vars) == 0:
+            # If the map is empty, return an empty xarray Dataset,
+            # with the unaltered spatial coords of the map
+            return super().to_dataset()
+        # Rewrap each data array in the data_1d to the original 2D grid shape
+        rewrapped_data = {}
+        for key in self.data_1d.data_vars:
+            # drop pixel dim from the end, and add the spatial coords as dims
+            rewrapped_dims = [
+                dim
+                for dim in self.data_1d[key].dims
+                if dim != CoordNames.GENERIC_PIXEL.value
+            ]
+            rewrapped_dims.extend(self.spatial_coords.keys())
+            rewrapped_data[key] = xr.DataArray(
+                spatial_utils.rewrap_even_spaced_az_el_grid(
+                    self.data_1d[key].values,
+                    self.binning_grid_shape,
+                ),
+                dims=rewrapped_dims,
+            )
+            # Add the output coordinates to the rewrapped data, excluding the pixel
+            self.non_spatial_coords.update(
+                {
+                    coord: self.data_1d[key].coords[coord]
+                    for coord in self.data_1d[key].coords
+                    if coord != CoordNames.GENERIC_PIXEL.value
+                }
+            )
+        return xr.Dataset(
+            rewrapped_data,
+            coords={**self.non_spatial_coords, **self.spatial_coords},
         )
 
     def __repr__(self) -> str:
@@ -1106,40 +1181,35 @@ class HealpixSkyMap(AbstractSkyMap):
         Whether the Healpix tessellation is nested. Default is False.
     """
 
+    tiling_type = SkyTilingType.HEALPIX
+
     def __init__(
         self, nside: int, spice_frame: geometry.SpiceFrame, nested: bool = False
     ):
         # Define the core properties of the map:
-        self.tiling_type = SkyTilingType.HEALPIX
-        self.spice_reference_frame = spice_frame
-
-        # Initialize values to be used by the instrument code to push/pull
-        self.values_to_push_project: list[str] = []
-        self.values_to_pull_project: list[str] = []
+        super().__init__(spice_frame)
 
         # Tile the sky with a Healpix tessellation. Defined by nside, nested parameters.
         self.nside = nside
         self.nested = nested
 
-        # Calculate how many pixels cover the sky and the approximate resolution (deg)
-        self.num_points = hp.nside2npix(nside)
+        # Calculate the approximate resolution (deg)
         self.approx_resolution = np.rad2deg(hp.nside2resol(nside, arcmin=False))
-        # Define binning_grid_shape for consistency with RectangularSkyMap
-        self.binning_grid_shape = (self.num_points,)
+
+        # The centers of each pixel in the Healpix tessellation in azimuth (az) and
+        # elevation (el) coordinates (degrees) within the map's Spice frame.
+        pixel_az, pixel_el = hp.pix2ang(
+            nside=nside, ipix=np.arange(hp.nside2npix(nside)), nest=nested, lonlat=True
+        )
+        # Stack so axis 0 is different pixels, and axis 1 is (az, el) of the pixel
+        self.az_el_points = np.column_stack((pixel_az, pixel_el))
+
         self.spatial_coords = {
             CoordNames.HEALPIX_INDEX.value: xr.DataArray(
                 np.arange(self.num_points),
                 dims=[CoordNames.HEALPIX_INDEX.value],
             )
         }
-
-        # The centers of each pixel in the Healpix tessellation in azimuth (az) and
-        # elevation (el) coordinates (degrees) within the map's Spice frame.
-        pixel_az, pixel_el = hp.pix2ang(
-            nside=nside, ipix=np.arange(self.num_points), nest=nested, lonlat=True
-        )
-        # Stack so axis 0 is different pixels, and axis 1 is (az, el) of the pixel
-        self.az_el_points = np.column_stack((pixel_az, pixel_el))
 
         # Tracks Per-Pixel Solid Angle in steradians.
         self.solid_angle = hp.nside2pixarea(nside, degrees=False)
@@ -1153,6 +1223,40 @@ class HealpixSkyMap(AbstractSkyMap):
             coords={
                 CoordNames.GENERIC_PIXEL.value: np.arange(self.num_points),
             }
+        )
+
+    @property
+    def binning_grid_shape(self) -> tuple[int]:
+        """
+        Binning_grid_shape for consistency with RectangularSkyMap.
+
+        Returns
+        -------
+        binning_grid_shape : tuple[int]
+            Shape of the AzElSkyGrid (num_az_bins, num_el_bins).
+        """
+        return (self.num_points,)
+
+    def to_dataset(self) -> xr.Dataset:
+        """
+        Get the SkyMap data as a formatted xarray Dataset.
+
+        Returns
+        -------
+        xr.Dataset
+            The SkyMap data as a formatted xarray Dataset with dims and coords.
+            If the SkyMap is empty, an empty xarray Dataset is returned.
+            Otherwise, he data is unchanged from the data_1d, but
+            the pixel coordinate is renamed to CoordNames.HEALPIX_INDEX.value.
+        """
+        if len(self.data_1d.data_vars) == 0:
+            # If the map is empty, return an empty xarray Dataset,
+            # with the unaltered spatial coords of the map
+            return super().to_dataset()
+        # return the data_1d as is, but with the pixel coordinate
+        # renamed to CoordNames.HEALPIX_INDEX.value
+        return self.data_1d.rename(
+            {CoordNames.GENERIC_PIXEL.value: CoordNames.HEALPIX_INDEX.value}
         )
 
     # Define several methods for converting a Healpix map to a Rectangular map:

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -1160,10 +1160,12 @@ class TestAbstractSkyMap:
     def test_to_dict_and_from_dict(self, skymap_props_dict):
         """Test serialization to and from dictionary"""
         # Make a SkyMap from the original properties dict
-        skymap_from_dict = ena_maps.AbstractSkyMap.from_dict(skymap_props_dict)
+        skymap_from_dict = ena_maps.AbstractSkyMap.from_properties_dict(
+            skymap_props_dict
+        )
 
         # Use the SkyMap to create a new properties dict
-        dict_from_skymap = skymap_from_dict.to_dict()
+        dict_from_skymap = skymap_from_dict.to_properties_dict()
 
         assert (
             skymap_from_dict.spice_reference_frame

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -1243,13 +1243,15 @@ class TestAbstractSkyMap:
             temp_file_path_input = temp_file.name
 
         # Read the json file and create a new SkyMap from it
-        skymap_from_json = ena_maps.AbstractSkyMap.from_json(temp_file_path_input)
+        skymap_from_json = ena_maps.AbstractSkyMap.from_properties_json(
+            temp_file_path_input
+        )
 
         # Create json output from the SkyMap at a separate temporary file path
         temp_file_path_output = tempfile.NamedTemporaryFile(
             delete=False, suffix=".json", mode="w"
         ).name
-        skymap_from_json.to_json(json_path=temp_file_path_output)
+        skymap_from_json.to_properties_json(json_path=temp_file_path_output)
 
         assert skymap_from_json.spice_reference_frame == geometry.SpiceFrame.ECLIPJ2000
         assert skymap_from_json.tiling_type is ena_maps.SkyTilingType.HEALPIX

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -91,7 +91,7 @@ class TestUltraL2:
                 ultra_l1c_psets=[
                     pset,
                 ],
-                output_map_structure=ena_maps.AbstractSkyMap.from_dict(
+                output_map_structure=ena_maps.AbstractSkyMap.from_properties_dict(
                     {
                         "sky_tiling_type": "HEALPIX",
                         "spice_reference_frame": map_frame,
@@ -159,7 +159,7 @@ class TestUltraL2:
             with furnish_kernels(self.required_kernel_names):
                 hp_skymap = ultra_l2.generate_ultra_healpix_skymap(
                     ultra_l1c_psets=self.ultra_psets,
-                    output_map_structure=ena_maps.AbstractSkyMap.from_dict(
+                    output_map_structure=ena_maps.AbstractSkyMap.from_properties_dict(
                         {
                             "sky_tiling_type": "RECTANGULAR",
                             "spice_reference_frame": "ECLIPJ2000",
@@ -213,7 +213,7 @@ class TestUltraL2:
 
     @pytest.mark.usefixtures("_setup_spice_kernels_list")
     def test_ultra_l2_output_unbinned_healpix(self, mock_data_dict, furnish_kernels):
-        map_structure = ena_maps.AbstractSkyMap.from_dict(
+        map_structure = ena_maps.AbstractSkyMap.from_properties_dict(
             {
                 "sky_tiling_type": "HEALPIX",
                 "spice_reference_frame": "ECLIPJ2000",
@@ -241,7 +241,7 @@ class TestUltraL2:
 
     @pytest.mark.usefixtures("_setup_spice_kernels_list")
     def test_ultra_l2_rectangular(self, mock_data_dict, furnish_kernels):
-        rect_map_structure = ena_maps.AbstractSkyMap.from_dict(
+        rect_map_structure = ena_maps.AbstractSkyMap.from_properties_dict(
             {
                 "sky_tiling_type": "RECTANGULAR",
                 "spice_reference_frame": "ECLIPJ2000",
@@ -255,7 +255,7 @@ class TestUltraL2:
                 "spacing_deg": 10,  # Larger spacing for faster test
             }
         )
-        hp_map_structure = ena_maps.AbstractSkyMap.from_dict(
+        hp_map_structure = ena_maps.AbstractSkyMap.from_properties_dict(
             {
                 "sky_tiling_type": "HEALPIX",
                 "spice_reference_frame": "ECLIPJ2000",
@@ -444,7 +444,7 @@ class TestUltraL2:
     def test_ultra_l2_error_for_push_and_pull(
         self, mock_data_dict, furnish_kernels, caplog
     ):
-        map_structure = ena_maps.AbstractSkyMap.from_dict(
+        map_structure = ena_maps.AbstractSkyMap.from_properties_dict(
             {
                 "sky_tiling_type": "HEALPIX",
                 "spice_reference_frame": "ECLIPJ2000",

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -17,7 +17,7 @@ logger.info("Importing ultra_l2 module")
 
 # Default properties for the Ultra L2 map
 DEFAULT_ULTRA_L2_MAP_STRUCTURE: ena_maps.RectangularSkyMap | ena_maps.HealpixSkyMap = (
-    ena_maps.AbstractSkyMap.from_dict(
+    ena_maps.AbstractSkyMap.from_properties_dict(
         {
             "sky_tiling_type": "HEALPIX",
             "spice_reference_frame": "ECLIPJ2000",


### PR DESCRIPTION
# Change Summary

## Overview
Some cleanup and move toward more OO code for the SkyMap classes.

## Updated Files
- imap_processing/ena_maps/ena_maps.py
   - Move shared __init__ code into base class
   - Define required class variables in class definitions
   - Make `to_dataset()` a required `@abstractmethod` needed in each subclass of AbstractSkyMap
   - Make `binning_grid_shape` an abstract property
   - Make `num_points` a property instead of a variable
   - Make `to_dict()` an abstract method to move class specific implementation into subclasses
   - Make `tiling_type` a class variable
   - Make `RectangularSkyMap.spacing_deg` a property

Closes: #1730 
