### PR TITLE
IDEX L2B rename attrs

### DIFF
--- a/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
@@ -4,28 +4,28 @@ double_fillval: &double_fillval -1.0E31
 
 # Label attributes
 mass_labels:
-  CATDESC: Labels for mass bins
-  FIELDNAM: Mass Bin Labels
+  CATDESC: Labels for Mass (kg)
+  FIELDNAM: Mass (kg)
   VAR_TYPE: metadata
   FORMAT: A8
-  DEPEND_1: mass_bins
+  DEPEND_1: mass
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 charge_labels:
-  CATDESC: Labels for impact charge bins
-  FIELDNAM: Impact Charge Bin Labels
+  CATDESC: Labels for Impact Charge (fC)
+  FIELDNAM: Impact Charge (fC)
   VAR_TYPE: metadata
   FORMAT: A8
-  DEPEND_1: impact_charge_bins
+  DEPEND_1: impact_charge
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 spin_phase_labels:
-    CATDESC: Labels for spin phase bins
-    FIELDNAM: Spin Phase Bin Labels
-    VAR_TYPE: metadata
-    FORMAT: A8
-    DEPEND_1: spin_phase_bins
-    DICT_KEY: SPASE>Support>SupportQuantity:Other
+  CATDESC: Labels for Spin Phase (deg)
+  FIELDNAM: Spin Phase (deg)
+  VAR_TYPE: metadata
+  FORMAT: A8
+  DEPEND_1: spin_phase
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 rectangular_lon_pixel_label:
   CATDESC: Longitude pixel index label for IDEX SkyMap.
@@ -40,26 +40,27 @@ rectangular_lat_pixel_label:
   FORMAT: A5
   VAR_TYPE: metadata
   DICT_KEY: SPASE>Support>SupportQuantity:Other
+
 # Index attributes
-mass_bins:
-  CATDESC: Log-spaced mass bins
-  FIELDNAM: Mass Bins
-  UNITS: " "
+mass:
+  CATDESC: Log-spaced mass
+  FIELDNAM: Mass (kg)
+  UNITS: kg
   FORMAT: I4
   VAR_TYPE: support_data
-  SCALETYP: linear
-  LABLAXIS: Mass Bins
+  SCALETYP: log
+  LABLAXIS: Mass (kg)
   VALIDMIN: 0
   VALIDMAX: 10
-  FILLVAL: *int_fillval
+  FILLVAL: *double_fillval
   LABL_PTR_1: mass_labels
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
-spin_phase_bins:
+spin_phase:
     CATDESC: The spacecraft spin phase at the time of detection
     VAR_NOTES: This is given in 4 bins [315-45, 45-135, 135-225, 225-315] degrees.
-    FIELDNAM: Spin Phase Bins
-    LABLAXIS: Spin Phase Bins
+    FIELDNAM: Spin Phase (deg)
+    LABLAXIS: Spin Phase (deg)
     VAR_TYPE: support_data
     SCALETYP: linear
     FILLVAL: *int_fillval
@@ -67,22 +68,21 @@ spin_phase_bins:
     VALIDMIN: 0
     VALIDMAX: 3
     LABL_PTR_1: spin_phase_labels
-    UNITS: " "
+    UNITS: deg
     DICT_KEY: SPASE>SupportQuantity:SpinPhase,Qualifier:Array
 
-impact_charge_bins:
-    CATDESC: Log-spaced impact charge bins
-    VAR_NOTES: Impact Charge Bins
-    FIELDNAM: Impact Charge Bins
-    LABLAXIS: Impact Charge Bins
+impact_charge:
+    CATDESC: Log-spaced impact charge
+    FIELDNAM: Impact Charge (fC)
+    LABLAXIS: Impact Charge (fC)
     VAR_TYPE: support_data
-    SCALETYP: linear
+    SCALETYP: log
     FILLVAL: *int_fillval
     FORMAT: I4
     VALIDMIN: 0
     VALIDMAX: 10
     LABL_PTR_1: spin_phase_labels
-    UNITS: " "
+    UNITS: fC
     DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 rectangular_lon_pixel:
@@ -114,8 +114,8 @@ base_charge: &base_charge
     CATDESC: " "
     FIELDNAM: " "
     DEPEND_0: epoch
-    DEPEND_1: impact_charge_bins
-    DEPEND_2: spin_phase_bins
+    DEPEND_1: impact_charge
+    DEPEND_2: spin_phase
     LABL_PTR_1: charge_labels
     LABL_PTR_2: spin_phase_labels
     DISPLAY_TYPE: spectrogram
@@ -129,8 +129,8 @@ base_mass: &base_mass
     CATDESC: " "
     FIELDNAM: " "
     DEPEND_0: epoch
-    DEPEND_1: mass_bins
-    DEPEND_2: spin_phase_bins
+    DEPEND_1: mass
+    DEPEND_2: spin_phase
     LABL_PTR_1: mass_labels
     LABL_PTR_2: spin_phase_labels
     DISPLAY_TYPE: spectrogram

--- a/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
@@ -157,7 +157,7 @@ base_mass_map: &base_mass_map
 rate_by_charge:
     <<: *base_charge
     CATDESC: Count rate per day by impact charge and spin phase.
-    FIELDNAM: Rate by Charge
+    FIELDNAM: Rate (day^-1) by Charge
     UNITS: day^-1
     FILLVAL: *double_fillval
     DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
@@ -165,7 +165,7 @@ rate_by_charge:
 rate_by_charge_map:
     <<: *base_charge_map
     CATDESC: Count rate per day by impact charge, longitude, and latitude.
-    FIELDNAM: Rate by Charge Map
+    FIELDNAM: Rate (day^-1) by Charge Map
     UNITS: day^-1
     FILLVAL: *double_fillval
     DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
@@ -173,7 +173,7 @@ rate_by_charge_map:
 rate_by_mass:
     <<: *base_mass
     CATDESC: Count rate per day by mass and spin phase.
-    FIELDNAM: Rate by Mass
+    FIELDNAM: Rate (day^-1) by Mass
     UNITS: day^-1
     FILLVAL: *double_fillval
     DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
@@ -181,7 +181,7 @@ rate_by_mass:
 rate_by_mass_map:
     <<: *base_mass_map
     CATDESC: Count rate per day by mass, longitude, and latitude.
-    FIELDNAM: Rate by Mass Map
+    FIELDNAM: Rate (day^-1) by Mass Map
     UNITS: day^-1
     FILLVAL: *double_fillval
     DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -133,8 +133,8 @@ def idex_l2b(
         daily_on_percentage,
     )
     # Create l2b Dataset
-    charge_bins = np.arange(len(CHARGE_BIN_EDGES))
-    mass_bins = np.arange(len(CHARGE_BIN_EDGES))
+    charge_bins = np.arange(len(CHARGE_BIN_EDGES) - 1)
+    mass_bins = np.arange(len(CHARGE_BIN_EDGES) - 1)
     spin_phase_bins = np.arange(len(SPIN_PHASE_BIN_EDGES) - 1)
     epoch = xr.DataArray(
         name="epoch",
@@ -332,20 +332,24 @@ def compute_counts_by_charge_and_mass(
         for each dataset, and a 1D array of daily epoch values.
     """
     # Initialize arrays to hold counts.
-    # There should be 4 spin phase bins, 11 charge bins, and 11 mass bins.
+    # There should be 4 spin phase bins, 10 charge bins, and 10 mass bins.
     # The first bin for charge and mass is for values below the first bin edge.
     counts_by_charge = np.zeros(
-        (len(epoch_doy_unique), len(CHARGE_BIN_EDGES), len(SPIN_PHASE_BIN_EDGES) - 1),
+        (
+            len(epoch_doy_unique),
+            len(CHARGE_BIN_EDGES) - 1,
+            len(SPIN_PHASE_BIN_EDGES) - 1,
+        ),
     )
     counts_by_mass = np.zeros(
-        (len(epoch_doy_unique), len(MASS_BIN_EDGES), len(SPIN_PHASE_BIN_EDGES) - 1),
+        (len(epoch_doy_unique), len(MASS_BIN_EDGES) - 1, len(SPIN_PHASE_BIN_EDGES) - 1),
     )
     # Initialize arrays to hold count maps. Each map is a 3 or 4D array with shape
-    # (epoch, 11 [charge or mass], 60 [longitude bins], 30 [latitude bins]).
+    # (epoch, 10 [charge or mass], 60 [longitude bins], 30 [latitude bins]).
     counts_by_charge_map = np.zeros(
         (
             len(epoch_doy_unique),
-            len(CHARGE_BIN_EDGES),
+            len(CHARGE_BIN_EDGES) - 1,
             len(LON_BINS_EDGES) - 1,
             len(LAT_BINS_EDGES) - 1,
         ),
@@ -353,7 +357,7 @@ def compute_counts_by_charge_and_mass(
     counts_by_mass_map = np.zeros(
         (
             len(epoch_doy_unique),
-            len(MASS_BIN_EDGES),
+            len(MASS_BIN_EDGES) - 1,
             len(LON_BINS_EDGES) - 1,
             len(LAT_BINS_EDGES) - 1,
         ),
@@ -391,9 +395,9 @@ def compute_counts_by_charge_and_mass(
         binned_latitude = np.clip(binned_latitude, 1, len(LAT_BINS_EDGES) - 1)
         # If the values in the array are beyond the bounds of bins, 0 or len(bins) it is
         # returned as such. In this case, the desired result is to place the values
-        # beyond the last bin into the last bin and keep the values below the first bin.
-        binned_charge = np.clip(binned_charge, 0, len(CHARGE_BIN_EDGES) - 1)
-        binned_mass = np.clip(binned_mass, 0, len(MASS_BIN_EDGES) - 1)
+        # beyond the first or last bin into the first or last bin, respectively.
+        binned_charge = np.clip(binned_charge, 1, len(CHARGE_BIN_EDGES) - 1)
+        binned_mass = np.clip(binned_mass, 1, len(MASS_BIN_EDGES) - 1)
 
         # Count dust events for each spin phase, mass bin, charge bin, and bin into
         # a rectangular grid
@@ -404,10 +408,10 @@ def compute_counts_by_charge_and_mass(
             binned_longitude,
             binned_latitude,
         ):
-            counts_by_mass[i, mass_bin, spin_phase_bin] += 1
-            counts_by_charge[i, charge_bin, spin_phase_bin] += 1
-            counts_by_mass_map[i, mass_bin, lon_bin - 1, lat_bin - 1] += 1
-            counts_by_charge_map[i, charge_bin, lon_bin - 1, lat_bin - 1] += 1
+            counts_by_mass[i, mass_bin - 1, spin_phase_bin] += 1
+            counts_by_charge[i, charge_bin - 1, spin_phase_bin] += 1
+            counts_by_mass_map[i, mass_bin - 1, lon_bin - 1, lat_bin - 1] += 1
+            counts_by_charge_map[i, charge_bin - 1, lon_bin - 1, lat_bin - 1] += 1
 
     return (
         counts_by_charge,

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -142,7 +142,7 @@ def idex_l2b(
         dims="epoch",
         attrs=idex_attrs.get_variable_attributes("epoch", check_schema=False),
     )
-    vars = {
+    data_vars = {
         "impact_day_of_year": xr.DataArray(
             name="impact_day_of_year",
             data=epoch_doy_unique,
@@ -158,7 +158,7 @@ def idex_l2b(
         "charge_labels": xr.DataArray(
             name="impact_charge_labels",
             data=charge_bins.astype(str),
-            dims="impact_charge_bins",
+            dims="impact_charge",
             attrs=idex_attrs.get_variable_attributes(
                 "charge_labels", check_schema=False
             ),
@@ -166,7 +166,7 @@ def idex_l2b(
         "spin_phase_labels": xr.DataArray(
             name="spin_phase_labels",
             data=spin_phase_bins.astype(str),
-            dims="spin_phase_bins",
+            dims="spin_phase",
             attrs=idex_attrs.get_variable_attributes(
                 "spin_phase_labels", check_schema=False
             ),
@@ -174,7 +174,7 @@ def idex_l2b(
         "mass_labels": xr.DataArray(
             name="mass_labels",
             data=mass_bins.astype(str),
-            dims="mass_bins",
+            dims="mass",
             attrs=idex_attrs.get_variable_attributes("mass_labels", check_schema=False),
         ),
         "rectangular_lon_pixel_label": xr.DataArray(
@@ -193,27 +193,25 @@ def idex_l2b(
                 "rectangular_lat_pixel_label", check_schema=False
             ),
         ),
-        "impact_charge_bins": xr.DataArray(
-            name="impact_charge_bins",
+        "impact_charge": xr.DataArray(
+            name="impact_charge",
             data=charge_bins,
-            dims="impact_charge_bins",
+            dims="impact_charge",
             attrs=idex_attrs.get_variable_attributes(
-                "impact_charge_bins", check_schema=False
+                "impact_charge", check_schema=False
             ),
         ),
-        "mass_bins": xr.DataArray(
-            name="mass_bins",
+        "mass": xr.DataArray(
+            name="mass",
             data=mass_bins,
-            dims="mass_bins",
-            attrs=idex_attrs.get_variable_attributes("mass_bins", check_schema=False),
+            dims="mass",
+            attrs=idex_attrs.get_variable_attributes("mass", check_schema=False),
         ),
-        "spin_phase_bins": xr.DataArray(
-            name="spin_phase_bins",
+        "spin_phase": xr.DataArray(
+            name="spin_phase",
             data=spin_phase_bins,
-            dims="spin_phase_bins",
-            attrs=idex_attrs.get_variable_attributes(
-                "spin_phase_bins", check_schema=False
-            ),
+            dims="spin_phase",
+            attrs=idex_attrs.get_variable_attributes("spin_phase", check_schema=False),
         ),
         "rectangular_lon_pixel": xr.DataArray(
             name="rectangular_lon_pixel",
@@ -234,25 +232,25 @@ def idex_l2b(
         "counts_by_charge": xr.DataArray(
             name="counts_by_charge",
             data=counts_by_charge.astype(np.int64),
-            dims=("epoch", "impact_charge_bins", "spin_phase_bins"),
+            dims=("epoch", "impact_charge", "spin_phase"),
             attrs=idex_attrs.get_variable_attributes("counts_by_charge"),
         ),
         "counts_by_mass": xr.DataArray(
             name="counts_by_mass",
             data=counts_by_mass.astype(np.int64),
-            dims=("epoch", "mass_bins", "spin_phase_bins"),
+            dims=("epoch", "mass", "spin_phase"),
             attrs=idex_attrs.get_variable_attributes("counts_by_mass"),
         ),
         "rate_by_charge": xr.DataArray(
             name="rate_by_charge",
             data=rate_by_charge,
-            dims=("epoch", "impact_charge_bins", "spin_phase_bins"),
+            dims=("epoch", "impact_charge", "spin_phase"),
             attrs=idex_attrs.get_variable_attributes("rate_by_charge"),
         ),
         "rate_by_mass": xr.DataArray(
             name="rate_by_mass",
             data=rate_by_mass,
-            dims=("epoch", "mass_bins", "spin_phase_bins"),
+            dims=("epoch", "mass", "spin_phase"),
             attrs=idex_attrs.get_variable_attributes("rate_by_mass"),
         ),
         "counts_by_charge_map": xr.DataArray(
@@ -260,7 +258,7 @@ def idex_l2b(
             data=counts_by_charge_map.astype(np.int64),
             dims=(
                 "epoch",
-                "impact_charge_bins",
+                "impact_charge",
                 "rectangular_lon_pixel",
                 "rectangular_lat_pixel",
             ),
@@ -271,7 +269,7 @@ def idex_l2b(
             data=counts_by_mass_map.astype(np.int64),
             dims=(
                 "epoch",
-                "mass_bins",
+                "mass",
                 "rectangular_lon_pixel",
                 "rectangular_lat_pixel",
             ),
@@ -282,7 +280,7 @@ def idex_l2b(
             data=rate_by_charge_map,
             dims=(
                 "epoch",
-                "impact_charge_bins",
+                "impact_charge",
                 "rectangular_lon_pixel",
                 "rectangular_lat_pixel",
             ),
@@ -293,7 +291,7 @@ def idex_l2b(
             data=rate_by_mass_map,
             dims=(
                 "epoch",
-                "mass_bins",
+                "mass",
                 "rectangular_lon_pixel",
                 "rectangular_lat_pixel",
             ),
@@ -302,7 +300,7 @@ def idex_l2b(
     }
     l2b_dataset = xr.Dataset(
         coords={"epoch": epoch},
-        data_vars=vars,
+        data_vars=data_vars,
         attrs=idex_attrs.get_global_attributes("imap_idex_l2b_sci"),
     )
 

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -181,12 +181,12 @@ def test_compute_counts_by_charge_and_mass():
 
     expected_shape = (
         len(epoch_doy_unique),
-        len(CHARGE_BIN_EDGES),
+        len(CHARGE_BIN_EDGES) - 1,
         len(SPIN_PHASE_BIN_EDGES) - 1,
     )
     expected_map_shape = (
         len(epoch_doy_unique),
-        len(CHARGE_BIN_EDGES),
+        len(CHARGE_BIN_EDGES) - 1,
         len(SKY_GRID.az_bin_edges) - 1,
         len(SKY_GRID.el_bin_edges) - 1,
     )
@@ -200,15 +200,15 @@ def test_compute_counts_by_charge_and_mass():
     expected_array = np.zeros(expected_shape)
     expected_map_array = np.zeros(expected_map_shape)
     # Add ones where we expect counts
-    expected_array[0, 1:3, 0] = 1
-    expected_array[1, 3:5, 0] = 1
-    expected_array[2, 5, 0] = 1
-    expected_array[3, 6, 0] = 1
+    expected_array[0, 0:2, 0] = 1
+    expected_array[1, 2:4, 0] = 1
+    expected_array[2, 4, 0] = 1
+    expected_array[3, 5, 0] = 1
     # Add ones where we expect counts for the map
-    expected_map_array[0, 1:3, 0, 15] = 1
-    expected_map_array[1, 3:5, 0, 15] = 1
-    expected_map_array[2, 5, 0, 15] = 1
-    expected_map_array[3, 6, 0, 15] = 1
+    expected_map_array[0, 0:2, 0, 15] = 1
+    expected_map_array[1, 2:4, 0, 15] = 1
+    expected_map_array[2, 4, 0, 15] = 1
+    expected_map_array[3, 5, 0, 15] = 1
     # assert that the counts are as expected
     np.testing.assert_array_equal(counts_by_charge, expected_array)
     np.testing.assert_array_equal(counts_by_mass, expected_array)
@@ -252,12 +252,12 @@ def test_compute_counts_by_charge_and_mass_out_of_bounds():
 
     expected_shape = (
         len(epoch_doy_unique),
-        len(CHARGE_BIN_EDGES),
+        len(CHARGE_BIN_EDGES) - 1,
         len(SPIN_PHASE_BIN_EDGES) - 1,
     )
     expected_map_shape = (
         len(epoch_doy_unique),
-        len(CHARGE_BIN_EDGES),
+        len(CHARGE_BIN_EDGES) - 1,
         len(SKY_GRID.az_bin_edges) - 1,
         len(SKY_GRID.el_bin_edges) - 1,
     )
@@ -272,10 +272,10 @@ def test_compute_counts_by_charge_and_mass_out_of_bounds():
     expected_map_array = np.zeros(expected_map_shape)
     # Add ones where we expect counts
     expected_array[0, 0, 0] = 1
-    expected_array[1, len(CHARGE_BIN_EDGES) - 1, 0] = 1
+    expected_array[1, len(CHARGE_BIN_EDGES) - 2, 0] = 1
     # Add ones where we expect counts for the map
     expected_map_array[0, 0, 0, 0] = 1
-    expected_map_array[1, len(CHARGE_BIN_EDGES) - 1, 0, 29] = 1
+    expected_map_array[1, len(CHARGE_BIN_EDGES) - 2, 0, 29] = 1
     # assert that the counts are as expected
     np.testing.assert_array_equal(counts_by_charge, expected_array)
     np.testing.assert_array_equal(counts_by_mass, expected_array)

--- a/imap_processing/tests/idex/test_idex_l2c.py
+++ b/imap_processing/tests/idex/test_idex_l2c.py
@@ -46,8 +46,8 @@ def test_l2c_attrs_and_vars(l2c_dataset: xr.Dataset, l2a_dataset: xr.Dataset):
     )
     assert l2c_dataset.sizes == {
         "epoch": 2,
-        "impact_charge_bins": 10,
-        "mass_bins": 10,
+        "impact_charge": 10,
+        "mass": 10,
         "rectangular_lon_pixel": int(360 / IDEX_SPACING_DEG),
         "rectangular_lat_pixel": int(180 / IDEX_SPACING_DEG),
     }

--- a/imap_processing/tests/idex/test_idex_l2c.py
+++ b/imap_processing/tests/idex/test_idex_l2c.py
@@ -46,8 +46,8 @@ def test_l2c_attrs_and_vars(l2c_dataset: xr.Dataset, l2a_dataset: xr.Dataset):
     )
     assert l2c_dataset.sizes == {
         "epoch": 2,
-        "impact_charge_bins": 11,
-        "mass_bins": 11,
+        "impact_charge_bins": 10,
+        "mass_bins": 10,
         "rectangular_lon_pixel": int(360 / IDEX_SPACING_DEG),
         "rectangular_lat_pixel": int(180 / IDEX_SPACING_DEG),
     }


### PR DESCRIPTION
# Change Summary

## Overview
The IDEX team requested some attributes to be renamed. They also requested there to be 10 bins for mass and charge. 

Email from Jamey: 

1) For the depend_1 labels and variables, please use calibrated units instead of “bin” names, with the units in parenthesis going to the associated UNITS variable :

Mass (kg) : scaletyp = log
Charge (fC) : scaletyp = log
Spin phase (deg) : scaletyp = linear


2) For variable attribute labels, please use:
lablaxis = ‘Imp. Rate (day^-1)’

3) Suggest keeping 10 bins, doing something special for the bottom bin to include all lower values.


****NOTE - I have sent a follow up email about request number 2 because for variables with more than one dimension it requires LABL_PTR_1 and LABL_PTR_2 instead of LABLAXIS. The LABL_PTRs are just the string bin numbers so I was confused how to handle this. 

## Updated Files
- imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
   - Update Attrs 
- imap_processing/idex/idex_l2b.py
   - Clip mass and charge arrays so there are only 10 bins

## Testing
Fix tests to work with the 10 bins. 