### PR TITLE
I-ALiRT - account for outages

### DIFF
--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 def generate_coverage(
     start_time: str,
+    outages: dict | None = None,
 ) -> dict[str, np.ndarray]:
     """
     Build the output dictionary containing coverage time for each station.
@@ -22,6 +23,8 @@ def generate_coverage(
     ----------
     start_time : str
         Start time in UTC.
+    outages : dict, optional
+        Dictionary of outages for each station.
 
     Returns
     -------
@@ -45,6 +48,13 @@ def generate_coverage(
     for station_name, (lon, lat, alt, min_elevation) in stations.items():
         azimuth, elevation = calculate_azimuth_and_elevation(lon, lat, alt, time_range)
         visible = elevation > min_elevation
+
+        if outages and station_name in outages:
+            for start, end in outages[station_name]:
+                start_et = str_to_et(start)
+                end_et = str_to_et(end)
+                visible[(time_range >= start_et) & (time_range <= end_et)] = False
+
         total_visible_mask |= visible
         time_utc = et_to_utc(time_range[visible], format_str="ISOC")
 

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+import numpy as np
 import pytest
 
 from imap_processing.ialirt.generate_coverage import generate_coverage
@@ -22,7 +23,7 @@ def test_generate_coverage(furnish_kernels):
         "earth_1962_240827_2124_combined.bpc",
     ]
     with furnish_kernels(kernels):
-        coverage_dict = generate_coverage("2026 SEP 22 00:00:00")
+        coverage_dict = generate_coverage("2026-09-22T00:00:00Z")
 
     start = datetime.strptime(coverage_dict["Kiel_time"][0], "%Y-%m-%dT%H:%M:%S.%f")
     end = datetime.strptime(coverage_dict["Kiel_time"][-1], "%Y-%m-%dT%H:%M:%S.%f")
@@ -32,3 +33,45 @@ def test_generate_coverage(furnish_kernels):
 
     # Coverage duration should be approximately 9 hours.
     assert hours == pytest.approx(9, abs=1)
+
+
+@pytest.mark.external_kernel
+def test_use_outages(furnish_kernels):
+    """
+    Test that outages are properly used.
+    """
+    # Note: tested this code with the Sun and achieved expected
+    # results ~12 hours of coverage from horizon to horizon.
+    kernels = [
+        "naif0012.tls",
+        "pck00011.tpc",
+        "de440s.bsp",
+        "imap_spk_demo.bsp",
+        "earth_1962_240827_2124_combined.bpc",
+    ]
+
+    outages = {
+        "Kiel": [
+            ("2026-09-22T11:50:00.00Z", "2026-09-22T12:10:00Z"),
+            ("2026-09-22T13:50:00.00Z", "2026-09-22T14:10:00Z"),
+            ("2026-09-23T11:50:00.00Z", "2026-09-23T12:10:00Z"),
+        ],
+    }
+
+    with furnish_kernels(kernels):
+        coverage_dict = generate_coverage("2026-09-22T00:00:00Z", outages)
+
+    expected = np.array(
+        [
+            "2026-09-22T07:00:00.000",
+            "2026-09-22T08:00:00.000",
+            "2026-09-22T09:00:00.000",
+            "2026-09-22T10:00:00.000",
+            "2026-09-22T11:00:00.000",
+            "2026-09-22T13:00:00.000",
+            "2026-09-22T15:00:00.000",
+            "2026-09-22T16:00:00.000",
+        ]
+    )
+
+    np.testing.assert_array_equal(coverage_dict["Kiel_time"], expected)


### PR DESCRIPTION
# Change Summary

## Overview
Updated coverage code to account for outages from ground stations. Note that the plan is to:
1. Add a s3 directory for outage text files
2. Create a cron job that looks for new text files and generates coverage text files for a date 30 days into the future and a date in which there is a new outage

Or something like that. See the next PR in sds-data-manager.

## Updated Files
- generage_coverage.py
   - Updated coverage code to account for outages from ground stations.

## Testing
- test_generage_coverage.py
