### PR TITLE
Mag l1a dupe packets

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1123,10 +1123,10 @@ class Mag(ProcessInstrument):
             )
 
         for ds in datasets:
-            if not np.all(ds['epoch'].values[1:] > ds['epoch'].values[:-1]):
-                print("ERROR: NOT MONOTONICALLY INCREASING!!!!")
-
-
+            if not np.all(ds["epoch"].values[1:] > ds["epoch"].values[:-1]):
+                raise ValueError(
+                    "Timestamps for output file are not monotonically increasing."
+                )
         return datasets
 
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1122,6 +1122,11 @@ class Mag(ProcessInstrument):
                 mode=DataMode(descriptor_no_frame.upper()),
             )
 
+        for ds in datasets:
+            if not np.all(ds['epoch'].values[1:] > ds['epoch'].values[:-1]):
+                print("ERROR: NOT MONOTONICALLY INCREASING!!!!")
+
+
         return datasets
 
 

--- a/imap_processing/mag/l0/decom_mag.py
+++ b/imap_processing/mag/l0/decom_mag.py
@@ -43,7 +43,7 @@ def decom_packets(packet_file_path: str | Path) -> dict[str, list[MagL0]]:
 
     packet_definition = definitions.XtcePacketDefinition(xtce_document)
 
-    # We use a set for de-duplication, but we also keep a list to keep objects in order.
+    # Store in a dict for de-duplication. Only the keys are returned as a list.
     norm_dict: dict[MagL0, None] = {}
     burst_dict: dict[MagL0, None] = {}
 

--- a/imap_processing/mag/l0/decom_mag.py
+++ b/imap_processing/mag/l0/decom_mag.py
@@ -44,10 +44,8 @@ def decom_packets(packet_file_path: str | Path) -> dict[str, list[MagL0]]:
     packet_definition = definitions.XtcePacketDefinition(xtce_document)
 
     # We use a set for de-duplication, but we also keep a list to keep objects in order.
-    norm_set: set[MagL0] = set()
-    burst_set: set[MagL0] = set()
-    norm_list = []
-    burst_list = []
+    norm_dict: dict[MagL0, None] = {}
+    burst_dict: dict[MagL0, None] = {}
 
     with open(packet_file_path, "rb") as binary_data:
         mag_packets = packet_definition.packet_generator(binary_data)
@@ -58,17 +56,12 @@ def decom_packets(packet_file_path: str | Path) -> dict[str, list[MagL0]]:
                 values = [item.raw_value for item in packet.user_data.values()]
                 mag_l0 = MagL0(CcsdsData(packet.header), *values)
                 if apid == Mode.NORMAL:
-                    prev_len = len(norm_set)
-                    norm_set.add(mag_l0)
-                    if prev_len != len(norm_set):
-                        norm_list.append(mag_l0)
-                else:
-                    prev_len = len(burst_set)
-                    burst_set.add(mag_l0)
-                    if prev_len != len(burst_set):
-                        burst_list.append(mag_l0)
+                    if mag_l0 not in norm_dict:
+                        norm_dict[mag_l0] = None
+                elif mag_l0 not in burst_dict:
+                    burst_dict[mag_l0] = None
 
-    return {"norm": norm_list, "burst": burst_list}
+    return {"norm": list(norm_dict.keys()), "burst": list(burst_dict.keys())}
 
 
 def generate_dataset(

--- a/imap_processing/mag/l0/decom_mag.py
+++ b/imap_processing/mag/l0/decom_mag.py
@@ -43,8 +43,11 @@ def decom_packets(packet_file_path: str | Path) -> dict[str, list[MagL0]]:
 
     packet_definition = definitions.XtcePacketDefinition(xtce_document)
 
-    norm_data = []
-    burst_data = []
+    # We use a set for de-duplication, but we also keep a list to keep objects in order.
+    norm_set: set[MagL0] = set()
+    burst_set: set[MagL0] = set()
+    norm_list = []
+    burst_list = []
 
     with open(packet_file_path, "rb") as binary_data:
         mag_packets = packet_definition.packet_generator(binary_data)
@@ -53,12 +56,19 @@ def decom_packets(packet_file_path: str | Path) -> dict[str, list[MagL0]]:
             apid = packet["PKT_APID"]
             if apid in (Mode.BURST, Mode.NORMAL):
                 values = [item.raw_value for item in packet.user_data.values()]
+                mag_l0 = MagL0(CcsdsData(packet.header), *values)
                 if apid == Mode.NORMAL:
-                    norm_data.append(MagL0(CcsdsData(packet.header), *values))
+                    prev_len = len(norm_set)
+                    norm_set.add(mag_l0)
+                    if prev_len != len(norm_set):
+                        norm_list.append(mag_l0)
                 else:
-                    burst_data.append(MagL0(CcsdsData(packet.header), *values))
+                    prev_len = len(burst_set)
+                    burst_set.add(mag_l0)
+                    if prev_len != len(burst_set):
+                        burst_list.append(mag_l0)
 
-    return {"norm": norm_data, "burst": burst_data}
+    return {"norm": norm_list, "burst": burst_list}
 
 
 def generate_dataset(

--- a/imap_processing/mag/l0/mag_l0_data.py
+++ b/imap_processing/mag/l0/mag_l0_data.py
@@ -31,6 +31,9 @@ class MagL0:
     """
     Data class for MAG Level 0 data.
 
+    No attributes should be updated after creation. This class acts as a snapshot of the
+    packet data, and is read-only.
+
     Attributes
     ----------
     ccsds_header: CcsdsData
@@ -116,3 +119,46 @@ class MagL0:
 
         self.PRI_VECSEC = 2**self.PRI_VECSEC
         self.SEC_VECSEC = 2**self.SEC_VECSEC
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Compare two MagL0 objects for equality.
+
+        Two objects are said to be equal if the SHCOARSE, APID, and SRC_SEQ_CTR are
+        equal.
+
+        Parameters
+        ----------
+        other : object
+            The other MagL0 object to compare against.
+
+        Returns
+        -------
+        bool
+            True if the objects are equal, False otherwise.
+        """
+        if not isinstance(other, MagL0):
+            return NotImplemented
+
+        return (
+            self.SHCOARSE == other.SHCOARSE
+            and self.ccsds_header.PKT_APID == other.ccsds_header.PKT_APID
+            and self.ccsds_header.SRC_SEQ_CTR == other.ccsds_header.SRC_SEQ_CTR
+        )
+
+    def __hash__(self) -> int:
+        """
+        Return a hash of the MagL0 object for use in sets.
+
+        Returns
+        -------
+        int
+            The hash value of the MagL0 object.
+        """
+        return hash(
+            (
+                self.SHCOARSE,
+                self.ccsds_header.PKT_APID,
+                self.ccsds_header.SRC_SEQ_CTR,
+            )
+        )

--- a/imap_processing/tests/mag/test_mag_decom.py
+++ b/imap_processing/tests/mag/test_mag_decom.py
@@ -1,12 +1,16 @@
+from dataclasses import fields
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
+from imap_processing.ccsds.ccsds_data import CcsdsData
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import load_cdf, write_cdf
 from imap_processing.mag.constants import DataMode
 from imap_processing.mag.l0.decom_mag import decom_packets, generate_dataset
+from imap_processing.mag.l0.mag_l0_data import MagL0, Mode
 
 
 @pytest.fixture
@@ -118,3 +122,28 @@ def test_mag_raw_cdf_generation(cdf_attrs):
 
     input_xarray = load_cdf(output)
     assert input_xarray.attrs.keys() == burst_data.attrs.keys()
+
+
+def test_comparison():
+    l0_args = [f.name for f in fields(MagL0)][2:-1]
+    values = np.zeros(len(l0_args), dtype=int)
+    attrs = dict(zip(l0_args, values))
+    attrs["VECTORS"] = np.array([1.0, 2.0, 3.0, 4.0])
+    attrs["SHCOARSE"] = 1234
+    l0_match = MagL0(
+        CcsdsData({"PKT_APID": Mode.NORMAL, "SRC_SEQ_CTR": 1, "PKT_LEN": 100}),
+        **attrs,
+    )
+
+    attrs["VECTORS"] = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    l0_match_2 = MagL0(
+        CcsdsData({"PKT_APID": Mode.NORMAL, "SRC_SEQ_CTR": 1, "PKT_LEN": 100}), **attrs
+    )
+
+    assert l0_match == l0_match_2
+
+    l0_mismatch = MagL0(
+        CcsdsData({"PKT_APID": Mode.NORMAL, "SRC_SEQ_CTR": 2, "PKT_LEN": 100}),
+        **attrs,
+    )
+    assert l0_mismatch != l0_match

--- a/imap_processing/tests/mag/test_mag_decom.py
+++ b/imap_processing/tests/mag/test_mag_decom.py
@@ -147,3 +147,22 @@ def test_comparison():
         **attrs,
     )
     assert l0_mismatch != l0_match
+
+
+def test_duplicate_packets(tmpdir):
+    current_directory = Path(__file__).parent
+    packet_file = current_directory / "validation" / "mag_l0_test_data.pkts"
+    # Write the file out twice to double the number of binary packets in
+    # a new file for testing
+    with open(two_files := tmpdir / "two_files.pkts", "wb") as f:
+        with open(packet_file, "rb") as original_file:
+            data = original_file.read()
+            f.write(data)
+            f.write(data)
+
+    packets = decom_packets(str(packet_file))
+    one_file = packets["burst"] + packets["norm"]
+
+    packets = decom_packets(str(two_files))
+    two_file = packets["burst"] + packets["norm"]
+    assert len(two_file) == len(one_file)


### PR DESCRIPTION
# Change Summary
Remove duplicate packets from MAG if they have the same SHCOARSE, SRC_SQ_CTR, and APID. 

Fixes a bug found in L1a. Also adds an error throw if the data is non-monotonically increasing, so bugs like this are easier to find (as MAG is prone to them.)

Note that we don't expect to need this in prod, but most other instruments do it in the packets_to_dataset function. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Added a step which adds the MagL0 object to a set and confirms it is unique. This required the __eq__ and __hash__ functions on the dataclass. 

