### PR TITLE
Ultra L2 Metadata improvements

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -33,15 +33,6 @@ default_float32_attrs: &default_float32
   VALIDMAX: 3.4028235e+38
   dtype: float32
 
-# Define epoch_delta attributes
-epoch_delta:
-  <<: *default_int64
-  CATDESC: Number of nanoseconds covered by data included in this map product.
-  DISPLAY_TYPE: no_plot
-  VALIDMIN: 0
-  VAR_TYPE: metadata
-  UNITS: ns
-
 # Define Coordinate(s) which are tiling-independent
 energy:
   <<: *default_float32

--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -273,8 +273,8 @@ imap_ultra_l1a_90sensor-imgparams:
     Logical_source_description: IMAP-Ultra Instrument Level-1A Image Parameters Data for Ultra90.
 
 # Ultra L2 Global attributes for different sensors and sky tiling types and durations
-imap_ultra_l2_enamap-hf:
+imap_ultra_l2_enamap:
     <<: *instrument_base
-    Data_type: L2_{sensor}Sensor-enamap{tiling}-hf-{duration}>Level-2 ENA Intensity Map for Ultra{sensor}
-    Logical_source: imap_ultra_l2_{sensor}sensor-enamap{tiling}-hf-{duration}
-    Logical_source_description: IMAP-Ultra Instrument Level-2 ENA Intensity Map Data for Ultra{sensor} on {tiling} tiling in heliospheric frame over {duration} duration.
+    Data_type: L2_{sensor}Sensor-enamap{tiling}-{inertial_frame_short_name}-{duration}>Level-2 ENA Intensity Map for Ultra{sensor}
+    Logical_source: u{sensor}-ena-h-{inertial_frame_short_name}-nsp-full-hae-{resolution_string}-{duration}
+    Logical_source_description: IMAP-Ultra Instrument Level-2 ENA Intensity Map Data for Ultra{sensor} on {tiling} tiling in {inertial_frame_long_name} frame over {duration} duration.

--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -275,6 +275,6 @@ imap_ultra_l1a_90sensor-imgparams:
 # Ultra L2 Global attributes for different sensors and sky tiling types and durations
 imap_ultra_l2_enamap:
     <<: *instrument_base
-    Data_type: L2_{sensor}Sensor-enamap{tiling}-{inertial_frame_short_name}-{duration}>Level-2 ENA Intensity Map for Ultra{sensor}
-    Logical_source: u{sensor}-ena-h-{inertial_frame_short_name}-nsp-full-hae-{resolution_string}-{duration}
+    Data_type: L2_u{sensor}-ena-h-{inertial_frame_short_name}-nsp-full-hae-{resolution_string}-{duration}>Level-2 ENA Intensity Map for Ultra{sensor}
+    Logical_source: imap_ultra_l2_u{sensor}-ena-h-{inertial_frame_short_name}-nsp-full-hae-{resolution_string}-{duration}
     Logical_source_description: IMAP-Ultra Instrument Level-2 ENA Intensity Map Data for Ultra{sensor} on {tiling} tiling in {inertial_frame_long_name} frame over {duration} duration.

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -35,6 +35,13 @@ valid_spice_frame_strings = ["sf", "hf", "hk"]
 _spice_frame_str_types = Literal["sf", "hf", "hk"]
 _coord_frame_str_types = Literal["hae",]
 
+# Mapping of inertial frames to their longer names used in logical source descriptors
+INERTIAL_FRAME_LONG_NAMES = {
+    "hf": "heliospheric",
+    "sf": "spacecraft",
+    "hk": "heliocentric kinetic",
+}
+
 
 @dataclass
 class MapDescriptor:

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -249,7 +249,7 @@ class TestUltraL2:
 
         assert (
             map_dataset.attrs["Logical_source"]
-            == "u90-ena-h-unknown-nsp-full-hae-nside16-6mo"
+            == "imap_ultra_l2_u90-ena-h-unknown-nsp-full-hae-nside16-6mo"
         )
         assert "unknown frame" in map_dataset.attrs["Logical_source_description"]
 
@@ -488,7 +488,8 @@ class TestUltraL2:
             )[0]
 
         assert (
-            output_map.attrs["Logical_source"] == "u90-ena-h-hf-nsp-full-hae-6deg-6mo"
+            output_map.attrs["Logical_source"]
+            == "imap_ultra_l2_u90-ena-h-hf-nsp-full-hae-6deg-6mo"
         )
         assert "heliospheric frame" in output_map.attrs["Logical_source_description"]
 
@@ -506,7 +507,7 @@ class TestUltraL2:
         assert "spacecraft frame" in output_map.attrs["Logical_source_description"]
         assert (
             output_map.attrs["Logical_source"]
-            == "u90-ena-h-sf-nsp-full-hae-nside32-6mo"
+            == "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-nside32-6mo"
         )
         assert output_map.attrs["Spice_reference_frame"] == "ECLIPJ2000"
         assert output_map.attrs["HEALPix_nside"] == "32"

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -478,8 +478,12 @@ class TestUltraL2:
         with furnish_kernels(self.required_kernel_names):
             output_map = ultra_l2.ultra_l2(
                 data_dict=mock_data_dict,
-                descriptor="u90-ena-h-hf-nsp-full-hae-6deg-3mo",
+                descriptor="u90-ena-h-hf-nsp-full-hae-6deg-6mo",
             )[0]
+
+        assert (
+            output_map.attrs["Logical_source"] == "u90-ena-h-hf-nsp-full-hae-6deg-6mo"
+        )
 
         assert output_map.attrs["Spice_reference_frame"] == "ECLIPJ2000"
         assert output_map.attrs["Spacing_degrees"] == "6.0"
@@ -489,8 +493,13 @@ class TestUltraL2:
         with furnish_kernels(self.required_kernel_names):
             output_map = ultra_l2.ultra_l2(
                 data_dict=mock_data_dict,
-                descriptor="u90-ena-h-hf-nsp-full-hae-nside32-3mo",
+                descriptor="u90-ena-h-sf-nsp-full-hae-nside32-6mo",
             )[0]
 
+        assert "spacecraft" in output_map.attrs["Logical_source_description"]
+        assert (
+            output_map.attrs["Logical_source"]
+            == "u90-ena-h-sf-nsp-full-hae-nside32-6mo"
+        )
         assert output_map.attrs["Spice_reference_frame"] == "ECLIPJ2000"
         assert output_map.attrs["HEALPix_nside"] == "32"

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -247,6 +247,12 @@ class TestUltraL2:
                 output_map_structure=map_structure,
             )
 
+        assert (
+            map_dataset.attrs["Logical_source"]
+            == "u90-ena-h-unknown-nsp-full-hae-nside16-6mo"
+        )
+        assert "unknown frame" in map_dataset.attrs["Logical_source_description"]
+
         assert map_dataset.attrs["HEALPix_nside"] == str(map_structure.nside)
         assert map_dataset.attrs["HEALPix_nest"] == str(map_structure.nested)
         assert "6mo" in map_dataset.attrs["Logical_source"]
@@ -484,6 +490,7 @@ class TestUltraL2:
         assert (
             output_map.attrs["Logical_source"] == "u90-ena-h-hf-nsp-full-hae-6deg-6mo"
         )
+        assert "heliospheric frame" in output_map.attrs["Logical_source_description"]
 
         assert output_map.attrs["Spice_reference_frame"] == "ECLIPJ2000"
         assert output_map.attrs["Spacing_degrees"] == "6.0"
@@ -496,7 +503,7 @@ class TestUltraL2:
                 descriptor="u90-ena-h-sf-nsp-full-hae-nside32-6mo",
             )[0]
 
-        assert "spacecraft" in output_map.attrs["Logical_source_description"]
+        assert "spacecraft frame" in output_map.attrs["Logical_source_description"]
         assert (
             output_map.attrs["Logical_source"]
             == "u90-ena-h-sf-nsp-full-hae-nside32-6mo"

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -462,6 +462,14 @@ def ultra_l2(
 
         map_dataset = rectangular_skymap.to_dataset()
 
+        # Reshape the solid_angle to have an epoch dimension at the start
+        map_dataset["solid_angle"] = map_dataset["solid_angle"].expand_dims(
+            {
+                CoordNames.TIME.value: 1,
+            },
+            axis=0,
+        )
+
         # Add longitude_delta, latitude_delta to the map dataset
         map_dataset["longitude_delta"] = rectangular_skymap.spacing_deg / 2
         map_dataset["latitude_delta"] = rectangular_skymap.spacing_deg / 2
@@ -520,7 +528,7 @@ def ultra_l2(
     # Add epoch_delta
     map_dataset.coords["epoch_delta"] = xr.DataArray(
         [
-            map_duration_ns,
+            map_duration_ns.astype(np.int64),
         ],
         dims=(CoordNames.TIME.value,),
     )

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -12,7 +12,11 @@ from numpy.typing import NDArray
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.ena_maps import ena_maps
 from imap_processing.ena_maps.utils.coordinates import CoordNames
-from imap_processing.ena_maps.utils.naming import MapDescriptor, ns_to_duration_months
+from imap_processing.ena_maps.utils.naming import (
+    INERTIAL_FRAME_LONG_NAMES,
+    MapDescriptor,
+    ns_to_duration_months,
+)
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import get_energy_delta_minus_plus
 
 logger = logging.getLogger(__name__)
@@ -357,12 +361,16 @@ def ultra_l2(
         L2 output dataset containing map of the counts on the sky.
         Wrapped in a list for consistency with other product levels.
     """
+    inertial_frame = "unknown"
     if descriptor is not None:
-        output_map_structure = MapDescriptor.from_string(descriptor).to_empty_map()
         logger.info(
             f"Using the provided descriptor '{descriptor}' to set the map structure."
             "\nThis will override any input map structure."
         )
+        map_descriptor = MapDescriptor.from_string(descriptor)
+        output_map_structure = map_descriptor.to_empty_map()
+        inertial_frame = map_descriptor.frame_descriptor
+    inertial_frame_long_name = INERTIAL_FRAME_LONG_NAMES.get(inertial_frame, "unknown")
 
     # Object which holds CDF attributes for the map
     cdf_attrs = ImapCdfAttributes()
@@ -464,12 +472,22 @@ def ultra_l2(
 
     # Get the global attributes, and then fill the sensor, tiling, etc. in the
     # format-able strings.
-    map_attrs.update(cdf_attrs.get_global_attributes("imap_ultra_l2_enamap-hf"))
+    map_attrs.update(cdf_attrs.get_global_attributes("imap_ultra_l2_enamap"))
     for key in ["Data_type", "Logical_source", "Logical_source_description"]:
         map_attrs[key] = map_attrs[key].format(
             sensor=ultra_sensor_number,
             tiling=output_map_structure.tiling_type.value.lower(),
             duration=map_duration,
+            resolution_string=(
+                f"{output_map_structure.spacing_deg:.0f}deg"
+                if (
+                    output_map_structure.tiling_type
+                    is ena_maps.SkyTilingType.RECTANGULAR
+                )
+                else f"nside{output_map_structure.nside}"
+            ),
+            inertial_frame_short_name=inertial_frame,
+            inertial_frame_long_name=inertial_frame_long_name,
         )
 
     # Always add the following attributes to the map


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

Cleans up a few metadata issues affecting Ultra L2 and the ENA Maps in general: 
1. `epoch_delta` metadata had been being defined twice because of an unseen merge conflict - remove the duplicate. 
2. The Ultra ENA map global attrs (E.g., 'Logical_source') could be simplified and made to match the `description` string properly. 
3. For "solid_angle" (now created automatically by `ena_maps.py` for `RectangularSkyMaps`), the epoch dimension was not present in the data, though it was in the metadata. Add the epoch dim to the data. 

Closes #1774 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
  - remove duplicate metadata
- imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
  - change formatting, unify spacecraft and heliospheric frame global attr metadata by using string formatting on template global attrs. 
- imap_processing/ena_maps/utils/naming.py
  - Add dict of `INERTIAL_FRAME_LONG_NAMES` to go from "hf" --> "heliospheric" frame in attribute formatting
- imap_processing/ultra/l2/ultra_l2.py
  - Apply the string formatting to the global attribute metadata templates
  - Reshape the solid_angle for Rectangular Maps. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Test the global attr metadata 