### PR TITLE
I-ALIRT - Quick fix to return empty list

### DIFF
--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -6,10 +6,6 @@ from typing import Any
 
 import xarray as xr
 
-from imap_processing.codice import constants
-from imap_processing.ialirt.utils.time import calculate_time
-from imap_processing.spice.time import met_to_ttj2000ns, met_to_utc
-
 logger = logging.getLogger(__name__)
 
 FILLVAL_FLOAT32 = Decimal(str(-1.0e31))
@@ -28,7 +24,7 @@ def process_codice(
 
     Returns
     -------
-    codice_data : list[dict]
+    codice_data : tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         Dictionary of final data product.
 
     Notes
@@ -58,34 +54,8 @@ def process_codice(
     # Create mock dataset for I-ALiRT SIT
     # TODO: Once I-ALiRT test data is acquired that actually has data in it,
     #       we should be able to properly populate the I-ALiRT data, but for
-    #       now, just create lists of dicts with FILLVALs
-    cod_lo_data = []
-    cod_hi_data = []
-
-    for epoch in range(len(dataset.epoch.data)):
-        sc_sclk_sec = dataset.sc_sclk_sec.data[epoch]
-        sc_sclk_sub_sec = dataset.sc_sclk_sub_sec.data[epoch]
-        met = calculate_time(sc_sclk_sec, sc_sclk_sub_sec, 256)
-        utc = met_to_utc(met).split(".")[0]
-        ttj2000ns = int(met_to_ttj2000ns(met))
-
-        epoch_data = {
-            "apid": int(dataset.pkt_apid[epoch].data),
-            "met": int(met),
-            "met_to_utc": utc,
-            "ttj2000ns": ttj2000ns,
-        }
-
-        # Add in CoDICE-Lo specific data
-        cod_lo_epoch_data = epoch_data.copy()
-        for field in constants.CODICE_LO_IAL_DATA_FIELDS:
-            cod_lo_epoch_data[f"codicelo_{field}"] = []
-        cod_lo_data.append(cod_lo_epoch_data)
-
-        # Add in CoDICE-Hi specific data
-        cod_hi_epoch_data = epoch_data.copy()
-        for field in constants.CODICE_HI_IAL_DATA_FIELDS:
-            cod_hi_epoch_data[f"codicehi_{field}"] = []
-        cod_hi_data.append(cod_hi_epoch_data)
+    #       now, just create lists of dicts.
+    cod_lo_data: list[dict[str, Any]] = []
+    cod_hi_data: list[dict[str, Any]] = []
 
     return cod_lo_data, cod_hi_data


### PR DESCRIPTION
# Change Summary

## Overview
Quick fix to return empty list

## Updated Files
- process_codice.py
   - Returns empty list instead of FILL vals.