### PR TITLE
CoDICE: Change energy bin deltas to delta minus and delta plus

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -506,10 +506,15 @@ hi-ialirt-energy_h:
     DELTA_MINUS_VAR: energy_h_delta
     DELTA_PLUS_VAR: energy_h_delta
 
-hi-ialirt-energy_h_delta:
+hi-ialirt-energy_h_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for h
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for h
+    FIELDNAM: Energy Delta Minus
+
+hi-ialirt-energy_h_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for h
+    FIELDNAM: Energy Delta Plus
 
 # hi-omni
 hi-omni-h:
@@ -525,10 +530,15 @@ hi-omni-energy_h:
     DELTA_MINUS_VAR: energy_h_delta
     DELTA_PLUS_VAR: energy_h_delta
 
-hi-omni-energy_h_delta:
+hi-omni-energy_h_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for h
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for h
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_h_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for h
+    FIELDNAM: Energy Delta Plus
 
 hi-omni-he3:
     <<: *counters
@@ -543,10 +553,15 @@ hi-omni-energy_he3:
     DELTA_MINUS_VAR: energy_he3_delta
     DELTA_PLUS_VAR: energy_he3_delta
 
-hi-omni-energy_he3_delta:
+hi-omni-energy_he3_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for he3
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for he3
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_he3_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for he3
+    FIELDNAM: Energy Delta Plus
 
 hi-omni-he4:
     <<: *counters
@@ -561,10 +576,15 @@ hi-omni-energy_he4:
     DELTA_MINUS_VAR: energy_he4_delta
     DELTA_PLUS_VAR: energy_he4_delta
 
-hi-omni-energy_he4_delta:
+hi-omni-energy_he4_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for he4
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for he4
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_he4_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for he4
+    FIELDNAM: Energy Delta Plus
 
 hi-omni-c:
     <<: *counters
@@ -579,10 +599,15 @@ hi-omni-energy_c:
     DELTA_MINUS_VAR: energy_c_delta
     DELTA_PLUS_VAR: energy_c_delta
 
-hi-omni-energy_c_delta:
+hi-omni-energy_c_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for c
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for c
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_c_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for c
+    FIELDNAM: Energy Delta Plus
 
 hi-omni-o:
     <<: *counters
@@ -597,10 +622,15 @@ hi-omni-energy_o:
     DELTA_MINUS_VAR: energy_o_delta
     DELTA_PLUS_VAR: energy_o_delta
 
-hi-omni-energy_o_delta:
+hi-omni-energy_o_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for o
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for o
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_o_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for o
+    FIELDNAM: Energy Delta Plus
 
 hi-omni-ne_mg_si:
     <<: *counters
@@ -615,10 +645,15 @@ hi-omni-energy_ne_mg_si:
     DELTA_MINUS_VAR: energy_ne_mg_si_delta
     DELTA_PLUS_VAR: energy_ne_mg_si_delta
 
-hi-omni-energy_ne_mg_si_delta:
+hi-omni-energy_ne_mg_si_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for ne_mg_si
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for ne_mg_si
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_ne_mg_si_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for ne_mg_si
+    FIELDNAM: Energy Delta Plus
 
 hi-omni-fe:
     <<: *counters
@@ -633,10 +668,15 @@ hi-omni-energy_fe:
     DELTA_MINUS_VAR: energy_fe_delta
     DELTA_PLUS_VAR: energy_fe_delta
 
-hi-omni-energy_fe_delta:
+hi-omni-energy_fe_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for fe
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for fe
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_fe_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for fe
+    FIELDNAM: Energy Delta Plus
 
 hi-omni-uh:
     <<: *counters
@@ -651,10 +691,15 @@ hi-omni-energy_uh:
     DELTA_MINUS_VAR: energy_uh_delta
     DELTA_PLUS_VAR: energy_uh_delta
 
-hi-omni-energy_uh_delta:
+hi-omni-energy_uh_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for uh
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for uh
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_uh_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for uh
+    FIELDNAM: Energy Delta Plus
 
 hi-omni-junk:
     <<: *counters
@@ -669,10 +714,15 @@ hi-omni-energy_junk:
     DELTA_MINUS_VAR: energy_junk_delta
     DELTA_PLUS_VAR: energy_junk_delta
 
-hi-omni-energy_junk_delta:
+hi-omni-energy_junk_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for junk
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for junk
+    FIELDNAM: Energy Delta Minus
+
+hi-omni-energy_junk_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for junk
+    FIELDNAM: Energy Delta Plus
 
 # hi-priority
 hi-priority-Priority0:
@@ -723,10 +773,15 @@ hi-sectored-energy_h:
     DELTA_MINUS_VAR: energy_h_delta
     DELTA_PLUS_VAR: energy_h_delta
 
-hi-sectored-energy_h_delta:
+hi-sectored-energy_h_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for H
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for h
+    FIELDNAM: Energy Delta Minus
+
+hi-sectored-energy_h_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for h
+    FIELDNAM: Energy Delta Plus
 
 hi-sectored-he3he4:
     <<: *counters
@@ -745,10 +800,15 @@ hi-sectored-energy_he3he4:
     DELTA_MINUS_VAR: energy_he3he4_delta
     DELTA_PLUS_VAR: energy_he3he4_delta
 
-hi-sectored-energy_he3he4_delta:
+hi-sectored-energy_he3he4_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for He3He4
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for he3he4
+    FIELDNAM: Energy Delta Minus
+
+hi-sectored-energy_he3he3_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for he3he3
+    FIELDNAM: Energy Delta Plus
 
 hi-sectored-cno:
     <<: *counters
@@ -767,10 +827,15 @@ hi-sectored-energy_cno:
     DELTA_MINUS_VAR: energy_cno_delta
     DELTA_PLUS_VAR: energy_cno_delta
 
-hi-sectored-energy_cno_delta:
+hi-sectored-energy_cno_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for CNO
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for cno
+    FIELDNAM: Energy Delta Minus
+
+hi-sectored-energy_cno_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for cno
+    FIELDNAM: Energy Delta Plus
 
 hi-sectored-fe:
     <<: *counters
@@ -789,10 +854,15 @@ hi-sectored-energy_fe:
     DELTA_MINUS_VAR: energy_fe_delta
     DELTA_PLUS_VAR: energy_fe_delta
 
-hi-sectored-energy_fe_delta:
+hi-sectored-energy_fe_minus:
     <<: *hi_energies_default
-    CATDESC: Delta of energies for Fe
-    FIELDNAM: Delta Energy
+    CATDESC: Energy Table Minus Value for fe
+    FIELDNAM: Energy Delta Minus
+
+hi-sectored-energy_fe_plus:
+    <<: *hi_energies_default
+    CATDESC: Energy Table Plus Value for fe
+    FIELDNAM: Energy Delta Plus
 
 # lo-counters-aggregated
 lo-counters-aggregated-TCR:

--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -503,8 +503,8 @@ hi-ialirt-h:
 hi-ialirt-energy_h:
     <<: *hi_energies_default
     CATDESC: Energy Table for h
-    DELTA_MINUS_VAR: energy_h_delta
-    DELTA_PLUS_VAR: energy_h_delta
+    DELTA_MINUS_VAR: energy_h_minus
+    DELTA_PLUS_VAR: energy_h_plus
 
 hi-ialirt-energy_h_minus:
     <<: *hi_energies_default
@@ -527,8 +527,8 @@ hi-omni-h:
 hi-omni-energy_h:
     <<: *hi_energies_default
     CATDESC: Energy Table for h
-    DELTA_MINUS_VAR: energy_h_delta
-    DELTA_PLUS_VAR: energy_h_delta
+    DELTA_MINUS_VAR: energy_h_minus
+    DELTA_PLUS_VAR: energy_h_plus
 
 hi-omni-energy_h_minus:
     <<: *hi_energies_default
@@ -550,8 +550,8 @@ hi-omni-he3:
 hi-omni-energy_he3:
     <<: *hi_energies_default
     CATDESC: Energy Table for he3
-    DELTA_MINUS_VAR: energy_he3_delta
-    DELTA_PLUS_VAR: energy_he3_delta
+    DELTA_MINUS_VAR: energy_he3_minus
+    DELTA_PLUS_VAR: energy_he3_plus
 
 hi-omni-energy_he3_minus:
     <<: *hi_energies_default
@@ -573,8 +573,8 @@ hi-omni-he4:
 hi-omni-energy_he4:
     <<: *hi_energies_default
     CATDESC: Energy Table for he4
-    DELTA_MINUS_VAR: energy_he4_delta
-    DELTA_PLUS_VAR: energy_he4_delta
+    DELTA_MINUS_VAR: energy_he4_minus
+    DELTA_PLUS_VAR: energy_he4_plus
 
 hi-omni-energy_he4_minus:
     <<: *hi_energies_default
@@ -596,8 +596,8 @@ hi-omni-c:
 hi-omni-energy_c:
     <<: *hi_energies_default
     CATDESC: Energy Table for c
-    DELTA_MINUS_VAR: energy_c_delta
-    DELTA_PLUS_VAR: energy_c_delta
+    DELTA_MINUS_VAR: energy_c_minus
+    DELTA_PLUS_VAR: energy_c_plus
 
 hi-omni-energy_c_minus:
     <<: *hi_energies_default
@@ -619,8 +619,8 @@ hi-omni-o:
 hi-omni-energy_o:
     <<: *hi_energies_default
     CATDESC: Energy Table for o
-    DELTA_MINUS_VAR: energy_o_delta
-    DELTA_PLUS_VAR: energy_o_delta
+    DELTA_MINUS_VAR: energy_o_minus
+    DELTA_PLUS_VAR: energy_o_plus
 
 hi-omni-energy_o_minus:
     <<: *hi_energies_default
@@ -642,8 +642,8 @@ hi-omni-ne_mg_si:
 hi-omni-energy_ne_mg_si:
     <<: *hi_energies_default
     CATDESC: Energy Table for ne_mg_si
-    DELTA_MINUS_VAR: energy_ne_mg_si_delta
-    DELTA_PLUS_VAR: energy_ne_mg_si_delta
+    DELTA_MINUS_VAR: energy_ne_mg_si_minus
+    DELTA_PLUS_VAR: energy_ne_mg_si_plus
 
 hi-omni-energy_ne_mg_si_minus:
     <<: *hi_energies_default
@@ -665,8 +665,8 @@ hi-omni-fe:
 hi-omni-energy_fe:
     <<: *hi_energies_default
     CATDESC: Energy Table for fe
-    DELTA_MINUS_VAR: energy_fe_delta
-    DELTA_PLUS_VAR: energy_fe_delta
+    DELTA_MINUS_VAR: energy_fe_minus
+    DELTA_PLUS_VAR: energy_fe_plus
 
 hi-omni-energy_fe_minus:
     <<: *hi_energies_default
@@ -688,8 +688,8 @@ hi-omni-uh:
 hi-omni-energy_uh:
     <<: *hi_energies_default
     CATDESC: Energy Table for uh
-    DELTA_MINUS_VAR: energy_uh_delta
-    DELTA_PLUS_VAR: energy_uh_delta
+    DELTA_MINUS_VAR: energy_uh_minus
+    DELTA_PLUS_VAR: energy_uh_plus
 
 hi-omni-energy_uh_minus:
     <<: *hi_energies_default
@@ -711,8 +711,8 @@ hi-omni-junk:
 hi-omni-energy_junk:
     <<: *hi_energies_default
     CATDESC: Energy Table for junk
-    DELTA_MINUS_VAR: energy_junk_delta
-    DELTA_PLUS_VAR: energy_junk_delta
+    DELTA_MINUS_VAR: energy_junk_minus
+    DELTA_PLUS_VAR: energy_junk_plus
 
 hi-omni-energy_junk_minus:
     <<: *hi_energies_default
@@ -770,8 +770,8 @@ hi-sectored-h:
 hi-sectored-energy_h:
     <<: *hi_energies_default
     CATDESC: Energy Table for H
-    DELTA_MINUS_VAR: energy_h_delta
-    DELTA_PLUS_VAR: energy_h_delta
+    DELTA_MINUS_VAR: energy_h_minus
+    DELTA_PLUS_VAR: energy_h_plus
 
 hi-sectored-energy_h_minus:
     <<: *hi_energies_default
@@ -797,8 +797,8 @@ hi-sectored-he3he4:
 hi-sectored-energy_he3he4:
     <<: *hi_energies_default
     CATDESC: Energy Table for He3He4
-    DELTA_MINUS_VAR: energy_he3he4_delta
-    DELTA_PLUS_VAR: energy_he3he4_delta
+    DELTA_MINUS_VAR: energy_he3he4_minus
+    DELTA_PLUS_VAR: energy_he3he4_plus
 
 hi-sectored-energy_he3he4_minus:
     <<: *hi_energies_default
@@ -824,8 +824,8 @@ hi-sectored-cno:
 hi-sectored-energy_cno:
     <<: *hi_energies_default
     CATDESC: Energy Table for CNO
-    DELTA_MINUS_VAR: energy_cno_delta
-    DELTA_PLUS_VAR: energy_cno_delta
+    DELTA_MINUS_VAR: energy_cno_minus
+    DELTA_PLUS_VAR: energy_cno_plus
 
 hi-sectored-energy_cno_minus:
     <<: *hi_energies_default
@@ -851,8 +851,8 @@ hi-sectored-fe:
 hi-sectored-energy_fe:
     <<: *hi_energies_default
     CATDESC: Energy Table for Fe
-    DELTA_MINUS_VAR: energy_fe_delta
-    DELTA_PLUS_VAR: energy_fe_delta
+    DELTA_MINUS_VAR: energy_fe_minus
+    DELTA_PLUS_VAR: energy_fe_plus
 
 hi-sectored-energy_fe_minus:
     <<: *hi_energies_default

--- a/imap_processing/cdf/config/imap_codice_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1b_variable_attrs.yaml
@@ -504,8 +504,8 @@ hi-ialirt-h:
 hi-ialirt-energy_h:
     <<: *hi_energies_default
     CATDESC: Energy Table for h
-    DELTA_MINUS_VAR: energy_h_delta
-    DELTA_PLUS_VAR: energy_h_delta
+    DELTA_MINUS_VAR: energy_h_minus
+    DELTA_PLUS_VAR: energy_h_plus
 
 hi-ialirt-energy_h_delta:
     <<: *hi_energies_default
@@ -523,8 +523,8 @@ hi-omni-h:
 hi-omni-energy_h:
     <<: *hi_energies_default
     CATDESC: Energy Table for h
-    DELTA_MINUS_VAR: energy_h_delta
-    DELTA_PLUS_VAR: energy_h_delta
+    DELTA_MINUS_VAR: energy_h_minus
+    DELTA_PLUS_VAR: energy_h_plus
 
 hi-omni-energy_h_delta:
     <<: *hi_energies_default
@@ -541,8 +541,8 @@ hi-omni-he3:
 hi-omni-energy_he3:
     <<: *hi_energies_default
     CATDESC: Energy Table for he3
-    DELTA_MINUS_VAR: energy_he3_delta
-    DELTA_PLUS_VAR: energy_he3_delta
+    DELTA_MINUS_VAR: energy_he3_minus
+    DELTA_PLUS_VAR: energy_he3_plus
 
 hi-omni-energy_he3_delta:
     <<: *hi_energies_default
@@ -559,8 +559,8 @@ hi-omni-he4:
 hi-omni-energy_he4:
     <<: *hi_energies_default
     CATDESC: Energy Table for he4
-    DELTA_MINUS_VAR: energy_he4_delta
-    DELTA_PLUS_VAR: energy_he4_delta
+    DELTA_MINUS_VAR: energy_he4_minus
+    DELTA_PLUS_VAR: energy_he4_plus
 
 hi-omni-energy_he4_delta:
     <<: *hi_energies_default
@@ -577,8 +577,8 @@ hi-omni-c:
 hi-omni-energy_c:
     <<: *hi_energies_default
     CATDESC: Energy Table for c
-    DELTA_MINUS_VAR: energy_c_delta
-    DELTA_PLUS_VAR: energy_c_delta
+    DELTA_MINUS_VAR: energy_c_minus
+    DELTA_PLUS_VAR: energy_c_plus
 
 hi-omni-energy_c_delta:
     <<: *hi_energies_default
@@ -595,8 +595,8 @@ hi-omni-o:
 hi-omni-energy_o:
     <<: *hi_energies_default
     CATDESC: Energy Table for o
-    DELTA_MINUS_VAR: energy_o_delta
-    DELTA_PLUS_VAR: energy_o_delta
+    DELTA_MINUS_VAR: energy_o_minus
+    DELTA_PLUS_VAR: energy_o_plus
 
 hi-omni-energy_o_delta:
     <<: *hi_energies_default
@@ -613,8 +613,8 @@ hi-omni-ne_mg_si:
 hi-omni-energy_ne_mg_si:
     <<: *hi_energies_default
     CATDESC: Energy Table for ne_mg_si
-    DELTA_MINUS_VAR: energy_ne_mg_si_delta
-    DELTA_PLUS_VAR: energy_ne_mg_si_delta
+    DELTA_MINUS_VAR: energy_ne_mg_si_minus
+    DELTA_PLUS_VAR: energy_ne_mg_si_plus
 
 hi-omni-energy_ne_mg_si_delta:
     <<: *hi_energies_default
@@ -631,8 +631,8 @@ hi-omni-fe:
 hi-omni-energy_fe:
     <<: *hi_energies_default
     CATDESC: Energy Table for fe
-    DELTA_MINUS_VAR: energy_fe_delta
-    DELTA_PLUS_VAR: energy_fe_delta
+    DELTA_MINUS_VAR: energy_fe_minus
+    DELTA_PLUS_VAR: energy_fe_plus
 
 hi-omni-energy_fe_delta:
     <<: *hi_energies_default
@@ -649,8 +649,8 @@ hi-omni-uh:
 hi-omni-energy_uh:
     <<: *hi_energies_default
     CATDESC: Energy Table for uh
-    DELTA_MINUS_VAR: energy_uh_delta
-    DELTA_PLUS_VAR: energy_uh_delta
+    DELTA_MINUS_VAR: energy_uh_minus
+    DELTA_PLUS_VAR: energy_uh_plus
 
 hi-omni-energy_uh_delta:
     <<: *hi_energies_default
@@ -667,8 +667,8 @@ hi-omni-junk:
 hi-omni-energy_junk:
     <<: *hi_energies_default
     CATDESC: Energy Table for junk
-    DELTA_MINUS_VAR: energy_junk_delta
-    DELTA_PLUS_VAR: energy_junk_delta
+    DELTA_MINUS_VAR: energy_junk_minus
+    DELTA_PLUS_VAR: energy_junk_plus
 
 hi-omni-energy_junk_delta:
     <<: *hi_energies_default
@@ -721,8 +721,8 @@ hi-sectored-h:
 hi-sectored-energy_h:
     <<: *hi_energies_default
     CATDESC: Energy Table for H
-    DELTA_MINUS_VAR: energy_h_delta
-    DELTA_PLUS_VAR: energy_h_delta
+    DELTA_MINUS_VAR: energy_h_minus
+    DELTA_PLUS_VAR: energy_h_plus
 
 hi-sectored-energy_h_delta:
     <<: *hi_energies_default
@@ -743,8 +743,8 @@ hi-sectored-he3he4:
 hi-sectored-energy_he3he4:
     <<: *hi_energies_default
     CATDESC: Energy Table for He3He4
-    DELTA_MINUS_VAR: energy_he3he4_delta
-    DELTA_PLUS_VAR: energy_he3he4_delta
+    DELTA_MINUS_VAR: energy_he3he4_minus
+    DELTA_PLUS_VAR: energy_he3he4_plus
 
 hi-sectored-energy_he3he4_delta:
     <<: *hi_energies_default
@@ -765,8 +765,8 @@ hi-sectored-cno:
 hi-sectored-energy_cno:
     <<: *hi_energies_default
     CATDESC: Energy Table for CNO
-    DELTA_MINUS_VAR: energy_cno_delta
-    DELTA_PLUS_VAR: energy_cno_delta
+    DELTA_MINUS_VAR: energy_cno_minus
+    DELTA_PLUS_VAR: energy_cno_plus
 
 hi-sectored-energy_cno_delta:
     <<: *hi_energies_default
@@ -787,8 +787,8 @@ hi-sectored-fe:
 hi-sectored-energy_fe:
     <<: *hi_energies_default
     CATDESC: Energy Table for Fe
-    DELTA_MINUS_VAR: energy_fe_delta
-    DELTA_PLUS_VAR: energy_fe_delta
+    DELTA_MINUS_VAR: energy_fe_minus
+    DELTA_PLUS_VAR: energy_fe_plus
 
 hi-sectored-energy_fe_delta:
     <<: *hi_energies_default

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -313,7 +313,7 @@ class CoDICEL1aPipeline:
             ``xarray`` dataset for the data product, with added energy variables.
         """
         energy_bin_name = f"energy_{species}"
-        centers, deltas = self.get_hi_energy_table_data(
+        centers, deltas_minus, deltas_plus = self.get_hi_energy_table_data(
             energy_bin_name.split("energy_")[-1]
         )
 
@@ -326,11 +326,19 @@ class CoDICEL1aPipeline:
                 check_schema=False,
             ),
         )
-        dataset[f"{energy_bin_name}_delta"] = xr.DataArray(
-            deltas,
-            dims=[f"{energy_bin_name}_delta"],
+        dataset[f"{energy_bin_name}_minus"] = xr.DataArray(
+            deltas_minus,
+            dims=[f"{energy_bin_name}_minus"],
             attrs=self.cdf_attrs.get_variable_attributes(
-                f"{self.config['dataset_name'].split('_')[-1]}-{energy_bin_name}_delta",
+                f"{self.config['dataset_name'].split('_')[-1]}-{energy_bin_name}_minus",
+                check_schema=False,
+            ),
+        )
+        dataset[f"{energy_bin_name}_plus"] = xr.DataArray(
+            deltas_plus,
+            dims=[f"{energy_bin_name}_plus"],
+            attrs=self.cdf_attrs.get_variable_attributes(
+                f"{self.config['dataset_name'].split('_')[-1]}-{energy_bin_name}_plus",
                 check_schema=False,
             ),
         )
@@ -482,7 +490,7 @@ class CoDICEL1aPipeline:
 
     def get_hi_energy_table_data(
         self, species: str
-    ) -> tuple[NDArray[float], NDArray[float]]:
+    ) -> tuple[NDArray[float], NDArray[float], NDArray[float]]:
         """
         Retrieve energy table data for CoDICE-Hi products.
 
@@ -500,22 +508,22 @@ class CoDICEL1aPipeline:
         -------
         centers : NDArray[float]
             An array whose values represent the centers of the energy bins.
-        deltas : NDArray[float]
-            An array whose values represent the deltas of the energy bins.
+        deltas_minus : NDArray[float]
+            An array whose values represent the minus deltas of the energy bins.
+        deltas_plus : NDArray[float]
+            An array whose values represent the plus deltas of the energy bins.
         """
         data_product = self.config["dataset_name"].split("-")[-1].upper()
-        energy_table = getattr(constants, f"{data_product}_ENERGY_TABLE")[species]
+        energy_table = np.array(
+            getattr(constants, f"{data_product}_ENERGY_TABLE")[species]
+        )
 
         # Find the centers and deltas of the energy bins
-        centers = np.array(
-            [
-                (energy_table[i] + energy_table[i + 1]) / 2
-                for i in range(len(energy_table) - 1)
-            ]
-        )
-        deltas = energy_table[1:] - centers
+        centers = np.sqrt(energy_table[:-1] * energy_table[1:])
+        deltas_minus = centers - energy_table[:-1]
+        deltas_plus = energy_table[1:] - centers
 
-        return centers, deltas
+        return centers, deltas_minus, deltas_plus
 
     def reshape_binned_data(self, dataset: xr.Dataset) -> dict[str, list]:
         """

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -518,7 +518,10 @@ class CoDICEL1aPipeline:
             getattr(constants, f"{data_product}_ENERGY_TABLE")[species]
         )
 
-        # Find the centers and deltas of the energy bins
+        # Find the geometric centers and deltas of the energy bins
+        # The delta minus is the difference between the center of the bin
+        # and the 'left edge' of the bin. The delta plus is the difference
+        # between the 'right edge' of the bin and the center of the bin
         centers = np.sqrt(energy_table[:-1] * energy_table[1:])
         deltas_minus = centers - energy_table[:-1]
         deltas_plus = energy_table[1:] - centers


### PR DESCRIPTION
This PR changes the defined energy bin deltas to separate delta minus and delta plus values in CoDICE L1a energy-binned datasets, calculated via the geometric mean, as preferred by the CoDICE instrument team.

Closes #1960 