### PR TITLE
Spase metadata ✨ 

### DIFF
--- a/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
@@ -45,6 +45,7 @@ time_data_defaults: &time_data_defaults
   UNITS: N/A
   VALIDMIN: 0
   VALIDMAX: 0
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal
 
 lightcurve_defaults: &lightcurve_defaults
   <<: *support_data_defaults
@@ -65,11 +66,12 @@ bins_dim:
   FILLVAL: *max_uint16
   MONOTON: INCREASE
   SCALETYP: linear
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 flags_dim:
   <<: *default_attrs
   FILLVAL: 255
-  CATDESC: Flag index for daily-occurence counters of L1B flags
+  CATDESC: Flag index for daily-occurrence counters of L1B flags
   FIELDNAM: L1B flag index
   UNITS: ' '
   FORMAT: I2
@@ -77,6 +79,7 @@ flags_dim:
   VALIDMAX: 16
   VALIDMIN: 0
   VAR_TYPE: support_data
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 ecliptic_dim:
   <<: *default_attrs
@@ -90,6 +93,8 @@ ecliptic_dim:
   FILLVAL: 255
   VAR_TYPE: support_data
   FORMAT: I1
+  DICT_KEY: SPASE>Support>SupportQuantity:Orientation
+
 
 number_of_good_l1b_inputs:
   <<: *support_data_defaults
@@ -99,6 +104,7 @@ number_of_good_l1b_inputs:
   FILLVAL: *max_uint16
   FORMAT: I5
   VALIDMAX: 20000 # 3 days * 86400 s / 14.6 s rounded up
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 total_l1b_inputs:
   <<: *support_data_defaults
@@ -108,6 +114,7 @@ total_l1b_inputs:
   FILLVAL: *max_uint16
   FORMAT: I5
   VALIDMAX: 20000
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 identifier:
   <<: *support_data_defaults
@@ -117,6 +124,7 @@ identifier:
   FILLVAL: *max_uint32
   FORMAT: I5
   VALIDMAX: 99999
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal
 
 start_time:
   <<: *time_data_defaults
@@ -142,6 +150,7 @@ filter_temperature_average:
   VALIDMIN: -30.0
   VALIDMAX: 60.0
   UNITS: Celsius
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 filter_temperature_std_dev:
   <<: *support_data_defaults
@@ -153,6 +162,7 @@ filter_temperature_std_dev:
   VALIDMIN: 0.0
   VALIDMAX: 90.0
   UNITS: Celsius
+  DICT_KEY: SPASE>Support>SupportQuantity:Housekeeping
 
 hv_voltage_average:
   <<: *support_data_defaults
@@ -164,6 +174,7 @@ hv_voltage_average:
   VALIDMIN: 0.0
   VALIDMAX: 3500.0
   UNITS: V
+  DICT_KEY: SPASE>Support>SupportQuantity:Housekeeping
 
 hv_voltage_std_dev:
   <<: *support_data_defaults
@@ -175,6 +186,7 @@ hv_voltage_std_dev:
   VALIDMIN: 0.0
   VALIDMAX: 3500.0
   UNITS: V
+  DICT_KEY: SPASE>Support>SupportQuantity:Housekeeping
 
 spin_period_average:
   <<: *support_data_defaults
@@ -188,7 +200,7 @@ spin_period_average:
   UNITS: s
   VALIDMIN: 14.6
   VALIDMAX: 15.4
-  #VAR_TYPE: support_data
+  DICT_KEY: SPASE>Support>SupportQuantity:SpinPeriod
 
 spin_period_std_dev:
   <<: *support_data_defaults
@@ -200,6 +212,7 @@ spin_period_std_dev:
   UNITS: s
   VALIDMIN: 0.0
   VALIDMAX: 9.9
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 # TODO review these
 spin_period_ground_average:
@@ -214,7 +227,7 @@ spin_period_ground_average:
   UNITS: s
   VALIDMIN: 14.6
   VALIDMAX: 15.4
-  #VAR_TYPE: support_data
+  DICT_KEY: SPASE>Support>SupportQuantity:SpinPeriod
 
 spin_period_ground_std_dev:
   <<: *support_data_defaults
@@ -226,6 +239,7 @@ spin_period_ground_std_dev:
   UNITS: s
   VALIDMIN: 0.0
   VALIDMAX: 9.9
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 pulse_length_average:
   <<: *support_data_defaults
@@ -237,6 +251,7 @@ pulse_length_average:
   UNITS: us
   VALIDMIN: 0.0
   VALIDMAX: 12.75
+  DICT_KEY: SPASE>Support>SupportQuantity:Housekeeping
 
 pulse_length_std_dev:
   <<: *support_data_defaults
@@ -248,6 +263,7 @@ pulse_length_std_dev:
   UNITS: us
   VALIDMIN: 0.0
   VALIDMAX: 12.75
+  DICT_KEY: SPASE>Support>SupportQuantity:Housekeeping
 
 position_angle_offset_average:
   <<: *support_data_defaults
@@ -259,6 +275,7 @@ position_angle_offset_average:
   UNITS: degrees
   VALIDMIN: 0.0
   VALIDMAX: 360.0
+  DICT_KEY: SPASE>Support>SupportQuantity:Positional
 
 position_angle_offset_std_dev:
   <<: *support_data_defaults
@@ -270,6 +287,7 @@ position_angle_offset_std_dev:
   UNITS: degrees
   VALIDMIN: 0.0
   VALIDMAX: 360.0
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 spin_axis_orientation_average:
   <<: *support_data_defaults
@@ -281,6 +299,7 @@ spin_axis_orientation_average:
   UNITS: degrees
   VALIDMIN: -90.0
   VALIDMAX: 360.0
+  DICT_KEY: SPASE>Support>SupportQuantity:SpinPhase
 
 spin_axis_orientation_std_dev:
   <<: *support_data_defaults
@@ -292,6 +311,7 @@ spin_axis_orientation_std_dev:
   UNITS: degrees
   VALIDMIN: 0.0
   VALIDMAX: 360.0
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 spacecraft_location_average:
   <<: *support_data_defaults
@@ -305,6 +325,8 @@ spacecraft_location_average:
   UNITS: km
   VALIDMIN: -9.999999999E+8
   VALIDMAX: 9.999999999E+8
+  DICT_KEY: SPASE>Support>SupportQuantity:Positional
+
 
 spacecraft_location_std_dev:
   <<: *support_data_defaults
@@ -318,6 +340,7 @@ spacecraft_location_std_dev:
   UNITS: km
   VALIDMIN: 0.0
   VALIDMAX: 1.5E+7 # 50 km/s * 3 days * 86400 s < 1.5e7
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 spacecraft_velocity_average:
   <<: *support_data_defaults
@@ -331,6 +354,7 @@ spacecraft_velocity_average:
   UNITS: km/s
   VALIDMIN: -50.0
   VALIDMAX: 50.0
+  DICT_KEY: SPASE>Support>SupportQuantity:Velocity
 
 spacecraft_velocity_std_dev:
   <<: *support_data_defaults
@@ -344,6 +368,7 @@ spacecraft_velocity_std_dev:
   UNITS: km/s
   VALIDMIN: 0.0
   VALIDMAX: 9.9
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 bad_time_flag_occurrences:
   <<: *support_data_defaults
@@ -356,6 +381,7 @@ bad_time_flag_occurrences:
   FORMAT: I5
   VALIDMAX: 20000
   LABLAXIS: No. of cases
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 spin_angle:
   <<: *lightcurve_defaults
@@ -368,6 +394,7 @@ spin_angle:
   FORMAT: F7.3
   VALIDMIN: 0.0
   VALIDMAX: 360.0
+  DICT_KEY: SPASE>Support>SupportQuantity:SpinPhase
 
 photon_flux:
   <<: *lightcurve_defaults
@@ -380,6 +407,8 @@ photon_flux:
   FORMAT: F8.2
   VALIDMIN: 0.0
   VALIDMAX: 30000.0 # max 30000 cps in FDIR / from 1 to 3.37 cps-per-R
+  # SPASE data pulled from TWINS 1 LAD metadata
+  DICT_KEY: SPASE>Wave>WaveType:Electromagnetic,WaveQuantity:Intensity,Qualifier:Scalar
 
 raw_histograms:
   <<: *lightcurve_defaults
@@ -392,6 +421,7 @@ raw_histograms:
   FORMAT: I8
   VALIDMIN: 0
   VALIDMAX: 35000000 # max 30000 cps in FDIR * 3 days * 86400 s / 225 bins rounded up
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 exposure_times:
   <<: *lightcurve_defaults
@@ -404,6 +434,7 @@ exposure_times:
   FORMAT: F7.2
   VALIDMIN: 0.0
   VALIDMAX: 1200.0 # 3 days * 86400 s / 225 bins rounded up
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 flux_uncertainties:
   <<: *lightcurve_defaults
@@ -416,6 +447,7 @@ flux_uncertainties:
   FORMAT: F8.2
   VALIDMIN: 0.0
   VALIDMAX: 30000.0 # the same VALIDMAX as for photon_flux assumed
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 histogram_flag_array:
   <<: *lightcurve_defaults
@@ -428,6 +460,7 @@ histogram_flag_array:
   FORMAT: I2
   VALIDMIN: 0
   VALIDMAX: 15 # only 4 bits currently used
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 ecliptic_lon:
   <<: *lightcurve_defaults
@@ -440,6 +473,7 @@ ecliptic_lon:
   FORMAT: F7.3
   VALIDMIN: 0.0
   VALIDMAX: 360.0
+  DICT_KEY: SPASE>Support>SupportQuantity:Positional
 
 ecliptic_lat:
   <<: *lightcurve_defaults
@@ -452,6 +486,7 @@ ecliptic_lat:
   FORMAT: F7.3
   VALIDMIN: -90.0
   VALIDMAX: 90.0
+  DICT_KEY: SPASE>Support>SupportQuantity:Positional
 
 number_of_bins:
   <<: *support_data_defaults
@@ -464,6 +499,7 @@ number_of_bins:
   FORMAT: I4
   VALIDMIN: 225
   VALIDMAX: 3600
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 # M. Strumik comment: this variable is obsolete and should not be used
 raw_uncertainties:

--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -1,0 +1,160 @@
+# <=== Label Attributes ===>
+# LABL_PTR_i expects VAR_TYPE of metadata with char data type.
+default_attrs: &default
+  # Assumed values for all variable attrs unless overwritten
+  DEPEND_0: epoch
+  DISPLAY_TYPE: time_series
+  FILLVAL: -9223372036854775808
+  FORMAT: I12
+  VALIDMIN: -9223372036854775808
+  VALIDMAX: 9223372036854775807
+  VAR_TYPE: data
+  UNITS: ' '
+
+default_coords: &default_coords
+  # Assumed values for all coordinate attrs unless overwritten
+  FORMAT: F2.4  # Float with 4 digits
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: time_series
+  FILLVAL: -9223372036854775808
+  VALIDMIN: -9223372036854775808
+  VALIDMAX: 9223372036854775807
+  UNITS: counts
+
+mag_support_attrs: &support_default
+    <<: *default
+    VAR_TYPE: support_data
+    DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+mag_metadata_attrs: &metadata_default
+    <<: *default
+    VAR_TYPE: metadata
+
+direction_label:
+  CATDESC: magnetic field vector data
+  FIELDNAM: Magnetic Field Vector
+  FORMAT: A3
+  VAR_TYPE: metadata
+
+compression_label:
+  CATDESC: Compression and width
+  FIELDNAM: Compression and width
+  FORMAT: A2
+  VAR_TYPE: metadata
+
+vector_attrs: &vectors_default
+    <<: *default
+    CATDESC: Magnetic field vectors with x y z varying by time
+    DEPEND_1: direction
+    FIELDNAM: Magnetic Field Vector
+    LABL_PTR_1: direction_label
+    FILLVAL: 9223372036854775807
+    FORMAT: F12.5
+
+direction_attrs:
+    <<: *default_coords
+    CATDESC: Magnetic field vector
+    FIELDNAM: \[xyz\] magnetic field vector
+    FORMAT: I3
+    VAR_TYPE: support_data
+    DISPLAY_TYPE: time_series
+    LABLAXIS: Magnetic field vector
+
+compression_attrs:
+  <<: *default_coords
+  CATDESC: Data compression flag
+  FIELDNAM: Compression
+  LABLAXIS: Compressed
+  FORMAT: I2
+  VAR_TYPE: support_data
+  VALIDMAX: 21
+  VALIDMIN: 0
+  DISPLAY_TYPE: no_plot
+
+compression_flags_attrs:
+  <<: *support_default
+  CATDESC: Compression information per time stamp, includes a flag and the compression width
+  FIELDNAM: Compression information per time stamp
+  DEPEND_0: epoch
+  DEPEND_1: compression
+  FORMAT: I2
+  VALIDMAX: 21
+  VALIDMIN: 0
+  LABL_PTR_1: compression_label
+  DISPLAY_TYPE: no_plot
+
+compression:
+    <<: *support_default
+    CATDESC: Data compression flag
+    FIELDNAM: Data is compressed
+    LABLAXIS: Compressed
+    FILLVAL: 255
+    FORMAT: I1
+    VALIDMAX: 1
+    VALIDMIN: 0
+    DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
+
+compression_width:
+  <<: *support_default
+  CATDESC: Compression bit width
+  DEPEND_0: epoch
+  DISPLAY_TYPE: time_series
+  FIELDNAM: Compressed data bit width
+  LABLAXIS: Bit width
+  FILLVAL: 255
+  FORMAT: I2
+  UNITS: 'bits'
+  VALIDMAX: 21
+  VALIDMIN: 0
+
+pri_sens:
+    <<: *support_default
+    CATDESC: Indicates the primary sensor. 0 is MAGo, 1 is MAGi
+    FIELDNAM: Primary Sensor
+    LABLAXIS: Primary Sensor
+    FILLVAL: 255
+    FORMAT: I1
+    UNITS: ' '
+    VALIDMAX: 1
+    VALIDMIN: 0
+    DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
+
+vecsec:
+    <<: *support_default
+    CATDESC: Vectors per second
+    FIELDNAM: Vectors per second
+    LABLAXIS: Vectors/sec
+    FILLVAL: 0
+    FORMAT: I3
+    UNITS: 'Hz'
+    VALIDMAX: 128
+    VALIDMIN: 1
+    DICT_KEY: SPASE>Support>SupportQuantity:Housekeeping
+
+vectors:
+    <<: *vectors_default
+    CATDESC: Magnetic field vectors with x y z and sensor range varying by time
+    FIELDNAM: Magnetic field
+    LABLAXIS: Magnetic field
+
+qf_bitmask:
+  <<: *support_default
+  CATDESC: Eight-bit Data quality bitmask
+  FIELDNAM: Quality Flag
+  LABLAXIS: QF
+  FILLVAL: 255
+  FORMAT: I3
+  VALIDMAX: 255
+  VALIDMIN: 0
+  DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
+
+qf:
+  <<: *support_default
+  CATDESC: Data quality flag
+  FIELDNAM: Quality Flag
+  LABLAXIS: QF
+  FILLVAL: 255
+  FORMAT: I1
+  VALIDMAX: 1
+  VALIDMIN: 0
+  DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode

--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -50,6 +50,7 @@ vector_attrs: &vectors_default
     LABL_PTR_1: direction_label
     FILLVAL: 9223372036854775807
     FORMAT: F12.5
+    DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:DSRF,CoordinateRepresentation:Cartesian"
 
 direction_attrs:
     <<: *default_coords
@@ -59,42 +60,11 @@ direction_attrs:
     VAR_TYPE: support_data
     DISPLAY_TYPE: time_series
     LABLAXIS: Magnetic field vector
+    DICT_KEY: SPASE>Support>SupportQuantity:Orientation
 
-compression_attrs:
-  <<: *default_coords
-  CATDESC: Data compression flag
-  FIELDNAM: Compression
-  LABLAXIS: Compressed
-  FORMAT: I2
-  VAR_TYPE: support_data
-  VALIDMAX: 21
-  VALIDMIN: 0
-  DISPLAY_TYPE: no_plot
 
-compression_flags_attrs:
-  <<: *support_default
-  CATDESC: Compression information per time stamp, includes a flag and the compression width
-  FIELDNAM: Compression information per time stamp
-  DEPEND_0: epoch
-  DEPEND_1: compression
-  FORMAT: I2
-  VALIDMAX: 21
-  VALIDMIN: 0
-  LABL_PTR_1: compression_label
-  DISPLAY_TYPE: no_plot
-
-compression:
-    <<: *support_default
-    CATDESC: Data compression flag
-    FIELDNAM: Data is compressed
-    LABLAXIS: Compressed
-    FILLVAL: 255
-    FORMAT: I1
-    VALIDMAX: 1
-    VALIDMIN: 0
-    DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
-
-compression_width:
+# TODO: Add magnitude and range attributes, remove this
+fill:
   <<: *support_default
   CATDESC: Compression bit width
   DEPEND_0: epoch
@@ -106,6 +76,7 @@ compression_width:
   UNITS: 'bits'
   VALIDMAX: 21
   VALIDMIN: 0
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 pri_sens:
     <<: *support_default
@@ -119,23 +90,6 @@ pri_sens:
     VALIDMIN: 0
     DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
 
-vecsec:
-    <<: *support_default
-    CATDESC: Vectors per second
-    FIELDNAM: Vectors per second
-    LABLAXIS: Vectors/sec
-    FILLVAL: 0
-    FORMAT: I3
-    UNITS: 'Hz'
-    VALIDMAX: 128
-    VALIDMIN: 1
-    DICT_KEY: SPASE>Support>SupportQuantity:Housekeeping
-
-vectors:
-    <<: *vectors_default
-    CATDESC: Magnetic field vectors with x y z and sensor range varying by time
-    FIELDNAM: Magnetic field
-    LABLAXIS: Magnetic field
 
 qf_bitmask:
   <<: *support_default
@@ -146,7 +100,7 @@ qf_bitmask:
   FORMAT: I3
   VALIDMAX: 255
   VALIDMIN: 0
-  DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 qf:
   <<: *support_default
@@ -157,4 +111,4 @@ qf:
   FORMAT: I1
   VALIDMAX: 1
   VALIDMIN: 0
-  DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -34,8 +34,6 @@ class DailyLightcurve:
         ecliptic latitude of bin centers [deg]
     number_of_bins : int
         number of bins in lightcurve
-    raw_uncertainties : numpy.ndarray
-        statistical uncertainties for raw histograms (sqrt of self.raw_histograms)
     l1b_data : xarray.Dataset
         L1B data filtered by good times, good angles, and good bins.
     """
@@ -52,7 +50,6 @@ class DailyLightcurve:
     ecliptic_lon: np.ndarray = field(init=False)
     ecliptic_lat: np.ndarray = field(init=False)
     number_of_bins: int = field(init=False)
-    raw_uncertainties: np.ndarray = field(init=False)
     l1b_data: InitVar[xr.Dataset]
 
     def __post_init__(self, l1b_data: xr.Dataset) -> None:
@@ -76,14 +73,14 @@ class DailyLightcurve:
         self.exposure_times = self.calculate_exposure_times(
             l1b_data, exposure_times_per_timestamp
         )
-        self.raw_uncertainties = np.sqrt(self.raw_histograms)
+        raw_uncertainties = np.sqrt(self.raw_histograms)
         self.photon_flux = np.zeros(len(self.raw_histograms))
         self.flux_uncertainties = np.zeros(len(self.raw_histograms))
 
         # TODO: Only where exposure counts != 0
         if len(self.exposure_times) != 0:
             self.photon_flux = self.raw_histograms / self.exposure_times
-            self.flux_uncertainties = self.raw_uncertainties / self.exposure_times
+            self.flux_uncertainties = raw_uncertainties / self.exposure_times
 
         # TODO: Average this, or should they all be the same?
         self.spin_angle = np.average(l1b_data["imap_spin_angle_bin_cntr"].data, axis=0)
@@ -135,7 +132,7 @@ class DailyLightcurve:
             Sum of valid histograms across all timestamps.
         """
         histograms[histograms == -1] = 0
-        return np.sum(histograms, axis=0)
+        return np.sum(histograms, axis=0, dtype=np.int64)
 
 
 @dataclass

--- a/imap_processing/mag/l2/mag_l2.py
+++ b/imap_processing/mag/l2/mag_l2.py
@@ -107,7 +107,7 @@ def mag_l2(
     attributes = ImapCdfAttributes()
     attributes.add_instrument_global_attrs("mag")
     # temporarily point to l1c
-    attributes.add_instrument_variable_attrs("mag", "l1c")
+    attributes.add_instrument_variable_attrs("mag", "l2")
     return [input_data.generate_dataset(attributes, day)]
 
 

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -253,14 +253,14 @@ class MagL2:
             name="range",
             dims=["epoch"],
             # TODO temp attrs
-            attrs=attribute_manager.get_variable_attributes("compression_width"),
+            attrs=attribute_manager.get_variable_attributes("fill"),
         )
 
         magnitude = xr.DataArray(
             self.magnitude,
             name="magnitude",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("compression_width"),
+            attrs=attribute_manager.get_variable_attributes("fill"),
         )
 
         global_attributes = (

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -222,7 +222,9 @@ class MagL2:
             self.epoch,
             name="epoch",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("epoch"),
+            attrs=attribute_manager.get_variable_attributes(
+                "epoch", check_schema=False
+            ),
         )
 
         vectors = xr.DataArray(
@@ -236,14 +238,14 @@ class MagL2:
             self.quality_flags,
             name="quality_flags",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("compression"),
+            attrs=attribute_manager.get_variable_attributes("qf_bitmask"),
         )
 
         quality_bitmask = xr.DataArray(
             self.quality_flags,
             name="quality_flags",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("compression"),
+            attrs=attribute_manager.get_variable_attributes("qf"),
         )
 
         rng = xr.DataArray(


### PR DESCRIPTION
# Change Summary
Adding SPASE metadata for MAG and GLOWS. 

This hasn't been reviewed by instrument teams but we have discussed some of the info. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
- add SPASE metadata for MAG
- Add a MAG L2 attributes file (for now exact duplicate of L1C)
- Add SPASE metadata for GLOWS L2
- Remove one unneeded data var/attribute

Tested both and both run without failures. 
