### PR TITLE
Created cdf for Ultra l1c pset helio frame

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -478,8 +478,12 @@ def test_get_spin_number(test_fixture, use_fake_spin_data_for_time):
 
     # Convert shcoarse (time) to MET relative to first value
     # Take off first partial spin.
-    de_met = de_dataset["shcoarse"].values[19::] - de_dataset["shcoarse"].values[19]
-    de_spin = de_dataset["spin"].values[19::]
+    first_spin_index = 19
+    de_met = (
+        de_dataset["shcoarse"].values[first_spin_index:]
+        - de_dataset["shcoarse"].values[first_spin_index]
+    )
+    de_spin = de_dataset["spin"].values[first_spin_index:]
 
     spin_number = get_spin_number(de_met, de_spin)
     # First spin number is 128.

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -473,23 +473,15 @@ def test_get_spin_number(test_fixture, use_fake_spin_data_for_time):
     """Tests that get_spin_number assigns the correct spin number."""
     df_filt, _, _, de_dataset = test_fixture
 
-    # Simulate a spin table from MET = 0 to MET = 141*15 seconds
-    use_fake_spin_data_for_time(start_met=0, end_met=141 * 15)
+    # Simulate a spin table from MET = 0 to MET = 500*15 seconds
+    use_fake_spin_data_for_time(start_met=0, end_met=500 * 15)
 
-    # Convert shcoarse (time) to MET relative to first value
-    # Take off first partial spin.
-    first_spin_index = 19
-    de_met = (
-        de_dataset["shcoarse"].values[first_spin_index:]
-        - de_dataset["shcoarse"].values[first_spin_index]
-    )
-    de_spin = de_dataset["spin"].values[first_spin_index:]
+    de_met = np.array([0, 0, 5760, 5760, 5760, 5760, 5760, 5760])
+    de_spin = np.array([128, 128, 129, 129, 130, 130, 131, 131], dtype=np.uint8)
 
     spin_number = get_spin_number(de_met, de_spin)
-    # First spin number is 128.
-    expected_spin_number = de_spin - 128
 
-    assert np.array_equal(spin_number, expected_spin_number)
+    assert np.array_equal(spin_number & 0xFF, de_spin)
 
 
 def test_get_eventtimes(test_fixture, use_fake_spin_data_for_time):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -28,6 +28,7 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
     get_path_length,
     get_ph_tof_and_back_positions,
     get_phi_theta,
+    get_spin_number,
     get_ssd_back_position_and_tof_offset,
     get_ssd_tof,
     interpolate_fwhm,
@@ -466,6 +467,25 @@ def test_get_phi_theta(test_fixture):
 
     np.testing.assert_allclose(phi, expected_phi, atol=1e-03, rtol=0)
     np.testing.assert_allclose(theta, expected_theta, atol=1e-03, rtol=0)
+
+
+def test_get_spin_number(test_fixture, use_fake_spin_data_for_time):
+    """Tests that get_spin_number assigns the correct spin number."""
+    df_filt, _, _, de_dataset = test_fixture
+
+    # Simulate a spin table from MET = 0 to MET = 141*15 seconds
+    use_fake_spin_data_for_time(start_met=0, end_met=141 * 15)
+
+    # Convert shcoarse (time) to MET relative to first value
+    # Take off first partial spin.
+    de_met = de_dataset["shcoarse"].values[19::] - de_dataset["shcoarse"].values[19]
+    de_spin = de_dataset["spin"].values[19::]
+
+    spin_number = get_spin_number(de_met, de_spin)
+    # First spin number is 128.
+    expected_spin_number = de_spin - 128
+
+    assert np.array_equal(spin_number, expected_spin_number)
 
 
 def test_get_eventtimes(test_fixture, use_fake_spin_data_for_time):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -200,3 +200,78 @@ def test_calculate_spacecraft_pset_with_cdf():
         test_data_path.name
         == "imap_ultra_l1c_45sensor-spacecraftpset_20250415-repoint00001_v999.cdf"
     )
+
+
+@pytest.mark.external_test_data
+@pytest.mark.external_kernel
+@ensure_spice
+@pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
+def test_calculate_helio_pset_with_cdf():
+    """Tests ultra_l1c function with imported test data."""
+
+    df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
+
+    # Select a single pointing number
+    pointing = 0
+    df_subset = df[df["pointing_number"] == pointing].copy()
+
+    de_dict = {}
+
+    de_dict["epoch"] = df_subset["epoch"].values
+    # Fake SCLK in seconds that matches SPICE.
+    de_dict["event_times"] = np.full(len(df_subset), 2.41187e13)
+    species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
+
+    # PosYSlit is True for left (start_type = 1)
+    # PosYSlit is False for right (start_type = 2)
+    start_type = np.where(df_subset["PosYSlit"].values, 1, 2)
+    d, yf = get_front_y_position(start_type, df_subset["StopY"].values * 100)
+    tof_tenths_ns = df_subset["TOF"].values * 10000
+    v, _, _ = get_de_velocity(
+        (df_subset["StartX"].values * 100, yf),
+        (df_subset["StopX"].values * 100, df_subset["StopY"].values * 100),
+        d,
+        tof_tenths_ns,
+    )
+    de_dict["direct_event_velocity"] = v.astype(np.float32)
+
+    ultra_frame = SpiceFrame.IMAP_ULTRA_45
+    _, _, helio_dps_velocity = get_annotated_particle_velocity(
+        df_subset["tdb"].values,
+        de_dict["direct_event_velocity"],
+        ultra_frame,
+        SpiceFrame.IMAP_DPS,
+        SpiceFrame.IMAP_SPACECRAFT,
+    )
+
+    de_dict["velocity_dps_helio"] = helio_dps_velocity
+    de_dict["energy_heliosphere"] = get_de_energy_kev(helio_dps_velocity, species_bin)
+
+    name = "imap_ultra_l1b_45sensor-de"
+    dataset = create_dataset(de_dict, name, "l1b")
+
+    data_dict = {
+        "imap_ultra_l1b_45sensor-de": dataset,
+        "imap_ultra_l1b_45sensor-extendedspin": xr.Dataset(),  # placeholder
+        "imap_ultra_l1b_45sensor-cullingmask": xr.Dataset(),  # placeholder
+    }
+
+    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+    ancillary_files = {
+        "l1c-90sensor-dps-exposure": path
+        / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
+        "l1c-90sensor-efficiencies": path
+        / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
+        "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
+    }
+
+    output_datasets = ultra_l1c(data_dict, ancillary_files, has_spice=True)
+    output_datasets[0].attrs["Data_version"] = "999"
+    output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
+    test_data_path = write_cdf(output_datasets[0], istp=True)
+
+    assert test_data_path.exists()
+    assert (
+        test_data_path.name
+        == "imap_ultra_l1c_45sensor-heliopset_20250415-repoint00001_v999.cdf"
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -12,7 +12,6 @@ from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     get_energy_delta_minus_plus,
     get_helio_background_rates,
     get_helio_exposure_times,
-    get_helio_histogram,
     get_helio_sensitivity,
     get_spacecraft_background_rates,
     get_spacecraft_exposure_times,
@@ -121,31 +120,6 @@ def test_get_spacecraft_histogram(test_data):
 def mock_imap_state(time, ref_frame):
     # Position (0, 0, 0), exaggerated velocity to force visible transformation
     return np.array([0, 0, 0, 0, 0, 0])
-
-
-def test_get_helio_histogram(monkeypatch, test_data):
-    """Tests get_helio_histogram function."""
-    v, energy = test_data
-
-    monkeypatch.setattr(ultra_l1c_pset_bins, "imap_state", mock_imap_state)
-
-    energy_bin_edges, _, _ = build_energy_bins()
-    subset_energy_bin_edges = energy_bin_edges[:3]
-
-    start_time = 829485054.185627
-    end_time = 829567884.185627
-
-    mid_time = np.average([start_time, end_time])
-
-    hist_helio, _, _, n_pix = get_helio_histogram(
-        mid_time, v, energy, subset_energy_bin_edges, nside=1
-    )
-
-    hist_sc, _, _, n_pix = get_spacecraft_histogram(
-        v, energy, subset_energy_bin_edges, nside=1
-    )
-
-    assert np.array_equal(hist_helio, hist_sc)
 
 
 def test_get_spacecraft_background_rates():

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -174,10 +174,10 @@ def test_get_helio_exposure_times():
 
     nside = 128
     npix = hp.nside2npix(nside)
-    assert helio_exposure.shape == (npix, len(energy_midpoints))
+    assert helio_exposure.shape == (len(energy_midpoints), npix)
 
     total_input = np.sum(df_exposure["Exposure Time"].values)
-    total_output = np.sum(helio_exposure[:, 23])
+    total_output = np.sum(helio_exposure[23, :])
 
     assert np.allclose(total_input, total_output, atol=1e-6)
 
@@ -256,7 +256,7 @@ def test_get_helio_sensitivity(monkeypatch):
     for energy in energy_midpoints:
         s = grid_sensitivity(df_efficiencies, df_geometric_function, energy)
         sc_sensitivity.append(s)
-    sc_sensitivity = np.stack(sc_sensitivity, axis=1)  # shape: (npix, n_energy_bins)
+    sc_sensitivity = np.stack(sc_sensitivity, axis=1).T  # shape: (n_energy_bins, npix)
 
     # Compute helio-frame sensitivity
     helio_sensitivity = get_helio_sensitivity(

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -25,6 +25,7 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
     get_path_length,
     get_ph_tof_and_back_positions,
     get_phi_theta,
+    get_spin_number,
     get_ssd_back_position_and_tof_offset,
     get_ssd_tof,
 )
@@ -59,7 +60,10 @@ def calculate_de(
 
     # Define epoch and spin.
     de_dict["epoch"] = de_dataset["epoch"].data
-    de_dict["spin"] = de_dataset["spin"].data
+    spin_number = get_spin_number(
+        de_dataset["shcoarse"].values, de_dataset["spin"].values
+    )
+    de_dict["spin"] = spin_number
 
     # Add already populated fields.
     keys = [
@@ -133,7 +137,7 @@ def calculate_de(
         spin_starts[valid_indices],
         spin_period_sec[valid_indices],
     ) = get_eventtimes(
-        de_dataset["spin"].data[valid_indices],
+        de_dict["spin"][valid_indices],
         de_dataset["phase_angle"].data[valid_indices],
     )
 

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -59,6 +59,7 @@ def calculate_de(
 
     # Define epoch and spin.
     de_dict["epoch"] = de_dataset["epoch"].data
+    # TODO
     de_dict["spin"] = de_dataset["spin"].data
 
     # Add already populated fields.
@@ -127,7 +128,7 @@ def calculate_de(
         f"ultra{sensor}",
     )
     start_type[valid_indices] = de_dataset["start_type"].data[valid_indices]
-
+    # TODO
     (
         event_times[valid_indices],
         spin_starts[valid_indices],

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -59,7 +59,6 @@ def calculate_de(
 
     # Define epoch and spin.
     de_dict["epoch"] = de_dataset["epoch"].data
-    # TODO
     de_dict["spin"] = de_dataset["spin"].data
 
     # Add already populated fields.
@@ -128,7 +127,7 @@ def calculate_de(
         f"ultra{sensor}",
     )
     start_type[valid_indices] = de_dataset["start_type"].data[valid_indices]
-    # TODO
+
     (
         event_times[valid_indices],
         spin_starts[valid_indices],

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -833,19 +833,22 @@ def get_spin_number(de_met: NDArray, de_spin: NDArray) -> NDArray:
     spin_start_indices = np.where(is_new_spin)[0]
     spin_end_indices = np.append(spin_start_indices[1:], len(de_met_sorted))
 
-    assigned_spin_number_sorted = np.empty_like(de_spin_sorted)
-
     spin_start_mets = spin_df["spin_start_met"].values
     spin_numbers = spin_df["spin_number"].values
+    assigned_spin_number_sorted = np.empty(de_spin_sorted.shape, dtype=np.uint32)
+    # Take last 8 bits of spin numbers.
+    possible_spins = spin_numbers & 0xFF
 
     # Assign each group based on median time.
     for start, end in zip(spin_start_indices, spin_end_indices):
-        # Get median time for the spin.
-        median_time = np.median(de_met_sorted[start:end])
-        spin_idx = np.searchsorted(spin_start_mets, median_time, side="right") - 1
-        # Handle edge cases.
-        spin_idx = np.clip(spin_idx, 0, len(spin_numbers) - 1)
-        assigned_spin_number_sorted[start:end] = spin_numbers[spin_idx]
+        # Get possible times to match to universal spin table.
+        possible_times = spin_start_mets[possible_spins == de_spin_sorted[start]]
+        # Get nearest time for matching spins.
+        nearest_idx = np.abs(possible_times - de_met_sorted[start]).argmin()
+        nearest_value = possible_times[nearest_idx]
+        assigned_spin_number_sorted[start:end] = spin_numbers[
+            spin_start_mets == nearest_value
+        ]
 
     # Undo the sort to match original order.
     assigned_spin_number = np.empty_like(assigned_spin_number_sorted)

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -821,27 +821,37 @@ def get_spin_number(de_met: NDArray, de_spin: NDArray) -> NDArray:
     assigned_spin_number : NDArray
         Spin number for DE data product.
     """
-    spin_df = get_spin_data()
-
-    # Get de sorting indices based on time.
+    # DE packet data.
+    # Since the spin number in the direct events packet
+    # is only 8 bits it goes from 0-255.
+    # Within a pointing that means we will always have duplicate spin numbers.
+    # In other words, different spins will be represented by the same spin number.
+    # Just to make certain that we won't accidentally combine
+    # multiple spins we need to sort by time here.
     sort_idx = np.argsort(de_met)
     de_met_sorted = de_met[sort_idx]
     de_spin_sorted = de_spin[sort_idx]
-
-    # Determine the indices of new spins.
+    # Here we are finding the start and end indices of each spin in the sorted array.
     is_new_spin = np.concatenate([[True], de_spin_sorted[1:] != de_spin_sorted[:-1]])
     spin_start_indices = np.where(is_new_spin)[0]
     spin_end_indices = np.append(spin_start_indices[1:], len(de_met_sorted))
 
+    # Universal Spin Table.
+    spin_df = get_spin_data()
+    # Retrieve the met values of the start of the spin.
     spin_start_mets = spin_df["spin_start_met"].values
+    # Retrieve the corresponding spin numbers.
     spin_numbers = spin_df["spin_number"].values
     assigned_spin_number_sorted = np.empty(de_spin_sorted.shape, dtype=np.uint32)
-    # Take last 8 bits of spin numbers.
+    # These last 8 bits are the same as the spin number in the DE packet.
+    # So this will give us choices of which spins are
+    # available to assign to the DE data.
     possible_spins = spin_numbers & 0xFF
 
-    # Assign each group based on median time.
+    # Assign each group based on time.
     for start, end in zip(spin_start_indices, spin_end_indices):
-        # Get possible times to match to universal spin table.
+        # Now that we have the possible spins from the Universal Spin Table,
+        # we match the times of those spins to the nearest times in the DE data.
         possible_times = spin_start_mets[possible_spins == de_spin_sorted[start]]
         # Get nearest time for matching spins.
         nearest_idx = np.abs(possible_times - de_met_sorted[start]).argmin()

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -805,6 +805,55 @@ def get_phi_theta(
     return np.degrees(phi), np.degrees(theta)
 
 
+def get_spin_number(de_met: NDArray, de_spin: NDArray) -> NDArray:
+    """
+    Get the spin number.
+
+    Parameters
+    ----------
+    de_met : NDArray
+        Mission elapsed time.
+    de_spin : NDArray
+        Spin number 0-255.
+
+    Returns
+    -------
+    assigned_spin_number : NDArray
+        Spin number for DE data product.
+    """
+    spin_df = get_spin_data()
+
+    # Get de sorting indices based on time.
+    sort_idx = np.argsort(de_met)
+    de_met_sorted = de_met[sort_idx]
+    de_spin_sorted = de_spin[sort_idx]
+
+    # Determine the indices of new spins.
+    is_new_spin = np.concatenate([[True], de_spin_sorted[1:] != de_spin_sorted[:-1]])
+    spin_start_indices = np.where(is_new_spin)[0]
+    spin_end_indices = np.append(spin_start_indices[1:], len(de_met_sorted))
+
+    assigned_spin_number_sorted = np.empty_like(de_spin_sorted)
+
+    spin_start_mets = spin_df["spin_start_met"].values
+    spin_numbers = spin_df["spin_number"].values
+
+    # Assign each group based on median time.
+    for start, end in zip(spin_start_indices, spin_end_indices):
+        # Get median time for the spin.
+        median_time = np.median(de_met_sorted[start:end])
+        spin_idx = np.searchsorted(spin_start_mets, median_time, side="right") - 1
+        # Handle edge cases.
+        spin_idx = np.clip(spin_idx, 0, len(spin_numbers) - 1)
+        assigned_spin_number_sorted[start:end] = spin_numbers[spin_idx]
+
+    # Undo the sort to match original order.
+    assigned_spin_number = np.empty_like(assigned_spin_number_sorted)
+    assigned_spin_number[sort_idx] = assigned_spin_number_sorted
+
+    return assigned_spin_number
+
+
 def get_eventtimes(
     spin: NDArray, phase_angle: NDArray
 ) -> tuple[NDArray, NDArray, NDArray]:

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -69,7 +69,7 @@ def calculate_helio_pset(
 
     df_efficiencies = pd.read_csv(efficiencies)
     df_geometric_function = pd.read_csv(geometric_function)
-    mid_time = sct_to_et(de_dataset["event_times"].data.median())
+    mid_time = sct_to_et(np.median(de_dataset["event_times"].data))
     sensitivity = get_helio_sensitivity(
         mid_time,
         df_efficiencies,

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -1,10 +1,17 @@
 """Calculate Pointing Set Grids."""
 
-import astropy_healpix.healpy as hp
 import numpy as np
+import pandas as pd
 import xarray as xr
 
-from imap_processing.ultra.l1c.ultra_l1c_pset_bins import build_energy_bins
+from imap_processing.spice.time import sct_to_et
+from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
+    build_energy_bins,
+    get_helio_background_rates,
+    get_helio_exposure_times,
+    get_helio_sensitivity,
+    get_spacecraft_histogram,
+)
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 
@@ -36,17 +43,57 @@ def calculate_helio_pset(
     dataset : xarray.Dataset
         Dataset containing the data.
     """
-    # TODO: Fill in the rest of this later.
     pset_dict: dict[str, np.ndarray] = {}
-    healpix = np.arange(hp.nside2npix(128))
-    _, _, energy_bin_geometric_means = build_energy_bins()
 
+    v_mag_helio_spacecraft = np.linalg.norm(
+        de_dataset["velocity_dps_helio"].values, axis=1
+    )
+    vhat_dps_helio = (
+        de_dataset["velocity_dps_helio"].values / v_mag_helio_spacecraft[:, np.newaxis]
+    )
+    intervals, _, energy_bin_geometric_means = build_energy_bins()
+    counts, latitude, longitude, n_pix = get_spacecraft_histogram(
+        vhat_dps_helio,
+        de_dataset["energy_heliosphere"].values,
+        intervals,
+        nside=128,
+    )
+
+    healpix = np.arange(n_pix)
+
+    # calculate background rates
+    background_rates = get_helio_background_rates()
+
+    efficiencies = ancillary_files["l1c-90sensor-efficiencies"]
+    geometric_function = ancillary_files["l1c-90sensor-gf"]
+
+    df_efficiencies = pd.read_csv(efficiencies)
+    df_geometric_function = pd.read_csv(geometric_function)
+    mid_time = sct_to_et(de_dataset["event_times"].data.mean())
+    sensitivity = get_helio_sensitivity(
+        mid_time,
+        df_efficiencies,
+        df_geometric_function,
+    )
+
+    # Calculate exposure
+    constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
+    df_exposure = pd.read_csv(constant_exposure)
+    exposure_pointing = get_helio_exposure_times(mid_time, df_exposure)
+
+    # For ISTP, epoch should be the center of the time bin.
     pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)
-    pset_dict["pixel_index"] = healpix
+    pset_dict["counts"] = counts[np.newaxis, ...]
+    pset_dict["latitude"] = latitude[np.newaxis, ...]
+    pset_dict["longitude"] = longitude[np.newaxis, ...]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
-    pset_dict["exposure_factor"] = np.zeros(len(healpix), dtype=np.uint8)[
+    pset_dict["background_rates"] = background_rates[np.newaxis, ...]
+    pset_dict["helio_exposure_factor"] = exposure_pointing[np.newaxis, ...]
+    pset_dict["pixel_index"] = healpix
+    pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
         np.newaxis, ...
     ]
+    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -69,7 +69,7 @@ def calculate_helio_pset(
 
     df_efficiencies = pd.read_csv(efficiencies)
     df_geometric_function = pd.read_csv(geometric_function)
-    mid_time = sct_to_et(de_dataset["event_times"].data.mean())
+    mid_time = sct_to_et(de_dataset["event_times"].data.median())
     sensitivity = get_helio_sensitivity(
         mid_time,
         df_efficiencies,

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -151,110 +151,6 @@ def get_spacecraft_histogram(
     return hist, latitude, longitude, n_pix
 
 
-def get_helio_histogram(
-    time: NDArray,
-    vhat: NDArray,
-    energy: NDArray,
-    energy_bin_edges: list[tuple[float, float]],
-    nside: int = 128,
-    nested: bool = False,
-) -> tuple[NDArray, NDArray, NDArray, NDArray]:
-    """
-    Compute a 3D histogram of the particle data using HEALPix binning.
-
-    Parameters
-    ----------
-    time : np.ndarray
-        Median time of pointing in et.
-    vhat : tuple[np.ndarray, np.ndarray, np.ndarray]
-        The x,y,z-components of the unit velocity vector.
-    energy : np.ndarray
-        The particle energy.
-    energy_bin_edges : list[tuple[float, float]]
-        Array of energy bin edges.
-    nside : int, optional
-        The nside parameter of the Healpix tessellation.
-        Default is 128.
-    nested : bool, optional
-        Whether the Healpix tessellation is nested. Default is False.
-
-    Returns
-    -------
-    hist : np.ndarray
-        A 3D histogram array with shape (n_pix, n_energy_bins).
-    latitude : np.ndarray
-        Array of latitude values.
-    longitude : np.ndarray
-        Array of longitude values.
-    n_pix : int
-        Number of healpix pixels.
-
-    Notes
-    -----
-    The histogram will work properly for overlapping energy bins, i.e.
-    the same energy value can fall into multiple bins if the intervals overlap.
-
-    azimuthal angle [0, 360], elevation angle [-90, 90]
-    """
-    # Compute number of HEALPix pixels that cover the sphere
-    n_pix = hp.nside2npix(nside)
-
-    # Calculate the corresponding longitude (az) latitude (el)
-    # center coordinates
-    longitude, latitude = hp.pix2ang(nside, np.arange(n_pix), lonlat=True)
-
-    # The Cartesian state vector representing the position and velocity of the
-    # IMAP spacecraft.
-    state = imap_state(time, ref_frame=SpiceFrame.IMAP_DPS)
-
-    # Extract the velocity part of the state vector
-    spacecraft_velocity = state[3:6]
-
-    # Initialize histogram: (n_energy_bins, n_HEALPix pixels)
-    hist = np.zeros((len(energy_bin_edges), n_pix))
-
-    # Bin data in energy & HEALPix space
-    for i, (e_min, e_max) in enumerate(energy_bin_edges):
-        # Convert the midpoint energy to a velocity (km/s).
-        # Based on kinetic energy equation: E = 1/2 * m * v^2.
-        energy_midpoint = (e_min + e_max) / 2
-        energy_velocity = (
-            np.sqrt(2 * energy_midpoint * UltraConstants.KEV_J / UltraConstants.MASS_H)
-            / 1e3
-        )
-
-        # Use Galilean Transform to transform the velocity wrt spacecraft
-        # to the velocity wrt heliosphere.
-        # energy_velocity * cartesian -> apply the magnitude of the velocity
-        # to every position on the grid in the despun grid.
-        mask = (energy >= e_min) & (energy < e_max)
-        vx, vy, vz = vhat.T
-
-        # Select only the particles that fall within the energy bin.
-        vx_bin, vy_bin, vz_bin = vx[mask], vy[mask], vz[mask]
-        vhat_bin = np.stack((vx_bin, vy_bin, vz_bin), axis=1)
-        helio_velocity = spacecraft_velocity.reshape(1, 3) + energy_velocity * vhat_bin
-
-        # Normalized vectors representing the direction of the heliocentric velocity.
-        helio_normalized = -helio_velocity / np.linalg.norm(
-            helio_velocity, axis=1, keepdims=True
-        )
-
-        # Convert Cartesian heliocentric vectors into spherical coordinates.
-        # Result: azimuth (longitude) and elevation (latitude) in degrees.
-        helio_spherical = cartesian_to_spherical(np.squeeze(helio_normalized))
-        helio_spherical = np.atleast_2d(helio_spherical)
-        az, el = helio_spherical[:, 1], helio_spherical[:, 2]
-
-        # Convert azimuth/elevation directions to HEALPix pixel indices.
-        hpix_idx = hp.ang2pix(nside, az, el, nest=nested, lonlat=True)
-
-        # Only count the events that fall within the energy bin
-        hist[i, :] += np.bincount(hpix_idx, minlength=n_pix).astype(np.float64)
-
-    return hist, latitude, longitude, n_pix
-
-
 def get_spacecraft_background_rates(
     nside: int = 128,
 ) -> NDArray:
@@ -384,7 +280,7 @@ def get_helio_exposure_times(
     # Initialize output array.
     # Each row corresponds to a HEALPix pixel, and each column to an energy bin.
     npix = hp.nside2npix(nside)
-    helio_exposure = np.zeros((npix, len(energy_midpoints)))
+    helio_exposure = np.zeros((len(energy_midpoints), npix))
 
     # Loop through energy bins and compute transformed exposure.
     for i, energy_midpoint in enumerate(energy_midpoints):
@@ -415,7 +311,7 @@ def get_helio_exposure_times(
         hpix_idx = hp.ang2pix(nside, az, el, nest=nested, lonlat=True)
 
         # Accumulate exposure values into HEALPix pixels for this energy bin.
-        helio_exposure[:, i] = np.bincount(
+        helio_exposure[i, :] = np.bincount(
             hpix_idx, weights=exposure_flat, minlength=npix
         )
 
@@ -597,7 +493,7 @@ def get_helio_sensitivity(
     # Initialize output array.
     # Each row corresponds to a HEALPix pixel, and each column to an energy bin.
     npix = hp.nside2npix(nside)
-    helio_sensitivity = np.zeros((npix, len(energy_midpoints)))
+    helio_sensitivity = np.zeros((len(energy_midpoints), npix))
 
     # Loop through energy bins and compute transformed sensitivity.
     for i, energy in enumerate(energy_midpoints):
@@ -628,7 +524,7 @@ def get_helio_sensitivity(
         gridded_sensitivity = grid_sensitivity(efficiencies, geometric_function, energy)
 
         # Accumulate sensitivity values into HEALPix pixels for this energy bin.
-        helio_sensitivity[:, i] = np.bincount(
+        helio_sensitivity[i, :] = np.bincount(
             hpix_idx, weights=gridded_sensitivity, minlength=npix
         )
 

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -126,12 +126,18 @@ def create_dataset(  # noqa: PLR0912
                 dims=["epoch", "pixel_index"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-        elif key in {"counts", "background_rates", "sensitivity"}:
+        elif key in {
+            "counts",
+            "background_rates",
+            "helio_exposure_factor",
+            "sensitivity",
+        }:
             dataset[key] = xr.DataArray(
                 data,
                 dims=["epoch", "energy_bin_geometric_mean", "pixel_index"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
+            print("hi")
         else:
             dataset[key] = xr.DataArray(
                 data,

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -137,7 +137,6 @@ def create_dataset(  # noqa: PLR0912
                 dims=["epoch", "energy_bin_geometric_mean", "pixel_index"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-            print("hi")
         else:
             dataset[key] = xr.DataArray(
                 data,


### PR DESCRIPTION
# Change Summary

## Overview
This is taking the original code and formatting it so that it can be placed into a cdf. I also had feedback from Nick Dutton that I can delete the helio frame histogram function and instead use the spacecraft histogram function if I have appropriate inputs. I also wrote a test using fake data provided by Nick Dutton. 

## Updated Files
- helio_pset.py
   - Format existing code to create a cdf
- ultra_l1c_pset_bins.py
   - Remove helio histogram code per Nick Dutton’s recommendation. I am instead using the spacecraft histogram code.
- ultra_l1_utils.py
   - Update data array structure for histogram
- ultra_l1b_extended.py
   - Quick fix to calculate spin number for direct events data product.
- de.py
   - Include spin number calculation in direct events data product.

## Testing
test_ultra_l1c.py
test_ultra_l1c_pset_bins.py
test_ultra_l1b_extended.py