### PR TITLE
Return paths to generated CDFs from post_processing

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -18,7 +18,7 @@ import re
 import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import final
+from typing import final, Optional
 
 import imap_data_access
 import numpy as np
@@ -517,7 +517,7 @@ class ProcessInstrument(ABC):
         self,
         processed_data: list[xr.Dataset | Path],
         dependencies: ProcessingInputCollection,
-    ) -> None:
+    ) -> Optional[list[Path]]:
         """
         Complete post-processing.
 
@@ -582,6 +582,7 @@ class ProcessInstrument(ABC):
                 products.append(ds)
 
         self.upload_products(products)
+        return products
 
     @final
     def cleanup(self) -> None:

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -545,8 +545,13 @@ class ProcessInstrument(ABC):
             method.
         dependencies : ProcessingInputCollection
             Object containing dependencies to process.
+
+        Returns
+        -------
+        list[Path]
+        List of paths to CDF files produced.
         """
-        products = []
+        products: list[Path] = []
 
         if len(processed_data) == 0:
             logger.info("No products to write to CDF file.")

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -18,7 +18,7 @@ import re
 import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import final, Optional
+from typing import final
 
 import imap_data_access
 import numpy as np

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -549,7 +549,7 @@ class ProcessInstrument(ABC):
         Returns
         -------
         list[Path]
-        List of paths to CDF files produced.
+            List of paths to CDF files produced.
         """
         products: list[Path] = []
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -517,7 +517,7 @@ class ProcessInstrument(ABC):
         self,
         processed_data: list[xr.Dataset | Path],
         dependencies: ProcessingInputCollection,
-    ) -> Optional[list[Path]]:
+    ) -> list[Path]:
         """
         Complete post-processing.
 
@@ -546,9 +546,11 @@ class ProcessInstrument(ABC):
         dependencies : ProcessingInputCollection
             Object containing dependencies to process.
         """
+        products = []
+
         if len(processed_data) == 0:
             logger.info("No products to write to CDF file.")
-            return
+            return products
 
         logger.info("Writing products to local storage")
 
@@ -568,7 +570,6 @@ class ProcessInstrument(ABC):
         # start_date.
         # If it is start_date, skip repointing in the output filename.
 
-        products = []
         for ds in processed_data:
             if isinstance(ds, xr.Dataset):
                 ds.attrs["Data_version"] = self.version[1:]  # Strip 'v' from version

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -257,6 +257,20 @@ def test_post_processing_returns_path_to_written_cdf(mock_instrument_dependencie
     assert returned_path == [expected_path]
 
 
+def test_post_processing_returns_empty_list_if_invoked_with_no_data(mock_instrument_dependencies):
+    test_datasets = []
+    input_collection = ProcessingInputCollection()
+    instrument = Glows(
+        "l1a", "hist", "", None, "repoint00002", "v001", False
+    )
+
+    # Call the method that uses write_cdf
+    returned_products = instrument.post_processing(test_datasets, input_collection)
+
+    # Assert that post_processing returned the path to the CDF written in write_cdf
+    assert returned_products == []
+
+
 @pytest.mark.parametrize(
     "data_level, science_input, anc_input, n_prods",
     [

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -257,7 +257,9 @@ def test_post_processing_returns_path_to_written_cdf(mock_instrument_dependencie
     assert returned_path == [expected_path]
 
 
-def test_post_processing_returns_empty_list_if_invoked_with_no_data(mock_instrument_dependencies):
+def test_post_processing_returns_empty_list_if_invoked_with_no_data(
+        mock_instrument_dependencies
+):
     test_datasets = []
     input_collection = ProcessingInputCollection()
     instrument = Glows(

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -258,13 +258,11 @@ def test_post_processing_returns_path_to_written_cdf(mock_instrument_dependencie
 
 
 def test_post_processing_returns_empty_list_if_invoked_with_no_data(
-        mock_instrument_dependencies
+    mock_instrument_dependencies,
 ):
     test_datasets = []
     input_collection = ProcessingInputCollection()
-    instrument = Glows(
-        "l1a", "hist", "", None, "repoint00002", "v001", False
-    )
+    instrument = Glows("l1a", "hist", "", None, "repoint00002", "v001", False)
 
     # Call the method that uses write_cdf
     returned_products = instrument.post_processing(test_datasets, input_collection)

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -234,6 +234,29 @@ def test_repointing_file_creation(mock_instrument_dependencies):
     )
 
 
+def test_post_processing_returns_path_to_written_cdf(mock_instrument_dependencies):
+    test_datasets = [xr.Dataset({}, attrs={"cdf_filename": "file0"})]
+    input_collection = ProcessingInputCollection(
+        ScienceInput("imap_glows_l0_raw_20230822-repoint00001_v001.pkts")
+    )
+    dependency_str = (
+        '[{"type": "science","files": '
+        '["imap_glows_l0_raw_20230822-repoint00001_v001.pkts"]}]'
+    )
+    instrument = Glows(
+        "l1a", "hist", dependency_str, None, "repoint00002", "v001", False
+    )
+
+    expected_path = "/path/to/file0"
+    mock_instrument_dependencies["mock_write_cdf"].side_effect = [expected_path]
+
+    # Call the method that uses write_cdf
+    returned_path = instrument.post_processing(test_datasets, input_collection)
+
+    # Assert that post_processing returned the path to the CDF written in write_cdf
+    assert returned_path == [expected_path]
+
+
 @pytest.mark.parametrize(
     "data_level, science_input, anc_input, n_prods",
     [


### PR DESCRIPTION
## Summary
Returns paths to CDFs written during ProcessInstrument post_processing.

## Testing
Added unit test verifying the path returned by write_cdf is returned by post_processing

- George and Ethan