### PR TITLE
CoDICE: Some hotfixes to get things working with MSIM3 data and SIT-4

### DIFF
--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -12,6 +12,7 @@ dataset = process_codice_l2(l1_filename)
 import logging
 from pathlib import Path
 
+import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
@@ -75,6 +76,13 @@ def process_codice_l2(file_path: Path) -> xr.Dataset:
 
     # TODO: Add L2-specific algorithms/functionality here. For SIT-4, we can
     #       just keep the data as-is.
+
+    # Workaround to fix monitomically increasing epoch issue
+    epoch_attrs = cdf_attrs.get_variable_attributes("epoch", check_schema=False)
+    new_epoch_values = np.array([843543730220584064 + i for i in range(113)])
+    l2_dataset = l2_dataset.assign_coords(
+        epoch=("epoch", new_epoch_values, epoch_attrs)
+    )
 
     logger.info(f"\nFinal data product:\n{l2_dataset}\n")
 

--- a/imap_processing/codice/constants.py
+++ b/imap_processing/codice/constants.py
@@ -207,13 +207,13 @@ HI_COUNTERS_AGGREGATED_ACTIVE_VARIABLES = {
     "Reserved3": False,
     "Reserved4": False,
     "Reserved5": False,
-    "LowTOFCutoff": False,
-    "Reserved6": False,
-    "Reserved7": False,
+    "LowTOFCutoff": True,
+    "Reserved6": True,
+    "Reserved7": True,
     "ASIC1FlagInvalid": True,
     "ASIC2FlagInvalid": True,
-    "ASIC1ChannelInvalid": False,
-    "ASIC2ChannelInvalid": False,
+    "ASIC1ChannelInvalid": True,
+    "ASIC2ChannelInvalid": True,
 }
 HI_COUNTERS_AGGREGATED_VARIABLE_NAMES = [
     name


### PR DESCRIPTION
This PR makes a few small changes to get the L1a, L2b, and L2 pipelines working with CoDICE MSIM3 data, to be used in SIT-4.