### PR TITLE
SWAPI: adding sci start time and update epoch to center time

### DIFF
--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -128,6 +128,25 @@ metadata_default: &metadata_default
   SCALETYP: linear
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
+sci_start_time:
+  CATDESC: Start time of sweep
+  DEPEND_0: epoch
+  FIELDNAM: Science Start time
+  LABLAXIS: sci_start_time
+  FILLVAL: -9223372036854775808
+  FORMAT: " " # Supposedly not required, fails in xarray_to_cdf
+  VALIDMIN: -9223372036854775808
+  VALIDMAX: 9223372036854775807
+  UNITS: ns
+  VAR_TYPE: support_data
+  SCALETYP: linear
+  MONOTON: INCREASE
+  TIME_BASE: J2000
+  TIME_SCALE: Terrestrial Time
+  REFERENCE_POSITION: Rotating Earth Geoid
+  RESOLUTION: ' '
+  DICT_KEY: "SPASE>Support>SupportQantity:Temporal"
+
 # Minimum attrs setting for HK data
 hk_attrs: &hk_attrs
   CATDESC: Housekeeping data

--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -631,7 +631,7 @@ def process_swapi_science(
         dims=["epoch"],
         attrs=cdf_manager.get_variable_attributes("plan_id"),
     )
-    # Store start time of L3 purposes per SWAPI requests
+    # Store start time for L3 purposes per SWAPI requests
     dataset["sci_start_time"] = xr.DataArray(
         good_sweep_sci["epoch"].data.reshape(total_full_sweeps, 12)[:, 0],
         name="sci_start_time",

--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -558,8 +558,11 @@ def process_swapi_science(
     # Step 3: Create xarray.Dataset
     # ===================================================================
 
-    # epoch time. Should be same dimension as number of good sweeps
-    epoch_values = good_sweep_sci["epoch"].data.reshape(total_full_sweeps, 12)[:, 0]
+    # epoch time. Should be same dimension as number of good sweeps.
+    # Use center time for epoch to line up with mission requests. Center time
+    # of SWAPI is time of 7th packet(aka SEQ_NUMBER == 6) creation time at the
+    # beginning of 7th packet.
+    epoch_values = good_sweep_sci["epoch"].data.reshape(total_full_sweeps, 12)[:, 6]
 
     epoch_time = xr.DataArray(
         epoch_values,
@@ -627,6 +630,13 @@ def process_swapi_science(
         name="plan_id",
         dims=["epoch"],
         attrs=cdf_manager.get_variable_attributes("plan_id"),
+    )
+    # Store start time of L3 purposes per SWAPI requests
+    dataset["sci_start_time"] = xr.DataArray(
+        good_sweep_sci["epoch"].data.reshape(total_full_sweeps, 12)[:, 0],
+        name="sci_start_time",
+        dims=["epoch"],
+        attrs=cdf_manager.get_variable_attributes("sci_start_time"),
     )
     # Add ESA_LVL5 for L2 and L3 purposes.
     # We need to store ESA_LVL5 at SEQ_NUMBER==11

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -149,15 +149,16 @@ def swapi_l2(
     # Copy over only certain variables from L1 to L2 dataset
     l1_data_keys = [
         "epoch",
+        "esa_lvl5",
         "esa_step",
         "esa_step_label",
-        "swp_l1a_flags",
-        "sweep_table",
-        "plan_id",
-        "lut_choice",
-        "fpga_type",
         "fpga_rev",
-        "esa_lvl5",
+        "fpga_type",
+        "lut_choice",
+        "plan_id",
+        "sci_start_time",
+        "sweep_table",
+        "swp_l1a_flags",
     ]
     l2_dataset = l1_dataset[l1_data_keys]
 


### PR DESCRIPTION
# Change Summary
closes #1881 

## Overview
Update epoch to use center time and keep start time in new variable per SWAPI requests.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
   - Add attrs for new variable
- imap_processing/swapi/l1/swapi_l1.py
   - Update L1 to do main part of this PR
- imap_processing/swapi/l2/swapi_l2.py
   - put variable names in alphabetic order and added new variable to carry in L2 file which can be used in L3.
## Testing

