### PR TITLE
Tiny bugfix: fix energy independent `obs_date_range` metadata

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -228,6 +228,9 @@ exposure_factor_energy_independent:
 obs_date_energy_independent:
   <<: *obs_date
 
+obs_date_range_energy_independent:
+  <<: *obs_date
+
 solid_angle:
   <<: *default_float32
   CATDESC: Solid angle subtended by each pixel.

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -83,7 +83,7 @@ obs_date_energy_independent:
   DEPEND_1: pixel_index
   LABL_PTR_1: pixel_index_label
 
-obs_date_range:
+obs_date_range_energy_independent:
   DEPEND_1: pixel_index
   LABL_PTR_1: pixel_index_label
 

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -84,7 +84,11 @@ VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION = [
 # These variables may or may not be energy dependent, depending on the
 # input data. They must be handled slightly differently when it comes to adding
 # metadata to the map dataset.
-INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES = ["obs_date", "exposure_factor"]
+INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES = [
+    "obs_date",
+    "exposure_factor",
+    "obs_date_range",
+]
 
 
 def get_variable_attributes_optional_energy_dependence(


### PR DESCRIPTION
# Change Summary

## Overview
Small bugfix: In a recent PR, the default was changed so that variables are expected to be energy dependent. The obs_date_range metadata needs to be slightly updated to work with this new organization. 