### PR TITLE
HIT L2 - Fix missing value for Ne particle

### DIFF
--- a/imap_processing/hit/l2/constants.py
+++ b/imap_processing/hit/l2/constants.py
@@ -169,7 +169,7 @@ STANDARD_PARTICLE_ENERGY_RANGE_MAPPING = {
         {"energy_min": 5.0, "energy_max": 6.0, "R2": [59], "R3": [], "R4": []},
         {"energy_min": 6.0, "energy_max": 8.0, "R2": [60], "R3": [63], "R4": []},
         {"energy_min": 8.0, "energy_max": 10.0, "R2": [61], "R3": [64], "R4": []},
-        {"energy_min": 10.0, "energy_max": 12.0, "R2": [], "R3": [65], "R4": []},
+        {"energy_min": 10.0, "energy_max": 12.0, "R2": [62], "R3": [65], "R4": []},
         {"energy_min": 12.0, "energy_max": 15.0, "R2": [], "R3": [66], "R4": []},
         {"energy_min": 15.0, "energy_max": 21.0, "R2": [], "R3": [67], "R4": []},
         {"energy_min": 21.0, "energy_max": 27.0, "R2": [], "R3": [68], "R4": []},

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -632,7 +632,7 @@ def process_summed_intensity(
             summed_intensity_dataset = add_total_uncertainties(
                 summed_intensity_dataset, var
             )
-            # Expand the variable name to include standard intensity
+            # Expand the variable name to include summed intensity
             summed_intensity_dataset = summed_intensity_dataset.rename(
                 {var: f"{var}_summed_intensity"}
             )


### PR DESCRIPTION
This PR makes a minor update to the standard intensity product to address a missing value needed for the Ne particle. The error was identified by HIT during validation of the product. The fix is simple by adding an R2 index value to the STANDARD_PARTICLE_ENERGY_RANGE_MAPPING dictionary.

Closes #1941 


