### PR TITLE
I-ALiRT - update swe to be broken into half cycles

### DIFF
--- a/imap_processing/ialirt/l0/process_swe.py
+++ b/imap_processing/ialirt/l0/process_swe.py
@@ -542,16 +542,32 @@ def process_swe(accumulated_data: xr.Dataset, in_flight_cal_files: list) -> list
         summed_first = normalized_first_half.sum(axis=(1, 2))
         summed_second = normalized_second_half.sum(axis=(1, 2))
 
+        met_first_half = int(
+            grouped["met"].where(grouped["swe_seq"] == 0, drop=True).values[0]
+        )
+        met_second_half = int(
+            grouped["met"].where(grouped["swe_seq"] == 30, drop=True).values[0]
+        )
+
         swe_data.append(
             {
                 "apid": 478,
-                "met": int(grouped["met"].min()),
-                "met_in_utc": met_to_utc(grouped["met"].min()).split(".")[0],
-                "ttj2000ns": int(met_to_ttj2000ns(grouped["met"].min())),
-                "swe_normalized_counts_half_1_esa": [int(val) for val in summed_first],
-                "swe_normalized_counts_half_2_esa": [int(val) for val in summed_second],
-                "swe_counterstreaming_electrons": max(bde_first_half, bde_second_half),
-            }
+                "met": met_first_half,
+                "met_in_utc": met_to_utc(met_first_half).split(".")[0],
+                "ttj2000ns": int(met_to_ttj2000ns(met_first_half)),
+                "swe_normalized_counts": [int(val) for val in summed_first],
+                "swe_counterstreaming_electrons": bde_first_half,
+            },
+        )
+        swe_data.append(
+            {
+                "apid": 478,
+                "met": met_second_half,
+                "met_in_utc": met_to_utc(met_second_half).split(".")[0],
+                "ttj2000ns": int(met_to_ttj2000ns(met_second_half)),
+                "swe_normalized_counts": [int(val) for val in summed_second],
+                "swe_counterstreaming_electrons": bde_second_half,
+            },
         )
 
     return swe_data

--- a/imap_processing/tests/ialirt/unit/test_process_swe.py
+++ b/imap_processing/tests/ialirt/unit/test_process_swe.py
@@ -176,7 +176,7 @@ def test_process_spacecraft_packet(
 
     swe_product = process_swe(sc_xarray_data, [in_flight_cal_file])
 
-    assert len(swe_product[0].keys()) == 7
+    assert len(swe_product[0].keys()) == 6
 
 
 def test_get_energy():
@@ -461,4 +461,4 @@ def test_process_swe(mock_read_cal, swe_test_data, fields_to_test):
     # TODO: add tests with test data here.
 
     # Check that all groups in the data are accounted for.
-    assert len(swe_data) == 912 // 60
+    assert len(swe_data) == 912 // 60 * 2


### PR DESCRIPTION
# Change Summary

## Overview
Had some feedback from Ruth about how to combine the data for the final data product. She wants:

1. Include only two quarter cycles to determine counterstreaming
2. Data products for each half-cycle

## Updated Files
- process_swe.py
   - Separate counterstreaming into half-cycles instead of combining them
   - Create separate entries for each half-cycle

## Testing
test_process_swe.py
