### PR TITLE
Add L2 to Hi do_processing

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -692,8 +692,8 @@ class Hi(ProcessInstrument):
         elif self.data_level == "l2":
             science_paths = dependencies.get_file_paths(source="hi", data_type="l2")
             # TODO get ancillary paths
-            geometric_factors_path = None
-            esa_energies_path = None
+            geometric_factors_path = ""
+            esa_energies_path = ""
             datasets = hi_l2.hi_l2(
                 science_paths,
                 geometric_factors_path,

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -48,6 +48,7 @@ from imap_processing.glows.l2.glows_l2 import glows_l2
 from imap_processing.hi.l1a import hi_l1a
 from imap_processing.hi.l1b import hi_l1b
 from imap_processing.hi.l1c import hi_l1c
+from imap_processing.hi.l2 import hi_l2
 from imap_processing.hit.l1a.hit_l1a import hit_l1a
 from imap_processing.hit.l1b.hit_l1b import hit_l1b
 from imap_processing.hit.l2.hit_l2 import hit_l2
@@ -661,34 +662,44 @@ class Hi(ProcessInstrument):
         print(f"Processing IMAP-Hi {self.data_level}")
         datasets: list[xr.Dataset] = []
 
-        dependency_list = dependencies.processing_input
         if self.data_level == "l1a":
-            # File path is expected output file path
-            if len(dependency_list) > 1:
-                raise ValueError(
-                    f"Unexpected dependencies found for Hi L1A:"
-                    f"{dependency_list}. Expected only one dependency."
-                )
             science_files = dependencies.get_file_paths(source="hi")
+            if len(science_files) != 1:
+                raise ValueError(
+                    f"Unexpected science_files found for Hi L1A:"
+                    f"{science_files}. Expected only one dependency."
+                )
             datasets = hi_l1a.hi_l1a(science_files[0])
         elif self.data_level == "l1b":
             l0_files = dependencies.get_file_paths(source="hi", descriptor="raw")
             if l0_files:
                 datasets = hi_l1b.hi_l1b(l0_files[0])
             else:
-                l1a_files = dependencies.get_file_paths(source="hi")
+                l1a_files = dependencies.get_file_paths(source="hi", data_type="l1a")
                 datasets = hi_l1b.hi_l1b(load_cdf(l1a_files[0]))
         elif self.data_level == "l1c":
-            # TODO: Add PSET calibration product config file dependency and remove
-            #    below injected dependency
-            hi_dependencies = dependencies.get_file_paths(source="hi")
-            hi_dependencies.append(
-                Path(__file__).parent
-                / "tests/hi/test_data/l1"
-                / "imap_his_pset-calibration-prod-config_20240101_v001.csv"
+            science_paths = dependencies.get_file_paths(source="hi", data_type="l1b")
+            if len(science_paths) != 1:
+                raise ValueError(
+                    f"Expected only one science dependency. Got {science_paths}"
+                )
+            anc_paths = dependencies.get_file_paths(data_type="ancillary")
+            if len(anc_paths) != 1:
+                raise ValueError(
+                    f"Expected only one ancillary dependency. Got {anc_paths}"
+                )
+            datasets = hi_l1c.hi_l1c(load_cdf(science_paths[0]), anc_paths[0])
+        elif self.data_level == "l2":
+            science_paths = dependencies.get_file_paths(source="hi", data_type="l2")
+            # TODO get ancillary paths
+            geometric_factors_path = None
+            esa_energies_path = None
+            datasets = hi_l2.hi_l2(
+                science_paths,
+                geometric_factors_path,
+                esa_energies_path,
+                self.descriptor,
             )
-            hi_dependencies[0] = load_cdf(hi_dependencies[0])
-            datasets = hi_l1c.hi_l1c(hi_dependencies)
         else:
             raise NotImplementedError(
                 f"Hi processing not implemented for level {self.data_level}"

--- a/imap_processing/hi/l1c/hi_l1c.py
+++ b/imap_processing/hi/l1c/hi_l1c.py
@@ -42,7 +42,9 @@ SPIN_PHASE_BIN_CENTERS = (SPIN_PHASE_BIN_EDGES[:-1] + SPIN_PHASE_BIN_EDGES[1:]) 
 logger = logging.getLogger(__name__)
 
 
-def hi_l1c(dependencies: list) -> list[xr.Dataset]:
+def hi_l1c(
+    de_dataset: xr.Dataset, calibration_prod_config_path: Path
+) -> list[xr.Dataset]:
     """
     High level IMAP-Hi l1c processing function.
 
@@ -53,8 +55,10 @@ def hi_l1c(dependencies: list) -> list[xr.Dataset]:
 
     Parameters
     ----------
-    dependencies : list
-        Input dependencies needed for l1c processing.
+    de_dataset : xarray.Dataset
+        IMAP-Hi l1b de product.
+    calibration_prod_config_path : Path
+        Calibration product configuration file.
 
     Returns
     -------
@@ -65,12 +69,7 @@ def hi_l1c(dependencies: list) -> list[xr.Dataset]:
 
     # TODO: I am not sure what the input for Goodtimes will be so for now,
     #    If the input is an xarray Dataset, do pset processing
-    if len(dependencies) == 2 and isinstance(dependencies[0], xr.Dataset):
-        l1c_dataset = generate_pset_dataset(*dependencies)
-    else:
-        raise NotImplementedError(
-            "Input dependencies not recognized for l1c pset processing."
-        )
+    l1c_dataset = generate_pset_dataset(de_dataset, calibration_prod_config_path)
 
     return [l1c_dataset]
 

--- a/imap_processing/hi/l2/hi_l2.py
+++ b/imap_processing/hi/l2/hi_l2.py
@@ -219,14 +219,14 @@ def calculate_ena_intensity(
         ENA Intensity with statistical and systematic uncertainties.
     """
     # TODO: Implement geometric factor lookup
-    if geometric_factors_path is not None:
+    if geometric_factors_path != "":
         raise NotImplementedError
     geometric_factor = xr.DataArray(
         np.ones((map_ds["esa_energy_step"].size, map_ds["calibration_prod"].size)),
         coords=[map_ds["esa_energy_step"], map_ds["calibration_prod"]],
     )
     # TODO: Implement esa energies lookup
-    if esa_energies_path is not None:
+    if esa_energies_path != "":
         raise NotImplementedError
     esa_energy = xr.ones_like(map_ds["esa_energy_step"])
 

--- a/imap_processing/hi/l2/hi_l2.py
+++ b/imap_processing/hi/l2/hi_l2.py
@@ -219,14 +219,14 @@ def calculate_ena_intensity(
         ENA Intensity with statistical and systematic uncertainties.
     """
     # TODO: Implement geometric factor lookup
-    if geometric_factors_path != "":
+    if geometric_factors_path:
         raise NotImplementedError
     geometric_factor = xr.DataArray(
         np.ones((map_ds["esa_energy_step"].size, map_ds["calibration_prod"].size)),
         coords=[map_ds["esa_energy_step"], map_ds["calibration_prod"]],
     )
     # TODO: Implement esa energies lookup
-    if esa_energies_path != "":
+    if esa_energies_path:
         raise NotImplementedError
     esa_energy = xr.ones_like(map_ds["esa_energy_step"])
 

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -28,15 +28,9 @@ def hi_test_cal_prod_config_path(hi_l1_test_data_path):
 def test_hi_l1c(mock_generate_pset_dataset, hi_test_cal_prod_config_path):
     """Test coverage for hi_l1c function"""
     mock_generate_pset_dataset.return_value = xr.Dataset()
-    pset = hi_l1c.hi_l1c([xr.Dataset(), hi_test_cal_prod_config_path])[0]
+    pset = hi_l1c.hi_l1c(xr.Dataset(), hi_test_cal_prod_config_path)[0]
     # Empty attributes, global values get added in post-processing
     assert pset.attrs == {}
-
-
-def test_hi_l1c_not_implemented():
-    """Test coverage for hi_l1c function with unrecognized dependencies"""
-    with pytest.raises(NotImplementedError):
-        hi_l1c.hi_l1c([None, None])
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -11,6 +11,7 @@ import pytest
 import spiceypy
 import xarray as xr
 from imap_data_access.processing_input import (
+    AncillaryInput,
     ProcessingInputCollection,
     ScienceInput,
     SPICEInput,
@@ -178,21 +179,38 @@ def test_repointing_file_creation(mock_instrument_dependencies):
 
 
 @pytest.mark.parametrize(
-    "data_level, science_input, n_prods",
+    "data_level, science_input, anc_input, n_prods",
     [
-        ("l1a", ["imap_hi_l0_raw_20231212_v001.pkts"], 2),
-        ("l1b", ["imap_hi_l1a_90sensor-de_20241105_v001.cdf"], 1),
-        ("l1b", ["imap_hi_l0_raw_20231212_v001.pkts"], 2),
-        ("l1c", ["imap_hi_l1b_45sensor-de_20250415_v001.cdf"], 1),
+        ("l1a", ["imap_hi_l0_raw_20231212_v001.pkts"], [], 2),
+        ("l1b", ["imap_hi_l1a_90sensor-de_20241105_v001.cdf"], [], 1),
+        ("l1b", ["imap_hi_l0_raw_20231212_v001.pkts"], [], 2),
+        (
+            "l1c",
+            ["imap_hi_l1b_45sensor-de_20250415_v001.cdf"],
+            ["imap_hi_calibration-prod-config_20240101_v001.csv"],
+            1,
+        ),
+        (
+            "l2",
+            [
+                "imap_hi_l1c_90sensor-pset_20250415_v001.cdf",
+                "imap_hi_l1c_90sensor-pset_20250416_v001.cdf",
+            ],
+            [],
+            1,
+        ),
     ],
 )
-def test_hi_l1(mock_instrument_dependencies, data_level, science_input, n_prods):
+def test_hi(
+    mock_instrument_dependencies, data_level, science_input, anc_input, n_prods
+):
     """Test coverage for cli.Hi class"""
     mocks = mock_instrument_dependencies
     mocks["mock_write_cdf"].side_effect = ["/path/to/file0"] * n_prods
     mocks["mock_load_cdf"].return_value = xr.Dataset()
     input_collection = ProcessingInputCollection(
-        *[ScienceInput(file) for file in science_input]
+        *[ScienceInput(file) for file in science_input],
+        *[AncillaryInput(file) for file in anc_input],
     )
     mocks["mock_pre_processing"].return_value = input_collection
 


### PR DESCRIPTION


# Change Summary

## Overview
Update l1c processing to accept input of ancillary file.
Add l2 processing to Hi.do_processing()

## Updated Files
- imap_processing/cli.py
   - Rework how hi l1c works
   - Add L2 to Hi.do_processing
- imap_processing/hi/l1c/hi_l1c.py
   - split l1c inputs into dataset and ancillary file in `hi_l1c` signature
   - Remove no longer needed hi_l1c test
- imap_processing/tests/hi/test_hi_l1c.py
   - Update tests with updated function signature
- imap_processing/tests/test_cli.py
   - Update test coverage for Hi.do_processing


Closes: #1726 