### PR TITLE
HIT L1A - Add attributes to science datasets

### DIFF
--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -97,7 +97,7 @@ adc_channels_label:
   VAR_TYPE: metadata
 
 
-# <=== Data Variable Attributes ===>
+# <=== Housekeeping Data Variable Attributes ===>
 
 # CCSDS header variables
 version:

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -1,5 +1,3 @@
-# TODO: add attributes for science packets
-
 # <=== Defaults ===>
 # Default values for variable attrs unless overwritten
 default_attrs: &default
@@ -71,14 +69,6 @@ hk_default_attrs: &hk_default
   VALIDMAX: 4095
   FORMAT: I4
 
-counts_support_attrs: &counts_support_default
-  <<: *default
-  DISPLAY_TYPE: no_plot
-  VAR_TYPE: support_data
-  FILLVAL: -1.00E+31
-  VALIDMIN: 0
-  VALIDMAX: 1000
-
 index_support_attrs: &index_support_default
   <<: *default_uint32
   DISPLAY_TYPE: no_plot
@@ -94,8 +84,25 @@ energy_support_attrs: &energy_support_default
   UNITS: MeV
   FORMAT: F5.1
 
+counts_support_attrs: &counts_support_default
+  <<: *default
+  DISPLAY_TYPE: no_plot
+  VAR_TYPE: support_data
+  FILLVAL: -1.00E+31
+  VALIDMIN: 0
+  VALIDMAX: 1000
 
-# <=== Counts Coordinates ===>
+counts_attrs: &counts_default
+  <<: *default
+  DISPLAY_TYPE: time_series
+  VAR_TYPE: data
+  FORMAT: I10
+  VALIDMIN: 0
+  VALIDMAX: 10000000000
+  UNITS: counts
+  SCALETYP: log
+
+# <=== Coordinates ===>
 sc_tick:
   <<: *default_uint32
   CATDESC: Raw spacecraft tick time per integration
@@ -107,19 +114,20 @@ sc_tick:
   UNITS: ''
   SCALETYP: linear
 
+# Counts Dataset Coordinates
 declination:
     <<: *counts_support_default
-    CATDESC: Declination
+    CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
     FIELDNAM: Declination
     LABLAXIS: Declination
     FORMAT: F5.1
     UNITS: deg
 
-inclination:
+azimuth:
     <<: *counts_support_default
-    CATDESC: Inclination
-    FIELDNAM: Inclination
-    LABLAXIS: Inclination
+    CATDESC: Spin angle in 15 bins (0 deg. is zero of spin phase)
+    FIELDNAM: Azimuth
+    LABLAXIS: Azimuth
     FORMAT: F5.1
     UNITS: deg
 
@@ -228,7 +236,7 @@ fe_energy_mean:
   FIELDNAM: Fe energy mean
 
 
-# <=== Housekeeping Coordinates ===>
+# Housekeeping Dataset Coordinates
 adc_channels:   # adc_channels is a dependency for leak_i data variable
   DISPLAY_TYPE: no_plot
   FILLVAL: -9223372036854775808
@@ -242,17 +250,17 @@ adc_channels:   # adc_channels is a dependency for leak_i data variable
   LABLAXIS: Channel
   FORMAT: I2
 
-# <=== Housekeeping Label Attributes ===>
-# LABL_PTR_i expects VAR_TYPE of metadata with char data type
-
+# <=== Label Attributes ===>
+# Housekeeping Labels
 adc_channels_label:
   CATDESC: Analog Digital Converter Channels
   FIELDNAM: ADC Channels
   FORMAT: A2
   VAR_TYPE: metadata
 
+#TODO: add labels for counts dataset
 
-# <=== Housekeeping Data Variable Attributes ===>
+# <=== Data Variable Attributes ===>
 
 # CCSDS header variables
 version:
@@ -304,8 +312,333 @@ pkt_len:
   VAR_TYPE: support_data
   DEPEND_0: sc_tick
 
+# Counts dataset variables
+#TODO: add counts dataset variables
+hdr_frame_version:
+  <<: *counts_default
+  CATDESC: Raw header frame version per integration
+  FIELDNAM: Header frame version
+  LABLAXIS: hdr_frame_version
+  UNITS: ''
 
-# Housekeeping variables
+hdr_dynamic_threshold_state:
+  <<: *counts_default
+  CATDESC: Raw header dynamic threshold state per integration
+  FIELDNAM: Header dynamic threshold state
+  LABLAXIS: hdr_dynamic_threshold_state
+  UNITS: ''
+  VALIDMAX: 3
+
+hdr_leak_conv:
+  <<: *counts_default
+  CATDESC: Raw header leak conversion per integration
+  FIELDNAM: Header leak conversion
+  LABLAXIS: hdr_leak_conv
+  UNITS: ''
+
+hdr_heavy_duty_cycle:
+  <<: *counts_default
+  CATDESC: Raw header heavy duty cycle per integration
+  FIELDNAM: Header heavy duty cycle
+  LABLAXIS: hdr_heavy_duty_cycle
+  UNITS: ''
+
+hdr_code_ok:
+  <<: *counts_default
+  CATDESC: Raw header code ok per integration
+  FIELDNAM: Header code ok
+  LABLAXIS: hdr_code_ok
+  UNITS: ''
+
+hdr_unit_num:
+  <<: *counts_default
+  CATDESC: Raw header unit number per integration
+  FIELDNAM: Header unit number
+  LABLAXIS: hdr_unit_num
+  UNITS: ''
+
+hdr_minute_cnt:
+  <<: *counts_default
+  CATDESC: Raw header minute count per integration
+  FIELDNAM: Header minute count
+  LABLAXIS: hdr_minute_cnt
+
+livetime_counter:
+  <<: *counts_default
+  CATDESC: Raw livetime counter per integration
+  FIELDNAM: Livetime counter
+  LABLAXIS: Livetime counter
+
+num_trig:
+  <<: *counts_default
+  CATDESC: Raw number of triggers per integration
+  FIELDNAM: Number of triggers
+  LABLAXIS: num_trig
+
+num_reject:
+  <<: *counts_default
+  CATDESC: Raw number of rejects per integration
+  FIELDNAM: Number of rejects
+  LABLAXIS: num_reject
+
+num_acc_w_phase:
+  <<: *counts_default
+  CATDESC: Raw number of accepted events with PHA data per integration
+  FIELDNAM: Number of accepted events with PHA
+  LABLAXIS: num_acc_w_phase
+
+num_acc_no_phase:
+  <<: *counts_default
+  CATDESC: Raw number of events without PHA data per integration
+  FIELDNAM: Number of events without PHA
+  LABLAXIS: num_acc_no_phase
+
+num_haz_trig:
+  <<: *counts_default
+  CATDESC: Raw number of hazard triggers per integration
+  FIELDNAM: Number of hazard triggers
+  LABLAXIS: num_haz_trig
+
+num_haz_reject:
+  <<: *counts_default
+  CATDESC: Raw number of rejected events with hazard per integration
+  FIELDNAM: Number of hazard rejects
+  LABLAXIS: num_haz_reject
+
+num_haz_acc_w_phase:
+  <<: *counts_default
+  CATDESC: Raw number of accepted hazard events with PHA data per integration
+  FIELDNAM: Number of accepted hazard events with PHA
+  LABLAXIS: num_haz_acc_w_phase
+
+num_haz_acc_no_phase:
+  <<: *counts_default
+  CATDESC: Raw number of hazard events without PHA data per integration
+  FIELDNAM: Number of hazard events without PHA
+  LABLAXIS: num_haz_acc_no_phase
+
+nread:
+  <<: *counts_default
+  CATDESC: Raw number of events read per integration
+  FIELDNAM: Number of read events
+  LABLAXIS: nread
+
+nhazard:
+  <<: *counts_default
+  CATDESC: Raw number of hazard events per integration
+  FIELDNAM: Number of hazard events
+  LABLAXIS: nhazard
+
+nadcstim:
+  <<: *counts_default
+  CATDESC: Raw number of ADC-stim events per integration
+  FIELDNAM: Number of ADC-stim events
+  LABLAXIS: nadcstim
+
+nodd:
+  <<: *counts_default
+  CATDESC: Raw number of odd events per integration
+  FIELDNAM: Number of odd events
+  LABLAXIS: nodd
+
+noddfix:
+  <<: *counts_default
+  CATDESC: Raw number of fixed odd events per integration
+  FIELDNAM: Number of fixed odd events
+  LABLAXIS: noddfix
+
+nmulti:
+  <<: *counts_default
+  CATDESC: Raw number of events with multiple hits in a single detector per integration
+  FIELDNAM: Number of events with multiple hits
+  LABLAXIS: nmulti
+
+nmultifix:
+  <<: *counts_default
+  CATDESC: Raw number of multi events that were fixed per integration
+  FIELDNAM: Number of fixed multiple hits
+  LABLAXIS: nmultifix
+
+sngrates:
+  <<: *counts_default
+  DEPEND_1: gain
+  DEPEND_2: sngrates_index
+  CATDESC: Raw single rates per integration
+  FIELDNAM: sngrates
+  LABL_PTR_1: sngrates_index
+  DELTA_MINUS_VAR: sngrates_stat_uncert_minus
+  DELTA_PLUS_VAR: sngrates_stat_uncert_plus
+
+coinrates:
+  <<: *counts_default
+  DEPEND_1: coinrates_index
+  CATDESC: Raw coincidence rates per integration
+  FIELDNAM: coinrates
+  LABL_PTR_1: coinrates_index
+  DELTA_MINUS_VAR: coinrates_stat_uncert_minus
+  DELTA_PLUS_VAR: coinrates_stat_uncert_plus
+
+pbufrates:
+  <<: *counts_default
+  DEPEND_1: pbufrates_index
+  CATDESC: Raw priority buffer rates per integration
+  FIELDNAM: pbufrates
+  LABL_PTR_1: pbufrates_index
+  DELTA_MINUS_VAR: pbufrates_stat_uncert_minus
+  DELTA_PLUS_VAR: pbufrates_stat_uncert_plus
+
+l2fgrates:
+  <<: *counts_default
+  DEPEND_1: l2fgrates_index
+  CATDESC: Raw range 2 foreground rates per integration
+  FIELDNAM: l2fgrates
+  LABL_PTR_1: l2fgrates_index
+  DELTA_MINUS_VAR: l2fgrates_stat_uncert_minus
+  DELTA_PLUS_VAR: l2fgrates_stat_uncert_plus
+
+l2bgrates:
+  <<: *counts_default
+  DEPEND_1: l2bgrates_index
+  CATDESC: Raw range 2 background rates per integration
+  FIELDNAM: l2bgrates
+  LABL_PTR_1: l2bgrates_index
+  DELTA_MINUS_VAR: l2bgrates_stat_uncert_minus
+  DELTA_PLUS_VAR: l2bgrates_stat_uncert_plus
+
+l3fgrates:
+  <<: *counts_default
+  DEPEND_1: l3fgrates_index
+  CATDESC: Raw range 3 foreground rates per integration
+  FIELDNAM: l3fgrates
+  LABL_PTR_1: l3fgrates_index
+  DELTA_MINUS_VAR: l3fgrates_stat_uncert_minus
+  DELTA_PLUS_VAR: l3fgrates_stat_uncert_plus
+
+l3bgrates:
+  <<: *counts_default
+  DEPEND_1: l3bgrates_index
+  CATDESC: Raw range 3 background rates per integration
+  FIELDNAM: l3bgrates
+  LABL_PTR_1: l3bgrates_index
+  DELTA_MINUS_VAR: l3bgrates_stat_uncert_minus
+  DELTA_PLUS_VAR: l3bgrates_stat_uncert_plus
+
+penfgrates:
+  <<: *counts_default
+  DEPEND_1: penfgrates_index
+  CATDESC: Raw range 4 foreground rates per integration
+  FIELDNAM: penfgrates
+  LABL_PTR_1: penfgrates_index
+  DELTA_MINUS_VAR: penfgrates_stat_uncert_minus
+  DELTA_PLUS_VAR: penfgrates_stat_uncert_plus
+
+penbgrates:
+  <<: *counts_default
+  DEPEND_1: penbgrates_index
+  CATDESC: Raw range 4 background rates per integration
+  FIELDNAM: penbgrates
+  LABL_PTR_1: penbgrates_index
+  DELTA_MINUS_VAR: penbgrates_stat_uncert_minus
+  DELTA_PLUS_VAR: penbgrates_stat_uncert_plus
+
+ialirtrates:
+  <<: *counts_default
+  DEPEND_1: ialirtrates_index
+  CATDESC: Raw ialirtrates per integration
+  FIELDNAM: ialirtrates
+  LABL_PTR_1: ialirtrates_index
+  DELTA_MINUS_VAR: ialirtrates_stat_uncert_minus
+  DELTA_PLUS_VAR: ialirtrates_stat_uncert_plus
+
+l4fgrates:
+  <<: *counts_default
+  DEPEND_1: l4fgrates_index
+  CATDESC: Raw L4 ions foreground rates per integration
+  FIELDNAM: l4fgrates
+  LABL_PTR_1: l4fgrates_index
+  DELTA_MINUS_VAR: l4fgrates_stat_uncert_minus
+  DELTA_PLUS_VAR: l4fgrates_stat_uncert_plus
+
+l4bgrates:
+  <<: *counts_default
+  DEPEND_1: l4bgrates_index
+  CATDESC: Raw L4 ions background rates per integration
+  FIELDNAM: l4bgrates
+  LABL_PTR_1: l4bgrates_index
+  DELTA_MINUS_VAR: l4bgrates_stat_uncert_minus
+  DELTA_PLUS_VAR: l4bgrates_stat_uncert_plus
+
+sectorates:
+  <<: *counts_default
+  DEPEND_1: declination
+  DEPEND_2: azimuth
+  CATDESC: Raw sectored rates per integration
+  FIELDNAM: Sectored rates
+  LABL_PTR_1: declination
+  LABL_PTR_2: azimuth
+  DELTA_MINUS_VAR: sectorates_stat_uncert_minus
+  DELTA_PLUS_VAR: sectorates_stat_uncert_plus
+
+h_sectored_counts:
+  <<: *counts_default
+  DEPEND_1: declination
+  DEPEND_2: azimuth
+  CATDESC: Raw H sectored counts per integration
+  FIELDNAM: H sectored counts
+  LABL_PTR_1: declination
+  LABL_PTR_2: azimuth
+  DELTA_MINUS_VAR: h_sectored_counts_stat_uncert_minus
+  DELTA_PLUS_VAR: h_sectored_counts_stat_uncert_plus
+
+he4_sectored_counts:
+  <<: *counts_default
+  DEPEND_1: declination
+  DEPEND_2: azimuth
+  CATDESC: Raw He4 sectored counts per integration
+  FIELDNAM: He4 sectored counts
+  LABL_PTR_1: declination
+  LABL_PTR_2: azimuth
+  DELTA_MINUS_VAR: he4_sectored_counts_stat_uncert_minus
+  DELTA_PLUS_VAR: he4_sectored_counts_stat_uncert_plus
+
+cno_sectored_counts:
+  <<: *counts_default
+  DEPEND_1: declination
+  DEPEND_2: azimuth
+  CATDESC: Raw C, N, O sectored counts per integration
+  FIELDNAM: C, N, O sectored counts
+  LABL_PTR_1: declination
+  LABL_PTR_2: azimuth
+  DELTA_MINUS_VAR: cno_sectored_counts_stat_uncert_minus
+  DELTA_PLUS_VAR: cno_sectored_counts_stat_uncert_plus
+
+nemgsi_sectored_counts:
+  <<: *counts_default
+  DEPEND_1: declination
+  DEPEND_2: azimuth
+  CATDESC: Raw Ne, Mg, Si sectored counts per integration
+  FIELDNAM: Ne, Mg, Si sectored counts
+  LABL_PTR_1: declination
+  LABL_PTR_2: azimuth
+  DELTA_MINUS_VAR: nemgsi_sectored_counts_stat_uncert_minus
+  DELTA_PLUS_VAR: nemgsi_sectored_counts_stat_uncert_plus
+
+fe_sectored_counts:
+  <<: *counts_default
+  DEPEND_1: declination
+  DEPEND_2: azimuth
+  CATDESC: Raw Fe sectored counts per integration
+  FIELDNAM: Fe sectored counts
+  LABL_PTR_1: declination
+  LABL_PTR_2: azimuth
+  DELTA_MINUS_VAR: fe_sectored_counts_stat_uncert_minus
+  DELTA_PLUS_VAR: fe_sectored_counts_stat_uncert_plus
+
+
+#TODO - energy deltas
+#TODO - uncertainties
+
+# Housekeeping dataset variables
 fsw_version_a:
   <<: *hk_support_default
   VALIDMAX: 63

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -73,7 +73,165 @@ hk_default_attrs: &hk_default
   VALIDMAX: 4095
   FORMAT: I4
 
-# <=== Coordinates ===>
+counts_support_attrs: &counts_support_default
+  <<: *default
+  DISPLAY_TYPE: no_plot
+  VAR_TYPE: ignore_data
+
+
+# <=== Counts Coordinates ===>
+sc_tick:
+  <<: *default_uint32
+  CATDESC: Raw spacecraft tick time per integration
+  FIELDNAM: Spacecraft Tick
+  LABLAXIS: SC_Tick
+  FORMAT: I10
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  UNITS: ''
+  SCALETYP: linear
+
+declination:
+    <<: *counts_support_default
+    CATDESC: Declination
+    FIELDNAM: Declination
+    LABLAXIS: Declination
+    FORMAT: F5.1
+
+inclination:
+    <<: *counts_support_default
+    CATDESC: Inclination
+    FIELDNAM: Inclination
+    LABLAXIS: Inclination
+    FORMAT: F5.1
+
+gain:
+    <<: *counts_support_default
+    CATDESC: Single rates gain. 0=low, 1=high
+    FIELDNAM: Gain
+    LABLAXIS: Gain
+    FORMAT: I2
+
+sngrates_index:
+    <<: *counts_support_default
+    CATDESC: Single rates index
+    FIELDNAM: SNGRATES Index
+    LABLAXIS: SNGRATES Index
+    FORMAT: I12
+
+coinrates_index:
+  <<: *counts_support_default
+  CATDESC: Coincidence rates index
+  FIELDNAM: COINRATES index
+  LABLAXIS: COINRATES index
+  FORMAT: I12
+
+pbufrates_index:
+  <<: *counts_support_default
+  CATDESC: Priority buffer rates index
+  FIELDNAM: pbufrates Index
+  LABLAXIS: pbufrates Index
+  FORMAT: I12
+
+l2fgrates_index:
+  <<: *counts_support_default
+  CATDESC: l2fgrates index
+  FIELDNAM: l2fgrates Index
+  LABLAXIS: l2fgrates Index
+  FORMAT: I12
+
+l2bgrates_index:
+  <<: *counts_support_default
+  CATDESC: l2bgrates index
+  FIELDNAM: l2bgrates Index
+  LABLAXIS: l2bgrates Index
+  FORMAT: I12
+
+l3fgrates_index:
+  <<: *counts_support_default
+  CATDESC: l3fgrates index
+  FIELDNAM: l3fgrates Index
+  LABLAXIS: l3fgrates Index
+  FORMAT: I12
+
+l3bgrates_index:
+  <<: *counts_support_default
+  CATDESC: l3bgrates index
+  FIELDNAM: l3bgrates Index
+  LABLAXIS: l3bgrates Index
+  FORMAT: I12
+
+penfgrates_index:
+  <<: *counts_support_default
+  CATDESC: penfgrates index
+  FIELDNAM: penfgrates Index
+  LABLAXIS: penfgrates Index
+  FORMAT: I12
+
+penbgrates_index:
+  <<: *counts_support_default
+  CATDESC: penbgrates index
+  FIELDNAM: penbgrates Index
+  LABLAXIS: penbgrates Index
+  FORMAT: I12
+
+ialirtrates_index:
+  <<: *counts_support_default
+  CATDESC: ialirtrates index
+  FIELDNAM: ialirtrates Index
+  LABLAXIS: ialirtrates Index
+  FORMAT: I12
+
+l4fgrates_index:
+  <<: *counts_support_default
+  CATDESC: l4fgrates index
+  FIELDNAM: l4fgrates Index
+  LABLAXIS: l4fgrates Index
+  FORMAT: I12
+
+l4bgrates_index:
+  <<: *counts_support_default
+  CATDESC: l4bgrates index
+  FIELDNAM: l4bgrates Index
+  LABLAXIS: l4bgrates Index
+  FORMAT: I12
+
+h_energy_index:
+  <<: *counts_support_default
+  CATDESC: h energy index
+  FIELDNAM: h energy Index
+  LABLAXIS: h energy Index
+  FORMAT: I12
+
+he4_energy_index:
+  <<: *counts_support_default
+  CATDESC: he4 energy index
+  FIELDNAM: he4 energy Index
+  LABLAXIS: he4 energy Index
+  FORMAT: I12
+
+cno_energy_index:
+  <<: *counts_support_default
+  CATDESC: cno energy index
+  FIELDNAM: cno energy Index
+  LABLAXIS: cno energy Index
+  FORMAT: I12
+
+nemgsi_energy_index:
+  <<: *counts_support_default
+  CATDESC: nemgsi energy index
+  FIELDNAM: nemgsi energy Index
+  LABLAXIS: nemgsi energy Index
+  FORMAT: I12
+
+fe_energy_index:
+  <<: *counts_support_default
+  CATDESC: fe energy index
+  FIELDNAM: fe energy Index
+  LABLAXIS: fe energy Index
+  FORMAT: I12
+
+# <=== Housekeeping Coordinates ===>
 adc_channels:   # adc_channels is a dependency for leak_i data variable
   DISPLAY_TYPE: no_plot
   FILLVAL: -9223372036854775808
@@ -87,7 +245,7 @@ adc_channels:   # adc_channels is a dependency for leak_i data variable
   LABLAXIS: Channel
   FORMAT: I2
 
-# <=== Label Attributes ===>
+# <=== Housekeeping Label Attributes ===>
 # LABL_PTR_i expects VAR_TYPE of metadata with char data type
 
 adc_channels_label:

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -115,11 +115,11 @@ sc_tick:
   SCALETYP: linear
 
 # Counts Dataset Coordinates
-declination:
+zenith:
     <<: *counts_support_default
     CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
-    FIELDNAM: Declination
-    LABLAXIS: Declination
+    FIELDNAM: Zenith
+    LABLAXIS: Zenith
     FORMAT: F5.1
     UNITS: deg
 
@@ -129,7 +129,7 @@ azimuth:
     FIELDNAM: Azimuth
     LABLAXIS: Azimuth
     FORMAT: F5.1
-    UNITS: deg
+    UNITS: Deg
 
 gain:
     <<: *counts_support_default
@@ -141,74 +141,74 @@ gain:
 sngrates_index:
     <<: *index_support_default
     CATDESC: Single rates index
-    FIELDNAM: SNGRATES Index
-    LABLAXIS: SNGRATES Index
+    FIELDNAM: sngrates index
+    LABLAXIS: sngrates index
 
 coinrates_index:
   <<: *index_support_default
   CATDESC: Coincidence rates index
-  FIELDNAM: COINRATES index
-  LABLAXIS: COINRATES index
+  FIELDNAM: coinrates index
+  LABLAXIS: coinrates index
 
 pbufrates_index:
   <<: *index_support_default
   CATDESC: Priority buffer rates index
-  FIELDNAM: pbufrates Index
-  LABLAXIS: pbufrates Index
+  FIELDNAM: pbufrates index
+  LABLAXIS: pbufrates index
 
 l2fgrates_index:
   <<: *index_support_default
   CATDESC: Range 2 foreground rates index
-  FIELDNAM: l2fgrates Index
-  LABLAXIS: l2fgrates Index
+  FIELDNAM: l2fgrates index
+  LABLAXIS: l2fgrates index
 
 l2bgrates_index:
   <<: *index_support_default
   CATDESC: Range 2 background rates index
-  FIELDNAM: l2bgrates Index
-  LABLAXIS: l2bgrates Index
+  FIELDNAM: l2bgrates index
+  LABLAXIS: l2bgrates index
 
 l3fgrates_index:
   <<: *index_support_default
   CATDESC: Range 3 foreground rates index
-  FIELDNAM: l3fgrates Index
-  LABLAXIS: l3fgrates Index
+  FIELDNAM: l3fgrates index
+  LABLAXIS: l3fgrates index
 
 l3bgrates_index:
   <<: *index_support_default
   CATDESC: Range 3 background rates index
-  FIELDNAM: l3bgrates Index
-  LABLAXIS: l3bgrates Index
+  FIELDNAM: l3bgrates index
+  LABLAXIS: l3bgrates index
 
 penfgrates_index:
   <<: *index_support_default
   CATDESC: Range 4 foreground rates index
-  FIELDNAM: penfgrates Index
-  LABLAXIS: penfgrates Index
+  FIELDNAM: penfgrates index
+  LABLAXIS: penfgrates index
 
 penbgrates_index:
   <<: *index_support_default
   CATDESC: Range 4 background rates index
-  FIELDNAM: penbgrates Index
-  LABLAXIS: penbgrates Index
+  FIELDNAM: penbgrates index
+  LABLAXIS: penbgrates index
 
 ialirtrates_index:
   <<: *index_support_default
   CATDESC: ialirtrates index
-  FIELDNAM: ialirtrates Index
-  LABLAXIS: ialirtrates Index
+  FIELDNAM: ialirtrates index
+  LABLAXIS: ialirtrates index
 
 l4fgrates_index:
   <<: *index_support_default
   CATDESC: L4 ions foreground rates index
-  FIELDNAM: l4fgrates Index
-  LABLAXIS: l4fgrates Index
+  FIELDNAM: l4fgrates index
+  LABLAXIS: l4fgrates index
 
 l4bgrates_index:
   <<: *index_support_default
   CATDESC: L4 ions background rates index
-  FIELDNAM: l4bgrates Index
-  LABLAXIS: l4bgrates Index
+  FIELDNAM: l4bgrates index
+  LABLAXIS: l4bgrates index
 
 h_energy_mean:
   <<: *energy_support_default
@@ -257,6 +257,129 @@ adc_channels_label:
   FIELDNAM: ADC Channels
   FORMAT: A2
   VAR_TYPE: metadata
+
+# Counts Dataset Labels
+zenith_label:
+  CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
+  FIELDNAM: Zenith Angle
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+azimuth_label:
+  CATDESC: Spin angle in 15 bins (0 deg. is zero of spin phase)
+  FIELDNAM: Azimuth Angle
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+gain_label:
+  CATDESC: Single rates gain. 0=low, 1=high
+  FIELDNAM: Gain
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+sngrates_index_label:
+  CATDESC: Single rates index
+  FIELDNAM: SNGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+coinrates_index_label:
+  CATDESC: Coincidence rates index
+  FIELDNAM: COINRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+pbufrates_index_label:
+  CATDESC: Priority buffer rates index
+  FIELDNAM: PBUFRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+l2fgrates_index_label:
+  CATDESC: Range 2 foreground rates index
+  FIELDNAM: L2FGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+l2bgrates_index_label:
+  CATDESC: Range 2 background rates index
+  FIELDNAM: L2BGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+l3fgrates_index_label:
+  CATDESC: Range 3 foreground rates index
+  FIELDNAM: L2FGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+l3bgrates_index_label:
+  CATDESC: Range 3 background rates index
+  FIELDNAM: L3BGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+penfgrates_index_label:
+  CATDESC: Range 4 foreground rates index
+  FIELDNAM: PENFGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+penbgrates_index_label:
+  CATDESC: Range 4 background rates index
+  FIELDNAM: PENBGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+ialirtrates_index_label:
+  CATDESC: ialirtrates index
+  FIELDNAM: IALIRTRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+l4fgrates_index_label:
+  CATDESC: L4 ions foreground rates index
+  FIELDNAM: L4FGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+l4bgrates_index_label:
+  CATDESC: L4 ions background rates index
+  FIELDNAM: L4BGRATES Index
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+h_energy_mean_label:
+  CATDESC: Geometric mean energy for H
+  FIELDNAM: H Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+he4_energy_mean_label:
+  CATDESC: Geometric mean energy for He4
+  FIELDNAM: He4 Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+nemgsi_energy_mean_label:
+  CATDESC: Geometric mean energy for NeMgSi
+  FIELDNAM: NeMgSi Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+cno_energy_mean_label:
+  CATDESC: Geometric mean energy for CNO
+  FIELDNAM: CNO Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+fe_energy_mean_label:
+  CATDESC: Geometric mean energy for Fe
+  FIELDNAM: Fe Energy
+  FORMAT: A5
+  VAR_TYPE: metadata
+
+
 
 #TODO: add labels for counts dataset
 
@@ -570,66 +693,66 @@ l4bgrates:
 
 sectorates:
   <<: *counts_default
-  DEPEND_1: declination
+  DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw sectored rates per integration
   FIELDNAM: Sectored rates
-  LABL_PTR_1: declination
+  LABL_PTR_1: zenith
   LABL_PTR_2: azimuth
   DELTA_MINUS_VAR: sectorates_stat_uncert_minus
   DELTA_PLUS_VAR: sectorates_stat_uncert_plus
 
 h_sectored_counts:
   <<: *counts_default
-  DEPEND_1: declination
+  DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw H sectored counts per integration
   FIELDNAM: H sectored counts
-  LABL_PTR_1: declination
+  LABL_PTR_1: zenith
   LABL_PTR_2: azimuth
   DELTA_MINUS_VAR: h_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: h_sectored_counts_stat_uncert_plus
 
 he4_sectored_counts:
   <<: *counts_default
-  DEPEND_1: declination
+  DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw He4 sectored counts per integration
   FIELDNAM: He4 sectored counts
-  LABL_PTR_1: declination
+  LABL_PTR_1: zenith
   LABL_PTR_2: azimuth
   DELTA_MINUS_VAR: he4_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: he4_sectored_counts_stat_uncert_plus
 
 cno_sectored_counts:
   <<: *counts_default
-  DEPEND_1: declination
+  DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw C, N, O sectored counts per integration
   FIELDNAM: C, N, O sectored counts
-  LABL_PTR_1: declination
+  LABL_PTR_1: zenith
   LABL_PTR_2: azimuth
   DELTA_MINUS_VAR: cno_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: cno_sectored_counts_stat_uncert_plus
 
 nemgsi_sectored_counts:
   <<: *counts_default
-  DEPEND_1: declination
+  DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw Ne, Mg, Si sectored counts per integration
   FIELDNAM: Ne, Mg, Si sectored counts
-  LABL_PTR_1: declination
+  LABL_PTR_1: zenith
   LABL_PTR_2: azimuth
   DELTA_MINUS_VAR: nemgsi_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: nemgsi_sectored_counts_stat_uncert_plus
 
 fe_sectored_counts:
   <<: *counts_default
-  DEPEND_1: declination
+  DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw Fe sectored counts per integration
   FIELDNAM: Fe sectored counts
-  LABL_PTR_1: declination
+  LABL_PTR_1: zenith
   LABL_PTR_2: azimuth
   DELTA_MINUS_VAR: fe_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: fe_sectored_counts_stat_uncert_plus

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -97,7 +97,7 @@ sc_tick:
   <<: *default_uint32
   CATDESC: Raw spacecraft tick time per integration
   FIELDNAM: Spacecraft Tick
-  LABLAXIS: SC_Tick
+  LABLAXIS: sc_tick
   FORMAT: I10
   VAR_TYPE: support_data
   DISPLAY_TYPE: no_plot
@@ -124,38 +124,38 @@ azimuth:
 gain:
   <<: *default_counts_support
   CATDESC: Single rates gain. 0=low, 1=high
-  FIELDNAM: Gain
+  FIELDNAM: gain
   LABLAXIS: Gain
-  FORMAT: I5
+  FORMAT: I1
 
 sngrates_index:
   <<: *default_index
   CATDESC: Single rates index
-  FIELDNAM: sngrates index
+  FIELDNAM: sngrates_index
   LABLAXIS: sngrates index
 
 coinrates_index:
   <<: *default_index
   CATDESC: Coincidence rates index
-  FIELDNAM: coinrates index
+  FIELDNAM: coinrates_index
   LABLAXIS: coinrates index
 
 pbufrates_index:
   <<: *default_index
   CATDESC: Priority buffer rates index
-  FIELDNAM: pbufrates index
+  FIELDNAM: pbufrates_index
   LABLAXIS: pbufrates index
 
 l2fgrates_index:
   <<: *default_index
   CATDESC: Range 2 foreground rates index
-  FIELDNAM: l2fgrates index
+  FIELDNAM: l2fgrates_index
   LABLAXIS: l2fgrates index
 
 l2bgrates_index:
   <<: *default_index
   CATDESC: Range 2 background rates index
-  FIELDNAM: l2bgrates index
+  FIELDNAM: l2bgrates_index
   LABLAXIS: l2bgrates index
 
 l3fgrates_index:
@@ -379,6 +379,7 @@ version:
   <<: *default_uint8
   CATDESC: CCSDS packet version number
   FIELDNAM: CCSDS version
+  LABLAXIS: Value
   VAR_TYPE: support_data
   DEPEND_0: sc_tick
 
@@ -386,6 +387,7 @@ type:
   <<: *default_uint8
   CATDESC: CCSDS packet type
   FIELDNAM: CCSDS type
+  LABLAXIS: Value
   VAR_TYPE: support_data
   DEPEND_0: sc_tick
 
@@ -393,6 +395,7 @@ sec_hdr_flg:
   <<: *default_uint8
   CATDESC: CCSDS secondary header flag
   FIELDNAM: CCSDS secondary header flag
+  LABLAXIS: Value
   VAR_TYPE: support_data
   DEPEND_0: sc_tick
 
@@ -400,6 +403,7 @@ pkt_apid:
   <<: *default_uint16
   CATDESC: CCSDS application process ID
   FIELDNAM: CCSDS APID
+  LABLAXIS: Value
   VAR_TYPE: support_data
   DEPEND_0: sc_tick
 
@@ -407,6 +411,7 @@ seq_flgs:
   <<: *default_uint8
   CATDESC: CCSDS sequence flags
   FIELDNAM: CCSDS sequence flags
+  LABLAXIS: Value
   VAR_TYPE: support_data
   DEPEND_0: sc_tick
 
@@ -414,6 +419,7 @@ src_seq_ctr:
   <<: *default_uint16
   CATDESC: CCSDS source sequence counter
   FIELDNAM: CCSDS sequence counter
+  LABLAXIS: Value
   VAR_TYPE: support_data
   DEPEND_0: sc_tick
 
@@ -421,6 +427,7 @@ pkt_len:
   <<: *default_uint16
   CATDESC: CCSDS packet length
   FIELDNAM: CCSDS packet length
+  LABLAXIS: Value
   VAR_TYPE: support_data
   DEPEND_0: sc_tick
 
@@ -429,37 +436,43 @@ hdr_frame_version:
   <<: *default_counts
   CATDESC: Raw header frame version per integration
   FIELDNAM: hdr_frame_version
+  LABLAXIS: Value
   UNITS: ''
 
 hdr_dynamic_threshold_state:
   <<: *default_counts
   CATDESC: Raw header dynamic threshold state per integration
   FIELDNAM: hdr_dynamic_threshold_state
-  UNITS: ''
+  LABLAXIS: State
+  UNITS: state
   VALIDMAX: 3
 
 hdr_leak_conv:
   <<: *default_counts
   CATDESC: Raw header leak conversion per integration
   FIELDNAM: hdr_leak_conv
+  LABLAXIS: Value
   UNITS: ''
 
 hdr_heavy_duty_cycle:
   <<: *default_counts
   CATDESC: Raw header heavy duty cycle per integration
   FIELDNAM: hdr_heavy_duty_cycle
+  LABLAXIS: Value
   UNITS: ''
 
 hdr_code_ok:
   <<: *default_counts
   CATDESC: Raw header code ok per integration
   FIELDNAM: hdr_code_ok
+  LABLAXIS: Value
   UNITS: ''
 
 hdr_unit_num:
   <<: *default_counts
   CATDESC: Raw header unit number per integration
   FIELDNAM: hdr_unit_num
+  LABLAXIS: Value
   UNITS: ''
 
 hdr_minute_cnt:
@@ -470,7 +483,7 @@ hdr_minute_cnt:
 livetime_counter:
   <<: *default_counts
   CATDESC: Raw livetime counter per integration
-  FIELDNAM: Livetime counter
+  FIELDNAM: livetime_counter
 
 num_trig:
   <<: *default_counts

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -487,175 +487,175 @@ livetime_counter:
 
 num_trig:
   <<: *default_counts
-  CATDESC: Raw number of triggers per integration
+  CATDESC: Raw number of triggers
   FIELDNAM: num_trig
   DELTA_MINUS_VAR: num_trig_stat_uncert_minus
   DELTA_PLUS_VAR: num_trig_stat_uncert_plus
 
 num_reject:
   <<: *default_counts
-  CATDESC: Raw number of rejects per integration
+  CATDESC: Raw number of rejected events
   FIELDNAM: num_reject
   DELTA_MINUS_VAR: num_reject_stat_uncert_minus
   DELTA_PLUS_VAR: num_reject_stat_uncert_plus
 
 num_acc_w_pha:
   <<: *default_counts
-  CATDESC: Raw number of accepted events with PHA data per integration
+  CATDESC: Raw number of accepted events with PHA data
   FIELDNAM: num_acc_w_pha
   DELTA_MINUS_VAR: num_acc_w_pha_stat_uncert_minus
   DELTA_PLUS_VAR: num_acc_w_pha_stat_uncert_plus
 
 num_acc_no_pha:
   <<: *default_counts
-  CATDESC: Raw number of events without PHA data per integration
+  CATDESC: Raw number of events without PHA data
   FIELDNAM: num_acc_no_pha
   DELTA_MINUS_VAR: num_acc_no_pha_stat_uncert_minus
   DELTA_PLUS_VAR: num_acc_no_pha_stat_uncert_plus
 
 num_haz_trig:
   <<: *default_counts
-  CATDESC: Raw number of hazard triggers per integration
+  CATDESC: Raw number of events triggered with a hazard condition
   FIELDNAM: num_haz_trig
   DELTA_MINUS_VAR: num_haz_trig_stat_uncert_minus
   DELTA_PLUS_VAR: num_haz_trig_stat_uncert_plus
 
 num_haz_reject:
   <<: *default_counts
-  CATDESC: Raw number of rejected events with hazard per integration
+  CATDESC: Raw number of events rejected for hazard condition
   FIELDNAM: num_haz_reject
   DELTA_MINUS_VAR: num_haz_reject_stat_uncert_minus
   DELTA_PLUS_VAR: num_haz_reject_stat_uncert_plus
 
 num_haz_acc_w_pha:
   <<: *default_counts
-  CATDESC: Raw number of accepted hazard events with PHA data per integration
+  CATDESC: Raw number of events with hazard condition with PHA data
   FIELDNAM: num_haz_acc_w_pha
   DELTA_MINUS_VAR: num_haz_acc_w_pha_stat_uncert_minus
   DELTA_PLUS_VAR: num_haz_acc_w_pha_stat_uncert_plus
 
 num_haz_acc_no_pha:
   <<: *default_counts
-  CATDESC: Raw number of hazard events without PHA data per integration
+  CATDESC: Raw number of events accepted with hazard condition without PHA data
   FIELDNAM: num_haz_acc_no_pha
   DELTA_MINUS_VAR: num_haz_acc_no_pha_stat_uncert_minus
   DELTA_PLUS_VAR: num_haz_acc_no_pha_stat_uncert_plus
 
 nread:
   <<: *default_counts
-  CATDESC: Raw number of events read per integration
+  CATDESC: Raw number of events read from event FIFO
   FIELDNAM: nread
   DELTA_MINUS_VAR: nread_stat_uncert_minus
   DELTA_PLUS_VAR: nread_stat_uncert_plus
 
 nhazard:
   <<: *default_counts
-  CATDESC: Raw number of hazard events per integration
+  CATDESC: Raw number of events rejected for Hazard condition
   FIELDNAM: nhazard
   DELTA_MINUS_VAR: nhazard_stat_uncert_minus
   DELTA_PLUS_VAR: nhazard_stat_uncert_plus
 
 nadcstim:
   <<: *default_counts
-  CATDESC: Raw number of ADC-stim events per integration
+  CATDESC: Raw number of ADC-calibration STIM events
   FIELDNAM: nadcstim
   DELTA_MINUS_VAR: nadcstim_stat_uncert_minus
   DELTA_PLUS_VAR: nadcstim_stat_uncert_plus
 
 nodd:
   <<: *default_counts
-  CATDESC: Raw number of odd events per integration
+  CATDESC: Raw number of odd events
   FIELDNAM: nodd
   DELTA_MINUS_VAR: nodd_stat_uncert_minus
   DELTA_PLUS_VAR: nodd_stat_uncert_plus
 
 noddfix:
   <<: *default_counts
-  CATDESC: Raw number of fixed odd events per integration
+  CATDESC: Raw number of fixed odd events
   FIELDNAM: noddfix
   DELTA_MINUS_VAR: noddfix_stat_uncert_minus
   DELTA_PLUS_VAR: noddfix_stat_uncert_plus
 
 nmulti:
   <<: *default_counts
-  CATDESC: Raw number of events with multiple hits in a single detector per integration
+  CATDESC: Raw number of events with multiple hits in relevant layers
   FIELDNAM: nmulti
   DELTA_MINUS_VAR: nmulti_stat_uncert_minus
   DELTA_PLUS_VAR: nmulti_stat_uncert_plus
 
 nmultifix:
   <<: *default_counts
-  CATDESC: Raw number of multi events that were fixed per integration
+  CATDESC: Raw number of fix multi events
   FIELDNAM: nmultifix
   DELTA_MINUS_VAR: nmultifix_stat_uncert_minus
   DELTA_PLUS_VAR: nmultifix_stat_uncert_plus
 
 nbadtraj:
   <<: *default_counts
-  CATDESC: Raw number of bad trajectory events per integration
+  CATDESC: Raw number of events rejected for inconsistent/bad trajectory
   FIELDNAM: nbadtraj
   DELTA_MINUS_VAR: nbadtraj_stat_uncert_minus
   DELTA_PLUS_VAR: nbadtraj_stat_uncert_plus
 
 nl2:
   <<: *default_counts
-  CATDESC: Raw number of nl2 events per integration
+  CATDESC: Raw number of events sorted into L12 event category
   FIELDNAM: nl2
   DELTA_MINUS_VAR: nl2_stat_uncert_minus
   DELTA_PLUS_VAR: nl2_stat_uncert_plus
 
 nl3:
   <<: *default_counts
-  CATDESC: Raw number of nl3 events per integration
+  CATDESC: Raw number of events sorted into L123 event category
   FIELDNAM: nl3
   DELTA_MINUS_VAR: nl3_stat_uncert_minus
   DELTA_PLUS_VAR: nl3_stat_uncert_plus
 
 nl4:
   <<: *default_counts
-  CATDESC: Raw number of nl4 events per integration
+  CATDESC: Raw number of events sorted into L1423 event category
   FIELDNAM: nl4
   DELTA_MINUS_VAR: nl4_stat_uncert_minus
   DELTA_PLUS_VAR: nl4_stat_uncert_plus
 
 npen:
   <<: *default_counts
-  CATDESC: Raw number of npen events per integration
+  CATDESC: Raw number of events sorted into PEN event category
   FIELDNAM: npen
   DELTA_MINUS_VAR: npen_stat_uncert_minus
   DELTA_PLUS_VAR: npen_stat_uncert_plus
 
 nformat:
   <<: *default_counts
-  CATDESC: Raw number of nformat events per integration
+  CATDESC: Raw number of events handled by the telemetry event formatter
   FIELDNAM: nformat
   DELTA_MINUS_VAR: nformat_stat_uncert_minus
   DELTA_PLUS_VAR: nformat_stat_uncert_plus
 
 naside:
   <<: *default_counts
-  CATDESC: Raw number of naside events per integration
+  CATDESC: Raw number of events the software assumed were A-side events
   FIELDNAM: naside
   DELTA_MINUS_VAR: naside_stat_uncert_minus
   DELTA_PLUS_VAR: naside_stat_uncert_plus
 
 nbside:
   <<: *default_counts
-  CATDESC: Raw number of nbside events per integration
+  CATDESC: Raw number of events the software assumed were B-side events
   FIELDNAM: nbside
   DELTA_MINUS_VAR: nbside_stat_uncert_minus
   DELTA_PLUS_VAR: nbside_stat_uncert_plus
 
 nerror:
   <<: *default_counts
-  CATDESC: Raw number of nerror events per integration
+  CATDESC: Raw number of events that caused a processing error
   FIELDNAM: nerror
   DELTA_MINUS_VAR: nerror_stat_uncert_minus
   DELTA_PLUS_VAR: nerror_stat_uncert_plus
 
 nbadtags:
   <<: *default_counts
-  CATDESC: Raw number of nbadtags per integration
+  CATDESC: Raw number of events with bad tags from onboard event-processing
   FIELDNAM: nbadtags
   DELTA_MINUS_VAR: nbadtags_stat_uncert_minus
   DELTA_PLUS_VAR: nbadtags_stat_uncert_plus
@@ -1452,6 +1452,12 @@ nbadtags_stat_uncert_minus:
   CATDESC: Minus statistical uncertainty for number of bad tags
   FIELDNAM: nbadtags uncertainty
 
+# PHA dataset variables
+pha_raw:
+  DEPEND_0: epoch
+  CATDESC: Raw instrument pulse height analyzer data.  Further processed in HIT L3 data.
+  VAR_TYPE: ignore_data
+  DISPLAY_TYPE: no_plot
 
 # Housekeeping dataset variables
 fsw_version_a:
@@ -1846,4 +1852,5 @@ ebox_p2d0vd:
   CATDESC: +2.0VD Ebox (Digital)
   FIELDNAM: +2.0VD Ebox (Digital)
   LABLAXIS: +2.0VD Ebox
+
 

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -35,64 +35,17 @@ default_uint32_attrs: &default_uint32
   VALIDMAX: 4294967295
   dtype: uint32
 
-default_int64_attrs: &default_int64
-  <<: *default
-  FILLVAL: -9223372036854775808
-  FORMAT: I20
-  VALIDMIN: -9223372036854775808
-  VALIDMAX: 9223372036854775807
-  dtype: int64
-
-default_int32_attrs: &default_int32
-  <<: *default
-  FILLVAL: -2147483648
-  FORMAT: I10
-  VALIDMIN: -2147483648
-  VALIDMAX: 2147483647
-  dtype: int32
-
-default_float32_attrs: &default_float32
-  <<: *default
-  FILLVAL: .NAN
-  FORMAT: F10.2
-  VALIDMIN: -3.4028235e+38
-  VALIDMAX: 3.4028235e+38
-  dtype: float32
-
-hk_support_attrs: &hk_support_default
-  <<: *default
-  DISPLAY_TYPE: no_plot
-  VAR_TYPE: ignore_data
-
-hk_default_attrs: &hk_default
+default_hk_attrs: &default_hk
   <<: *default
   VALIDMAX: 4095
   FORMAT: I4
 
-index_support_attrs: &index_support_default
-  <<: *default_uint32
-  DISPLAY_TYPE: no_plot
-  VAR_TYPE: support_data
-  VALIDMAX: 1000
-
-energy_support_attrs: &energy_support_default
+default_hk_support_attrs: &default_hk_support
   <<: *default
   DISPLAY_TYPE: no_plot
-  VAR_TYPE: support_data
-  VALIDMAX: 1000
-  LABLAXIS: Energy
-  UNITS: MeV
-  FORMAT: F5.1
+  VAR_TYPE: ignore_data
 
-counts_support_attrs: &counts_support_default
-  <<: *default
-  DISPLAY_TYPE: no_plot
-  VAR_TYPE: support_data
-  FILLVAL: -1.00E+31
-  VALIDMIN: 0
-  VALIDMAX: 1000
-
-counts_attrs: &counts_default
+default_counts_attrs: &default_counts
   <<: *default
   DISPLAY_TYPE: time_series
   VAR_TYPE: data
@@ -100,7 +53,44 @@ counts_attrs: &counts_default
   VALIDMIN: 0
   VALIDMAX: 10000000000
   UNITS: counts
+  LABLAXIS: Counts
   SCALETYP: log
+
+default_counts_support_attrs: &default_counts_support
+  <<: *default
+  DISPLAY_TYPE: no_plot
+  VAR_TYPE: support_data
+  FILLVAL: -1.00E+31
+  VALIDMIN: 0
+  VALIDMAX: 1000
+
+default_index_attrs: &default_index
+  <<: *default_uint32
+  DISPLAY_TYPE: no_plot
+  VAR_TYPE: support_data
+  VALIDMAX: 1000
+
+default_energy_attrs: &default_energy
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  LABLAXIS: Energy
+  FILLVAL: -1.00E+31
+  VALIDMIN: 0
+  VALIDMAX: 1000
+  FORMAT: F5.1
+  UNITS: MeV
+  SCALE_TYP: log
+
+default_uncertainty_attrs: &default_uncertainty
+  DEPEND_0: epoch
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  VALIDMIN: 0
+  VALIDMAX: 10000000000
+  FILLVAL: -1.00E+31
+  FORMAT: F9.3
+  UNITS: counts
+  SCALE_TYP: log
 
 # <=== Coordinates ===>
 sc_tick:
@@ -116,128 +106,130 @@ sc_tick:
 
 # Counts Dataset Coordinates
 zenith:
-    <<: *counts_support_default
-    CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
-    FIELDNAM: Zenith
-    LABLAXIS: Zenith
-    FORMAT: F5.1
-    UNITS: deg
+  <<: *default_counts_support
+  CATDESC: Angle from the spin axis (0 deg.) to anti-spin axis (180 deg.) in 8 bins
+  FIELDNAM: Zenith
+  LABLAXIS: Zenith
+  FORMAT: F5.1
+  UNITS: deg
 
 azimuth:
-    <<: *counts_support_default
-    CATDESC: Spin angle in 15 bins (0 deg. is zero of spin phase)
-    FIELDNAM: Azimuth
-    LABLAXIS: Azimuth
-    FORMAT: F5.1
-    UNITS: Deg
+  <<: *default_counts_support
+  CATDESC: Spin angle in 15 bins (0 deg. is zero of spin phase)
+  FIELDNAM: Azimuth
+  LABLAXIS: Azimuth
+  FORMAT: F5.1
+  UNITS: Deg
 
 gain:
-    <<: *counts_support_default
-    CATDESC: Single rates gain. 0=low, 1=high
-    FIELDNAM: Gain
-    LABLAXIS: Gain
-    FORMAT: I2
+  <<: *default_counts_support
+  CATDESC: Single rates gain. 0=low, 1=high
+  FIELDNAM: Gain
+  LABLAXIS: Gain
+  FORMAT: I5
 
 sngrates_index:
-    <<: *index_support_default
-    CATDESC: Single rates index
-    FIELDNAM: sngrates index
-    LABLAXIS: sngrates index
+  <<: *default_index
+  CATDESC: Single rates index
+  FIELDNAM: sngrates index
+  LABLAXIS: sngrates index
 
 coinrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: Coincidence rates index
   FIELDNAM: coinrates index
   LABLAXIS: coinrates index
 
 pbufrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: Priority buffer rates index
   FIELDNAM: pbufrates index
   LABLAXIS: pbufrates index
 
 l2fgrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: Range 2 foreground rates index
   FIELDNAM: l2fgrates index
   LABLAXIS: l2fgrates index
 
 l2bgrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: Range 2 background rates index
   FIELDNAM: l2bgrates index
   LABLAXIS: l2bgrates index
 
 l3fgrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: Range 3 foreground rates index
   FIELDNAM: l3fgrates index
   LABLAXIS: l3fgrates index
 
 l3bgrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: Range 3 background rates index
   FIELDNAM: l3bgrates index
   LABLAXIS: l3bgrates index
 
 penfgrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: Range 4 foreground rates index
   FIELDNAM: penfgrates index
   LABLAXIS: penfgrates index
 
 penbgrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: Range 4 background rates index
   FIELDNAM: penbgrates index
   LABLAXIS: penbgrates index
 
 ialirtrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: ialirtrates index
   FIELDNAM: ialirtrates index
   LABLAXIS: ialirtrates index
 
 l4fgrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: L4 ions foreground rates index
   FIELDNAM: l4fgrates index
   LABLAXIS: l4fgrates index
 
 l4bgrates_index:
-  <<: *index_support_default
+  <<: *default_index
   CATDESC: L4 ions background rates index
   FIELDNAM: l4bgrates index
   LABLAXIS: l4bgrates index
 
 h_energy_mean:
-  <<: *energy_support_default
+  <<: *default_energy
   CATDESC: H sectored geometric mean energy
   FIELDNAM: H energy mean
+  DELTA_MINUS_VAR: h_energy_delta_minus
+  DELTA_PLUS_VAR: h_energy_delta_plus
 
 he4_energy_mean:
-  <<: *energy_support_default
+  <<: *default_energy
   CATDESC: He4 sectored geometric mean energy
   FIELDNAM: He4 energy mean
 
 cno_energy_mean:
-  <<: *energy_support_default
+  <<: *default_energy
   CATDESC: C, N, O sectored geometric mean energy
   FIELDNAM: C, N, O energy mean
 
 nemgsi_energy_mean:
-  <<: *energy_support_default
+  <<: *default_energy
   CATDESC: Ne, Mg, Si sectored geometric mean energy
   FIELDNAM: Ne, Mg, Si energy mean
 
 fe_energy_mean:
-  <<: *energy_support_default
+  <<: *default_energy
   CATDESC: Fe sectored geometric mean energy
   FIELDNAM: Fe energy mean
 
 
 # Housekeeping Dataset Coordinates
-adc_channels:   # adc_channels is a dependency for leak_i data variable
+adc_channels:
   DISPLAY_TYPE: no_plot
   FILLVAL: -9223372036854775808
   UNITS: ' '
@@ -249,6 +241,7 @@ adc_channels:   # adc_channels is a dependency for leak_i data variable
   FIELDNAM: ADC Channel
   LABLAXIS: Channel
   FORMAT: I2
+
 
 # <=== Label Attributes ===>
 # Housekeeping Labels
@@ -379,10 +372,6 @@ fe_energy_mean_label:
   FORMAT: A5
   VAR_TYPE: metadata
 
-
-
-#TODO: add labels for counts dataset
-
 # <=== Data Variable Attributes ===>
 
 # CCSDS header variables
@@ -436,334 +425,1024 @@ pkt_len:
   DEPEND_0: sc_tick
 
 # Counts dataset variables
-#TODO: add counts dataset variables
 hdr_frame_version:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw header frame version per integration
-  FIELDNAM: Header frame version
-  LABLAXIS: hdr_frame_version
+  FIELDNAM: hdr_frame_version
   UNITS: ''
 
 hdr_dynamic_threshold_state:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw header dynamic threshold state per integration
-  FIELDNAM: Header dynamic threshold state
-  LABLAXIS: hdr_dynamic_threshold_state
+  FIELDNAM: hdr_dynamic_threshold_state
   UNITS: ''
   VALIDMAX: 3
 
 hdr_leak_conv:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw header leak conversion per integration
-  FIELDNAM: Header leak conversion
-  LABLAXIS: hdr_leak_conv
+  FIELDNAM: hdr_leak_conv
   UNITS: ''
 
 hdr_heavy_duty_cycle:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw header heavy duty cycle per integration
-  FIELDNAM: Header heavy duty cycle
-  LABLAXIS: hdr_heavy_duty_cycle
+  FIELDNAM: hdr_heavy_duty_cycle
   UNITS: ''
 
 hdr_code_ok:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw header code ok per integration
-  FIELDNAM: Header code ok
-  LABLAXIS: hdr_code_ok
+  FIELDNAM: hdr_code_ok
   UNITS: ''
 
 hdr_unit_num:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw header unit number per integration
-  FIELDNAM: Header unit number
-  LABLAXIS: hdr_unit_num
+  FIELDNAM: hdr_unit_num
   UNITS: ''
 
 hdr_minute_cnt:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw header minute count per integration
-  FIELDNAM: Header minute count
-  LABLAXIS: hdr_minute_cnt
+  FIELDNAM: hdr_minute_cnt
 
 livetime_counter:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw livetime counter per integration
   FIELDNAM: Livetime counter
-  LABLAXIS: Livetime counter
 
 num_trig:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of triggers per integration
-  FIELDNAM: Number of triggers
-  LABLAXIS: num_trig
+  FIELDNAM: num_trig
+  DELTA_MINUS_VAR: num_trig_stat_uncert_minus
+  DELTA_PLUS_VAR: num_trig_stat_uncert_plus
 
 num_reject:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of rejects per integration
-  FIELDNAM: Number of rejects
-  LABLAXIS: num_reject
+  FIELDNAM: num_reject
+  DELTA_MINUS_VAR: num_reject_stat_uncert_minus
+  DELTA_PLUS_VAR: num_reject_stat_uncert_plus
 
-num_acc_w_phase:
-  <<: *counts_default
+num_acc_w_pha:
+  <<: *default_counts
   CATDESC: Raw number of accepted events with PHA data per integration
-  FIELDNAM: Number of accepted events with PHA
-  LABLAXIS: num_acc_w_phase
+  FIELDNAM: num_acc_w_pha
+  DELTA_MINUS_VAR: num_acc_w_pha_stat_uncert_minus
+  DELTA_PLUS_VAR: num_acc_w_pha_stat_uncert_plus
 
-num_acc_no_phase:
-  <<: *counts_default
+num_acc_no_pha:
+  <<: *default_counts
   CATDESC: Raw number of events without PHA data per integration
-  FIELDNAM: Number of events without PHA
-  LABLAXIS: num_acc_no_phase
+  FIELDNAM: num_acc_no_pha
+  DELTA_MINUS_VAR: num_acc_no_pha_stat_uncert_minus
+  DELTA_PLUS_VAR: num_acc_no_pha_stat_uncert_plus
 
 num_haz_trig:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of hazard triggers per integration
-  FIELDNAM: Number of hazard triggers
-  LABLAXIS: num_haz_trig
+  FIELDNAM: num_haz_trig
+  DELTA_MINUS_VAR: num_haz_trig_stat_uncert_minus
+  DELTA_PLUS_VAR: num_haz_trig_stat_uncert_plus
 
 num_haz_reject:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of rejected events with hazard per integration
-  FIELDNAM: Number of hazard rejects
-  LABLAXIS: num_haz_reject
+  FIELDNAM: num_haz_reject
+  DELTA_MINUS_VAR: num_haz_reject_stat_uncert_minus
+  DELTA_PLUS_VAR: num_haz_reject_stat_uncert_plus
 
-num_haz_acc_w_phase:
-  <<: *counts_default
+num_haz_acc_w_pha:
+  <<: *default_counts
   CATDESC: Raw number of accepted hazard events with PHA data per integration
-  FIELDNAM: Number of accepted hazard events with PHA
-  LABLAXIS: num_haz_acc_w_phase
+  FIELDNAM: num_haz_acc_w_pha
+  DELTA_MINUS_VAR: num_haz_acc_w_pha_stat_uncert_minus
+  DELTA_PLUS_VAR: num_haz_acc_w_pha_stat_uncert_plus
 
-num_haz_acc_no_phase:
-  <<: *counts_default
+num_haz_acc_no_pha:
+  <<: *default_counts
   CATDESC: Raw number of hazard events without PHA data per integration
-  FIELDNAM: Number of hazard events without PHA
-  LABLAXIS: num_haz_acc_no_phase
+  FIELDNAM: num_haz_acc_no_pha
+  DELTA_MINUS_VAR: num_haz_acc_no_pha_stat_uncert_minus
+  DELTA_PLUS_VAR: num_haz_acc_no_pha_stat_uncert_plus
 
 nread:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of events read per integration
-  FIELDNAM: Number of read events
-  LABLAXIS: nread
+  FIELDNAM: nread
+  DELTA_MINUS_VAR: nread_stat_uncert_minus
+  DELTA_PLUS_VAR: nread_stat_uncert_plus
 
 nhazard:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of hazard events per integration
-  FIELDNAM: Number of hazard events
-  LABLAXIS: nhazard
+  FIELDNAM: nhazard
+  DELTA_MINUS_VAR: nhazard_stat_uncert_minus
+  DELTA_PLUS_VAR: nhazard_stat_uncert_plus
 
 nadcstim:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of ADC-stim events per integration
-  FIELDNAM: Number of ADC-stim events
-  LABLAXIS: nadcstim
+  FIELDNAM: nadcstim
+  DELTA_MINUS_VAR: nadcstim_stat_uncert_minus
+  DELTA_PLUS_VAR: nadcstim_stat_uncert_plus
 
 nodd:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of odd events per integration
-  FIELDNAM: Number of odd events
-  LABLAXIS: nodd
+  FIELDNAM: nodd
+  DELTA_MINUS_VAR: nodd_stat_uncert_minus
+  DELTA_PLUS_VAR: nodd_stat_uncert_plus
 
 noddfix:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of fixed odd events per integration
-  FIELDNAM: Number of fixed odd events
-  LABLAXIS: noddfix
+  FIELDNAM: noddfix
+  DELTA_MINUS_VAR: noddfix_stat_uncert_minus
+  DELTA_PLUS_VAR: noddfix_stat_uncert_plus
 
 nmulti:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of events with multiple hits in a single detector per integration
-  FIELDNAM: Number of events with multiple hits
-  LABLAXIS: nmulti
+  FIELDNAM: nmulti
+  DELTA_MINUS_VAR: nmulti_stat_uncert_minus
+  DELTA_PLUS_VAR: nmulti_stat_uncert_plus
 
 nmultifix:
-  <<: *counts_default
+  <<: *default_counts
   CATDESC: Raw number of multi events that were fixed per integration
-  FIELDNAM: Number of fixed multiple hits
-  LABLAXIS: nmultifix
+  FIELDNAM: nmultifix
+  DELTA_MINUS_VAR: nmultifix_stat_uncert_minus
+  DELTA_PLUS_VAR: nmultifix_stat_uncert_plus
+
+nbadtraj:
+  <<: *default_counts
+  CATDESC: Raw number of bad trajectory events per integration
+  FIELDNAM: nbadtraj
+  DELTA_MINUS_VAR: nbadtraj_stat_uncert_minus
+  DELTA_PLUS_VAR: nbadtraj_stat_uncert_plus
+
+nl2:
+  <<: *default_counts
+  CATDESC: Raw number of nl2 events per integration
+  FIELDNAM: nl2
+  DELTA_MINUS_VAR: nl2_stat_uncert_minus
+  DELTA_PLUS_VAR: nl2_stat_uncert_plus
+
+nl3:
+  <<: *default_counts
+  CATDESC: Raw number of nl3 events per integration
+  FIELDNAM: nl3
+  DELTA_MINUS_VAR: nl3_stat_uncert_minus
+  DELTA_PLUS_VAR: nl3_stat_uncert_plus
+
+nl4:
+  <<: *default_counts
+  CATDESC: Raw number of nl4 events per integration
+  FIELDNAM: nl4
+  DELTA_MINUS_VAR: nl4_stat_uncert_minus
+  DELTA_PLUS_VAR: nl4_stat_uncert_plus
+
+npen:
+  <<: *default_counts
+  CATDESC: Raw number of npen events per integration
+  FIELDNAM: npen
+  DELTA_MINUS_VAR: npen_stat_uncert_minus
+  DELTA_PLUS_VAR: npen_stat_uncert_plus
+
+nformat:
+  <<: *default_counts
+  CATDESC: Raw number of nformat events per integration
+  FIELDNAM: nformat
+  DELTA_MINUS_VAR: nformat_stat_uncert_minus
+  DELTA_PLUS_VAR: nformat_stat_uncert_plus
+
+naside:
+  <<: *default_counts
+  CATDESC: Raw number of naside events per integration
+  FIELDNAM: naside
+  DELTA_MINUS_VAR: naside_stat_uncert_minus
+  DELTA_PLUS_VAR: naside_stat_uncert_plus
+
+nbside:
+  <<: *default_counts
+  CATDESC: Raw number of nbside events per integration
+  FIELDNAM: nbside
+  DELTA_MINUS_VAR: nbside_stat_uncert_minus
+  DELTA_PLUS_VAR: nbside_stat_uncert_plus
+
+nerror:
+  <<: *default_counts
+  CATDESC: Raw number of nerror events per integration
+  FIELDNAM: nerror
+  DELTA_MINUS_VAR: nerror_stat_uncert_minus
+  DELTA_PLUS_VAR: nerror_stat_uncert_plus
+
+nbadtags:
+  <<: *default_counts
+  CATDESC: Raw number of nbadtags per integration
+  FIELDNAM: nbadtags
+  DELTA_MINUS_VAR: nbadtags_stat_uncert_minus
+  DELTA_PLUS_VAR: nbadtags_stat_uncert_plus
 
 sngrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: gain
   DEPEND_2: sngrates_index
   CATDESC: Raw single rates per integration
   FIELDNAM: sngrates
-  LABL_PTR_1: sngrates_index
+  LABL_PTR_1: sngrates_index_label
+  LABL_PTR_2: gain_label
   DELTA_MINUS_VAR: sngrates_stat_uncert_minus
   DELTA_PLUS_VAR: sngrates_stat_uncert_plus
 
 coinrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: coinrates_index
   CATDESC: Raw coincidence rates per integration
   FIELDNAM: coinrates
-  LABL_PTR_1: coinrates_index
+  LABL_PTR_1: coinrates_index_label
   DELTA_MINUS_VAR: coinrates_stat_uncert_minus
   DELTA_PLUS_VAR: coinrates_stat_uncert_plus
 
 pbufrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: pbufrates_index
   CATDESC: Raw priority buffer rates per integration
   FIELDNAM: pbufrates
-  LABL_PTR_1: pbufrates_index
+  LABL_PTR_1: pbufrates_index_label
   DELTA_MINUS_VAR: pbufrates_stat_uncert_minus
   DELTA_PLUS_VAR: pbufrates_stat_uncert_plus
 
 l2fgrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: l2fgrates_index
   CATDESC: Raw range 2 foreground rates per integration
   FIELDNAM: l2fgrates
-  LABL_PTR_1: l2fgrates_index
+  LABL_PTR_1: l2fgrates_index_label
   DELTA_MINUS_VAR: l2fgrates_stat_uncert_minus
   DELTA_PLUS_VAR: l2fgrates_stat_uncert_plus
 
 l2bgrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: l2bgrates_index
   CATDESC: Raw range 2 background rates per integration
   FIELDNAM: l2bgrates
-  LABL_PTR_1: l2bgrates_index
+  LABL_PTR_1: l2bgrates_index_label
   DELTA_MINUS_VAR: l2bgrates_stat_uncert_minus
   DELTA_PLUS_VAR: l2bgrates_stat_uncert_plus
 
 l3fgrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: l3fgrates_index
   CATDESC: Raw range 3 foreground rates per integration
   FIELDNAM: l3fgrates
-  LABL_PTR_1: l3fgrates_index
+  LABL_PTR_1: l3fgrates_index_label
   DELTA_MINUS_VAR: l3fgrates_stat_uncert_minus
   DELTA_PLUS_VAR: l3fgrates_stat_uncert_plus
 
 l3bgrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: l3bgrates_index
   CATDESC: Raw range 3 background rates per integration
   FIELDNAM: l3bgrates
-  LABL_PTR_1: l3bgrates_index
+  LABL_PTR_1: l3bgrates_index_label
   DELTA_MINUS_VAR: l3bgrates_stat_uncert_minus
   DELTA_PLUS_VAR: l3bgrates_stat_uncert_plus
 
 penfgrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: penfgrates_index
   CATDESC: Raw range 4 foreground rates per integration
   FIELDNAM: penfgrates
-  LABL_PTR_1: penfgrates_index
+  LABL_PTR_1: penfgrates_index_label
   DELTA_MINUS_VAR: penfgrates_stat_uncert_minus
   DELTA_PLUS_VAR: penfgrates_stat_uncert_plus
 
 penbgrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: penbgrates_index
   CATDESC: Raw range 4 background rates per integration
   FIELDNAM: penbgrates
-  LABL_PTR_1: penbgrates_index
+  LABL_PTR_1: penbgrates_index_label
   DELTA_MINUS_VAR: penbgrates_stat_uncert_minus
   DELTA_PLUS_VAR: penbgrates_stat_uncert_plus
 
 ialirtrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: ialirtrates_index
   CATDESC: Raw ialirtrates per integration
   FIELDNAM: ialirtrates
-  LABL_PTR_1: ialirtrates_index
+  LABL_PTR_1: ialirtrates_index_label
   DELTA_MINUS_VAR: ialirtrates_stat_uncert_minus
   DELTA_PLUS_VAR: ialirtrates_stat_uncert_plus
 
 l4fgrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: l4fgrates_index
   CATDESC: Raw L4 ions foreground rates per integration
   FIELDNAM: l4fgrates
-  LABL_PTR_1: l4fgrates_index
+  LABL_PTR_1: l4fgrates_index_label
   DELTA_MINUS_VAR: l4fgrates_stat_uncert_minus
   DELTA_PLUS_VAR: l4fgrates_stat_uncert_plus
 
 l4bgrates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: l4bgrates_index
   CATDESC: Raw L4 ions background rates per integration
   FIELDNAM: l4bgrates
-  LABL_PTR_1: l4bgrates_index
+  LABL_PTR_1: l4bgrates_index_label
   DELTA_MINUS_VAR: l4bgrates_stat_uncert_minus
   DELTA_PLUS_VAR: l4bgrates_stat_uncert_plus
 
 sectorates:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw sectored rates per integration
   FIELDNAM: Sectored rates
-  LABL_PTR_1: zenith
-  LABL_PTR_2: azimuth
+  LABL_PTR_1: azimuth_label
+  LABL_PTR_2: zenith_label
   DELTA_MINUS_VAR: sectorates_stat_uncert_minus
   DELTA_PLUS_VAR: sectorates_stat_uncert_plus
 
 h_sectored_counts:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw H sectored counts per integration
   FIELDNAM: H sectored counts
-  LABL_PTR_1: zenith
-  LABL_PTR_2: azimuth
+  LABL_PTR_1: azimuth_label
+  LABL_PTR_2: zenith_label
   DELTA_MINUS_VAR: h_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: h_sectored_counts_stat_uncert_plus
 
 he4_sectored_counts:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw He4 sectored counts per integration
   FIELDNAM: He4 sectored counts
-  LABL_PTR_1: zenith
-  LABL_PTR_2: azimuth
+  LABL_PTR_1: azimuth_label
+  LABL_PTR_2: zenith_label
   DELTA_MINUS_VAR: he4_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: he4_sectored_counts_stat_uncert_plus
 
 cno_sectored_counts:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw C, N, O sectored counts per integration
   FIELDNAM: C, N, O sectored counts
-  LABL_PTR_1: zenith
-  LABL_PTR_2: azimuth
+  LABL_PTR_1: azimuth_label
+  LABL_PTR_2: zenith_label
   DELTA_MINUS_VAR: cno_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: cno_sectored_counts_stat_uncert_plus
 
 nemgsi_sectored_counts:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw Ne, Mg, Si sectored counts per integration
   FIELDNAM: Ne, Mg, Si sectored counts
-  LABL_PTR_1: zenith
-  LABL_PTR_2: azimuth
+  LABL_PTR_1: azimuth_label
+  LABL_PTR_2: zenith_label
   DELTA_MINUS_VAR: nemgsi_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: nemgsi_sectored_counts_stat_uncert_plus
 
 fe_sectored_counts:
-  <<: *counts_default
+  <<: *default_counts
   DEPEND_1: zenith
   DEPEND_2: azimuth
   CATDESC: Raw Fe sectored counts per integration
   FIELDNAM: Fe sectored counts
-  LABL_PTR_1: zenith
-  LABL_PTR_2: azimuth
+  LABL_PTR_1: azimuth_label
+  LABL_PTR_2: zenith_label
   DELTA_MINUS_VAR: fe_sectored_counts_stat_uncert_minus
   DELTA_PLUS_VAR: fe_sectored_counts_stat_uncert_plus
 
+# Counts energy delta variables
+h_energy_delta_plus:
+  <<: *default_energy
+  DEPEND_1: h_energy_mean
+  CATDESC: H energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: H energy delta plus
 
-#TODO - energy deltas
-#TODO - uncertainties
+h_energy_delta_minus:
+  <<: *default_energy
+  DEPEND_1: h_energy_mean
+  CATDESC: H energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: H energy delta minus
+
+he4_energy_delta_plus:
+  <<: *default_energy
+  DEPEND_1: he4_energy_mean
+  CATDESC: He4 energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: He4 energy delta plus
+
+he4_energy_delta_minus:
+  <<: *default_energy
+  DEPEND_1: he4_energy_mean
+  CATDESC: He4 energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: He4 energy delta minus
+
+cno_energy_delta_plus:
+  <<: *default_energy
+  DEPEND_1: cno_energy_mean
+  CATDESC: C, N, O energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: C, N, O energy delta plus
+
+cno_energy_delta_minus:
+  <<: *default_energy
+  DEPEND_1: cno_energy_mean
+  CATDESC: C, N, O energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: C, N, O energy delta minus
+
+nemgsi_energy_delta_plus:
+  <<: *default_energy
+  DEPEND_1: nemgsi_energy_mean
+  CATDESC: Ne, Mg, Si energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Ne, Mg, Si energy delta plus
+
+nemgsi_energy_delta_minus:
+  <<: *default_energy
+  DEPEND_1: nemgsi_energy_mean
+  CATDESC: Ne, Mg, Si energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Ne, Mg, Si energy delta minus
+
+fe_energy_delta_plus:
+  <<: *default_energy
+  DEPEND_1: fe_energy_mean
+  CATDESC: Fe energy delta plus (maximum bin energy minus geometric mean)
+  FIELDNAM: Fe energy delta plus
+
+fe_energy_delta_minus:
+  <<: *default_energy
+  DEPEND_1: fe_energy_mean
+  CATDESC: Fe energy delta minus (geometric mean minus minimum bin energy)
+  FIELDNAM: Fe energy delta minus
+
+# Counts uncertainty variables
+sectorates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for sector rates
+  FIELDNAM: Sectored Rates Uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: h_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+sectorates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for sector rates
+  FIELDNAM: Sectored Rates Uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: h_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+h_sectored_counts_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for H
+  FIELDNAM: H Uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: h_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+h_sectored_counts_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for H
+  FIELDNAM: H Uncertainty
+  DEPEND_1: h_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: h_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+he4_sectored_counts_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for He4
+  FIELDNAM: He4 Uncertainty
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: he4_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+he4_sectored_counts_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for He4
+  FIELDNAM: He4 Uncertainty
+  DEPEND_1: he4_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: he4_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+cno_sectored_counts_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for C, N, O
+  FIELDNAM: CNO Uncertainty
+  DEPEND_1: cno_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: cno_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+cno_sectored_counts_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for C, N, O
+  FIELDNAM: CNO Uncertainty
+  DEPEND_1: cno_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: cno_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+nemgsi_sectored_counts_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for Ne, Mg, Si
+  FIELDNAM: NeMgSi Uncertainty
+  DEPEND_1: nemgsi_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: nemgsi_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+nemgsi_sectored_counts_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for Ne, Mg, Si
+  FIELDNAM: NeMgSi Uncertainty
+  DEPEND_1: nemgsi_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: nemgsi_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+fe_sectored_counts_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for Fe
+  FIELDNAM: Fe Uncertainty
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: fe_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+fe_sectored_counts_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for Fe
+  FIELDNAM: Fe Uncertainty
+  DEPEND_1: fe_energy_mean
+  DEPEND_2: azimuth
+  DEPEND_3: zenith
+  LABL_PTR_1: fe_energy_mean_label
+  LABL_PTR_2: azimuth_label
+  LABL_PTR_3: zenith_label
+
+sngrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for single rates
+  FIELDNAM: sngrates uncertainty
+  DEPEND_1: sngrates_index
+  DEPEND_2: gain
+  LABL_PTR_1: sngrates_index_label
+  LABL_PTR_2: gain_label
+
+sngrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for single rates
+  FIELDNAM: sngrates uncertainty
+  DEPEND_1: sngrates_index
+  DEPEND_2: gain
+  LABL_PTR_1: sngrates_index_label
+  LABL_PTR_2: gain_label
+
+coinrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for coincidence rates
+  FIELDNAM: coinrates uncertainty
+  DEPEND_1: coinrates_index
+  LABL_PTR_1: coinrates_index_label
+
+coinrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for coincidence rates
+  FIELDNAM: coinrates uncertainty
+  DEPEND_1: coinrates_index
+  LABL_PTR_1: coinrates_index_label
+
+pbufrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for priority buffer rates
+  FIELDNAM: pbufrates uncertainty
+  DEPEND_1: pbufrates_index
+  LABL_PTR_1: pbufrates_index_label
+
+pbufrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for priority buffer rates
+  FIELDNAM: pbufrates uncertainty
+  DEPEND_1: pbufrates_index
+  LABL_PTR_1: pbufrates_index_label
+
+l2fgrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for range 2 foreground rates
+  FIELDNAM: l2fgrates uncertainty
+  DEPEND_1: l2fgrates_index
+  LABL_PTR_1: l2fgrates_index_label
+
+l2fgrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for range 2 foreground rates
+  FIELDNAM: l2fgrates uncertainty
+  DEPEND_1: l2fgrates_index
+  LABL_PTR_1: l2fgrates_index_label
+
+l2bgrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for range 2 background rates
+  FIELDNAM: l2bgrates uncertainty
+  DEPEND_1: l2bgrates_index
+  LABL_PTR_1: l2bgrates_index_label
+
+l2bgrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for range 2 background rates
+  FIELDNAM: l2bgrates uncertainty
+  DEPEND_1: l2bgrates_index
+  LABL_PTR_1: l2bgrates_index_label
+
+l3fgrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for range 3 foreground rates
+  FIELDNAM: l3fgrates uncertainty
+  DEPEND_1: l3fgrates_index
+  LABL_PTR_1: l3fgrates_index_label
+
+l3fgrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for range 3 foreground rates
+  FIELDNAM: l3fgrates uncertainty
+  DEPEND_1: l3fgrates_index
+  LABL_PTR_1: l3fgrates_index_label
+
+l3bgrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for range 3 background rates
+  FIELDNAM: l3bgrates uncertainty
+  DEPEND_1: l3bgrates_index
+  LABL_PTR_1: l3bgrates_index_label
+
+l3bgrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for range 3 background rates
+  FIELDNAM: l3bgrates uncertainty
+  DEPEND_1: l3bgrates_index
+  LABL_PTR_1: l3bgrates_index_label
+
+penfgrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for range 4 foreground rates
+  FIELDNAM: penfgrates uncertainty
+  DEPEND_1: penfgrates_index
+  LABL_PTR_1: penfgrates_index_label
+
+penfgrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for range 4 foreground rates
+  FIELDNAM: penfgrates uncertainty
+  DEPEND_1: penfgrates_index
+  LABL_PTR_1: penfgrates_index_label
+
+penbgrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for range 4 background rates
+  FIELDNAM: penbgrates uncertainty
+  DEPEND_1: penbgrates_index
+  LABL_PTR_1: penbgrates_index_label
+
+penbgrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for range 4 background rates
+  FIELDNAM: penbgrates uncertainty
+  DEPEND_1: penbgrates_index
+  LABL_PTR_1: penbgrates_index_label
+
+ialirtrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for ialirtrates
+  FIELDNAM: ialirtrates uncertainty
+  DEPEND_1: ialirtrates_index
+  LABL_PTR_1: ialirtrates_index_label
+
+ialirtrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for ialirtrates
+  FIELDNAM: ialirtrates uncertainty
+  DEPEND_1: ialirtrates_index
+  LABL_PTR_1: ialirtrates_index_label
+
+l4fgrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for L4 ions foreground rates
+  FIELDNAM: l4fgrates uncertainty
+  DEPEND_1: l4fgrates_index
+  LABL_PTR_1: l4fgrates_index_label
+
+l4fgrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for L4 ions foreground rates
+  FIELDNAM: l4fgrates uncertainty
+  DEPEND_1: l4fgrates_index
+  LABL_PTR_1: l4fgrates_index_label
+
+l4bgrates_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for L4 ions background rates
+  FIELDNAM: l4bgrates uncertainty
+  DEPEND_1: l4bgrates_index
+  LABL_PTR_1: l4bgrates_index_label
+
+l4bgrates_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for L4 ions background rates
+  FIELDNAM: l4bgrates uncertainty
+  DEPEND_1: l4bgrates_index
+  LABL_PTR_1: l4bgrates_index_label
+
+num_trig_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of triggers
+  FIELDNAM: num_trig uncertainty
+
+num_trig_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of triggers
+  FIELDNAM: num_trig uncertainty
+
+num_reject_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of rejects
+  FIELDNAM: num_reject uncertainty
+
+num_reject_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of rejects
+  FIELDNAM: num_reject uncertainty
+
+num_acc_w_pha_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of accepted events with PHA data
+  FIELDNAM: num_acc_w_pha uncertainty
+
+num_acc_w_pha_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of accepted events with PHA data
+  FIELDNAM: num_acc_w_pha uncertainty
+
+num_acc_no_pha_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of events without PHA data
+  FIELDNAM: num_acc_no_pha uncertainty
+
+num_acc_no_pha_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of events without PHA data
+  FIELDNAM: num_acc_no_pha uncertainty
+
+num_haz_trig_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of hazard triggers
+  FIELDNAM: num_haz_trig uncertainty
+
+num_haz_trig_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of hazard triggers
+  FIELDNAM: num_haz_trig uncertainty
+
+num_haz_reject_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of rejected events with hazard
+  FIELDNAM: num_haz_reject uncertainty
+
+num_haz_reject_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of rejected events with hazard
+  FIELDNAM: num_haz_reject uncertainty
+
+num_haz_acc_w_pha_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of accepted hazard events with PHA data
+  FIELDNAM: num_haz_acc_w_pha uncertainty
+
+num_haz_acc_w_pha_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of accepted hazard events with PHA data
+  FIELDNAM: num_haz_acc_w_pha uncertainty
+
+num_haz_acc_no_pha_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of hazard events without PHA data
+  FIELDNAM: num_haz_acc_no_pha uncertainty
+
+num_haz_acc_no_pha_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of hazard events without PHA data
+  FIELDNAM: num_haz_acc_no_pha uncertainty
+
+nread_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of events read
+  FIELDNAM: nread uncertainty
+
+nread_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of events read
+  FIELDNAM: nread uncertainty
+
+nhazard_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of hazard events
+  FIELDNAM: nhazard uncertainty
+
+nhazard_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of hazard events
+  FIELDNAM: nhazard uncertainty
+
+nadcstim_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of ADC-stim events
+  FIELDNAM: nadcstim uncertainty
+
+nadcstim_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of ADC-stim events
+  FIELDNAM: nadcstim uncertainty
+
+nodd_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of odd events
+  FIELDNAM: nodd uncertainty
+
+nodd_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of odd events
+  FIELDNAM: nodd uncertainty
+
+noddfix_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of fixed odd events
+  FIELDNAM: noddfix uncertainty
+
+noddfix_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of fixed odd events
+  FIELDNAM: noddfix uncertainty
+
+nmulti_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of events with multiple hits
+  FIELDNAM: nmulti uncertainty
+
+nmulti_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of events with multiple hits
+  FIELDNAM: nmulti uncertainty
+
+nmultifix_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of fixed multiple hits
+  FIELDNAM: nmultifix uncertainty
+
+nmultifix_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of fixed multiple hits
+  FIELDNAM: nmultifix uncertainty
+
+nbadtraj_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of bad trajectory events
+  FIELDNAM: nbadtraj uncertainty
+
+nbadtraj_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of bad trajectory events
+  FIELDNAM: nbadtraj uncertainty
+
+nl2_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of L2 events
+  FIELDNAM: nl2 uncertainty
+
+nl2_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of L2 events
+  FIELDNAM: nl2 uncertainty
+
+nl3_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of L3 events
+  FIELDNAM: nl3 uncertainty
+
+nl3_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of L3 events
+  FIELDNAM: nl3 uncertainty
+
+nl4_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of L4 events
+  FIELDNAM: nl4 uncertainty
+
+nl4_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of L4 events
+  FIELDNAM: nl4 uncertainty
+
+npen_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of pen events
+  FIELDNAM: npen uncertainty
+
+npen_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of pen events
+  FIELDNAM: npen uncertainty
+
+nformat_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of format events
+  FIELDNAM: nformat uncertainty
+
+nformat_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of format events
+  FIELDNAM: nformat uncertainty
+
+naside_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of A-side events
+  FIELDNAM: naside uncertainty
+
+naside_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of A-side events
+  FIELDNAM: naside uncertainty
+
+nbside_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of B-side events
+  FIELDNAM: nbside uncertainty
+
+nbside_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of B-side events
+  FIELDNAM: nbside uncertainty
+
+nerror_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of error events
+  FIELDNAM: nerror uncertainty
+
+nerror_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of error events
+  FIELDNAM: nerror uncertainty
+
+nbadtags_stat_uncert_plus:
+  <<: *default_uncertainty
+  CATDESC: Plus statistical uncertainty for number of bad tags
+  FIELDNAM: nbadtags uncertainty
+
+nbadtags_stat_uncert_minus:
+  <<: *default_uncertainty
+  CATDESC: Minus statistical uncertainty for number of bad tags
+  FIELDNAM: nbadtags uncertainty
+
 
 # Housekeeping dataset variables
 fsw_version_a:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 63
   CATDESC: Flight Software Version Number (A.B.C bits)
   FIELDNAM: Flight Software Version Number A
@@ -771,7 +1450,7 @@ fsw_version_a:
   FORMAT: I2
 
 fsw_version_b:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 63
   CATDESC: Flight Software Version Number (A.B.C bits)
   FIELDNAM: Flight Software Version Number B
@@ -779,7 +1458,7 @@ fsw_version_b:
   FORMAT: I2
 
 fsw_version_c:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 63
   CATDESC: Flight Software Version Number (A.B.C bits)
   FIELDNAM: Flight Software Version Number C
@@ -787,7 +1466,7 @@ fsw_version_c:
   FORMAT: I2
 
 num_good_cmds:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 255
   CATDESC: Number of Good Commands
   FIELDNAM: Number of Good Commands
@@ -795,7 +1474,7 @@ num_good_cmds:
   FORMAT: I3
 
 last_good_cmd:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 255
   CATDESC: Last Good Command
   FIELDNAM: Last Good Command
@@ -803,7 +1482,7 @@ last_good_cmd:
   FORMAT: I3
 
 last_good_seq_num:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 255
   CATDESC: Last Good Sequence Number
   FIELDNAM: Last Good Sequence Number
@@ -811,7 +1490,7 @@ last_good_seq_num:
   FORMAT: I3
 
 num_bad_cmds:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 255
   CATDESC: Number of Bad Commands
   FIELDNAM: Number of Bad Commands
@@ -819,7 +1498,7 @@ num_bad_cmds:
   FORMAT: I3
 
 last_bad_cmd:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 255
   CATDESC: Last Bad Command
   FIELDNAM: Last Bad Command
@@ -827,7 +1506,7 @@ last_bad_cmd:
   FORMAT: I3
 
 last_bad_seq_num:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 255
   CATDESC: Last Bad Sequence Number
   FIELDNAM: Last Bad Sequence Number
@@ -835,7 +1514,7 @@ last_bad_seq_num:
   FORMAT: I3
 
 fee_running:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - FEE Running (1) or Reset (0)
   FIELDNAM: FEE Running (1) or Reset (0)
@@ -843,7 +1522,7 @@ fee_running:
   FORMAT: I1
 
 mram_disabled:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - MRAM Disabled (1) or Enabled (0)
   FIELDNAM: MRAM Disabled (1) or Enabled (0)
@@ -851,7 +1530,7 @@ mram_disabled:
   FORMAT: I1
 
 enable_50khz:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - 50kHz Enabled (1) or Disabled (0)
   FIELDNAM: 50kHz Enabled (1) or Disabled (0)
@@ -859,7 +1538,7 @@ enable_50khz:
   FORMAT: I1
 
 enable_hvps:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - HVPS Enabled (1) or Disabled (0)
   FIELDNAM: HVPS Enabled (1) or Disabled (0)
@@ -867,7 +1546,7 @@ enable_hvps:
   FORMAT: I1
 
 table_status:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - Table Status OK (1) or Error (0)
   FIELDNAM: Table Status OK (1) or Error (0)
@@ -875,7 +1554,7 @@ table_status:
   FORMAT: I1
 
 heater_control:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 2
   CATDESC: State - Heater Control (0=None, 1=Pri, 2=Sec)
   FIELDNAM: Heater Control (0=None, 1=Pri, 2=Sec)
@@ -883,7 +1562,7 @@ heater_control:
   FORMAT: I1
 
 adc_mode:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 3
   CATDESC: State - ADC Mode (0=quiet, 1=normal, 2=adcstim, 3=adcThreshold)
   FIELDNAM: ADC Mode (0=quiet, 1=normal, 2=adcstim, 3=adcThreshold)
@@ -891,7 +1570,7 @@ adc_mode:
   FORMAT: I1
 
 mode:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 3
   CATDESC: State - Mode (0=Boot, 1=Maintenance, 2=Standby, 3=Science)
   FIELDNAM: Mode (0=Boot, 1=Maintenance, 2=Standby, 3=Science)
@@ -899,7 +1578,7 @@ mode:
   FORMAT: I1
 
 dyn_thresh_lvl:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 3
   CATDESC: Dynamic Threshold Level (0-3)
   FIELDNAM: Dynamic Threshold Level (0-3)
@@ -907,7 +1586,7 @@ dyn_thresh_lvl:
   FORMAT: I1
 
 num_evnt_last_hk:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 4294967295
   CATDESC: Number of Events Since Last HK Update
   FIELDNAM: Number of Events Since Last HK Update
@@ -915,7 +1594,7 @@ num_evnt_last_hk:
   FORMAT: I10
 
 num_errors:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 255
   CATDESC: Number of Errors
   FIELDNAM: Number of Errors
@@ -923,7 +1602,7 @@ num_errors:
   FORMAT: I3
 
 last_error_num:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 255
   CATDESC: State - Last Error Number
   FIELDNAM: Last Error Number
@@ -931,7 +1610,7 @@ last_error_num:
   FORMAT: I3
 
 code_checksum:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 65535
   CATDESC: Code Checksum
   FIELDNAM: Code Checksum
@@ -939,7 +1618,7 @@ code_checksum:
   FORMAT: I5
 
 spin_period_short:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 65535
   CATDESC: Spin Period Short at T=0
   FIELDNAM: Spin Period Short at T=0
@@ -947,7 +1626,7 @@ spin_period_short:
   FORMAT: I5
 
 spin_period_long:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 65535
   CATDESC: Spin Period Long at T=0
   FIELDNAM: Spin Period Long at T=0
@@ -955,7 +1634,7 @@ spin_period_long:
   FORMAT: I5
 
 leak_i:
-  <<: *hk_support_default
+  <<: *default_hk_support
   DEPEND_1: adc_channels
   CATDESC: Leakage Current [I]
   FIELDNAM: Leakage Current [I]
@@ -964,7 +1643,7 @@ leak_i:
   FORMAT: I19
 
 phasic_stat:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - Phasic Status
   FIELDNAM: Phasic Status
@@ -972,7 +1651,7 @@ phasic_stat:
   FORMAT: I1
 
 active_heater:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - Active Heater
   FIELDNAM: Active Heater
@@ -980,7 +1659,7 @@ active_heater:
   FORMAT: I1
 
 heater_on:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - Heater On/Off
   FIELDNAM: Heater On/Off
@@ -988,7 +1667,7 @@ heater_on:
   FORMAT: I1
 
 test_pulser_on:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - Test Pulser On/Off
   FIELDNAM: Test Pulser On/Off
@@ -996,7 +1675,7 @@ test_pulser_on:
   FORMAT: I1
 
 dac0_enable:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - DAC 0 Enable
   FIELDNAM: DAC 0 Enable
@@ -1004,7 +1683,7 @@ dac0_enable:
   FORMAT: I1
 
 dac1_enable:
-  <<: *hk_support_default
+  <<: *default_hk_support
   VALIDMAX: 1
   CATDESC: State - DAC 1 Enable
   FIELDNAM: DAC 1 Enable
@@ -1012,145 +1691,145 @@ dac1_enable:
   FORMAT: I1
 
 preamp_l234a:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Preamp L234A
   FIELDNAM: Preamp L234A
   LABLAXIS: Preamp L234A
 
 preamp_l1a:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Preamp L1A
   FIELDNAM: Preamp L1A
   LABLAXIS: Preamp L1A
 
 preamp_l1b:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Preamp L1B
   FIELDNAM: Preamp L1B
   LABLAXIS: Preamp L1B
 
 preamp_l234b:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Preamp L234B
   FIELDNAM: Preamp L234B
   LABLAXIS: Preamp L234B
 
 temp0:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: FEE LDO Regulator Mounted on the Board Next to the Low-dropout Regulator
   FIELDNAM: FEE LDO Regulator
   LABLAXIS: Temp0
 
 temp1:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Primary Heater Mounted on the Board Next to the Primary Heater Circuit
   FIELDNAM: Primary Heater
   LABLAXIS: Temp1
 
 temp2:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: FEE FPGA Mounted on the Board Next to the FPGA
   FIELDNAM: FEE FPGA
   LABLAXIS: Temp2
 
 temp3:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Secondary Heater
   FIELDNAM: Secondary Heater
   LABLAXIS: Temp3
 
 analog_temp:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Chassis Temp Mounted on the Analog Board Close to Thermostats, Heaters, and Chassis
   FIELDNAM: Analog Temp
   LABLAXIS: Analog temp
 
 hvps_temp:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Board Temp Mounted Inside Faraday Cage in Middle of Board Near Connector Side
   FIELDNAM: Board Temp
   LABLAXIS: HVPS temp
 
 idpu_temp:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: LDO Temp Mounted on Top of the Low-dropout Regulator
   FIELDNAM: LDO Temp
   LABLAXIS: IDPU temp
 
 lvps_temp:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: Board Temp Mounted in the Middle of Board on Opposite Side of Hottest Component
   FIELDNAM: Board Temp
   LABLAXIS: LVPS temp
 
 ebox_3d4vd:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: 3.4VD Ebox (Digital)
   FIELDNAM: 3.4VD Ebox (Digital)
   LABLAXIS: 3.4VD Ebox
 
 ebox_5d1vd:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: 5.1VD Ebox (Digital)
   FIELDNAM: 5.1VD Ebox (Digital)
   LABLAXIS: 5.1VD Ebox
 
 ebox_p12va:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: +12VA Ebox (Analog)
   FIELDNAM: +12VA Ebox (Analog)
   LABLAXIS: +12VA Ebox
 
 ebox_m12va:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: -12VA Ebox (Analog)
   FIELDNAM: -12VA Ebox (Analog)
   LABLAXIS: -12VA Ebox
 
 ebox_p5d7va:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: +5.7VA Ebox (Analog)
   FIELDNAM: +5.7VA Ebox (Analog)
   LABLAXIS: +5.7VA Ebox
 
 ebox_m5d7va:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: -5.7VA Ebox (Analog)
   FIELDNAM: -5.7VA Ebox (Analog)
   LABLAXIS: -5.7VA Ebox
 
 ref_p5v:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: +5V ref
   FIELDNAM: +5V ref
   LABLAXIS: +5V ref
 
 l1ab_bias:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: L1A/B Bias
   FIELDNAM: L1A/B Bias
   LABLAXIS: L1A/B Bias
 
 l2ab_bias:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: L2A/B Bias
   FIELDNAM: L2A/B Bias
   LABLAXIS: L2A/B Bias
 
 l34a_bias:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: L3/4A Bias
   FIELDNAM: L3/4A Bias
   LABLAXIS: L3/4A Bias
 
 l34b_bias:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: L3/4B Bias
   FIELDNAM: L3/4B Bias
   LABLAXIS: L3/4B Bias
 
 ebox_p2d0vd:
-  <<: *hk_default
+  <<: *default_hk
   CATDESC: +2.0VD Ebox (Digital)
   FIELDNAM: +2.0VD Ebox (Digital)
   LABLAXIS: +2.0VD Ebox

--- a/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
@@ -20,7 +20,6 @@ default_uint8_attrs: &default_uint8
   VALIDMIN: 0
   VALIDMAX: 255
   dtype: uint8
-  DEPEND_0: sc_tick
 
 default_uint16_attrs: &default_uint16
   <<: *default
@@ -29,7 +28,6 @@ default_uint16_attrs: &default_uint16
   VALIDMIN: 0
   VALIDMAX: 65535
   dtype: uint16
-  DEPEND_0: sc_tick
 
 default_uint32_attrs: &default_uint32
   <<: *default
@@ -76,7 +74,25 @@ hk_default_attrs: &hk_default
 counts_support_attrs: &counts_support_default
   <<: *default
   DISPLAY_TYPE: no_plot
-  VAR_TYPE: ignore_data
+  VAR_TYPE: support_data
+  FILLVAL: -1.00E+31
+  VALIDMIN: 0
+  VALIDMAX: 1000
+
+index_support_attrs: &index_support_default
+  <<: *default_uint32
+  DISPLAY_TYPE: no_plot
+  VAR_TYPE: support_data
+  VALIDMAX: 1000
+
+energy_support_attrs: &energy_support_default
+  <<: *default
+  DISPLAY_TYPE: no_plot
+  VAR_TYPE: support_data
+  VALIDMAX: 1000
+  LABLAXIS: Energy
+  UNITS: MeV
+  FORMAT: F5.1
 
 
 # <=== Counts Coordinates ===>
@@ -97,6 +113,7 @@ declination:
     FIELDNAM: Declination
     LABLAXIS: Declination
     FORMAT: F5.1
+    UNITS: deg
 
 inclination:
     <<: *counts_support_default
@@ -104,6 +121,7 @@ inclination:
     FIELDNAM: Inclination
     LABLAXIS: Inclination
     FORMAT: F5.1
+    UNITS: deg
 
 gain:
     <<: *counts_support_default
@@ -113,123 +131,102 @@ gain:
     FORMAT: I2
 
 sngrates_index:
-    <<: *counts_support_default
+    <<: *index_support_default
     CATDESC: Single rates index
     FIELDNAM: SNGRATES Index
     LABLAXIS: SNGRATES Index
-    FORMAT: I12
 
 coinrates_index:
-  <<: *counts_support_default
+  <<: *index_support_default
   CATDESC: Coincidence rates index
   FIELDNAM: COINRATES index
   LABLAXIS: COINRATES index
-  FORMAT: I12
 
 pbufrates_index:
-  <<: *counts_support_default
+  <<: *index_support_default
   CATDESC: Priority buffer rates index
   FIELDNAM: pbufrates Index
   LABLAXIS: pbufrates Index
-  FORMAT: I12
 
 l2fgrates_index:
-  <<: *counts_support_default
-  CATDESC: l2fgrates index
+  <<: *index_support_default
+  CATDESC: Range 2 foreground rates index
   FIELDNAM: l2fgrates Index
   LABLAXIS: l2fgrates Index
-  FORMAT: I12
 
 l2bgrates_index:
-  <<: *counts_support_default
-  CATDESC: l2bgrates index
+  <<: *index_support_default
+  CATDESC: Range 2 background rates index
   FIELDNAM: l2bgrates Index
   LABLAXIS: l2bgrates Index
-  FORMAT: I12
 
 l3fgrates_index:
-  <<: *counts_support_default
-  CATDESC: l3fgrates index
+  <<: *index_support_default
+  CATDESC: Range 3 foreground rates index
   FIELDNAM: l3fgrates Index
   LABLAXIS: l3fgrates Index
-  FORMAT: I12
 
 l3bgrates_index:
-  <<: *counts_support_default
-  CATDESC: l3bgrates index
+  <<: *index_support_default
+  CATDESC: Range 3 background rates index
   FIELDNAM: l3bgrates Index
   LABLAXIS: l3bgrates Index
-  FORMAT: I12
 
 penfgrates_index:
-  <<: *counts_support_default
-  CATDESC: penfgrates index
+  <<: *index_support_default
+  CATDESC: Range 4 foreground rates index
   FIELDNAM: penfgrates Index
   LABLAXIS: penfgrates Index
-  FORMAT: I12
 
 penbgrates_index:
-  <<: *counts_support_default
-  CATDESC: penbgrates index
+  <<: *index_support_default
+  CATDESC: Range 4 background rates index
   FIELDNAM: penbgrates Index
   LABLAXIS: penbgrates Index
-  FORMAT: I12
 
 ialirtrates_index:
-  <<: *counts_support_default
+  <<: *index_support_default
   CATDESC: ialirtrates index
   FIELDNAM: ialirtrates Index
   LABLAXIS: ialirtrates Index
-  FORMAT: I12
 
 l4fgrates_index:
-  <<: *counts_support_default
-  CATDESC: l4fgrates index
+  <<: *index_support_default
+  CATDESC: L4 ions foreground rates index
   FIELDNAM: l4fgrates Index
   LABLAXIS: l4fgrates Index
-  FORMAT: I12
 
 l4bgrates_index:
-  <<: *counts_support_default
-  CATDESC: l4bgrates index
+  <<: *index_support_default
+  CATDESC: L4 ions background rates index
   FIELDNAM: l4bgrates Index
   LABLAXIS: l4bgrates Index
-  FORMAT: I12
 
-h_energy_index:
-  <<: *counts_support_default
-  CATDESC: h energy index
-  FIELDNAM: h energy Index
-  LABLAXIS: h energy Index
-  FORMAT: I12
+h_energy_mean:
+  <<: *energy_support_default
+  CATDESC: H sectored geometric mean energy
+  FIELDNAM: H energy mean
 
-he4_energy_index:
-  <<: *counts_support_default
-  CATDESC: he4 energy index
-  FIELDNAM: he4 energy Index
-  LABLAXIS: he4 energy Index
-  FORMAT: I12
+he4_energy_mean:
+  <<: *energy_support_default
+  CATDESC: He4 sectored geometric mean energy
+  FIELDNAM: He4 energy mean
 
-cno_energy_index:
-  <<: *counts_support_default
-  CATDESC: cno energy index
-  FIELDNAM: cno energy Index
-  LABLAXIS: cno energy Index
-  FORMAT: I12
+cno_energy_mean:
+  <<: *energy_support_default
+  CATDESC: C, N, O sectored geometric mean energy
+  FIELDNAM: C, N, O energy mean
 
-nemgsi_energy_index:
-  <<: *counts_support_default
-  CATDESC: nemgsi energy index
-  FIELDNAM: nemgsi energy Index
-  LABLAXIS: nemgsi energy Index
-  FORMAT: I12
+nemgsi_energy_mean:
+  <<: *energy_support_default
+  CATDESC: Ne, Mg, Si sectored geometric mean energy
+  FIELDNAM: Ne, Mg, Si energy mean
 
-fe_energy_index:
-  <<: *counts_support_default
-  CATDESC: fe energy index
-  FIELDNAM: fe energy Index
-  LABLAXIS: fe energy Index
-  FORMAT: I12
+fe_energy_mean:
+  <<: *energy_support_default
+  CATDESC: Fe sectored geometric mean energy
+  FIELDNAM: Fe energy mean
+
 
 # <=== Housekeeping Coordinates ===>
 adc_channels:   # adc_channels is a dependency for leak_i data variable
@@ -239,7 +236,7 @@ adc_channels:   # adc_channels is a dependency for leak_i data variable
   SCALETYP: linear
   VALIDMIN: 0
   VALIDMAX: 63
-  VAR_TYPE: metadata
+  VAR_TYPE: support data
   CATDESC: ADC Channel
   FIELDNAM: ADC Channel
   LABLAXIS: Channel
@@ -263,48 +260,49 @@ version:
   CATDESC: CCSDS packet version number
   FIELDNAM: CCSDS version
   VAR_TYPE: support_data
+  DEPEND_0: sc_tick
 
 type:
   <<: *default_uint8
   CATDESC: CCSDS packet type
   FIELDNAM: CCSDS type
   VAR_TYPE: support_data
+  DEPEND_0: sc_tick
 
 sec_hdr_flg:
   <<: *default_uint8
   CATDESC: CCSDS secondary header flag
   FIELDNAM: CCSDS secondary header flag
   VAR_TYPE: support_data
+  DEPEND_0: sc_tick
 
 pkt_apid:
   <<: *default_uint16
   CATDESC: CCSDS application process ID
   FIELDNAM: CCSDS APID
   VAR_TYPE: support_data
+  DEPEND_0: sc_tick
 
 seq_flgs:
   <<: *default_uint8
   CATDESC: CCSDS sequence flags
   FIELDNAM: CCSDS sequence flags
   VAR_TYPE: support_data
+  DEPEND_0: sc_tick
 
 src_seq_ctr:
   <<: *default_uint16
   CATDESC: CCSDS source sequence counter
   FIELDNAM: CCSDS sequence counter
   VAR_TYPE: support_data
+  DEPEND_0: sc_tick
 
 pkt_len:
   <<: *default_uint16
   CATDESC: CCSDS packet length
   FIELDNAM: CCSDS packet length
   VAR_TYPE: support_data
-
-sc_tick:
-  <<: *default_uint32
-  CATDESC: CCSDS secondary header - Spacecraft Tick
-  FIELDNAM: Spacecraft Tick
-  VAR_TYPE: support_data
+  DEPEND_0: sc_tick
 
 
 # Housekeeping variables

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -89,7 +89,7 @@ def parse_count_rates(sci_dataset: xr.Dataset) -> None:
         if all(x not in field for x in ["hdr", "spare", "pha"]):
             parsed_data = np.vectorize(decompress_rates_16_to_32)(parsed_data)
 
-        # Get dims for data variables (yaml file not created yet)
+        # Get dims for data variables
         if len(field_meta.shape) > 1:
             if "sectorates" in field:
                 # Reshape data to 15x8 for azimuth and zenith look directions

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -279,39 +279,38 @@ def process_science(
     # Calculate uncertainties for count rates
     count_rates_dataset = calculate_uncertainties(count_rates_dataset)
 
-    # Logical sources for the two products.
-    logical_sources = ["imap_hit_l1a_counts", "imap_hit_l1a_direct-events"]
+    l1a_datasets: dict = {
+        "imap_hit_l1a_counts": count_rates_dataset,
+        "imap_hit_l1a_direct-events": pha_raw_dataset,
+    }
 
-    datasets = []
     # Update attributes and dimensions
-    for ds, logical_source in zip(
-        [count_rates_dataset, pha_raw_dataset], logical_sources
-    ):
+    for logical_source, ds in l1a_datasets.items():
         ds.attrs = attr_mgr.get_global_attributes(logical_source)
 
-        # TODO: Add CDF attributes to yaml once they're defined for L1A science data
         # Assign attributes and dimensions to each data array in the Dataset
         for field in ds.data_vars.keys():
             try:
-                # Create a dict of dimensions using the DEPEND_I keys in the
-                # attributes
-                dims = {
-                    key: value
-                    for key, value in attr_mgr.get_variable_attributes(field).items()
-                    if "DEPEND" in key
-                }
                 ds[field].attrs = attr_mgr.get_variable_attributes(field)
-                ds[field].assign_coords(dims)
             except KeyError:
                 print(f"Field {field} not found in attribute manager.")
                 logger.warning(f"Field {field} not found in attribute manager.")
 
-        # Skip schema check for epoch to prevent attr_mgr from adding the
-        # DEPEND_0 attribute which isn't required for epoch
-        ds.epoch.attrs = attr_mgr.get_variable_attributes("epoch", check_schema=False)
-
-        datasets.append(ds)
+        # check_schema=False to avoid attr_mgr adding stuff dimensions don't need
+        for dim in ds.dims:
+            ds[dim].attrs = attr_mgr.get_variable_attributes(dim, check_schema=False)
+            # TODO: should labels be added as coordinates? Check with SPDF
+            if dim != "epoch":
+                label_array = xr.DataArray(
+                    ds[dim].values.astype(str),
+                    name=f"{dim}_label",
+                    dims=[dim],
+                    attrs=attr_mgr.get_variable_attributes(
+                        f"{dim}_label", check_schema=False
+                    ),
+                )
+                ds.coords[f"{dim}_label"] = label_array
 
         logger.info(f"HIT L1A dataset created for {logical_source}")
 
-    return datasets
+    return list(l1a_datasets.values())

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -134,18 +134,15 @@ def add_cdf_attributes(
         dataset[dim].attrs = attr_mgr.get_variable_attributes(dim, check_schema=False)
         # TODO: should labels be added as coordinates? Check with SPDF
         if dim != "epoch":
-            dataset = dataset.assign_coords(
-                {
-                    f"{dim}_label": xr.DataArray(
-                        dataset[dim].values.astype(str),
-                        name=f"{dim}_label",
-                        dims=[dim],
-                        attrs=attr_mgr.get_variable_attributes(
-                            f"{dim}_label", check_schema=False
-                        ),
-                    )
-                }
+            label_array = xr.DataArray(
+                dataset[dim].values.astype(str),
+                name=f"{dim}_label",
+                dims=[dim],
+                attrs=attr_mgr.get_variable_attributes(
+                    f"{dim}_label", check_schema=False
+                ),
             )
+            dataset.coords[f"{dim}_label"] = label_array
 
     return dataset
 

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -351,28 +351,41 @@ def test_process_standard_rates_data(l1a_counts_dataset, livetime):
         "dynamic_threshold_state",
     }
 
-    valid_coords = [
+    valid_coords = {
         "epoch",
         "gain",
+        "gain_label",
         "sngrates_index",
+        "sngrates_index_label",
         "coinrates_index",
+        "coinrates_index_label",
         "pbufrates_index",
+        "pbufrates_index_label",
         "l2fgrates_index",
+        "l2fgrates_index_label",
         "l2bgrates_index",
+        "l2bgrates_index_label",
         "l3fgrates_index",
+        "l3fgrates_index_label",
         "l3bgrates_index",
+        "l3bgrates_index_label",
         "penfgrates_index",
+        "penfgrates_index_label",
         "penbgrates_index",
+        "penbgrates_index_label",
         "ialirtrates_index",
+        "ialirtrates_index_label",
         "l4fgrates_index",
+        "l4fgrates_index_label",
         "l4bgrates_index",
-    ]
+        "l4bgrates_index_label",
+    }
 
     # Check that the dataset has the correct variables
     assert valid_data_vars == set(l1b_standard_rates_dataset.data_vars.keys()), (
         "Data variables mismatch"
     )
-    assert valid_coords == list(l1b_standard_rates_dataset.coords), (
+    assert valid_coords == set(l1b_standard_rates_dataset.coords), (
         "Coordinates mismatch"
     )
 
@@ -387,15 +400,23 @@ def test_process_sectored_rates_data(l1a_counts_dataset, livetime):
     # Check that a xarray dataset is returned
     assert isinstance(l1b_sectored_rates_dataset, xr.Dataset)
 
+    # Define the data variables that should be present in the dataset
     valid_coords = {
         "epoch",
         "zenith",
+        "zenith_label",
         "azimuth",
+        "azimuth_label",
         "h_energy_mean",
+        "h_energy_mean_label",
         "he4_energy_mean",
+        "he4_energy_mean_label",
         "cno_energy_mean",
+        "cno_energy_mean_label",
         "nemgsi_energy_mean",
+        "nemgsi_energy_mean_label",
         "fe_energy_mean",
+        "fe_energy_mean_label",
     }
 
     # Check that the dataset has the correct coords and variables

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -687,13 +687,20 @@ def test_process_macropixel_intensity(
 
     valid_coords = {
         "epoch",
-        "azimuth",
         "zenith",
+        "zenith_label",
+        "azimuth",
+        "azimuth_label",
         "h_energy_mean",
+        "h_energy_mean_label",
         "he4_energy_mean",
+        "he4_energy_mean_label",
         "cno_energy_mean",
+        "cno_energy_mean_label",
         "nemgsi_energy_mean",
+        "nemgsi_energy_mean_label",
         "fe_energy_mean",
+        "fe_energy_mean_label",
     }
 
     # Check that the dataset has the correct coords and variables


### PR DESCRIPTION
This PR adds L1A science data attributes to the yaml file and updates L1A processing to assign attributes to science datasets

Closes #1056 
Closes #1193 

## Updated Files
- imap_processing/cdf/config/imap_hit_l1a_variable_attrs.yaml
   - added science dataset attributes
- imap_processing/hit/l0/decom_hit.py
   - removed comment
- imap_processing/hit/l1a/hit_l1a.py
   - Updated code that adds attributes to science dataset
- imap_processing/hit/l2/hit_l2.py
   - Minor update to code that adds dimension labels to datasets to match approach in L1A

## Testing
Updated tests where needed. Mostly related to validating coordinates that now have dimension labels
