### PR TITLE
Ultra SIT 4 - Incorporating anc and spice into code

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -334,6 +334,7 @@ spin_start_time:
   LABLAXIS: spin start time
   # TODO: come back to format
   UNITS: s
+  DEPEND_0: spin_number
 
 spin_period:
   <<: *default
@@ -341,6 +342,7 @@ spin_period:
   FIELDNAM: spin_period
   LABLAXIS: spin_period
   UNITS: s
+  DEPEND_0: spin_number
 
 spin_rate:
   <<: *default
@@ -348,6 +350,7 @@ spin_rate:
   FIELDNAM: spin_rate
   LABLAXIS: spin_rate
   UNITS: rpm
+  DEPEND_0: spin_number
 
 rate_start_pulses:
   <<: *default
@@ -424,6 +427,7 @@ quality_attitude:
   LABLAXIS: quality attitude
   # TODO: come back to format
   UNITS: " "
+  DEPEND_0: spin_number
 
 quality_instruments:
   <<: *default_uint16

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -48,7 +48,7 @@ exposure_factor:
   UNITS: seconds
 
 sensitivity:
-  <<: *default
+  <<: *default_float32
   CATDESC: Calibration/sensitivity factor.
   FIELDNAM: sensitivity
   LABLAXIS: sensitivity

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1340,14 +1340,24 @@ class Ultra(ProcessInstrument):
                 science_files = dependencies.get_file_paths(
                     source="ultra", descriptor=input_type.descriptor
                 )
-                if science_files:
+                if science_files and input_type.data_type != "ancillary":
                     dataset = load_cdf(science_files[0])
                     data_dict[dataset.attrs["Logical_source"]] = dataset
-            datasets = ultra_l1b.ultra_l1b(data_dict)
-        elif self.data_level == "l1c":
-            science_paths = dependencies.get_file_paths(source="ultra", data_type="l1b")
             anc_paths = dependencies.get_file_paths(data_type="ancillary")
-            datasets = ultra_l1c.ultra_l1c(load_cdf(science_paths[0]), anc_paths[0])
+            ancillary_files = {f.name: f for f in anc_paths}
+            datasets = ultra_l1b.ultra_l1b(data_dict, ancillary_files)
+        elif self.data_level == "l1c":
+            data_dict = {}
+            for input_type in dependencies.processing_input:
+                science_files = dependencies.get_file_paths(
+                    source="ultra", descriptor=input_type.descriptor
+                )
+                if science_files and input_type.data_type != "ancillary":
+                    dataset = load_cdf(science_files[0])
+                    data_dict[dataset.attrs["Logical_source"]] = dataset
+            anc_paths = dependencies.get_file_paths(data_type="ancillary")
+            ancillary_files = {f.name: f for f in anc_paths}
+            datasets = ultra_l1c.ultra_l1c(data_dict, ancillary_files)
 
         elif self.data_level == "l2":
             all_pset_filepaths = dependencies.get_file_paths(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1348,7 +1348,10 @@ class Ultra(ProcessInstrument):
             datasets = ultra_l1b.ultra_l1b(data_dict, ancillary_files)
         elif self.data_level == "l1c":
             data_dict = {}
+            has_spice = False
             for input_type in dependencies.processing_input:
+                if input_type.input_type == ProcessingInputType.SPICE_FILE:
+                    has_spice = True
                 science_files = dependencies.get_file_paths(
                     source="ultra", descriptor=input_type.descriptor
                 )
@@ -1357,7 +1360,7 @@ class Ultra(ProcessInstrument):
                     data_dict[dataset.attrs["Logical_source"]] = dataset
             anc_paths = dependencies.get_file_paths(data_type="ancillary")
             ancillary_files = {f.name: f for f in anc_paths}
-            datasets = ultra_l1c.ultra_l1c(data_dict, ancillary_files)
+            datasets = ultra_l1c.ultra_l1c(data_dict, ancillary_files, has_spice)
 
         elif self.data_level == "l2":
             all_pset_filepaths = dependencies.get_file_paths(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1335,33 +1335,44 @@ class Ultra(ProcessInstrument):
                 )
             datasets = ultra_l1a.ultra_l1a(science_files[0])
         elif self.data_level == "l1b":
-            data_dict = {}
-            for input_type in dependencies.processing_input:
-                science_files = dependencies.get_file_paths(
-                    source="ultra", descriptor=input_type.descriptor
-                )
-                if science_files and input_type.data_type != "ancillary":
-                    dataset = load_cdf(science_files[0])
-                    data_dict[dataset.attrs["Logical_source"]] = dataset
+            science_files = dependencies.get_file_paths(source="ultra", data_type="l1a")
+            l1a_dict = {
+                dataset.attrs["Logical_source"]: dataset
+                for dataset in [load_cdf(sci_file) for sci_file in science_files]
+            }
+            science_files = dependencies.get_file_paths(source="ultra", data_type="l1b")
+            l1b_dict = {
+                dataset.attrs["Logical_source"]: dataset
+                for dataset in [load_cdf(sci_file) for sci_file in science_files]
+            }
+            combined = {**l1a_dict, **l1b_dict}
             anc_paths = dependencies.get_file_paths(data_type="ancillary")
-            ancillary_files = {f.name: f for f in anc_paths}
-            datasets = ultra_l1b.ultra_l1b(data_dict, ancillary_files)
+            ancillary_files = {}
+            for path in anc_paths:
+                ancillary_files[path.stem.split("_")[2]] = path
+            datasets = ultra_l1b.ultra_l1b(combined, ancillary_files)
         elif self.data_level == "l1c":
-            data_dict = {}
-            has_spice = False
-            for input_type in dependencies.processing_input:
-                if input_type.input_type == ProcessingInputType.SPICE_FILE:
-                    has_spice = True
-                science_files = dependencies.get_file_paths(
-                    source="ultra", descriptor=input_type.descriptor
-                )
-                if science_files and input_type.data_type != "ancillary":
-                    dataset = load_cdf(science_files[0])
-                    data_dict[dataset.attrs["Logical_source"]] = dataset
+            science_files = dependencies.get_file_paths(source="ultra", data_type="l1a")
+            l1a_dict = {
+                dataset.attrs["Logical_source"]: dataset
+                for dataset in [load_cdf(sci_file) for sci_file in science_files]
+            }
+            science_files = dependencies.get_file_paths(source="ultra", data_type="l1b")
+            l1b_dict = {
+                dataset.attrs["Logical_source"]: dataset
+                for dataset in [load_cdf(sci_file) for sci_file in science_files]
+            }
+            combined = {**l1a_dict, **l1b_dict}
             anc_paths = dependencies.get_file_paths(data_type="ancillary")
-            ancillary_files = {f.name: f for f in anc_paths}
-            datasets = ultra_l1c.ultra_l1c(data_dict, ancillary_files, has_spice)
-
+            ancillary_files = {}
+            for path in anc_paths:
+                ancillary_files[path.stem.split("_")[2]] = path
+            spice_paths = dependencies.get_file_paths(data_type="spice")
+            if spice_paths:
+                has_spice = True
+            else:
+                has_spice = False
+            datasets = ultra_l1c.ultra_l1c(combined, ancillary_files, has_spice)
         elif self.data_level == "l2":
             all_pset_filepaths = dependencies.get_file_paths(
                 source="ultra", descriptor="pset"

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1326,30 +1326,22 @@ class Ultra(ProcessInstrument):
         print(f"Processing IMAP-Ultra {self.data_level}")
         datasets: list[xr.Dataset] = []
 
-        dependency_list = dependencies.processing_input
         if self.data_level == "l1a":
-            # File path is expected output file path
-            if len(dependency_list) > 1:
-                raise ValueError(
-                    f"Unexpected dependencies found for ULTRA L1A:"
-                    f"{dependency_list}. Expected only one dependency."
-                )
             science_files = dependencies.get_file_paths(source="ultra")
+            if len(science_files) != 1:
+                raise ValueError(
+                    f"Unexpected science_files found for ULTRA L1A:"
+                    f"{science_files}. Expected only one dependency."
+                )
             datasets = ultra_l1a.ultra_l1a(science_files[0])
-
         elif self.data_level == "l1b":
-            data_dict = {}
-            for dep in dependency_list:
-                dataset = load_cdf(dep.imap_file_paths[0])
-                data_dict[dataset.attrs["Logical_source"]] = dataset
-            datasets = ultra_l1b.ultra_l1b(data_dict)
-
+            science_paths = dependencies.get_file_paths(source="ultra", data_type="l1a")
+            datasets = ultra_l1b.ultra_l1b(load_cdf(science_paths[0]))
+            print("hi")
         elif self.data_level == "l1c":
-            data_dict = {}
-            for dep in dependency_list:
-                dataset = load_cdf(dep.imap_file_paths[0])
-                data_dict[dataset.attrs["Logical_source"]] = dataset
-            datasets = ultra_l1c.ultra_l1c(data_dict)
+            science_paths = dependencies.get_file_paths(source="ultra", data_type="l1b")
+            anc_paths = dependencies.get_file_paths(data_type="ancillary")
+            datasets = ultra_l1c.ultra_l1c(load_cdf(science_paths[0]), anc_paths[0])
 
         elif self.data_level == "l2":
             all_pset_filepaths = dependencies.get_file_paths(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1335,9 +1335,15 @@ class Ultra(ProcessInstrument):
                 )
             datasets = ultra_l1a.ultra_l1a(science_files[0])
         elif self.data_level == "l1b":
-            science_paths = dependencies.get_file_paths(source="ultra", data_type="l1a")
-            datasets = ultra_l1b.ultra_l1b(load_cdf(science_paths[0]))
-            print("hi")
+            data_dict = {}
+            for input_type in dependencies.processing_input:
+                science_files = dependencies.get_file_paths(
+                    source="ultra", descriptor=input_type.descriptor
+                )
+                if science_files:
+                    dataset = load_cdf(science_files[0])
+                    data_dict[dataset.attrs["Logical_source"]] = dataset
+            datasets = ultra_l1b.ultra_l1b(data_dict)
         elif self.data_level == "l1c":
             science_paths = dependencies.get_file_paths(source="ultra", data_type="l1b")
             anc_paths = dependencies.get_file_paths(data_type="ancillary")

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -239,40 +239,40 @@ def _test_data_paths():
             / "ultra-90_raw_event_data_shortened.csv",
         ),
         (
-            "Ultra_90_DPS_efficiencies_all.csv",
+            "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
             imap_module_directory
             / "tests"
             / "ultra"
             / "data"
             / "l1"
-            / "Ultra_90_DPS_efficiencies_all.csv",
+            / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
         ),
         (
-            "ultra_90_dps_gf.csv",
+            "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
             imap_module_directory
             / "tests"
             / "ultra"
             / "data"
             / "l1"
-            / "ultra_90_dps_gf.csv",
+            / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
         ),
         (
-            "ultra_90_dps_exposure.csv",
+            "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
             imap_module_directory
             / "tests"
             / "ultra"
             / "data"
             / "l1"
-            / "ultra_90_dps_exposure.csv",
+            / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
         ),
         (
-            "Ultra_efficiencies_45_combined_logistic_interpolation.csv",
+            "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv",
             imap_module_directory
             / "tests"
             / "ultra"
             / "data"
             / "l1"
-            / "Ultra_efficiencies_45_combined_logistic_interpolation.csv",
+            / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv",
         ),
     ]
 

--- a/imap_processing/tests/test_utils.py
+++ b/imap_processing/tests/test_utils.py
@@ -6,6 +6,7 @@ import pytest
 import xarray as xr
 
 from imap_processing import imap_module_directory, utils
+from imap_processing.ultra.utils.ultra_l1_utils import extract_data_dict
 
 
 def test_convert_raw_to_eu(tmp_path):
@@ -230,3 +231,31 @@ def test_packet_file_to_datasets_flat_definition():
     )
     with pytest.raises(ValueError, match="Packet fields do not match"):
         utils.packet_file_to_datasets(packet_files, packet_definition)
+
+
+def test_extract_data_dict():
+    """Test extract_data_dict function."""
+    data_vars = {
+        "field_a": (["spin_number"], np.array([1, 2, 3])),
+        "field_b": (["spin_number"], np.array([4, 5, 6])),
+    }
+    coords = {
+        "spin_number": np.array([0, 1, 2]),
+        "energy_bin_geometric_mean": np.array([10.0, 20.0, 30.0]),
+        "epoch": np.array(
+            ["2025-01-01", "2025-01-02", "2025-01-03"], dtype="datetime64[ns]"
+        ),
+    }
+    ds = xr.Dataset(data_vars=data_vars, coords=coords)
+
+    result = extract_data_dict(ds)
+
+    assert set(result.keys()) == {
+        "field_a",
+        "field_b",
+        "spin_number",
+        "energy_bin_geometric_mean",
+        "epoch",
+    }
+    np.testing.assert_array_equal(result["field_a"], np.array([1, 2, 3]))
+    np.testing.assert_array_equal(result["spin_number"], np.array([0, 1, 2]))

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -208,12 +208,12 @@ def faux_aux_dataset():
 
     test_aux_dataset = xr.Dataset(
         data_vars={
-            "TIMESPINSTART": ("epoch", spin_start_sec),
-            "TIMESPINSTARTSUB": ("epoch", spin_start_subsec),
-            "DURATION": ("epoch", spin_period_sec),
-            "SPINNUMBER": ("epoch", spin_number),
-            "TIMESPINDATA": ("epoch", spin_start_time),
-            "SPINPERIOD": ("epoch", spin_period_sec),
+            "timespinstart": ("epoch", spin_start_sec),
+            "timespinstartsub": ("epoch", spin_start_subsec),
+            "duration": ("epoch", spin_period_sec),
+            "spinnumber": ("epoch", spin_number),
+            "timespindata": ("epoch", spin_start_time),
+            "spinperiod": ("epoch", spin_period_sec),
         },
         coords={"epoch": ("epoch", epoch)},
     )

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -87,7 +87,7 @@ def test_get_energy_efficiencies():
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary_files = {
-        "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv": path
+        "l1b-45sensor-logistic-interpolation": path
         / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
     }
     u45_efficiencies = get_energy_efficiencies(ancillary_files)

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -85,6 +85,11 @@ def test_get_angular_profiles():
 def test_get_energy_efficiencies():
     """Tests function get_get_energy_efficiencies."""
 
-    u45_efficiencies = get_energy_efficiencies()
+    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+    ancillary_files = {
+        "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv": path
+        / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
+    }
+    u45_efficiencies = get_energy_efficiencies(ancillary_files)
 
     assert u45_efficiencies.shape == (58081, 157)

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -70,12 +70,11 @@ def test_calculate_spacecraft_pset():
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary = {
-        "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv": path
+        "l1c-90sensor-dps-exposure": path
         / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
-        "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv": path
+        "l1c-90sensor-efficiencies": path
         / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
-        "imap_ultra_l1c-90sensor-gf_20250101_v000.csv": path
-        / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+        "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
     }
 
     spacecraft_pset = calculate_spacecraft_pset(
@@ -139,12 +138,11 @@ def test_calculate_spacecraft_pset_with_cdf():
 
         path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
         ancillary = {
-            "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv": path
+            "l1c-90sensor-dps-exposure": path
             / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
-            "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv": path
+            "l1c-90sensor-efficiencies": path
             / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
-            "imap_ultra_l1c-90sensor-gf_20250101_v000.csv": path
-            / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+            "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
         }
 
         spacecraft_pset = calculate_spacecraft_pset(

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -68,11 +68,22 @@ def test_calculate_spacecraft_pset():
         },
     )
 
+    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+    ancillary = {
+        "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
+        "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
+        "imap_ultra_l1c-90sensor-gf_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+    }
+
     spacecraft_pset = calculate_spacecraft_pset(
         test_l1b_de_dataset,
         test_l1b_de_dataset,  # placeholder for extendedspin_dataset
         test_l1b_de_dataset,  # placeholder for cullingmask_dataset
         "imap_ultra_l1c_45sensor-spacecraftpset",
+        ancillary,
     )
     assert "pixel_index" in spacecraft_pset.coords
     assert "epoch" in spacecraft_pset.coords
@@ -126,11 +137,22 @@ def test_calculate_spacecraft_pset_with_cdf():
         name = "imap_ultra_l1b_45sensor-de"
         dataset = create_dataset(de_dict, name, "l1b")
 
+        path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+        ancillary = {
+            "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv": path
+            / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
+            "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv": path
+            / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
+            "imap_ultra_l1c-90sensor-gf_20250101_v000.csv": path
+            / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+        }
+
         spacecraft_pset = calculate_spacecraft_pset(
             dataset,
             xr.Dataset(),  # placeholder for extendedspin_dataset
             xr.Dataset(),  # placeholder for cullingmask_dataset
             "imap_ultra_l1c_45sensor-spacecraftpset",
+            ancillary,
         )
         # TODO: validate with output histogram data once we have it in healpix.
         assert (

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -225,19 +225,14 @@ def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_da
     data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
 
-    l1b_extendedspin_dataset = ultra_l1b(data_dict)
-    l1b_extendedspin_dataset[1].attrs["Data_version"] = "999"
-    l1b_extendedspin_dataset[1].attrs["Repointing"] = "repoint99999"
-    test_data_path = write_cdf(l1b_extendedspin_dataset[1], istp=True)
     ancillary_files = {}
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
 
-    ancillary_files = {}
     cullingmask_dataset = ultra_l1b(
         {"imap_ultra_l1b_45sensor-extendedspin": l1b_extendedspin_dataset[0]},
         ancillary_files,
     )
-    cullingmask_dataset[0].attrs["Data_version"] = "v999"
+    cullingmask_dataset[0].attrs["Data_version"] = "999"
     cullingmask_dataset[0].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(cullingmask_dataset[0], istp=True)
     assert test_data_path.exists()
@@ -264,10 +259,6 @@ def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_datas
     data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
 
-    l1b_extendedspin_dataset = ultra_l1b(data_dict)
-    l1b_extendedspin_dataset[2].attrs["Data_version"] = "999"
-    l1b_extendedspin_dataset[2].attrs["Repointing"] = "repoint99999"
-    test_data_path = write_cdf(l1b_extendedspin_dataset[2], istp=True)
     ancillary_files = {}
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
 
@@ -284,7 +275,7 @@ def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_datas
         },
         ancillary_files,
     )
-    l1b_badtimes_dataset[0].attrs["Data_version"] = "v999"
+    l1b_badtimes_dataset[0].attrs["Data_version"] = "999"
     l1b_badtimes_dataset[0].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(l1b_badtimes_dataset[0], istp=True)
     assert test_data_path.exists()

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -300,5 +300,7 @@ def test_ultra_l1b_error(mock_data_l1a_rates_dict):
         "imap_ultra_l1a_45sensor-rates"
     )
     ancillary_files = {}
-    with pytest.raises(ValueError, match="No matching L1A or L1B data found."):
+    with pytest.raises(
+        ValueError, match="Data dictionary does not contain the expected keys."
+    ):
         ultra_l1b(mock_data_l1a_rates_dict, ancillary_files)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -128,7 +128,12 @@ def test_cdf_de(
 
     mock_get_annotated_particle_velocity.side_effect = side_effect_func
 
-    l1b_de_dataset = ultra_l1b(data_dict)
+    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+    ancillary_files = {
+        "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv": path
+        / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
+    }
+    l1b_de_dataset = ultra_l1b(data_dict, ancillary_files)
 
     assert (
         l1b_de_dataset[0].attrs["Logical_source_description"]
@@ -158,27 +163,20 @@ def test_ultra_l1b_extendedspin(
         key: l1b_de_dataset
         for key in [
             "imap_ultra_l1b_45sensor-de",
-            "imap_ultra_l1a_45sensor-hk",
             "imap_ultra_l1a_45sensor-params",
         ]
     }
     data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
 
-    l1b_extendedspin_dataset = ultra_l1b(data_dict)
+    ancillary_files = {}
+    l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
 
-    assert len(l1b_extendedspin_dataset) == 3
-
-    # Define the suffixes and prefix
-    prefix = "imap_ultra_l1b_45sensor"
-    suffixes = ["extendedspin", "cullingmask", "badtimes"]
-
-    for i in range(len(suffixes)):
-        expected_logical_source = f"{prefix}-{suffixes[i]}"
-        assert (
-            l1b_extendedspin_dataset[i].attrs["Logical_source"]
-            == expected_logical_source
-        )
+    assert len(l1b_extendedspin_dataset) == 1
+    assert (
+        l1b_extendedspin_dataset[0].attrs["Logical_source"]
+        == "imap_ultra_l1b_45sensor-extendedspin"
+    )
 
 
 @pytest.mark.external_test_data
@@ -191,14 +189,14 @@ def test_cdf_extendedspin(use_fake_spin_data_for_time, faux_aux_dataset, rates_d
         key: l1b_de_dataset
         for key in [
             "imap_ultra_l1b_45sensor-de",
-            "imap_ultra_l1a_45sensor-hk",
             "imap_ultra_l1a_45sensor-params",
         ]
     }
     data_dict["imap_ultra_l1a_45sensor-aux"] = faux_aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
 
-    l1b_extendedspin_dataset = ultra_l1b(data_dict)
+    ancillary_files = {}
+    l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
     """Tests that CDF file is created and contains same attributes as xarray."""
     l1b_extendedspin_dataset[0].attrs["Data_version"] = "999"
     l1b_extendedspin_dataset[0].attrs["Repointing"] = "repoint99999"
@@ -221,7 +219,6 @@ def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_da
         key: l1b_de_dataset
         for key in [
             "imap_ultra_l1b_45sensor-de",
-            "imap_ultra_l1a_45sensor-hk",
             "imap_ultra_l1a_45sensor-params",
         ]
     }
@@ -232,6 +229,17 @@ def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_da
     l1b_extendedspin_dataset[1].attrs["Data_version"] = "999"
     l1b_extendedspin_dataset[1].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[1], istp=True)
+    ancillary_files = {}
+    l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
+
+    ancillary_files = {}
+    cullingmask_dataset = ultra_l1b(
+        {"imap_ultra_l1b_45sensor-extendedspin": l1b_extendedspin_dataset[0]},
+        ancillary_files,
+    )
+    cullingmask_dataset[0].attrs["Data_version"] = "v999"
+    cullingmask_dataset[0].attrs["Repointing"] = "repoint99999"
+    test_data_path = write_cdf(cullingmask_dataset[0], istp=True)
     assert test_data_path.exists()
     assert (
         test_data_path.name
@@ -250,7 +258,6 @@ def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_datas
         key: l1b_de_dataset
         for key in [
             "imap_ultra_l1b_45sensor-de",
-            "imap_ultra_l1a_45sensor-hk",
             "imap_ultra_l1a_45sensor-params",
         ]
     }
@@ -261,6 +268,25 @@ def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_datas
     l1b_extendedspin_dataset[2].attrs["Data_version"] = "999"
     l1b_extendedspin_dataset[2].attrs["Repointing"] = "repoint99999"
     test_data_path = write_cdf(l1b_extendedspin_dataset[2], istp=True)
+    ancillary_files = {}
+    l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
+
+    ancillary_files = {}
+    cullingmask_dataset = ultra_l1b(
+        {"imap_ultra_l1b_45sensor-extendedspin": l1b_extendedspin_dataset[0]},
+        ancillary_files,
+    )
+
+    l1b_badtimes_dataset = ultra_l1b(
+        {
+            "imap_ultra_l1b_45sensor-extendedspin": l1b_extendedspin_dataset[0],
+            "imap_ultra_l1b_45sensor-cullingmask": cullingmask_dataset[0],
+        },
+        ancillary_files,
+    )
+    l1b_badtimes_dataset[0].attrs["Data_version"] = "v999"
+    l1b_badtimes_dataset[0].attrs["Repointing"] = "repoint99999"
+    test_data_path = write_cdf(l1b_badtimes_dataset[0], istp=True)
     assert test_data_path.exists()
     assert (
         test_data_path.name
@@ -273,7 +299,6 @@ def test_ultra_l1b_error(mock_data_l1a_rates_dict):
     mock_data_l1a_rates_dict["bad_key"] = mock_data_l1a_rates_dict.pop(
         "imap_ultra_l1a_45sensor-rates"
     )
-    with pytest.raises(
-        ValueError, match="Data dictionary does not contain the expected keys."
-    ):
-        ultra_l1b(mock_data_l1a_rates_dict)
+    ancillary_files = {}
+    with pytest.raises(ValueError, match="No matching L1A or L1B data found."):
+        ultra_l1b(mock_data_l1a_rates_dict, ancillary_files)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -130,7 +130,7 @@ def test_cdf_de(
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary_files = {
-        "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv": path
+        "l1b-45sensor-logistic-interpolation": path
         / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
     }
     l1b_de_dataset = ultra_l1b(data_dict, ancillary_files)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -104,7 +104,7 @@ def test_flag_spin(test_data):
 def test_compare_aux_univ_spin_table(use_fake_spin_data_for_time, faux_aux_dataset):
     """Tests compare_aux_univ_spin_table function."""
     use_fake_spin_data_for_time(0, 15 * 147)
-    spins = faux_aux_dataset["SPINNUMBER"].values
+    spins = faux_aux_dataset["spinnumber"].values
     spin_df = get_spin_data()
 
     result = compare_aux_univ_spin_table(faux_aux_dataset, spins, spin_df)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -61,7 +61,7 @@ def test_flag_attitude(use_fake_spin_data_for_time, faux_aux_dataset):
 
     use_fake_spin_data_for_time(0, 15 * 147)
     quality_flags, spin_rates, spin_period, spin_start_time = flag_attitude(
-        faux_aux_dataset["SPINNUMBER"].values, faux_aux_dataset
+        faux_aux_dataset["spinnumber"].values, faux_aux_dataset
     )
 
     flag = ImapAttitudeUltraFlags(quality_flags[0])

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -587,7 +587,7 @@ def test_get_efficiency():
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary_files = {
-        "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv": path
+        "l1b-45sensor-logistic-interpolation": path
         / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
     }
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -585,7 +585,13 @@ def test_get_efficiency():
     phi = np.array([-60, 60, -60, -50])
     energy = np.array([3, 80, 39.75, 7])
 
-    efficiency = get_efficiency(energy, phi, theta)
+    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+    ancillary_files = {
+        "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv": path
+        / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
+    }
+
+    efficiency = get_efficiency(energy, phi, theta, ancillary_files)
     expected_efficiency = np.array([0.0593281, 0.21803386, 0.0593281, 0.0628940])
 
     np.testing.assert_allclose(efficiency, expected_efficiency, atol=1e-03, rtol=0)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -97,12 +97,11 @@ def test_ultra_l1c(mock_data_l1b_dict):
     """Tests that L1c data is created."""
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary_files = {
-        "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv": path
+        "l1c-90sensor-dps-exposure": path
         / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
-        "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv": path
+        "l1c-90sensor-efficiencies": path
         / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
-        "imap_ultra_l1c-90sensor-gf_20250101_v000.csv": path
-        / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+        "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
     }
 
     output_datasets = ultra_l1c(mock_data_l1b_dict, ancillary_files, has_spice=False)
@@ -184,12 +183,11 @@ def test_calculate_spacecraft_pset_with_cdf():
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary_files = {
-        "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv": path
+        "l1c-90sensor-dps-exposure": path
         / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
-        "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv": path
+        "l1c-90sensor-efficiencies": path
         / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
-        "imap_ultra_l1c-90sensor-gf_20250101_v000.csv": path
-        / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+        "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
     }
 
     output_datasets = ultra_l1c(data_dict, ancillary_files, has_spice=False)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -182,7 +182,17 @@ def test_calculate_spacecraft_pset_with_cdf():
         "imap_ultra_l1b_45sensor-cullingmask": xr.Dataset(),  # placeholder
     }
 
-    output_datasets = ultra_l1c(data_dict)
+    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+    ancillary_files = {
+        "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
+        "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
+        "imap_ultra_l1c-90sensor-gf_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+    }
+
+    output_datasets = ultra_l1c(data_dict, ancillary_files, has_spice=False)
     output_datasets[0].attrs["Data_version"] = "999"
     output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
     test_data_path = write_cdf(output_datasets[0], istp=True)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -95,7 +95,17 @@ def test_create_dataset(mock_data_l1c_dict):
 
 def test_ultra_l1c(mock_data_l1b_dict):
     """Tests that L1c data is created."""
-    output_datasets = ultra_l1c(mock_data_l1b_dict)
+    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+    ancillary_files = {
+        "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
+        "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
+        "imap_ultra_l1c-90sensor-gf_20250101_v000.csv": path
+        / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+    }
+
+    output_datasets = ultra_l1c(mock_data_l1b_dict, ancillary_files, has_spice=False)
 
     assert len(output_datasets) == 1
     assert (
@@ -113,10 +123,11 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
     mock_data_l1b_dict["bad_key"] = mock_data_l1b_dict.pop(
         "imap_ultra_l1a_45sensor-histogram"
     )
+    ancillary_files = {}
     with pytest.raises(
         ValueError, match="Data dictionary does not contain the expected keys."
     ):
-        ultra_l1c(mock_data_l1b_dict)
+        ultra_l1c(mock_data_l1b_dict, ancillary_files, has_spice=False)
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -165,7 +165,9 @@ def test_get_helio_background_rates():
 @pytest.mark.external_test_data
 def test_get_spacecraft_exposure_times():
     """Test get_spacecraft_exposure_times function."""
-    constant_exposure = TEST_PATH / "ultra_90_dps_exposure.csv"
+    constant_exposure = (
+        TEST_PATH / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
+    )
     df_exposure = pd.read_csv(constant_exposure)
     exposure_pointing = get_spacecraft_exposure_times(df_exposure)
     assert exposure_pointing.shape == (196608,)
@@ -187,7 +189,9 @@ def test_get_helio_exposure_times():
 
     mid_time = np.average([start_time, end_time])
 
-    constant_exposure = TEST_PATH / "ultra_90_dps_exposure.csv"
+    constant_exposure = (
+        TEST_PATH / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
+    )
     df_exposure = pd.read_csv(constant_exposure)
 
     helio_exposure = get_helio_exposure_times(mid_time, df_exposure)
@@ -208,8 +212,8 @@ def test_get_helio_exposure_times():
 def test_get_spacecraft_sensitivity():
     """Tests get_spacecraft_sensitivity function."""
     # TODO: remove below here with lookup table aux api
-    efficiencies = TEST_PATH / "Ultra_90_DPS_efficiencies_all.csv"
-    geometric_function = TEST_PATH / "ultra_90_dps_gf.csv"
+    efficiencies = TEST_PATH / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv"
+    geometric_function = TEST_PATH / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv"
 
     df_efficiencies = pd.read_csv(efficiencies)
     df_geometric_function = pd.read_csv(geometric_function)
@@ -259,8 +263,8 @@ def test_get_helio_sensitivity(monkeypatch):
     """Test get_helio_sensitivity function."""
 
     # Load test data
-    efficiencies = TEST_PATH / "Ultra_90_DPS_efficiencies_all.csv"
-    geometric_function = TEST_PATH / "ultra_90_dps_gf.csv"
+    efficiencies = TEST_PATH / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv"
+    geometric_function = TEST_PATH / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv"
     df_efficiencies = pd.read_csv(efficiencies)
     df_geometric_function = pd.read_csv(geometric_function)
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -19,6 +19,7 @@ from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     get_spacecraft_histogram,
     get_spacecraft_sensitivity,
     grid_sensitivity,
+    interpolate_sensitivity,
 )
 
 BASE_PATH = imap_module_directory / "ultra" / "lookup_tables"
@@ -243,9 +244,12 @@ def test_get_spacecraft_sensitivity():
 
     assert np.allclose(result, expected_result, atol=1e-5)
 
-    # Check that out-of-bounds energy returns all NaNs
+    # Check that out-of-bounds energy returns all FILL values
     result = grid_sensitivity(df_efficiencies, df_geometric_function, 2.5)
-    assert np.isnan(result).all()
+    assert np.all(result == -1.0e31)
+
+    result = interpolate_sensitivity(df_efficiencies, df_geometric_function)
+    assert result.shape == (24, 196608)
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -189,7 +189,7 @@ def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
     }
 
     # Add the event data to the expanded dataset.
-    for key in event_data_list[0]:
+    for key in EVENT_FIELD_RANGES:
         expanded_data[key] = np.array([event[key] for event in all_events])
 
     event_ids = get_event_id(expanded_data["shcoarse"])

--- a/imap_processing/ultra/l0/ultra_utils.py
+++ b/imap_processing/ultra/l0/ultra_utils.py
@@ -65,7 +65,6 @@ ULTRA_HK = PacketProperties(
     apid=[
         866,
         867,
-        868,
         869,
         870,
         873,
@@ -74,7 +73,6 @@ ULTRA_HK = PacketProperties(
         877,
         930,
         931,
-        932,
         933,
         934,
         937,
@@ -85,7 +83,6 @@ ULTRA_HK = PacketProperties(
     logical_source=[
         "imap_ultra_l1a_45sensor-alarm",
         "imap_ultra_l1a_45sensor-memchecksum",
-        "imap_ultra_l1a_45sensor-memdump",
         "imap_ultra_l1a_45sensor-status",
         "imap_ultra_l1a_45sensor-bootstatus",
         "imap_ultra_l1a_45sensor-monitorlimits",
@@ -94,7 +91,6 @@ ULTRA_HK = PacketProperties(
         "imap_ultra_l1a_45sensor-imgparams",
         "imap_ultra_l1a_90sensor-alarm",
         "imap_ultra_l1a_90sensor-memchecksum",
-        "imap_ultra_l1a_90sensor-memdump",
         "imap_ultra_l1a_90sensor-status",
         "imap_ultra_l1a_90sensor-bootstatus",
         "imap_ultra_l1a_90sensor-monitorlimits",

--- a/imap_processing/ultra/l1b/badtimes.py
+++ b/imap_processing/ultra/l1b/badtimes.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
 
-from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
+from imap_processing.ultra.utils.ultra_l1_utils import create_dataset, extract_data_dict
 
 FILLVAL_UINT16 = 65535
 FILLVAL_FLOAT64 = -1.0e31
@@ -41,16 +41,7 @@ def calculate_badtimes(
     )
     filtered_dataset = extendedspin_dataset.sel(spin_number=culled_spins)
 
-    data_dict = {
-        var: filtered_dataset[var].values for var in filtered_dataset.data_vars
-    }
-    data_dict.update(
-        {
-            coord: filtered_dataset.coords[coord].values
-            for coord in filtered_dataset.coords
-            if coord in ("spin_number", "energy_bin_geometric_mean", "epoch")
-        }
-    )
+    data_dict = extract_data_dict(filtered_dataset)
 
     badtimes_dataset = create_dataset(data_dict, name, "l1b")
 

--- a/imap_processing/ultra/l1b/badtimes.py
+++ b/imap_processing/ultra/l1b/badtimes.py
@@ -36,10 +36,23 @@ def calculate_badtimes(
     culled_spins = np.setdiff1d(
         extendedspin_dataset["spin_number"].values, cullingmask_spins
     )
-
+    extendedspin_dataset = extendedspin_dataset.assign_coords(
+        epoch=("spin_number", extendedspin_dataset["epoch"].values)
+    )
     filtered_dataset = extendedspin_dataset.sel(spin_number=culled_spins)
 
-    badtimes_dataset = create_dataset(filtered_dataset, name, "l1b")
+    data_dict = {
+        var: filtered_dataset[var].values for var in filtered_dataset.data_vars
+    }
+    data_dict.update(
+        {
+            coord: filtered_dataset.coords[coord].values
+            for coord in filtered_dataset.coords
+            if coord in ("spin_number", "energy_bin_geometric_mean", "epoch")
+        }
+    )
+
+    badtimes_dataset = create_dataset(data_dict, name, "l1b")
 
     if badtimes_dataset["spin_number"].size == 0:
         badtimes_dataset = badtimes_dataset.drop_dims("spin_number")

--- a/imap_processing/ultra/l1b/cullingmask.py
+++ b/imap_processing/ultra/l1b/cullingmask.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
-from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
+from imap_processing.ultra.utils.ultra_l1_utils import create_dataset, extract_data_dict
 
 FILLVAL_UINT16 = 65535
 FILLVAL_FLOAT64 = -1.0e31
@@ -51,16 +51,7 @@ def calculate_cullingmask(extendedspin_dataset: xr.Dataset, name: str) -> xr.Dat
         spin_number=extendedspin_dataset["spin_number"][good_mask]
     )
 
-    data_dict = {
-        var: filtered_dataset[var].values for var in filtered_dataset.data_vars
-    }
-    data_dict.update(
-        {
-            coord: filtered_dataset.coords[coord].values
-            for coord in filtered_dataset.coords
-            if coord in ("spin_number", "energy_bin_geometric_mean", "epoch")
-        }
-    )
+    data_dict = extract_data_dict(filtered_dataset)
 
     cullingmask_dataset = create_dataset(data_dict, name, "l1b")
 

--- a/imap_processing/ultra/l1b/cullingmask.py
+++ b/imap_processing/ultra/l1b/cullingmask.py
@@ -44,11 +44,25 @@ def calculate_cullingmask(extendedspin_dataset: xr.Dataset, name: str) -> xr.Dat
             == 0
         ).all(dim="energy_bin_geometric_mean")
     )
+    extendedspin_dataset = extendedspin_dataset.assign_coords(
+        epoch=("spin_number", extendedspin_dataset["epoch"].values)
+    )
     filtered_dataset = extendedspin_dataset.sel(
         spin_number=extendedspin_dataset["spin_number"][good_mask]
     )
 
-    cullingmask_dataset = create_dataset(filtered_dataset, name, "l1b")
+    data_dict = {
+        var: filtered_dataset[var].values for var in filtered_dataset.data_vars
+    }
+    data_dict.update(
+        {
+            coord: filtered_dataset.coords[coord].values
+            for coord in filtered_dataset.coords
+            if coord in ("spin_number", "energy_bin_geometric_mean", "epoch")
+        }
+    )
+
+    cullingmask_dataset = create_dataset(data_dict, name, "l1b")
 
     if cullingmask_dataset["spin_number"].size == 0:
         cullingmask_dataset = cullingmask_dataset.drop_dims("spin_number")

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -106,7 +106,11 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
     energy = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
     species_bin = np.full(len(de_dataset["epoch"]), FILLVAL_UINT8, dtype=np.uint8)
     t2 = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
-    event_times = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float64)
+    event_times = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
+    shape = (len(de_dataset["epoch"]), 3)
+    sc_velocity = np.full(shape, FILLVAL_FLOAT32, dtype=np.float32)
+    sc_dps_velocity = np.full(shape, FILLVAL_FLOAT32, dtype=np.float32)
+    helio_velocity = np.full(shape, FILLVAL_FLOAT32, dtype=np.float32)
     spin_starts = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float64)
     spin_period_sec = np.full(
         len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float64
@@ -224,13 +228,21 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
 
     # Annotated Events.
     ultra_frame = getattr(SpiceFrame, f"IMAP_ULTRA_{sensor}")
-    sc_velocity, sc_dps_velocity, helio_velocity = get_annotated_particle_velocity(
-        event_times,
-        de_dict["direct_event_velocity"],
-        ultra_frame,
-        SpiceFrame.IMAP_DPS,
-        SpiceFrame.IMAP_SPACECRAFT,
-    )
+
+    # Account for counts=0 (event times have FILL value)
+    valid_events = event_times != FILLVAL_FLOAT32
+    if np.any(valid_events):
+        (
+            sc_velocity[valid_events],
+            sc_dps_velocity[valid_events],
+            helio_velocity[valid_events],
+        ) = get_annotated_particle_velocity(
+            event_times[valid_events],
+            de_dict["direct_event_velocity"][valid_events],
+            ultra_frame,
+            SpiceFrame.IMAP_DPS,
+            SpiceFrame.IMAP_SPACECRAFT,
+        )
 
     de_dict["velocity_sc"] = sc_velocity
     de_dict["velocity_dps_sc"] = sc_dps_velocity

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -47,7 +47,7 @@ def calculate_de(
     name : str
         Name of the l1a dataset.
     ancillary_files : dict
-        Calibration product configuration file.
+        Ancillary files.
 
     Returns
     -------

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -34,7 +34,9 @@ FILLVAL_UINT8 = 255
 FILLVAL_FLOAT32 = -1.0e31
 
 
-def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
+def calculate_de(
+    de_dataset: xr.Dataset, name: str, ancillary_files: dict
+) -> xr.Dataset:
     """
     Create dataset with defined datatypes for Direct Event Data.
 
@@ -44,6 +46,8 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
         L1a dataset containing direct event data.
     name : str
         Name of the l1a dataset.
+    ancillary_files : dict
+        Calibration product configuration file.
 
     Returns
     -------
@@ -259,9 +263,7 @@ def calculate_de(de_dataset: xr.Dataset, name: str) -> xr.Dataset:
         de_dict["theta"],
     )
     de_dict["event_efficiency"] = get_efficiency(
-        de_dict["tof_energy"],
-        de_dict["phi"],
-        de_dict["theta"],
+        de_dict["tof_energy"], de_dict["phi"], de_dict["theta"], ancillary_files
     )
 
     dataset = create_dataset(de_dict, name, "l1b")

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -223,10 +223,6 @@ def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
     lookup_table : DataFrame
         Efficiencies lookup table for a given sensor.
     """
-    lookup_table = pd.read_csv(
-        ancillary_files[
-            "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
-        ]
-    )
+    lookup_table = pd.read_csv(ancillary_files["l1b-45sensor-logistic-interpolation"])
 
     return lookup_table

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -223,6 +223,7 @@ def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
     lookup_table : DataFrame
         Efficiencies lookup table for a given sensor.
     """
+    # TODO: add sensor to input when new lookup tables are available.
     lookup_table = pd.read_csv(ancillary_files["l1b-45sensor-logistic-interpolation"])
 
     return lookup_table

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -216,7 +216,7 @@ def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
     Parameters
     ----------
     ancillary_files : dict[Path]
-        Calibration product configuration file.
+        Ancillary files.
 
     Returns
     -------

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -206,23 +206,27 @@ def get_angular_profiles(start_type: str, sensor: str) -> pd.DataFrame:
     return lookup_table
 
 
-def get_energy_efficiencies() -> pd.DataFrame:
+def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
     """
     Lookup table for efficiencies for theta and phi.
 
     Further description is available starting on
     page 18 of the Algorithm Document.
 
+    Parameters
+    ----------
+    ancillary_files : dict[Path]
+        Calibration product configuration file.
+
     Returns
     -------
     lookup_table : DataFrame
         Efficiencies lookup table for a given sensor.
     """
-    # TODO: Move this out of tests directory once we have the aux api
-    # TODO: ultra90 efficiencies
-    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     lookup_table = pd.read_csv(
-        path / "Ultra_efficiencies_45_combined_logistic_interpolation.csv"
+        ancillary_files[
+            "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
+        ]
     )
 
     return lookup_table

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -66,18 +66,25 @@ def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
                 f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
                 instrument_id,
             )
+            output_datasets.append(extendedspin_dataset)
+        elif f"imap_ultra_l1b_{instrument_id}sensor-extendedspin" in data_dict:
             cullingmask_dataset = calculate_cullingmask(
-                extendedspin_dataset,
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
                 f"imap_ultra_l1b_{instrument_id}sensor-cullingmask",
             )
+            output_datasets.append(cullingmask_dataset)
+        elif (
+            f"imap_ultra_l1b_{instrument_id}sensor-extendedspin" in data_dict
+            and f"imap_ultra_l1b_{instrument_id}sensor-cullingmask" in data_dict
+        ):
             badtimes_dataset = calculate_badtimes(
-                extendedspin_dataset,
-                cullingmask_dataset["spin_number"].values,
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"][
+                    "spin_number"
+                ].values,
                 f"imap_ultra_l1b_{instrument_id}sensor-badtimes",
             )
-            output_datasets.extend(
-                [extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
-            )
+            output_datasets.append(badtimes_dataset)
     if not output_datasets:
         raise ValueError("No matching L1A or L1B data found.")
 

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -52,8 +52,8 @@ def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
                 f"imap_ultra_l1a_{instrument_id}sensor-aux": data_dict[
                     f"imap_ultra_l1a_{instrument_id}sensor-aux"
                 ],
-                f"imap_ultra_l1a_{instrument_id}sensor-hk": data_dict[
-                    f"imap_ultra_l1a_{instrument_id}sensor-hk"
+                f"imap_ultra_l1a_{instrument_id}sensor-params": data_dict[
+                    f"imap_ultra_l1a_{instrument_id}sensor-params"
                 ],
                 f"imap_ultra_l1a_{instrument_id}sensor-rates": data_dict[
                     f"imap_ultra_l1a_{instrument_id}sensor-rates"

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -89,6 +89,6 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
             )
             output_datasets.append(cullingmask_dataset)
     if not output_datasets:
-        raise ValueError("No matching L1A or L1B data found.")
+        raise ValueError("Data dictionary does not contain the expected keys.")
 
     return output_datasets

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -17,7 +17,7 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
     data_dict : dict
         The data itself and its dependent data.
     ancillary_files : dict
-        Calibration product configuration file.
+        Ancillary files.
 
     Returns
     -------

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -30,54 +30,55 @@ def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
     3. l1b extended, culling, badtimes created here
     """
     output_datasets = []
-    instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90
 
-    # L1b de data will be created if L1a de data is available
-    if f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict:
-        de_dataset = calculate_de(
-            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
-            f"imap_ultra_l1b_{instrument_id}sensor-de",
-        )
-        output_datasets.append(de_dataset)
-    # L1b extended data will be created if L1a hk, rates,
-    # aux, params, and l1b de data are available
-    elif (
-        f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
-        and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
-        and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
-        and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
-    ):
-        extendedspin_dataset = calculate_extendedspin(
-            {
-                f"imap_ultra_l1a_{instrument_id}sensor-aux": data_dict[
-                    f"imap_ultra_l1a_{instrument_id}sensor-aux"
-                ],
-                f"imap_ultra_l1a_{instrument_id}sensor-params": data_dict[
-                    f"imap_ultra_l1a_{instrument_id}sensor-params"
-                ],
-                f"imap_ultra_l1a_{instrument_id}sensor-rates": data_dict[
-                    f"imap_ultra_l1a_{instrument_id}sensor-rates"
-                ],
-                f"imap_ultra_l1b_{instrument_id}sensor-de": data_dict[
-                    f"imap_ultra_l1b_{instrument_id}sensor-de"
-                ],
-            },
-            f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
-            instrument_id,
-        )
-        cullingmask_dataset = calculate_cullingmask(
-            extendedspin_dataset,
-            f"imap_ultra_l1b_{instrument_id}sensor-cullingmask",
-        )
-        badtimes_dataset = calculate_badtimes(
-            extendedspin_dataset,
-            cullingmask_dataset["spin_number"].values,
-            f"imap_ultra_l1b_{instrument_id}sensor-badtimes",
-        )
-        output_datasets.extend(
-            [extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
-        )
-    else:
-        raise ValueError("Data dictionary does not contain the expected keys.")
+    # Account for possibility of having 45 and 90 in dictionary.
+    for instrument_id in [45, 90]:
+        # L1b de data will be created if L1a de data is available
+        if f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict:
+            de_dataset = calculate_de(
+                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
+                f"imap_ultra_l1b_{instrument_id}sensor-de",
+            )
+            output_datasets.append(de_dataset)
+        # L1b extended data will be created if L1a hk, rates,
+        # aux, params, and l1b de data are available
+        elif (
+            f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
+            and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
+            and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
+            and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
+        ):
+            extendedspin_dataset = calculate_extendedspin(
+                {
+                    f"imap_ultra_l1a_{instrument_id}sensor-aux": data_dict[
+                        f"imap_ultra_l1a_{instrument_id}sensor-aux"
+                    ],
+                    f"imap_ultra_l1a_{instrument_id}sensor-params": data_dict[
+                        f"imap_ultra_l1a_{instrument_id}sensor-params"
+                    ],
+                    f"imap_ultra_l1a_{instrument_id}sensor-rates": data_dict[
+                        f"imap_ultra_l1a_{instrument_id}sensor-rates"
+                    ],
+                    f"imap_ultra_l1b_{instrument_id}sensor-de": data_dict[
+                        f"imap_ultra_l1b_{instrument_id}sensor-de"
+                    ],
+                },
+                f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
+                instrument_id,
+            )
+            cullingmask_dataset = calculate_cullingmask(
+                extendedspin_dataset,
+                f"imap_ultra_l1b_{instrument_id}sensor-cullingmask",
+            )
+            badtimes_dataset = calculate_badtimes(
+                extendedspin_dataset,
+                cullingmask_dataset["spin_number"].values,
+                f"imap_ultra_l1b_{instrument_id}sensor-badtimes",
+            )
+            output_datasets.extend(
+                [extendedspin_dataset, cullingmask_dataset, badtimes_dataset]
+            )
+    if not output_datasets:
+        raise ValueError("No matching L1A or L1B data found.")
 
     return output_datasets

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -8,7 +8,7 @@ from imap_processing.ultra.l1b.de import calculate_de
 from imap_processing.ultra.l1b.extendedspin import calculate_extendedspin
 
 
-def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
+def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A data into L1B CDF files at output_filepath.
 
@@ -16,6 +16,8 @@ def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
     ----------
     data_dict : dict
         The data itself and its dependent data.
+    ancillary_files : dict
+        Calibration product configuration file.
 
     Returns
     -------
@@ -38,6 +40,7 @@ def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
             de_dataset = calculate_de(
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
                 f"imap_ultra_l1b_{instrument_id}sensor-de",
+                ancillary_files,
             )
             output_datasets.append(de_dataset)
         # L1b extended data will be created if L1a hk, rates,

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -67,12 +67,6 @@ def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
                 instrument_id,
             )
             output_datasets.append(extendedspin_dataset)
-        elif f"imap_ultra_l1b_{instrument_id}sensor-extendedspin" in data_dict:
-            cullingmask_dataset = calculate_cullingmask(
-                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
-                f"imap_ultra_l1b_{instrument_id}sensor-cullingmask",
-            )
-            output_datasets.append(cullingmask_dataset)
         elif (
             f"imap_ultra_l1b_{instrument_id}sensor-extendedspin" in data_dict
             and f"imap_ultra_l1b_{instrument_id}sensor-cullingmask" in data_dict
@@ -85,6 +79,12 @@ def ultra_l1b(data_dict: dict) -> list[xr.Dataset]:
                 f"imap_ultra_l1b_{instrument_id}sensor-badtimes",
             )
             output_datasets.append(badtimes_dataset)
+        elif f"imap_ultra_l1b_{instrument_id}sensor-extendedspin" in data_dict:
+            cullingmask_dataset = calculate_cullingmask(
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
+                f"imap_ultra_l1b_{instrument_id}sensor-cullingmask",
+            )
+            output_datasets.append(cullingmask_dataset)
     if not output_datasets:
         raise ValueError("No matching L1A or L1B data found.")
 

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -14,6 +14,8 @@ from imap_processing.ultra.constants import UltraConstants
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+SPIN_DURATION = 15  # Default spin duration in seconds.
+
 
 def get_energy_histogram(
     spin_number: NDArray, energy: NDArray
@@ -62,7 +64,7 @@ def get_energy_histogram(
         if not np.any(matched_spins):
             # TODO: we might throw an exception here instead.
             logger.info(f"Unmatched spin number: {unique_spin_number[i]}")
-            spin_duration = 15  # Default to 15 seconds if no match found
+            spin_duration = SPIN_DURATION  # Default to 15 seconds if no match found
         else:
             spin_duration = spin_df.spin_period_sec[
                 spin_df.spin_number == unique_spin_number[i]

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -1,5 +1,7 @@
 """Culls Events for ULTRA L1b."""
 
+import logging
+
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -8,6 +10,9 @@ from numpy.typing import NDArray
 from imap_processing.quality_flags import ImapAttitudeUltraFlags, ImapRatesUltraFlags
 from imap_processing.spice.spin import get_spin_data
 from imap_processing.ultra.constants import UltraConstants
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def get_energy_histogram(
@@ -38,7 +43,8 @@ def get_energy_histogram(
     """
     spin_df = get_spin_data()
 
-    spin_edges = np.unique(spin_number)
+    unique_spin_number = np.unique(spin_number)
+    spin_edges = unique_spin_number.astype(np.uint16)
     spin_edges = np.append(spin_edges, spin_edges.max() + 1)
 
     # Counts per spin at each energy bin.
@@ -52,9 +58,17 @@ def get_energy_histogram(
 
     # Count rate per spin at each energy bin.
     for i in range(hist.shape[1]):
-        spin_duration = spin_df.spin_period_sec[spin_df.spin_number == i]
-        hist[:, i] /= spin_duration.values[0]
-        total_spin_duration += spin_duration.sum()
+        matched_spins = spin_df.spin_number == unique_spin_number[i]
+        if not np.any(matched_spins):
+            # TODO: we might throw an exception here instead.
+            logger.info(f"Unmatched spin number: {unique_spin_number[i]}")
+            spin_duration = 15  # Default to 15 seconds if no match found
+        else:
+            spin_duration = spin_df.spin_period_sec[
+                spin_df.spin_number == unique_spin_number[i]
+            ].values[0]
+        hist[:, i] /= spin_duration
+        total_spin_duration += spin_duration
 
     mean_duration = total_spin_duration / hist.shape[1]
 
@@ -201,26 +215,42 @@ def compare_aux_univ_spin_table(
     mismatch_indices : np.ndarray
         Boolean array indicating which spins have mismatches.
     """
-    univ_mask = np.isin(spin_df["spin_number"].values, spins)
-    aux_mask = np.isin(aux_dataset["SPINNUMBER"].values, spins)
+    # Identify valid spin matches
+    univ_spins = spin_df["spin_number"].values
+    aux_spins = aux_dataset["spinnumber"].values
+    present_in_both = np.intersect1d(univ_spins, aux_spins)
 
-    filtered_univ = spin_df[univ_mask]
-    filtered_aux = {field: aux_dataset[field].values[aux_mask] for field in aux_dataset}
+    # Filter and align by spin number
+    df_univ = spin_df.set_index("spin_number").loc[present_in_both]
+    df_aux = (
+        pd.DataFrame({field: aux_dataset[field].values for field in aux_dataset})
+        .groupby("spinnumber", as_index=True)
+        .first()
+        .loc[present_in_both]
+    )
 
     mismatch_indices = np.zeros(len(spins), dtype=bool)
 
     fields_to_compare = [
-        ("TIMESPINSTART", "spin_start_sec_sclk"),
-        ("TIMESPINSTARTSUB", "spin_start_subsec_sclk"),
-        ("DURATION", "spin_period_sec"),
-        ("TIMESPINDATA", "spin_start_met"),
-        ("SPINPERIOD", "spin_period_sec"),
+        ("timespinstart", "spin_start_sec_sclk"),
+        ("timespinstartsub", "spin_start_subsec_sclk"),
+        ("duration", "spin_period_sec"),
+        ("timespindata", "spin_start_met"),
+        ("spinperiod", "spin_period_sec"),
     ]
 
+    # Compare fields
+    mismatch = np.zeros(len(df_aux), dtype=bool)
     for aux_field, spin_field in fields_to_compare:
-        aux_values = filtered_aux[aux_field]
-        spin_values = filtered_univ[spin_field].values
+        mismatch |= df_aux[aux_field].values != df_univ[spin_field].values
 
-        mismatch_indices |= aux_values != spin_values
+    # Get spin numbers where mismatch is True
+    mismatched_spin_numbers = present_in_both[mismatch]
+    # Find indices in `spins` that correspond to these mismatched spins
+    mismatch_indices[np.isin(spins, mismatched_spin_numbers)] = True
+
+    # Also flag any spins not present in the intersection
+    missing_spin_mask = ~np.isin(spins, present_in_both)
+    mismatch_indices[missing_spin_mask] = True
 
     return mismatch_indices

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -110,7 +110,7 @@ def flag_attitude(
     )
 
     quality_flags = np.full(
-        spin_rates.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
+        spins.shape, ImapAttitudeUltraFlags.NONE.value, dtype=np.uint16
     )
     quality_flags[bad_spin_rate_indices] |= ImapAttitudeUltraFlags.SPINRATE.value
     mismatch_indices = compare_aux_univ_spin_table(aux_dataset, spins, spin_df)

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -941,9 +941,7 @@ def get_fwhm(
 
 
 def get_efficiency(
-    energy: NDArray,
-    phi_inst: NDArray,
-    theta_inst: NDArray,
+    energy: NDArray, phi_inst: NDArray, theta_inst: NDArray, ancillary_files: dict
 ) -> NDArray:
     """
     Interpolate efficiency values for each event.
@@ -956,13 +954,15 @@ def get_efficiency(
         Instrument-frame azimuth angle for each event.
     theta_inst : NDArray
         Instrument-frame elevation angle for each event.
+    ancillary_files : dict
+        Dictionary containing paths to ancillary files.
 
     Returns
     -------
     efficiency : NDArray
         Interpolated efficiency values.
     """
-    lookup_table = get_energy_efficiencies()
+    lookup_table = get_energy_efficiencies(ancillary_files)
 
     theta_vals = np.sort(lookup_table["theta (deg)"].unique())
     phi_vals = np.sort(lookup_table["phi (deg)"].unique())

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -955,7 +955,7 @@ def get_efficiency(
     theta_inst : NDArray
         Instrument-frame elevation angle for each event.
     ancillary_files : dict
-        Dictionary containing paths to ancillary files.
+        Ancillary files.
 
     Returns
     -------

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -45,7 +45,7 @@ def calculate_helio_pset(
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
     pset_dict["exposure_factor"] = np.zeros(len(healpix), dtype=np.uint8)[
-        ..., np.newaxis
+        np.newaxis, ...
     ]
 
     dataset = create_dataset(pset_dict, name, "l1c")

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -1,0 +1,53 @@
+"""Calculate Pointing Set Grids."""
+
+import astropy_healpix.healpy as hp
+import numpy as np
+import xarray as xr
+
+from imap_processing.ultra.l1c.ultra_l1c_pset_bins import build_energy_bins
+from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
+
+
+def calculate_helio_pset(
+    de_dataset: xr.Dataset,
+    extendedspin_dataset: xr.Dataset,
+    cullingmask_dataset: xr.Dataset,
+    name: str,
+    ancillary_files: dict,
+) -> xr.Dataset:
+    """
+    Create dictionary with defined datatype for Pointing Set Grid Data.
+
+    Parameters
+    ----------
+    de_dataset : xarray.Dataset
+        Dataset containing de data.
+    extendedspin_dataset : xarray.Dataset
+        Dataset containing extendedspin data.
+    cullingmask_dataset : xarray.Dataset
+        Dataset containing cullingmask data.
+    name : str
+        Name of the dataset.
+    ancillary_files : dict
+        Ancillary files.
+
+    Returns
+    -------
+    dataset : xarray.Dataset
+        Dataset containing the data.
+    """
+    # TODO: Fill in the rest of this later.
+    pset_dict: dict[str, np.ndarray] = {}
+    healpix = np.arange(hp.nside2npix(128))
+    _, _, energy_bin_geometric_means = build_energy_bins()
+
+    pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)
+    pset_dict["pixel_index"] = healpix
+    pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
+    pset_dict["exposure_factor"] = np.zeros(len(healpix), dtype=np.uint8)[
+        ..., np.newaxis
+    ]
+
+    dataset = create_dataset(pset_dict, name, "l1c")
+
+    return dataset

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -22,6 +22,7 @@ def calculate_spacecraft_pset(
     extendedspin_dataset: xr.Dataset,
     cullingmask_dataset: xr.Dataset,
     name: str,
+    ancillary_files: dict,
 ) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
@@ -36,6 +37,8 @@ def calculate_spacecraft_pset(
         Dataset containing cullingmask data.
     name : str
         Name of the dataset.
+    ancillary_files : dict
+        Ancillary files.
 
     Returns
     -------
@@ -64,7 +67,9 @@ def calculate_spacecraft_pset(
     # TODO: calculate sensitivity and interpolate based on energy.
 
     # Calculate exposure
-    constant_exposure = TEST_PATH / "ultra_90_dps_exposure.csv"
+    constant_exposure = ancillary_files[
+        "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
+    ]
     df_exposure = pd.read_csv(constant_exposure)
     exposure_pointing = get_spacecraft_exposure_times(df_exposure)
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -61,19 +61,15 @@ def calculate_spacecraft_pset(
     # calculate background rates
     background_rates = get_spacecraft_background_rates()
 
-    efficiencies = ancillary_files[
-        "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv"
-    ]
-    geometric_function = ancillary_files["imap_ultra_l1c-90sensor-gf_20250101_v000.csv"]
+    efficiencies = ancillary_files["l1c-90sensor-efficiencies"]
+    geometric_function = ancillary_files["l1c-90sensor-gf"]
 
     df_efficiencies = pd.read_csv(efficiencies)
     df_geometric_function = pd.read_csv(geometric_function)
     sensitivity = interpolate_sensitivity(df_efficiencies, df_geometric_function)
 
     # Calculate exposure
-    constant_exposure = ancillary_files[
-        "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
-    ]
+    constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
     df_exposure = pd.read_csv(constant_exposure)
     exposure_pointing = get_spacecraft_exposure_times(df_exposure)
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -79,15 +79,17 @@ def calculate_spacecraft_pset(
 
     # For ISTP, epoch should be the center of the time bin.
     pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)
-    pset_dict["counts"] = counts
-    pset_dict["latitude"] = latitude
-    pset_dict["longitude"] = longitude
+    pset_dict["counts"] = counts[..., np.newaxis]
+    pset_dict["latitude"] = latitude[..., np.newaxis]
+    pset_dict["longitude"] = longitude[..., np.newaxis]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
-    pset_dict["background_rates"] = background_rates
-    pset_dict["exposure_factor"] = exposure_pointing
+    pset_dict["background_rates"] = background_rates[..., np.newaxis]
+    pset_dict["exposure_factor"] = exposure_pointing.to_numpy()[..., np.newaxis]
     pset_dict["pixel_index"] = healpix
-    pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()
-    pset_dict["sensitivity"] = sensitivity
+    pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
+        ..., np.newaxis
+    ]
+    pset_dict["sensitivity"] = sensitivity[..., np.newaxis]
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -4,17 +4,14 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from imap_processing import imap_module_directory
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_spacecraft_background_rates,
     get_spacecraft_exposure_times,
     get_spacecraft_histogram,
+    interpolate_sensitivity,
 )
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
-
-# TODO: This is a placeholder for the API lookup table directory.
-TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 
 def calculate_spacecraft_pset(
@@ -64,7 +61,14 @@ def calculate_spacecraft_pset(
     # calculate background rates
     background_rates = get_spacecraft_background_rates()
 
-    # TODO: calculate sensitivity and interpolate based on energy.
+    efficiencies = ancillary_files[
+        "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv"
+    ]
+    geometric_function = ancillary_files["imap_ultra_l1c-90sensor-gf_20250101_v000.csv"]
+
+    df_efficiencies = pd.read_csv(efficiencies)
+    df_geometric_function = pd.read_csv(geometric_function)
+    sensitivity = interpolate_sensitivity(df_efficiencies, df_geometric_function)
 
     # Calculate exposure
     constant_exposure = ancillary_files[
@@ -83,6 +87,7 @@ def calculate_spacecraft_pset(
     pset_dict["exposure_factor"] = exposure_pointing
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()
+    pset_dict["sensitivity"] = sensitivity
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -75,17 +75,17 @@ def calculate_spacecraft_pset(
 
     # For ISTP, epoch should be the center of the time bin.
     pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)
-    pset_dict["counts"] = counts[..., np.newaxis]
-    pset_dict["latitude"] = latitude[..., np.newaxis]
-    pset_dict["longitude"] = longitude[..., np.newaxis]
+    pset_dict["counts"] = counts[np.newaxis, ...]
+    pset_dict["latitude"] = latitude[np.newaxis, ...]
+    pset_dict["longitude"] = longitude[np.newaxis, ...]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
-    pset_dict["background_rates"] = background_rates[..., np.newaxis]
-    pset_dict["exposure_factor"] = exposure_pointing.to_numpy()[..., np.newaxis]
+    pset_dict["background_rates"] = background_rates[np.newaxis, ...]
+    pset_dict["exposure_factor"] = exposure_pointing.to_numpy()[np.newaxis, ...]
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
-        ..., np.newaxis
+        np.newaxis, ...
     ]
-    pset_dict["sensitivity"] = sensitivity[..., np.newaxis]
+    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -68,6 +68,6 @@ def ultra_l1c(
             )
             output_datasets = [spacecraft_pset]
     if not output_datasets:
-        raise ValueError("No matching L1A or L1B data found.")
+        raise ValueError("Data dictionary does not contain the expected keys.")
 
     return output_datasets

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -6,7 +6,7 @@ from imap_processing.ultra.l1c.histogram import calculate_histogram
 from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
 
 
-def ultra_l1c(data_dict: dict) -> list[xr.Dataset]:
+def ultra_l1c(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A and L1B data into L1C CDF files at output_filepath.
 
@@ -14,6 +14,8 @@ def ultra_l1c(data_dict: dict) -> list[xr.Dataset]:
     ----------
     data_dict : dict
         The data itself and its dependent data.
+    ancillary_files : dict
+        Ancillary files.
 
     Returns
     -------
@@ -41,6 +43,7 @@ def ultra_l1c(data_dict: dict) -> list[xr.Dataset]:
             data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
             data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"],
             f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset",
+            ancillary_files,
         )
         # TODO: add calculate_helio_pset here
         output_datasets = [spacecraft_pset]

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -2,11 +2,14 @@
 
 import xarray as xr
 
+from imap_processing.ultra.l1c.helio_pset import calculate_helio_pset
 from imap_processing.ultra.l1c.histogram import calculate_histogram
 from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
 
 
-def ultra_l1c(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
+def ultra_l1c(
+    data_dict: dict, ancillary_files: dict, has_spice: bool
+) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A and L1B data into L1C CDF files at output_filepath.
 
@@ -16,38 +19,55 @@ def ultra_l1c(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
         The data itself and its dependent data.
     ancillary_files : dict
         Ancillary files.
+    has_spice : bool
+        Whether to use SPICE data.
 
     Returns
     -------
     output_datasets : list[xarray.Dataset]
         List of xarray.Dataset.
     """
-    instrument_id = 45 if any("45" in key for key in data_dict.keys()) else 90
+    output_datasets = []
 
-    if (
-        f"imap_ultra_l1a_{instrument_id}sensor-histogram" in data_dict
-        and f"imap_ultra_l1b_{instrument_id}sensor-cullingmask" in data_dict
-    ):
-        histogram_dataset = calculate_histogram(
-            data_dict[f"imap_ultra_l1a_{instrument_id}sensor-histogram"],
-            f"imap_ultra_l1c_{instrument_id}sensor-histogram",
-        )
-        output_datasets = [histogram_dataset]
-    elif (
-        f"imap_ultra_l1b_{instrument_id}sensor-cullingmask" in data_dict
-        and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
-        and f"imap_ultra_l1b_{instrument_id}sensor-extendedspin" in data_dict
-    ):
-        spacecraft_pset = calculate_spacecraft_pset(
-            data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
-            data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
-            data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"],
-            f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset",
-            ancillary_files,
-        )
-        # TODO: add calculate_helio_pset here
-        output_datasets = [spacecraft_pset]
-    else:
-        raise ValueError("Data dictionary does not contain the expected keys.")
+    # Account for possibility of having 45 and 90 in dictionary.
+    for instrument_id in [45, 90]:
+        if (
+            f"imap_ultra_l1a_{instrument_id}sensor-histogram" in data_dict
+            and f"imap_ultra_l1b_{instrument_id}sensor-cullingmask" in data_dict
+        ):
+            histogram_dataset = calculate_histogram(
+                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-histogram"],
+                f"imap_ultra_l1c_{instrument_id}sensor-histogram",
+            )
+            output_datasets = [histogram_dataset]
+        elif (
+            f"imap_ultra_l1b_{instrument_id}sensor-cullingmask" in data_dict
+            and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
+            and f"imap_ultra_l1b_{instrument_id}sensor-extendedspin" in data_dict
+            and has_spice
+        ):
+            helio_pset = calculate_helio_pset(
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"],
+                f"imap_ultra_l1c_{instrument_id}sensor-heliopset",
+                ancillary_files,
+            )
+            output_datasets = [helio_pset]
+        elif (
+            f"imap_ultra_l1b_{instrument_id}sensor-cullingmask" in data_dict
+            and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
+            and f"imap_ultra_l1b_{instrument_id}sensor-extendedspin" in data_dict
+        ):
+            spacecraft_pset = calculate_spacecraft_pset(
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"],
+                f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset",
+                ancillary_files,
+            )
+            output_datasets = [spacecraft_pset]
+    if not output_datasets:
+        raise ValueError("No matching L1A or L1B data found.")
 
     return output_datasets

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -15,6 +15,7 @@ from imap_processing.spice.geometry import (
 from imap_processing.ultra.constants import UltraConstants
 
 # TODO: add species binning.
+FILLVAL_FLOAT32 = -1.0e31
 
 
 def build_energy_bins() -> tuple[list[tuple[float, float]], np.ndarray, np.ndarray]:
@@ -478,8 +479,6 @@ def grid_sensitivity(
         Efficiencies at different energy levels.
     geometric_function : pandas.DataFrame
         Geometric function.
-        energy : np.ndarray
-        The particle energy.
     energy : float
         Energy to which we are interpolating.
 
@@ -503,8 +502,47 @@ def grid_sensitivity(
 
     # Interpolate to energy
     interpolated = interp_func(energy)
+    interpolated = np.where(np.isnan(interpolated), FILLVAL_FLOAT32, interpolated)
 
     return interpolated
+
+
+def interpolate_sensitivity(
+    efficiencies: pd.DataFrame,
+    geometric_function: pd.DataFrame,
+    nside: int = 128,
+) -> NDArray:
+    """
+    Interpolate the sensitivity and bin it in HEALPix space.
+
+    Parameters
+    ----------
+    efficiencies : pandas.DataFrame
+        Efficiencies at different energy levels.
+    geometric_function : pandas.DataFrame
+        Geometric function.
+    nside : int, optional
+        Healpix nside resolution (default is 128).
+
+    Returns
+    -------
+    interpolated_sensitivity : np.ndarray
+        Array of shape (n_energy_bins, n_healpix_pixels).
+    """
+    _, _, energy_bin_geometric_means = build_energy_bins()
+    npix = hp.nside2npix(nside)
+
+    interpolated_sensitivity = np.full(
+        (len(energy_bin_geometric_means), npix), FILLVAL_FLOAT32
+    )
+
+    for i, energy in enumerate(energy_bin_geometric_means):
+        pixel_sensitivity = grid_sensitivity(
+            efficiencies, geometric_function, energy
+        ).flatten()
+        interpolated_sensitivity[i, :] = pixel_sensitivity
+
+    return interpolated_sensitivity
 
 
 def get_helio_sensitivity(

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -138,3 +138,28 @@ def create_dataset(  # noqa: PLR0912
             )
 
     return dataset
+
+
+def extract_data_dict(dataset: xr.Dataset) -> dict:
+    """
+    Convert variables and selected coordinates into a dictionary.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The input xarray Dataset.
+
+    Returns
+    -------
+    data_dict : dict
+        Dictionary with data variables and selected coordinates.
+    """
+    data_dict = {var: dataset[var].values for var in dataset.data_vars}
+    data_dict.update(
+        {
+            coord: dataset.coords[coord].values
+            for coord in ("spin_number", "energy_bin_geometric_mean", "epoch")
+            if coord in dataset.coords
+        }
+    )
+    return data_dict

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -100,10 +100,16 @@ def create_dataset(  # noqa: PLR0912
                 dims=["epoch", "component"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-        elif key in ("ena_rates_threshold", "energy_bin_delta"):
+        elif key in ("ena_rates_threshold"):
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean"],
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            )
+        elif key == "energy_bin_delta":
+            dataset[key] = xr.DataArray(
+                data,
+                dims=["energy_bin_geometric_mean", "epoch"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in rates_keys:
@@ -112,16 +118,16 @@ def create_dataset(  # noqa: PLR0912
                 dims=["energy_bin_geometric_mean", "spin_number"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-        elif key in ["spin_start_time", "spin_period", "spin_rate", "quality_attitude"]:
+        elif key in {"latitude", "longitude", "exposure_factor"}:
             dataset[key] = xr.DataArray(
                 data,
-                dims=["spin_number"],
+                dims=["pixel_index", "epoch"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in {"counts", "background_rates", "sensitivity"}:
             dataset[key] = xr.DataArray(
                 data,
-                dims=["energy_bin_geometric_mean", "pixel_index"],
+                dims=["energy_bin_geometric_mean", "pixel_index", "epoch"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         else:

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -46,9 +46,9 @@ def create_dataset(  # noqa: PLR0912
     # L1c pset data products
     elif "pixel_index" in data_dict:
         coords = {
+            "epoch": data_dict["epoch"],
             "pixel_index": data_dict["pixel_index"],
             "energy_bin_geometric_mean": data_dict["energy_bin_geometric_mean"],
-            "epoch": data_dict["epoch"],
         }
         default_dimension = "pixel_index"
     # L1b de data product
@@ -109,7 +109,7 @@ def create_dataset(  # noqa: PLR0912
         elif key == "energy_bin_delta":
             dataset[key] = xr.DataArray(
                 data,
-                dims=["energy_bin_geometric_mean", "epoch"],
+                dims=["epoch", "energy_bin_geometric_mean"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in rates_keys:
@@ -121,13 +121,13 @@ def create_dataset(  # noqa: PLR0912
         elif key in {"latitude", "longitude", "exposure_factor"}:
             dataset[key] = xr.DataArray(
                 data,
-                dims=["pixel_index", "epoch"],
+                dims=["epoch", "pixel_index"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in {"counts", "background_rates", "sensitivity"}:
             dataset[key] = xr.DataArray(
                 data,
-                dims=["energy_bin_geometric_mean", "pixel_index", "epoch"],
+                dims=["epoch", "energy_bin_geometric_mean", "pixel_index"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         else:

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -6,7 +6,7 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 
 
-def create_dataset(
+def create_dataset(  # noqa: PLR0912
     data_dict: dict,
     name: str,
     level: str,
@@ -35,9 +35,11 @@ def create_dataset(
     # L1b extended spin, badtimes, and cullingmask data products
     if "spin_number" in data_dict.keys():
         coords = {
-            "spin_number": data_dict["spin_number"],
-            "energy_bin_geometric_mean": data_dict["energy_bin_geometric_mean"],
-            # Start time aligns with the universal spin table
+            "spin_number": ("spin_number", data_dict["spin_number"]),
+            "energy_bin_geometric_mean": (
+                "energy_bin_geometric_mean",
+                data_dict["energy_bin_geometric_mean"],
+            ),
             "epoch": ("spin_number", np.asarray(data_dict["epoch"])),
         }
         default_dimension = "spin_number"
@@ -108,6 +110,12 @@ def create_dataset(
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean", "spin_number"],
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            )
+        elif key in ["spin_start_time", "spin_period", "spin_rate", "quality_attitude"]:
+            dataset[key] = xr.DataArray(
+                data,
+                dims=["spin_number"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in {"counts", "background_rates"}:

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -100,7 +100,7 @@ def create_dataset(  # noqa: PLR0912
                 dims=["epoch", "component"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-        elif key in ("ena_rates_threshold"):
+        elif key == "ena_rates_threshold":
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean"],

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -118,7 +118,7 @@ def create_dataset(  # noqa: PLR0912
                 dims=["spin_number"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-        elif key in {"counts", "background_rates"}:
+        elif key in {"counts", "background_rates", "sensitivity"}:
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean", "pixel_index"],


### PR DESCRIPTION
# Change Summary

## Overview
Ultra SIT 4 - Incorporating anc and spice into code

## New Files
- helio_pset.py
   - Placeholder file.

## Updated Files
- ultra_l1b_culling.py
   - This one was a larger change. I had to account for spin_numbers between the universal spin table and my direct event data product not matching.

- ultra_l1c_pset_bins.py
   - Added a function to interpolate sensitivity

- imap_ultra_l1b_variable_attrs.yaml
   - Extendedspin table variables should be dependent on spin_number and not epoch

- imap_ultra_l1c_variable_attrs.yaml
   - Sensitivity should be a float

- cli.py
   - Reformat based on ancillary and spice inputs

- conftest.py in test directory
   - Rename conftest.py files

- ultra/unit/conftest.py
   - Capitalization change

- decom_ultra.py
   - Refactor loop to use predefined field list

- ultra_utils.py
   - Remove memdump apid for now since I haven’t finished that one yet

- cullingmask.py and badtimes.py
   - Account for changes based on cdf writes (epoch coordinate being assigned)
   - Create a data dictionary instead of passing a dataset since the coordinates in the dataset were causing problems.

- de.py
   - Account for counts equal to 0 for calculating the annotated events
   - Pass in ancillary files

- lookup_utils.py
   - Pass in ancillary files

- ultra_l1b.py
   - Pass in ancillary files
   - Change in logic

- ultra_l1b_extended.py
   - Pass in ancillary files.

- helio_pset.py
   - Pass in ancillary files.

- ultra_l1c.py
   - Pass in ancillary files
   - Change in some logic

- ultra_l1_utils.py
   - Minor changes to setup the dataset

## Testing
- test_lookup_utils.py
- test_spacecrat_pset.py
- test_ultra_l1b.py
- test_ultra_l1b_culling.py
- test_ultra_l1b_extended.py
- test_ultra_l1c.py
- test_ultra_l1c_pset_bins.py