### PR TITLE
Ultra l1a - energy events (apid 897)

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -68,6 +68,18 @@ imap_ultra_l1a_90sensor-de:
     Logical_source: imap_ultra_l1a_90sensor-de
     Logical_source_description: IMAP-Ultra Instrument Level-1A Direct Event Data.
 
+imap_ultra_l1a_45sensor-energy-de:
+    <<: *instrument_base
+    Data_type: L1A_ENERGY_DE>Level-1A Energy Direct Event
+    Logical_source: imap_ultra_l1a_45sensor-energy-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1A Energy Direct Event Data.
+
+imap_ultra_l1a_90sensor-energy-de:
+    <<: *instrument_base
+    Data_type: L1A_ENERGY_DE>Level-1A EnergyDirect Event
+    Logical_source: imap_ultra_l1a_90sensor-energy-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1A Energy Direct Event Data.
+
 imap_ultra_l1b_45sensor-de:
     <<: *instrument_base
     Data_type: L1B_45Sensor-DE>Level-1B Direct Events for Ultra45

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -63,6 +63,8 @@ EXTERNAL_TEST_DATA = [
     ("IMAP-Ultra45_r1_L1_V0_shortened.csv", "ultra/data/l1/"),
 
     # Ultra
+    ("ultra45_raw_sc_rawnrgevnt_FM45_UltraFM45_Functional_2024-01-22T0105_20240122T010548.csv", "ultra/data/l0/"),
+    ("ultra45_raw_sc_imgpriority1evnt_FM45_UltraFM45Extra_TV_Tests_2024-01-22T0930_20240122T093008.csv", "ultra/data/l0/"),
     ("ultra45_raw_sc_ultranrgrates_FM45_UltraFM45_Functional_"
      "2024-01-22T0105_20240122T010548.csv", "ultra/data/l0/"),
     ("imap_ultra_l0_raw_20260924_v001.pkts", "ultra/data/l0/"),

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -173,16 +173,15 @@ def decom_test_data(request, xtce_path):
 
     strategy_dict = {
         ULTRA_TOF.apid[0]: lambda ds, _: process_ultra_tof(ds),
-        ULTRA_ENERGY_EVENTS.apid[0]: process_ultra_events,
-        ULTRA_EVENTS.apid[0]: process_ultra_events,
-        ULTRA_RATES.apid[0]: lambda ds, _: process_ultra_rates(ds),
         ULTRA_TOF.apid[1]: lambda ds, _: process_ultra_tof(ds),
-        ULTRA_ENERGY_RATES.apid[0]: process_ultra_energy_rates,
-        ULTRA_TOF.apid[1]: process_ultra_tof,
-        ULTRA_ENERGY_EVENTS.apid[1]: process_ultra_events,
-        ULTRA_EVENTS.apid[1]: process_ultra_events,
+        ULTRA_ENERGY_EVENTS.apid[0]: lambda ds, _: process_ultra_events(ds),
+        ULTRA_ENERGY_EVENTS.apid[1]: lambda ds, _: process_ultra_events(ds),
+        ULTRA_EVENTS.apid[0]: lambda ds, _: process_ultra_events(ds),
+        ULTRA_EVENTS.apid[1]: lambda ds, _: process_ultra_events(ds),
+        ULTRA_RATES.apid[0]: lambda ds, _: process_ultra_rates(ds),
         ULTRA_RATES.apid[1]: lambda ds, _: process_ultra_rates(ds),
-        ULTRA_ENERGY_RATES.apid[1]: process_ultra_energy_rates,
+        ULTRA_ENERGY_RATES.apid[0]: lambda ds, _: process_ultra_energy_rates(ds),
+        ULTRA_ENERGY_RATES.apid[1]: lambda ds, _: process_ultra_energy_rates(ds),
     }
 
     process_function = strategy_dict.get(apid, lambda *args: False)

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -172,16 +172,16 @@ def decom_test_data(request, xtce_path):
     datasets_by_apid = packet_file_to_datasets(ccsds_path, xtce_path)
 
     strategy_dict = {
-        ULTRA_TOF.apid[0]: lambda ds, _: process_ultra_tof(ds),
-        ULTRA_TOF.apid[1]: lambda ds, _: process_ultra_tof(ds),
-        ULTRA_ENERGY_EVENTS.apid[0]: lambda ds, _: process_ultra_events(ds),
-        ULTRA_ENERGY_EVENTS.apid[1]: lambda ds, _: process_ultra_events(ds),
-        ULTRA_EVENTS.apid[0]: lambda ds, _: process_ultra_events(ds),
-        ULTRA_EVENTS.apid[1]: lambda ds, _: process_ultra_events(ds),
-        ULTRA_RATES.apid[0]: lambda ds, _: process_ultra_rates(ds),
-        ULTRA_RATES.apid[1]: lambda ds, _: process_ultra_rates(ds),
-        ULTRA_ENERGY_RATES.apid[0]: lambda ds, _: process_ultra_energy_rates(ds),
-        ULTRA_ENERGY_RATES.apid[1]: lambda ds, _: process_ultra_energy_rates(ds),
+        ULTRA_TOF.apid[0]: lambda ds, apid: process_ultra_tof(ds),
+        ULTRA_TOF.apid[1]: lambda ds, apid: process_ultra_tof(ds),
+        ULTRA_ENERGY_EVENTS.apid[0]: lambda ds, apid: process_ultra_events(ds, apid),
+        ULTRA_ENERGY_EVENTS.apid[1]: lambda ds, apid: process_ultra_events(ds, apid),
+        ULTRA_EVENTS.apid[0]: lambda ds, apid: process_ultra_events(ds, apid),
+        ULTRA_EVENTS.apid[1]: lambda ds, apid: process_ultra_events(ds, apid),
+        ULTRA_RATES.apid[0]: lambda ds, apid: process_ultra_rates(ds),
+        ULTRA_RATES.apid[1]: lambda ds, apid: process_ultra_rates(ds),
+        ULTRA_ENERGY_RATES.apid[0]: lambda ds, apid: process_ultra_energy_rates(ds),
+        ULTRA_ENERGY_RATES.apid[1]: lambda ds, apid: process_ultra_energy_rates(ds),
     }
 
     process_function = strategy_dict.get(apid, lambda *args: False)

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -172,15 +172,16 @@ def decom_test_data(request, xtce_path):
     datasets_by_apid = packet_file_to_datasets(ccsds_path, xtce_path)
 
     strategy_dict = {
-        ULTRA_TOF.apid[0]: process_ultra_tof,
+        ULTRA_TOF.apid[0]: lambda ds, _: process_ultra_tof(ds),
         ULTRA_ENERGY_EVENTS.apid[0]: process_ultra_events,
         ULTRA_EVENTS.apid[0]: process_ultra_events,
-        ULTRA_RATES.apid[0]: process_ultra_rates,
+        ULTRA_RATES.apid[0]: lambda ds, _: process_ultra_rates(ds),
+        ULTRA_TOF.apid[1]: lambda ds, _: process_ultra_tof(ds),
         ULTRA_ENERGY_RATES.apid[0]: process_ultra_energy_rates,
         ULTRA_TOF.apid[1]: process_ultra_tof,
         ULTRA_ENERGY_EVENTS.apid[1]: process_ultra_events,
         ULTRA_EVENTS.apid[1]: process_ultra_events,
-        ULTRA_RATES.apid[1]: process_ultra_rates,
+        ULTRA_RATES.apid[1]: lambda ds, _: process_ultra_rates(ds),
         ULTRA_ENERGY_RATES.apid[1]: process_ultra_energy_rates,
     }
 

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -13,6 +13,7 @@ from imap_processing.ultra.l0.decom_ultra import (
 )
 from imap_processing.ultra.l0.ultra_utils import (
     ULTRA_AUX,
+    ULTRA_ENERGY_EVENTS,
     ULTRA_ENERGY_RATES,
     ULTRA_EVENTS,
     ULTRA_RATES,
@@ -172,17 +173,19 @@ def decom_test_data(request, xtce_path):
 
     strategy_dict = {
         ULTRA_TOF.apid[0]: process_ultra_tof,
+        ULTRA_ENERGY_EVENTS.apid[0]: process_ultra_events,
         ULTRA_EVENTS.apid[0]: process_ultra_events,
         ULTRA_RATES.apid[0]: process_ultra_rates,
         ULTRA_ENERGY_RATES.apid[0]: process_ultra_energy_rates,
         ULTRA_TOF.apid[1]: process_ultra_tof,
+        ULTRA_ENERGY_EVENTS.apid[1]: process_ultra_events,
         ULTRA_EVENTS.apid[1]: process_ultra_events,
         ULTRA_RATES.apid[1]: process_ultra_rates,
         ULTRA_ENERGY_RATES.apid[1]: process_ultra_energy_rates,
     }
 
     process_function = strategy_dict.get(apid, lambda *args: False)
-    data_packet_xarray = process_function(datasets_by_apid[apid])
+    data_packet_xarray = process_function(datasets_by_apid[apid], apid)
 
     return data_packet_xarray
 

--- a/imap_processing/tests/ultra/unit/test_decom_apid_897.py
+++ b/imap_processing/tests/ultra/unit/test_decom_apid_897.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from imap_processing.ultra.l0.ultra_utils import ULTRA_ENERGY_EVENTS
+
+
+@pytest.mark.parametrize(
+    "decom_test_data",
+    [
+        pytest.param(
+            {
+                "apid": ULTRA_ENERGY_EVENTS.apid[0],
+                "filename": "FM45_7P_Phi0.0_BeamCal_LinearScan_phi0.04"
+                "_theta-0.01_20230821T121304.CCSDS",
+            }
+        )
+    ],
+    indirect=True,
+)
+def test_image_raw_energy_events_decom(
+    decom_test_data, events_test_path, ccsds_path_events, xtce_path
+):
+    """This function reads validation data and checks that decom data
+    matches validation data for image rate packet"""
+    decom_ultra = decom_test_data
+
+    df = pd.read_csv(events_test_path, index_col="MET")
+
+    # # Check all values of each column are as expected,
+    # except for those set to fill value
+    np.testing.assert_array_equal(
+        df["StopType"].values[df["StopType"].values != -1],
+        decom_ultra["stop_type"].values[df["StopType"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["EnergyOrPH"].values[df["EnergyOrPH"].values != -1],
+        decom_ultra["energy_ph"].values[df["EnergyOrPH"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["PulseWidth"].values[df["PulseWidth"].values != -1],
+        decom_ultra["pulse_width"].values[df["PulseWidth"].values != -1],
+    )
+    np.testing.assert_array_equal(
+        df["Bin"].values[df["Bin"].values != -1],
+        decom_ultra["bin"].values[df["Bin"].values != -1],
+    )

--- a/imap_processing/tests/ultra/unit/test_decom_apid_897.py
+++ b/imap_processing/tests/ultra/unit/test_decom_apid_897.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from imap_processing import imap_module_directory
 from imap_processing.ultra.l0.ultra_utils import ULTRA_ENERGY_EVENTS
 
 
@@ -11,21 +12,29 @@ from imap_processing.ultra.l0.ultra_utils import ULTRA_ENERGY_EVENTS
         pytest.param(
             {
                 "apid": ULTRA_ENERGY_EVENTS.apid[0],
-                "filename": "FM45_7P_Phi0.0_BeamCal_LinearScan_phi0.04"
-                "_theta-0.01_20230821T121304.CCSDS",
+                "filename": "FM45_UltraFM45_Functional_"
+                "2024-01-22T0105_20240122T010548.CCSDS",
             }
         )
     ],
     indirect=True,
 )
-def test_image_raw_energy_events_decom(
-    decom_test_data, events_test_path, ccsds_path_events, xtce_path
-):
+@pytest.mark.external_test_data
+def test_image_raw_energy_events_decom(decom_test_data, ccsds_path_events, xtce_path):
     """This function reads validation data and checks that decom data
-    matches validation data for image rate packet"""
+    matches validation data for the packet"""
+
+    filename = (
+        "ultra45_raw_sc_rawnrgevnt_FM45_UltraFM45_Functional_"
+        "2024-01-22T0105_20240122T010548.csv"
+    )
+    energy_events_test_path = (
+        imap_module_directory / "tests" / "ultra" / "data" / "l0" / filename
+    )
+
     decom_ultra = decom_test_data
 
-    df = pd.read_csv(events_test_path, index_col="MET")
+    df = pd.read_csv(energy_events_test_path, index_col="MET")
 
     # # Check all values of each column are as expected,
     # except for those set to fill value
@@ -34,8 +43,8 @@ def test_image_raw_energy_events_decom(
         decom_ultra["stop_type"].values[df["StopType"].values != -1],
     )
     np.testing.assert_array_equal(
-        df["EnergyOrPH"].values[df["EnergyOrPH"].values != -1],
-        decom_ultra["energy_ph"].values[df["EnergyOrPH"].values != -1],
+        df["EnergyPH"].values[df["EnergyPH"].values != -1],
+        decom_ultra["energy_ph"].values[df["EnergyPH"].values != -1],
     )
     np.testing.assert_array_equal(
         df["PulseWidth"].values[df["PulseWidth"].values != -1],

--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -8,6 +8,7 @@ from imap_processing.cdf.utils import write_cdf
 from imap_processing.ultra.l0.decom_ultra import get_event_id
 from imap_processing.ultra.l0.ultra_utils import (
     ULTRA_AUX,
+    ULTRA_ENERGY_EVENTS,
     ULTRA_ENERGY_RATES,
     ULTRA_EVENTS,
     ULTRA_RATES,
@@ -135,6 +136,20 @@ def test_cdf_events(ccsds_path_theta_0):
     assert (
         test_data_path.name
         == "imap_ultra_l1a_45sensor-de_20240207-repoint99999_v999.cdf"
+    )
+
+
+def test_cdf_energy_events(ccsds_path_functional):
+    """Tests that CDF file can be created."""
+    test_data = ultra_l1a(ccsds_path_functional, apid_input=ULTRA_ENERGY_EVENTS.apid[0])
+    test_data[0].attrs["Data_version"] = "999"
+    test_data[0].attrs["Repointing"] = "repoint99999"
+    test_data_path = write_cdf(test_data[0], istp=True)
+
+    assert test_data_path.exists()
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1a_45sensor-energy-de_20240122-repoint99999_v999.cdf"
     )
 
 

--- a/imap_processing/ultra/l0/decom_tools.py
+++ b/imap_processing/ultra/l0/decom_tools.py
@@ -259,7 +259,7 @@ def read_image_raw_events_binary(
         Event data.
     """
     binary = convert_to_binary_string(event_data)
-    length = max(end for _, (_, end) in field_ranges.items())
+    length = max(end for (_, end) in field_ranges.values())
     # bits per event
     event_length = length if count else 0
     event_data_list = []

--- a/imap_processing/ultra/l0/decom_tools.py
+++ b/imap_processing/ultra/l0/decom_tools.py
@@ -239,6 +239,7 @@ def decompress_image(
 def read_image_raw_events_binary(
     event_data: bytes,
     count: int,
+    field_ranges: dict,
 ) -> NDArray:
     """
     Convert contents of binary string 'EVENTDATA' into values.
@@ -249,6 +250,8 @@ def read_image_raw_events_binary(
         Event data.
     count : int
         Number of events.
+    field_ranges : dict
+        Field ranges for the event data.
 
     Returns
     -------
@@ -256,15 +259,16 @@ def read_image_raw_events_binary(
         Event data.
     """
     binary = convert_to_binary_string(event_data)
-    # 166 bits per event
-    event_length = 166 if count else 0
+    length = max(end for _, (_, end) in field_ranges.items())
+    # bits per event
+    event_length = length if count else 0
     event_data_list = []
 
     # For all packets with event data, parses the binary string
     for i in range(count):
         start_index = i * event_length
         event_binary = binary[start_index : start_index + event_length]
-        parsed_event = parse_event(event_binary)
+        parsed_event = parse_event(event_binary, field_ranges)
         event_data_list.append(parsed_event)
 
     return np.array(event_data_list)

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -19,8 +19,8 @@ from imap_processing.ultra.l0.ultra_utils import (
     ENERGY_RATES_KEYS,
     EVENT_FIELD_RANGES,
     RATES_KEYS,
-    ULTRA_ENERGY_RATES,
     ULTRA_ENERGY_EVENTS,
+    ULTRA_ENERGY_RATES,
     ULTRA_EVENTS,
     ULTRA_RATES,
     ULTRA_TOF,
@@ -162,7 +162,7 @@ def process_ultra_events(ds: xr.Dataset, apid: int) -> xr.Dataset:
     elif apid in ULTRA_ENERGY_EVENTS.apid:
         field_ranges = ENERGY_EVENT_FIELD_RANGES
     else:
-        logger.error(f"APID {apid} not recognized for Ultra events processing.")
+        raise ValueError(f"APID {apid} not recognized for Ultra events processing.")
 
     all_events = []
     all_indices = []

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -20,6 +20,8 @@ from imap_processing.ultra.l0.ultra_utils import (
     EVENT_FIELD_RANGES,
     RATES_KEYS,
     ULTRA_ENERGY_RATES,
+    ULTRA_ENERGY_EVENTS,
+    ULTRA_EVENTS,
     ULTRA_RATES,
     ULTRA_TOF,
 )
@@ -139,7 +141,7 @@ def get_event_id(shcoarse: NDArray) -> NDArray:
     return np.array(event_ids, dtype=np.int64)
 
 
-def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
+def process_ultra_events(ds: xr.Dataset, apid: int) -> xr.Dataset:
     """
     Unpack and decode Ultra EVENTS packets.
 
@@ -147,12 +149,21 @@ def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
     ----------
     ds : xarray.Dataset
         Events dataset.
+    apid : int
+        APID of the events dataset.
 
     Returns
     -------
     ds : xarray.Dataset
         Dataset containing the decoded and decompressed data.
     """
+    if apid in ULTRA_EVENTS.apid:
+        field_ranges = EVENT_FIELD_RANGES
+    elif apid in ULTRA_ENERGY_EVENTS.apid:
+        field_ranges = ENERGY_EVENT_FIELD_RANGES
+    else:
+        logger.error(f"APID {apid} not recognized for Ultra events processing.")
+
     all_events = []
     all_indices = []
 
@@ -163,7 +174,7 @@ def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
         field: attrs.get_variable_attributes(field).get(
             "FILLVAL", np.iinfo(np.int64).min
         )
-        for field in EVENT_FIELD_RANGES
+        for field in field_ranges
     }
 
     counts = ds["count"].values
@@ -176,7 +187,9 @@ def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
         else:
             # Here there are multiple images in a single packet,
             # so we need to loop through each image and decompress it.
-            event_data_list = read_image_raw_events_binary(eventdata_array[i], count)
+            event_data_list = read_image_raw_events_binary(
+                eventdata_array[i], count, field_ranges
+            )
             all_events.extend(event_data_list)
             # Keep track of how many times does the event occurred at this epoch.
             all_indices.extend([i] * count)
@@ -192,80 +205,7 @@ def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
     }
 
     # Add the event data to the expanded dataset.
-    for key in EVENT_FIELD_RANGES:
-        expanded_data[key] = np.array([event[key] for event in all_events])
-
-    event_ids = get_event_id(expanded_data["shcoarse"])
-
-    coords = {
-        "epoch": ds["epoch"].values[idx],
-        "event_id": ("epoch", event_ids),
-    }
-
-    dataset = xr.Dataset(coords=coords)
-    for key, data in expanded_data.items():
-        dataset[key] = xr.DataArray(
-            data,
-            dims=["epoch"],
-        )
-
-    return dataset
-
-
-def process_ultra_energy_events(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Unpack and decode Ultra ENERGY EVENTS packets.
-
-    Parameters
-    ----------
-    ds : xarray.Dataset
-        Events dataset.
-
-    Returns
-    -------
-    ds : xarray.Dataset
-        Dataset containing the decoded and decompressed data.
-    """
-    all_events = []
-    all_indices = []
-
-    attrs = ImapCdfAttributes()
-    attrs.add_instrument_variable_attrs("ultra", level="l1a")
-
-    empty_event = {
-        field: attrs.get_variable_attributes(field).get(
-            "FILLVAL", np.iinfo(np.int64).min
-        )
-        for field in ENERGY_EVENT_FIELD_RANGES
-    }
-
-    counts = ds["count"].values
-    eventdata_array = ds["eventdata"].values
-
-    for i, count in enumerate(counts):
-        if count == 0:
-            all_events.append(empty_event)
-            all_indices.append(i)
-        else:
-            # Here there are multiple images in a single packet,
-            # so we need to loop through each image and decompress it.
-            event_data_list = read_image_raw_events_binary(eventdata_array[i], count)
-            all_events.extend(event_data_list)
-            # Keep track of how many times does the event occurred at this epoch.
-            all_indices.extend([i] * count)
-
-    # Now we have the event data, we need to create the xarray dataset.
-    # We cannot append to the existing dataset (sorted_packets)
-    # because there are multiple events for each epoch.
-    idx = np.array(all_indices)
-
-    # Expand the existing dataset so that it is the same length as the event data.
-    expanded_data = {
-        var: ds[var].values[idx] for var in ds.data_vars if var != "eventdata"
-    }
-
-    # Add the event data to the expanded dataset.
-    for key in EVENT_FIELD_RANGES:
+    for key in field_ranges:
         expanded_data[key] = np.array([event[key] for event in all_events])
 
     event_ids = get_event_id(expanded_data["shcoarse"])

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -15,6 +15,7 @@ from imap_processing.ultra.l0.decom_tools import (
     read_image_raw_events_binary,
 )
 from imap_processing.ultra.l0.ultra_utils import (
+    ENERGY_EVENT_FIELD_RANGES,
     ENERGY_RATES_KEYS,
     EVENT_FIELD_RANGES,
     RATES_KEYS,
@@ -163,6 +164,79 @@ def process_ultra_events(ds: xr.Dataset) -> xr.Dataset:
             "FILLVAL", np.iinfo(np.int64).min
         )
         for field in EVENT_FIELD_RANGES
+    }
+
+    counts = ds["count"].values
+    eventdata_array = ds["eventdata"].values
+
+    for i, count in enumerate(counts):
+        if count == 0:
+            all_events.append(empty_event)
+            all_indices.append(i)
+        else:
+            # Here there are multiple images in a single packet,
+            # so we need to loop through each image and decompress it.
+            event_data_list = read_image_raw_events_binary(eventdata_array[i], count)
+            all_events.extend(event_data_list)
+            # Keep track of how many times does the event occurred at this epoch.
+            all_indices.extend([i] * count)
+
+    # Now we have the event data, we need to create the xarray dataset.
+    # We cannot append to the existing dataset (sorted_packets)
+    # because there are multiple events for each epoch.
+    idx = np.array(all_indices)
+
+    # Expand the existing dataset so that it is the same length as the event data.
+    expanded_data = {
+        var: ds[var].values[idx] for var in ds.data_vars if var != "eventdata"
+    }
+
+    # Add the event data to the expanded dataset.
+    for key in EVENT_FIELD_RANGES:
+        expanded_data[key] = np.array([event[key] for event in all_events])
+
+    event_ids = get_event_id(expanded_data["shcoarse"])
+
+    coords = {
+        "epoch": ds["epoch"].values[idx],
+        "event_id": ("epoch", event_ids),
+    }
+
+    dataset = xr.Dataset(coords=coords)
+    for key, data in expanded_data.items():
+        dataset[key] = xr.DataArray(
+            data,
+            dims=["epoch"],
+        )
+
+    return dataset
+
+
+def process_ultra_energy_events(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Unpack and decode Ultra ENERGY EVENTS packets.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Events dataset.
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        Dataset containing the decoded and decompressed data.
+    """
+    all_events = []
+    all_indices = []
+
+    attrs = ImapCdfAttributes()
+    attrs.add_instrument_variable_attrs("ultra", level="l1a")
+
+    empty_event = {
+        field: attrs.get_variable_attributes(field).get(
+            "FILLVAL", np.iinfo(np.int64).min
+        )
+        for field in ENERGY_EVENT_FIELD_RANGES
     }
 
     counts = ds["count"].values

--- a/imap_processing/ultra/l0/ultra_utils.py
+++ b/imap_processing/ultra/l0/ultra_utils.py
@@ -73,6 +73,18 @@ ULTRA_EVENTS = PacketProperties(
     len_array=None,
     mantissa_bit_length=None,
 )
+ULTRA_ENERGY_EVENTS = PacketProperties(
+    apid=[897, 961],
+    logical_source=[
+        "imap_ultra_l1a_45sensor-energy-de",
+        "imap_ultra_l1a_90sensor-energy-de",
+    ],
+    addition_to_logical_desc="Single Energy Events",
+    width=None,
+    block=None,
+    len_array=None,
+    mantissa_bit_length=None,
+)
 ULTRA_HK = PacketProperties(
     apid=[
         866,
@@ -216,6 +228,18 @@ EVENT_FIELD_RANGES = {
     "bin": (148, 156),
     # Phase Angle
     "phase_angle": (156, 166),
+}
+
+# Module-level constant for event field ranges
+ENERGY_EVENT_FIELD_RANGES = {
+    # Stop Type
+    "stop_type": (0, 4),
+    # Energy/Pulse Height
+    "energy_ph": (5, 17),
+    # Pulse Width
+    "pulse_width": (18, 29),
+    # Bin
+    "bin": (30, 34),
 }
 
 

--- a/imap_processing/ultra/l0/ultra_utils.py
+++ b/imap_processing/ultra/l0/ultra_utils.py
@@ -235,11 +235,11 @@ ENERGY_EVENT_FIELD_RANGES = {
     # Stop Type
     "stop_type": (0, 4),
     # Energy/Pulse Height
-    "energy_ph": (5, 17),
+    "energy_ph": (4, 16),
     # Pulse Width
-    "pulse_width": (18, 29),
+    "pulse_width": (16, 27),
     # Bin
-    "bin": (30, 34),
+    "bin": (27, 33),
 }
 
 
@@ -359,7 +359,6 @@ RATES_KEYS = [
     # "discarded_events"
 ]
 
-
 ENERGY_RATES_KEYS = [
     # SSD0 Energy LED
     "ssd0_energy_led",
@@ -386,7 +385,7 @@ ENERGY_RATES_KEYS = [
 ]
 
 
-def parse_event(event_binary: str) -> dict:
+def parse_event(event_binary: str, field_ranges: dict) -> dict:
     """
     Parse a binary string representing a single event.
 
@@ -394,6 +393,8 @@ def parse_event(event_binary: str) -> dict:
     ----------
     event_binary : str
         Event binary string.
+    field_ranges : dict
+        The field ranges for the event data.
 
     Returns
     -------
@@ -401,7 +402,7 @@ def parse_event(event_binary: str) -> dict:
         Dict of the fields for a single event.
     """
     fields_dict = {}
-    for field, (start, end) in EVENT_FIELD_RANGES.items():
+    for field, (start, end) in field_ranges.items():
         field_value = int(event_binary[start:end], 2)
         fields_dict[field] = field_value
     return fields_dict

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -86,13 +86,13 @@ def ultra_l1a(packet_file: str, apid_input: Optional[int] = None) -> list[xr.Dat
                 ULTRA_ENERGY_RATES.apid.index(apid)
             ]
         elif apid in ULTRA_EVENTS.apid:
-            decom_ultra_dataset = process_ultra_events(datasets_by_apid[apid])
+            decom_ultra_dataset = process_ultra_events(datasets_by_apid[apid], apid)
             gattr_key = ULTRA_EVENTS.logical_source[ULTRA_EVENTS.apid.index(apid)]
             # Add coordinate attributes
             attrs = attr_mgr.get_variable_attributes("event_id")
             decom_ultra_dataset.coords["event_id"].attrs.update(attrs)
         elif apid in ULTRA_ENERGY_EVENTS.apid:
-            decom_ultra_dataset = process_ultra_energy_events(datasets_by_apid[apid])
+            decom_ultra_dataset = process_ultra_events(datasets_by_apid[apid], apid)
             gattr_key = ULTRA_ENERGY_EVENTS.logical_source[
                 ULTRA_ENERGY_EVENTS.apid.index(apid)
             ]

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -8,7 +8,6 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.ultra.l0.decom_ultra import (
-    process_ultra_energy_events,
     process_ultra_energy_rates,
     process_ultra_events,
     process_ultra_rates,
@@ -29,7 +28,7 @@ from imap_processing.utils import packet_file_to_datasets
 logger = logging.getLogger(__name__)
 
 
-def ultra_l1a(packet_file: str, apid_input: Optional[int] = None) -> list[xr.Dataset]:
+def ultra_l1a(packet_file: str, apid_input: Optional[int] = None) -> list[xr.Dataset]:  # noqa: PLR0912
     """
     Will process ULTRA L0 data into L1A CDF files at output_filepath.
 

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -8,6 +8,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.ultra.l0.decom_ultra import (
+    process_ultra_energy_events,
     process_ultra_energy_rates,
     process_ultra_events,
     process_ultra_rates,
@@ -16,6 +17,7 @@ from imap_processing.ultra.l0.decom_ultra import (
 from imap_processing.ultra.l0.ultra_utils import (
     ULTRA_AUX,
     ULTRA_CMD_TEXT,
+    ULTRA_ENERGY_EVENTS,
     ULTRA_ENERGY_RATES,
     ULTRA_EVENTS,
     ULTRA_HK,
@@ -86,6 +88,14 @@ def ultra_l1a(packet_file: str, apid_input: Optional[int] = None) -> list[xr.Dat
         elif apid in ULTRA_EVENTS.apid:
             decom_ultra_dataset = process_ultra_events(datasets_by_apid[apid])
             gattr_key = ULTRA_EVENTS.logical_source[ULTRA_EVENTS.apid.index(apid)]
+            # Add coordinate attributes
+            attrs = attr_mgr.get_variable_attributes("event_id")
+            decom_ultra_dataset.coords["event_id"].attrs.update(attrs)
+        elif apid in ULTRA_ENERGY_EVENTS.apid:
+            decom_ultra_dataset = process_ultra_energy_events(datasets_by_apid[apid])
+            gattr_key = ULTRA_ENERGY_EVENTS.logical_source[
+                ULTRA_ENERGY_EVENTS.apid.index(apid)
+            ]
             # Add coordinate attributes
             attrs = attr_mgr.get_variable_attributes("event_id")
             decom_ultra_dataset.coords["event_id"].attrs.update(attrs)


### PR DESCRIPTION
# Change Summary

## Overview
This creates the data product for apid 897.

## Updated Files
- imap_ultra_global_cdf_attrs.yaml
   - Update to global attributes
- external_test_data_config.py
   - Added external test data
- decom_tools.py
   - Added ability to pass in field ranges for various apids
- decom_ultra.py
   - Added ability to pass in field ranges for various apids
- ultra_utils.py
   - Added packet properties and field ranges for energy events
- ultra_l1a.py
   - Added ultra energy events logic

## Testing
conftest.py
test_decom_apid_897.py
test_ultra_l1a.py
