### PR TITLE
BUG fix for SPICE furnishing and idex l1b processing check

### DIFF
--- a/examples/Dockerfile.processing
+++ b/examples/Dockerfile.processing
@@ -5,7 +5,7 @@ FROM public.ecr.aws/docker/library/python:3.10-slim
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y git
 #RUN pip install git+https://github.com/IMAP-Science-Operations-Center/imap_processing.git@dev
-RUN pip install git+https://github.com/maxinelasp/imap_processing.git@mag_l1a_compression
+RUN pip install git+https://github.com/lacoak21/imap_processing.git@idex_spice_test
 
 # Uncomment this once imap_processing is released
 # RUN pip install imap_processing

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -799,16 +799,16 @@ class Idex(ProcessInstrument):
 
         dependency_list = dependencies.processing_input
         if self.data_level == "l1a":
-            if len(dependency_list) > 1:
+            if len(dependency_list) > 2:
                 raise ValueError(
                     f"Unexpected dependencies found for IDEX L1A:"
-                    f"{dependency_list}. Expected only one dependency."
+                    f"{dependency_list}. Expected only two dependencies."
                 )
             # get l0 file
             science_files = dependencies.get_file_paths(source="idex")
             datasets = PacketParser(science_files[0]).data
         elif self.data_level == "l1b":
-            if len(dependency_list) > 1:
+            if len(dependency_list) > 3:
                 raise ValueError(
                     f"Unexpected dependencies found for IDEX L1B:"
                     f"{dependency_list}. Expected only one science dependency."

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1099,10 +1099,11 @@ class Swe(ProcessInstrument):
 
         dependency_list = dependencies.processing_input
         if self.data_level == "l1a":
-            if len(dependency_list) > 1:
+            print(f"len(dependency_list) = {len(dependency_list)}")
+            if len(dependency_list) != 2:
                 raise ValueError(
                     f"Unexpected dependencies found for SWE L1A:"
-                    f"{dependency_list}. Expected only one dependency."
+                    f"{dependency_list}. Expected only two dependencies."
                 )
             science_files = dependencies.get_file_paths(source="swe")
             datasets = swe_l1a(str(science_files[0]))

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -445,18 +445,7 @@ class ProcessInstrument(ABC):
         dependencies = ProcessingInputCollection()
         dependencies.deserialize(self.dependency_str)
         dependencies.download_all_files()
-        logger.info(f"deserialized dependencies: {self.dependency_str}")
-        logger.info(f"dependency filepaths:{dependencies.get_file_paths()}")
-        logger.info(
-            f"dependency filepaths filtered by source:"
-            f"{dependencies.get_file_paths(source=SPICESource.SPICE.value)}"
-        )
-        logger.info(
-            f"dependency filepaths filtered by source as string:"
-            f"{dependencies.get_file_paths(source='spice')}"
-        )
-        for filepath in dependencies.get_file_paths():
-            logger.info(filepath.exists(), filepath)
+
         # Furnish spice kernels
         kernel_paths = dependencies.get_file_paths(data_type=SPICESource.SPICE.value)
         logger.info(f"Furnishing kernels: {kernel_paths}")

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -445,10 +445,18 @@ class ProcessInstrument(ABC):
         dependencies = ProcessingInputCollection()
         dependencies.deserialize(self.dependency_str)
         dependencies.download_all_files()
-        print("deserialized dependencies:", self.dependency_str)
-        print("dependency filepaths: ", dependencies.get_file_paths())
+        logger.info(f"deserialized dependencies: {self.dependency_str}")
+        logger.info(f"dependency filepaths:{dependencies.get_file_paths()}")
+        logger.info(
+            f"dependency filepaths filtered by source:"
+            f"{dependencies.get_file_paths(source=SPICESource.SPICE.value)}"
+        )
+        logger.info(
+            f"dependency filepaths filtered by source as string:"
+            f"{dependencies.get_file_paths(source='spice')}"
+        )
         for filepath in dependencies.get_file_paths():
-            print(filepath.exists(), filepath)
+            logger.info(filepath.exists(), filepath)
         # Furnish spice kernels
         kernel_paths = dependencies.get_file_paths(source=SPICESource.SPICE.value)
         logger.info(f"Furnishing kernels: {kernel_paths}")

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -53,6 +53,8 @@ from imap_processing.hit.l1b.hit_l1b import hit_l1b
 from imap_processing.hit.l2.hit_l2 import hit_l2
 from imap_processing.idex.idex_l1a import PacketParser
 from imap_processing.idex.idex_l1b import idex_l1b
+from imap_processing.idex.idex_l2a import idex_l2a
+from imap_processing.idex.idex_l2b import idex_l2b
 from imap_processing.lo.l1a import lo_l1a
 from imap_processing.lo.l1b import lo_l1b
 from imap_processing.lo.l1c import lo_l1c
@@ -802,7 +804,7 @@ class Idex(ProcessInstrument):
             if len(dependency_list) > 2:
                 raise ValueError(
                     f"Unexpected dependencies found for IDEX L1A:"
-                    f"{dependency_list}. Expected only two dependencies."
+                    f"{dependency_list}. Expected only two dependency."
                 )
             # get l0 file
             science_files = dependencies.get_file_paths(source="idex")
@@ -811,13 +813,36 @@ class Idex(ProcessInstrument):
             if len(dependency_list) > 3:
                 raise ValueError(
                     f"Unexpected dependencies found for IDEX L1B:"
-                    f"{dependency_list}. Expected only one science dependency."
+                    f"{dependency_list}. Expected only three dependencies."
                 )
             # get CDF file
             science_files = dependencies.get_file_paths(source="idex")
             # process data
             dependency = load_cdf(science_files[0])
             datasets = [idex_l1b(dependency)]
+        elif self.data_level == "l2a":
+            if len(dependency_list) > 1:
+                raise ValueError(
+                    f"Unexpected dependencies found for IDEX L2A:"
+                    f"{dependency_list}. Expected only one dependency."
+                )
+            science_files = dependencies.get_file_paths(source="idex")
+            dependency = load_cdf(science_files[0])
+            datasets = [idex_l2a(dependency)]
+        elif self.data_level == "l2b":
+            if len(dependency_list) > 2:
+                raise ValueError(
+                    f"Unexpected dependencies found for IDEX L2B:"
+                    f"{dependency_list}. Expected only two dependency."
+                )
+            sci_files = dependencies.get_file_paths(
+                source="idex", descriptor="sci-1week"
+            )
+            dependency = load_cdf(sci_files[0])
+            # TODO update l2b to use hk files
+            # hk_files = dependencies.get_file_paths(source="idex", descriptor="evt")
+            # hk_dependency = [load_cdf(dep) for dep in hk_files]
+            datasets = [idex_l2b(dependency)]
         return datasets
 
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -445,7 +445,10 @@ class ProcessInstrument(ABC):
         dependencies = ProcessingInputCollection()
         dependencies.deserialize(self.dependency_str)
         dependencies.download_all_files()
-        print(self.dependency_str)
+        print("deserialized dependencies:", self.dependency_str)
+        print("dependency filepaths: ", dependencies.get_file_paths())
+        for filepath in dependencies.get_file_paths():
+            print(filepath.exists(), filepath)
         # Furnish spice kernels
         kernel_paths = dependencies.get_file_paths(source=SPICESource.SPICE.value)
         logger.info(f"Furnishing kernels: {kernel_paths}")

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -458,7 +458,7 @@ class ProcessInstrument(ABC):
         for filepath in dependencies.get_file_paths():
             logger.info(filepath.exists(), filepath)
         # Furnish spice kernels
-        kernel_paths = dependencies.get_file_paths(source=SPICESource.SPICE.value)
+        kernel_paths = dependencies.get_file_paths(data_type=SPICESource.SPICE.value)
         logger.info(f"Furnishing kernels: {kernel_paths}")
         spiceypy.furnsh([str(kernel_path.resolve()) for kernel_path in kernel_paths])
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1099,7 +1099,6 @@ class Swe(ProcessInstrument):
 
         dependency_list = dependencies.processing_input
         if self.data_level == "l1a":
-            print(f"len(dependency_list) = {len(dependency_list)}")
             if len(dependency_list) != 2:
                 raise ValueError(
                     f"Unexpected dependencies found for SWE L1A:"

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -445,7 +445,7 @@ class ProcessInstrument(ABC):
         dependencies = ProcessingInputCollection()
         dependencies.deserialize(self.dependency_str)
         dependencies.download_all_files()
-
+        print(self.dependency_str)
         # Furnish spice kernels
         kernel_paths = dependencies.get_file_paths(source=SPICESource.SPICE.value)
         logger.info(f"Furnishing kernels: {kernel_paths}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -625,13 +625,13 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.24.0"
+version = "0.26.0"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap_data_access-0.24.0-py3-none-any.whl", hash = "sha256:e3df17b169d431153c3b215266f62f0f7295574ff0a847eb91e95027755c5946"},
-    {file = "imap_data_access-0.24.0.tar.gz", hash = "sha256:a5f80521d8b38a9d05722ec2c7b2c770b1f6a5de4b105c6dd63579761b274ad3"},
+    {file = "imap_data_access-0.26.0-py3-none-any.whl", hash = "sha256:353a1d4031eac519cb479e4c8dba0d9395c42073bcdee1bbe676ecafc70cd35b"},
+    {file = "imap_data_access-0.26.0.tar.gz", hash = "sha256:6e5392a15db045359ebf8c269a8f92b613bb4e97a79561f212963f76e99f407a"},
 ]
 
 [package.dependencies]
@@ -2188,4 +2188,4 @@ tools = ["openpyxl", "pandas"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "52848f093af8c3a8965b37a4f6cb4572668988c9ac58653982da81ac431debe5"
+content-hash = "1243717d047bd234bb90498747d164778b620ded31fa729b2b8634213f48a819"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 [tool.poetry]
 name = "imap-processing"
 # Gets updated dynamically by the poetry-dynamic-versioning plugin
-version = "0.0.0"
+version = "0.13.0.post36.dev0+88bbafa"
 description = "IMAP Science Operations Center Processing"
 authors = ["IMAP SDC Developers <imap-sdc@lists.lasp.colorado.edu>"]
 readme = "README.md"
@@ -28,6 +28,9 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
+
+# Exclude tests from build
+exclude = ["imap_processing/tests"]
 
 [tool.poetry.dependencies]
 astropy-healpix = ">=1.0"
@@ -116,7 +119,7 @@ imap_xtce = 'imap_processing.ccsds.excel_to_xtce:main'
 ignore-words-list = "livetime"
 
 [tool.poetry-dynamic-versioning]
-enable = true
+enable = false
 vcs = "git"
 
 [tool.poetry-dynamic-versioning.files."imap_processing/_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 [tool.poetry]
 name = "imap-processing"
 # Gets updated dynamically by the poetry-dynamic-versioning plugin
-version = "0.13.0.post36.dev0+88bbafa"
+version = "0.0.0"
 description = "IMAP Science Operations Center Processing"
 authors = ["IMAP SDC Developers <imap-sdc@lists.lasp.colorado.edu>"]
 readme = "README.md"
@@ -119,7 +119,7 @@ imap_xtce = 'imap_processing.ccsds.excel_to_xtce:main'
 ignore-words-list = "livetime"
 
 [tool.poetry-dynamic-versioning]
-enable = false
+enable = true
 vcs = "git"
 
 [tool.poetry-dynamic-versioning.files."imap_processing/_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ exclude = ["imap_processing/tests"]
 [tool.poetry.dependencies]
 astropy-healpix = ">=1.0"
 cdflib = "^1.3.1"
-imap-data-access = ">=0.24.0"
+imap-data-access = ">=0.26.0"
 python = ">=3.10,<4"
 space_packet_parser = "^5.0.1"
 spiceypy = ">=6.0.0"


### PR DESCRIPTION
# Change Summary

## Overview
- upgrade imap-data-acces
- Fix processingInputCollection get_file_path bug 
- Fix idex l1b dependency check in cli.py

## New Dependencies
upgrade imap-data-access to use 0.26.0


## Updated Files
- imap_processing/cli.py
   - Fix get_file_paths to use data_type instead of source
   - Fix idex l1b dependency check

