### PR TITLE
Add spice time conversions

### DIFF
--- a/imap_processing/spice/time.py
+++ b/imap_processing/spice/time.py
@@ -131,6 +131,33 @@ def ttj2000ns_to_et(tt_ns: npt.ArrayLike) -> npt.NDArray[float]:
 
 
 @typing.no_type_check
+@ensure_spice
+def et_to_ttj2000ns(et: npt.ArrayLike) -> npt.NDArray[float]:
+    """
+    Convert TDB J2000 epoch seconds to TT J2000 epoch nanoseconds.
+
+    Opposite of `ttj2000ns_to_et`.
+
+    Parameters
+    ----------
+    et : float, numpy.ndarray
+        Number of seconds since the J2000 epoch in the TDB timescale.
+
+    Returns
+    -------
+    numpy.ndarray[float]
+        Number of nanoseconds since the J2000 epoch in the TT timescale.
+    """
+    # tt_seconds = np.asarray(tt_ns, dtype=np.float64) / 1e9
+    vectorized_unitim = _vectorize(
+        spiceypy.unitim, otypes=[float], excluded=["insys", "outsys"]
+    )
+    tt_s = vectorized_unitim(et, "ET", "TT")
+    tt_ns = np.asarray(tt_s, dtype=np.float64) * 1e9
+    return tt_ns
+
+
+@typing.no_type_check
 @ensure_spice(time_kernels_only=True)
 def met_to_utc(met: npt.ArrayLike, precision: int = 9) -> npt.NDArray[str]:
     """

--- a/imap_processing/spice/time.py
+++ b/imap_processing/spice/time.py
@@ -202,6 +202,25 @@ def met_to_datetime64(
     return np.array(met_to_utc(met), dtype=np.datetime64)[()]
 
 
+def et_to_datetime64(
+    et: npt.ArrayLike,
+) -> Union[np.datetime64, npt.NDArray[np.datetime64]]:
+    """
+    Convert ET to datetime.datetime.
+
+    Parameters
+    ----------
+    et : float, numpy.ndarray
+        Number of seconds since the J2000 epoch in the TDB timescale.
+
+    Returns
+    -------
+    numpy.ndarray[str]
+        The mission elapsed time converted to numpy.datetime64.
+    """
+    return np.array(et_to_utc(et), dtype=np.datetime64)[()]
+
+
 @typing.no_type_check
 @ensure_spice
 def sct_to_et(

--- a/imap_processing/spice/time.py
+++ b/imap_processing/spice/time.py
@@ -148,7 +148,6 @@ def et_to_ttj2000ns(et: npt.ArrayLike) -> npt.NDArray[float]:
     numpy.ndarray[float]
         Number of nanoseconds since the J2000 epoch in the TT timescale.
     """
-    # tt_seconds = np.asarray(tt_ns, dtype=np.float64) / 1e9
     vectorized_unitim = _vectorize(
         spiceypy.unitim, otypes=[float], excluded=["insys", "outsys"]
     )
@@ -206,7 +205,7 @@ def et_to_datetime64(
     et: npt.ArrayLike,
 ) -> Union[np.datetime64, npt.NDArray[np.datetime64]]:
     """
-    Convert ET to datetime.datetime.
+    Convert ET to numpy datetime64.
 
     Parameters
     ----------

--- a/imap_processing/tests/spice/test_time.py
+++ b/imap_processing/tests/spice/test_time.py
@@ -8,6 +8,7 @@ from imap_processing.spice import IMAP_SC_ID
 from imap_processing.spice.time import (
     TICK_DURATION,
     epoch_to_doy,
+    et_to_ttj2000ns,
     et_to_utc,
     met_to_datetime64,
     met_to_sclkticks,
@@ -66,6 +67,32 @@ def test_ttj2000ns_to_et(furnish_time_kernels):
     )
     j2000s = ttj2000ns_to_et(epoch)
     np.testing.assert_array_equal(j2000s, ets)
+
+
+def test_et_to_ttj2000ns(furnish_time_kernels):
+    """Test coverage for ttj2000ns_to_et function."""
+    # Use spice to come up with reasonable J2000 values
+    utc = "2025-09-23T00:00:00.000"
+    # Test single value input
+    et = spiceypy.str2et(utc)
+    epoch = int(spiceypy.unitim(et, "ET", "TT") * 1e9)
+    j2000ns = et_to_ttj2000ns(et)
+    assert j2000ns == epoch
+
+    # Test converting back
+    et_roundtrip = ttj2000ns_to_et(j2000ns)
+    assert et_roundtrip == et
+
+    # Test for bug when spiceypy tries to iterate over 0-d array returned by
+    # np.vectorize for the scalar case
+    assert not spiceypy.support_types.is_iterable(et)
+    # Test array input
+    ets = np.arange(et, et + 10000, 100)
+    epoch = np.array([spiceypy.unitim(et, "ET", "TT") * 1e9 for et in ets]).astype(
+        np.int64
+    )
+    j2000ns = et_to_ttj2000ns(ets)
+    np.testing.assert_array_equal(j2000ns, epoch)
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/spice/test_time.py
+++ b/imap_processing/tests/spice/test_time.py
@@ -8,6 +8,7 @@ from imap_processing.spice import IMAP_SC_ID
 from imap_processing.spice.time import (
     TICK_DURATION,
     epoch_to_doy,
+    et_to_datetime64,
     et_to_ttj2000ns,
     et_to_utc,
     met_to_datetime64,
@@ -230,6 +231,15 @@ def test_et_to_utc(furnish_time_kernels):
     )
     actual_utc_array = et_to_utc(array_of_et)
     assert np.array_equal(expected_utc_array, actual_utc_array)
+
+
+def test_et_to_datetime(furnish_time_kernels):
+    et = 553333629.1837274
+    # Test single value input
+    expected_dt = np.datetime64("2017-07-14T19:46:00.000")
+
+    actual_dt = et_to_datetime64(et)
+    assert actual_dt == expected_dt
 
 
 def test_epoch_to_doy():


### PR DESCRIPTION
# Change Summary
ET is a convenient transition point when converting between time formats, but it doesn't have some of the ET -> other format conversions that I wanted. This meant I had to go from J2000->ET->UTC string -> np.datetime64 which is annoying. There was also no way to go from ET to J2000ns, so for example when using the start_time input from the CLI, I couldn't go from a string -> ET -> J2000ns. 

This change adds both of those functionalities. The to datetime64 is mostly for convenience, with the other one bridging a gap in functionality.

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
- Added et_to_ttj2000ns()
- Added et_to_datetime64()

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
For testing, I basically duplicated the tests for ttj2000ns_to_et and added in a round-trip conversion using both methods. For et_to_datetime64 I kept it very simple since it's just a wrapper around et_to_utc anyway.

Other notes: I found the function added by @lacoak21 , `epoch_to_doy()` threw errors when I called it with J2000 ns... not sure if I was using it incorrectly, just wanted to note that. 