### PR TITLE
ULTRA L1C Dead time correction calculation 

### DIFF
--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -495,3 +495,35 @@ def ancillary_files():
         "l1b-egynorm-lookup": path / "imap_ultra_l1b-egynorm-lookup_20250101_v000.csv",
         "l1b-yadjust-lookup": path / "imap_ultra_l1b-yadjust-lookup_20250101_v001.csv",
     }
+
+
+@pytest.fixture
+def deadtime_datasets():
+    """Fixture to create params and rates datasets needed to calculate the spacecraft
+    exposure time."""
+    # Simulate a test rates dataset.
+    epoch = 200
+    test_l1a_rates_dataset = xr.Dataset(
+        {
+            "fifo_valid_events": (["epoch"], np.random.randint(100, 200, epoch)),
+            "event_active_time": (["epoch"], np.random.uniform(0, 10, epoch)),
+            "start_pos": (["epoch"], np.random.randint(0, 5, epoch)),
+            "start_rf": (["epoch"], np.random.randint(0, 5, epoch)),
+            "start_lf": (["epoch"], np.random.randint(0, 5, epoch)),
+            "coin_tn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "coin_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "stop_tn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+        }
+    )
+    # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).
+    # each time the mode changes, it is recorded in the params packet.
+    # Create a test params dataset that simulates the mode changing to 3, 3 times.
+    modes = np.tile(np.arange(4), 3)
+    test_l1a_params_dataset = xr.Dataset(
+        {
+            "imageratescadence": (["epoch"], modes),
+        },
+        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
+    )
+    return {"rates": test_l1a_rates_dataset, "params": test_l1a_params_dataset}

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -108,7 +108,7 @@ def test_calculate_spacecraft_pset(ccsds_path_all_apids, ccsds_path_theta_0):
         test_l1b_de_dataset,  # placeholder for cullingmask_dataset
         test_l1a_rates_dataset,
         test_l1a_params_dataset,
-        "imap_ultra_1c_45sensor-spacecraftpset",
+        "imap_ultra_l1c_45sensor-spacecraftpset",
         ancillary,
     )
     assert "pixel_index" in spacecraft_pset.coords

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -26,7 +26,7 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-def test_calculate_spacecraft_pset():
+def test_calculate_spacecraft_pset(deadtime_datasets):
     """Tests calculate_spacecraft_pset function."""
     # This is just setting up the data so that it is in the format of l1b_de_dataset.
     test_path = TEST_PATH / "ultra-90_raw_event_data_shortened.csv"
@@ -66,31 +66,6 @@ def test_calculate_spacecraft_pset():
             "component": ("component", ["vx", "vy", "vz"]),
         },
     )
-    # Simulate a test rates dataset.
-    epoch = 200
-    test_l1a_rates_dataset = xr.Dataset(
-        {
-            "fifo_valid_events": (["epoch"], np.random.randint(100, 200, epoch)),
-            "event_active_time": (["epoch"], np.random.uniform(0, 10, epoch)),
-            "start_pos": (["epoch"], np.random.randint(0, 5, epoch)),
-            "start_rf": (["epoch"], np.random.randint(0, 5, epoch)),
-            "start_lf": (["epoch"], np.random.randint(0, 5, epoch)),
-            "coin_tn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "coin_bn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "stop_tn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
-        }
-    )
-    # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).
-    # each time the mode changes, it is recorded in the params packet.
-    # Create a test params dataset that simulates the mode changing to 3, 3 times.
-    modes = np.tile(np.arange(4), 3)
-    test_l1a_params_dataset = xr.Dataset(
-        {
-            "imageratescadence": (["epoch"], modes),
-        },
-        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
-    )
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary = {
@@ -105,8 +80,8 @@ def test_calculate_spacecraft_pset():
         test_l1b_de_dataset,
         test_l1b_de_dataset,  # placeholder for extendedspin_dataset
         test_l1b_de_dataset,  # placeholder for cullingmask_dataset
-        test_l1a_rates_dataset,
-        test_l1a_params_dataset,
+        deadtime_datasets["rates"],
+        deadtime_datasets["params"],
         "imap_ultra_l1c_45sensor-spacecraftpset",
         ancillary,
     )
@@ -119,7 +94,7 @@ def test_calculate_spacecraft_pset():
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-def test_calculate_spacecraft_pset_with_cdf(ancillary_files):
+def test_calculate_spacecraft_pset_with_cdf(ancillary_files, deadtime_datasets):
     """Tests calculate_spacecraft_pset function with imported test data."""
 
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
@@ -177,6 +152,8 @@ def test_calculate_spacecraft_pset_with_cdf(ancillary_files):
             dataset,
             xr.Dataset(),  # placeholder for extendedspin_dataset
             xr.Dataset(),  # placeholder for cullingmask_dataset
+            deadtime_datasets["rates"],
+            deadtime_datasets["params"],
             "imap_ultra_l1c_45sensor-spacecraftpset",
             ancillary,
         )

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -23,11 +23,10 @@ from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 
-@pytest.mark.external_test_data
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-def test_calculate_spacecraft_pset(ccsds_path_all_apids, ccsds_path_theta_0):
+def test_calculate_spacecraft_pset():
     """Tests calculate_spacecraft_pset function."""
     # This is just setting up the data so that it is in the format of l1b_de_dataset.
     test_path = TEST_PATH / "ultra-90_raw_event_data_shortened.csv"

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -27,7 +27,7 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-def test_calculate_spacecraft_pset():
+def test_calculate_spacecraft_pset(ccsds_path_all_apids, ccsds_path_theta_0):
     """Tests calculate_spacecraft_pset function."""
     # This is just setting up the data so that it is in the format of l1b_de_dataset.
     test_path = TEST_PATH / "ultra-90_raw_event_data_shortened.csv"
@@ -67,6 +67,31 @@ def test_calculate_spacecraft_pset():
             "component": ("component", ["vx", "vy", "vz"]),
         },
     )
+    # Simulate a test rates dataset.
+    epoch = 200
+    test_l1a_rates_dataset = xr.Dataset(
+        {
+            "fifo_valid_events": (["epoch"], np.random.randint(100, 200, epoch)),
+            "event_active_time": (["epoch"], np.random.uniform(0, 10, epoch)),
+            "start_pos": (["epoch"], np.random.randint(0, 5, epoch)),
+            "start_rf": (["epoch"], np.random.randint(0, 5, epoch)),
+            "start_lf": (["epoch"], np.random.randint(0, 5, epoch)),
+            "coin_tn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "coin_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "stop_tn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+        }
+    )
+    # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).
+    # each time the mode changes, it is recorded in the params packet.
+    # Create a test params dataset that simulates the mode changing to 3, 3 times.
+    modes = np.tile(np.arange(4), 3)
+    test_l1a_params_dataset = xr.Dataset(
+        {
+            "imageratescadence": (["epoch"], modes),
+        },
+        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
+    )
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary = {
@@ -81,7 +106,9 @@ def test_calculate_spacecraft_pset():
         test_l1b_de_dataset,
         test_l1b_de_dataset,  # placeholder for extendedspin_dataset
         test_l1b_de_dataset,  # placeholder for cullingmask_dataset
-        "imap_ultra_l1c_45sensor-spacecraftpset",
+        test_l1a_rates_dataset,
+        test_l1a_params_dataset,
+        "imap_ultra_1c_45sensor-spacecraftpset",
         ancillary,
     )
     assert "pixel_index" in spacecraft_pset.coords

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -133,7 +133,7 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
 @pytest.mark.external_kernel
 @ensure_spice
 @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
-def test_calculate_spacecraft_pset_with_cdf(ancillary_files):
+def test_calculate_spacecraft_pset_with_cdf(ancillary_files, deadtime_datasets):
     """Tests ultra_l1c function with imported test data."""
 
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
@@ -181,6 +181,8 @@ def test_calculate_spacecraft_pset_with_cdf(ancillary_files):
         "imap_ultra_l1b_45sensor-de": dataset,
         "imap_ultra_l1b_45sensor-extendedspin": xr.Dataset(),  # placeholder
         "imap_ultra_l1b_45sensor-cullingmask": xr.Dataset(),  # placeholder
+        "imap_ultra_45sensor-rates": deadtime_datasets["rates"],
+        "imap_ultra_45sensor-params": deadtime_datasets["params"],
     }
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -189,13 +189,15 @@ def test_get_deadtime_correction_factors():
 
 
 @pytest.mark.external_test_data
-def test_get_spacecraft_exposure_times():
+def test_get_spacecraft_exposure_times(deadtime_datasets):
     """Test get_spacecraft_exposure_times function."""
     constant_exposure = (
         TEST_PATH / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
     )
     df_exposure = pd.read_csv(constant_exposure)
-    exposure_pointing = get_spacecraft_exposure_times(df_exposure)
+    exposure_pointing = get_spacecraft_exposure_times(
+        df_exposure, deadtime_datasets["rates"], deadtime_datasets["params"]
+    )
     assert exposure_pointing.shape == (196608,)
 
     np.testing.assert_allclose(

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -185,9 +185,7 @@ def test_get_deadtime_correction_factors():
     )
     deadtime_correction_factors = get_deadtime_correction_factors(sectored_rates_ds)
     assert deadtime_correction_factors.shape == (sectored_rates_ds.sizes["epoch"],)
-    assert np.all(
-        (deadtime_correction_factors >= 0) & (deadtime_correction_factors <= 1)
-    )
+    assert np.all(deadtime_correction_factors >= 0)
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -164,6 +164,16 @@ def test_get_sectored_rates():
         sectored_rates["test_data"].data,
         np.hstack([np.arange(10, 20), np.arange(30, 40), np.arange(50, 60)]),
     )
+    # Test with one mode shift in the middle of the dataset.
+    modes = np.array([1, 3, 1])
+    test_l1a_params_dataset = xr.Dataset(
+        {
+            "imageratescadence": (["epoch"], modes),
+        },
+        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
+    )
+    sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
+    np.testing.assert_array_equal(sectored_rates["test_data"].data, np.arange(20, 40))
 
 
 def test_get_deadtime_correction_factors():
@@ -194,10 +204,10 @@ def test_get_spacecraft_exposure_times(deadtime_datasets):
     constant_exposure = (
         TEST_PATH / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
     )
+    rates = deadtime_datasets["rates"]
+    params = deadtime_datasets["params"]
     df_exposure = pd.read_csv(constant_exposure)
-    exposure_pointing = get_spacecraft_exposure_times(
-        df_exposure, deadtime_datasets["rates"], deadtime_datasets["params"]
-    )
+    exposure_pointing = get_spacecraft_exposure_times(df_exposure, rates, params)
     assert exposure_pointing.shape == (196608,)
 
     np.testing.assert_allclose(

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -4,15 +4,18 @@ import astropy_healpix.healpy as hp
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.ultra.l1c import ultra_l1c_pset_bins
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
+    get_deadtime_correction_factors,
     get_energy_delta_minus_plus,
     get_helio_background_rates,
     get_helio_exposure_times,
     get_helio_sensitivity,
+    get_sectored_rates,
     get_spacecraft_background_rates,
     get_spacecraft_exposure_times,
     get_spacecraft_histogram,
@@ -134,6 +137,57 @@ def test_get_helio_background_rates():
     background_rates = get_helio_background_rates(nside=128)
     _, energy_midpoints, _ = build_energy_bins()
     assert background_rates.shape == (len(energy_midpoints), hp.nside2npix(128))
+
+
+def test_get_sectored_rates():
+    """Tests get_sectored_rates function."""
+
+    # Simulate a test rates dataset.
+    epoch = 60
+    test_l1a_rates_dataset = xr.Dataset(
+        {
+            "test_data": (["epoch"], np.arange(epoch)),
+        },
+    )
+    # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).
+    # each time the mode changes, it is recorded in the params packet.
+    # Create a test params dataset that simulates the mode changing to 3, 3 times.
+    modes = np.tile(np.array([1, 3]), 3)
+    test_l1a_params_dataset = xr.Dataset(
+        {
+            "imageratescadence": (["epoch"], modes),
+        },
+        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
+    )
+    sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
+    np.testing.assert_array_equal(
+        sectored_rates["test_data"].data,
+        np.hstack([np.arange(10, 20), np.arange(30, 40), np.arange(50, 60)]),
+    )
+
+
+def test_get_deadtime_correction_factors():
+    """Tests get_deadtime_correction_factors function."""
+    # Simulate a test sectored rates dataset.
+    epoch = 10
+    sectored_rates_ds = xr.Dataset(
+        {
+            "fifo_valid_events": (["epoch"], np.random.randint(100, 200, epoch)),
+            "event_active_time": (["epoch"], np.random.uniform(0, 10, epoch)),
+            "start_pos": (["epoch"], np.random.randint(0, 5, epoch)),
+            "start_rf": (["epoch"], np.random.randint(0, 5, epoch)),
+            "start_lf": (["epoch"], np.random.randint(0, 5, epoch)),
+            "coin_tn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "coin_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "stop_tn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+        }
+    )
+    deadtime_correction_factors = get_deadtime_correction_factors(sectored_rates_ds)
+    assert deadtime_correction_factors.shape == (sectored_rates_ds.sizes["epoch"],)
+    assert np.all(
+        (deadtime_correction_factors >= 0) & (deadtime_correction_factors <= 1)
+    )
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -18,6 +18,8 @@ def calculate_spacecraft_pset(
     de_dataset: xr.Dataset,
     extendedspin_dataset: xr.Dataset,
     cullingmask_dataset: xr.Dataset,
+    rates_dataset: xr.Dataset,
+    params_dataset: xr.Dataset,
     name: str,
     ancillary_files: dict,
 ) -> xr.Dataset:
@@ -32,6 +34,10 @@ def calculate_spacecraft_pset(
         Dataset containing extendedspin data.
     cullingmask_dataset : xarray.Dataset
         Dataset containing cullingmask data.
+    rates_dataset : xarray.Dataset
+        Dataset containing image rates data.
+    params_dataset : xarray.Dataset
+        Dataset containing image parameters data.
     name : str
         Name of the dataset.
     ancillary_files : dict
@@ -71,7 +77,9 @@ def calculate_spacecraft_pset(
     # Calculate exposure
     constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
     df_exposure = pd.read_csv(constant_exposure)
-    exposure_pointing = get_spacecraft_exposure_times(df_exposure)
+    exposure_pointing = get_spacecraft_exposure_times(
+        df_exposure, rates_dataset, params_dataset
+    )
 
     # For ISTP, epoch should be the center of the time bin.
     pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -63,8 +63,8 @@ def ultra_l1c(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"],
-                data_dict[f"imap_ultra_{instrument_id}sensor-params"],
                 data_dict[f"imap_ultra_{instrument_id}sensor-rates"],
+                data_dict[f"imap_ultra_{instrument_id}sensor-params"],
                 f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset",
                 ancillary_files,
             )

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -63,6 +63,8 @@ def ultra_l1c(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"],
+                data_dict[f"imap_ultra_{instrument_id}sensor-params"],
+                data_dict[f"imap_ultra_{instrument_id}sensor-rates"],
                 f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset",
                 ancillary_files,
             )

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -220,7 +220,7 @@ def get_deadtime_correction_factors(sectored_rates_ds: xr.Dataset) -> xr.DataArr
 
     Returns
     -------
-    dead_time_ratio : numpy.ndarray
+    dead_time_ratio : xarray.DataArray
         Dead time correction factor for each sector.
     """
     # Compute the correction factor at each sector

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -317,8 +317,9 @@ def get_spacecraft_exposure_times(
         Healpix tessellation of the sky
         in the pointing (dps) frame.
     """
-    sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
-    get_deadtime_correction_factors(sectored_rates)
+    # TODO: uncomment these lines when the deadtime correction is implemented
+    # sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
+    # get_deadtime_correction_factors(sectored_rates)
     # TODO: calculate the deadtime correction function
     # TODO: Apply the deadtime correction to the exposure times
     # TODO: use the universal spin table and

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -230,7 +230,7 @@ def get_deadtime_correction_factors(sectored_rates_ds: xr.Dataset) -> xr.DataArr
     )
 
     start_full = sectored_rates_ds.start_rf + sectored_rates_ds.start_lf
-    b = a * np.exp((start_full) * 1e-7 * 5)
+    b = a * np.exp(start_full * 1e-7 * 5)
 
     coin_stop_nd = (
         sectored_rates_ds.coin_tn
@@ -267,8 +267,8 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
     # sector mode. At the normal 15-second spin period, each 24° sector takes ~1 second.
 
     # This means that data was collected as a function of spin allowing for fine grained
-    # rate analysis at different spin phases.
-    sector_mode_start_inds = np.where(params_ds.imageratescadence == 3)[0]
+    # rate analysis.
+    sector_mode_start_inds = np.where(params_ds["imageratescadence"] == 3)[0]
     # get the sector mode start and stop indices
     sector_mode_stop_inds = sector_mode_start_inds + 1
     # get the sector mode start and stop times

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -4,6 +4,7 @@ import astropy_healpix.healpy as hp
 import numpy as np
 import pandas
 import pandas as pd
+import xarray as xr
 from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 
@@ -205,7 +206,98 @@ def get_helio_background_rates(
     return background
 
 
-def get_spacecraft_exposure_times(constant_exposure: pandas.DataFrame) -> NDArray:
+def get_deadtime_correction_factors(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
+    """
+    Compute the dead time correction factor at each sector.
+
+    Further description is available in section 3.4.3 of the IMAP-Ultra Algorithm
+    Document.
+
+    Parameters
+    ----------
+    sectored_rates_ds : xarray.Dataset
+        Dataset containing sector mode image rates data.
+
+    Returns
+    -------
+    dead_time_ratio : numpy.ndarray
+        Dead time correction factor for each sector.
+    """
+    # Compute the correction factor at each sector
+    a = sectored_rates_ds.fifo_valid_events / (
+        1
+        - (sectored_rates_ds.event_active_time + 2 * sectored_rates_ds.start_pos) * 1e-7
+    )
+
+    start_full = sectored_rates_ds.start_rf + sectored_rates_ds.start_lf
+    b = a * np.exp((start_full) * 1e-7 * 5)
+
+    coin_stop_nd = (
+        sectored_rates_ds.coin_tn
+        + sectored_rates_ds.coin_bn
+        - sectored_rates_ds.stop_tn
+        - sectored_rates_ds.stop_bn
+    )
+
+    corrected_valid_events = b * np.exp(1e-7 * 8 * coin_stop_nd)
+
+    # Compute dead time ratio
+    dead_time_ratios = sectored_rates_ds.fifo_valid_events / corrected_valid_events
+
+    return dead_time_ratios
+
+
+def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Dataset:
+    """
+    Filter rates dataset to only include sector mode data.
+
+    Parameters
+    ----------
+    rates_ds : xarray.Dataset
+        Dataset containing image rates data.
+    params_ds : xarray.Dataset
+        Dataset containing image parameters data.
+
+    Returns
+    -------
+    rates : xarray.Dataset
+        Rates dataset with only the sector mode data.
+    """
+    # Find indices in which the parameters dataset, indicates that ULTRA was in
+    # sector mode. At the normal 15-second spin period, each 24° sector takes ~1 second.
+
+    # This means that data was collected as a function of spin allowing for fine grained
+    # rate analysis at different spin phases.
+    sector_mode_start_inds = np.where(params_ds.imageratescadence == 3)[0]
+    # get the sector mode start and stop indices
+    sector_mode_stop_inds = sector_mode_start_inds + 1
+    # get the sector mode start and stop times
+    mode_3_start = params_ds["epoch"].values[sector_mode_start_inds]
+
+    # if the last mode is a sector mode, we can assume that the sector data goes through
+    # the end of the dataset, so we append np.inf to the end of the last time range.
+    if sector_mode_stop_inds[-1] == len(params_ds["epoch"]):
+        mode_3_end = np.append(
+            params_ds["epoch"].values[sector_mode_stop_inds[:-1]], np.inf
+        )
+    else:
+        mode_3_end = params_ds["epoch"].values[sector_mode_stop_inds]
+
+    # Build a list of conditions for each sector mode time range
+    conditions = [
+        (rates_ds["epoch"] >= start) & (rates_ds["epoch"] < end)
+        for start, end in zip(mode_3_start, mode_3_end)
+    ]
+
+    sector_mode_mask = np.logical_or.reduce(conditions)
+    return rates_ds.isel(epoch=sector_mode_mask)
+
+
+def get_spacecraft_exposure_times(
+    constant_exposure: pandas.DataFrame,
+    rates_dataset: xr.Dataset,
+    params_dataset: xr.Dataset,
+) -> NDArray:
     """
     Compute exposure times for HEALPix pixels.
 
@@ -213,6 +305,10 @@ def get_spacecraft_exposure_times(constant_exposure: pandas.DataFrame) -> NDArra
     ----------
     constant_exposure : pandas.DataFrame
         Exposure data.
+    rates_dataset : xarray.Dataset
+        Dataset containing image rates data.
+    params_dataset : xarray.Dataset
+        Dataset containing image parameters data.
 
     Returns
     -------
@@ -221,6 +317,10 @@ def get_spacecraft_exposure_times(constant_exposure: pandas.DataFrame) -> NDArra
         Healpix tessellation of the sky
         in the pointing (dps) frame.
     """
+    sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
+    get_deadtime_correction_factors(sectored_rates)
+    # TODO: calculate the deadtime correction function
+    # TODO: Apply the deadtime correction to the exposure times
     # TODO: use the universal spin table and
     #  universal pointing table here to determine actual number of spins
     exposure_pointing = (


### PR DESCRIPTION
# Change Summary

closes #1974
## Overview
Calculate the dead time ratios for each sector using the params and rates packets. 

## Updated Files
- imap_processing/ultra/l1c/spacecraft_pset.py, imap_processing/ultra/l1c/ultra_l1c.py
   - update exposure function to include dead time calculation 
- imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
   - Add function to get sectored rates and dead time ratios 

## Testing
Add tests for the two new functions 
