### PR TITLE
1727 hi l2   dataset metadata for cdf

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -167,7 +167,7 @@ obs_date_energy_dependent:
 
 solid_angle:
   <<: *default_float32
-  CATDESC: Solid angle of subtended by each pixel.
+  CATDESC: Solid angle subtended by each pixel.
   FIELDNAM: Solid Angle
   DEPEND_0: epoch
   UNITS: sr

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -164,3 +164,13 @@ exposure_factor_energy_dependent:
 
 obs_date_energy_dependent:
   <<: *obs_date_energy_independent
+
+solid_angle:
+  <<: *default_float32
+  CATDESC: Solid angle of subtended by each pixel.
+  FIELDNAM: Solid Angle
+  DEPEND_0: epoch
+  UNITS: sr
+  VAR_TYPE: data
+  LABLAXIS: Solid Angle
+  DISPLAY_TYPE: image

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -134,6 +134,16 @@ ena_intensity_stat_unc:
   LABLAXIS: Statistical Unc
   DISPLAY_TYPE: image
 
+ena_intensity_sys_err:
+  <<: *default_float32
+  CATDESC: ENA intensity non-statistical error.
+  FIELDNAM: Intensity non-stat error
+  UNITS: counts/(s * cm^2 * Sr * KeV)
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  LABLAXIS: Non-Statistical Err
+  DISPLAY_TYPE: image
+
 sensitivity:
   <<: *default_float32
   CATDESC: Calibration/sensitivity factor calculated from multiple pointing sets.
@@ -159,6 +169,17 @@ obs_date: &obs_date_energy_independent
   datatype: int64
   CATDESC: Exposure time weighted mean collection date of data in a pixel.
   FIELDNAM: J2000 Nanoseconds
+  UNITS: ns
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  LABLAXIS: epoch
+  DISPLAY_TYPE: image
+
+obs_date_range:
+  <<: *default_int64
+  datatype: int64
+  CATDESC: Standard deviation of the observation date.
+  FIELDNAM: Observation date range
   UNITS: ns
   DEPEND_0: epoch
   VAR_TYPE: data

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -33,6 +33,15 @@ default_float32_attrs: &default_float32
   VALIDMAX: 3.4028235e+38
   dtype: float32
 
+# Define epoch_delta attributes
+epoch_delta:
+  <<: *default_int64
+  CATDESC: Number of nanoseconds covered by data included in this map product.
+  DISPLAY_TYPE: no_plot
+  VALIDMIN: 0
+  VAR_TYPE: metadata
+  UNITS: ns
+
 # Define Coordinate(s) which are tiling-independent
 energy:
   <<: *default_float32

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -88,3 +88,7 @@ obs_date_energy_dependent:
   DEPEND_2: pixel_index
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
+
+solid_angle:
+  DEPEND_1: pixel_index
+  LABL_PTR_1: pixel_index_label

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -60,6 +60,12 @@ ena_intensity_stat_unc:
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
 
+ena_intensity_sys_err:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
+
 sensitivity:
   DEPEND_1: energy
   DEPEND_2: pixel_index
@@ -74,6 +80,10 @@ exposure_factor:
   LABL_PTR_1: pixel_index_label
 
 obs_date:
+  DEPEND_1: pixel_index
+  LABL_PTR_1: pixel_index_label
+
+obs_date_range:
   DEPEND_1: pixel_index
   LABL_PTR_1: pixel_index_label
 

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -109,3 +109,9 @@ obs_date_energy_dependent:
   LABL_PTR_1: energy_label
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
+
+solid_angle:
+  DEPEND_1: longitude
+  DEPEND_2: latitude
+  LABL_PTR_1: longitude_label
+  LABL_PTR_2: latitude_label

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -71,6 +71,14 @@ ena_intensity_stat_unc:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
+ena_intensity_sys_err:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
 sensitivity:
   DEPEND_1: energy
   DEPEND_2: longitude
@@ -89,6 +97,12 @@ exposure_factor:
   LABL_PTR_2: latitude_label
 
 obs_date:
+  DEPEND_1: longitude
+  DEPEND_2: latitude
+  LABL_PTR_1: longitude_label
+  LABL_PTR_2: latitude_label
+
+obs_date_range:
   DEPEND_1: longitude
   DEPEND_2: latitude
   LABL_PTR_1: longitude_label

--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -48,3 +48,8 @@ imap_hi_l1c_pset_attrs:
     Data_type: L1C_PSET>Level-1C Pointing Set
     Logical_source: imap_hi_l1c_{sensor}-pset
     Logical_source_description: IMAP-Hi Instrument Level-1C Pointing Set Data.
+
+imap_hi_l2_enamap-sf:
+    Data_type: L2_{descriptor}>Level-2 ENA Intensity Map for Hi{sensor}
+    Logical_source: imap_hi_l2_{descriptor}
+    Logical_source_description: IMAP-Hi Instrument Level-2 ENA Intensity Map Data for Hi{sensor} on rectangular tiling.

--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -49,6 +49,7 @@ imap_hi_l1c_pset_attrs:
     Logical_source: imap_hi_l1c_{sensor}-pset
     Logical_source_description: IMAP-Hi Instrument Level-1C Pointing Set Data.
 
+# TODO: Finalize these global attributes
 imap_hi_l2_enamap-sf:
     Data_type: L2_{descriptor}>Level-2 ENA Intensity Map for Hi{sensor}
     Logical_source: imap_hi_l2_{descriptor}

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -7,7 +7,7 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 import astropy_healpix.healpy as hp
 import numpy as np
@@ -1117,10 +1117,10 @@ class RectangularSkyMap(AbstractSkyMap):
             )
         # Add the solid angle variable to the data_1d Dataset
         self.data_1d["solid_angle"] = xr.DataArray(
-                self.solid_angle_points,
-                name="solid_angle",
-                dims=[CoordNames.GENERIC_PIXEL.value],
-            )
+            self.solid_angle_points,
+            name="solid_angle",
+            dims=[CoordNames.GENERIC_PIXEL.value],
+        )
         # Rewrap each data array in the data_1d to the original 2D grid shape
         rewrapped_data = {}
         for key in self.data_1d.data_vars:
@@ -1157,7 +1157,7 @@ class RectangularSkyMap(AbstractSkyMap):
         level: str,
         frame: str,
         descriptor: str,
-        sensor: Optional[str] = None,
+        sensor: str | None = None,
     ) -> xr.Dataset:
         """
         Format the data into a xarray.Dataset and add required CDF variables.

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -646,6 +646,7 @@ class AbstractSkyMap(ABC):
     # Lists of variables to project using push and pull methods
     values_to_push_project: list[str]
     values_to_pull_project: list[str]
+    # Variables used to track min/max epoch of data that gets projected to map
     min_epoch: int
     max_epoch: int
 
@@ -1069,12 +1070,6 @@ class RectangularSkyMap(AbstractSkyMap):
             coords={
                 CoordNames.GENERIC_PIXEL.value: np.arange(self.num_points),
             },
-            data_vars={
-                "solid_angle": xr.DataArray(
-                    self.solid_angle_points,
-                    dims=[CoordNames.GENERIC_PIXEL.value],
-                )
-            },
         )
 
     @property
@@ -1119,6 +1114,12 @@ class RectangularSkyMap(AbstractSkyMap):
             return xr.Dataset(
                 {},
                 coords={**self.spatial_coords},
+            )
+        # Add the solid angle variable to the data_1d Dataset
+        self.data_1d["solid_angle"] = xr.DataArray(
+                self.solid_angle_points,
+                name="solid_angle",
+                dims=[CoordNames.GENERIC_PIXEL.value],
             )
         # Rewrap each data array in the data_1d to the original 2D grid shape
         rewrapped_data = {}

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -833,6 +833,8 @@ class AbstractSkyMap(ABC):
             # that correspond to each map pixel as the weights.
             self.data_1d[value_key] += pointing_projected_values
 
+        # TODO: The max epoch needs to include the pset duration. Right now it
+        #     is just capturing the start epoch. See issue #1747
         self.min_epoch = min(self.min_epoch, pointing_set.epoch)
         self.max_epoch = max(self.max_epoch, pointing_set.epoch)
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -7,13 +7,14 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 import astropy_healpix.healpy as hp
 import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
 
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.ena_maps.utils import map_utils, spatial_utils
 
@@ -645,6 +646,8 @@ class AbstractSkyMap(ABC):
     # Lists of variables to project using push and pull methods
     values_to_push_project: list[str]
     values_to_pull_project: list[str]
+    min_epoch: int
+    max_epoch: int
 
     # ======== Attributes required to be set in a subclass ========
     # Azimuth and elevation coordinates of each spatial pixel. The ndarray should
@@ -668,6 +671,11 @@ class AbstractSkyMap(ABC):
         # Initialize values to be used by the instrument code to push/pull
         self.values_to_push_project = []
         self.values_to_pull_project = []
+
+        # Initialize min and max epoch variables that are used to keep track of
+        # PSET epochs that get binned to the map
+        self.min_epoch = np.iinfo(np.int64).max
+        self.max_epoch = np.iinfo(np.int64).min
 
     @abstractmethod
     def to_dataset(self) -> xr.Dataset:
@@ -823,6 +831,9 @@ class AbstractSkyMap(ABC):
             # For unweighted means, we could use the number of pointing set pixels
             # that correspond to each map pixel as the weights.
             self.data_1d[value_key] += pointing_projected_values
+
+        self.min_epoch = min(self.min_epoch, pointing_set.epoch)
+        self.max_epoch = max(self.max_epoch, pointing_set.epoch)
 
     @classmethod
     def from_properties_json(
@@ -1138,6 +1149,136 @@ class RectangularSkyMap(AbstractSkyMap):
             rewrapped_data,
             coords={**self.non_spatial_coords, **self.spatial_coords},
         )
+
+    def build_cdf_dataset(
+        self,
+        instrument: str,
+        level: str,
+        frame: str,
+        descriptor: str,
+        sensor: Optional[str] = None,
+    ) -> xr.Dataset:
+        """
+        Format the data into a xarray.Dataset and add required CDF variables.
+
+        Parameters
+        ----------
+        instrument : str
+            Instrument name. "hi", "lo", "ultra".
+        level : str
+            Product level. "l2" or "l3".
+        frame : str
+            Map frame. "sf", "hf" or "hk".
+        descriptor : str
+            Descriptor for filename.
+        sensor : str, optional
+            Sensor number "45" or "90".
+
+        Returns
+        -------
+        xarray.Dataset
+            - Data is reshaped into expected shapes with coordinates:
+            (epoch, energy, longitude, latitude)
+            - Label variables are generated for coordinates other than epoch
+            - Delta variables are generated and set for spatial coordinates
+            - Delta plus/minus variables are generated and set to NaN for energy.
+        """
+        # TODO: some of this could be moved into a AbstractSkyMap method so
+        #    that HealpixSkyMap would benefit from this as well.
+
+        logger.info("Building CDF ready dataset from RectangularSkyMap data.")
+
+        cdf_ds = self.to_dataset()
+
+        # Set the value of the epoch coord
+        cdf_ds = cdf_ds.assign_coords(**{CoordNames.TIME.value: [self.min_epoch]})
+
+        # Drop variables dependent on dimensions not in L2 output
+        # Need to iterate over CoordNames.__members__ because for an Enum, labels
+        # with duplicate values are turned into aliases for the first such label.
+        l2_coords = [
+            coord_name.value
+            for name, coord_name in CoordNames.__members__.items()
+            if ("L2" in name)
+        ]
+        l2_coords.append(CoordNames.TIME.value)
+        for map_coord in cdf_ds.dims.keys():
+            if map_coord not in l2_coords:
+                cdf_ds = cdf_ds.drop_dims(map_coord)
+
+        # Add coordinate label and delta variables (not needed for epoch)
+        for coord_name in l2_coords:
+            # Label variable not needed for epoch
+            if coord_name != CoordNames.TIME.value:
+                cdf_ds[f"{coord_name}_label"] = xr.DataArray(
+                    cdf_ds[coord_name].values.astype(str),
+                    name=f"{coord_name}_label",
+                    dims=[coord_name],
+                )
+            # We can set the correct delta value of the spatial coordinates
+            if coord_name == CoordNames.TIME.value:
+                cdf_ds[f"{coord_name}_delta"] = xr.DataArray(
+                    xr.full_like(cdf_ds[coord_name], self.max_epoch - self.min_epoch),
+                    name=f"{coord_name}_delta",
+                    dims=[coord_name],
+                )
+            elif coord_name in self.spatial_coords:
+                cdf_ds[f"{coord_name}_delta"] = xr.DataArray(
+                    xr.full_like(cdf_ds[coord_name], self.spacing_deg / 2),
+                    name=f"{coord_name}_delta",
+                    dims=[coord_name],
+                )
+            # Add energy delta_minus and delta_plus variables
+            elif coord_name == CoordNames.ENERGY_L2.value:
+                cdf_ds[f"{coord_name}_delta_minus"] = xr.DataArray(
+                    xr.full_like(cdf_ds[coord_name], np.nan),
+                    name=f"{coord_name}_delta",
+                    dims=[coord_name],
+                )
+                cdf_ds[f"{coord_name}_delta_plus"] = xr.DataArray(
+                    xr.full_like(cdf_ds[coord_name], np.nan),
+                    name=f"{coord_name}_delta",
+                    dims=[coord_name],
+                )
+
+        # Object which holds CDF attributes for the map
+        cdf_attrs = ImapCdfAttributes()
+        cdf_attrs.add_instrument_global_attrs(instrument=instrument)
+        cdf_attrs.add_instrument_variable_attrs(instrument="enamaps", level="l2-common")
+        # Load rectangular map specific variable attributes
+        cdf_attrs.add_instrument_variable_attrs(
+            instrument="enamaps", level="l2-rectangular"
+        )
+
+        # Now set global attributes
+        map_attrs = cdf_attrs.get_global_attributes(
+            f"imap_{instrument}_{level}_enamap-{frame}"
+        )
+        map_attrs["Spacing_degrees"] = str(self.spacing_deg)
+        for key in ["Data_type", "Logical_source", "Logical_source_description"]:
+            map_attrs[key] = map_attrs[key].format(
+                descriptor=descriptor,
+                sensor=sensor,
+            )
+            # Always add the following attributes to the map
+        map_attrs.update(
+            {
+                "Sky_tiling_type": self.tiling_type.value,
+                "Spice_reference_frame": self.spice_reference_frame.name,
+            }
+        )
+        cdf_ds.attrs.update(map_attrs)
+
+        # Set the variable attributes
+        for var in [*cdf_ds.data_vars, *cdf_ds.coords]:
+            cdf_ds[var].attrs.update(
+                cdf_attrs.get_variable_attributes(
+                    variable_name=var,
+                    check_schema=False,
+                )
+            )
+
+        return cdf_ds
 
     def to_properties_dict(self) -> dict:
         """

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1274,12 +1274,17 @@ class RectangularSkyMap(AbstractSkyMap):
 
         # Set the variable attributes
         for var in [*cdf_ds.data_vars, *cdf_ds.coords]:
-            cdf_ds[var].attrs.update(
-                cdf_attrs.get_variable_attributes(
+            try:
+                var_attrs = cdf_attrs.get_variable_attributes(
                     variable_name=var,
-                    check_schema=False,
                 )
-            )
+            except KeyError as e:
+                raise KeyError(
+                    f"Attributes for variable {var} not found in "
+                    f"loaded variable attributes."
+                ) from e
+
+            cdf_ds[var].attrs.update(var_attrs)
 
         return cdf_ds
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -605,6 +605,11 @@ class HiPointingSet(PointingSet):
             }
         )
 
+        # Add obs_date variable to be used in determining a map mean obs_date
+        self.data["obs_date"] = xr.full_like(
+            self.data["exposure_factor"], self.data["epoch"].values[0]
+        )
+
         self.az_el_points = np.column_stack(
             (
                 np.squeeze(self.data["hae_longitude"]),
@@ -1052,7 +1057,13 @@ class RectangularSkyMap(AbstractSkyMap):
         self.data_1d: xr.Dataset = xr.Dataset(
             coords={
                 CoordNames.GENERIC_PIXEL.value: np.arange(self.num_points),
-            }
+            },
+            data_vars={
+                "solid_angle": xr.DataArray(
+                    self.solid_angle_points,
+                    dims=[CoordNames.GENERIC_PIXEL.value],
+                )
+            },
         )
 
     @property

--- a/imap_processing/hi/l2/hi_l2.py
+++ b/imap_processing/hi/l2/hi_l2.py
@@ -108,14 +108,9 @@ def generate_hi_map(
     if direction != "full":
         raise NotImplementedError
 
-    min_epoch = np.nan
-    max_epoch = np.nan
-
     for pset_path in psets:
         logger.info(f"Processing {pset_path}")
         pset = HiPointingSet(pset_path)
-        min_epoch = np.nanmin(min_epoch, pset.epoch)
-        max_epoch = np.nanmax(max_epoch, pset.epoch)
 
         # Background rate and uncertainty are exposure time weighted means in
         # the map.

--- a/imap_processing/hi/l2/hi_l2.py
+++ b/imap_processing/hi/l2/hi_l2.py
@@ -16,16 +16,64 @@ logger = logging.getLogger(__name__)
 VARS_TO_EXPOSURE_TIME_AVERAGE = ["bg_rates", "bg_rates_unc", "obs_date"]
 
 
+def hi_l2(
+    psets: list[str | Path],
+    geometric_factors_path: str | Path,
+    esa_energies_path: str | Path,
+    descriptor: str,
+) -> list[xr.Dataset]:
+    """
+    High level IMAP-Hi L2 processing function.
+
+    Parameters
+    ----------
+    psets : list of str or Path
+        List of input PSETs to make a map from.
+    geometric_factors_path : str or Path
+        Where to get the geometric factors from.
+    esa_energies_path : str or Path
+        Where to get the energies from.
+    descriptor : str
+        Output filename descriptor. Contains full configuration for the options
+        of how to generate the map.
+
+    Returns
+    -------
+    l2_dataset : list[xr.Dataset]
+        Level 2 IMAP-Hi dataset ready to be written to a CDF file.
+    """
+    # TODO: parse descriptor to determine map configuration
+    sensor = "45" if "45" in descriptor else "90"
+    direction: Literal["full"] = "full"
+    cg_corrected = False
+    map_spacing = 4
+
+    rect_map = generate_hi_map(
+        psets,
+        geometric_factors_path,
+        esa_energies_path,
+        direction=direction,
+        cg_corrected=cg_corrected,
+        map_spacing=map_spacing,
+    )
+
+    # Get the map dataset with variables/coordinates in the correct shape
+    # TODO get the correct descriptor and frame
+    l2_ds = rect_map.build_cdf_dataset("hi", "l2", "sf", descriptor, sensor=sensor)
+
+    return [l2_ds]
+
+
 def generate_hi_map(
     psets: list[str | Path],
     geometric_factors_path: str | Path,
     esa_energies_path: str | Path,
     cg_corrected: bool = False,
     direction: Literal["ram", "anti-ram", "full"] = "full",
-    map_spacing_deg: int = 4,
-) -> xr.Dataset:
+    map_spacing: int = 4,
+) -> RectangularSkyMap:
     """
-    High level IMAP-Hi L2 processing function.
+    Project Hi PSET data into a rectangular sky map.
 
     Parameters
     ----------
@@ -41,16 +89,16 @@ def generate_hi_map(
     direction : str, optional
         Apply filtering to PSET data include ram or anti-ram or full spin data.
         Defaults to "full".
-    map_spacing_deg : int, optional
-        Pixel spacing of the output map in degrees. Defaults to 4.
+    map_spacing : int, optional
+        Pixel spacing, in degrees, of the output map in degrees. Defaults to 4.
 
     Returns
     -------
-    l2_dataset : xr.Dataset
-        Level 2 IMAP-Hi dataset ready to be written to a CDF file.
+    sky_map : RectangularSkyMap
+        The sky map with all the PSET data projected into the map.
     """
     rect_map = RectangularSkyMap(
-        spacing_deg=map_spacing_deg, spice_frame=SpiceFrame.ECLIPJ2000
+        spacing_deg=map_spacing, spice_frame=SpiceFrame.ECLIPJ2000
     )
 
     # TODO: Implement Compton-Getting correction
@@ -60,9 +108,14 @@ def generate_hi_map(
     if direction != "full":
         raise NotImplementedError
 
+    min_epoch = np.nan
+    max_epoch = np.nan
+
     for pset_path in psets:
         logger.info(f"Processing {pset_path}")
         pset = HiPointingSet(pset_path)
+        min_epoch = np.nanmin(min_epoch, pset.epoch)
+        max_epoch = np.nanmax(max_epoch, pset.epoch)
 
         # Background rate and uncertainty are exposure time weighted means in
         # the map.
@@ -75,44 +128,36 @@ def generate_hi_map(
             ["counts", "exposure_factor", "bg_rates", "bg_rates_unc", "obs_date"],
         )
 
-    # Get the map dataset with variables/coordinates in the correct shape
-    map_ds = rect_map.to_dataset()
-
     # Finish the exposure time weighted mean calculation of backgrounds
     # Allow divide by zero to fill set pixels with zero exposure time to NaN
     with np.errstate(divide="ignore"):
         for var in VARS_TO_EXPOSURE_TIME_AVERAGE:
-            map_ds[var] /= map_ds["exposure_factor"]
+            rect_map.data_1d[var] /= rect_map.data_1d["exposure_factor"]
 
-    map_ds.update(calculate_ena_signal_rates(map_ds))
-    map_ds.update(
-        calculate_ena_intensity(map_ds, geometric_factors_path, esa_energies_path)
+    rect_map.data_1d.update(calculate_ena_signal_rates(rect_map.data_1d))
+    rect_map.data_1d.update(
+        calculate_ena_intensity(
+            rect_map.data_1d, geometric_factors_path, esa_energies_path
+        )
     )
-
-    # By dropping the calibration_prod dimension, the correct set of variables
-    # also get removed
-    map_ds = map_ds.drop_dims("calibration_prod")
-
-    # TODO: the correct conversion from esa_energy_step to esa_energy
-    esa_energy_step_conversion = (np.arange(10, dtype=float) + 1) * 1000
-    map_ds = map_ds.rename({"esa_energy_step": "energy"})
-    map_ds = map_ds.assign_coords(
-        energy=esa_energy_step_conversion[map_ds["energy"].values]
-    )
-    map_ds = map_ds.drop("esa_energy_step_label")
-    map_ds["energy_label"] = xr.DataArray(
-        map_ds["energy"].values.astype(str),
-        name="energy_label",
-        dims=["energy"],
-    )
-    # TODO: get the correct energy delta values
-    map_ds["energy_delta_minus"] = xr.full_like(map_ds["energy"], np.nan)
-    map_ds["energy_delta_plus"] = xr.full_like(map_ds["energy"], np.nan)
 
     # TODO: Figure out how to compute obs_date_range (stddev of obs_date)
-    map_ds["obs_date_range"] = xr.zeros_like(map_ds["obs_date"])
+    rect_map.data_1d["obs_date_range"] = xr.zeros_like(rect_map.data_1d["obs_date"])
 
-    return map_ds
+    # Rename and convert coordinate from esa_energy_step energy
+    # TODO: the correct conversion from esa_energy_step to esa_energy
+    esa_energy_step_conversion = (np.arange(10, dtype=float) + 1) * 1000
+    rect_map.data_1d = rect_map.data_1d.rename({"esa_energy_step": "energy"})
+    rect_map.data_1d = rect_map.data_1d.assign_coords(
+        energy=esa_energy_step_conversion[rect_map.data_1d["energy"].values]
+    )
+    # Set the energy_step_delta values
+    # TODO: get the correct energy delta values (they are set to NaN) in
+    #    rect_map.build_cdf_dataset()
+
+    rect_map.data_1d = rect_map.data_1d.drop("esa_energy_step_label")
+
+    return rect_map
 
 
 def calculate_ena_signal_rates(map_ds: xr.Dataset) -> dict[str, xr.DataArray]:

--- a/imap_processing/hi/l2/hi_l2.py
+++ b/imap_processing/hi/l2/hi_l2.py
@@ -12,7 +12,8 @@ from imap_processing.spice.geometry import SpiceFrame
 
 logger = logging.getLogger(__name__)
 
-VARS_TO_EXPOSURE_TIME_AVERAGE = ["bg_rates", "bg_rates_unc"]
+# TODO: is an exposure time weighted average for obs_date appropriate?
+VARS_TO_EXPOSURE_TIME_AVERAGE = ["bg_rates", "bg_rates_unc", "obs_date"]
 
 
 def generate_hi_map(
@@ -71,12 +72,7 @@ def generate_hi_map(
         # Project (bin) the PSET variables into the map pixels
         rect_map.project_pset_values_to_map(
             pset,
-            [
-                "counts",
-                "exposure_factor",
-                "bg_rates",
-                "bg_rates_unc",
-            ],
+            ["counts", "exposure_factor", "bg_rates", "bg_rates_unc", "obs_date"],
         )
 
     # Get the map dataset with variables/coordinates in the correct shape
@@ -93,8 +89,28 @@ def generate_hi_map(
         calculate_ena_intensity(map_ds, geometric_factors_path, esa_energies_path)
     )
 
-    # TODO: Get Dataset ready for writing to CDF by removing some variables
-    #    and adding global and variable attributes
+    # By dropping the calibration_prod dimension, the correct set of variables
+    # also get removed
+    map_ds = map_ds.drop_dims("calibration_prod")
+
+    # TODO: the correct conversion from esa_energy_step to esa_energy
+    esa_energy_step_conversion = (np.arange(10, dtype=float) + 1) * 1000
+    map_ds = map_ds.rename({"esa_energy_step": "energy"})
+    map_ds = map_ds.assign_coords(
+        energy=esa_energy_step_conversion[map_ds["energy"].values]
+    )
+    map_ds = map_ds.drop("esa_energy_step_label")
+    map_ds["energy_label"] = xr.DataArray(
+        map_ds["energy"].values.astype(str),
+        name="energy_label",
+        dims=["energy"],
+    )
+    # TODO: get the correct energy delta values
+    map_ds["energy_delta_minus"] = xr.full_like(map_ds["energy"], np.nan)
+    map_ds["energy_delta_plus"] = xr.full_like(map_ds["energy"], np.nan)
+
+    # TODO: Figure out how to compute obs_date_range (stddev of obs_date)
+    map_ds["obs_date_range"] = xr.zeros_like(map_ds["obs_date"])
 
     return map_ds
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -466,10 +466,9 @@ class TestRectangularSkyMap:
             ),
         )
 
-    @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
-    def test_build_cdf_dataset(self, mock_to_dataset):
-        """Test coverage for the RectangularSkyMap.build_cdf_dataset method."""
-        # Set up the mock
+    @pytest.fixture
+    def mock_data_for_build_cdf_dataset(self):
+        """Setup Dataset to use as mock data from `to_dataset()` function."""
         coord_sizes = {
             CoordNames.TIME.value: 1,
             CoordNames.ENERGY_L2.value: 5,
@@ -499,7 +498,13 @@ class TestRectangularSkyMap:
             name="foo_var",
             dims=[k for k in coord_sizes.keys()],
         )
-        mock_to_dataset.return_value = mock_dataset
+        return mock_dataset
+
+    @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
+    def test_build_cdf_dataset(self, mock_to_dataset, mock_data_for_build_cdf_dataset):
+        """Test coverage for the RectangularSkyMap.build_cdf_dataset method."""
+        # Set up the mock
+        mock_to_dataset.return_value = mock_data_for_build_cdf_dataset
 
         skymap = ena_maps.RectangularSkyMap(6, geometry.SpiceFrame.ECLIPJ2000)
         skymap.min_epoch = 10
@@ -531,6 +536,34 @@ class TestRectangularSkyMap:
         assert CoordNames.ELEVATION_L2.value in cdf_dataset
         assert f"{CoordNames.ELEVATION_L2.value}_delta" in cdf_dataset
         assert f"{CoordNames.ELEVATION_L2.value}_label" in cdf_dataset
+
+    @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
+    def test_build_cdf_dataset_key_error(
+        self, mock_to_dataset, mock_data_for_build_cdf_dataset
+    ):
+        """Test build_cdf_dataset raising a KeyError."""
+        mock_dataset = mock_data_for_build_cdf_dataset
+        # Add ena intensity variable
+        mock_dataset["no_attrs_var"] = xr.DataArray(
+            np.ones(
+                tuple(s for s in mock_data_for_build_cdf_dataset.coords.sizes.values())[
+                    :-1
+                ]
+            ),
+            name="no_attrs_var",
+            dims=[k for k in mock_data_for_build_cdf_dataset.coords.sizes.keys()][:-1],
+        )
+        mock_to_dataset.return_value = mock_dataset
+
+        skymap = ena_maps.RectangularSkyMap(6, geometry.SpiceFrame.ECLIPJ2000)
+        skymap.min_epoch = 10
+        skymap.max_epoch = 15
+        with pytest.raises(
+            KeyError, match="Attributes for variable no_attrs_var not found"
+        ):
+            _ = skymap.build_cdf_dataset(
+                "hi", "l2", "sf", "foo_descriptor", sensor="45"
+            )
 
 
 class TestHealpixSkyMap:

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -465,6 +465,72 @@ class TestRectangularSkyMap:
             ),
         )
 
+    @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
+    def test_build_cdf_dataset(self, mock_to_dataset):
+        """Test coverage for the RectangularSkyMap.build_cdf_dataset method."""
+        # Set up the mock
+        coord_sizes = {
+            CoordNames.TIME.value: 1,
+            CoordNames.ENERGY_L2.value: 5,
+            CoordNames.AZIMUTH_L2.value: 20,
+            CoordNames.ELEVATION_L2.value: 10,
+            "foo_coord": 2,
+        }
+        mock_dataset = xr.Dataset(
+            coords={
+                key: xr.DataArray(
+                    np.arange(value),
+                    name=key,
+                    dims=[key],
+                )
+                for key, value in coord_sizes.items()
+            }
+        )
+        # Add ena intensity variable
+        mock_dataset["ena_intensity"] = xr.DataArray(
+            np.ones(tuple(s for s in coord_sizes.values())[:-1]),
+            name="ena_intesity",
+            dims=[k for k in coord_sizes.keys()][:-1],
+        )
+        # Add one variable that is expected to get removed
+        mock_dataset["foo_var"] = xr.DataArray(
+            np.ones(tuple(s for s in coord_sizes.values())),
+            name="foo_var",
+            dims=[k for k in coord_sizes.keys()],
+        )
+        mock_to_dataset.return_value = mock_dataset
+
+        skymap = ena_maps.RectangularSkyMap(6, geometry.SpiceFrame.ECLIPJ2000)
+        skymap.min_epoch = 10
+        skymap.max_epoch = 15
+        cdf_dataset = skymap.build_cdf_dataset(
+            "hi", "l2", "sf", "foo_descriptor", sensor="45"
+        )
+
+        # Check that expected var gets removed
+        assert "foo_var" not in cdf_dataset
+        # Check the epoch values
+        assert CoordNames.TIME.value in cdf_dataset
+        assert cdf_dataset[CoordNames.TIME.value].values[0] == skymap.min_epoch
+        assert f"{CoordNames.TIME.value}_delta" in cdf_dataset
+        assert (
+            cdf_dataset[f"{CoordNames.TIME.value}_delta"].values[0]
+            == skymap.max_epoch - skymap.min_epoch
+        )
+
+        assert CoordNames.ENERGY_L2.value in cdf_dataset
+        assert f"{CoordNames.ENERGY_L2.value}_delta_plus" in cdf_dataset
+        assert f"{CoordNames.ENERGY_L2.value}_delta_minus" in cdf_dataset
+        assert f"{CoordNames.ENERGY_L2.value}_label" in cdf_dataset
+
+        assert CoordNames.AZIMUTH_L2.value in cdf_dataset
+        assert f"{CoordNames.AZIMUTH_L2.value}_delta" in cdf_dataset
+        assert f"{CoordNames.AZIMUTH_L2.value}_label" in cdf_dataset
+
+        assert CoordNames.ELEVATION_L2.value in cdf_dataset
+        assert f"{CoordNames.ELEVATION_L2.value}_delta" in cdf_dataset
+        assert f"{CoordNames.ELEVATION_L2.value}_label" in cdf_dataset
+
 
 class TestHealpixSkyMap:
     @pytest.fixture(autouse=True)

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -442,6 +442,7 @@ class TestRectangularSkyMap:
         # innefficient, as it would require all the same, computationally intensive
         # operations to be repeated as this test
         rect_map_ds = rectangular_map.to_dataset()
+        assert "solid_angle" in rect_map_ds.data_vars
         assert "counts" in rect_map_ds.data_vars
         assert rect_map_ds["counts"].shape == (
             1,

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -58,6 +58,11 @@ def test_genarate_hi_map(hi_l1_test_data_path):
     assert isinstance(sky_map, RectangularSkyMap)
     assert sky_map.spacing_deg == 6
 
+    # Test that we got some non-zero values
+    for var_name in ["counts", "exposure_factor", "obs_date"]:
+        assert var_name in sky_map.data_1d.data_vars
+        assert np.nanmax(sky_map.data_1d[var_name].data) > 0
+
 
 def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):
     """Test coverage for calculate_ena_signal_rates"""

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -4,10 +4,12 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from imap_processing.ena_maps.ena_maps import RectangularSkyMap
 from imap_processing.hi.l2.hi_l2 import (
     calculate_ena_intensity,
     calculate_ena_signal_rates,
     generate_hi_map,
+    hi_l2,
 )
 
 
@@ -38,8 +40,23 @@ def empty_rectangular_map_dataset() -> xr.Dataset:
 def test_hi_l2(hi_l1_test_data_path):
     """Integration type test for hi_l2()"""
     pset_path = hi_l1_test_data_path / "imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
-    l2_dataset = generate_hi_map([pset_path], None, None)
+    l2_dataset = hi_l2([pset_path], None, None, "h90-ena-h-sf-nsp-full-hae-4deg-3mo")[0]
     assert isinstance(l2_dataset, xr.Dataset)
+    assert len(l2_dataset.data_vars) == 15
+    np.testing.assert_array_equal(
+        l2_dataset["ena_intensity"].dims, ["epoch", "energy", "longitude", "latitude"]
+    )
+
+
+@pytest.mark.external_test_data
+def test_genarate_hi_map(hi_l1_test_data_path):
+    """Test coverage for genarate_hi_map()"""
+    pset_path = hi_l1_test_data_path / "imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
+    sky_map = generate_hi_map(
+        [pset_path], None, None, cg_corrected=False, direction="full", map_spacing=6
+    )
+    assert isinstance(sky_map, RectangularSkyMap)
+    assert sky_map.spacing_deg == 6
 
 
 def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):


### PR DESCRIPTION
# Change Summary

## Overview
This PR covers work to get data from the RectangularSkyMap CDF ready. It adds this to the Hi L2 code.

## Updated Files
- imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
   - Add global attributes for hi_l2_enamap-sf data products. These are placeholders, not finalized
- imap_processing/ena_maps/ena_maps.py
   - Add "obs_date" variable to HiPointingSet for tracking obs_date when projecting
   - Add `min_epoch` and `max_epoch` as instance variables to `AbstractSkyMap` class. These are used to store the min/max epochs from any PSET that gets projected into the SkyMap.
   - Add `solid_angle` to data_1d in RectangularSkyMap __init__ method
   - Add `build_cdf_dataset` method to `RectangularSkyMap` that gets the 1D data ready to write to a CDF.
- imap_processing/tests/ena_maps/test_ena_maps.py
   - Test coverage for new `build_cdf_dataset()` method.
   - imap_processing/hi/l2/hi_l2.py
      - Add `hi_l2` function that will be called by cli.py module.
      - Add `obs_date` to values to project
      - Add code to get RectangularSkyMap data ready for writing to CDF
   - imap_processing/tests/hi/test_hi_l2.py
      - Add test coverage for updates to hi_l2 module

Closes: #1727 
