### PR TITLE
Add k-factor to CoDICE L1 datasets

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -295,7 +295,7 @@ energy_table:
     VAR_TYPE: support_data
 
 k_factor:
-    CATDESC: K Factor
+    CATDESC: K Factor constant that is used to convert voltages to energies
     FIELDNAM: K Factor
     FORMAT: F5.2
     LABLAXIS: K Factor

--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -294,6 +294,17 @@ energy_table:
     VALIDMAX: 14100.0
     VAR_TYPE: support_data
 
+k_factor:
+    CATDESC: K Factor
+    FIELDNAM: K Factor
+    FORMAT: F5.2
+    LABLAXIS: K Factor
+    SCALETYP: linear
+    UNITS: " "
+    VALIDMIN: 1.0
+    VALIDMAX: 100.0
+    VAR_TYPE: support_data
+
 nso_half_spin:
     <<: *default
     CATDESC: When No Scan Operation (NSO) was activated

--- a/imap_processing/cdf/config/imap_codice_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1b_variable_attrs.yaml
@@ -295,6 +295,17 @@ energy_table:
     VALIDMAX: 14100.0
     VAR_TYPE: support_data
 
+k_factor:
+    CATDESC: K Factor
+    FIELDNAM: K Factor
+    FORMAT: F5.2
+    LABLAXIS: K Factor
+    SCALETYP: linear
+    UNITS: " "
+    VALIDMIN: 1.0
+    VALIDMAX: 100.0
+    VAR_TYPE: support_data
+
 nso_half_spin:
     <<: *default
     CATDESC: When No Scan Operation (NSO) was activated

--- a/imap_processing/cdf/config/imap_codice_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1b_variable_attrs.yaml
@@ -296,7 +296,7 @@ energy_table:
     VAR_TYPE: support_data
 
 k_factor:
-    CATDESC: K Factor
+    CATDESC: K Factor constant that is used to convert voltages to energies
     FIELDNAM: K Factor
     FORMAT: F5.2
     LABLAXIS: K Factor

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -405,6 +405,12 @@ class CoDICEL1aPipeline:
                 dims = ["epoch"]
                 attrs = self.cdf_attrs.get_variable_attributes("spin_period")
 
+            # THe k-factor is a constant that maps voltages to energies
+            elif variable_name == "k_factor":
+                variable_data = np.array([constants.K_FACTOR], dtype=np.float32)
+                dims = [""]
+                attrs = self.cdf_attrs.get_variable_attributes("k_factor")
+
             # Add variable to the dataset
             dataset[variable_name] = xr.DataArray(
                 variable_data,

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -405,7 +405,7 @@ class CoDICEL1aPipeline:
                 dims = ["epoch"]
                 attrs = self.cdf_attrs.get_variable_attributes("spin_period")
 
-            # THe k-factor is a constant that maps voltages to energies
+            # The k-factor is a constant that maps voltages to energies
             elif variable_name == "k_factor":
                 variable_data = np.array([constants.K_FACTOR], dtype=np.float32)
                 dims = [""]

--- a/imap_processing/codice/constants.py
+++ b/imap_processing/codice/constants.py
@@ -59,6 +59,7 @@ CODICEAPID_MAPPING = {
 
 # Numerical constants
 SPIN_PERIOD_CONVERSION = 0.00032
+K_FACTOR = 5.76
 
 # CDF variable names used for lo data products
 LO_COUNTERS_SINGLES_VARIABLE_NAMES = ["apd_singles"]
@@ -504,6 +505,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_IALIRT_VARIABLE_NAMES,
     },
@@ -523,6 +525,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_COUNTERS_AGGREGATED_VARIABLE_NAMES,
     },
@@ -540,6 +543,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_COUNTERS_SINGLES_VARIABLE_NAMES,
     },
@@ -557,6 +561,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_SW_ANGULAR_VARIABLE_NAMES,
     },
@@ -574,6 +579,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_NSW_ANGULAR_VARIABLE_NAMES,
     },
@@ -591,6 +597,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_SW_PRIORITY_VARIABLE_NAMES,
     },
@@ -608,6 +615,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_NSW_PRIORITY_VARIABLE_NAMES,
     },
@@ -625,6 +633,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_SW_SPECIES_VARIABLE_NAMES,
     },
@@ -642,6 +651,7 @@ DATA_PRODUCT_CONFIGURATIONS: dict[CODICEAPID | int, dict] = {
             "st_bias_gain_mode",
             "data_quality",
             "spin_period",
+            "k_factor",
         ],
         "variable_names": LO_NSW_SPECIES_VARIABLE_NAMES,
     },

--- a/imap_processing/codice/constants.py
+++ b/imap_processing/codice/constants.py
@@ -59,7 +59,7 @@ CODICEAPID_MAPPING = {
 
 # Numerical constants
 SPIN_PERIOD_CONVERSION = 0.00032
-K_FACTOR = 5.76
+K_FACTOR = 5.76  # This is used to convert voltages to energies in L2
 
 # CDF variable names used for lo data products
 LO_COUNTERS_SINGLES_VARIABLE_NAMES = ["apd_singles"]

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -74,16 +74,16 @@ EXPECTED_HI_OMNI_ARRAY_SHAPES = {
 
 EXPECTED_NUM_VARIABLES = [
     3,  # hi-ialirt
-    17,  # lo-ialirt
+    18,  # lo-ialirt
     139,  # hskp
-    8 + len(constants.LO_COUNTERS_AGGREGATED_VARIABLE_NAMES),  # lo-counters-aggregated
-    9,  # lo-counters-singles
-    13,  # lo-sw-priority
-    10,  # lo-nsw-priority
-    24,  # lo-sw-species
-    16,  # lo-nsw-species
-    12,  # lo-sw-angular
-    9,  # lo-nsw-angular
+    9 + len(constants.LO_COUNTERS_AGGREGATED_VARIABLE_NAMES),  # lo-counters-aggregated
+    10,  # lo-counters-singles
+    14,  # lo-sw-priority
+    11,  # lo-nsw-priority
+    25,  # lo-sw-species
+    17,  # lo-nsw-species
+    13,  # lo-sw-angular
+    10,  # lo-nsw-angular
     2 + len(constants.HI_COUNTERS_AGGREGATED_VARIABLE_NAMES),  # hi-counters-aggregated
     5,  # hi-counters-singles
     11,  # hi-omni
@@ -176,6 +176,9 @@ def test_l1a_data_array_shape(test_l1a_data, index):
             # For some direct event variables:
             elif re.match(r"P[0-7]_(NumEvents|DataQuality)", variable):
                 assert processed_dataset[variable].data.shape == (77,)
+            # For the k-factor
+            elif variable == "k_factor":
+                assert processed_dataset[variable].data.shape == (1,)
             # For nominal variables
             else:
                 assert processed_dataset[variable].data.shape == expected_shape


### PR DESCRIPTION
This PR adds a `k_factor` data variable to CoDICE L1 datasets. This is a constant that will be used to convert voltages to energies in L2 processing.

Closes #1948 