### PR TITLE
Coverage plots

### DIFF
--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -45,11 +45,13 @@ class StationProperties(NamedTuple):
     longitude: float  # longitude in degrees
     latitude: float  # latitude in degrees
     altitude: float  # altitude in kilometers
+    min_elevation_deg: float  # minimum elevation angle in degrees
 
 
-# Define StationProperties instances
+# TODO: Verify longitude, latitude, altitude.
 KIEL = StationProperties(
-    longitude=-71.41,  # longitude in degrees
-    latitude=-33.94,  # latitude in degrees
-    altitude=0.157,  # altitude in kilometers
+    longitude=10.122,  # degrees East
+    latitude=54.339,  # degrees North
+    altitude=0.043,  # approx 43 meters
+    min_elevation_deg=10,  # 10 degrees is the requirement
 )

--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -49,9 +49,11 @@ class StationProperties(NamedTuple):
 
 
 # TODO: Verify longitude, latitude, altitude.
-KIEL = StationProperties(
-    longitude=10.122,  # degrees East
-    latitude=54.339,  # degrees North
-    altitude=0.043,  # approx 43 meters
-    min_elevation_deg=10,  # 10 degrees is the requirement
-)
+STATIONS = {
+    "Kiel": StationProperties(
+        longitude=10.122,  # degrees East
+        latitude=54.339,  # degrees North
+        altitude=0.043,  # approx 43 meters
+        min_elevation_deg=10,  # 10 degrees is the requirement
+    )
+}

--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -1,6 +1,7 @@
 """Module for constants and useful shared classes used in I-ALiRT processing."""
 
 from dataclasses import dataclass
+from typing import NamedTuple
 
 import numpy as np
 
@@ -36,3 +37,19 @@ class IalirtSwapiConstants:
     az_fov = np.deg2rad(30)  # azimuthal width of the field of view, radians
     fwhm_width = 0.085  # FWHM of energy width
     speed_ew = 0.5 * fwhm_width  # speed width of energy passband
+
+
+class StationProperties(NamedTuple):
+    """Class that represents properties of ground stations."""
+
+    longitude: float  # longitude in degrees
+    latitude: float  # latitude in degrees
+    altitude: float  # altitude in kilometers
+
+
+# Define StationProperties instances
+KIEL = StationProperties(
+    longitude=-71.41,  # longitude in degrees
+    latitude=-33.94,  # latitude in degrees
+    altitude=0.157,  # altitude in kilometers
+)

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -4,7 +4,7 @@ import logging
 
 import numpy as np
 
-from imap_processing.ialirt.constants import KIEL
+from imap_processing.ialirt.constants import STATIONS
 from imap_processing.ialirt.process_ephemeris import calculate_azimuth_and_elevation
 from imap_processing.spice.time import et_to_utc, str_to_et
 
@@ -32,7 +32,7 @@ def generate_coverage(
     time_step = 3600  # 1 hr in seconds
 
     stations = {
-        "Kiel": KIEL,
+        "Kiel": STATIONS["Kiel"],
     }
     coverage_dict = {}
 

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -1,0 +1,63 @@
+"""Coverage time for each station."""
+
+import logging
+
+import numpy as np
+
+from imap_processing.ialirt.constants import KIEL
+from imap_processing.ialirt.process_ephemeris import calculate_azimuth_and_elevation
+from imap_processing.spice.time import et_to_utc, str_to_et
+
+# Logger setup
+logger = logging.getLogger(__name__)
+
+
+def generate_coverage(
+    start_time: str,
+) -> dict[str, np.ndarray]:
+    """
+    Build the output dictionary containing coverage time for each station.
+
+    Parameters
+    ----------
+    start_time : str
+        Start time in UTC.
+
+    Returns
+    -------
+    coverage_dict: dict
+        Coverage for each station.
+    """
+    duration_seconds = 24 * 60 * 60  # 86400 seconds in 24 hours
+    time_step = 3600  # 1 hr in seconds
+
+    stations = {
+        "Kiel": KIEL,
+    }
+    coverage_dict = {}
+
+    start_et_input = str_to_et(start_time)
+    stop_et_input = start_et_input + duration_seconds
+
+    time_range = np.arange(start_et_input, stop_et_input, time_step)
+    total_visible_mask = np.zeros(time_range.shape, dtype=bool)
+
+    for station_name, (lon, lat, alt) in stations.items():
+        azimuth, elevation = calculate_azimuth_and_elevation(lon, lat, alt, time_range)
+        visible = elevation > 0
+        total_visible_mask |= visible
+        time_utc = et_to_utc(time_range[visible], format_str="ISOC")
+
+        coverage_dict[f"{station_name}_time"] = time_utc
+
+    # Total coverage percentage
+    total_coverage_percent = (
+        np.count_nonzero(total_visible_mask) / time_range.size
+    ) * 100
+    coverage_dict["total_coverage_percent"] = total_coverage_percent
+
+    logger.info(
+        f"Calculated station time coverage for stations: {', '.join(stations.keys())}."
+    )
+
+    return coverage_dict

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -29,7 +29,7 @@ def generate_coverage(
         Coverage for each station.
     """
     duration_seconds = 24 * 60 * 60  # 86400 seconds in 24 hours
-    time_step = 300  # 1 hr in seconds
+    time_step = 3600  # 1 hr in seconds
 
     stations = {
         "Kiel": KIEL,

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -29,7 +29,7 @@ def generate_coverage(
         Coverage for each station.
     """
     duration_seconds = 24 * 60 * 60  # 86400 seconds in 24 hours
-    time_step = 3600  # 1 hr in seconds
+    time_step = 300  # 1 hr in seconds
 
     stations = {
         "Kiel": KIEL,
@@ -42,9 +42,9 @@ def generate_coverage(
     time_range = np.arange(start_et_input, stop_et_input, time_step)
     total_visible_mask = np.zeros(time_range.shape, dtype=bool)
 
-    for station_name, (lon, lat, alt) in stations.items():
+    for station_name, (lon, lat, alt, min_elevation) in stations.items():
         azimuth, elevation = calculate_azimuth_and_elevation(lon, lat, alt, time_range)
-        visible = elevation > 0
+        visible = elevation > min_elevation
         total_visible_mask |= visible
         time_utc = et_to_utc(time_range[visible], format_str="ISOC")
 

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -1,0 +1,23 @@
+"""Test processEphemeris functions."""
+
+import pytest
+
+from imap_processing.ialirt.generate_coverage import generate_coverage
+
+
+@pytest.mark.external_kernel
+def test_generate_coverage(furnish_kernels):
+    """
+    Test the generate_coverage function.
+    """
+    kernels = [
+        "naif0012.tls",
+        "pck00011.tpc",
+        "de440s.bsp",
+        "imap_spk_demo.bsp",
+        "earth_1962_240827_2124_combined.bpc",
+    ]
+    with furnish_kernels(kernels):
+        coverage_dict = generate_coverage("2026 SEP 22 00:00:00")
+    # TODO: add assertions and make a plot
+    assert coverage_dict is not None

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -1,5 +1,7 @@
 """Test processEphemeris functions."""
 
+from datetime import datetime
+
 import pytest
 
 from imap_processing.ialirt.generate_coverage import generate_coverage
@@ -10,6 +12,8 @@ def test_generate_coverage(furnish_kernels):
     """
     Test the generate_coverage function.
     """
+    # Note: tested this code with the Sun and achieved expected
+    # results ~12 hours of coverage from horizon to horizon.
     kernels = [
         "naif0012.tls",
         "pck00011.tpc",
@@ -19,5 +23,12 @@ def test_generate_coverage(furnish_kernels):
     ]
     with furnish_kernels(kernels):
         coverage_dict = generate_coverage("2026 SEP 22 00:00:00")
-    # TODO: add assertions and make a plot
-    assert coverage_dict is not None
+
+    start = datetime.strptime(coverage_dict["Kiel_time"][0], "%Y-%m-%dT%H:%M:%S.%f")
+    end = datetime.strptime(coverage_dict["Kiel_time"][-1], "%Y-%m-%dT%H:%M:%S.%f")
+
+    duration = end - start
+    hours = duration.total_seconds() / 3600
+
+    # Coverage duration should be approximately 9 hours.
+    assert hours == pytest.approx(9, abs=1)


### PR DESCRIPTION
# Change Summary

## Overview
We have a requirement for the I-ALiRT Coordinator Study to generate coverage plots for the ground stations. This code finds out the time in UTC that each ground station (right now only for Kiel; later KSWC) will provide satellite coverage and calculates the percent coverage for the day. 

## New Files
- coverage.py
   - Calculate the coverage of the ground stations

## Updated Files
- constants.py
   - Added station properties for the ground stations

## Testing
test_coverage.py
![coverage_plot](https://github.com/user-attachments/assets/85b55a7e-24aa-41e6-816a-7bc1790543f5)