### PR TITLE
Lo L1C - PSET Exposure Time

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -52,7 +52,9 @@ def lo_l1b(dependencies: dict) -> list[Path]:
         # Get the start and end times for each spin epoch
         acq_start, acq_end = convert_start_end_acq_times(spin_data)
         # Get the average spin durations for each epoch
-        avg_spin_durations = get_avg_spin_durations(acq_start, acq_end)
+        avg_spin_durations_per_cycle = get_avg_spin_durations_per_cycle(
+            acq_start, acq_end
+        )
         # get spin angle (0 - 360 degrees) for each DE
         spin_angle = get_spin_angle(l1a_de)
         # calculate and set the spin bin based on the spin angle
@@ -63,9 +65,15 @@ def lo_l1b(dependencies: dict) -> list[Path]:
         # get spin start times for each event
         spin_start_time = get_spin_start_times(l1a_de, l1b_de, spin_data, acq_end)
         # get the absolute met for each event
-        l1b_de = set_event_met(l1a_de, l1b_de, spin_start_time, avg_spin_durations)
+        l1b_de = set_event_met(
+            l1a_de, l1b_de, spin_start_time, avg_spin_durations_per_cycle
+        )
         # set the epoch for each event
         l1b_de = set_each_event_epoch(l1b_de)
+        # Set the average spin duration for each direct event
+        l1b_de = set_avg_spin_durations_per_event(
+            l1a_de, l1b_de, avg_spin_durations_per_cycle
+        )
         # calculate the TOF1 for golden triples
         # store in the l1a dataset to use in l1b calculations
         l1a_de = calculate_tof1_for_golden_triples(l1a_de)
@@ -167,7 +175,7 @@ def convert_start_end_acq_times(
     return (acq_start, acq_end)
 
 
-def get_avg_spin_durations(
+def get_avg_spin_durations_per_cycle(
     acq_start: xr.DataArray, acq_end: xr.DataArray
 ) -> xr.DataArray:
     """
@@ -187,8 +195,8 @@ def get_avg_spin_durations(
     """
     # Get the avg spin duration for each spin epoch
     # There are 28 spins per epoch (1 aggregated science cycle)
-    avg_spin_durations = (acq_end - acq_start) / 28
-    return avg_spin_durations
+    avg_spin_durations_per_cycle = (acq_end - acq_start) / 28
+    return avg_spin_durations_per_cycle
 
 
 def get_spin_angle(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
@@ -403,6 +411,36 @@ def set_each_event_epoch(l1b_de: xr.Dataset) -> xr.Dataset:
         met_to_ttj2000ns(l1b_de["event_met"].values),
         dims=["epoch"],
         # attrs=attr_mgr.get_variable_attributes("epoch")
+    )
+    return l1b_de
+
+
+def set_avg_spin_durations_per_event(
+    l1a_de: xr.Dataset, l1b_de: xr.Dataset, avg_spin_durations_per_cycle: xr.DataArray
+) -> xr.DataArray:
+    """
+    Set the average spin duration for each direct event.
+
+    Parameters
+    ----------
+    l1a_de : xarray.Dataset
+        The L1A DE dataset.
+    l1b_de : xarray.Dataset
+        The L1B DE dataset.
+    avg_spin_durations_per_cycle : xarray.DataArray
+        The average spin duration for each spin epoch.
+
+    Returns
+    -------
+    l1b_de : xarray.Dataset
+        The L1B DE dataset with the average spin duration added.
+    """
+    # repeat the average spin durations for each cycle based on the direct event count
+    # to get an average spin duration for each direct event. This will be used in L1C
+    # to calculate the exposure time for each direct event.
+    l1b_de["avg_spin_durations"] = xr.DataArray(
+        np.repeat(avg_spin_durations_per_cycle.values, l1a_de["de_count"]),
+        dims=["epoch"],
     )
     return l1b_de
 

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -421,6 +421,12 @@ def set_avg_spin_durations_per_event(
     """
     Set the average spin duration for each direct event.
 
+    The average spin duration for each cycle is repeated for the number of
+    direct event counts in the cycle. For example, if there are two Aggregated
+    Science Cycles with 2 events in the first cycle and 1 event in the second
+    cycle and the average spin duration for each cycle is duration1, duration2,
+    this will result in: [duration1, duration 1, duration2]
+
     Parameters
     ----------
     l1a_de : xarray.Dataset

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -277,7 +277,8 @@ def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.Dat
 
     result = binned_statistic_dd(
         data,
-        l1b_de["avg_spin_durations"].to_numpy(),
+        # exposure time equation from Lo Alg Document 10.1.1.4
+        4 * l1b_de["avg_spin_durations"].to_numpy() / 3600,
         statistic="mean",
         bins=[lon_edges, lat_edges, energy_edges],
     )

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -6,6 +6,7 @@ from enum import Enum
 import numpy as np
 import pandas as pd
 import xarray as xr
+from scipy.stats import binned_statistic_dd
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.spice.time import met_to_ttj2000ns
@@ -54,6 +55,7 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
 
         l1b_goodtimes_only = filter_goodtimes(l1b_de, anc_dependencies)
         pset = initialize_pset(l1b_goodtimes_only, attr_mgr, logical_source)
+        full_counts = create_pset_counts(l1b_goodtimes_only)
         pset["triples_counts"] = create_pset_counts(
             l1b_goodtimes_only, FilterType.TRIPLES
         )
@@ -62,6 +64,9 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         )
         pset["h_counts"] = create_pset_counts(l1b_goodtimes_only, FilterType.HYDROGEN)
         pset["o_counts"] = create_pset_counts(l1b_goodtimes_only, FilterType.OXYGEN)
+        pset["exposure_time"] = calculate_exposure_times(
+            full_counts, l1b_goodtimes_only
+        )
     return [pset]
 
 
@@ -239,6 +244,52 @@ def create_pset_counts(
     )
 
     return counts
+
+
+def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:
+    """
+    Calculate the exposure times for the L1B Direct Event dataset.
+
+    The exposure times are calculated by binning the data into 3600 longitude bins,
+    40 latitude bins, and 7 energy bins. If more than one exposure time is in a bin,
+    the average is taken.
+
+    Parameters
+    ----------
+    counts : xarray.DataArray
+        An event counts array with dimensions (epoch, lon_bins, lat_bins, energy_bins).
+    l1b_de : xarray.Dataset
+        L1B Direct Event dataset. This data contains the average spin durations.
+
+    Returns
+    -------
+    exposure_time : xarray.DataArray
+        The exposure times for the L1B Direct Event dataset.
+    """
+    # Create bin edges
+    lon_edges = np.arange(3601)
+    lat_edges = np.arange(41)
+    energy_edges = np.arange(8)
+
+    data = np.column_stack(
+        (l1b_de["pointing_bin_lon"], l1b_de["pointing_bin_lat"], l1b_de["esa_step"])
+    )
+
+    result = binned_statistic_dd(
+        data,
+        l1b_de["avg_spin_durations"].to_numpy(),
+        statistic="mean",
+        bins=[lon_edges, lat_edges, energy_edges],
+    )
+
+    stat = result.statistic[np.newaxis, :, :, :]
+
+    exposure_time = xr.DataArray(
+        data=stat.astype(np.float16),
+        dims=["epoch", "lon_bins", "lat_bins", "energy_bins"],
+    )
+
+    return exposure_time
 
 
 def create_datasets(

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -13,12 +13,13 @@ from imap_processing.lo.l1b.lo_l1b import (
     convert_start_end_acq_times,
     convert_tofs_to_eu,
     create_datasets,
-    get_avg_spin_durations,
+    get_avg_spin_durations_per_cycle,
     get_spin_angle,
     get_spin_start_times,
     identify_species,
     initialize_l1b_de,
     lo_l1b,
+    set_avg_spin_durations_per_event,
     set_bad_times,
     set_coincidence_type,
     set_each_event_epoch,
@@ -200,7 +201,7 @@ def test_get_avg_spin_durations():
     expected_avg_spin_durations = np.array([422.8, 423, 423.5]) / 28
 
     # Act
-    avg_spin_durations = get_avg_spin_durations(acq_start, acq_end)
+    avg_spin_durations = get_avg_spin_durations_per_cycle(acq_start, acq_end)
 
     # Assert
     np.testing.assert_array_equal(avg_spin_durations, expected_avg_spin_durations)
@@ -364,6 +365,25 @@ def test_set_event_met():
             epoch_expected,
             atol=1e-4,
         )
+
+
+def test_set_avg_spin_durations_per_event():
+    l1a_de = xr.Dataset(
+        {
+            "de_count": ("epoch", [2, 3]),
+        }
+    )
+    l1b_de = xr.Dataset(coords={"epoch": [0, 1, 2, 3, 4]})
+
+    avg_spin_durations = xr.DataArray([5, 10])
+
+    # Act
+    l1b_de = set_avg_spin_durations_per_event(l1a_de, l1b_de, avg_spin_durations)
+
+    # Assert
+    np.testing.assert_array_equal(
+        l1b_de["avg_spin_durations"].values, np.array([5, 5, 10, 10, 10])
+    )
 
 
 def test_calculate_tof1_for_golden_triples():

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -6,6 +6,7 @@ from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.lo.l1c.lo_l1c import (
     FilterType,
+    calculate_exposure_times,
     create_pset_counts,
     filter_goodtimes,
     initialize_pset,
@@ -206,3 +207,23 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
 
     # Assert
     np.testing.assert_array_equal(counts, doubles_counts)
+
+
+def test_calculate_exposure_times(l1b_de):
+    # Arrange
+    counts = create_pset_counts(l1b_de)
+    expected_exposure_times = np.full((1, 3600, 40, 7), np.nan)
+    # Average of the exposure times for each bin
+    expected_exposure_times[0, 20, 20, 1] = np.mean([15.2, 14.9])
+    expected_exposure_times[0, 2000, 20, 4] = 15
+    expected_exposure_times[0, 3500, 20, 5] = 14.9
+    expected_exposure_times[0, 0, 20, 2] = 15.2
+    # Act
+    exposure_times = calculate_exposure_times(counts, l1b_de)
+
+    # Assert
+    np.testing.assert_allclose(
+        exposure_times,
+        expected_exposure_times,
+        atol=1e-2,
+    )

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -214,10 +214,10 @@ def test_calculate_exposure_times(l1b_de):
     counts = create_pset_counts(l1b_de)
     expected_exposure_times = np.full((1, 3600, 40, 7), np.nan)
     # Average of the exposure times for each bin
-    expected_exposure_times[0, 20, 20, 1] = np.mean([15.2, 14.9])
-    expected_exposure_times[0, 2000, 20, 4] = 15
-    expected_exposure_times[0, 3500, 20, 5] = 14.9
-    expected_exposure_times[0, 0, 20, 2] = 15.2
+    expected_exposure_times[0, 20, 20, 1] = 4 * np.mean([15.2, 14.9]) / 3600
+    expected_exposure_times[0, 2000, 20, 4] = 4 * 15 / 3600
+    expected_exposure_times[0, 3500, 20, 5] = 4 * 14.9 / 3600
+    expected_exposure_times[0, 0, 20, 2] = 4 * 15.2 / 2600
     # Act
     exposure_times = calculate_exposure_times(counts, l1b_de)
 


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds the exposure time calculation to the L1C PSET and adds a small function to L1B DE to retain the average spin duration for each event which is needed for the exposure time calculation.

## Updated Files
- imap_processing/lo/l1b/lo_l1b.py
   - Added set_avg_spin_durations_per_event function to retain the avg spin duration for each event
   - changed name of get_avg_spin_durations to get_avg_spin_durations_per_cycle to differentiate from new function
- imap_processing/lo/l1c/lo_l1c.py
   - added the exposure time calculation

## Testing
Added unit test for new L1B function and new unit test for L1C function.

Closes #1757 