### PR TITLE
HIT L0 - Fix angle dimension order error

### DIFF
--- a/imap_processing/hit/l0/constants.py
+++ b/imap_processing/hit/l0/constants.py
@@ -100,7 +100,9 @@ COUNTS_DATA_STRUCTURE = {
     "penfgrates": HITPacking(16, 528, (33,)),  # range 4 foreground rates
     "penbgrates": HITPacking(16, 240, (15,)),  # range 4 background rates
     "ialirtrates": HITPacking(16, 320, (20,)),  # ialirt rates
-    "sectorates": HITPacking(16, 1920, (8, 15)),  # sectored rates
+    "sectorates": HITPacking(
+        16, 1920, (8, 15)
+    ),  # sectored rates (8 zenith angles, 15 azimuth angles)
     "l4fgrates": HITPacking(16, 768, (48,)),  # all range foreground rates
     "l4bgrates": HITPacking(16, 384, (24,)),  # all range foreground rates
 }

--- a/imap_processing/hit/l0/constants.py
+++ b/imap_processing/hit/l0/constants.py
@@ -100,7 +100,7 @@ COUNTS_DATA_STRUCTURE = {
     "penfgrates": HITPacking(16, 528, (33,)),  # range 4 foreground rates
     "penbgrates": HITPacking(16, 240, (15,)),  # range 4 background rates
     "ialirtrates": HITPacking(16, 320, (20,)),  # ialirt rates
-    "sectorates": HITPacking(16, 1920, (15, 8)),  # sectored rates
+    "sectorates": HITPacking(16, 1920, (8, 15)),  # sectored rates
     "l4fgrates": HITPacking(16, 768, (48,)),  # all range foreground rates
     "l4bgrates": HITPacking(16, 384, (24,)),  # all range foreground rates
 }

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -92,8 +92,9 @@ def parse_count_rates(sci_dataset: xr.Dataset) -> None:
         # Get dims for data variables (yaml file not created yet)
         if len(field_meta.shape) > 1:
             if "sectorates" in field:
-                # Reshape data to 15x8 for azimuth and zenith look directions
+                # Transpose data to 15x8 for azimuth and zenith look directions
                 parsed_data = np.array(parsed_data).reshape((-1, *field_meta.shape))
+                parsed_data = np.transpose(parsed_data, axes=(0, 2, 1))
                 dims = ["epoch", "azimuth", "zenith"]
                 # Add angle values to coordinates
                 sci_dataset.coords["zenith"] = xr.DataArray(

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -92,8 +92,10 @@ def parse_count_rates(sci_dataset: xr.Dataset) -> None:
         # Get dims for data variables (yaml file not created yet)
         if len(field_meta.shape) > 1:
             if "sectorates" in field:
-                # Transpose data to 15x8 for azimuth and zenith look directions
+                # Reshape data into (num_frames, 8, 15) for zenith and azimuth
+                # look directions
                 parsed_data = np.array(parsed_data).reshape((-1, *field_meta.shape))
+                # Transpose data to (num_frames, 15, 8) for flipped look directions
                 parsed_data = np.transpose(parsed_data, axes=(0, 2, 1))
                 dims = ["epoch", "azimuth", "zenith"]
                 # Add angle values to coordinates

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -13,7 +13,11 @@ from imap_processing.hit.hit_utils import (
     get_datasets_by_apid,
     process_housekeeping_data,
 )
-from imap_processing.hit.l0.constants import MOD_10_MAPPING
+from imap_processing.hit.l0.constants import (
+    AZIMUTH_ANGLES,
+    MOD_10_MAPPING,
+    ZENITH_ANGLES,
+)
 from imap_processing.hit.l0.decom_hit import decom_hit
 
 logger = logging.getLogger(__name__)
@@ -104,12 +108,16 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
     hdr_min_count_mod_10 = updated_dataset.hdr_minute_cnt.values % 10
 
     # Reference mod 10 mapping to initialize data structure for species and
-    # energy ranges and add 15x8 arrays with fill values for each science frame.
+    # energy ranges and add arrays with fill values for each science frame.
     num_frames = len(hdr_min_count_mod_10)
     data_by_species_and_energy_range = {
         key: {
             **value,
-            "counts": np.full((num_frames, 15, 8), fill_value=fillval, dtype=np.int64),
+            "counts": np.full(
+                (num_frames, len(AZIMUTH_ANGLES), len(ZENITH_ANGLES)),
+                fill_value=fillval,
+                dtype=np.int64,
+            ),
         }
         for key, value in MOD_10_MAPPING.items()
     }


### PR DESCRIPTION
This PR updates how the raw binary sectorates data is processed. It needs to be processed with a shape of 8x15 and then transposed to 15x8 to ensure that the data ends up in the correct spots in the data array. I was shaping the data as 15x8 from the start, but since the data comes out of flight software and it has the opposite order defined, this was not producing expected results during validation.

Closes #1836 


## Updated Files
- imap_processing/hit/l0/constants.py
   - Changed shape definition back to 8x15 for sectorates
- imap_processing/hit/l0/decom_hit.py
   - Transposed decommutated sectorates data to 15x8
- imap_processing/hit/l1a/hit_l1a.py
   - Replaced hard coded values for dimension sizes with length of constants for those dimensions
