### PR TITLE
Ultra L2: Add epoch_delta and map duration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -55,14 +55,11 @@ energy_label:
 
 epoch_delta:
   <<: *default_int64
-  CATDESC: Time difference between the start and end of the exposure.
+  CATDESC: Number of nanoseconds covered by data included in this map product.
   FIELDNAM: epoch_delta
   UNITS: ns
   VAR_TYPE: support_data
   DISPLAY_TYPE: no_plot
-  DEPEND_0: epoch
-  dtype: int64
-  TIME_BASE: J2000
   TIME_SCALE: Terrestrial Time
 
 energy_delta_minus:

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -53,6 +53,18 @@ energy_label:
   FORMAT: A16
   DEPEND_1: energy
 
+epoch_delta:
+  <<: *default_int64
+  CATDESC: Time difference between the start and end of the exposure.
+  FIELDNAM: epoch_delta
+  UNITS: ns
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  DEPEND_0: epoch
+  dtype: int64
+  TIME_BASE: J2000
+  TIME_SCALE: Terrestrial Time
+
 energy_delta_minus:
   <<: *default_float32
   VAR_TYPE: support_data

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -8,6 +8,9 @@ from typing import Literal
 
 from imap_processing.spice.geometry import SpiceFrame
 
+# Set a constant number of days in a month to calculate the duration of maps
+DAYS_IN_MONTH = 28.5
+
 
 class MappableInstrumentShortName(Enum):
     """Enumeration of the short names of the ENA and other mappable instruments."""
@@ -133,12 +136,12 @@ def build_l2_map_descriptor(  # noqa: PLR0912
 
     # Handle duration
     if isinstance(duration, timedelta):
-        # Convert timedelta to a string representation of number of 28.5 day months
-        num_months = int(duration.days // 28.5)
+        # Convert timedelta to str representation of number of DAYS_IN_MONTH-day months
+        num_months = int(duration.days // DAYS_IN_MONTH)
         duration = f"{num_months}mo"
     elif isinstance(duration, int):
-        # Assume number of days and convert to 28.5-day months
-        duration = f"{int(duration // 28.5)}mo"
+        # Assume number of days and convert to DAYS_IN_MONTH-day months
+        duration = f"{int(duration // DAYS_IN_MONTH)}mo"
     elif isinstance(duration, str):
         pass
     # Replace 12mo with 1yr
@@ -169,7 +172,7 @@ def build_l2_map_descriptor(  # noqa: PLR0912
 
 def ns_to_duration_months(ns: int) -> int:
     """
-    Convert nanoseconds to months using 28.5 days per month approximation.
+    Convert nanoseconds to months using DAYS_IN_MONTH days per month approximation.
 
     Parameters
     ----------
@@ -186,7 +189,7 @@ def ns_to_duration_months(ns: int) -> int:
     This can be used to convert from the difference between two epochs in ns to the
     number of months between them.
 
-    This is a very simple estimate, which assumes that a month is 28.5 days and
+    This is a very simple estimate, which assumes that a month is DAYS_IN_MONTH days and
     floors the result.
 
     This successfully yields:
@@ -196,7 +199,7 @@ def ns_to_duration_months(ns: int) -> int:
     - 3 months for 91.3125 days (365.25/4) in ns
     """
     days = ns / (1e9 * 60 * 60 * 24)
-    months = days // 28.5
+    months = days // DAYS_IN_MONTH
     return int(months)
 
 

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -167,6 +167,39 @@ def build_l2_map_descriptor(  # noqa: PLR0912
     return map_descriptor
 
 
+def ns_to_duration_months(ns: int) -> int:
+    """
+    Convert nanoseconds to months using 28.5 days per month approximation.
+
+    Parameters
+    ----------
+    ns : int
+        The number of nanoseconds to convert.
+
+    Returns
+    -------
+    int
+        The number of months, floored to the nearest integer.
+
+    Notes
+    -----
+    This can be used to convert from the difference between two epochs in ns to the
+    number of months between them.
+
+    This is a very simple estimate, which assumes that a month is 28.5 days and
+    floors the result.
+
+    This successfully yields:
+    - 12 months for 365.25 days in ns
+    - 6 months for 182.625 days (365.25/2) in ns
+    - 4 months for 121.75 days (365.25/3) in ns
+    - 3 months for 91.3125 days (365.25/4) in ns
+    """
+    days = ns / (1e9 * 60 * 60 * 24)
+    months = days // 28.5
+    return int(months)
+
+
 def build_friendly_date_descriptor(
     start_datestring: str,
     duration_months: int,

--- a/imap_processing/tests/ena_maps/utils/test_naming.py
+++ b/imap_processing/tests/ena_maps/utils/test_naming.py
@@ -91,9 +91,7 @@ def test_build_friendly_date_descriptor(start_datestring):
     assert friendly_date_descriptor == "202605m03"
 
 
-def test_ns_to_duration_months(
-    self,
-):
+def test_ns_to_duration_months():
     days_per_avg_year = 365.25
     ns_per_day = 24 * 60 * 60 * 1e9
 

--- a/imap_processing/tests/ena_maps/utils/test_naming.py
+++ b/imap_processing/tests/ena_maps/utils/test_naming.py
@@ -6,6 +6,7 @@ from imap_processing.ena_maps.utils.naming import (
     MappableInstrumentShortName,
     build_friendly_date_descriptor,
     build_l2_map_descriptor,
+    ns_to_duration_months,
 )
 from imap_processing.spice.geometry import SpiceFrame
 
@@ -88,3 +89,21 @@ def test_build_friendly_date_descriptor(start_datestring):
         duration_months=3,
     )
     assert friendly_date_descriptor == "202605m03"
+
+
+def test_ns_to_duration_months(
+    self,
+):
+    days_per_avg_year = 365.25
+    ns_per_day = 24 * 60 * 60 * 1e9
+
+    for fraction_of_year, expected_months in [
+        (1 / 2, 6),
+        (1 / 3, 4),
+        (1 / 4, 3),
+        (3 / 4, 9),
+    ]:
+        assert (
+            ns_to_duration_months(fraction_of_year * days_per_avg_year * ns_per_day)
+            == expected_months
+        )


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

Ultra L2: calculate an epoch_delta in nanoseconds based on: `(max PSET epoch + 1 day) - the min PSET epoch`. Add a TODO to replace this 1 day with the true duration of the final PSET, but that is not yet available. See #1747. This should always be a small difference compared to the duration of an L2 map, so a day is a good starting assumption.  

Also add a function to take such a time delta in ns and return a month number calculated by a very simple 1month = 28.5 days, then use that function to set the map duration. 

Closes #1696 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
   - Add epoch_delta to the common map parameters
-  imap_processing/ena_maps/utils/naming.py
   - define ns_to_duration_months function
- imap_processing/ultra/l2/ultra_l2.py
   - Ensure we get the epoch = min PSET time
   - Calculate epoch_delta and add it to the dataset
   - Set the map duration based on epoch_delta. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Tests for new function, duration of output L2 map