### PR TITLE
Ultra l1b - add geometric factor

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -256,6 +256,20 @@ theta:
   LABLAXIS: theta
   UNITS: degrees
 
+geometric_factor_blades:
+  <<: *default_float32
+  CATDESC: Ultra sensitive area within the field of view.
+  FIELDNAM: geometric_function_blades
+  LABLAXIS: geometric function blades
+  UNITS: " "
+
+geometric_factor_noblades:
+  <<: *default_float32
+  CATDESC: Ultra sensitive area within the field of regard.
+  FIELDNAM: geometric_function_noblades
+  LABLAXIS: geometric function noblades
+  UNITS: " "
+
 phi_fwhm:
   <<: *default_float32
   CATDESC: FWHM of the phi distribution.

--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -508,3 +508,11 @@ quality_hk:
   DEPEND_0: epoch
   DEPEND_1: spin_number
   DEPEND_2: energy_bin_geometric_mean
+
+quality_fov:
+  <<: *default_uint16
+  CATDESC: Quality flag for direct event for events outside of the FOV.
+  FIELDNAM: quality_fov
+  LABLAXIS: quality fov
+  # TODO: come back to format
+  UNITS: " "

--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -37,6 +37,14 @@ class ENAFlags(FlagNameMixin):
     BADSPIN = 2**2  # bit 2, Bad spin
 
 
+class ImapDEUltraFlags(FlagNameMixin):
+    """IMAP Ultra flags."""
+
+    NONE = CommonFlags.NONE
+    BLADESFOV = 2**0  # bit 0
+    NOBLADESFOV = 2**1  # bit 1
+
+
 class ImapHkUltraFlags(FlagNameMixin):
     """IMAP Ultra flags."""
 

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -85,6 +85,8 @@ EXTERNAL_TEST_DATA = [
     ("imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv",
      "ultra/data/l1/"),
+    ("imap_ultra_l1b-sensor-gf-blades_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1b-sensor-gf-noblades_20250101_v000.csv", "ultra/data/l1/"),
 
     # MAG
     ("mag-l1b-l1c-t013-magi-burst-in.csv",

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -113,7 +113,7 @@ def test_get_geometric_function():
         ancillary_files, "l1b-sensor-gf-noblades", phi, theta, quality_flags
     )
 
-    assert np.array_equal(
+    np.testing.assert_array_equal(
         gf, np.array([0, 0, 0.13713, 0.1792, 0.35507, 0.1792, 0.13713, 0, 0])
     )
-    assert np.array_equal(quality_flags, np.array([2, 2, 0, 0, 0, 0, 0, 2, 2]))
+    np.testing.assert_array_equal(quality_flags, np.array([2, 2, 0, 0, 0, 0, 0, 2, 2]))

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from imap_processing import imap_module_directory
+from imap_processing.quality_flags import ImapDEUltraFlags
 from imap_processing.ultra.l1b.lookup_utils import (
     get_angular_profiles,
     get_back_position,
@@ -107,8 +108,12 @@ def test_get_geometric_function():
     }
     phi = np.array([-65, -64, -39, -1.3, 0, 1.3, 39, 64, 65])
     theta = np.array([-65, -64, -39, -1.3, 0, 1.3, 39, 64, 65])
-    gf = get_geometric_factor(ancillary_files, "l1b-sensor-gf-noblades", phi, theta)
+    quality_flags = np.full(phi.shape, ImapDEUltraFlags.NONE.value, dtype=np.uint16)
+    gf = get_geometric_factor(
+        ancillary_files, "l1b-sensor-gf-noblades", phi, theta, quality_flags
+    )
 
     assert np.array_equal(
         gf, np.array([0, 0, 0.13713, 0.1792, 0.35507, 0.1792, 0.13713, 0, 0])
     )
+    assert np.array_equal(quality_flags, np.array([2, 2, 0, 0, 0, 0, 0, 2, 2]))

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -8,6 +8,7 @@ from imap_processing.ultra.l1b.lookup_utils import (
     get_back_position,
     get_energy_efficiencies,
     get_energy_norm,
+    get_geometric_factor,
     get_image_params,
     get_norm,
     get_y_adjust,
@@ -93,3 +94,21 @@ def test_get_energy_efficiencies():
     u45_efficiencies = get_energy_efficiencies(ancillary_files)
 
     assert u45_efficiencies.shape == (58081, 157)
+
+
+@pytest.mark.external_test_data
+def test_get_geometric_function():
+    """Tests function get_get_energy_efficiencies."""
+
+    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+    ancillary_files = {
+        "l1b-sensor-gf-noblades": path
+        / "imap_ultra_l1b-sensor-gf-noblades_20250101_v000.csv"
+    }
+    phi = np.array([-65, -64, -39, -1.3, 0, 1.3, 39, 64, 65])
+    theta = np.array([-65, -64, -39, -1.3, 0, 1.3, 39, 64, 65])
+    gf = get_geometric_factor(ancillary_files, "l1b-sensor-gf-noblades", phi, theta)
+
+    assert np.array_equal(
+        gf, np.array([0, 0, 0.13713, 0.1792, 0.35507, 0.1792, 0.13713, 0, 0])
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -131,7 +131,11 @@ def test_cdf_de(
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary_files = {
         "l1b-45sensor-logistic-interpolation": path
-        / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
+        / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv",
+        "l1b-sensor-gf-noblades": path
+        / "imap_ultra_l1b-sensor-gf-noblades_20250101_v000.csv",
+        "l1b-sensor-gf-blades": path
+        / "imap_ultra_l1b-sensor-gf-blades_20250101_v000.csv",
     }
     l1b_de_dataset = ultra_l1b(data_dict, ancillary_files)
 

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -4,6 +4,7 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
+from imap_processing.quality_flags import ImapDEUltraFlags
 from imap_processing.spice.geometry import SpiceFrame
 from imap_processing.ultra.l1b.lookup_utils import get_geometric_factor
 from imap_processing.ultra.l1b.ultra_l1b_annotated import (
@@ -123,6 +124,9 @@ def calculate_de(
     spin_starts = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float64)
 
     start_type = np.full(len(de_dataset["epoch"]), FILLVAL_UINT8, dtype=np.uint8)
+    quality_flags = np.full(
+        de_dataset["epoch"].shape, ImapDEUltraFlags.NONE.value, dtype=np.uint16
+    )
 
     xf[valid_indices] = get_front_x_position(
         de_dataset["start_type"].data[valid_indices],
@@ -268,11 +272,20 @@ def calculate_de(
         de_dict["tof_energy"], de_dict["phi"], de_dict["theta"], ancillary_files
     )
     de_dict["geometric_factor_blades"] = get_geometric_factor(
-        ancillary_files, "l1b-sensor-gf-blades", de_dict["phi"], de_dict["theta"]
+        ancillary_files,
+        "l1b-sensor-gf-blades",
+        de_dict["phi"],
+        de_dict["theta"],
+        quality_flags,
     )
     de_dict["geometric_factor_noblades"] = get_geometric_factor(
-        ancillary_files, "l1b-sensor-gf-noblades", de_dict["phi"], de_dict["theta"]
+        ancillary_files,
+        "l1b-sensor-gf-noblades",
+        de_dict["phi"],
+        de_dict["theta"],
+        quality_flags,
     )
+    de_dict["quality_fov"] = quality_flags
 
     dataset = create_dataset(de_dict, name, "l1b")
 

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.spice.geometry import SpiceFrame
+from imap_processing.ultra.l1b.lookup_utils import get_geometric_factor
 from imap_processing.ultra.l1b.ultra_l1b_annotated import (
     get_annotated_particle_velocity,
 )
@@ -265,6 +266,12 @@ def calculate_de(
     )
     de_dict["event_efficiency"] = get_efficiency(
         de_dict["tof_energy"], de_dict["phi"], de_dict["theta"], ancillary_files
+    )
+    de_dict["geometric_factor_blades"] = get_geometric_factor(
+        ancillary_files, "l1b-sensor-gf-blades", de_dict["phi"], de_dict["theta"]
+    )
+    de_dict["geometric_factor_noblades"] = get_geometric_factor(
+        ancillary_files, "l1b-sensor-gf-noblades", de_dict["phi"], de_dict["theta"]
     )
 
     dataset = create_dataset(de_dict, name, "l1b")

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import xarray as xr
+from numpy.typing import NDArray
 
 from imap_processing import imap_module_directory
 
@@ -227,3 +228,49 @@ def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
     lookup_table = pd.read_csv(ancillary_files["l1b-45sensor-logistic-interpolation"])
 
     return lookup_table
+
+
+def get_geometric_factor(
+    ancillary_files: dict, filename: str, phi: NDArray, theta: NDArray
+) -> tuple[NDArray, NDArray]:
+    """
+    Lookup table for geometric factor using nearest neighbor.
+
+    Parameters
+    ----------
+    ancillary_files : dict[Path]
+        Ancillary files.
+    filename : str
+        Name of the file in ancillary_files to use.
+    phi : NDArray
+        Azimuth angles in degrees.
+    theta : NDArray
+        Elevation angles in degrees.
+
+    Returns
+    -------
+    geometric_factor : NDArray
+        Geometric factor.
+    """
+    gf_table = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=6, nrows=301
+    ).to_numpy(dtype=float)
+    theta_table = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=308, nrows=301
+    ).to_numpy(dtype=float)
+    phi_table = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=610, nrows=301
+    ).to_numpy(dtype=float)
+
+    # Assume uniform grids: extract 1D arrays from first row/col
+    theta_vals = theta_table[0, :]  # columns represent theta
+    phi_vals = phi_table[:, 0]  # rows represent phi
+
+    # Find nearest index in table for each input value
+    phi_idx = np.abs(phi_vals[:, None] - phi).argmin(axis=0)
+    theta_idx = np.abs(theta_vals[:, None] - theta).argmin(axis=0)
+
+    # Fetch geometric factor values at nearest (phi, theta) pairs
+    geometric_factor = gf_table[phi_idx, theta_idx]
+
+    return geometric_factor

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -280,6 +280,7 @@ def get_geometric_factor(
     # Fetch geometric factor values at nearest (phi, theta) pairs
     geometric_factor = gf_table[phi_idx, theta_idx]
 
+    # If the geometric factor is zero it means that the instrument is out of the FOV.
     if filename == "l1b-sensor-gf-noblades":
         quality_flag[geometric_factor == 0] |= ImapDEUltraFlags.NOBLADESFOV.value
     if filename == "l1b-sensor-gf-blades":

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -7,6 +7,7 @@ import xarray as xr
 from numpy.typing import NDArray
 
 from imap_processing import imap_module_directory
+from imap_processing.quality_flags import ImapDEUltraFlags
 
 BASE_PATH = imap_module_directory / "ultra" / "lookup_tables"
 
@@ -231,7 +232,11 @@ def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
 
 
 def get_geometric_factor(
-    ancillary_files: dict, filename: str, phi: NDArray, theta: NDArray
+    ancillary_files: dict,
+    filename: str,
+    phi: NDArray,
+    theta: NDArray,
+    quality_flag: NDArray,
 ) -> tuple[NDArray, NDArray]:
     """
     Lookup table for geometric factor using nearest neighbor.
@@ -246,6 +251,8 @@ def get_geometric_factor(
         Azimuth angles in degrees.
     theta : NDArray
         Elevation angles in degrees.
+    quality_flag : NDArray
+        Quality flag to set when geometric factor is zero.
 
     Returns
     -------
@@ -272,5 +279,10 @@ def get_geometric_factor(
 
     # Fetch geometric factor values at nearest (phi, theta) pairs
     geometric_factor = gf_table[phi_idx, theta_idx]
+
+    if filename == "l1b-sensor-gf-noblades":
+        quality_flag[geometric_factor == 0] |= ImapDEUltraFlags.NOBLADESFOV.value
+    if filename == "l1b-sensor-gf-blades":
+        quality_flag[geometric_factor == 0] |= ImapDEUltraFlags.BLADESFOV.value
 
     return geometric_factor


### PR DESCRIPTION
# Change Summary

## Overview
Adds geometric factor to the l1b de data product and adds quality flag if the geometric factor is equal to zero, which indicates that the event is out of the FOV.

## Updated Files
- lookup_utils.py
   - Interpolation of lookup table
- de.py
   - Added data product to dictionary
- imap_ultra_l1b_variable_attrs.yaml
   - Update variable attributes
- quality_flags.py
   - Update the quality flags

## Testing
test_ultra_l1b.py
test_lookup_utils.py
external_test_data_config.py