### PR TITLE
FIX: Remove duplicate packets from dataset

### DIFF
--- a/imap_processing/tests/test_utils.py
+++ b/imap_processing/tests/test_utils.py
@@ -222,6 +222,35 @@ def test_packet_file_to_datasets(use_derived_value, expected_mode):
     np.testing.assert_array_equal(np.unique(data["mode"].data), expected_mode)
 
 
+def test_packet_file_to_datasets_duplicates(tmpdir, caplog):
+    """
+    Test that all datatypes aren't all int64 and that we get
+    uint8/uint16 from header items as expected.
+
+    Test that we get multiple apids in the output.
+    """
+    test_file = "tests/swapi/l0_data/imap_swapi_l0_raw_20240924_v001.pkts"
+    packet_file = imap_module_directory / test_file
+
+    # Write the file out twice to double the number of binary packets in
+    # a new file for testing
+    with open(two_files := tmpdir / "two_files.pkts", "wb") as f:
+        with open(packet_file, "rb") as original_file:
+            data = original_file.read()
+            f.write(data)
+            f.write(data)
+
+    packet_definition = (
+        imap_module_directory / "swapi/packet_definitions/swapi_packet_definition.xml"
+    )
+    ds_two_files = utils.packet_file_to_datasets(two_files, packet_definition)
+    ds_one_file = utils.packet_file_to_datasets(packet_file, packet_definition)
+    assert len(ds_two_files[1188]["epoch"]) == len(ds_one_file[1188]["epoch"])
+    assert len(ds_two_files[1188]["epoch"]) == 153
+
+    assert "Dropping duplicate packets" in caplog.records[0].message
+
+
 def test_packet_file_to_datasets_flat_definition():
     test_file = "tests/idex/test_data/imap_idex_l0_raw_20231218_v001.pkts"
     packet_files = imap_module_directory / test_file

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -347,6 +347,26 @@ def packet_file_to_datasets(
             coords={"epoch": time_data},
         )
         ds = ds.sortby("epoch")
+        # We may get duplicate packets within the packet file if packets were
+        # ingested multiple times by the POC. We want to drop packets where
+        # apid, epoch, and src_seq_ctr are the same.
+
+        # xarray only supports dropping duplicates by index, so we instead go
+        # to pandas multi-index dataframe to identify the unique positions
+        unique_indices = (
+            ds[["src_seq_ctr"]]
+            .to_dataframe()
+            .reset_index()
+            .drop_duplicates()
+            .index.values
+        )
+        nduplicates = len(ds["epoch"]) - len(unique_indices)
+        if nduplicates != 0:
+            logger.warning(
+                f"Found [{nduplicates}] duplicate packets for APID {apid}. "
+                "Dropping duplicate packets and continuing processing."
+            )
+            ds = ds.isel(epoch=unique_indices)
 
         # Strip any leading characters before "." from the field names which was due
         # to the packet_name being a part of the variable name in the XTCE definition


### PR DESCRIPTION
# Change Summary

## Overview

Our packet files can contain duplicates if the database we are drawing from does not remove the duplicates for us. We can remove the duplicate SHCOARSE values from each apid to make sure this does not happen.