### PR TITLE
I-ALiRT - Create a way to mimic attitude kernels

### DIFF
--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -79,7 +79,9 @@ def transform_instrument_vectors_to_inertial(
     spin_phase: NDArray,
     sc_inertial_right: NDArray,
     sc_inertial_decline: NDArray,
-    et: np.ndarray,
+    et: NDArray,
+    instrument_frame: SpiceFrame = SpiceFrame.IMAP_MAG,
+    spacecraft_frame: SpiceFrame = SpiceFrame.IMAP_SPACECRAFT,
 ) -> NDArray:
     """
     Transform instrument-frame vectors into the inertial frame (ECLIPJ2000).
@@ -96,6 +98,10 @@ def transform_instrument_vectors_to_inertial(
         Spacecraft declination in radians. Shape: (N,).
     et : np.ndarray
         Ephemeris time. Shape: (N,).
+    instrument_frame : SpiceFrame
+        Instrument frame.
+    spacecraft_frame : SpiceFrame
+        Spacecraft frame.
 
     Returns
     -------
@@ -113,20 +119,22 @@ def transform_instrument_vectors_to_inertial(
     vectors_urf = get_instrument_vector(
         et,
         instrument_vectors,
+        instrument_frame,
+        spacecraft_frame,
     )
 
     vectors_inertial = np.array(
-        [spice.mxv(r.T, v) for r, v in zip(rot_matrices, vectors_urf)]
+        [spice.mxv(r.T.copy(), v) for r, v in zip(rot_matrices, vectors_urf)]
     )
 
     return vectors_inertial
 
 
 def get_instrument_vector(
-    et: np.ndarray,
-    vector: np.ndarray,
-    instrument_frame: SpiceFrame = SpiceFrame.IMAP_MAG,
-    spacecraft_frame: SpiceFrame = SpiceFrame.IMAP_SPACECRAFT,
+    et: NDArray,
+    vector: NDArray,
+    instrument_frame: SpiceFrame,
+    spacecraft_frame: SpiceFrame,
 ) -> np.ndarray:
     """
     Get the vectors wrt the spacecraft.
@@ -149,10 +157,10 @@ def get_instrument_vector(
     """
     # Instrument frame → SC frame (URF)
     vector_urf = frame_transform(
-        et=et,
-        position=vector,
-        from_frame=instrument_frame,
-        to_frame=spacecraft_frame,
+        et,
+        vector,
+        instrument_frame,
+        spacecraft_frame,
     )
 
     return vector_urf

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -101,9 +101,6 @@ def compute_sc_to_inertial_rotation_matrix_from_z(
         # Columns = spacecraft axes in inertial frame:
         # SPICE: Zsc → X, Ysc → Y, Xsc → Z
         R = np.stack([x_rot, y_rot, z], axis=1)
-        # Orthonormalize
-        u, _, vh = np.linalg.svd(R)
-        R = u @ vh
         R_all.append(R)
 
     return np.stack(R_all)
@@ -133,7 +130,7 @@ def transform_instrument_vectors_to_inertial(
     R_mount = spice.pxform("IMAP_MAG", "IMAP_SPACECRAFT", 0.0)
 
     # SC → inertial
-    R_sc_to_inertial = spice.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et[0])
+    #R_sc_to_inertial = spice.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et[0])
 
     R_sc_to_inertial_test = compute_sc_to_inertial_rotation_matrix_from_z(
         z_axis,

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -4,7 +4,11 @@ import numpy as np
 import spiceypy as spice
 from numpy.typing import NDArray
 
-from imap_processing.spice.geometry import spherical_to_cartesian
+from imap_processing.spice.geometry import (
+    SpiceFrame,
+    frame_transform,
+    spherical_to_cartesian,
+)
 
 
 def get_z_axis(sc_inertial_right: NDArray, sc_inertial_decline: NDArray) -> NDArray:
@@ -108,3 +112,39 @@ def transform_instrument_vectors_to_urf(
     )
 
     return vectors_urf
+
+
+def get_instrument_vector(
+    et: np.ndarray,
+    vector: np.ndarray,
+    instrument_frame: SpiceFrame = SpiceFrame.IMAP_MAG,
+    spacecraft_frame: SpiceFrame = SpiceFrame.IMAP_SPACECRAFT,
+) -> np.ndarray:
+    """
+    Get the vectors wrt the spacecraft.
+
+    Parameters
+    ----------
+    et : np.ndarray
+        Ephemeris time.
+    vector : np.ndarray
+        Vector in the instrument frame.
+    instrument_frame : SpiceFrame
+        Instrument frame.
+    spacecraft_frame : SpiceFrame
+        Spacecraft frame.
+
+    Returns
+    -------
+    vector_urf : np.ndarray
+        Transformed vector(s) in the spacecraft frame.
+    """
+    # Instrument frame → SC frame (URF)
+    vector_urf = frame_transform(
+        et=et,
+        position=vector,
+        from_frame=instrument_frame,
+        to_frame=spacecraft_frame,
+    )
+
+    return vector_urf

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -74,7 +74,7 @@ def get_rotation_matrix(z_axis: NDArray, spin_phase: NDArray) -> NDArray:
     return rot_matrices
 
 
-def transform_instrument_vectors_to_urf(
+def transform_instrument_vectors_to_inertial(
     instrument_vectors: NDArray,
     spin_phase: NDArray,
     sc_inertial_right: NDArray,
@@ -82,7 +82,7 @@ def transform_instrument_vectors_to_urf(
     et: np.ndarray,
 ) -> NDArray:
     """
-    Transform instrument-frame vectors into the spacecraft URF frame.
+    Transform instrument-frame vectors into the inertial frame (ECLIPJ2000).
 
     Parameters
     ----------
@@ -95,17 +95,18 @@ def transform_instrument_vectors_to_urf(
     sc_inertial_decline : np.ndarray
         Spacecraft declination in radians. Shape: (N,).
     et : np.ndarray
-        Ephemeris time.
+        Ephemeris time. Shape: (N,).
 
     Returns
     -------
-    vectors_urf : np.ndarray
-        Vectors in the spacecraft URF frame. Shape: (N, 3).
+    vectors_inertial : np.ndarray
+        Vectors in the inertial frame. Shape: (N, 3).
 
     Notes
     -----
-    URF = Unrotated Reference Frame.
-    It is a spacecraft-fixed frame that rotates with the spacecraft.
+    This function transforms vectors from the instrument
+    frame through the spacecraft URF, then despins them
+    using onboard RA/Dec and spin phase to get inertial directions.
     """
     z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
     rot_matrices = get_rotation_matrix(z_axis, spin_phase)

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -120,7 +120,7 @@ def compute_total_rotation(
     total_rotations : NDArray
         Instrument to inertial rotation matrices (N, 3, 3).
     """
-    total_rotations = inertial_frames @ spin_rotations @ mount_matrix
+    total_rotations = mount_matrix @ spin_rotations @ inertial_frames
 
     return total_rotations
 
@@ -183,7 +183,10 @@ def transform_instrument_vectors_to_inertial(
 
     # Apply to instrument vectors
     vectors = np.array(
-        [spice.mxv(rot, vec) for rot, vec in zip(total_rotations, instrument_vectors)]
+        [
+            spice.mxv(rot.T.copy(), vec)
+            for rot, vec in zip(total_rotations, instrument_vectors)
+        ]
     )
 
     return vectors

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -120,7 +120,7 @@ def get_x_y_axes(z_axis: NDArray) -> tuple[NDArray, NDArray]:
     # Take the cross product to get the X-axis.
     x_axis = np.cross(y_axis, z_axis)
 
-    frames = np.stack([x_axis, y_axis, z_axis], axis=1)
+    frames = np.stack([y_axis, z_axis, x_axis], axis=1)
 
     return frames
 
@@ -167,7 +167,7 @@ def transform_instrument_vectors_to_inertial(
     # Step 2: build inertial S/C frames
     inertial_frames = build_sc_frame_in_inertial(z_axis)
 
-    x_axis, y_axis = get_x_y_axes(z_axis)
+    inertial_frames2 = get_x_y_axes(z_axis)
 
     # Step 3: get spin rotation matrices (around Z)
     spin_rotations = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -102,7 +102,7 @@ def get_x_y_axes(z_axis: NDArray) -> tuple[NDArray, NDArray]:
         Array of shape (N, 3) perpendicular to z_axis.
     """
     # Pick a fixed reference vector.
-    v_ref = np.array([0, 1, 0])
+    v_ref = np.array([0, 0, 1])
 
     # Detect if z_axis is nearly aligned with v_ref.
     dot_products = np.dot(z_axis, v_ref)
@@ -112,14 +112,17 @@ def get_x_y_axes(z_axis: NDArray) -> tuple[NDArray, NDArray]:
     v_refs = np.tile(v_ref, (z_axis.shape[0], 1))
     v_refs[too_parallel] = np.array([1, 0, 0])
 
-    # Compute a temporary X-axis: perpendicular to both v_ref and z_axis.
-    x_temp = np.cross(v_refs, z_axis)
-    x_axis = x_temp / np.linalg.norm(x_temp, axis=-1, keepdims=True)
+    # Compute a temporary Y-axis: perpendicular to both z_axis and v_ref.
+    y_temp = np.cross(z_axis, v_refs)
+    # Make it a unit vector.
+    y_axis = y_temp / np.linalg.norm(y_temp, axis=-1, keepdims=True)
 
-    # Take the cross product to get the Y-axis.
-    y_axis = np.cross(z_axis, x_axis)
+    # Take the cross product to get the X-axis.
+    x_axis = np.cross(y_axis, z_axis)
 
-    return x_axis, y_axis
+    frames = np.stack([x_axis, y_axis, z_axis], axis=1)
+
+    return frames
 
 
 def get_instrument_mount_matrix(instrument_frame: SpiceFrame, spacecraft_frame: SpiceFrame) -> NDArray:

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -74,6 +74,40 @@ def get_rotation_matrix(z_axis: NDArray, spin_phase: NDArray) -> NDArray:
     return rot_matrices
 
 
+def compute_sc_to_inertial_rotation_matrix_from_z(
+    z_axis: NDArray,
+    spin_phase: NDArray,
+) -> NDArray:
+    """
+    Replace SPICE pxform('IMAP_SPACECRAFT', 'ECLIPJ2000', et)
+    using onboard spin axis and spin phase.
+
+    Returns matrix such that: inertial = R @ spacecraft_vector
+    """
+    R_all = []
+
+    for z, phi in zip(z_axis, spin_phase):
+        # Choose reference orthogonal to z
+        ref = np.array([0.0, 0.0, 1.0]) if not np.allclose(z, [0, 0, 1.0]) else np.array([1.0, 0.0, 0.0])
+        y0 = np.cross(z, ref)
+        y0 /= np.linalg.norm(y0)
+        x0 = np.cross(y0, z)
+
+        # Spin rotation in XY plane
+        cos_phi, sin_phi = np.cos(phi), np.sin(phi)
+        x_rot = cos_phi * x0 + sin_phi * y0
+        y_rot = -sin_phi * x0 + cos_phi * y0
+
+        # Columns = spacecraft axes in inertial frame:
+        # SPICE: Zsc → X, Ysc → Y, Xsc → Z
+        R = np.stack([x_rot, y_rot, z], axis=1)
+        R_all.append(R)
+
+    return np.stack(R_all)
+
+
+
+
 def transform_instrument_vectors_to_inertial(
     instrument_vectors: NDArray,
     spin_phase: NDArray,
@@ -97,6 +131,11 @@ def transform_instrument_vectors_to_inertial(
 
     # SC → inertial
     R_sc_to_inertial = spice.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et[0])
+
+    R_sc_to_inertial = compute_sc_to_inertial_rotation_matrix_from_z(
+        z_axis,
+        spin_phase,
+    )
 
     # Final transform matrix: (N, 3, 3)
     rot_total = np.array([

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -17,50 +17,46 @@ def get_z_axis(sc_inertial_right: NDArray, sc_inertial_decline: NDArray) -> NDAr
     Parameters
     ----------
     sc_inertial_right : NDArray
-        Right ascension of the spacecraft spin-axis in radians.
+        Right ascension of the spacecraft spin-axis in degrees.
 
     sc_inertial_decline : NDArray
-        Declination of the spacecraft spin-axis in radians.
+        Declination of the spacecraft spin-axis in degrees.
 
     Returns
     -------
     z_axis : np.ndarray
         Unit vectors of the spacecraft Z-axis (N, 3).
     """
-    # Convert right ascension from radians to degrees.
-    ra_deg = np.degrees(sc_inertial_right)
-    # Convert declination from radians to degrees.
-    dec_deg = np.degrees(sc_inertial_decline)
-
     # All vectors are unit-length; we only care about direction, not magnitude.
     # So we explicitly set radius r = 1 for all RA/Dec samples.
-    r = np.ones_like(ra_deg)
+    r = np.ones_like(sc_inertial_right)
 
     # Prepare input of shape (N, 3): (r, azimuth=RA, elevation=Dec)
-    spherical = np.stack([r, ra_deg, dec_deg], axis=-1)
+    spherical = np.stack([r, sc_inertial_right, sc_inertial_decline], axis=-1)
     z_axis = spherical_to_cartesian(spherical)  # shape: (n, 3)
 
     return z_axis
 
 
-def get_rotation_matrix(z_axis: NDArray, spin_phase: NDArray) -> NDArray:
+def get_rotation_matrix(axis: NDArray, angle: NDArray) -> NDArray:
     """
-    Create rotation matrices for spin about the spacecraft Z-axis.
+    Construct a rotation matrix that rotates vectors by an angle about a specified axis.
 
     Parameters
     ----------
-    z_axis : NDArray
-        Unit vector of spacecraft spin axis (Z-axis).
-    spin_phase : NDArray
-        Spin phase angle in radians.
+    axis : NDArray
+        Rotation axis.
+    angle : NDArray
+        Rotation angle, in degrees.
 
     Returns
     -------
     rot_matrices : NDArray
         Rotation matrices to rotate vectors around Z by spin_phase.
     """
+    angle_rad = np.radians(angle)
     rot_matrices = np.array(
-        [spice.axisar(z, float(phase)) for z, phase in zip(z_axis, spin_phase)]
+        [spice.axisar(z, float(phase)) for z, phase in zip(axis, angle_rad)]
     )
 
     return rot_matrices

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -95,7 +95,7 @@ def get_x_y_axes(z_axis: NDArray) -> NDArray:
     # Take the cross product to get the X-axis.
     x_axis = np.cross(y_axis, z_axis)
 
-    frames = np.stack([z_axis, y_axis, x_axis], axis=1)
+    frames = np.stack([x_axis, y_axis, z_axis], axis=1)
 
     return frames
 
@@ -120,16 +120,7 @@ def compute_total_rotation(
     total_rotations : NDArray
         Instrument to inertial rotation matrices (N, 3, 3).
     """
-    total_rotations = []
-
-    for rotation_sc, spin in zip(inertial_frames, spin_rotations):
-        # Multiply the three matrices: inertial, spin, and mount.
-        # instrument → spacecraft → rotated spacecraft → inertial
-        rotation_inst_to_inertial = rotation_sc @ spin @ mount_matrix
-
-        total_rotations.append(rotation_inst_to_inertial)
-
-    total_rotations = np.array(total_rotations)
+    total_rotations = inertial_frames @ spin_rotations @ mount_matrix
 
     return total_rotations
 
@@ -163,7 +154,7 @@ def transform_instrument_vectors_to_inertial(
     Returns
     -------
     vectors : NDArray
-        Array of transformed vectors in inertial frame, shape (N, 3).
+        Transformed vectors in the inertial frame (ECLIPJ2000), shape (N, 3).
 
     Notes
     -----

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -125,13 +125,6 @@ def get_x_y_axes(z_axis: NDArray) -> tuple[NDArray, NDArray]:
     return frames
 
 
-def get_instrument_mount_matrix(instrument_frame: SpiceFrame, spacecraft_frame: SpiceFrame) -> NDArray:
-    """
-    Get static instrument-to-spacecraft rotation matrix.
-    """
-    return spice.pxform(instrument_frame.name, spacecraft_frame.name, 0.0)
-
-
 def compute_total_rotation(
     inertial_frames: NDArray,
     spin_rotations: NDArray,
@@ -139,8 +132,25 @@ def compute_total_rotation(
 ) -> NDArray:
     """
     Compute full rotation matrices from instrument to inertial frame.
+    instrument → spacecraft → spun spacecraft → inertial frame
     """
-    return np.array([R_sc @ spin @ mount_matrix for R_sc, spin in zip(inertial_frames, spin_rotations)])
+
+    total_rotations = []
+
+    # loop over each time sample
+    for r_sc, spin in zip(inertial_frames, spin_rotations):
+
+        # multiply the three matrices: inertial, spin, and mount.
+        # instrument → spacecraft → rotated spacecraft → inertial
+        # Read in reverse order: mount_matrix, spin, r_sc.
+        R_inst_to_inertial = r_sc @ spin @ mount_matrix
+
+        total_rotations.append(R_inst_to_inertial)
+
+    # Convert list of matrices to array
+    total_rotations = np.array(total_rotations)
+
+    return total_rotations
 
 
 def apply_rotations_to_vectors(rotations: NDArray, vectors: NDArray) -> NDArray:
@@ -161,17 +171,19 @@ def transform_instrument_vectors_to_inertial(
     """
     Transform instrument-frame vectors into the inertial frame (ECLIPJ2000).
     """
-    # Step 1: compute spin axis
-    z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
+    # Step 1: compute inertial spin axis
+    inertial_z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
 
     # Step 2: build inertial S/C frames
-    inertial_frames = get_x_y_axes(z_axis)
+    inertial_frames = get_x_y_axes(inertial_z_axis)
 
-    # Step 3: get spin rotation matrices (around Z)
+    # Step 3: get spin rotation matrices (around Z) in the spacecraft frame
+    # The spin rotation happens in the spacecraft frame, not in inertial frame.
+    # In the spacecraft frame, the spin axis is always exactly [0, 0, 1]
     spin_rotations = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)
 
     # Step 4: get static mount matrix
-    mount_matrix = get_instrument_mount_matrix(instrument_frame, spacecraft_frame)
+    mount_matrix = spice.pxform(instrument_frame.name, spacecraft_frame.name, 0.0)
 
     # Step 5: compute total rotations
     total_rotations = compute_total_rotation(inertial_frames, spin_rotations, mount_matrix)

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -152,9 +152,9 @@ def transform_instrument_vectors_to_inertial(
     spin_phase : NDArray
         Spin phase angles (radians), shape (N,).
     sc_inertial_right : NDArray
-        Right ascension of spacecraft spin axis (radians), shape (N,).
+        Right ascension of spacecraft spin axis (degrees), shape (N,).
     sc_inertial_decline : NDArray
-        Declination of spacecraft spin axis (radians), shape (N,).
+        Declination of spacecraft spin axis (degrees), shape (N,).
     instrument_frame : SpiceFrame, optional
         SPICE frame of the instrument.
     spacecraft_frame : SpiceFrame, optional

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -101,6 +101,9 @@ def compute_sc_to_inertial_rotation_matrix_from_z(
         # Columns = spacecraft axes in inertial frame:
         # SPICE: Zsc → X, Ysc → Y, Xsc → Z
         R = np.stack([x_rot, y_rot, z], axis=1)
+        # Orthonormalize
+        u, _, vh = np.linalg.svd(R)
+        R = u @ vh
         R_all.append(R)
 
     return np.stack(R_all)
@@ -132,10 +135,11 @@ def transform_instrument_vectors_to_inertial(
     # SC → inertial
     R_sc_to_inertial = spice.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et[0])
 
-    R_sc_to_inertial = compute_sc_to_inertial_rotation_matrix_from_z(
+    R_sc_to_inertial_test = compute_sc_to_inertial_rotation_matrix_from_z(
         z_axis,
         spin_phase,
     )
+    R_sc_to_inertial = R_sc_to_inertial_test[0]
 
     # Final transform matrix: (N, 3, 3)
     rot_total = np.array([

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -87,6 +87,41 @@ def build_sc_frame_in_inertial(z_axis: NDArray) -> NDArray:
     return np.array(frames)
 
 
+def get_x_y_axes(z_axis: NDArray) -> tuple[NDArray, NDArray]:
+    """
+    Compute X and Y vectors that are perpendicular to Z and to each other.
+    Parameters
+    ----------
+    z_axis : NDArray
+        Array of shape (N, 3).
+    Returns
+    -------
+    x_axis : NDArray
+        Array of shape (N, 3) perpendicular to z_axis.
+    y_axis : NDArray
+        Array of shape (N, 3) perpendicular to z_axis.
+    """
+    # Pick a fixed reference vector.
+    v_ref = np.array([0, 1, 0])
+
+    # Detect if z_axis is nearly aligned with v_ref.
+    dot_products = np.dot(z_axis, v_ref)
+    too_parallel = np.abs(dot_products) > 0.99
+
+    # Use alternate reference vector where needed.
+    v_refs = np.tile(v_ref, (z_axis.shape[0], 1))
+    v_refs[too_parallel] = np.array([1, 0, 0])
+
+    # Compute a temporary X-axis: perpendicular to both v_ref and z_axis.
+    x_temp = np.cross(v_refs, z_axis)
+    x_axis = x_temp / np.linalg.norm(x_temp, axis=-1, keepdims=True)
+
+    # Take the cross product to get the Y-axis.
+    y_axis = np.cross(z_axis, x_axis)
+
+    return x_axis, y_axis
+
+
 def get_instrument_mount_matrix(instrument_frame: SpiceFrame, spacecraft_frame: SpiceFrame) -> NDArray:
     """
     Get static instrument-to-spacecraft rotation matrix.
@@ -128,6 +163,8 @@ def transform_instrument_vectors_to_inertial(
 
     # Step 2: build inertial S/C frames
     inertial_frames = build_sc_frame_in_inertial(z_axis)
+
+    x_axis, y_axis = get_x_y_axes(z_axis)
 
     # Step 3: get spin rotation matrices (around Z)
     spin_rotations = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -79,6 +79,7 @@ def transform_instrument_vectors_to_urf(
     spin_phase: NDArray,
     sc_inertial_right: NDArray,
     sc_inertial_decline: NDArray,
+    et: np.ndarray,
 ) -> NDArray:
     """
     Transform instrument-frame vectors into the spacecraft URF frame.
@@ -93,6 +94,8 @@ def transform_instrument_vectors_to_urf(
         Spacecraft right ascension in radians. Shape: (N,).
     sc_inertial_decline : np.ndarray
         Spacecraft declination in radians. Shape: (N,).
+    et : np.ndarray
+        Ephemeris time.
 
     Returns
     -------
@@ -106,12 +109,16 @@ def transform_instrument_vectors_to_urf(
     """
     z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
     rot_matrices = get_rotation_matrix(z_axis, spin_phase)
-
-    vectors_urf = np.array(
-        [spice.mxv(r, v) for r, v in zip(rot_matrices, instrument_vectors)]
+    vectors_urf = get_instrument_vector(
+        et,
+        instrument_vectors,
     )
 
-    return vectors_urf
+    vectors_inertial = np.array(
+        [spice.mxv(r.T, v) for r, v in zip(rot_matrices, vectors_urf)]
+    )
+
+    return vectors_inertial
 
 
 def get_instrument_vector(

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -85,82 +85,26 @@ def transform_instrument_vectors_to_inertial(
 ) -> NDArray:
     """
     Transform instrument-frame vectors into the inertial frame (ECLIPJ2000).
-
-    Parameters
-    ----------
-    instrument_vectors : np.ndarray
-        Vectors in the instrument frame. Shape: (N, 3).
-    spin_phase : np.ndarray
-        Spin phase angle(s) in radians. Shape: (N,).
-    sc_inertial_right : np.ndarray
-        Spacecraft right ascension in radians. Shape: (N,).
-    sc_inertial_decline : np.ndarray
-        Spacecraft declination in radians. Shape: (N,).
-    et : np.ndarray
-        Ephemeris time. Shape: (N,).
-    instrument_frame : SpiceFrame
-        Instrument frame.
-    spacecraft_frame : SpiceFrame
-        Spacecraft frame.
-
-    Returns
-    -------
-    vectors_inertial : np.ndarray
-        Vectors in the inertial frame. Shape: (N, 3).
-
-    Notes
-    -----
-    This function transforms vectors from the instrument
-    frame through the spacecraft URF, then despins them
-    using onboard RA/Dec and spin phase to get inertial directions.
     """
+    # Convert RA/Dec → inertial Z-axis
     z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
-    rot_matrices = get_rotation_matrix(z_axis, spin_phase)
-    vectors_urf = get_instrument_vector(
-        et,
-        instrument_vectors,
-        instrument_frame,
-        spacecraft_frame,
-    )
 
-    vectors_inertial = np.array(
-        [spice.mxv(r.T.copy(), v) for r, v in zip(rot_matrices, vectors_urf)]
-    )
+    # Rotation about Z-axis (spin), shape (N, 3, 3)
+    rot_spin = get_rotation_matrix(z_axis, spin_phase)
+
+    # Static mount matrix: MAG → SC
+    R_mount = spice.pxform("IMAP_MAG", "IMAP_SPACECRAFT", et[0])
+
+    # SC → inertial
+    R_sc_to_inertial = spice.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et[0])
+
+    # Final transform matrix: (N, 3, 3)
+    rot_total = np.array([
+        R_sc_to_inertial @ spin @ R_mount for spin in rot_spin
+    ])
+
+    # Apply transform
+    vectors_inertial = np.einsum("nij,nj->ni", rot_total, instrument_vectors)
 
     return vectors_inertial
 
-
-def get_instrument_vector(
-    et: NDArray,
-    vector: NDArray,
-    instrument_frame: SpiceFrame,
-    spacecraft_frame: SpiceFrame,
-) -> np.ndarray:
-    """
-    Get the vectors wrt the spacecraft.
-
-    Parameters
-    ----------
-    et : np.ndarray
-        Ephemeris time.
-    vector : np.ndarray
-        Vector in the instrument frame.
-    instrument_frame : SpiceFrame
-        Instrument frame.
-    spacecraft_frame : SpiceFrame
-        Spacecraft frame.
-
-    Returns
-    -------
-    vector_urf : np.ndarray
-        Transformed vector(s) in the spacecraft frame.
-    """
-    # Instrument frame → SC frame (URF)
-    vector_urf = frame_transform(
-        et,
-        vector,
-        instrument_frame,
-        spacecraft_frame,
-    )
-
-    return vector_urf

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -93,7 +93,7 @@ def transform_instrument_vectors_to_inertial(
     rot_spin = get_rotation_matrix(z_axis, spin_phase)
 
     # Static mount matrix: MAG → SC
-    R_mount = spice.pxform("IMAP_MAG", "IMAP_SPACECRAFT", et[0])
+    R_mount = spice.pxform("IMAP_MAG", "IMAP_SPACECRAFT", 0.0)
 
     # SC → inertial
     R_sc_to_inertial = spice.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et[0])
@@ -104,7 +104,10 @@ def transform_instrument_vectors_to_inertial(
     ])
 
     # Apply transform
-    vectors_inertial = np.einsum("nij,nj->ni", rot_total, instrument_vectors)
+    vectors_inertial = np.array([
+        spice.mxv(rot, vec)
+        for rot, vec in zip(rot_total, instrument_vectors)
+    ])
 
     return vectors_inertial
 

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -1,4 +1,4 @@
-"""Module to calculate attitude."""
+"""Module to simulate SPICE calls with attitude kernels."""
 
 import numpy as np
 import spiceypy as spice
@@ -12,14 +12,14 @@ from imap_processing.spice.geometry import (
 
 def get_z_axis(sc_inertial_right: NDArray, sc_inertial_decline: NDArray) -> NDArray:
     """
-    Compute the spacecraft Z-axis (angular momentum direction) in inertial coordinates.
+    Compute the spacecraft Z-axis in inertial coordinates.
 
     Parameters
     ----------
-    sc_inertial_right : np.ndarray
+    sc_inertial_right : NDArray
         Right ascension of the spacecraft spin-axis in radians.
 
-    sc_inertial_decline : np.ndarray
+    sc_inertial_decline : NDArray
         Declination of the spacecraft spin-axis in radians.
 
     Returns
@@ -45,27 +45,20 @@ def get_z_axis(sc_inertial_right: NDArray, sc_inertial_decline: NDArray) -> NDAr
 
 def get_rotation_matrix(z_axis: NDArray, spin_phase: NDArray) -> NDArray:
     """
-    Rotate a spacecraft frame about the spin axis by the given spin phase angle.
+    Create rotation matrices for spin about the spacecraft Z-axis.
 
     Parameters
     ----------
     z_axis : NDArray
-        Unit vector spacecraft Z-axis.
+        Unit vector of spacecraft spin axis (Z-axis).
     spin_phase : NDArray
         Spin phase angle in radians.
 
     Returns
     -------
     rot_matrices : NDArray
-        Rotation matrix.
-
-    Notes
-    -----
-    This matrix acts just like SPICE's pxform(instrument_frame, "IMAP_SPACECRAFT", et).
-    A forward rotation that transforms vectors from the instrument's local frame
-    to the spacecraft’s rotating frame (URF)
+        Rotation matrices to rotate vectors around Z by spin_phase.
     """
-    # Rotation matrix to rotate about z_axis by spin_phase
     rot_matrices = np.array(
         [spice.axisar(z, float(phase)) for z, phase in zip(z_axis, spin_phase)]
     )
@@ -73,33 +66,19 @@ def get_rotation_matrix(z_axis: NDArray, spin_phase: NDArray) -> NDArray:
     return rot_matrices
 
 
-def build_sc_frame_in_inertial(z_axis: NDArray) -> NDArray:
+def get_x_y_axes(z_axis: NDArray) -> NDArray:
     """
-    Create spacecraft orthonormal frame in inertial space for each z-axis.
-    """
-    frames = []
-    for z in z_axis:
-        ref = np.array([0.0, 0.0, 1.0]) if not np.allclose(z, [0, 0, 1.0]) else np.array([1.0, 0.0, 0.0])
-        y = np.cross(z, ref)
-        y /= np.linalg.norm(y)
-        x = np.cross(y, z)
-        frames.append(np.stack([x, y, z], axis=1))
-    return np.array(frames)
+    Build orthonormal frames from input Z-axis vectors.
 
-
-def get_x_y_axes(z_axis: NDArray) -> tuple[NDArray, NDArray]:
-    """
-    Compute X and Y vectors that are perpendicular to Z and to each other.
     Parameters
     ----------
     z_axis : NDArray
-        Array of shape (N, 3).
+        Array of spacecraft Z-axis unit vectors, shape (N, 3).
+
     Returns
     -------
-    x_axis : NDArray
-        Array of shape (N, 3) perpendicular to z_axis.
-    y_axis : NDArray
-        Array of shape (N, 3) perpendicular to z_axis.
+    frames : NDArray
+        Array of rotation matrices, shape (N, 3, 3).
     """
     # Pick a fixed reference vector.
     v_ref = np.array([0, 0, 1])
@@ -131,33 +110,36 @@ def compute_total_rotation(
     mount_matrix: NDArray
 ) -> NDArray:
     """
-    Compute full rotation matrices from instrument to inertial frame.
-    instrument → spacecraft → spun spacecraft → inertial frame
+    Map instrument vectors to inertial space.
+
+    Parameters
+    ----------
+    inertial_frames : NDArray
+        Spacecraft to inertial rotation matrices (N, 3, 3).
+    spin_rotations : NDArray
+        Spacecraft spin rotation matrices (N, 3, 3).
+    mount_matrix : NDArray
+        Matrix for instrument to spacecraft alignment (3, 3).
+
+    Returns
+    -------
+    total_rotations : NDArray
+        Instrument to inertial rotation matrices (N, 3, 3).
     """
 
     total_rotations = []
 
-    # loop over each time sample
-    for r_sc, spin in zip(inertial_frames, spin_rotations):
+    for rotation_sc, spin in zip(inertial_frames, spin_rotations):
 
-        # multiply the three matrices: inertial, spin, and mount.
+        # Multiply the three matrices: inertial, spin, and mount.
         # instrument → spacecraft → rotated spacecraft → inertial
-        # Read in reverse order: mount_matrix, spin, r_sc.
-        R_inst_to_inertial = r_sc @ spin @ mount_matrix
+        rotation_inst_to_inertial = rotation_sc @ spin @ mount_matrix
 
-        total_rotations.append(R_inst_to_inertial)
+        total_rotations.append(rotation_inst_to_inertial)
 
-    # Convert list of matrices to array
     total_rotations = np.array(total_rotations)
 
     return total_rotations
-
-
-def apply_rotations_to_vectors(rotations: NDArray, vectors: NDArray) -> NDArray:
-    """
-    Apply rotation matrices to instrument vectors.
-    """
-    return np.array([spice.mxv(rot, vec) for rot, vec in zip(rotations, vectors)])
 
 
 def transform_instrument_vectors_to_inertial(
@@ -169,25 +151,50 @@ def transform_instrument_vectors_to_inertial(
     spacecraft_frame: SpiceFrame = SpiceFrame.IMAP_SPACECRAFT,
 ) -> NDArray:
     """
-    Transform instrument-frame vectors into the inertial frame (ECLIPJ2000).
+    Rotate instrument vectors into the inertial frame (ECLIPJ2000).
+
+    Parameters
+    ----------
+    instrument_vectors : NDArray
+        Array of instrument-frame vectors, shape (N, 3).
+    spin_phase : NDArray
+        Spin phase angles (radians), shape (N,).
+    sc_inertial_right : NDArray
+        Right ascension of spacecraft spin axis (radians), shape (N,).
+    sc_inertial_decline : NDArray
+        Declination of spacecraft spin axis (radians), shape (N,).
+    instrument_frame : SpiceFrame, optional
+        SPICE frame of the instrument.
+    spacecraft_frame : SpiceFrame, optional
+        SPICE frame of the spacecraft.
+
+    Returns
+    -------
+    vectors : NDArray
+        Array of transformed vectors in inertial frame, shape (N, 3).
+
+    Notes
+    -------
+    Applies: instrument → spacecraft → spun spacecraft → inertial frame.
     """
-    # Step 1: compute inertial spin axis
+    # Compute inertial spin axis
     inertial_z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
 
-    # Step 2: build inertial S/C frames
+    # Build inertial S/C frames
     inertial_frames = get_x_y_axes(inertial_z_axis)
 
-    # Step 3: get spin rotation matrices (around Z) in the spacecraft frame
+    # Get spin rotation matrices (around Z) in the spacecraft frame
     # The spin rotation happens in the spacecraft frame, not in inertial frame.
     # In the spacecraft frame, the spin axis is always exactly [0, 0, 1]
     spin_rotations = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)
 
-    # Step 4: get static mount matrix
+    # Get static mount matrix
     mount_matrix = spice.pxform(instrument_frame.name, spacecraft_frame.name, 0.0)
 
-    # Step 5: compute total rotations
+    # Compute total rotations
     total_rotations = compute_total_rotation(inertial_frames, spin_rotations, mount_matrix)
 
-    # Step 6: apply to instrument vectors
-    return apply_rotations_to_vectors(total_rotations, instrument_vectors)
+    # Apply to instrument vectors
+    vectors = np.array([spice.mxv(rot, vec) for rot, vec in zip(total_rotations, instrument_vectors)])
 
+    return vectors

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -120,7 +120,7 @@ def get_x_y_axes(z_axis: NDArray) -> tuple[NDArray, NDArray]:
     # Take the cross product to get the X-axis.
     x_axis = np.cross(y_axis, z_axis)
 
-    frames = np.stack([y_axis, z_axis, x_axis], axis=1)
+    frames = np.stack([z_axis, y_axis, x_axis], axis=1)
 
     return frames
 
@@ -165,9 +165,7 @@ def transform_instrument_vectors_to_inertial(
     z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
 
     # Step 2: build inertial S/C frames
-    inertial_frames = build_sc_frame_in_inertial(z_axis)
-
-    inertial_frames2 = get_x_y_axes(z_axis)
+    inertial_frames = get_x_y_axes(z_axis)
 
     # Step 3: get spin rotation matrices (around Z)
     spin_rotations = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -6,7 +6,6 @@ from numpy.typing import NDArray
 
 from imap_processing.spice.geometry import (
     SpiceFrame,
-    frame_transform,
     spherical_to_cartesian,
 )
 
@@ -74,40 +73,6 @@ def get_rotation_matrix(z_axis: NDArray, spin_phase: NDArray) -> NDArray:
     return rot_matrices
 
 
-def compute_sc_to_inertial_rotation_matrix_from_z(
-    z_axis: NDArray,
-    spin_phase: NDArray,
-) -> NDArray:
-    """
-    Replace SPICE pxform('IMAP_SPACECRAFT', 'ECLIPJ2000', et)
-    using onboard spin axis and spin phase.
-
-    Returns matrix such that: inertial = R @ spacecraft_vector
-    """
-    R_all = []
-
-    for z, phi in zip(z_axis, spin_phase):
-        # Choose reference orthogonal to z
-        ref = np.array([0.0, 0.0, 1.0]) if not np.allclose(z, [0, 0, 1.0]) else np.array([1.0, 0.0, 0.0])
-        y0 = np.cross(z, ref)
-        y0 /= np.linalg.norm(y0)
-        x0 = np.cross(y0, z)
-
-        # Spin rotation in XY plane
-        cos_phi, sin_phi = np.cos(phi), np.sin(phi)
-        x_rot = cos_phi * x0 + sin_phi * y0
-        y_rot = -sin_phi * x0 + cos_phi * y0
-
-        # Columns = spacecraft axes in inertial frame:
-        # SPICE: Zsc → X, Ysc → Y, Xsc → Z
-        R = np.stack([x_rot, y_rot, z], axis=1)
-        R_all.append(R)
-
-    return np.stack(R_all)
-
-
-
-
 def transform_instrument_vectors_to_inertial(
     instrument_vectors: NDArray,
     spin_phase: NDArray,
@@ -126,7 +91,11 @@ def transform_instrument_vectors_to_inertial(
     inertial_frames = []
     for z in z_axis:
         # Pick a reference not parallel to z
-        ref = np.array([0.0, 0.0, 1.0]) if not np.allclose(z, [0, 0, 1.0]) else np.array([1.0, 0.0, 0.0])
+        ref = (
+            np.array([0.0, 0.0, 1.0])
+            if not np.allclose(z, [0, 0, 1.0])
+            else np.array([1.0, 0.0, 0.0])
+        )
         y = np.cross(z, ref)
         y /= np.linalg.norm(y)
         x = np.cross(y, z)
@@ -141,16 +110,13 @@ def transform_instrument_vectors_to_inertial(
     R_mount = spice.pxform(instrument_frame.name, spacecraft_frame.name, 0.0)
 
     # Final transform: inertial = R_sc @ spin @ R_mount @ instrument_vector
-    rot_total = np.array([
-        R_sc @ spin @ R_mount
-        for R_sc, spin in zip(inertial_frames, rot_spin)
-    ])
+    rot_total = np.array(
+        [R_sc @ spin @ R_mount for R_sc, spin in zip(inertial_frames, rot_spin)]
+    )
 
     # Apply to instrument vectors
-    vectors_inertial = np.array([
-        spice.mxv(rot, vec)
-        for rot, vec in zip(rot_total, instrument_vectors)
-    ])
+    vectors_inertial = np.array(
+        [spice.mxv(rot, vec) for rot, vec in zip(rot_total, instrument_vectors)]
+    )
 
     return vectors_inertial
-

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -150,7 +150,7 @@ def transform_instrument_vectors_to_inertial(
     instrument_vectors : NDArray
         Array of instrument-frame vectors, shape (N, 3).
     spin_phase : NDArray
-        Spin phase angles (radians), shape (N,).
+        Spin phase angles (degrees), shape (N,).
     sc_inertial_right : NDArray
         Right ascension of spacecraft spin axis (degrees), shape (N,).
     sc_inertial_decline : NDArray

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -120,30 +120,33 @@ def transform_instrument_vectors_to_inertial(
     """
     Transform instrument-frame vectors into the inertial frame (ECLIPJ2000).
     """
-    # Convert RA/Dec → inertial Z-axis
     z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
 
-    # Rotation about Z-axis (spin), shape (N, 3, 3)
-    rot_spin = get_rotation_matrix(z_axis, spin_phase)
+    # Construct orthonormal S/C frame in inertial space
+    inertial_frames = []
+    for z in z_axis:
+        # Pick a reference not parallel to z
+        ref = np.array([0.0, 0.0, 1.0]) if not np.allclose(z, [0, 0, 1.0]) else np.array([1.0, 0.0, 0.0])
+        y = np.cross(z, ref)
+        y /= np.linalg.norm(y)
+        x = np.cross(y, z)
+        R_sc_to_inertial = np.stack([x, y, z], axis=1)
+        inertial_frames.append(R_sc_to_inertial)
+    inertial_frames = np.array(inertial_frames)
 
-    # Static mount matrix: MAG → SC
-    R_mount = spice.pxform("IMAP_MAG", "IMAP_SPACECRAFT", 0.0)
+    # Rotation about z by spin phase (in spacecraft XY plane)
+    rot_spin = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)
 
-    # SC → inertial
-    #R_sc_to_inertial = spice.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et[0])
+    # Static mount matrix from instrument to spacecraft
+    R_mount = spice.pxform(instrument_frame.name, spacecraft_frame.name, 0.0)
 
-    R_sc_to_inertial_test = compute_sc_to_inertial_rotation_matrix_from_z(
-        z_axis,
-        spin_phase,
-    )
-    R_sc_to_inertial = R_sc_to_inertial_test[0]
-
-    # Final transform matrix: (N, 3, 3)
+    # Final transform: inertial = R_sc @ spin @ R_mount @ instrument_vector
     rot_total = np.array([
-        R_sc_to_inertial @ spin @ R_mount for spin in rot_spin
+        R_sc @ spin @ R_mount
+        for R_sc, spin in zip(inertial_frames, rot_spin)
     ])
 
-    # Apply transform
+    # Apply to instrument vectors
     vectors_inertial = np.array([
         spice.mxv(rot, vec)
         for rot, vec in zip(rot_total, instrument_vectors)

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -73,50 +73,71 @@ def get_rotation_matrix(z_axis: NDArray, spin_phase: NDArray) -> NDArray:
     return rot_matrices
 
 
+def build_sc_frame_in_inertial(z_axis: NDArray) -> NDArray:
+    """
+    Create spacecraft orthonormal frame in inertial space for each z-axis.
+    """
+    frames = []
+    for z in z_axis:
+        ref = np.array([0.0, 0.0, 1.0]) if not np.allclose(z, [0, 0, 1.0]) else np.array([1.0, 0.0, 0.0])
+        y = np.cross(z, ref)
+        y /= np.linalg.norm(y)
+        x = np.cross(y, z)
+        frames.append(np.stack([x, y, z], axis=1))
+    return np.array(frames)
+
+
+def get_instrument_mount_matrix(instrument_frame: SpiceFrame, spacecraft_frame: SpiceFrame) -> NDArray:
+    """
+    Get static instrument-to-spacecraft rotation matrix.
+    """
+    return spice.pxform(instrument_frame.name, spacecraft_frame.name, 0.0)
+
+
+def compute_total_rotation(
+    inertial_frames: NDArray,
+    spin_rotations: NDArray,
+    mount_matrix: NDArray
+) -> NDArray:
+    """
+    Compute full rotation matrices from instrument to inertial frame.
+    """
+    return np.array([R_sc @ spin @ mount_matrix for R_sc, spin in zip(inertial_frames, spin_rotations)])
+
+
+def apply_rotations_to_vectors(rotations: NDArray, vectors: NDArray) -> NDArray:
+    """
+    Apply rotation matrices to instrument vectors.
+    """
+    return np.array([spice.mxv(rot, vec) for rot, vec in zip(rotations, vectors)])
+
+
 def transform_instrument_vectors_to_inertial(
     instrument_vectors: NDArray,
     spin_phase: NDArray,
     sc_inertial_right: NDArray,
     sc_inertial_decline: NDArray,
-    et: NDArray,
     instrument_frame: SpiceFrame = SpiceFrame.IMAP_MAG,
     spacecraft_frame: SpiceFrame = SpiceFrame.IMAP_SPACECRAFT,
 ) -> NDArray:
     """
     Transform instrument-frame vectors into the inertial frame (ECLIPJ2000).
     """
+    # Step 1: compute spin axis
     z_axis = get_z_axis(sc_inertial_right, sc_inertial_decline)
 
-    # Construct orthonormal S/C frame in inertial space
-    inertial_frames = []
-    for z in z_axis:
-        # Pick a reference not parallel to z
-        ref = (
-            np.array([0.0, 0.0, 1.0])
-            if not np.allclose(z, [0, 0, 1.0])
-            else np.array([1.0, 0.0, 0.0])
-        )
-        y = np.cross(z, ref)
-        y /= np.linalg.norm(y)
-        x = np.cross(y, z)
-        R_sc_to_inertial = np.stack([x, y, z], axis=1)
-        inertial_frames.append(R_sc_to_inertial)
-    inertial_frames = np.array(inertial_frames)
+    # Step 2: build inertial S/C frames
+    inertial_frames = build_sc_frame_in_inertial(z_axis)
 
-    # Rotation about z by spin phase (in spacecraft XY plane)
-    rot_spin = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)
+    # Step 3: get spin rotation matrices (around Z)
+    spin_rotations = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)
 
-    # Static mount matrix from instrument to spacecraft
-    R_mount = spice.pxform(instrument_frame.name, spacecraft_frame.name, 0.0)
+    # Step 4: get static mount matrix
+    mount_matrix = get_instrument_mount_matrix(instrument_frame, spacecraft_frame)
 
-    # Final transform: inertial = R_sc @ spin @ R_mount @ instrument_vector
-    rot_total = np.array(
-        [R_sc @ spin @ R_mount for R_sc, spin in zip(inertial_frames, rot_spin)]
-    )
+    # Step 5: compute total rotations
+    total_rotations = compute_total_rotation(inertial_frames, spin_rotations, mount_matrix)
 
-    # Apply to instrument vectors
-    vectors_inertial = np.array(
-        [spice.mxv(rot, vec) for rot, vec in zip(rot_total, instrument_vectors)]
-    )
+    # Step 6: apply to instrument vectors
+    return apply_rotations_to_vectors(total_rotations, instrument_vectors)
 
-    return vectors_inertial

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -105,9 +105,7 @@ def get_x_y_axes(z_axis: NDArray) -> NDArray:
 
 
 def compute_total_rotation(
-    inertial_frames: NDArray,
-    spin_rotations: NDArray,
-    mount_matrix: NDArray
+    inertial_frames: NDArray, spin_rotations: NDArray, mount_matrix: NDArray
 ) -> NDArray:
     """
     Map instrument vectors to inertial space.
@@ -126,11 +124,9 @@ def compute_total_rotation(
     total_rotations : NDArray
         Instrument to inertial rotation matrices (N, 3, 3).
     """
-
     total_rotations = []
 
     for rotation_sc, spin in zip(inertial_frames, spin_rotations):
-
         # Multiply the three matrices: inertial, spin, and mount.
         # instrument → spacecraft → rotated spacecraft → inertial
         rotation_inst_to_inertial = rotation_sc @ spin @ mount_matrix
@@ -174,7 +170,7 @@ def transform_instrument_vectors_to_inertial(
         Array of transformed vectors in inertial frame, shape (N, 3).
 
     Notes
-    -------
+    -----
     Applies: instrument → spacecraft → spun spacecraft → inertial frame.
     """
     # Compute inertial spin axis
@@ -186,15 +182,21 @@ def transform_instrument_vectors_to_inertial(
     # Get spin rotation matrices (around Z) in the spacecraft frame
     # The spin rotation happens in the spacecraft frame, not in inertial frame.
     # In the spacecraft frame, the spin axis is always exactly [0, 0, 1]
-    spin_rotations = get_rotation_matrix(np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase)
+    spin_rotations = get_rotation_matrix(
+        np.tile([0, 0, 1], (len(spin_phase), 1)), spin_phase
+    )
 
     # Get static mount matrix
     mount_matrix = spice.pxform(instrument_frame.name, spacecraft_frame.name, 0.0)
 
     # Compute total rotations
-    total_rotations = compute_total_rotation(inertial_frames, spin_rotations, mount_matrix)
+    total_rotations = compute_total_rotation(
+        inertial_frames, spin_rotations, mount_matrix
+    )
 
     # Apply to instrument vectors
-    vectors = np.array([spice.mxv(rot, vec) for rot, vec in zip(total_rotations, instrument_vectors)])
+    vectors = np.array(
+        [spice.mxv(rot, vec) for rot, vec in zip(total_rotations, instrument_vectors)]
+    )
 
     return vectors

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -84,18 +84,19 @@ def test_get_x_y_axes():
         ]
     )
     frames = get_x_y_axes(z_axis)
-    x_axis = frames[:, 0, :]
+    z_axis = frames[:, 0, :]
     y_axis = frames[:, 1, :]
-    z_axis = frames[:, 2, :]
+    x_axis = frames[:, 2, :]
 
     # Check that the axes are unit vectors.
     assert np.allclose(np.linalg.norm(x_axis, axis=1), 1.0, atol=1e-6)
     assert np.allclose(np.linalg.norm(y_axis, axis=1), 1.0, atol=1e-6)
+    assert np.allclose(np.linalg.norm(z_axis, axis=1), 1.0, atol=1e-6)
 
     # Check each pair of vectors is 90 degrees apart.
-    assert np.allclose(np.sum(x_axis * y_axis, axis=1), 0.0, atol=1e-6)
-    assert np.allclose(np.sum(x_axis * z_axis, axis=1), 0.0, atol=1e-6)
-    assert np.allclose(np.sum(y_axis * z_axis, axis=1), 0.0, atol=1e-6)
+    assert np.allclose(np.sum(z_axis * y_axis, axis=1), 0.0, atol=1e-6)
+    assert np.allclose(np.sum(z_axis * x_axis, axis=1), 0.0, atol=1e-6)
+    assert np.allclose(np.sum(y_axis * x_axis, axis=1), 0.0, atol=1e-6)
 
     # Check cross(X, Y) = Z.
     reconstructed_z = np.cross(x_axis, y_axis)

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -153,7 +153,6 @@ def test_transform_instrument_vectors_to_inertial(
         spin_phase,
         np.array([ra]),
         np.array([dec]),
-        np.array([et]),
     )
 
     # SPICE direct transform from instrument frame to inertial

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -177,6 +177,49 @@ def test_transform_instrument_vectors_to_inertial(
         atol=1e-9,
     )
 
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+@pytest.mark.external_kernel
+@ensure_spice
+def test_extract_spin_phase_from_spice_rotation(spice_test_data_path, use_test_metakernel):
+    """Extract spacecraft spin phase from rotation matrix using SPICE."""
+
+    ck_path = spice_test_data_path / "sim_1yr_imap_attitude.bc"
+    id_imap_spacecraft = spiceypy.gipool("FRAME_IMAP_SPACECRAFT", 0, 1)
+
+    # Get mid-point of CK coverage
+    ck_cover = spiceypy.ckcov(str(ck_path), int(id_imap_spacecraft), True, "INTERVAL", 0.0, "TDB")
+    et = (ck_cover[0] + ck_cover[1]) / 2.0
+
+    # Get rotation matrix from spacecraft to ECLIPJ2000
+    r_sc_to_inertial = spiceypy.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et)
+
+    # Extract inertial-frame X and Y axes
+    x_inertial = r_sc_to_inertial[:, 0]
+    y_inertial = r_sc_to_inertial[:, 1]
+    z_inertial = r_sc_to_inertial[:, 2]  # Spin axis
+
+    # Construct a frame where +X is reference direction in SC XY-plane
+    # In spacecraft frame, +X is initial direction before spin
+    # Project inertial +X axis onto XY plane orthogonal to Z
+    x_proj = x_inertial - np.dot(x_inertial, z_inertial) * z_inertial
+    y_proj = y_inertial - np.dot(y_inertial, z_inertial) * z_inertial
+
+    x_proj /= np.linalg.norm(x_proj)
+    y_proj /= np.linalg.norm(y_proj)
+
+    # Compute spin phase (angle between inertial +X projection and a reference)
+    spin_phase_rad = np.arctan2(
+        np.dot(y_proj, [0, 1, 0]),  # sinθ
+        np.dot(x_proj, [1, 0, 0])   # cosθ
+    )
+    spin_phase_deg = np.degrees(spin_phase_rad) % 360
+
+    print(f"Spin phase at ET {et:.2f} is approximately {spin_phase_deg:.2f} degrees")
+
+
+
+
+
 
 @pytest.mark.use_test_metakernel("imap_ialirt_sim_metakernel.template")
 @pytest.mark.external_kernel

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -23,10 +23,7 @@ def test_get_z_axis():
     ra_deg = np.array([0.0, 90.0, 0.0])
     dec_deg = np.array([0.0, 0.0, 90.0])
 
-    ra_rad = np.radians(ra_deg)
-    dec_rad = np.radians(dec_deg)
-
-    z_axis = get_z_axis(ra_rad, dec_rad)
+    z_axis = get_z_axis(ra_deg, dec_deg)
 
     expected = np.array(
         [
@@ -53,8 +50,8 @@ def test_get_rotation_matrix():
         ]
     )
 
-    # Rotate 90 degrees (π/2 radians)
-    spin_phase = np.array([np.pi / 2, np.pi / 2, np.pi / 2])
+    # Rotate 90 degrees
+    spin_phase = np.array([90, 90, 90])
 
     # Get rotation matrix
     r = get_rotation_matrix(z_axis, spin_phase)

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -124,13 +124,11 @@ def test_transform_instrument_vectors_to_inertial_no_spice(spice_test_data_path)
         ]
     )
 
-    et = np.array([0.0, 0.0, 0.0])
     result = transform_instrument_vectors_to_inertial(
         instrument_vectors,
         spin_phase,
         sc_inertial_right,
         sc_inertial_decline,
-        et,
         SpiceFrame.IMAP_SPACECRAFT,
         SpiceFrame.IMAP_SPACECRAFT,
     )

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -81,9 +81,9 @@ def test_get_x_y_axes():
         ]
     )
     frames = get_x_y_axes(z_axis)
-    z_axis = frames[:, 0, :]
+    x_axis = frames[:, 0, :]
     y_axis = frames[:, 1, :]
-    x_axis = frames[:, 2, :]
+    z_axis = frames[:, 2, :]
 
     # Check that the axes are unit vectors.
     assert np.allclose(np.linalg.norm(x_axis, axis=1), 1.0, atol=1e-6)
@@ -103,20 +103,50 @@ def test_get_x_y_axes():
 def test_compute_total_rotation():
     """Test compute_total_rotation function."""
 
-    r_sc = spin = mount_matrix = [
-        [1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0],
-        [0.0, 0.0, 1.0],
-    ]
-
-    total_rotations = compute_total_rotation(
-        np.array([r_sc]), np.array([spin]), np.array(mount_matrix)
+    # Rotation about Z by 90°
+    rz_90 = np.array(
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
     )
 
-    instrument_vector = np.array([1.0, 2.0, 3.0])
-    output_vector = spiceypy.mxv(total_rotations[0], instrument_vector)
+    # Rotation about Y by 90°
+    ry_90 = np.array(
+        [
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+        ]
+    )
 
-    np.testing.assert_allclose(output_vector, instrument_vector, atol=1e-9)
+    # Rotation about X by 90°
+    rx_90 = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, -1.0],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+
+    total = compute_total_rotation(
+        inertial_frames=np.array([rx_90]),
+        spin_rotations=np.array([rz_90]),
+        mount_matrix=ry_90,
+    )
+
+    # Instrument vector: along +X in instrument frame
+    v_instrument = np.array([1.0, 0.0, 0.0])
+
+    # Manually compute expected result:
+    intermediate = ry_90 @ v_instrument  # → [0, 0, -1]
+    intermediate = rz_90 @ intermediate  # → [0, 0, -1]
+    expected = rx_90 @ intermediate  # → [0, 1, 0]
+
+    output_vector = spiceypy.mxv(total[0], v_instrument)
+
+    np.testing.assert_allclose(output_vector, expected, atol=1e-9)
 
 
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
@@ -140,7 +170,7 @@ def test_transform_instrument_vectors_to_inertial(
     et = (et_start + et_end) / 2.0
 
     # Assume IMAP_MAG +X is boresight
-    instrument_vector = np.array([[1.0, 0.0, 0.0]])
+    instrument_vector = np.array([[10.0, 2.0, 3.0]])
 
     # Get RA/Dec of angular momentum vector (Z-axis) from SPICE
     rot_sc_to_j2000 = spiceypy.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et)
@@ -176,49 +206,6 @@ def test_transform_instrument_vectors_to_inertial(
         v_spice,
         atol=1e-9,
     )
-
-@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-@pytest.mark.external_kernel
-@ensure_spice
-def test_extract_spin_phase_from_spice_rotation(spice_test_data_path, use_test_metakernel):
-    """Extract spacecraft spin phase from rotation matrix using SPICE."""
-
-    ck_path = spice_test_data_path / "sim_1yr_imap_attitude.bc"
-    id_imap_spacecraft = spiceypy.gipool("FRAME_IMAP_SPACECRAFT", 0, 1)
-
-    # Get mid-point of CK coverage
-    ck_cover = spiceypy.ckcov(str(ck_path), int(id_imap_spacecraft), True, "INTERVAL", 0.0, "TDB")
-    et = (ck_cover[0] + ck_cover[1]) / 2.0
-
-    # Get rotation matrix from spacecraft to ECLIPJ2000
-    r_sc_to_inertial = spiceypy.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et)
-
-    # Extract inertial-frame X and Y axes
-    x_inertial = r_sc_to_inertial[:, 0]
-    y_inertial = r_sc_to_inertial[:, 1]
-    z_inertial = r_sc_to_inertial[:, 2]  # Spin axis
-
-    # Construct a frame where +X is reference direction in SC XY-plane
-    # In spacecraft frame, +X is initial direction before spin
-    # Project inertial +X axis onto XY plane orthogonal to Z
-    x_proj = x_inertial - np.dot(x_inertial, z_inertial) * z_inertial
-    y_proj = y_inertial - np.dot(y_inertial, z_inertial) * z_inertial
-
-    x_proj /= np.linalg.norm(x_proj)
-    y_proj /= np.linalg.norm(y_proj)
-
-    # Compute spin phase (angle between inertial +X projection and a reference)
-    spin_phase_rad = np.arctan2(
-        np.dot(y_proj, [0, 1, 0]),  # sinθ
-        np.dot(x_proj, [1, 0, 0])   # cosθ
-    )
-    spin_phase_deg = np.degrees(spin_phase_rad) % 360
-
-    print(f"Spin phase at ET {et:.2f} is approximately {spin_phase_deg:.2f} degrees")
-
-
-
-
 
 
 @pytest.mark.use_test_metakernel("imap_ialirt_sim_metakernel.template")

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -5,6 +5,7 @@ import pytest
 import spiceypy
 
 from imap_processing.ialirt.l0.ialirt_spice import (
+    compute_total_rotation,
     get_rotation_matrix,
     get_x_y_axes,
     get_z_axis,
@@ -134,6 +135,27 @@ def test_transform_instrument_vectors_to_inertial_no_spice(spice_test_data_path)
     )
 
     np.testing.assert_allclose(result, expected, atol=1e-8)
+
+
+def test_compute_total_rotation_identity_case():
+    """Test compute_total_rotation with all identity inputs (no rotation)."""
+
+    r_sc = spin = mount_matrix = [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ]
+
+    total_rotations = compute_total_rotation(
+        np.array([r_sc]),
+        np.array([spin]),
+        np.array(mount_matrix)
+    )
+
+    instrument_vector = np.array([1.0, 2.0, 3.0])
+    output_vector = spiceypy.mxv(total_rotations[0], instrument_vector)
+
+    np.testing.assert_allclose(output_vector, instrument_vector, atol=1e-9)
 
 
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -11,7 +11,6 @@ from imap_processing.ialirt.l0.ialirt_spice import (
     get_z_axis,
     transform_instrument_vectors_to_inertial,
 )
-from imap_processing.spice.geometry import SpiceFrame
 from imap_processing.spice.kernels import ensure_spice
 
 
@@ -114,9 +113,7 @@ def test_compute_total_rotation():
     ]
 
     total_rotations = compute_total_rotation(
-        np.array([r_sc]),
-        np.array([spin]),
-        np.array(mount_matrix)
+        np.array([r_sc]), np.array([spin]), np.array(mount_matrix)
     )
 
     instrument_vector = np.array([1.0, 2.0, 3.0])

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -107,50 +107,8 @@ def test_transform_instrument_vectors_to_inertial_no_spice(spice_test_data_path)
     np.testing.assert_allclose(result, expected, atol=1e-8)
 
 
-def test_get_instrument_vector():
-    """Test get_instrument_vector function."""
-    et = np.array([0.0])
-    vector = np.array([[1.0, 0.0, 0.0]])
-
-    result = get_instrument_vector(
-        et,
-        vector,
-        SpiceFrame.IMAP_SPACECRAFT,
-        SpiceFrame.IMAP_SPACECRAFT,
-    )
-
-    np.testing.assert_allclose(result, vector, atol=1e-8)
-
-
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-@ensure_spice
-def test_get_instrument_vector2(use_test_metakernel, spice_test_data_path):
-    """Test get_instrument_vector function."""
-    ck_path = spice_test_data_path / "sim_1yr_imap_attitude.bc"
-    id_imap_spacecraft = spiceypy.gipool("FRAME_IMAP_SPACECRAFT", 0, 1)
-
-    ck_cover = spiceypy.ckcov(
-        str(ck_path), int(id_imap_spacecraft), True, "INTERVAL", 0, "TDB"
-    )
-
-    # Pick midpoint of first coverage interval
-    et_start = ck_cover[0]
-    et_end = ck_cover[1]
-    et = (et_start + et_end) / 2.0
-    vector = np.array([[1.0, 0.0, 0.0]])
-
-    result = get_instrument_vector(
-        et,
-        vector,
-        SpiceFrame.IMAP_MAG,
-        SpiceFrame.IMAP_SPACECRAFT,
-    )
-    test = spiceypy.pxform("IMAP_MAG", "IMAP_SPACECRAFT", et)
-
-    np.testing.assert_allclose(result, vector, atol=1e-8)
-
-
-@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+# @pytest.mark.external_kernel
 @ensure_spice
 def test_transform_instrument_vectors_to_inertial(
     use_test_metakernel, spice_test_data_path
@@ -190,7 +148,6 @@ def test_transform_instrument_vectors_to_inertial(
     # At this timestamp for the attitude kernel.
     spin_phase = np.array([0.0])
 
-
     v_manual = transform_instrument_vectors_to_inertial(
         instrument_vector,
         spin_phase,
@@ -202,7 +159,7 @@ def test_transform_instrument_vectors_to_inertial(
     # SPICE direct transform from instrument frame to inertial
     rot_inst_to_inertial = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et)
     v_spice = spiceypy.mxv(rot_inst_to_inertial, instrument_vector[0])
-    print('hi')
+    print("hi")
     np.testing.assert_allclose(
         v_manual[0],
         v_spice,

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -166,13 +166,12 @@ def test_transform_instrument_vectors_to_inertial(
 
     # Pick midpoint of first coverage interval
     et_start = ck_cover[0]
-    et = et_start + 10
 
     # Assume IMAP_MAG +X is boresight
     instrument_vector = np.array([[10.0, 2.0, 3.0]])
 
     # Get RA/Dec of angular momentum vector (Z-axis) from SPICE
-    rot_sc_to_j2000 = spiceypy.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et)
+    rot_sc_to_j2000 = spiceypy.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et_start + 10)
     sc_z_inertial = rot_sc_to_j2000[:, 2]  # SC +Z axis (angular momentum)
     # Convert inertial Z into RA/Dec (radians)
     _, ra, dec = spiceypy.recrad(sc_z_inertial.copy())
@@ -188,21 +187,33 @@ def test_transform_instrument_vectors_to_inertial(
         atol=1e-9,
     )
 
-    spin_phase = np.array([120.0])
-
-    v_manual = transform_instrument_vectors_to_inertial(
+    v_manual_0 = transform_instrument_vectors_to_inertial(
         instrument_vector,
-        spin_phase,
+        np.array([120.0]),
+        np.array([np.degrees(ra)]),
+        np.array([np.degrees(dec)]),
+    )
+    v_manual_1 = transform_instrument_vectors_to_inertial(
+        instrument_vector,
+        np.array([240.0]),
         np.array([np.degrees(ra)]),
         np.array([np.degrees(dec)]),
     )
 
-    rot_inst_to_inertial = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et)
-    v_spice = spiceypy.mxv(rot_inst_to_inertial, instrument_vector[0])
+    rot_inst_to_inertial_0 = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et_start + 10)
+    rot_inst_to_inertial_1 = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et_start + 20)
+
+    v_spice_0 = spiceypy.mxv(rot_inst_to_inertial_0, instrument_vector[0])
+    v_spice_1 = spiceypy.mxv(rot_inst_to_inertial_1, instrument_vector[0])
 
     np.testing.assert_allclose(
-        v_manual[0],
-        v_spice,
+        v_manual_0[0],
+        v_spice_0,
+        atol=1e-9,
+    )
+    np.testing.assert_allclose(
+        v_manual_1[0],
+        v_spice_1,
         atol=1e-9,
     )
 

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -188,7 +188,8 @@ def test_transform_instrument_vectors_to_inertial(
     )
 
     # At this timestamp for the attitude kernel.
-    spin_phase = np.array([np.radians(-0.5)])
+    spin_phase = np.array([0.0])
+
 
     v_manual = transform_instrument_vectors_to_inertial(
         instrument_vector,

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -166,8 +166,7 @@ def test_transform_instrument_vectors_to_inertial(
 
     # Pick midpoint of first coverage interval
     et_start = ck_cover[0]
-    et_end = ck_cover[1]
-    et = (et_start + et_end) / 2.0
+    et = et_start + 10
 
     # Assume IMAP_MAG +X is boresight
     instrument_vector = np.array([[10.0, 2.0, 3.0]])
@@ -189,7 +188,7 @@ def test_transform_instrument_vectors_to_inertial(
         atol=1e-9,
     )
 
-    spin_phase = np.array([0.0])
+    spin_phase = np.array([120.0])
 
     v_manual = transform_instrument_vectors_to_inertial(
         instrument_vector,

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -3,10 +3,12 @@
 import numpy as np
 
 from imap_processing.ialirt.l0.ialirt_spice import (
+    get_instrument_vector,
     get_rotation_matrix,
     get_z_axis,
     transform_instrument_vectors_to_urf,
 )
+from imap_processing.spice.geometry import SpiceFrame
 
 
 def test_get_z_axis():
@@ -93,3 +95,18 @@ def test_transform_instrument_vectors_to_urf():
     )
 
     np.testing.assert_allclose(result, expected, atol=1e-8)
+
+
+def test_get_instrument_vector():
+    """Test get_instrument_vector function."""
+    et = np.array([0.0])
+    vector = np.array([[1.0, 0.0, 0.0]])
+
+    result = get_instrument_vector(
+        et,
+        vector,
+        SpiceFrame.IMAP_SPACECRAFT,
+        SpiceFrame.IMAP_SPACECRAFT,
+    )
+
+    np.testing.assert_allclose(result, vector, atol=1e-8)

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -201,7 +201,7 @@ def test_transform_instrument_vectors_to_inertial(
     # SPICE direct transform from instrument frame to inertial
     rot_inst_to_inertial = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et)
     v_spice = spiceypy.mxv(rot_inst_to_inertial, instrument_vector[0])
-
+    print('hi')
     np.testing.assert_allclose(
         v_manual[0],
         v_spice,

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -104,41 +104,8 @@ def test_get_x_y_axes():
     assert np.allclose(reconstructed_z, z_axis, atol=1e-6)
 
 
-def test_transform_instrument_vectors_to_inertial_no_spice(spice_test_data_path):
-    """Tests function transform_instrument_vectors_to_inertial."""
-
-    spiceypy.furnsh(str(spice_test_data_path / "imap_wkcp.tf"))
-    sc_inertial_right = np.zeros(3)  # RA = 0
-    sc_inertial_decline = np.radians([90, 90, 90])  # Z-axis = [0, 0, 1]
-
-    # Spin phases (0, 90, 180)
-    spin_phase = np.radians([0, 90, 180])
-
-    # Unit vector along +X
-    instrument_vectors = np.tile(np.array([1.0, 0.0, 0.0]), (3, 1))
-
-    expected = np.array(
-        [
-            [1.0, 0.0, 0.0],  # No rotation: remains [1, 0, 0]
-            [0.0, -1.0, 0.0],  # 90 about +Z: becomes [0, -1, 0]
-            [-1.0, 0.0, 0.0],  # 180 about +Z: becomes [-1, 0, 0]
-        ]
-    )
-
-    result = transform_instrument_vectors_to_inertial(
-        instrument_vectors,
-        spin_phase,
-        sc_inertial_right,
-        sc_inertial_decline,
-        SpiceFrame.IMAP_SPACECRAFT,
-        SpiceFrame.IMAP_SPACECRAFT,
-    )
-
-    np.testing.assert_allclose(result, expected, atol=1e-8)
-
-
-def test_compute_total_rotation_identity_case():
-    """Test compute_total_rotation with all identity inputs (no rotation)."""
+def test_compute_total_rotation():
+    """Test compute_total_rotation function."""
 
     r_sc = spin = mount_matrix = [
         [1.0, 0.0, 0.0],
@@ -159,7 +126,7 @@ def test_compute_total_rotation_identity_case():
 
 
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-# @pytest.mark.external_kernel
+@pytest.mark.external_kernel
 @ensure_spice
 def test_transform_instrument_vectors_to_inertial(
     use_test_metakernel, spice_test_data_path
@@ -196,6 +163,37 @@ def test_transform_instrument_vectors_to_inertial(
         atol=1e-9,
     )
 
+    spin_phase = np.array([0.0])
+
+    v_manual = transform_instrument_vectors_to_inertial(
+        instrument_vector,
+        spin_phase,
+        np.array([ra]),
+        np.array([dec]),
+    )
+
+    rot_inst_to_inertial = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et)
+    v_spice = spiceypy.mxv(rot_inst_to_inertial, instrument_vector[0])
+
+    np.testing.assert_allclose(
+        v_manual[0],
+        v_spice,
+        atol=1e-9,
+    )
+
+
+@pytest.mark.use_test_metakernel("imap_ialirt_sim_metakernel.template")
+@pytest.mark.external_kernel
+@ensure_spice
+def test_no_attitude():
+    """Test transform_instrument_vectors_to_inertial function."""
+
+    ra = 0.3653037895099079
+    dec = 4.440892098775276e-16
+
+    # Assume IMAP_MAG +X is boresight
+    instrument_vector = np.array([[1.0, 0.0, 0.0]])
+
     # At this timestamp for the attitude kernel.
     spin_phase = np.array([0.0])
 
@@ -206,12 +204,9 @@ def test_transform_instrument_vectors_to_inertial(
         np.array([dec]),
     )
 
-    # SPICE direct transform from instrument frame to inertial
-    rot_inst_to_inertial = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et)
-    v_spice = spiceypy.mxv(rot_inst_to_inertial, instrument_vector[0])
-    print("hi")
-    np.testing.assert_allclose(
-        v_manual[0],
-        v_spice,
-        atol=1e-9,
-    )
+    # TODO: Put this into GSE and GSM once we have proper kernels.
+    # Example:
+    # rotation_ecl_to_gse = spiceypy.pxform("ECLIPJ2000", "GSE", et)
+    # v_j2000 = spiceypy.mxv(rotation_ecl_to_gse, v_manual[0])
+
+    assert v_manual is not None

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -86,6 +86,7 @@ def test_get_x_y_axes():
     frames = get_x_y_axes(z_axis)
     x_axis = frames[:, 0, :]
     y_axis = frames[:, 1, :]
+    z_axis = frames[:, 2, :]
 
     # Check that the axes are unit vectors.
     assert np.allclose(np.linalg.norm(x_axis, axis=1), 1.0, atol=1e-6)

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -148,7 +148,9 @@ def test_transform_instrument_vectors_to_inertial(
     # Convert inertial Z into RA/Dec (radians)
     _, ra, dec = spiceypy.recrad(sc_z_inertial.copy())
 
-    z_axis = get_z_axis(np.array([ra]), np.array([dec]))[0]  # extract the single row
+    z_axis = get_z_axis(np.array([np.degrees(ra)]), np.array([np.degrees(dec)]))[
+        0
+    ]  # extract the single row
 
     # Test that our get_z_axis code is returning what SPICE returns.
     np.testing.assert_allclose(
@@ -162,8 +164,8 @@ def test_transform_instrument_vectors_to_inertial(
     v_manual = transform_instrument_vectors_to_inertial(
         instrument_vector,
         spin_phase,
-        np.array([ra]),
-        np.array([dec]),
+        np.array([np.degrees(ra)]),
+        np.array([np.degrees(dec)]),
     )
 
     rot_inst_to_inertial = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et)
@@ -194,8 +196,8 @@ def test_no_attitude():
     v_manual = transform_instrument_vectors_to_inertial(
         instrument_vector,
         spin_phase,
-        np.array([ra]),
-        np.array([dec]),
+        np.array([np.degrees(ra)]),
+        np.array([np.degrees(dec)]),
     )
 
     # TODO: Put this into GSE and GSM once we have proper kernels.

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -83,7 +83,9 @@ def test_get_x_y_axes():
             [0.0, 0.0, 1.0],  # RA=0°, Dec=90° → +Z
         ]
     )
-    x_axis, y_axis = get_x_y_axes(z_axis)
+    frames = get_x_y_axes(z_axis)
+    x_axis = frames[:, 0, :]
+    y_axis = frames[:, 1, :]
 
     # Check that the axes are unit vectors.
     assert np.allclose(np.linalg.norm(x_axis, axis=1), 1.0, atol=1e-6)

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -6,6 +6,7 @@ import spiceypy
 
 from imap_processing.ialirt.l0.ialirt_spice import (
     get_rotation_matrix,
+    get_x_y_axes,
     get_z_axis,
     transform_instrument_vectors_to_inertial,
 )
@@ -70,6 +71,32 @@ def test_get_rotation_matrix():
         ]
     )
     assert np.allclose(x_rot, expected, atol=1e-8)
+
+
+def test_get_x_y_axes():
+    """Tests get_x_y_axes function."""
+
+    z_axis = np.array(
+        [
+            [1.0, 0.0, 0.0],  # RA=0, Dec=0 → +X
+            [0.0, 1.0, 0.0],  # RA=90°, Dec=0° → +Y
+            [0.0, 0.0, 1.0],  # RA=0°, Dec=90° → +Z
+        ]
+    )
+    x_axis, y_axis = get_x_y_axes(z_axis)
+
+    # Check that the axes are unit vectors.
+    assert np.allclose(np.linalg.norm(x_axis, axis=1), 1.0, atol=1e-6)
+    assert np.allclose(np.linalg.norm(y_axis, axis=1), 1.0, atol=1e-6)
+
+    # Check each pair of vectors is 90 degrees apart.
+    assert np.allclose(np.sum(x_axis * y_axis, axis=1), 0.0, atol=1e-6)
+    assert np.allclose(np.sum(x_axis * z_axis, axis=1), 0.0, atol=1e-6)
+    assert np.allclose(np.sum(y_axis * z_axis, axis=1), 0.0, atol=1e-6)
+
+    # Check cross(X, Y) = Z.
+    reconstructed_z = np.cross(x_axis, y_axis)
+    assert np.allclose(reconstructed_z, z_axis, atol=1e-6)
 
 
 def test_transform_instrument_vectors_to_inertial_no_spice(spice_test_data_path):

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -1,14 +1,17 @@
 """Module to test attitude calculations."""
 
 import numpy as np
+import pytest
+import spiceypy
 
 from imap_processing.ialirt.l0.ialirt_spice import (
     get_instrument_vector,
     get_rotation_matrix,
     get_z_axis,
-    transform_instrument_vectors_to_urf,
+    transform_instrument_vectors_to_inertial,
 )
 from imap_processing.spice.geometry import SpiceFrame
+from imap_processing.spice.kernels import ensure_spice
 
 
 def test_get_z_axis():
@@ -70,9 +73,10 @@ def test_get_rotation_matrix():
     assert np.allclose(x_rot, expected, atol=1e-8)
 
 
-def test_transform_instrument_vectors_to_urf():
-    """Tests function transform_instrument_vectors_to_urf."""
+def test_transform_instrument_vectors_to_inertial_no_spice(spice_test_data_path):
+    """Tests function transform_instrument_vectors_to_inertial."""
 
+    spiceypy.furnsh(str(spice_test_data_path / "imap_wkcp.tf"))
     sc_inertial_right = np.zeros(3)  # RA = 0
     sc_inertial_decline = np.radians([90, 90, 90])  # Z-axis = [0, 0, 1]
 
@@ -85,13 +89,20 @@ def test_transform_instrument_vectors_to_urf():
     expected = np.array(
         [
             [1.0, 0.0, 0.0],  # No rotation: remains [1, 0, 0]
-            [0.0, 1.0, 0.0],  # 90 about +Z: becomes [0, 1, 0]
+            [0.0, -1.0, 0.0],  # 90 about +Z: becomes [0, -1, 0]
             [-1.0, 0.0, 0.0],  # 180 about +Z: becomes [-1, 0, 0]
         ]
     )
 
-    result = transform_instrument_vectors_to_urf(
-        instrument_vectors, spin_phase, sc_inertial_right, sc_inertial_decline
+    et = np.array([0.0, 0.0, 0.0])
+    result = transform_instrument_vectors_to_inertial(
+        instrument_vectors,
+        spin_phase,
+        sc_inertial_right,
+        sc_inertial_decline,
+        et,
+        SpiceFrame.IMAP_SPACECRAFT,
+        SpiceFrame.IMAP_SPACECRAFT,
     )
 
     np.testing.assert_allclose(result, expected, atol=1e-8)
@@ -110,3 +121,62 @@ def test_get_instrument_vector():
     )
 
     np.testing.assert_allclose(result, vector, atol=1e-8)
+
+
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+@ensure_spice
+def test_transform_instrument_vectors_to_inertial(
+    use_test_metakernel, spice_test_data_path
+):
+    """Test transform_instrument_vectors_to_inertial function."""
+
+    ck_path = spice_test_data_path / "sim_1yr_imap_attitude.bc"
+    id_imap_spacecraft = spiceypy.gipool("FRAME_IMAP_SPACECRAFT", 0, 1)
+
+    ck_cover = spiceypy.ckcov(
+        str(ck_path), int(id_imap_spacecraft), True, "INTERVAL", 0, "TDB"
+    )
+
+    # Pick midpoint of first coverage interval
+    et_start = ck_cover[0]
+    et_end = ck_cover[1]
+    et = (et_start + et_end) / 2.0
+
+    # Assume IMAP_MAG +X is boresight
+    instrument_vector = np.array([[1.0, 0.0, 0.0]])
+
+    # Get RA/Dec of angular momentum vector (Z-axis) from SPICE
+    rot_sc_to_j2000 = spiceypy.pxform("IMAP_SPACECRAFT", "ECLIPJ2000", et)
+    sc_z_inertial = rot_sc_to_j2000[:, 2]  # SC +Z axis (angular momentum)
+    # Convert inertial Z into RA/Dec (radians)
+    _, ra, dec = spiceypy.recrad(sc_z_inertial.copy())
+
+    z_axis = get_z_axis(np.array([ra]), np.array([dec]))[0]  # extract the single row
+
+    # Test that our get_z_axis code is returning what SPICE returns.
+    np.testing.assert_allclose(
+        z_axis,
+        sc_z_inertial,
+        atol=1e-9,
+    )
+
+    # i.e., no spin rotation
+    spin_phase = np.array([0.0])
+
+    v_manual = transform_instrument_vectors_to_inertial(
+        instrument_vector,
+        spin_phase,
+        np.array([ra]),
+        np.array([dec]),
+        np.array([et]),
+    )
+
+    # SPICE direct transform from instrument frame to inertial
+    rot_inst_to_inertial = spiceypy.pxform("IMAP_MAG", "ECLIPJ2000", et)
+    v_spice = spiceypy.mxv(rot_inst_to_inertial, instrument_vector[0])
+
+    np.testing.assert_allclose(
+        v_manual[0],
+        v_spice,
+        atol=1e-9,
+    )

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -5,7 +5,6 @@ import pytest
 import spiceypy
 
 from imap_processing.ialirt.l0.ialirt_spice import (
-    get_instrument_vector,
     get_rotation_matrix,
     get_z_axis,
     transform_instrument_vectors_to_inertial,
@@ -125,6 +124,34 @@ def test_get_instrument_vector():
 
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 @ensure_spice
+def test_get_instrument_vector2(use_test_metakernel, spice_test_data_path):
+    """Test get_instrument_vector function."""
+    ck_path = spice_test_data_path / "sim_1yr_imap_attitude.bc"
+    id_imap_spacecraft = spiceypy.gipool("FRAME_IMAP_SPACECRAFT", 0, 1)
+
+    ck_cover = spiceypy.ckcov(
+        str(ck_path), int(id_imap_spacecraft), True, "INTERVAL", 0, "TDB"
+    )
+
+    # Pick midpoint of first coverage interval
+    et_start = ck_cover[0]
+    et_end = ck_cover[1]
+    et = (et_start + et_end) / 2.0
+    vector = np.array([[1.0, 0.0, 0.0]])
+
+    result = get_instrument_vector(
+        et,
+        vector,
+        SpiceFrame.IMAP_MAG,
+        SpiceFrame.IMAP_SPACECRAFT,
+    )
+    test = spiceypy.pxform("IMAP_MAG", "IMAP_SPACECRAFT", et)
+
+    np.testing.assert_allclose(result, vector, atol=1e-8)
+
+
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+@ensure_spice
 def test_transform_instrument_vectors_to_inertial(
     use_test_metakernel, spice_test_data_path
 ):
@@ -161,7 +188,7 @@ def test_transform_instrument_vectors_to_inertial(
     )
 
     # i.e., no spin rotation
-    spin_phase = np.array([0.0])
+    spin_phase = np.array([np.radians(179.5 + 180.0)])
 
     v_manual = transform_instrument_vectors_to_inertial(
         instrument_vector,

--- a/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
+++ b/imap_processing/tests/ialirt/unit/test_ialirt_spice.py
@@ -187,8 +187,8 @@ def test_transform_instrument_vectors_to_inertial(
         atol=1e-9,
     )
 
-    # i.e., no spin rotation
-    spin_phase = np.array([np.radians(179.5 + 180.0)])
+    # At this timestamp for the attitude kernel.
+    spin_phase = np.array([np.radians(-0.5)])
 
     v_manual = transform_instrument_vectors_to_inertial(
         instrument_vector,

--- a/imap_processing/tests/spice/imap_ialirt_sim_metakernel.template
+++ b/imap_processing/tests/spice/imap_ialirt_sim_metakernel.template
@@ -1,6 +1,0 @@
-{SPICE_TEST_DATA_PATH}/imap_sclk_0000.tsc
-{SPICE_TEST_DATA_PATH}/naif0012.tls
-{SPICE_TEST_DATA_PATH}/imap_spk_demo.bsp
-{SPICE_TEST_DATA_PATH}/imap_wkcp.tf
-{SPICE_TEST_DATA_PATH}/de440s.bsp
-{SPICE_TEST_DATA_PATH}/pck00010.tpc

--- a/imap_processing/tests/spice/imap_ialirt_sim_metakernel.template
+++ b/imap_processing/tests/spice/imap_ialirt_sim_metakernel.template
@@ -1,0 +1,6 @@
+{SPICE_TEST_DATA_PATH}/imap_sclk_0000.tsc
+{SPICE_TEST_DATA_PATH}/naif0012.tls
+{SPICE_TEST_DATA_PATH}/imap_spk_demo.bsp
+{SPICE_TEST_DATA_PATH}/imap_wkcp.tf
+{SPICE_TEST_DATA_PATH}/de440s.bsp
+{SPICE_TEST_DATA_PATH}/pck00010.tpc

--- a/imap_processing/tests/spice/test_data/imap_ialirt_sim_metakernel.template
+++ b/imap_processing/tests/spice/test_data/imap_ialirt_sim_metakernel.template
@@ -3,4 +3,4 @@
 {SPICE_TEST_DATA_PATH}/imap_spk_demo.bsp
 {SPICE_TEST_DATA_PATH}/imap_wkcp.tf
 {SPICE_TEST_DATA_PATH}/de440s.bsp
-{SPICE_TEST_DATA_PATH}/pck00010.tpc
+{SPICE_TEST_DATA_PATH}/pck00011.tpc

--- a/imap_processing/tests/spice/test_data/imap_ialirt_sim_metakernel.template
+++ b/imap_processing/tests/spice/test_data/imap_ialirt_sim_metakernel.template
@@ -1,6 +1,1 @@
-{SPICE_TEST_DATA_PATH}/imap_sclk_0000.tsc
-{SPICE_TEST_DATA_PATH}/naif0012.tls
-{SPICE_TEST_DATA_PATH}/imap_spk_demo.bsp
 {SPICE_TEST_DATA_PATH}/imap_wkcp.tf
-{SPICE_TEST_DATA_PATH}/de440s.bsp
-{SPICE_TEST_DATA_PATH}/pck00011.tpc

--- a/imap_processing/tests/spice/test_data/imap_ialirt_sim_metakernel.template
+++ b/imap_processing/tests/spice/test_data/imap_ialirt_sim_metakernel.template
@@ -1,0 +1,6 @@
+{SPICE_TEST_DATA_PATH}/imap_sclk_0000.tsc
+{SPICE_TEST_DATA_PATH}/naif0012.tls
+{SPICE_TEST_DATA_PATH}/imap_spk_demo.bsp
+{SPICE_TEST_DATA_PATH}/imap_wkcp.tf
+{SPICE_TEST_DATA_PATH}/de440s.bsp
+{SPICE_TEST_DATA_PATH}/pck00010.tpc


### PR DESCRIPTION
# Change Summary

## Overview
This creates a way to mimic attitude kernel so we can transform the MAG data into different reference frames.

## Updated Files
- imap_ialirt_sim_metakernel.template
   - Added metakernel that will be used for I-ALiRT
- ialirt_spice.py
   - Creates matrices for each transformation
   - Multiplies matrices to get into inertial reference frame

## Testing
- test_ialirt_spice.py
   - Tests against what is produced using SPICE attitude kernels