### PR TITLE
HIT L0 - change epoch to center collection time

### DIFF
--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -314,7 +314,9 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
         )
 
     # Add new data variables to the dataset and update epoch coordinate
-    sci_dataset.coords["epoch"] = xr.DataArray(epoch_per_science_frame, dims=["epoch"])
+    sci_dataset.coords["epoch"] = xr.DataArray(
+        np.array(epoch_per_science_frame, dtype=np.int64), dims=["epoch"]
+    )
     sci_dataset["count_rates_raw"] = xr.DataArray(
         count_rates, dims=["epoch"], name="count_rates_raw"
     )

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -305,10 +305,13 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
         count_rates.append("".join(science_data_frame[:6]))
         # Last 14 packets contain pulse height event data in binary
         pha.append("".join(science_data_frame[6:]))
-        # Get first packet's epoch for the science frame
-        epoch_per_science_frame = np.append(epoch_per_science_frame, epoch_data[idx])
+        # Get the mean epoch in the frame to use as the data collection time
+        epoch_per_science_frame = np.append(
+            epoch_per_science_frame,
+            np.mean([epoch_data[idx], epoch_data[idx + FRAME_SIZE - 1]]),
+        )
 
-    # Add new data variables to the dataset
+    # Add new data variables to the dataset and update epoch coordinate
     sci_dataset = sci_dataset.drop_vars("epoch")
     sci_dataset.coords["epoch"] = epoch_per_science_frame
     sci_dataset["count_rates_raw"] = xr.DataArray(

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -310,7 +310,7 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
         pha.append("".join(science_data_frame[6:]))
         # Get the mean epoch in the frame to use as the data collection time
         epoch_per_science_frame.append(
-            np.mean([epoch_data[idx], epoch_data[idx + FRAME_SIZE - 1]])
+            calculate_epoch_mean(epoch_data, idx, FRAME_SIZE)
         )
 
     # Add new data variables to the dataset and update epoch coordinate
@@ -378,6 +378,31 @@ def decompress_rates_16_to_32(packed: int) -> int:
         decompressed_int = packed
 
     return decompressed_int
+
+
+def calculate_epoch_mean(
+    epoch_data: np.ndarray, idx: int, frame_size: int
+) -> np.floating:
+    """
+    Calculate the mean epoch for a science frame.
+
+    This function is used to get the center collection time for science data.
+
+    Parameters
+    ----------
+    epoch_data : np.ndarray
+        Array of epoch values for every science packet.
+    idx : int
+        Starting index of the science frame.
+    frame_size : int
+        Number of packets in the science frame.
+
+    Returns
+    -------
+    float
+        Mean epoch value for the science frame.
+    """
+    return np.mean([epoch_data[idx], epoch_data[idx + frame_size - 1]])
 
 
 def decom_hit(sci_dataset: xr.Dataset) -> xr.Dataset:

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -205,9 +205,12 @@ def update_ccsds_header_dims(sci_dataset: xr.Dataset) -> xr.Dataset:
     it will be updated later in the process to represent
     time per science frame, so another time dimension is
     needed for the ccsds header fields.This function
-    updates the dimension for these fields to use sc_tick
-    instead of epoch. sc_tick is the time the packet was
-    created.
+    updates the dimension for all data vars to use sc_tick
+    instead of epoch. It also temporarily sets sc_tick as the
+    dimension for the epoch coordinate (to be updated later
+    in the assemble_science_frames function).
+
+    Note: sc_tick is the time the packet was created.
 
     Parameters
     ----------

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -297,7 +297,7 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
     # Extract data per science frame and organize by L1A data products
     count_rates = []
     pha = []
-    epoch_per_science_frame = np.array([])
+    epoch_per_science_frame = []
     for idx in starting_indices:
         # Data from 20 packets in a science frame
         science_data_frame = science_data[idx : idx + FRAME_SIZE]
@@ -306,14 +306,12 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
         # Last 14 packets contain pulse height event data in binary
         pha.append("".join(science_data_frame[6:]))
         # Get the mean epoch in the frame to use as the data collection time
-        epoch_per_science_frame = np.append(
-            epoch_per_science_frame,
-            np.mean([epoch_data[idx], epoch_data[idx + FRAME_SIZE - 1]]),
+        epoch_per_science_frame.append(
+            np.mean([epoch_data[idx], epoch_data[idx + FRAME_SIZE - 1]])
         )
 
     # Add new data variables to the dataset and update epoch coordinate
-    sci_dataset = sci_dataset.drop_vars("epoch")
-    sci_dataset.coords["epoch"] = epoch_per_science_frame
+    sci_dataset.coords["epoch"] = xr.DataArray(epoch_per_science_frame, dims=["epoch"])
     sci_dataset["count_rates_raw"] = xr.DataArray(
         count_rates, dims=["epoch"], name="count_rates_raw"
     )

--- a/imap_processing/tests/hit/test_decom_hit.py
+++ b/imap_processing/tests/hit/test_decom_hit.py
@@ -200,6 +200,8 @@ def test_assemble_science_frames(sci_dataset):
     updated_dataset = assemble_science_frames(updated_dataset)
     assert "count_rates_raw" in updated_dataset
     assert "pha_raw" in updated_dataset
+    assert "epoch" in updated_dataset.dims
+    assert updated_dataset.epoch.shape == updated_dataset.count_rates_raw.shape
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/hit/test_decom_hit.py
+++ b/imap_processing/tests/hit/test_decom_hit.py
@@ -10,6 +10,7 @@ from imap_processing.hit.hit_utils import (
 from imap_processing.hit.l0.constants import AZIMUTH_ANGLES, ZENITH_ANGLES
 from imap_processing.hit.l0.decom_hit import (
     assemble_science_frames,
+    calculate_epoch_mean,
     decom_hit,
     decompress_rates_16_to_32,
     get_valid_starting_indices,
@@ -202,6 +203,20 @@ def test_assemble_science_frames(sci_dataset):
     assert "pha_raw" in updated_dataset
     assert "epoch" in updated_dataset.dims
     assert updated_dataset.epoch.shape == updated_dataset.count_rates_raw.shape
+
+
+@pytest.mark.parametrize(
+    "epoch_data, idx, frame_size, expected",
+    [
+        (np.array([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]), 2, 4, 450),
+        (np.array([100, 200, 300, 400]), 0, 4, 250),  # Frame size equals data length
+        (np.array([100, 200, 300, 400]), 1, 2, 250),  # Smaller frame size
+    ],
+)
+def test_calculate_epoch_mean(epoch_data, idx, frame_size, expected):
+    """Test the calculate_epoch_mean function with various cases."""
+    result = calculate_epoch_mean(epoch_data, idx, frame_size)
+    assert result == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR changes the epoch values used for science data to be the center collection time for that data. Previously, the starting time was being used.

Closes #1838 

## Updated Files
- imap_processing/hit/l0/decom_hit.py
   - Created an array of mean epoch values in science frames as the new epoch coordinate in the dataset
