### PR TITLE
Implement center/delta epoch values for most CoDICE L1a products

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -58,6 +58,30 @@ hi_priorities_attrs: &hi_priorities_default
 
 
 # <=== Coordinates ===>
+epoch_delta_minus:
+    CATDESC: Time from acquisition start to acquisition center
+    FIELDNAM: epoch_delta_minus
+    FILLVAL: *int_fillval
+    FORMAT: I18
+    LABLAXIS: epoch_delta_minus
+    SCALETYP: linear
+    UNITS: ns
+    VALIDMIN: *min_int
+    VALIDMAX: *max_int
+    VAR_TYPE: support_data
+
+epoch_delta_plus:
+    CATDESC: Time from acquisition center to acquisition end
+    FIELDNAM: epoch_delta_plus
+    FILLVAL: *int_fillval
+    FORMAT: I18
+    LABLAXIS: epoch_delta_plus
+    SCALETYP: linear
+    UNITS: ns
+    VALIDMIN: *min_int
+    VALIDMAX: *max_int
+    VAR_TYPE: support_data
+
 esa_step:
     CATDESC: Energy per charge (E/q) sweeping step
     FIELDNAM: Energy Index

--- a/imap_processing/cdf/config/imap_codice_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1b_variable_attrs.yaml
@@ -59,6 +59,30 @@ hi_priorities_attrs: &hi_priorities_default
 
 
 # <=== Coordinates ===>
+epoch_delta_minus:
+    CATDESC: Time from acquisition start to acquisition center
+    FIELDNAM: epoch_delta_minus
+    FILLVAL: *int_fillval
+    FORMAT: I18
+    LABLAXIS: epoch_delta_minus
+    SCALETYP: linear
+    UNITS: ns
+    VALIDMIN: *min_int
+    VALIDMAX: *max_int
+    VAR_TYPE: support_data
+
+epoch_delta_plus:
+    CATDESC: Time from acquisition center to acquisition end
+    FIELDNAM: epoch_delta_plus
+    FILLVAL: *int_fillval
+    FORMAT: I18
+    LABLAXIS: epoch_delta_plus
+    SCALETYP: linear
+    UNITS: ns
+    VALIDMIN: *min_int
+    VALIDMAX: *max_int
+    VAR_TYPE: support_data
+
 esa_step:
     CATDESC: Energy per charge (E/q) sweeping step
     FIELDNAM: Energy Index

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -54,8 +54,6 @@ class CoDICEL1aPipeline:
 
     Methods
     -------
-    calculate_epoch_values()
-        Calculate and return the values to be used for `epoch`.
     decompress_data(science_values)
         Perform decompression on the data.
     define_coordinates()
@@ -88,45 +86,6 @@ class CoDICEL1aPipeline:
         self.plan_id = plan_id
         self.plan_step = plan_step
         self.view_id = view_id
-
-    def calculate_epoch_values(self) -> tuple[NDArray[int], NDArray[int], NDArray[int]]:
-        """
-        Calculate and return the values to be used for `epoch`.
-
-        On CoDICE, the epoch values are derived from the `acq_start_seconds` and
-        `acq_start_subseconds` fields in the packet.
-
-        Note that the `acq_start_subseconds` field needs to be converted from
-        microseconds to seconds.
-
-        Returns
-        -------
-        epoch : NDArray[int]
-            List of centered epoch values.
-        epoch_delta_minus: NDArray[int]
-            List of values that represent the length of time from acquisition
-            start to the center of the acquisition time bin.
-        epoch_delta_plus: NDArray[int]
-            List of values that represent the length of time from the center of
-            the acquisition time bin to the end of acquisition.
-        """
-        # First calculate an epoch value based on the acquisition start
-        acq_start = met_to_ttj2000ns(
-            self.dataset["acq_start_seconds"]
-            + self.dataset["acq_start_subseconds"] / 1e6
-        )
-
-        # Apply correction to center the epoch bin
-        epoch = (acq_start[:-1] + acq_start[1:]) / 2
-        epoch_delta_minus = epoch - acq_start[:-1]
-        epoch_delta_plus = acq_start[1:] - epoch
-
-        # The end values are calculated differently
-        epoch = np.concatenate([epoch, [acq_start[-1]]])
-        epoch_delta_minus = np.concatenate([epoch_delta_minus, [epoch_delta_minus[-1]]])
-        epoch_delta_plus = np.concatenate([epoch_delta_plus, [epoch_delta_plus[-1]]])
-
-        return epoch, epoch_delta_minus, epoch_delta_plus
 
     def decompress_data(self, science_values: list[NDArray[str]] | list[str]) -> None:
         """
@@ -189,7 +148,9 @@ class CoDICEL1aPipeline:
         ]
 
         # Define epoch coordinates
-        epochs, epoch_delta_minus, epoch_delta_plus = self.calculate_epoch_values()
+        epochs, epoch_delta_minus, epoch_delta_plus = calculate_epoch_values(
+            self.dataset.acq_start_seconds, self.dataset.acq_start_subseconds
+        )
         for name, var in [
             ("epoch", epochs),
             ("epoch_delta_minus", epoch_delta_minus),
@@ -702,6 +663,52 @@ class CoDICEL1aPipeline:
         self.cdf_attrs.add_instrument_variable_attrs("codice", "l1a")
 
 
+def calculate_epoch_values(
+    acq_start_seconds: xr.DataArray, acq_start_subseconds: xr.DataArray
+) -> tuple[NDArray[int], NDArray[int], NDArray[int]]:
+    """
+    Calculate and return the values to be used for `epoch`.
+
+    On CoDICE, the epoch values are derived from the `acq_start_seconds` and
+    `acq_start_subseconds` fields in the packet.
+
+    Note that the `acq_start_subseconds` field needs to be converted from
+    microseconds to seconds.
+
+    Parameters
+    ----------
+    acq_start_seconds : xarray.DataArray
+        The acquisition times to calculate the epoch values from.
+    acq_start_subseconds : xarray.DataArray
+        The subseconds portion of the acquisition times.
+
+    Returns
+    -------
+    epoch : NDArray[int]
+        List of centered epoch values.
+    epoch_delta_minus: NDArray[int]
+        List of values that represent the length of time from acquisition
+        start to the center of the acquisition time bin.
+    epoch_delta_plus: NDArray[int]
+        List of values that represent the length of time from the center of
+        the acquisition time bin to the end of acquisition.
+    """
+    # First calculate an epoch value based on the acquisition start
+    acq_start = met_to_ttj2000ns(acq_start_seconds + acq_start_subseconds / 1e6)
+
+    # Apply correction to center the epoch bin
+    epoch = (acq_start[:-1] + acq_start[1:]) / 2
+    epoch_delta_minus = epoch - acq_start[:-1]
+    epoch_delta_plus = acq_start[1:] - epoch
+
+    # The end values are calculated differently
+    epoch = np.concatenate([epoch, [acq_start[-1]]])
+    epoch_delta_minus = np.concatenate([epoch_delta_minus, [epoch_delta_minus[-1]]])
+    epoch_delta_plus = np.concatenate([epoch_delta_plus, [epoch_delta_plus[-1]]])
+
+    return epoch, epoch_delta_minus, epoch_delta_plus
+
+
 def group_ialirt_data(
     packets: xr.Dataset, data_field_range: range, prefix: str
 ) -> list[bytearray]:
@@ -805,6 +812,8 @@ def create_binned_dataset(
         dims=["epoch"],
         attrs=pipeline.cdf_attrs.get_variable_attributes("epoch", check_schema=False),
     )
+    # TODO: Figure out how to calculate epoch centers and deltas and store them
+    #       in variables here
     dataset = xr.Dataset(
         coords={"epoch": coord},
         attrs=pipeline.cdf_attrs.get_global_attributes(pipeline.config["dataset_name"]),
@@ -897,7 +906,11 @@ def create_direct_event_dataset(apid: int, packets: xr.Dataset) -> xr.Dataset:
     )[0]
     acq_start_seconds = packets.acq_start_seconds[epoch_indices]
     acq_start_subseconds = packets.acq_start_subseconds[epoch_indices]
-    epochs = met_to_ttj2000ns(acq_start_seconds + acq_start_subseconds / 1e6)
+
+    # Calculate epoch variables
+    epochs, epochs_delta_minus, epochs_delta_plus = calculate_epoch_values(
+        acq_start_seconds, acq_start_subseconds
+    )
 
     # Define coordinates
     epoch = xr.DataArray(
@@ -905,6 +918,20 @@ def create_direct_event_dataset(apid: int, packets: xr.Dataset) -> xr.Dataset:
         name="epoch",
         dims=["epoch"],
         attrs=cdf_attrs.get_variable_attributes("epoch", check_schema=False),
+    )
+    epoch_delta_minus = xr.DataArray(
+        epochs_delta_minus,
+        name="epoch_delta_minus",
+        dims=["epoch_delta_minus"],
+        attrs=cdf_attrs.get_variable_attributes(
+            "epoch_delta_minus", check_schema=False
+        ),
+    )
+    epoch_delta_plus = xr.DataArray(
+        epochs_delta_plus,
+        name="epoch_delta_plus",
+        dims=["epoch_delta_plus"],
+        attrs=cdf_attrs.get_variable_attributes("epoch_delta_plus", check_schema=False),
     )
     event_num = xr.DataArray(
         np.arange(10000),
@@ -927,6 +954,8 @@ def create_direct_event_dataset(apid: int, packets: xr.Dataset) -> xr.Dataset:
     dataset = xr.Dataset(
         coords={
             "epoch": epoch,
+            "epoch_delta_minus": epoch_delta_minus,
+            "epoch_delta_plus": epoch_delta_plus,
             "event_num": event_num,
             "event_num_label": event_num_label,
         },

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -697,11 +697,13 @@ def calculate_epoch_values(
     acq_start = met_to_ttj2000ns(acq_start_seconds + acq_start_subseconds / 1e6)
 
     # Apply correction to center the epoch bin
-    epoch = ((acq_start[:-1] + acq_start[1:]) / 2).astype(int)
+    epoch = (acq_start[:-1] + acq_start[1:]) // 2
     epoch_delta_minus = epoch - acq_start[:-1]
     epoch_delta_plus = acq_start[1:] - epoch
 
-    # The end values are calculated differently
+    # Since the centers and deltas are determined by averaging sequential bins,
+    # the last elements must be calculated differently. For this, we just use
+    # the last acquisition start and the previous deltas
     epoch = np.concatenate([epoch, [acq_start[-1]]])
     epoch_delta_minus = np.concatenate([epoch_delta_minus, [epoch_delta_minus[-1]]])
     epoch_delta_plus = np.concatenate([epoch_delta_plus, [epoch_delta_plus[-1]]])

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -89,7 +89,7 @@ class CoDICEL1aPipeline:
         self.plan_step = plan_step
         self.view_id = view_id
 
-    def calculate_epoch_values(self) -> NDArray[int]:
+    def calculate_epoch_values(self) -> tuple[NDArray[int], NDArray[int], NDArray[int]]:
         """
         Calculate and return the values to be used for `epoch`.
 
@@ -102,14 +102,31 @@ class CoDICEL1aPipeline:
         Returns
         -------
         epoch : NDArray[int]
-            List of epoch values.
+            List of centered epoch values.
+        epoch_delta_minus: NDArray[int]
+            List of values that represent the length of time from acquisition
+            start to the center of the acquisition time bin.
+        epoch_delta_plus: NDArray[int]
+            List of values that represent the length of time from the center of
+            the acquisition time bin to the end of acquisition.
         """
-        epoch = met_to_ttj2000ns(
+        # First calculate an epoch value based on the acquisition start
+        acq_start = met_to_ttj2000ns(
             self.dataset["acq_start_seconds"]
             + self.dataset["acq_start_subseconds"] / 1e6
         )
 
-        return epoch
+        # Apply correction to center the epoch bin
+        epoch = (acq_start[:-1] + acq_start[1:]) / 2
+        epoch_delta_minus = epoch - acq_start[:-1]
+        epoch_delta_plus = acq_start[1:] - epoch
+
+        # The end values are calculated differently
+        epoch = np.concatenate([epoch, [acq_start[-1]]])
+        epoch_delta_minus = np.concatenate([epoch_delta_minus, [epoch_delta_minus[-1]]])
+        epoch_delta_plus = np.concatenate([epoch_delta_plus, [epoch_delta_plus[-1]]])
+
+        return epoch, epoch_delta_minus, epoch_delta_plus
 
     def decompress_data(self, science_values: list[NDArray[str]] | list[str]) -> None:
         """
@@ -167,17 +184,28 @@ class CoDICEL1aPipeline:
         self.coords = {}
 
         coord_names = [
-            "epoch",
             *self.config["output_dims"].keys(),
             *[key + "_label" for key in self.config["output_dims"].keys()],
         ]
 
+        # Define epoch coordinates
+        epochs, epoch_delta_minus, epoch_delta_plus = self.calculate_epoch_values()
+        for name, var in [
+            ("epoch", epochs),
+            ("epoch_delta_minus", epoch_delta_minus),
+            ("epoch_delta_plus", epoch_delta_plus),
+        ]:
+            coord = xr.DataArray(
+                var,
+                name=name,
+                dims=[name],
+                attrs=self.cdf_attrs.get_variable_attributes(name, check_schema=False),
+            )
+            self.coords[name] = var
+
         # Define the values for the coordinates
         for name in coord_names:
-            if name == "epoch":
-                values = self.calculate_epoch_values()
-                dims = [name]
-            elif name in [
+            if name in [
                 "esa_step",
                 "inst_az",
                 "spin_sector",

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -162,7 +162,7 @@ class CoDICEL1aPipeline:
                 dims=[name],
                 attrs=self.cdf_attrs.get_variable_attributes(name, check_schema=False),
             )
-            self.coords[name] = var
+            self.coords[name] = coord
 
         # Define the values for the coordinates
         for name in coord_names:
@@ -697,7 +697,7 @@ def calculate_epoch_values(
     acq_start = met_to_ttj2000ns(acq_start_seconds + acq_start_subseconds / 1e6)
 
     # Apply correction to center the epoch bin
-    epoch = (acq_start[:-1] + acq_start[1:]) / 2
+    epoch = ((acq_start[:-1] + acq_start[1:]) / 2).astype(int)
     epoch_delta_minus = epoch - acq_start[:-1]
     epoch_delta_plus = acq_start[1:] - epoch
 

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -280,7 +280,7 @@ def test_l1a_validate_epoch_values(test_l1a_data, index):
             f"Awaiting implementation of proper epoch calculation for {descriptor}"
         )
 
-    # TODO: One new L1a validation is used, this probably can be tweaked for
+    # TODO: Once new L1a validation is used, this probably can be tweaked for
     #       even lower tolerance, and we can add checks for epoch_delta_minus
     #       and epoch_delta_plus
     np.testing.assert_allclose(

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -258,6 +258,36 @@ def test_l1a_validate_data_arrays(test_l1a_data: xr.Dataset, index):
         )
 
 
+@pytest.mark.parametrize("index", range(len(DESCRIPTORS)))
+def test_l1a_validate_epoch_values(test_l1a_data, index):
+    """Tests that the epoch values in the generated data products match the
+    validation data.
+
+    Parameters
+    ----------
+    test_l1a_data : list[xarray.Dataset]
+        A list of ``xarray`` datasets containing the test data
+    index : int
+        The index of the list to test
+    """
+
+    descriptor = DESCRIPTORS[index]
+    dataset = test_l1a_data[index]
+    validation_dataset = load_cdf(VALIDATION_DATA[index])
+
+    if descriptor in ["hskp", "hi-ialirt", "hi-omni"]:
+        pytest.xfail(
+            f"Awaiting implementation of proper epoch calculation for {descriptor}"
+        )
+
+    # TODO: One new L1a validation is used, this probably can be tweaked for
+    #       even lower tolerance, and we can add checks for epoch_delta_minus
+    #       and epoch_delta_plus
+    np.testing.assert_allclose(
+        dataset.epoch.data, validation_dataset.Epoch.data, rtol=1e-6, atol=0
+    )
+
+
 def test_l1a_validate_hskp_data(test_l1a_data):
     """Tests that the L1a housekeeping data is valid"""
 


### PR DESCRIPTION
This PR implements epoch values that are centered within the acquisition time window, as well as data variables for their corresponding `delta_minus` and `delta_plus` for most CoDICE L1a data products. These calculations for the `hskp`, `hi-omni`, and `hi-ialirt` are a bit trickier and will be addressed in a separate PR.

Another thing to note is that this PR will be the first of several that makes (relatively) small changes to CoDICE L1a data products. The goal is to eventually re-validate against updated validation data once all of those fixes are in. In the meantime, I may need to tweak or turn off certain unit tests to get tests passing in this middle-ground state between sets of validation data.

Partially completes #1501 