### PR TITLE
Lo L1C - PSET Counts

### DIFF
--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -174,19 +174,26 @@ def create_pset_counts(de: xr.Dataset, filter: str = "") -> xr.DataArray:
         "o": "o",
     }
 
+    # if the filter is not in the options, raise an error
     if filter not in filter_options and filter != "":
         raise ValueError(f"Invalid filter option. Choose from {filter_options}")
 
+    # if the filter string is triples or doubles, filter using the coincidence type
     if filter in {"triples", "doubles"}:
         filter_idx = np.where(np.isin(de["coincidence_type"], filter_options[filter]))[
             0
         ]
+    # if the filter is h or o, filter using the species
     elif filter in {"h", "o"}:
         filter_idx = np.where(np.isin(de["species"], filter_options[filter]))[0]
     else:
+        # if no filter is specified, use all data
         filter_idx = np.arange(len(de["epoch"]))
 
+    # Filter the dataset using the filter index
     de_filtered = de.isel(epoch=filter_idx)
+
+    # stack the filtered data into the 3D array
     data = np.column_stack(
         (
             de_filtered["pointing_bin_lon"],
@@ -194,6 +201,7 @@ def create_pset_counts(de: xr.Dataset, filter: str = "") -> xr.DataArray:
             de_filtered["esa_step"],
         )
     )
+    # Create the histogram with 3600 longitude bins, 40 latitude bins, and 7 energy bins
     lon_edges = np.arange(3601)
     lat_edges = np.arange(41)
     energy_edges = np.arange(8)

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -153,8 +153,8 @@ def create_pset_counts(
     Create the PSET counts for the L1B Direct Event dataset.
 
     The counts are created by binning the data into 3600 longitude bins,
-    40 latitude bins, and 7 energy bins. The data is filtered based on
-    the specified filter: "triples", "doubles", "h", or "o".
+    40 latitude bins, and 7 energy bins. The data is filtered to only
+    include counts based on the specified filter: "triples", "doubles", "h", or "o".
 
     Parameters
     ----------

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -38,6 +38,10 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
 
         l1b_goodtimes_only = filter_goodtimes(l1b_de, anc_dependencies)
         pset = initialize_pset(l1b_goodtimes_only, attr_mgr, logical_source)
+        pset["triples_counts"] = create_pset_counts(l1b_goodtimes_only, "triples")
+        pset["doubles_counts"] = create_pset_counts(l1b_goodtimes_only, "doubles")
+        pset["h_counts"] = create_pset_counts(l1b_goodtimes_only, "h")
+        pset["o_counts"] = create_pset_counts(l1b_goodtimes_only, "o")
     return [pset]
 
 
@@ -120,6 +124,94 @@ def filter_goodtimes(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
     filtered_epochs = l1b_de.sel(epoch=goodtimes_mask)
 
     return filtered_epochs
+
+
+def create_pset_counts(de: xr.Dataset, filter: str = "") -> xr.DataArray:
+    """
+    Create the PSET counts for the L1B Direct Event dataset.
+
+    The counts are created by binning the data into 3600 longitude bins,
+    40 latitude bins, and 7 energy bins. The data is filtered based on
+    the specified filter: "triples", "doubles", "h", or "o".
+
+    Parameters
+    ----------
+    de : xarray.Dataset
+        L1B Direct Event dataset.
+    filter : str, optional
+        The filter to apply to the data. Options are "triples", "doubles", "h", or "o".
+
+    Returns
+    -------
+    counts : xarray.DataArray
+        The counts for the specified filter.
+    """
+    filter_options = {
+        # triples coincidence types
+        "triples": ["111111", "111100", "111000"],
+        # doubles coincidence types
+        "doubles": [
+            "110100",
+            "110000",
+            "101101",
+            "101100",
+            "101000",
+            "100100",
+            "100101",
+            "100000",
+            "011100",
+            "011000",
+            "010100",
+            "010101",
+            "010000",
+            "001100",
+            "001101",
+            "001000",
+        ],
+        # hydrogen species identifier
+        "h": "h",
+        # oxygen species identifier
+        "o": "o",
+    }
+
+    if filter not in filter_options and filter != "":
+        raise ValueError(f"Invalid filter option. Choose from {filter_options}")
+
+    if filter in {"triples", "doubles"}:
+        filter_idx = np.where(np.isin(de["coincidence_type"], filter_options[filter]))[
+            0
+        ]
+    elif filter in {"h", "o"}:
+        filter_idx = np.where(np.isin(de["species"], filter_options[filter]))[0]
+    else:
+        filter_idx = np.arange(len(de["epoch"]))
+
+    de_filtered = de.isel(epoch=filter_idx)
+    data = np.column_stack(
+        (
+            de_filtered["pointing_bin_lon"],
+            de_filtered["pointing_bin_lat"],
+            de_filtered["esa_step"],
+        )
+    )
+    lon_edges = np.arange(3601)
+    lat_edges = np.arange(41)
+    energy_edges = np.arange(8)
+
+    hist, edges = np.histogramdd(
+        data,
+        bins=[lon_edges, lat_edges, energy_edges],
+    )
+
+    # add a new axis of size 1 for the epoch
+    hist = hist[np.newaxis, :, :, :]
+
+    counts = xr.DataArray(
+        data=hist.astype(np.int16),
+        dims=["epoch", "lon_bins", "lat_bins", "energy_bins"],
+    )
+
+    return counts
 
 
 def create_datasets(

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -1,6 +1,7 @@
 """IMAP-Lo L1C Data Processing."""
 
 from dataclasses import Field
+from enum import Enum
 
 import numpy as np
 import pandas as pd
@@ -8,6 +9,21 @@ import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.spice.time import met_to_ttj2000ns
+
+
+class FilterType(str, Enum):
+    """
+    Enum for the filter types used in the PSET counts.
+
+    The filter types are used to filter the L1B Direct Event dataset
+    to only include the specified event types.
+    """
+
+    TRIPLES = "triples"
+    DOUBLES = "doubles"
+    HYDROGEN = "h"
+    OXYGEN = "o"
+    NONE = ""
 
 
 def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
@@ -38,10 +54,14 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
 
         l1b_goodtimes_only = filter_goodtimes(l1b_de, anc_dependencies)
         pset = initialize_pset(l1b_goodtimes_only, attr_mgr, logical_source)
-        pset["triples_counts"] = create_pset_counts(l1b_goodtimes_only, "triples")
-        pset["doubles_counts"] = create_pset_counts(l1b_goodtimes_only, "doubles")
-        pset["h_counts"] = create_pset_counts(l1b_goodtimes_only, "h")
-        pset["o_counts"] = create_pset_counts(l1b_goodtimes_only, "o")
+        pset["triples_counts"] = create_pset_counts(
+            l1b_goodtimes_only, FilterType.TRIPLES
+        )
+        pset["doubles_counts"] = create_pset_counts(
+            l1b_goodtimes_only, FilterType.DOUBLES
+        )
+        pset["h_counts"] = create_pset_counts(l1b_goodtimes_only, FilterType.HYDROGEN)
+        pset["o_counts"] = create_pset_counts(l1b_goodtimes_only, FilterType.OXYGEN)
     return [pset]
 
 
@@ -126,7 +146,9 @@ def filter_goodtimes(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
     return filtered_epochs
 
 
-def create_pset_counts(de: xr.Dataset, filter: str = "") -> xr.DataArray:
+def create_pset_counts(
+    de: xr.Dataset, filter: FilterType = FilterType.NONE
+) -> xr.DataArray:
     """
     Create the PSET counts for the L1B Direct Event dataset.
 
@@ -138,8 +160,9 @@ def create_pset_counts(de: xr.Dataset, filter: str = "") -> xr.DataArray:
     ----------
     de : xarray.Dataset
         L1B Direct Event dataset.
-    filter : str, optional
-        The filter to apply to the data. Options are "triples", "doubles", "h", or "o".
+    filter : FilterType, optional
+        The event type to include in the counts.
+        Can be "triples", "doubles", "h", or "o".
 
     Returns
     -------
@@ -148,9 +171,9 @@ def create_pset_counts(de: xr.Dataset, filter: str = "") -> xr.DataArray:
     """
     filter_options = {
         # triples coincidence types
-        "triples": ["111111", "111100", "111000"],
+        FilterType.TRIPLES: ["111111", "111100", "111000"],
         # doubles coincidence types
-        "doubles": [
+        FilterType.DOUBLES: [
             "110100",
             "110000",
             "101101",
@@ -169,22 +192,18 @@ def create_pset_counts(de: xr.Dataset, filter: str = "") -> xr.DataArray:
             "001000",
         ],
         # hydrogen species identifier
-        "h": "h",
+        FilterType.HYDROGEN: "h",
         # oxygen species identifier
-        "o": "o",
+        FilterType.OXYGEN: "o",
     }
 
-    # if the filter is not in the options, raise an error
-    if filter not in filter_options and filter != "":
-        raise ValueError(f"Invalid filter option. Choose from {filter_options}")
-
     # if the filter string is triples or doubles, filter using the coincidence type
-    if filter in {"triples", "doubles"}:
+    if filter in {FilterType.TRIPLES, FilterType.DOUBLES}:
         filter_idx = np.where(np.isin(de["coincidence_type"], filter_options[filter]))[
             0
         ]
     # if the filter is h or o, filter using the species
-    elif filter in {"h", "o"}:
+    elif filter in {FilterType.HYDROGEN, FilterType.OXYGEN}:
         filter_idx = np.where(np.isin(de["species"], filter_options[filter]))[0]
     else:
         # if no filter is specified, use all data

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -5,6 +5,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.lo.l1c.lo_l1c import (
+    FilterType,
     create_pset_counts,
     filter_goodtimes,
     initialize_pset,
@@ -177,7 +178,7 @@ def test_create_pset_counts(l1b_de):
 
 def test_create_h_pset_counts(l1b_de, h_counts):
     # Act
-    counts = create_pset_counts(l1b_de, "h")
+    counts = create_pset_counts(l1b_de, FilterType.HYDROGEN)
 
     # Assert
     np.testing.assert_array_equal(counts, h_counts)
@@ -185,7 +186,7 @@ def test_create_h_pset_counts(l1b_de, h_counts):
 
 def test_create_o_pset_counts(l1b_de, o_counts):
     # Act
-    counts = create_pset_counts(l1b_de, "o")
+    counts = create_pset_counts(l1b_de, FilterType.OXYGEN)
 
     # Assert
     np.testing.assert_array_equal(counts, o_counts)
@@ -193,7 +194,7 @@ def test_create_o_pset_counts(l1b_de, o_counts):
 
 def test_create_triples_pset_counts(l1b_de, triples_counts):
     # Act
-    counts = create_pset_counts(l1b_de, "triples")
+    counts = create_pset_counts(l1b_de, FilterType.TRIPLES)
 
     # Assert
     np.testing.assert_array_equal(counts, triples_counts)
@@ -201,7 +202,7 @@ def test_create_triples_pset_counts(l1b_de, triples_counts):
 
 def test_create_doubles_pset_counts(l1b_de, doubles_counts):
     # Act
-    counts = create_pset_counts(l1b_de, "doubles")
+    counts = create_pset_counts(l1b_de, FilterType.DOUBLES)
 
     # Assert
     np.testing.assert_array_equal(counts, doubles_counts)

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -5,6 +5,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.lo.l1c.lo_l1c import (
+    create_pset_counts,
     filter_goodtimes,
     initialize_pset,
     lo_l1c,
@@ -59,6 +60,44 @@ def attr_mgr():
     attr_mgr_l1b.add_instrument_global_attrs(instrument="lo")
     attr_mgr_l1b.add_instrument_variable_attrs(instrument="lo", level="l1c")
     return attr_mgr_l1b
+
+
+@pytest.fixture
+def counts():
+    """Fixture for initial counts."""
+    return np.zeros((1, 3600, 40, 7))
+
+
+@pytest.fixture
+def h_counts(counts):
+    h = counts.copy()
+    h[0, 20, 20, 1] = 2
+    h[0, 2000, 20, 4] = 1
+    return h
+
+
+@pytest.fixture
+def o_counts(counts):
+    o = counts.copy()
+    o[0, 3500, 20, 5] = 1
+    o[0, 0, 20, 2] = 1
+    return o
+
+
+@pytest.fixture
+def triples_counts(counts):
+    triples = counts.copy()
+    triples[0, 20, 20, 1] = 2
+    triples[0, 0, 20, 2] = 1
+    return triples
+
+
+@pytest.fixture
+def doubles_counts(counts):
+    doubles = counts.copy()
+    doubles[0, 2000, 20, 4] = 1
+    doubles[0, 3500, 20, 5] = 1
+    return doubles
 
 
 def test_lo_l1c(l1b_de, anc_dependencies):
@@ -119,3 +158,50 @@ def test_filter_goodtimes(l1b_de, anc_dependencies):
 
     # Assert
     xr.testing.assert_equal(l1b_no_badtimes, l1b_de_no_badtimes_expected)
+
+
+def test_create_pset_counts(l1b_de):
+    # Arrange
+    expected_counts = np.zeros((1, 3600, 40, 7))
+    expected_counts[0, 20, 20, 1] = 2
+    expected_counts[0, 2000, 20, 4] = 1
+    expected_counts[0, 3500, 20, 5] = 1
+    expected_counts[0, 0, 20, 2] = 1
+
+    # Act
+    counts = create_pset_counts(l1b_de)
+
+    # Assert
+    np.testing.assert_array_equal(counts, expected_counts)
+
+
+def test_create_h_pset_counts(l1b_de, h_counts):
+    # Act
+    counts = create_pset_counts(l1b_de, "h")
+
+    # Assert
+    np.testing.assert_array_equal(counts, h_counts)
+
+
+def test_create_o_pset_counts(l1b_de, o_counts):
+    # Act
+    counts = create_pset_counts(l1b_de, "o")
+
+    # Assert
+    np.testing.assert_array_equal(counts, o_counts)
+
+
+def test_create_triples_pset_counts(l1b_de, triples_counts):
+    # Act
+    counts = create_pset_counts(l1b_de, "triples")
+
+    # Assert
+    np.testing.assert_array_equal(counts, triples_counts)
+
+
+def test_create_doubles_pset_counts(l1b_de, doubles_counts):
+    # Act
+    counts = create_pset_counts(l1b_de, "doubles")
+
+    # Assert
+    np.testing.assert_array_equal(counts, doubles_counts)


### PR DESCRIPTION
# Change Summary

## Overview
This PR creates PSET Count fields (3600 x 40 x 7) arrays for triples, doubles, hydrogen, and oxygen.

## Updated Files
- imap_processing/lo/l1c/lo_l1c.py
   - added function to create pset count fields with filter option to specify triples, doubles, h, o

## Testing
created unit tests for each filter option

Closes #1750 