### PR TITLE
SWAPI: Segmented fix and adding l1a and l1b HK CDF files

### DIFF
--- a/imap_processing/__init__.py
+++ b/imap_processing/__init__.py
@@ -28,7 +28,7 @@ PROCESSING_LEVELS = {
     "lo": ["l1a", "l1b", "l1c", "l2"],
     "mag": ["l1a", "l1b", "l1c", "l1d", "l2"],
     "spacecraft": ["l1a", "spice"],
-    "swapi": ["l1", "l2", "l3a", "l3b"],
+    "swapi": ["l1a", "l1b", "l1", "l2", "l3a", "l3b"],
     "swe": ["l1a", "l1b", "l2"],
     "ultra": ["l1a", "l1b", "l1c", "l2"],
 }

--- a/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
@@ -16,11 +16,17 @@ imap_swapi_l1_sci:
   Logical_source: imap_swapi_l1_sci
   Logical_source_description: IMAP SWAPI Instrument Level-1 Science Data
 
-imap_swapi_l1_hk:
+imap_swapi_l1a_hk:
   <<: *instrument_base
-  Data_type: L1_HK>Level-1B Housekeeping data
-  Logical_source: imap_swapi_l1_hk
-  Logical_source_description: IMAP SWAPI Instrument Level-1 Housekeeping Data
+  Data_type: L1A_HK>Level-1A Housekeeping data
+  Logical_source: imap_swapi_l1a_hk
+  Logical_source_description: IMAP SWAPI Instrument Level-1A Housekeeping Data
+
+imap_swapi_l1b_hk:
+  <<: *instrument_base
+  Data_type: L1B_HK>Level-1B Housekeeping data
+  Logical_source: imap_swapi_l1b_hk
+  Logical_source_description: IMAP SWAPI Instrument Level-1B Housekeeping Data
 
 imap_swapi_l2_sci:
   <<: *instrument_base

--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -143,6 +143,14 @@ hk_attrs: &hk_attrs
   SCALETYP: linear
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
+# L1B HK data attrs for data with string values
+l1b_hk_string_attrs: &l1b_hk_string_attrs
+  CATDESC: Housekeeping derived data
+  FIELDNAM: Housekeeing Human Readable State
+  FORMAT: A80
+  VAR_TYPE: metadata
+  DEPEND_0: epoch
+
 pcem_counts:
   <<: *counts_default
   CATDESC: Primary Channel Electron Multiplier (CEM)  Counts
@@ -165,37 +173,37 @@ pcem_counts_uncertainty:
   <<: *counts_uncertainty_default
   CATDESC: Primary Channel Electron Multiplier (CEM) counts uncertainty
   FIELDNAM: Primary CEM Counts Uncertainty
-  LABLAXIS: pcem_stat_unc
+  LABLAXIS: pcem_cnts_stat_unc
 
 scem_counts_uncertainty:
   <<: *counts_uncertainty_default
   CATDESC: Secondary Channel Electron Multiplier (CEM) counts uncertainty
   FIELDNAM: Secondary CEM Counts Uncertainty
-  LABLAXIS: scem_stat_unc
+  LABLAXIS: scem_cnts_stat_unc
 
 coin_counts_uncertainty:
   <<: *counts_uncertainty_default
   CATDESC: Coincidence counts uncertainty
   FIELDNAM: Coincidence Counts Uncertainty
-  LABLAXIS: coin_stat_unc
+  LABLAXIS: coin_cnts_stat_unc
 
 pcem_rate_uncertainty:
   <<: *rate_uncertainty_default
   CATDESC: Primary Channel Electron Multiplier (CEM) rate uncertainty
   FIELDNAM: Primary CEM Rate Uncertainty
-  LABLAXIS: pcem_stat_unc
+  LABLAXIS: pcem_rate_stat_unc
 
 scem_rate_uncertainty:
   <<: *rate_uncertainty_default
   CATDESC: Secondary Channel Electron Multiplier (CEM) rate uncertainty
   FIELDNAM: Secondary CEM Rate Uncertainty
-  LABLAXIS: scem_stat_unc
+  LABLAXIS: scem_rate_stat_unc
 
 coin_rate_uncertainty:
   <<: *rate_uncertainty_default
   CATDESC: Coincidence rate uncertainty
   FIELDNAM: Coincidence Rate Uncertainty
-  LABLAXIS: coin_stat_unc
+  LABLAXIS: coin_rate_stat_unc
 
 pcem_rate:
   <<: *rate_default

--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -748,29 +748,43 @@ def swapi_l1(dependencies: ProcessingInputCollection) -> xr.Dataset:
             raise ValueError(
                 f"SWAPI SCI processing expected one L0 HK file. Found {len(hk_files)}."
             )
-        l1_hk_ds = load_cdf(hk_files[0])
+        l1b_hk_ds = load_cdf(hk_files[0])
         sci_dataset = process_swapi_science(
-            l0_unpacked_dict[SWAPIAPID.SWP_SCI], l1_hk_ds
+            l0_unpacked_dict[SWAPIAPID.SWP_SCI], l1b_hk_ds
         )
         return [sci_dataset]
 
     elif l0_unpacked_dict[SWAPIAPID.SWP_HK]:
         logger.info(f"Processing HK data for {l0_files[0]}.")
-        hk_ds = l0_unpacked_dict[SWAPIAPID.SWP_HK]
-        # Add HK datalevel attrs
+        # Get L1A and L1B HK data.
+        l1a_hk_data = l0_unpacked_dict[SWAPIAPID.SWP_HK]
+        l1b_hk_data = l0_unpacked_dict = packet_file_to_datasets(
+            l0_files[0], xtce_definition, use_derived_value=True
+        )[SWAPIAPID.SWP_HK]
+
+        # Add HK attrs to both L1A and L1B HK data
         imap_attrs = ImapCdfAttributes()
         imap_attrs.add_instrument_global_attrs("swapi")
         imap_attrs.add_instrument_variable_attrs(instrument="swapi", level=None)
-        hk_ds.attrs.update(imap_attrs.get_global_attributes("imap_swapi_l1_hk"))
+
+        l1a_hk_data.attrs.update(imap_attrs.get_global_attributes("imap_swapi_l1a_hk"))
+        l1b_hk_data.attrs.update(imap_attrs.get_global_attributes("imap_swapi_l1b_hk"))
         hk_common_attrs = imap_attrs.get_variable_attributes("hk_attrs")
-        hk_ds["epoch"].attrs.update(
+        l1a_hk_data["epoch"].attrs.update(
             imap_attrs.get_variable_attributes("epoch", check_schema=False)
         )
 
         # Add attrs to HK data variables
-        for var_name in hk_ds.data_vars:
-            hk_ds[var_name].attrs.update(hk_common_attrs)
-        return [hk_ds]
+        for var_name in l1a_hk_data.data_vars:
+            l1a_hk_data[var_name].attrs.update(hk_common_attrs)
+            # If HK L1B derived data is string, use string default attrs
+            if isinstance(l1b_hk_data[var_name].data[0], str):
+                l1b_hk_data[var_name].attrs.update(
+                    imap_attrs.get_variable_attributes("l1b_hk_string_attrs")
+                )
+            else:
+                l1b_hk_data[var_name].attrs.update(hk_common_attrs)
+        return [l1a_hk_data, l1b_hk_data]
 
     logger.warning(f"Unsupported SWAPI input data. {l0_unpacked_dict.keys()}")
     return []

--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -758,7 +758,7 @@ def swapi_l1(dependencies: ProcessingInputCollection) -> xr.Dataset:
         logger.info(f"Processing HK data for {l0_files[0]}.")
         # Get L1A and L1B HK data.
         l1a_hk_data = l0_unpacked_dict[SWAPIAPID.SWP_HK]
-        l1b_hk_data = l0_unpacked_dict = packet_file_to_datasets(
+        l1b_hk_data = packet_file_to_datasets(
             l0_files[0], xtce_definition, use_derived_value=True
         )[SWAPIAPID.SWP_HK]
 

--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -777,7 +777,11 @@ def swapi_l1(dependencies: ProcessingInputCollection) -> xr.Dataset:
         # Add attrs to HK data variables
         for var_name in l1a_hk_data.data_vars:
             l1a_hk_data[var_name].attrs.update(hk_common_attrs)
-            # If HK L1B derived data is string, use string default attrs
+            # In L1B HK data, we derived data which can result some data to
+            # be string. Eg. SWP_HK.PCEM_SAFE raw value can be 0 or 1,
+            # but the derived value is 'OK' or 'ERR'. Therefore, we need to use
+            # different attributes for data variables with string values to be
+            # ISTP compliant.
             if isinstance(l1b_hk_data[var_name].data[0], str):
                 l1b_hk_data[var_name].attrs.update(
                     imap_attrs.get_variable_attributes("l1b_hk_string_attrs")

--- a/imap_processing/swapi/packet_definitions/swapi_packet_definition.xml
+++ b/imap_processing/swapi/packet_definitions/swapi_packet_definition.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="SWP">
-	<xtce:Header date="05/02/2025" version="1" author="IMAP SDC" source_file="TLM_SWP.xlsx" />
+	<xtce:Header date="09/05/2025" version="1" author="IMAP SDC" source_file="TLM_SWP.xlsx" />
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="VERSION" signed="false">
@@ -197,8 +197,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="signed">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.784111993082661" exponent="0" />
-							<xtce:Term coefficient="-2.641481148440142" exponent="1" />
+							<xtce:Term coefficient="0.8536045153778105" exponent="0" />
+							<xtce:Term coefficient="-2.640659645474425" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -207,8 +207,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="signed">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="0.3392409365646927" exponent="0" />
-							<xtce:Term coefficient="2.640157732627925" exponent="1" />
+							<xtce:Term coefficient="0.3353377323464883" exponent="0" />
+							<xtce:Term coefficient="2.639151098340578" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -257,8 +257,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="signed">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="-3.213239072749474" exponent="0" />
-							<xtce:Term coefficient="-0.2768281702136274" exponent="1" />
+							<xtce:Term coefficient="-6.985294508398312" exponent="0" />
+							<xtce:Term coefficient="-0.2839533727705322" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -267,8 +267,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="signed">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="69.64215069080154" exponent="0" />
-							<xtce:Term coefficient="-0.308170409377625" exponent="1" />
+							<xtce:Term coefficient="58.79614883808286" exponent="0" />
+							<xtce:Term coefficient="-0.2955962271648258" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -325,7 +325,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="0" />
+							<xtce:Term coefficient="1.0" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -400,7 +400,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="-0.001821464429724529" exponent="0" />
+							<xtce:Term coefficient="0.001821464429724529" exponent="0" />
 							<xtce:Term coefficient="0.0148563058518021" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
@@ -410,8 +410,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="62.08471073457684" exponent="0" />
-							<xtce:Term coefficient="-0.01515976630152695" exponent="1" />
+							<xtce:Term coefficient="-0.009692036477526145" exponent="0" />
+							<xtce:Term coefficient="0.01515976630152695" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -457,12 +457,36 @@
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="SWP_HK.ESA_V" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
-					<xtce:DefaultCalibrator>
-						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="0.7328995176342232" exponent="0" />
-							<xtce:Term coefficient="-0.6002110155596884" exponent="1" />
-						</xtce:PolynomialCalibrator>
-					</xtce:DefaultCalibrator>
+					<xtce:ContextCalibratorList>
+						<xtce:ContextCalibrator>
+							<xtce:ContextMatch>
+								<xtce:ComparisonList>
+									<xtce:Comparison comparisonOperator="&gt;=" value="0" parameterRef="SWP_HK.ESA_V" useCalibratedValue="false" />
+									<xtce:Comparison comparisonOperator="&lt;=" value="2047" parameterRef="SWP_HK.ESA_V" useCalibratedValue="false" />
+								</xtce:ComparisonList>
+							</xtce:ContextMatch>
+							<xtce:Calibrator>
+								<xtce:PolynomialCalibrator>
+									<xtce:Term coefficient="0.7328995176342232" exponent="0" />
+									<xtce:Term coefficient="-0.6002110155596884" exponent="1" />
+								</xtce:PolynomialCalibrator>
+							</xtce:Calibrator>
+						</xtce:ContextCalibrator>
+						<xtce:ContextCalibrator>
+							<xtce:ContextMatch>
+								<xtce:ComparisonList>
+									<xtce:Comparison comparisonOperator="&gt;=" value="2048" parameterRef="SWP_HK.ESA_V" useCalibratedValue="false" />
+									<xtce:Comparison comparisonOperator="&lt;=" value="4095" parameterRef="SWP_HK.ESA_V" useCalibratedValue="false" />
+								</xtce:ComparisonList>
+							</xtce:ContextMatch>
+							<xtce:Calibrator>
+								<xtce:PolynomialCalibrator>
+									<xtce:Term coefficient="12292.97550071964" exponent="0" />
+									<xtce:Term coefficient="-6.003582784775521" exponent="1" />
+								</xtce:PolynomialCalibrator>
+							</xtce:Calibrator>
+						</xtce:ContextCalibrator>
+					</xtce:ContextCalibratorList>
 				</xtce:IntegerDataEncoding>
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="SWP_HK.P2_5_V" signed="true">
@@ -518,7 +542,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="5" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="7.8125e-07" exponent="1" />
+							<xtce:Term coefficient="0.78125" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -865,7 +889,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="0" />
+							<xtce:Term coefficient="1.0" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -894,8 +918,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="signed">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="-30.0063752836787" exponent="0" />
-							<xtce:Term coefficient="-0.4269107500560838" exponent="1" />
+							<xtce:Term coefficient="-30.61649427962872" exponent="0" />
+							<xtce:Term coefficient="-0.4280400183093689" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -904,8 +928,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="signed">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="-101.0927208994075" exponent="0" />
-							<xtce:Term coefficient="-0.2013535930625734" exponent="1" />
+							<xtce:Term coefficient="-100.8243287975546" exponent="0" />
+							<xtce:Term coefficient="-0.201881204826273" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -939,12 +963,36 @@
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="SWP_SCI.ESA_LVL5" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="13" encoding="unsigned">
-					<xtce:DefaultCalibrator>
-						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="-2.154606659914435" exponent="0" />
-							<xtce:Term coefficient="0.2503956575681914" exponent="1" />
-						</xtce:PolynomialCalibrator>
-					</xtce:DefaultCalibrator>
+					<xtce:ContextCalibratorList>
+						<xtce:ContextCalibrator>
+							<xtce:ContextMatch>
+								<xtce:ComparisonList>
+									<xtce:Comparison comparisonOperator="&gt;=" value="0" parameterRef="SWP_SCI.ESA_LVL5" useCalibratedValue="false" />
+									<xtce:Comparison comparisonOperator="&lt;=" value="4095" parameterRef="SWP_SCI.ESA_LVL5" useCalibratedValue="false" />
+								</xtce:ComparisonList>
+							</xtce:ContextMatch>
+							<xtce:Calibrator>
+								<xtce:PolynomialCalibrator>
+									<xtce:Term coefficient="-2.154606659914435" exponent="0" />
+									<xtce:Term coefficient="0.2503956575681914" exponent="1" />
+								</xtce:PolynomialCalibrator>
+							</xtce:Calibrator>
+						</xtce:ContextCalibrator>
+						<xtce:ContextCalibrator>
+							<xtce:ContextMatch>
+								<xtce:ComparisonList>
+									<xtce:Comparison comparisonOperator="&gt;=" value="4096" parameterRef="SWP_SCI.ESA_LVL5" useCalibratedValue="false" />
+									<xtce:Comparison comparisonOperator="&lt;=" value="8191" parameterRef="SWP_SCI.ESA_LVL5" useCalibratedValue="false" />
+								</xtce:ComparisonList>
+							</xtce:ContextMatch>
+							<xtce:Calibrator>
+								<xtce:PolynomialCalibrator>
+									<xtce:Term coefficient="-10281.21885237313" exponent="0" />
+									<xtce:Term coefficient="2.505531522417014" exponent="1" />
+								</xtce:PolynomialCalibrator>
+							</xtce:Calibrator>
+						</xtce:ContextCalibrator>
+					</xtce:ContextCalibratorList>
 				</xtce:IntegerDataEncoding>
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="SWP_SCI.SPARE_2" signed="false">
@@ -1169,10 +1217,10 @@
 				<xtce:LongDescription>WHICH LUT IS IN USE</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.PCEM_SAFE" parameterTypeRef="SWP_HK.PCEM_SAFE">
-				<xtce:LongDescription>IF THE CEM INTERRUPT OCCURS AND DIPPING THE SUPPLIES DOES NOT HELP WITHIN 3 (TBR) CONSECUTIVE SAMPLES THEN SWAPI IS SAFED.</xtce:LongDescription>
+				<xtce:LongDescription>INDICATES THE INSTRUMENT SAFED DUE TO PERSISTENT PCEM CURRENT INTERRUPT</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.SCEM_SAFE" parameterTypeRef="SWP_HK.SCEM_SAFE">
-				<xtce:LongDescription>IF THE CEM INTERRUPT OCCURS AND DIPPING THE SUPPLIES DOES NOT HELP WITHIN 3 (TBR) CONSECUTIVE SAMPLES THEN SWAPI IS SAFED.</xtce:LongDescription>
+				<xtce:LongDescription>INDICATES THE INSTRUMENT SAFED DUE TO PERSISTENT SCEM CURRENT INTERRUPT</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.WDT_ST" parameterTypeRef="SWP_HK.WDT_ST">
 				<xtce:LongDescription>SWAPI HAS REBOOTED DUE TO A WATCHDOG EXPIRATION.</xtce:LongDescription>
@@ -1184,16 +1232,16 @@
 				<xtce:LongDescription>SWAPI HAS SAFED ITSELF.  THE CAUSE WOULD BE DUE TO ONE OF THE FOLLOWING STATUS BITS.</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.PCEM_RATE_ST" parameterTypeRef="SWP_HK.PCEM_RATE_ST">
-				<xtce:LongDescription>THE COUNT RATE THRESHOLD FOR THE PCEM COUNTER HAS BEEN EXCEEDED ONCE AND HAS CONTINUED TO BE EXCEEDED DESPITE MEASURES BY SWAPIFW. THE PCEM COUNT RATE THRESHOLD DEFAULTS TO TBD BUT CAN BE UPDATED WITH COMMAND TBD.</xtce:LongDescription>
+				<xtce:LongDescription>THE COUNT RATE THRESHOLD FOR THE PCEM COUNTER HAS BEEN EXCEEDED ONCE AND HAS CONTINUED TO BE EXCEEDED DESPITE MEASURES BY SWAPIFW. THE PCEM COUNT RATE THRESHOLD DEFAULTS TO 0XFFFF (~6MHZ) AND CAN BE UPDATED WITH COMMAND SWP_PCEM_CNT_LIM_SET</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.SCEM_RATE_ST" parameterTypeRef="SWP_HK.SCEM_RATE_ST">
-				<xtce:LongDescription>THE COUNT RATE THRESHOLD FOR THE SCEM COUNTER HAS BEEN EXCEEDED ONCE AND HAS CONTINUED TO BE EXCEEDED DESPITE MEASURES BY SWAPIFW. THE SCEM COUNT RATE THRESHOLD DEFAULTS TO TBD BUT CAN BE UPDATED WITH COMMAND TBD.</xtce:LongDescription>
+				<xtce:LongDescription>THE COUNT RATE THRESHOLD FOR THE SCEM COUNTER HAS BEEN EXCEEDED ONCE AND HAS CONTINUED TO BE EXCEEDED DESPITE MEASURES BY SWAPIFW. THE SCEM COUNT RATE THRESHOLD DEFAULTS TO 0XFFFF (~6MHZ) AND CAN BE UPDATED WITH COMMAND SWP_SCEM_CNT_LIM_SET</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.PCEM_I_ST" parameterTypeRef="SWP_HK.PCEM_I_ST">
-				<xtce:LongDescription>THE CURRENT THRESHOLD FOR THE PCEM HAS BEEN EXCEEDED ONCE AND HAS CONTINUED TO BE EXCEEDED DESPITE MEASURES BY SWAPIFW.  AN OVERCURRENT ON THE CEM'S COLLECTIVELY TRIPS AN INTERRUPT WHICH THE SWAPIFW HANDLES.  THE SWAPIFW ALSO COLLECTS THE PCEM CURRENT MONITOR FOR COMPARISON AT 1 HZ. THE CEM CURRENT RATE THRESHOLD DEFAULTS TO TBD BUT CAN BE UPDATED WITH COMMAND TBD.</xtce:LongDescription>
+				<xtce:LongDescription>THE CURRENT THRESHOLD FOR THE PCEM HAS BEEN EXCEEDED ONCE AND HAS CONTINUED TO BE EXCEEDED DESPITE MEASURES BY SWAPIFW.  AN OVERCURRENT ON THE CEM'S COLLECTIVELY TRIPS AN INTERRUPT WHICH THE SWAPIFW HANDLES.  THE SWAPIFW ALSO COLLECTS THE PCEM CURRENT MONITOR FOR COMPARISON AT 1 HZ. THE CEM CURRENT THRESHOLD DEFAULTS TO 0X7FE (EFFECTIVELY DISABLED) AND CAN BE UPDATED WITH COMMAND SWP_PCEM_I_LIM_SET</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.SCEM_I_ST" parameterTypeRef="SWP_HK.SCEM_I_ST">
-				<xtce:LongDescription>THE CURRENT THRESHOLD FOR THE SCEM HAS BEEN EXCEEDED ONCE AND HAS CONTINUED TO BE EXCEEDED DESPITE MEASURES BY SWAPIFW.  AN OVERCURRENT ON THE CEMS COLLECTIVELY TRIPS AN INTERRUPT WHICH THE SWAPIFW HANDLES.  THE SWAPIFW ALSO COLLECTS THE SCEM CURRENT MONITOR FOR COMPARISON AT 1 HZ. THE CEM CURRENT RATE THRESHOLD DEFAULTS TO TBD BUT CAN BE UPDATED WITH COMMAND TBD.</xtce:LongDescription>
+				<xtce:LongDescription>THE CURRENT THRESHOLD FOR THE SCEM HAS BEEN EXCEEDED ONCE AND HAS CONTINUED TO BE EXCEEDED DESPITE MEASURES BY SWAPIFW.  AN OVERCURRENT ON THE CEMS COLLECTIVELY TRIPS AN INTERRUPT WHICH THE SWAPIFW HANDLES.  THE SWAPIFW ALSO COLLECTS THE SCEM CURRENT MONITOR FOR COMPARISON AT 1 HZ. THE CEM CURRENT  THRESHOLD DEFAULTS TO 0X7FE (EFFECTIVELY DISABLED) AND CAN BE UPDATED WITH COMMAND SWP_SCEM_I_LIM_SET</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.PCEM_V_ST" parameterTypeRef="SWP_HK.PCEM_V_ST">
 				<xtce:LongDescription>THE VOLTAGE TOLERANCE FOR THE PCEM FOR ITS CURRENT SETTING HAS BEEN EXCEEDED. THE PCEM VOLTAGE TOLERANCE IS SET BY SWAPIFW AND CANNOT BE ALTERED BY COMMAND.</xtce:LongDescription>
@@ -1301,7 +1349,7 @@
 				<xtce:LongDescription>VOLT MON OF ANALOG GROUND.</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.CEM_I" parameterTypeRef="SWP_HK.CEM_I">
-				<xtce:LongDescription>THE CURRENT LIMIT MONITOR FOR THE PCEM AND SCEM AT WHICH THE SWAPI SOFTWARE BRINGS DOWN THE PCEM AND SCEM BY TBD VOLTS FOR TBD SECONDS BEFORE THEY ARE BROUGHT BACK UP.</xtce:LongDescription>
+				<xtce:LongDescription>THE CURRENT LIMIT MONITOR FOR THE PCEM AND SCEM AT WHICH THE SWAPI SOFTWARE REDUCES THE PCEM AND SCEM VOLTAGE FOR A SHORT TIME.</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SWP_HK.ESA_V" parameterTypeRef="SWP_HK.ESA_V">
 				<xtce:LongDescription>VOLT MON OF ELECTROSTATIC ANALYZER HIGH-VOLTAGE POWER SUPPLY.</xtce:LongDescription>

--- a/imap_processing/swapi/packet_definitions/swapi_packet_definition.xml
+++ b/imap_processing/swapi/packet_definitions/swapi_packet_definition.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="SWP">
-	<xtce:Header date="09/05/2025" version="1" author="IMAP SDC" source_file="TLM_SWP.xlsx" />
+	<xtce:Header date="09/05/2025" version="1" author="IMAP SDC" source_file="TLM_SWP.xlsx, commit: 2893c15b050" />
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="VERSION" signed="false">

--- a/imap_processing/tests/swapi/test_swapi_l1.py
+++ b/imap_processing/tests/swapi/test_swapi_l1.py
@@ -205,9 +205,12 @@ def test_swapi_l1_cdf(mock_get_file_paths, swapi_l0_test_data_path):
     )
     processed_data = swapi_l1(collection_obj)
     # hk cdf file
-    hk_cdf_filename = "imap_swapi_l1_hk_20240924_v999.cdf"
+    l1a_hk_cdf_filename = "imap_swapi_l1a_hk_20240924_v999.cdf"
     hk_cdf_path = write_cdf(processed_data[0])
-    assert hk_cdf_path.name == hk_cdf_filename
+    assert hk_cdf_path.name == l1a_hk_cdf_filename
+    l1b_hk_cdf_filename = "imap_swapi_l1b_hk_20240924_v999.cdf"
+    l1b_hk_cdf_path = write_cdf(processed_data[1])
+    assert l1b_hk_cdf_path.name == l1b_hk_cdf_filename
 
     # Mock paths of files to be processed
     def second_get_file_paths_side_effect(descriptor):
@@ -221,7 +224,7 @@ def test_swapi_l1_cdf(mock_get_file_paths, swapi_l0_test_data_path):
     mock_get_file_paths.side_effect = second_get_file_paths_side_effect
     processing_input = [
         {"type": "science", "files": ["imap_swapi_l0_raw_20240924_v001.pkts"]},
-        {"type": "science", "files": ["imap_swapi_l1_hk_20240924_v999.cdf"]},
+        {"type": "science", "files": ["imap_swapi_l1a_hk_20240924_v999.cdf"]},
     ]
     collection_obj = ProcessingInputCollection()
     collection_obj.deserialize(

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -83,7 +83,7 @@ def test_swapi_l2_cdf(
     )
     # Create HK CDF File
     processed_hk_data = swapi_l1(collection_obj)
-    hk_cdf_filename = "imap_swapi_l1_hk_20240924_v999.cdf"
+    hk_cdf_filename = "imap_swapi_l1a_hk_20240924_v999.cdf"
     hk_cdf_path = write_cdf(processed_hk_data[0])
     assert hk_cdf_path.name == hk_cdf_filename
 
@@ -99,7 +99,7 @@ def test_swapi_l2_cdf(
     mock_get_file_paths.side_effect = second_get_file_paths_side_effect
     processing_input = [
         {"type": "science", "files": ["imap_swapi_l0_raw_20240924_v001.pkts"]},
-        {"type": "science", "files": ["imap_swapi_l1_hk_20240924_v999.cdf"]},
+        {"type": "science", "files": ["imap_swapi_l1a_hk_20240924_v999.cdf"]},
     ]
     collection_obj = ProcessingInputCollection()
     collection_obj.deserialize(


### PR DESCRIPTION
# Change Summary
closes #1589 #1778 

## Overview
updated:
1. both science and HK packets to use new feature of `imap_xtce` to be able to set proper segmented logics.
2. to produce l1a and l1b HK data files
3. valid SWAPI data levels
4. added string attrs for l1b derived string data.

## Updated Files
- imap_processing/__init__.py
- imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
- imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
- imap_processing/swapi/l1/swapi_l1.py
- imap_processing/swapi/packet_definitions/swapi_packet_definition.xml

## Testing
- imap_processing/tests/swapi/test_swapi_l1.py
- imap_processing/tests/swapi/test_swapi_l2.py
