### PR TITLE
1840 bug   hi l1b hi constants tof2 bad values

### DIFF
--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -65,8 +65,8 @@ class HiConstants:
 
     # These values are stored in the TOF telemetry when the TOF timer
     # does not have valid data.
-    TOF1_BAD_VALUES = (511, 1023)
-    TOF2_BAD_VALUES = (1023,)
+    TOF1_BAD_VALUES = (511,)
+    TOF2_BAD_VALUES = (511,)
     TOF3_BAD_VALUES = (1023,)
 
 

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -64,7 +64,8 @@ class HiConstants:
     TOF3_TICK_DUR = 0.5  # 0.5 ns
 
     # These values are stored in the TOF telemetry when the TOF timer
-    # does not have valid data.
+    # does not have valid data. See IMAP-Hi Algorithm Document Section
+    # 2.2.5 Annotated Direct Events
     TOF1_BAD_VALUES = (511,)
     TOF2_BAD_VALUES = (511,)
     TOF3_BAD_VALUES = (1023,)

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -59,16 +59,16 @@ def synthetic_trigger_id_and_tof_data():
     # -----|-------|-------------------------------
     #   0  |   0   | Non-event not recorded
     #   1  |   0   | Can't trigger c2 only
-    #   2  |   2   | trigger_id = 3, tof_3 invalid
-    #   3  |   2   | trigger_id = 3, tof_3 valid
-    #   4  |   2   | trigger_id = 2, no valid tofs
+    #   2  |   1   | trigger_id = 3, tof_3 invalid
+    #   3  |   1   | trigger_id = 3, tof_3 valid
+    #   4  |   1   | trigger_id = 2, no valid tofs
     #   5  |   0   | B and C2 not possible?
-    #   6  |   4   | trigger_id = 2 OR 3, tof_2 valid
-    #   7  |   4   | trigger_id = 2 OR 3, tof_2/3 valid
-    #   8  |   2   | trigger_id = 3, no valid tofs
+    #   6  |   2   | trigger_id = 2 OR 3, tof_2 valid
+    #   7  |   2   | trigger_id = 2 OR 3, tof_2/3 valid
+    #   8  |   1   | trigger_id = 3, no valid tofs
     #   9  |   0   | A and C2 not possible?
-    #  10  |   3   | trigger_id = 1, tof_2 OR trigger_id = 3, tof_1
-    #  11  |   3   | trigger_id = 1, tof_2/3, OR trigger_id = 3, tof_1/3
+    #  10  |   2   | trigger_id = 1, tof_2 OR trigger_id = 3, tof_1
+    #  11  |   2   | trigger_id = 1, tof_2/3, OR trigger_id = 3, tof_1/3
     #  12  |   2   | trigger_id = 1 OR 2, tof_1
     #  13  |   0   | A/B and C2 not possible?
     #  14  |   3   | trigger_id = 1 OR 2 OR 3, tof_1/2
@@ -102,7 +102,7 @@ def synthetic_trigger_id_and_tof_data():
         },
         data_vars=data_vars,
     )
-    expected_histogram = np.array([0, 0, 2, 2, 2, 0, 4, 4, 2, 0, 3, 3, 2, 0, 3, 3])
+    expected_histogram = np.array([0, 0, 1, 1, 1, 0, 2, 2, 1, 0, 2, 2, 2, 0, 3, 3])
     return synthetic_l1a_ds, expected_histogram
 
 


### PR DESCRIPTION
# Change Summary

## Overview
During validation of Hi L1B DE data, a bug was found caused by an update to the bad TOF telemetry values in the Hi Algorithm document. This bugfix updates those bad values to match the algorithm document. Validation with the fix in place confirmed that one validation discrepancy was resolved with this fix.

## Updated Files
- imap_processing/hi/utils.py
   - Update TOF1/2 bad values tuples
- imap_processing/tests/hi/test_hi_l1b.py
   - Updates to the numbers in the expected coincidence type histogram due to removal of one bad TOF value.

Closes: #1840 
