### PR TITLE
IDEX attribute fixes from Andriy

### DIFF
--- a/imap_processing/cdf/config/imap_idex_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l1a_variable_attrs.yaml
@@ -52,6 +52,7 @@ sample_rate_base: &sample_rate_base
   VALIDMAX: *sample_rate_max
   DEPEND_0: epoch
   FORMAT: F64.5
+  SCALETYP: linear
   LABLAXIS: Time
   UNITS: microseconds
   VAR_TYPE: data
@@ -96,6 +97,7 @@ low_sample_rate_attrs:
              microseconds in duration. Used by the Ion_Grid, Target_Low, and
              Target_High variables.
   DEPEND_1: time_low_sample_rate_index
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal
 
 high_sample_rate_attrs:
   <<:  *sample_rate_base
@@ -105,6 +107,7 @@ high_sample_rate_attrs:
     microseconds in duration. Used by the TOF_High, TOF_Mid, and
     TOF_Low variables.
   DEPEND_1: time_high_sample_rate_index
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal
 
 time_low_sample_rate_index:
   CATDESC: Low sampling rate time index
@@ -117,6 +120,7 @@ time_low_sample_rate_index:
   VALIDMAX: 511
   VALIDMIN: 0
   VAR_TYPE: support_data
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 time_high_sample_rate_index:
   CATDESC: High sampling rate time index
@@ -129,6 +133,7 @@ time_high_sample_rate_index:
   VALIDMAX: 8188
   VALIDMIN: 0
   VAR_TYPE: support_data
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 tof_high_attrs:
   <<: *l1a_tof_base

--- a/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
@@ -397,6 +397,7 @@ latitude:
   <<: *spice_base
   FIELDNAM: Latitude
   CATDESC: Latitude of the dust event as observed from Earth in the ECLIPJ2000 frame.
+  LABLAXIS: Latitude
   DICT_KEY: SPASE>Support>SupportQuantity:Latitude
 
 spin_phase:

--- a/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
@@ -391,12 +391,13 @@ longitude:
   FIELDNAM: Longitude
   CATDESC: Longitude of the dust event as observed from Earth in the ECLIPJ2000 frame.
   LABLAXIS: Longitude
+  DICT_KEY: SPASE>Support>SupportQuantity:Longitude
 
 latitude:
   <<: *spice_base
   FIELDNAM: Latitude
   CATDESC: Latitude of the dust event as observed from Earth in the ECLIPJ2000 frame.
-  LABLAXIS: Latitude
+  DICT_KEY: SPASE>Support>SupportQuantity:Latitude
 
 spin_phase:
   <<: *spice_base

--- a/imap_processing/cdf/config/imap_idex_l2a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2a_variable_attrs.yaml
@@ -117,6 +117,7 @@ mass_index:
   FORMAT: I4
   VAR_TYPE: support_data
   SCALETYP: linear
+  LABLAXIS: Mass Index
   VALIDMIN: 0
   VALIDMAX: 500
   FILLVAL: *int_fillval

--- a/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
@@ -79,7 +79,7 @@ counts: &counts
   FIELDNAM: Dust Counts
   FORMAT: I20
   UNITS: counts
-  VAR_TYPE: datagi
+  VAR_TYPE: data
   DISPLAY_TYPE: spectrogram
   DEPEND_0: epoch
   VALIDMIN: 0

--- a/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
@@ -79,8 +79,7 @@ counts: &counts
   FIELDNAM: Dust Counts
   FORMAT: I20
   UNITS: counts
-  VAR_TYPE: data
-  LABLAXIS: Counts
+  VAR_TYPE: datagi
   DISPLAY_TYPE: spectrogram
   DEPEND_0: epoch
   VALIDMIN: 0

--- a/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
@@ -77,7 +77,7 @@ rectangular_lat_pixel:
 counts: &counts
   CATDESC: Number of raw dust events for each pixel
   FIELDNAM: Dust Counts
-  FORMAT: I12
+  FORMAT: I20
   UNITS: counts
   VAR_TYPE: data
   DISPLAY_TYPE: time_series

--- a/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
@@ -80,7 +80,8 @@ counts: &counts
   FORMAT: I20
   UNITS: counts
   VAR_TYPE: data
-  DISPLAY_TYPE: time_series
+  LABLAXIS: Counts
+  DISPLAY_TYPE: spectrogram
   DEPEND_0: epoch
   VALIDMIN: 0
   VALIDMAX: *int_maxval

--- a/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
@@ -90,7 +90,7 @@ counts: &counts
 healpix_counts:
   <<: *counts
   DEPEND_1: pixel_index
-  LABL_PTR_1: pixel_label
+  LABLAXIS: Counts
 
 rectangular_counts:
   <<: *counts

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -419,6 +419,7 @@ class ProcessInstrument(ABC):
                     extension="cdf",
                     table="science",
                 )
+                logger.info("existingfield: %s", existing_file)
                 if existing_file:
                     raise ProcessInstrument.ImapFileExistsError(
                         f"File {filename} already exists in the IMAP SDC. "

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -419,7 +419,7 @@ class ProcessInstrument(ABC):
                     extension="cdf",
                     table="science",
                 )
-                logger.info("existingfield: %s", existing_file)
+
                 if existing_file:
                     raise ProcessInstrument.ImapFileExistsError(
                         f"File {filename} already exists in the IMAP SDC. "

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -419,7 +419,6 @@ class ProcessInstrument(ABC):
                     extension="cdf",
                     table="science",
                 )
-
                 if existing_file:
                     raise ProcessInstrument.ImapFileExistsError(
                         f"File {filename} already exists in the IMAP SDC. "

--- a/imap_processing/idex/idex_l2c.py
+++ b/imap_processing/idex/idex_l2c.py
@@ -125,7 +125,7 @@ def idex_healpix_map(
     counts = np.histogram(hpix_idx, bins=n_pix, range=(0, n_pix))[0]
     # Add epoch dimension
     counts_da = xr.DataArray(
-        counts[np.newaxis, :].astype(np.uint16),
+        counts[np.newaxis, :],
         name="counts",
         dims=("epoch", CoordNames.HEALPIX_INDEX.value),
         attrs=idex_attrs.get_variable_attributes("healpix_counts"),
@@ -147,10 +147,10 @@ def idex_healpix_map(
     )
     map_attrs = {
         "Sky_tiling_type": SkyTilingType.HEALPIX.value,
-        "HEALPix_nside": nside,
-        "HEALPix_nest": nested,
-        "Spice_reference_frame": IDEX_EVENT_REFERENCE_FRAME,
-        "num_points": n_pix,
+        "HEALPix_nside": str(nside),
+        "HEALPix_nest": str(nested),
+        "Spice_reference_frame": str(IDEX_EVENT_REFERENCE_FRAME.value),
+        "num_points": str(n_pix),
     } | idex_attrs.get_global_attributes("imap_idex_l2c_sci-healpix")
     l2c_dataset.attrs.update(map_attrs)
 
@@ -193,7 +193,7 @@ def idex_rectangular_map(
         longitude_wrapped, latitude, bins=[grid.az_bin_edges, grid.el_bin_edges]
     )
     counts_da = xr.DataArray(
-        counts[np.newaxis, :, :].astype(np.uint16),
+        counts[np.newaxis, :, :],
         name="counts",
         dims=("epoch", "rectangular_lon_pixel", "rectangular_lat_pixel"),
         attrs=idex_attrs.get_variable_attributes("rectangular_counts"),

--- a/imap_processing/idex/idex_l2c.py
+++ b/imap_processing/idex/idex_l2c.py
@@ -149,7 +149,7 @@ def idex_healpix_map(
         "Sky_tiling_type": SkyTilingType.HEALPIX.value,
         "HEALPix_nside": str(nside),
         "HEALPix_nest": str(nested),
-        "Spice_reference_frame": str(IDEX_EVENT_REFERENCE_FRAME.value),
+        "Spice_reference_frame": IDEX_EVENT_REFERENCE_FRAME.name,
         "num_points": str(n_pix),
     } | idex_attrs.get_global_attributes("imap_idex_l2c_sci-healpix")
     l2c_dataset.attrs.update(map_attrs)
@@ -242,7 +242,7 @@ def idex_rectangular_map(
     map_attrs = {
         "sky_tiling_type": SkyTilingType.RECTANGULAR.value,
         "Spacing_degrees": str(spacing_deg),
-        "Spice_reference_frame": IDEX_EVENT_REFERENCE_FRAME.value,
+        "Spice_reference_frame": IDEX_EVENT_REFERENCE_FRAME.name,
         "num_points": str(counts.size),
     } | idex_attrs.get_global_attributes("imap_idex_l2c_sci-rectangular")
 

--- a/imap_processing/idex/idex_l2c.py
+++ b/imap_processing/idex/idex_l2c.py
@@ -125,7 +125,7 @@ def idex_healpix_map(
     counts = np.histogram(hpix_idx, bins=n_pix, range=(0, n_pix))[0]
     # Add epoch dimension
     counts_da = xr.DataArray(
-        counts[np.newaxis, :],
+        counts[np.newaxis, :].astype(np.int64),
         name="counts",
         dims=("epoch", CoordNames.HEALPIX_INDEX.value),
         attrs=idex_attrs.get_variable_attributes("healpix_counts"),

--- a/imap_processing/idex/idex_l2c.py
+++ b/imap_processing/idex/idex_l2c.py
@@ -193,7 +193,7 @@ def idex_rectangular_map(
         longitude_wrapped, latitude, bins=[grid.az_bin_edges, grid.el_bin_edges]
     )
     counts_da = xr.DataArray(
-        counts[np.newaxis, :, :],
+        counts[np.newaxis, :, :].astype(np.int64),
         name="counts",
         dims=("epoch", "rectangular_lon_pixel", "rectangular_lat_pixel"),
         attrs=idex_attrs.get_variable_attributes("rectangular_counts"),
@@ -241,9 +241,9 @@ def idex_rectangular_map(
     )
     map_attrs = {
         "sky_tiling_type": SkyTilingType.RECTANGULAR.value,
-        "Spacing_degrees": spacing_deg,
-        "Spice_reference_frame": IDEX_EVENT_REFERENCE_FRAME,
-        "num_points": counts.size,
+        "Spacing_degrees": str(spacing_deg),
+        "Spice_reference_frame": IDEX_EVENT_REFERENCE_FRAME.value,
+        "num_points": str(counts.size),
     } | idex_attrs.get_global_attributes("imap_idex_l2c_sci-rectangular")
 
     l2c_dataset.attrs.update(map_attrs)


### PR DESCRIPTION
# Change Summary

## Overview
These fixes were requested by Andriy after reviewing the IDEX CDFS. 

## Updated Files
-imap_processing/cdf/config/imap_idex_l1a_variable_attrs.yaml
   - Add SPASE metadata to variables that will be carried over to l2 CDFs
- imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
   - Add SPASE metadata to variables that will be carried over to l2 CDFs
- imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
   - FIx display type 
- imap_processing/idex/idex_l2c.py
    - Make global attrs strings
