### PR TITLE
Lo L2 - Added L2 CLI processing and ISTP fixes

### DIFF
--- a/imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
@@ -77,8 +77,8 @@ imap_lo_l1c_pset:
   Logical_source: imap_lo_l1c_pset
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1C Data
 
-imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-1yr:
+imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-3mo:
     <<: *instrument_base
-    Data_type: L2_l090-ena-h-sf-nsp-ram-hae-6deg-1yr>Level-2 Low-Energy ENA Maps
-    Logical_source: imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-1yr
+    Data_type: L2_l090-ena-h-sf-nsp-ram-hae-6deg-3mo>Level-2 Low-Energy ENA Maps
+    Logical_source: imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-3mo
     Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-2 Low-Energy ENA Maps

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -66,6 +66,7 @@ from imap_processing.idex.idex_l2c import idex_l2c
 from imap_processing.lo.l1a import lo_l1a
 from imap_processing.lo.l1b import lo_l1b
 from imap_processing.lo.l1c import lo_l1c
+from imap_processing.lo.l2 import lo_l2
 from imap_processing.mag.l1a.mag_l1a import mag_l1a
 from imap_processing.mag.l1b.mag_l1b import mag_l1b
 from imap_processing.mag.l1c.mag_l1c import mag_l1c
@@ -962,15 +963,28 @@ class Lo(ProcessInstrument):
 
         elif self.data_level == "l1c":
             data_dict = {}
-            anc_depedencies: list = dependencies.get_file_paths(
+            anc_dependencies: list = dependencies.get_file_paths(
                 source="lo", descriptor="goodtimes"
             )
             science_files = dependencies.get_file_paths(source="lo", descriptor="de")
             for file in science_files:
                 dataset = load_cdf(file)
                 data_dict[dataset.attrs["Logical_source"]] = dataset
-            datasets = lo_l1c.lo_l1c(data_dict, anc_depedencies)
+            datasets = lo_l1c.lo_l1c(data_dict, anc_dependencies)
 
+        elif self.data_level == "l2":
+            data_dict = {}
+            # TODO: Add ancillary descriptors when maps using them are
+            #  implemented.
+            anc_dependencies = dependencies.get_file_paths(
+                source="lo",
+            )
+            science_files = dependencies.get_file_paths(source="lo", descriptor="pset")
+            psets = []
+            for file in science_files:
+                psets.append(load_cdf(file))
+            data_dict[psets[0].attrs["Logical_source"]] = psets
+            datasets = lo_l2.lo_l2(data_dict, anc_dependencies)
         return datasets
 
 

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -84,18 +84,7 @@ def project_pset_to_rect_map(
         spacing_deg=spacing_deg,
         spice_frame=spice_frame,
     )
-    print("PSET", psets)
     for pset in psets:
-        # Put energy dim before longitude and latitude
-        # TODO: L1C data should be in this format already.
-        #  This is a workaround for the current L1C data format.
-        for data_var in pset.data_vars:
-            if "energy" in pset[data_var].dims:
-                # move dim2 to before dim0 and dim1
-                pset[data_var] = pset[data_var].transpose(
-                    "epoch", "energy", "longitude", "latitude"
-                )
-
         lo_pset = ena_maps.LoPointingSet(pset)
         lo_rect_map.project_pset_values_to_map(
             pointing_set=lo_pset,
@@ -156,7 +145,7 @@ def add_attributes(
     lo_map: xr.Dataset, attr_mgr: ImapCdfAttributes, logical_source: str
 ) -> xr.Dataset:
     """
-    Add attributes to the dataset.
+    Add attributes to the map dataset.
 
     Parameters
     ----------
@@ -181,6 +170,7 @@ def add_attributes(
     #  to the attributes or if general ena intensities can be used or updated
     #  in the code. This dictionary is temporary solution for SIT-4
     map_fields = {
+        "epoch": "epoch",
         "h_flux": "ena_intensity",
         "h_rate": "ena_rate",
         "h_counts": "ena_count",
@@ -199,7 +189,6 @@ def add_attributes(
             lo_map[field].attrs.update(
                 attr_mgr.get_variable_attributes(attr_name, check_schema=False)
             )
-            print(f"{field}: {lo_map[field].attrs}")
 
     labels = {
         "energy": np.arange(1, 8).astype(str),

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -50,85 +50,8 @@ def lo_l2(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         # Create the dataset from the rectangular map.
         lo_rect_map_ds = lo_rect_map.to_dataset()
         # Add the attributes to the dataset.
-        # TODO: Temp quick fix for SIT-4. Pull into function and test after SIT-4.
-        lo_rect_map_ds.attrs.update(attr_mgr.get_global_attributes(logical_source))
-
-        # TODO: Lo is using different field names than what's in the attributes.
-        #  check if the Lo should use exposure factor instead of exposure time.
-        #  check if hydrogen and oxygen specific ena intensities should be added
-        #  to the attributes or if general ena intensities can be used or updated
-        #  in the code.
-        lo_rect_map_ds.h_flux.attrs.update(
-            attr_mgr.get_variable_attributes("ena_intensity")
-        )
-        lo_rect_map_ds.h_rate.attrs.update(attr_mgr.get_variable_attributes("ena_rate"))
-        lo_rect_map_ds.h_counts.attrs.update(
-            attr_mgr.get_variable_attributes("ena_count")
-        )
-        lo_rect_map_ds.exposure_time.attrs.update(
-            attr_mgr.get_variable_attributes("exposure_factor")
-        )
-        lo_rect_map_ds.energy.attrs.update(attr_mgr.get_variable_attributes("energy"))
-        lo_rect_map_ds.solid_angle.attrs.update(
-            attr_mgr.get_variable_attributes("solid_angle")
-        )
-        lo_rect_map_ds.longitude.attrs.update(
-            attr_mgr.get_variable_attributes("longitude")
-        )
-        lo_rect_map_ds.latitude.attrs.update(
-            attr_mgr.get_variable_attributes("latitude")
-        )
-
-        lo_rect_map_ds = lo_rect_map_ds.assign_coords(
-            {
-                "energy_label": xr.DataArray(
-                    np.arange(1, 8).astype(str),
-                    name="energy_label",
-                    dims=["energy"],
-                    attrs=attr_mgr.get_variable_attributes(
-                        "energy_label", check_schema=False
-                    ),
-                )
-            }
-        )
-
-        lo_rect_map_ds = lo_rect_map_ds.assign_coords(
-            {
-                "longitude_label": xr.DataArray(
-                    lo_rect_map_ds["longitude"].values.astype(str),
-                    name="longitude_label",
-                    dims=["longitude"],
-                    attrs=attr_mgr.get_variable_attributes(
-                        "longitude_label", check_schema=False
-                    ),
-                )
-            }
-        )
-
-        lo_rect_map_ds = lo_rect_map_ds.assign_coords(
-            {
-                "latitude_label": xr.DataArray(
-                    lo_rect_map_ds["latitude"].values.astype(str),
-                    name="latitude_label",
-                    dims=["latitude"],
-                    attrs=attr_mgr.get_variable_attributes(
-                        "latitude_label", check_schema=False
-                    ),
-                )
-            }
-        )
-
-        lo_rect_map_ds = lo_rect_map_ds.assign_coords(
-            {
-                "energy_label": xr.DataArray(
-                    np.arange(1, 8).astype(str),
-                    name="energy_label",
-                    dims=["energy"],
-                    attrs=attr_mgr.get_variable_attributes(
-                        "energy_label", check_schema=False
-                    ),
-                )
-            }
+        lo_rect_map_ds = add_attributes(
+            lo_rect_map_ds, attr_mgr, logical_source=logical_source
         )
 
     return [lo_rect_map_ds]
@@ -227,3 +150,75 @@ def calculate_fluxes(rates: xr.DataArray) -> xr.DataArray:
 
     flux = rates / (geometric_factor * energies * efficiency_factor)
     return flux
+
+
+def add_attributes(
+    lo_map: xr.Dataset, attr_mgr: ImapCdfAttributes, logical_source: str
+) -> xr.Dataset:
+    """
+    Add attributes to the dataset.
+
+    Parameters
+    ----------
+    lo_map : xr.Dataset
+        The dataset to add attributes to.
+    attr_mgr : ImapCdfAttributes
+        The attribute manager to use for adding attributes.
+    logical_source : str
+        The logical source for the dataset.
+
+    Returns
+    -------
+    xr.Dataset
+        The dataset with added attributes.
+    """
+    # Add the global attributes to the dataset.
+    lo_map.attrs.update(attr_mgr.get_global_attributes(logical_source))
+
+    # TODO: Lo is using different field names than what's in the attributes.
+    #  check if the Lo should use exposure factor instead of exposure time.
+    #  check if hydrogen and oxygen specific ena intensities should be added
+    #  to the attributes or if general ena intensities can be used or updated
+    #  in the code. This dictionary is temporary solution for SIT-4
+    map_fields = {
+        "h_flux": "ena_intensity",
+        "h_rate": "ena_rate",
+        "h_counts": "ena_count",
+        "exposure_time": "exposure_factor",
+        "energy": "energy",
+        "solid_angle": "solid_angle",
+        "longitude": "longitude",
+        "latitude": "latitude",
+    }
+
+    # TODO: The mapping utility is supposed to handle at least some of these
+    #  attributes but is not working. Need to investigate this after SIT-4
+    # Add the attributes to the dataset variables.
+    for field, attr_name in map_fields.items():
+        if field in lo_map.data_vars or field in lo_map.coords:
+            lo_map[field].attrs.update(
+                attr_mgr.get_variable_attributes(attr_name, check_schema=False)
+            )
+            print(f"{field}: {lo_map[field].attrs}")
+
+    labels = {
+        "energy": np.arange(1, 8).astype(str),
+        "longitude": lo_map["longitude"].values.astype(str),
+        "latitude": lo_map["latitude"].values.astype(str),
+    }
+    # add the coordinate labels to the dataset
+    for dim, values in labels.items():
+        lo_map = lo_map.assign_coords(
+            {
+                f"{dim}_label": xr.DataArray(
+                    values,
+                    name=f"{dim}_label",
+                    dims=[dim],
+                    attrs=attr_mgr.get_variable_attributes(
+                        f"{dim}_label", check_schema=False
+                    ),
+                )
+            }
+        )
+
+    return lo_map

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -34,7 +34,7 @@ def lo_l2(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
 
     # if the dependencies are used to create Annotated Direct Events
     if "imap_lo_l1c_pset" in sci_dependencies:
-        logical_source = "imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-1yr"
+        logical_source = "imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-3mo"
         psets = sci_dependencies["imap_lo_l1c_pset"]
 
         # Create the rectangular sky map from the pointing set.
@@ -68,6 +68,68 @@ def lo_l2(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         lo_rect_map_ds.exposure_time.attrs.update(
             attr_mgr.get_variable_attributes("exposure_factor")
         )
+        lo_rect_map_ds.energy.attrs.update(attr_mgr.get_variable_attributes("energy"))
+        lo_rect_map_ds.solid_angle.attrs.update(
+            attr_mgr.get_variable_attributes("solid_angle")
+        )
+        lo_rect_map_ds.longitude.attrs.update(
+            attr_mgr.get_variable_attributes("longitude")
+        )
+        lo_rect_map_ds.latitude.attrs.update(
+            attr_mgr.get_variable_attributes("latitude")
+        )
+
+        lo_rect_map_ds = lo_rect_map_ds.assign_coords(
+            {
+                "energy_label": xr.DataArray(
+                    np.arange(1, 8).astype(str),
+                    name="energy_label",
+                    dims=["energy"],
+                    attrs=attr_mgr.get_variable_attributes(
+                        "energy_label", check_schema=False
+                    ),
+                )
+            }
+        )
+
+        lo_rect_map_ds = lo_rect_map_ds.assign_coords(
+            {
+                "longitude_label": xr.DataArray(
+                    lo_rect_map_ds["longitude"].values.astype(str),
+                    name="longitude_label",
+                    dims=["longitude"],
+                    attrs=attr_mgr.get_variable_attributes(
+                        "longitude_label", check_schema=False
+                    ),
+                )
+            }
+        )
+
+        lo_rect_map_ds = lo_rect_map_ds.assign_coords(
+            {
+                "latitude_label": xr.DataArray(
+                    lo_rect_map_ds["latitude"].values.astype(str),
+                    name="latitude_label",
+                    dims=["latitude"],
+                    attrs=attr_mgr.get_variable_attributes(
+                        "latitude_label", check_schema=False
+                    ),
+                )
+            }
+        )
+
+        lo_rect_map_ds = lo_rect_map_ds.assign_coords(
+            {
+                "energy_label": xr.DataArray(
+                    np.arange(1, 8).astype(str),
+                    name="energy_label",
+                    dims=["energy"],
+                    attrs=attr_mgr.get_variable_attributes(
+                        "energy_label", check_schema=False
+                    ),
+                )
+            }
+        )
 
     return [lo_rect_map_ds]
 
@@ -99,6 +161,7 @@ def project_pset_to_rect_map(
         spacing_deg=spacing_deg,
         spice_frame=spice_frame,
     )
+    print("PSET", psets)
     for pset in psets:
         # Put energy dim before longitude and latitude
         # TODO: L1C data should be in this format already.

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -2,7 +2,9 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.lo.l2.lo_l2 import (
+    add_attributes,
     calculate_fluxes,
     calculate_rates,
     lo_l2,
@@ -13,27 +15,62 @@ from imap_processing.spice import geometry
 
 @pytest.fixture
 def pset():
-    h_counts = np.zeros((1, 3600, 40, 7))
-    h_counts[:, :, 0:10, :] = 1
+    h_counts = np.zeros((1, 7, 3600, 40))
+    h_counts[:, :, :, 0:10] = 1
 
-    exposure_time = np.full((1, 3600, 40, 7), 0.5)
+    exposure_time = np.full((1, 7, 3600, 40), 0.5)
 
     dataset = xr.Dataset(
         {
-            "h_counts": (("epoch", "longitude", "latitude", "energy"), h_counts),
+            "h_counts": (("epoch", "energy", "longitude", "latitude"), h_counts),
             "exposure_time": (
-                ("epoch", "longitude", "latitude", "energy"),
+                ("epoch", "energy", "longitude", "latitude"),
                 exposure_time,
             ),
         },
         coords={
             "epoch": [8.1794907049e17],
+            "energy": [i for i in range(1, 8)],
             "longitude": [i for i in range(3600)],
             "latitude": [i for i in range(40)],
+        },
+    )
+    return dataset
+
+
+@pytest.fixture
+def map():
+    fake_field = np.zeros((1, 7, 60, 30))
+    exposure_time = np.full((1, 7, 60, 30), 0.5)
+
+    dataset = xr.Dataset(
+        {
+            "h_counts": (("epoch", "energy", "longitude", "latitude"), fake_field),
+            "exposure_time": (
+                ("epoch", "energy", "longitude", "latitude"),
+                exposure_time,
+            ),
+            "h_rate": (("epoch", "energy", "longitude", "latitude"), fake_field),
+            "h_flux": (("epoch", "energy", "longitude", "latitude"), fake_field),
+            "solid_angle": (("epoch", "energy", "longitude", "latitude"), fake_field),
+        },
+        coords={
+            "epoch": [8.1794907049e17],
+            "longitude": [i for i in range(60)],
+            "latitude": [i for i in range(30)],
             "energy": [i for i in range(1, 8)],
         },
     )
     return dataset
+
+
+@pytest.fixture
+def attr_mgr():
+    attr_mgr = ImapCdfAttributes()
+    attr_mgr.add_instrument_global_attrs(instrument="lo")
+    attr_mgr.add_instrument_variable_attrs(instrument="enamaps", level="l2-common")
+    attr_mgr.add_instrument_variable_attrs(instrument="enamaps", level="l2-rectangular")
+    return attr_mgr
 
 
 @pytest.mark.external_kernel
@@ -99,9 +136,35 @@ def test_lo_l2(pset):
     assert len(hflux_map) == 1
     assert (
         hflux_map[0].attrs["Logical_source"]
-        == "imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-1yr"
+        == "imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-3mo"
     )
     data_vars = ["h_counts", "exposure_time", "h_rate", "h_flux", "solid_angle"]
     for var in data_vars:
         assert var in hflux_map[0].data_vars, f"Variable {var} not found in dataset"
     assert hflux_map[0].data_vars["h_rate"].shape == (1, 7, 60, 30)
+
+
+def test_add_attributes(map, attr_mgr):
+    # Arrange
+    logical_source = "imap_lo_l2_l090-ena-h-sf-nsp-ram-hae-6deg-3mo"
+
+    map_fields = {
+        "epoch": "epoch",
+        "h_flux": "ena_intensity",
+        "h_rate": "ena_rate",
+        "h_counts": "ena_count",
+        "exposure_time": "exposure_factor",
+        "energy": "energy",
+        "solid_angle": "solid_angle",
+        "longitude": "longitude",
+        "latitude": "latitude",
+    }
+
+    # Act
+    updated_map = add_attributes(map, attr_mgr, logical_source)
+
+    # Assert
+    for field, attr_name in map_fields.items():
+        assert updated_map[field].attrs == attr_mgr.get_variable_attributes(
+            attr_name, check_schema=False
+        )


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds L2 processing to the Lo CLI and makes ISTP fixes

## Updated Files
- imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
   - changed to do a 3mo map for SIT-4
- imap_processing/cli.py
   - added L2 processing
- imap_processing/lo/l2/lo_l2.py
   - created a new function to handle adding the attributes to the map
   - removed the dimension transposing which is no longer needed. The dimension ordering was fixed in L1C in a previous PR.
   
## Testing
- Added unit test for attribute function
- Updated existing L2 unit tests to account for dimension ordering fix in previous PR

Closes #1799 