### PR TITLE
Bugfixes for delta_energy with epoch as first dim

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -90,7 +90,7 @@ shcoarse:
 energy_bin_delta:
   <<: *default_float32
   CATDESC: Difference between the energy bin edges.
-  DEPEND_0: energy_bin_geometric_mean
+  DEPEND_1: energy_bin_geometric_mean
   FIELDNAM: energy_bin_delta
   LABLAXIS: energy bin delta
   UNITS: keV

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -69,6 +69,7 @@ class TestUltraL2:
     def mock_data_dict(self, _mock_multiple_psets):
         return {pset.attrs["Logical_file_id"]: pset for pset in self.ultra_psets}
 
+    @pytest.mark.parametrize("epoch_dim_for_energy_delta", [True, False])
     @pytest.mark.parametrize(
         ["map_frame", "rtol"],
         [
@@ -83,7 +84,7 @@ class TestUltraL2:
     )
     @pytest.mark.usefixtures("_mock_single_pset", "_setup_spice_kernels_list")
     def test_generate_ultra_healpix_skymap_single_pset(
-        self, map_frame, rtol, furnish_kernels
+        self, epoch_dim_for_energy_delta, map_frame, rtol, furnish_kernels
     ):
         # Avoid modifying the original pset
         pset = self.ultra_pset.copy(deep=True)
@@ -95,6 +96,11 @@ class TestUltraL2:
         pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
+        if epoch_dim_for_energy_delta:
+            # add an extra dim to the start
+            pset["energy_bin_delta"] = pset["energy_bin_delta"].expand_dims(
+                {CoordNames.TIME.value: pset["epoch"].values}
+            )
 
         # Create the Healpix skymap in the desired frame.
         with furnish_kernels(self.required_kernel_names):

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -306,6 +306,10 @@ def generate_ultra_healpix_skymap(
 
     # Get the energy bin widths from a PointingSet (they will all be the same)
     delta_energy = pointing_set.data["energy_bin_delta"]
+    if CoordNames.TIME.value in delta_energy.dims:
+        delta_energy = delta_energy.mean(
+            dim=CoordNames.TIME.value,
+        )
 
     # Core calculations of ena_intensity and its statistical uncertainty for L2
     # Exposure time may contain 0s, producing NaNs in the corrected count rate


### PR DESCRIPTION
# Change Summary

In pre-SIT4 testing, found bug with ena_intensity calculation. Coming from an unexpected "epoch" dim on the energy_delta

Also fix metadata bug