### PR TITLE
1885 write cdf   default compression to 6

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -44,7 +44,7 @@ def load_cdf(
     if isinstance(file_path, imap_data_access.ImapFilePath):
         file_path = file_path.construct_path()
 
-    dataset = cdf_to_xarray(file_path, kwargs)
+    dataset = cdf_to_xarray(file_path, **kwargs)
 
     # cdf_to_xarray converts single-value attributes to lists
     # convert these back to single values where applicable

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -44,6 +44,10 @@ def load_cdf(
     if isinstance(file_path, imap_data_access.ImapFilePath):
         file_path = file_path.construct_path()
 
+    # By default, do not convert epoch to datetime64. This ensures that the
+    # round-trip of writing and then loading a cdf keeps the dataset the same.
+    if "to_datetime" not in kwargs:
+        kwargs["to_datetime"] = False  # type: ignore
     dataset = cdf_to_xarray(file_path, **kwargs)
 
     # cdf_to_xarray converts single-value attributes to lists

--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -154,6 +154,8 @@ def write_cdf(
             extra_cdf_kwargs["terminate_on_warning"] = True  # type: ignore
         if "istp" not in extra_cdf_kwargs:
             extra_cdf_kwargs["istp"] = True  # type: ignore
+    if "compression" not in extra_cdf_kwargs:
+        extra_cdf_kwargs["compression"] = 6  # type: ignore
 
     xarray_to_cdf(dataset, str(file_path), **extra_cdf_kwargs)
     return file_path

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for the ``cdf.utils`` module."""
 
+from unittest import mock
+
 import imap_data_access
 import numpy as np
 import pytest
@@ -106,6 +108,21 @@ def test_repoint_start_date(test_dataset):
     test_dataset.attrs["Repointing"] = "12345"
     output_file_path = write_cdf(test_dataset)
     assert "imap_swe_l1a_sci_20001212-repoint12345_v001.cdf" in output_file_path.name
+
+
+def test_write_cdf_extra_cdf_kwargs(test_dataset):
+    """Test the kwargs passed to cdflib.xarray.xarray_to_cdf by write_cdf()"""
+    with mock.patch(
+        "imap_processing.cdf.utils.xarray_to_cdf", autospec=True
+    ) as xarray_to_cdf:
+        write_cdf(test_dataset)
+        assert xarray_to_cdf.call_args.kwargs["terminate_on_warning"] is False
+        assert xarray_to_cdf.call_args.kwargs["compression"] == 6
+        test_dataset.attrs["Logical_source"] = "imap_swe_l2_sci"
+        write_cdf(test_dataset, compression=9)
+        assert xarray_to_cdf.call_args.kwargs["terminate_on_warning"] is True
+        assert xarray_to_cdf.call_args.kwargs["istp"] is True
+        assert xarray_to_cdf.call_args.kwargs["compression"] == 9
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -68,6 +68,17 @@ def test_load_cdf(test_dataset):
             assert attr not in data_array.attrs
 
 
+def test_load_cdf_extra_kwargs(test_dataset):
+    """Test that load_cdf passes the correct extra kwargs to xarray_to_cdf"""
+    # Write the dataset to a CDF to be used to test the load function
+    file_path = write_cdf(test_dataset)
+    with mock.patch(
+        "imap_processing.cdf.utils.cdf_to_xarray", autospec=True
+    ) as mock_cdf_to_xarray:
+        load_cdf(file_path, to_datetime=False)
+        assert mock_cdf_to_xarray.call_args.kwargs["to_datetime"] is False
+
+
 def test_write_cdf(test_dataset):
     """Tests the ``write_cdf`` function.
 


### PR DESCRIPTION
# Change Summary

## Overview
This PR:
- Sets the default gzip compression for CDF variables to 6.
- Fixes a bug with how extra kwargs were being passed to `cdf_to_xarray`.

## Updated Files
- imap_processing/cdf/utils.py
   - Fix bug in how `kwargs` was being passed through to `cdf_to_xarray`
   - Set default compression in `write_cdf` to 6.
- imap_processing/tests/cdf/test_utils.py
   - Add test coverage for kwargs passed to `cdf_to_xarray` and `xarray_to_cdf`


Closes: #1885 
