### PR TITLE
HIT - implement handling for data spanning midnight

### DIFF
--- a/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
@@ -23,6 +23,12 @@ imap_hit_l1a_counts:
     Logical_source: imap_hit_l1a_counts
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Count Rates Data.
 
+imap_hit_l1a_counts_sectored:
+    <<: *instrument_base
+    Data_type: L1A_counts>Level-1A Sectored Counts
+    Logical_source: imap_hit_l1a_sectored_counts
+    Logical_source_description: IMAP Mission HIT Instrument Level-1A Sectored Count Rates Data.
+
 imap_hit_l1a_direct-events:
     <<: *instrument_base
     Data_type: L1A_pha>Level-1A Direct Events

--- a/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
@@ -17,11 +17,11 @@ imap_hit_l1a_hk:
     Logical_source: imap_hit_l1a_hk
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Housekeeping Data.
 
-imap_hit_l1a_counts:
+imap_hit_l1a_counts_standard:
     <<: *instrument_base
-    Data_type: L1A_counts>Level-1A Counts
-    Logical_source: imap_hit_l1a_counts
-    Logical_source_description: IMAP Mission HIT Instrument Level-1A Count Rates Data.
+    Data_type: L1A_counts>Level-1A Standard Counts
+    Logical_source: imap_hit_l1a_counts_standard
+    Logical_source_description: IMAP Mission HIT Instrument Level-1A Standard Count Rates Data.
 
 imap_hit_l1a_counts_sectored:
     <<: *instrument_base

--- a/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
@@ -26,7 +26,7 @@ imap_hit_l1a_counts:
 imap_hit_l1a_counts_sectored:
     <<: *instrument_base
     Data_type: L1A_counts>Level-1A Sectored Counts
-    Logical_source: imap_hit_l1a_sectored_counts
+    Logical_source: imap_hit_l1a_counts_sectored
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Sectored Count Rates Data.
 
 imap_hit_l1a_direct-events:

--- a/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
@@ -17,13 +17,13 @@ imap_hit_l1a_hk:
     Logical_source: imap_hit_l1a_hk
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Housekeeping Data.
 
-imap_hit_l1a_counts_standard:
+imap_hit_l1a_counts-standard:
     <<: *instrument_base
     Data_type: L1A_counts>Level-1A Standard Counts
     Logical_source: imap_hit_l1a_counts-standard
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Standard Count Rates Data.
 
-imap_hit_l1a_counts_sectored:
+imap_hit_l1a_counts-sectored:
     <<: *instrument_base
     Data_type: L1A_counts>Level-1A Sectored Counts
     Logical_source: imap_hit_l1a_counts-sectored

--- a/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
@@ -20,13 +20,13 @@ imap_hit_l1a_hk:
 imap_hit_l1a_counts_standard:
     <<: *instrument_base
     Data_type: L1A_counts>Level-1A Standard Counts
-    Logical_source: imap_hit_l1a_counts_standard
+    Logical_source: imap_hit_l1a_counts-standard
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Standard Count Rates Data.
 
 imap_hit_l1a_counts_sectored:
     <<: *instrument_base
     Data_type: L1A_counts>Level-1A Sectored Counts
-    Logical_source: imap_hit_l1a_counts_sectored
+    Logical_source: imap_hit_l1a_counts-sectored
     Logical_source_description: IMAP Mission HIT Instrument Level-1A Sectored Count Rates Data.
 
 imap_hit_l1a_direct-events:

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -789,11 +789,11 @@ class Hit(ProcessInstrument):
 
         dependency_list = dependencies.processing_input
         if self.data_level == "l1a":
-            # 1 science files and 2 spice files
-            if len(dependency_list) > 3:
+            # 1 science file and 2 spice files
+            if len(dependency_list) > 2:
                 raise ValueError(
                     f"Unexpected dependencies found for HIT L1A:"
-                    f"{dependency_list}. Expected only one dependency."
+                    f"{dependency_list}. Expected only 2 dependencies."
                 )
             # process data to L1A products
             science_files = dependencies.get_file_paths(source="hit", descriptor="raw")
@@ -801,25 +801,29 @@ class Hit(ProcessInstrument):
 
         elif self.data_level == "l1b":
             data_dict = {}
-            # TODO: Sean removed the file number error handling to work with the
-            #  new SPICE dependencies for SIT-4. Need to review and make changes
-            #  if needed.
             l0_files = dependencies.get_file_paths(source="hit", descriptor="raw")
             l1a_files = dependencies.get_file_paths(source="hit", data_type="l1a")
-            if len(l0_files) > 0:
+            if len(l0_files) == 1:
                 # Add path to CCSDS file to process housekeeping
                 data_dict["imap_hit_l0_raw"] = l0_files[0]
             else:
+                # 1 science file
+                if len(l1a_files) > 1:
+                    raise ValueError(
+                        f"Unexpected dependencies found for HIT L1B:"
+                        f"{l1a_files}. Expected only one dependency."
+                    )
                 # Add L1A dataset to process science data
                 l1a_dataset = load_cdf(l1a_files[0])
                 data_dict[l1a_dataset.attrs["Logical_source"]] = l1a_dataset
             # process data to L1B products
             datasets = hit_l1b(data_dict)
         elif self.data_level == "l2":
+            # 1 science files and 4 ancillary files
             if len(dependency_list) != 5:
                 raise ValueError(
                     f"Unexpected dependencies found for HIT L2:"
-                    f"{dependency_list}. Expected only one dependency."
+                    f"{dependency_list}. Expected only five dependencies."
                 )
             # Add L1B dataset to process science data
             science_files = dependencies.get_file_paths(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -797,7 +797,7 @@ class Hit(ProcessInstrument):
                 )
             # process data to L1A products
             science_files = dependencies.get_file_paths(source="hit", descriptor="raw")
-            datasets = hit_l1a(science_files[0])
+            datasets = hit_l1a(science_files[0], self.start_date)
 
         elif self.data_level == "l1b":
             data_dict = {}

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -789,11 +789,12 @@ class Hit(ProcessInstrument):
 
         dependency_list = dependencies.processing_input
         if self.data_level == "l1a":
-            # 1 science file and 2 spice files
+            # Two inputs - L0 and SPICE
             if len(dependency_list) > 2:
                 raise ValueError(
                     f"Unexpected dependencies found for HIT L1A:"
-                    f"{dependency_list}. Expected only 2 dependencies."
+                    f"{dependency_list}. Expected only 2 dependencies, "
+                    f"L0 and time kernels."
                 )
             # process data to L1A products
             science_files = dependencies.get_file_paths(source="hit", descriptor="raw")

--- a/imap_processing/hit/l0/constants.py
+++ b/imap_processing/hit/l0/constants.py
@@ -114,6 +114,9 @@ FLAG_PATTERN = np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 # Define size of science frame (num of packets)
 FRAME_SIZE = len(FLAG_PATTERN)
 
+# Mod 10 pattern
+MOD_10_PATTERN = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
 # Define the number of bits in the mantissa and exponent for
 # decompressing data
 MANTISSA_BITS = 12

--- a/imap_processing/hit/l0/decom_hit.py
+++ b/imap_processing/hit/l0/decom_hit.py
@@ -260,12 +260,9 @@ def assemble_science_frames(sci_dataset: xr.Dataset) -> xr.Dataset:
         height event data per valid science frame added as new
         data variables.
     """
-    # TODO: Figure out how to handle partial science frames at the
-    #  beginning and end of CCSDS files. These science frames are split
-    #  across CCSDS files and still need to be processed with packets
-    #  from the previous file. Only discard incomplete science frames
-    #  in the middle of the CCSDS file. The code currently skips all
-    #  incomplete science frames.
+    # TODO: The code currently skips all incomplete science frames.
+    #  Only discard incomplete science frames in the middle of the CCSDS file or
+    #  use fill values?
 
     # Convert sequence flags and counters to NumPy arrays for vectorized operations
     seq_flgs = sci_dataset.seq_flgs.values

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -36,7 +37,7 @@ logger = logging.getLogger(__name__)
 fillval = -9223372036854775808
 
 
-def hit_l1a(packet_file: str, packet_date: Optional[str]) -> list[xr.Dataset]:
+def hit_l1a(packet_file: Path, packet_date: Optional[str]) -> list[xr.Dataset]:
     """
     Will process HIT L0 data into L1A data products.
 

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -45,7 +45,8 @@ def hit_l1a(packet_file: str, packet_date: Optional[str]) -> list[xr.Dataset]:
     packet_file : str
         Path to the CCSDS data packet file.
     packet_date : str, optional
-        The date of the packet data in 'YYYYMMDD' format. This is used to filter.
+        The date of the packet data in 'YYYYMMDD' format. This is used to filter
+        data to the correct processing day since L0 will have a buffer around midnight.
 
     Returns
     -------
@@ -63,10 +64,6 @@ def hit_l1a(packet_file: str, packet_date: Optional[str]) -> list[xr.Dataset]:
         attr_mgr = get_attribute_manager("l1a")
 
         l1a_datasets = []
-
-        # TODO:
-        #  -how does packet file with a buffer affect housekeeping?
-        #   Filter housekeeping by the packet date
 
         # Process l1a data products
         if HitAPID.HIT_HSKP in datasets_by_apid:
@@ -612,12 +609,11 @@ def process_science(
     sectored_dataset = subset_sectored_counts(sectored_dataset, packet_date)
 
     # TODO:
-    #  - headers are values per packet rather than frame. Do these need to align
+    #  - headers are values per packet rather than per frame. Do these need to align
     #    with the science frames?
     #    For instance, the mean epoch for a frame that spans midnight might contain
     #    packets from the previous day but filtering sc_tick by processing day will
     #    exclude those packets. Is this an issue?
-    #  - include ccsds headers in sectored dataset?
     #  - drop sectorates from standard dataset?
 
     # Filter the science dataset to only include data from the processing day
@@ -648,20 +644,3 @@ def process_science(
         logger.info(f"HIT L1A dataset created for {logical_source}")
 
     return list(l1a_datasets.values())
-
-
-if __name__ == "__main__":
-    from imap_processing import imap_module_directory
-
-    # L0 file path
-    packet_file = (
-        imap_module_directory / "tests/hit/test_data/hit_l1a_sample_2_nu_v4.ccsds"
-    )
-
-    start_date = "20100106"
-
-    datasets = hit_l1a(packet_file, start_date)
-
-    # counts = datasets[0]
-    # print(counts)
-    # print(counts.data_vars)

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -59,7 +59,7 @@ def hit_l1a(packet_file: Path, packet_date: Optional[str]) -> list[xr.Dataset]:
         raise ValueError("Packet date cannot be None.")
     else:
         # Unpack ccsds file to xarray datasets
-        datasets_by_apid = get_datasets_by_apid(packet_file)
+        datasets_by_apid = get_datasets_by_apid(str(packet_file))
 
         # Create the attribute manager for this data level
         attr_mgr = get_attribute_manager("l1a")
@@ -615,7 +615,6 @@ def process_science(
     #    For instance, the mean epoch for a frame that spans midnight might contain
     #    packets from the previous day but filtering sc_tick by processing day will
     #    exclude those packets. Is this an issue?
-    #  - drop sectorates from standard dataset?
 
     # Filter the science dataset to only include data from the processing day
     sci_dataset = filter_dataset_to_processing_day(
@@ -626,7 +625,7 @@ def process_science(
     pha_raw_dataset = xr.Dataset(
         {"pha_raw": sci_dataset["pha_raw"]}, coords={"epoch": sci_dataset["epoch"]}
     )
-    count_rates_dataset = sci_dataset.drop_vars("pha_raw")
+    count_rates_dataset = sci_dataset.drop_vars(["pha_raw", "sectorates"])
 
     # Calculate uncertainties for count rates
     count_rates_dataset = calculate_uncertainties(count_rates_dataset)

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -46,7 +46,8 @@ def hit_l1a(packet_file: Path, packet_date: Union[str, None]) -> list[xr.Dataset
         Path to the CCSDS data packet file.
     packet_date : str
         The date of the packet data in 'YYYYMMDD' format. This is used to filter
-        data to the correct processing day since L0 will have a buffer around midnight.
+        data to the correct processing day since L0 will have a 20-minute
+        buffer before and after the processing day.
 
     Returns
     -------

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -70,11 +70,12 @@ def hit_l1a(packet_file: str, packet_date: Optional[str]) -> list[xr.Dataset]:
         # Process l1a data products
         if HitAPID.HIT_HSKP in datasets_by_apid:
             logger.info("Creating HIT L1A housekeeping dataset")
-            l1a_datasets.append(
-                process_housekeeping_data(
-                    datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1a_hk"
-                )
+            hk_dataset = process_housekeeping_data(
+                datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1a_hk"
             )
+            # filter the housekeeping dataset to the processing day
+            hk_dataset = filter_dataset_to_processing_day(hk_dataset, packet_date)
+            l1a_datasets.append(hk_dataset)
         if HitAPID.HIT_SCIENCE in datasets_by_apid:
             l1a_datasets.extend(
                 process_science(

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -1,6 +1,8 @@
 """Decommutate HIT CCSDS data and create L1a data products."""
 
 import logging
+from datetime import datetime
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -19,6 +21,11 @@ from imap_processing.hit.l0.constants import (
     ZENITH_ANGLES,
 )
 from imap_processing.hit.l0.decom_hit import decom_hit
+from imap_processing.spice.time import (
+    et_to_datetime64,
+    met_to_datetime64,
+    ttj2000ns_to_et,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +35,7 @@ logger = logging.getLogger(__name__)
 fillval = -9223372036854775808
 
 
-def hit_l1a(packet_file: str) -> list[xr.Dataset]:
+def hit_l1a(packet_file: str, packet_date: Optional[str]) -> list[xr.Dataset]:
     """
     Will process HIT L0 data into L1A data products.
 
@@ -36,33 +43,45 @@ def hit_l1a(packet_file: str) -> list[xr.Dataset]:
     ----------
     packet_file : str
         Path to the CCSDS data packet file.
+    packet_date : str, optional
+        The date of the packet data in 'YYYYMMDD' format. This is used to filter.
 
     Returns
     -------
     processed_data : list[xarray.Dataset]
         List of Datasets of L1A processed data.
     """
-    # Unpack ccsds file to xarray datasets
-    datasets_by_apid = get_datasets_by_apid(packet_file)
+    if not packet_date:
+        logger.error("Packet date is required for processing L1A data.")
+        raise ValueError("Packet date cannot be None.")
+    else:
+        # Unpack ccsds file to xarray datasets
+        datasets_by_apid = get_datasets_by_apid(packet_file)
 
-    # Create the attribute manager for this data level
-    attr_mgr = get_attribute_manager("l1a")
+        # Create the attribute manager for this data level
+        attr_mgr = get_attribute_manager("l1a")
 
-    l1a_datasets = []
+        l1a_datasets = []
 
-    # Process l1a data products
-    if HitAPID.HIT_HSKP in datasets_by_apid:
-        logger.info("Creating HIT L1A housekeeping dataset")
-        l1a_datasets.append(
-            process_housekeeping_data(
-                datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1a_hk"
+        # TODO:
+        #  -how does packet file with a buffer affect housekeeping?
+        #   Filter housekeeping by the packet date
+
+        # Process l1a data products
+        if HitAPID.HIT_HSKP in datasets_by_apid:
+            logger.info("Creating HIT L1A housekeeping dataset")
+            l1a_datasets.append(
+                process_housekeeping_data(
+                    datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1a_hk"
+                )
             )
-        )
-    if HitAPID.HIT_SCIENCE in datasets_by_apid:
-        l1a_datasets.extend(
-            process_science(datasets_by_apid[HitAPID.HIT_SCIENCE], attr_mgr)
-        )
-    return l1a_datasets
+        if HitAPID.HIT_SCIENCE in datasets_by_apid:
+            l1a_datasets.extend(
+                process_science(
+                    datasets_by_apid[HitAPID.HIT_SCIENCE], attr_mgr, str(packet_date)
+                )
+            )
+        return l1a_datasets
 
 
 def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
@@ -102,7 +121,15 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
     sci_dataset : xarray.Dataset
         Xarray dataset with sectored rates data organized by species.
     """
-    updated_dataset = sci_dataset.copy()
+    # Initialize the dataset with the required variables
+    updated_dataset = xr.Dataset(
+        {
+            "sectorates": sci_dataset["sectorates"],
+            "hdr_minute_cnt": sci_dataset["hdr_minute_cnt"],
+            "livetime_counter": sci_dataset["livetime_counter"],
+        },
+        coords={"epoch": sci_dataset["epoch"]},
+    )
 
     # Calculate mod 10 values
     hdr_min_count_mod_10 = updated_dataset.hdr_minute_cnt.values % 10
@@ -308,25 +335,242 @@ def add_cdf_attributes(
     return dataset
 
 
+def find_complete_mod10_sets(mod_vals: np.ndarray, window_size: int = 10) -> np.ndarray:
+    """
+    Find start indices where mod_vals matches [0,1,...,9] pattern.
+
+    Parameters
+    ----------
+    mod_vals : np.ndarray
+        1D array of mod 10 values from the hdr_minute_cnt field in the L1A counts data.
+    window_size : int, optional
+        The size of the sliding window to match the pattern. Default is 10.
+
+    Returns
+    -------
+    np.ndarray
+        Indices in mod_vals where the complete pattern [0, 1, ..., 9] starts.
+    """
+    pattern = np.arange(window_size)
+    # Use sliding windows to find pattern matches
+    sw_view = np.lib.stride_tricks.sliding_window_view(mod_vals, window_size)
+    matches = np.all(sw_view == pattern, axis=1)
+    return np.where(matches)[0]
+
+
+def subset_sectored_counts(
+    sectored_counts_dataset: xr.Dataset, packet_date: str
+) -> tuple[xr.Dataset, np.ndarray]:
+    """
+    Subset data for complete sets of sectored counts and corresponding livetime values.
+
+    A set of sectored data starts with hydrogen and ends with iron and correspond to
+    the mod 10 values 0-9. The livetime values from the previous 10 minutes are used
+    to calculate the rates for each set since those counts are transmitted 10 minutes
+    after they were collected. Therefore, only complete sets of sectored counts where
+    livetime from the previous 10 minutes are available are included in the output.
+
+    Parameters
+    ----------
+    sectored_counts_dataset : xr.Dataset
+        The sectored counts dataset.
+
+    packet_date : str
+        The date of the packet data in 'YYYYMMDD' format, used for filtering.
+
+    Returns
+    -------
+    tuple[xr.Dataset, np.ndarray]
+        Dataset of complete sectored counts and mean epoch values
+        for the complete sets of sectored counts.
+    """
+    # TODO: Update to use fill values for partial frames rather than drop them
+
+    # Modify livetime_counter to use a new epoch coordinate
+    # that is aligned with the original epoch dimension. This
+    # ensures that livetime doesn't get filtered when the original
+    # epoch dimension is filtered for complete sets.
+    sectored_counts_dataset = update_livetime_coord(sectored_counts_dataset)
+
+    # Identify 10-minute intervals of complete sectored counts.
+    bin_size = 10
+    mod_10 = sectored_counts_dataset.hdr_minute_cnt.values % 10
+    start_indices = find_complete_mod10_sets(mod_10)
+
+    # Filter out start indices that are less than or equal to the bin size
+    # since the previous 10 minutes are needed for calculating rates
+    if start_indices.size == 0:
+        logger.error(
+            "No data to process - valid start indices not found for "
+            "complete sectored counts."
+        )
+        raise ValueError("No valid start indices found for complete sectored counts.")
+    else:
+        start_indices = start_indices[start_indices >= bin_size]
+
+    # Subset data for complete sets of sectored counts.
+    # Each set of sectored counts is 10 minutes long, so we take the indices
+    # starting from the start indices and extending to the bin size of 10.
+    # This creates a 1D array of indices that correspond to the complete
+    # sets of sectored counts which is used to filter the L1A dataset and
+    # create the L1B sectored rates dataset.
+    data_indices = np.concatenate(
+        [np.arange(idx, idx + bin_size) for idx in start_indices]
+    )
+    complete_sectored_counts_dataset = sectored_counts_dataset.isel(epoch=data_indices)
+
+    epoch_per_complete_set = np.repeat(
+        [
+            complete_sectored_counts_dataset.epoch[idx : idx + bin_size].mean().item()
+            for idx in range(0, len(complete_sectored_counts_dataset.epoch), 10)
+        ],
+        bin_size,
+    )
+
+    filtered_dataset = filter_dataset_to_processing_day(
+        complete_sectored_counts_dataset, packet_date, epoch_per_complete_set
+    )
+
+    # Trim livetime to the size of the filtered dataset but shifted 10 minutes earlier.
+    filtered_dataset = subset_livetime(filtered_dataset)
+    return filtered_dataset, epoch_per_complete_set
+
+
+def update_livetime_coord(sectored_dataset: xr.Dataset) -> xr.Dataset:
+    """
+    Update livetime_counter to use a new epoch coordinate.
+
+    Parameters
+    ----------
+    sectored_dataset : xarray.Dataset
+        The dataset containing sectored counts and livetime data.
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset with modified livetime_counter.
+    """
+    epoch_values = sectored_dataset.epoch.values
+    sectored_dataset = sectored_dataset.assign_coords(
+        {
+            "epoch_livetime": ("epoch", epoch_values),
+        }
+    )
+    da = sectored_dataset["livetime_counter"]
+    da = da.assign_coords(epoch_livetime=("epoch", epoch_values))
+
+    # Swap the dimension from 'epoch' to 'epoch_livetime'
+    da = da.swap_dims({"epoch": "epoch_livetime"})
+
+    # Update the dataset with the modified variable
+    sectored_dataset["livetime_counter"] = da
+
+    return sectored_dataset
+
+
+def subset_livetime(dataset: xr.Dataset) -> xr.Dataset:
+    """
+    Trim livetime to values shifted 10 minutes earlier than sectored data.
+
+    This ensures that the livetime values correspond to the sectored counts correctly
+    since sectored data is collected 10 minutes before it's transmitted.
+
+    Parameters
+    ----------
+    dataset : xarray.Dataset
+        The dataset containing sectored counts and livetime data.
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset with trimmed livetime data.
+    """
+    # Get index positions of epoch[0] and epoch[-1] in epoch_livetime
+    epoch_vals = dataset["epoch"].values
+    livetime_vals = dataset["epoch_livetime"].values
+
+    start_idx = np.where(livetime_vals == epoch_vals[0])[0][0]
+    end_idx = np.where(livetime_vals == epoch_vals[-1])[0][0]
+
+    # Compute shifted indices
+    start_trimmed = max(start_idx - 10, 0)
+    end_trimmed = max(end_idx - 10, 0)
+
+    return dataset.isel(epoch_livetime=slice(start_trimmed, end_trimmed + 1))
+
+
+def filter_dataset_to_processing_day(
+    dataset: xr.Dataset,
+    packet_date: str,
+    epoch_array: Optional[np.ndarray] = None,
+    sc_tick: bool = False,
+) -> xr.Dataset:
+    """
+    Filter the dataset for data within the processing day.
+
+    Parameters
+    ----------
+    dataset : xarray.Dataset
+        The dataset to filter.
+    packet_date : str
+        The date of the packet data in 'YYYYMMDD' format.
+    epoch_array : np.ndarray, optional
+        An array of epoch values to filter by. If not provided,
+        the dataset's epoch will be used. This is used for sectored
+        counts data where an array of mean epoch values for major frames
+        (10 minute intervals) is used to filter the dataset to ensure
+        that major frames that span midnight, but belong to the processing
+        day, are included.
+    sc_tick : bool, optional
+        If true, the dataset's sc_tick will be used to filter data as well.
+        This ensures that the ccsds headers that use sc_tick as a coordinate,
+        instead of epoch, also corresponds to the processing day.
+
+    Returns
+    -------
+    xarray.Dataset
+        The filtered dataset containing data within the processing day.
+    """
+    processing_day = datetime.strptime(packet_date, "%Y%m%d").strftime("%Y-%m-%d")
+
+    # Filter dataset by epoch
+    epoch = dataset["epoch"].values if epoch_array is None else epoch_array
+    epoch_dt = et_to_datetime64(ttj2000ns_to_et(epoch))
+    epochs_in_processing_day = np.where(
+        epoch_dt.astype("datetime64[D]") == np.datetime64(processing_day)
+    )[0]
+    dataset = dataset.isel(epoch=epochs_in_processing_day)
+
+    # If sc_tick is provided (coord for ccsds headers), filter by sc_tick too
+    if sc_tick:
+        sc_tick_dt = met_to_datetime64(dataset["sc_tick"].values)
+        indices_in_processing_day = np.where(
+            sc_tick_dt.astype("datetime64[D]") == np.datetime64(processing_day)
+        )[0]
+        dataset = dataset.isel(sc_tick=indices_in_processing_day)
+    return dataset
+
+
 def process_science(
-    dataset: xr.Dataset, attr_mgr: ImapCdfAttributes
+    dataset: xr.Dataset, attr_mgr: ImapCdfAttributes, packet_date: str
 ) -> list[xr.Dataset]:
     """
     Will process science datasets for CDF products.
 
-    Process binary science data for CDF creation. The data is
-    grouped into science frames, decommutated and decompressed,
-    and split into count rates and event datasets. Updates the
-    dataset attributes and coordinates and data variable
-    dimensions according to specifications in a cdf yaml file.
+    The function processes binary science data for CDF creation.
+    The data is decommutated, decompressed, grouped into science frames,
+    and split into count rates, sectored count rates, and event datasets.
+    It also updates the dataset attributes according to specifications
+    in a cdf yaml file.
 
     Parameters
     ----------
     dataset : xarray.Dataset
         A dataset containing HIT science data.
-
     attr_mgr : ImapCdfAttributes
         Attribute manager used to get the data product field's attributes.
+    packet_date : str
+        The date of the packet data, used for processing.
 
     Returns
     -------
@@ -338,8 +582,26 @@ def process_science(
     # Decommutate and decompress the science data
     sci_dataset = decom_hit(dataset)
 
-    # Organize sectored rates by species type
-    sci_dataset = subcom_sectorates(sci_dataset)
+    # Create dataset for sectored data organized by species type
+    sectored_dataset = subcom_sectorates(sci_dataset)
+
+    # Subset sectored data for complete sets (10 min intervals covering all species)
+    sectored_dataset, major_frame_epochs = subset_sectored_counts(
+        sectored_dataset, packet_date
+    )
+
+    # TODO:
+    #  - headers are values per packet rather than frame. Do these need to align
+    #    with the science frames?
+    #    For instance, the mean epoch for a frame that spans midngight might contain
+    #    packets from the previous day and filtering sc_tick by processing day will
+    #    exclude those packets. Is this an issue?
+    #  - add headers to sectored dataset?
+
+    # Filter the science dataset to only include data from the processing day
+    sci_dataset = filter_dataset_to_processing_day(
+        sci_dataset, packet_date, sc_tick=True
+    )
 
     # Split the science data into count rates and event datasets
     pha_raw_dataset = xr.Dataset(
@@ -349,9 +611,11 @@ def process_science(
 
     # Calculate uncertainties for count rates
     count_rates_dataset = calculate_uncertainties(count_rates_dataset)
+    sectored_count_rates_dataset = calculate_uncertainties(sectored_dataset)
 
     l1a_datasets: dict = {
         "imap_hit_l1a_counts": count_rates_dataset,
+        "imap_hit_l1a_counts_sectored": sectored_count_rates_dataset,
         "imap_hit_l1a_direct-events": pha_raw_dataset,
     }
 
@@ -362,3 +626,20 @@ def process_science(
         logger.info(f"HIT L1A dataset created for {logical_source}")
 
     return list(l1a_datasets.values())
+
+
+if __name__ == "__main__":
+    from imap_processing import imap_module_directory
+
+    # L0 file path
+    packet_file = (
+        imap_module_directory / "tests/hit/test_data/hit_l1a_sample_2_nu_v4.ccsds"
+    )
+
+    start_date = "20100106"
+
+    datasets = hit_l1a(packet_file, start_date)
+
+    # counts = datasets[0]
+    # print(counts)
+    # print(counts.data_vars)

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -19,7 +19,6 @@ from imap_processing.hit.hit_utils import (
 from imap_processing.hit.l0.constants import (
     AZIMUTH_ANGLES,
     MOD_10_MAPPING,
-    MOD_10_PATTERN,
     ZENITH_ANGLES,
 )
 from imap_processing.hit.l0.decom_hit import decom_hit
@@ -37,7 +36,7 @@ logger = logging.getLogger(__name__)
 fillval = -9223372036854775808
 
 
-def hit_l1a(packet_file: Path, packet_date: Union[str, Path]) -> list[xr.Dataset]:
+def hit_l1a(packet_file: Path, packet_date: Union[str, None]) -> list[xr.Dataset]:
     """
     Will process HIT L0 data into L1A data products.
 
@@ -56,31 +55,32 @@ def hit_l1a(packet_file: Path, packet_date: Union[str, Path]) -> list[xr.Dataset
     """
     if not packet_date:
         raise ValueError("Packet date is required for processing L1A data.")
-    else:
-        # Unpack ccsds file to xarray datasets
-        datasets_by_apid = get_datasets_by_apid(str(packet_file))
 
-        # Create the attribute manager for this data level
-        attr_mgr = get_attribute_manager("l1a")
+    # Unpack ccsds file to xarray datasets
+    datasets_by_apid = get_datasets_by_apid(str(packet_file))
 
-        l1a_datasets = []
+    # Create the attribute manager for this data level
+    attr_mgr = get_attribute_manager("l1a")
 
-        # Process l1a data products
-        if HitAPID.HIT_HSKP in datasets_by_apid:
-            logger.info("Creating HIT L1A housekeeping dataset")
-            hk_dataset = process_housekeeping_data(
-                datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1a_hk"
+    # Process l1a data products
+    l1a_datasets = []
+    if HitAPID.HIT_HSKP in datasets_by_apid:
+        logger.info("Creating HIT L1A housekeeping dataset")
+        hk_dataset = process_housekeeping_data(
+            datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1a_hk"
+        )
+        # filter the housekeeping dataset to the processing day
+        hk_dataset = filter_dataset_to_processing_day(
+            hk_dataset, str(packet_date), epoch_vals=hk_dataset["epoch"].values
+        )
+        l1a_datasets.append(hk_dataset)
+    if HitAPID.HIT_SCIENCE in datasets_by_apid:
+        l1a_datasets.extend(
+            process_science(
+                datasets_by_apid[HitAPID.HIT_SCIENCE], attr_mgr, str(packet_date)
             )
-            # filter the housekeeping dataset to the processing day
-            hk_dataset = filter_dataset_to_processing_day(hk_dataset, str(packet_date))
-            l1a_datasets.append(hk_dataset)
-        if HitAPID.HIT_SCIENCE in datasets_by_apid:
-            l1a_datasets.extend(
-                process_science(
-                    datasets_by_apid[HitAPID.HIT_SCIENCE], attr_mgr, str(packet_date)
-                )
-            )
-        return l1a_datasets
+        )
+    return l1a_datasets
 
 
 def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
@@ -121,15 +121,14 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
         Xarray dataset with sectored rates data organized by species.
     """
     # Initialize the dataset with the required variables
-    updated_dataset = xr.Dataset(
-        {
-            "sectorates": sci_dataset["sectorates"],
-            "hdr_minute_cnt": sci_dataset["hdr_minute_cnt"],
-            "livetime_counter": sci_dataset["livetime_counter"],
-            "hdr_dynamic_threshold_state": sci_dataset["hdr_dynamic_threshold_state"],
-        },
-        coords={"epoch": sci_dataset["epoch"]},
-    )
+    updated_dataset = sci_dataset[
+        [
+            "sectorates",
+            "hdr_minute_cnt",
+            "livetime_counter",
+            "hdr_dynamic_threshold_state",
+        ]
+    ].copy(deep=True)
 
     # Calculate mod 10 values
     hdr_min_count_mod_10 = updated_dataset.hdr_minute_cnt.values % 10
@@ -337,7 +336,7 @@ def add_cdf_attributes(
 
 def find_complete_mod10_sets(mod_vals: np.ndarray) -> np.ndarray:
     """
-    Find start indices where mod_vals matches [0,1,...,9] pattern.
+    Find start indices where mod values match [0,1,2,3,4,5,6,7,8,9] pattern.
 
     Parameters
     ----------
@@ -349,7 +348,8 @@ def find_complete_mod10_sets(mod_vals: np.ndarray) -> np.ndarray:
     np.ndarray
         Indices in mod_vals where the complete pattern [0, 1, ..., 9] starts.
     """
-    window_size = len(MOD_10_PATTERN)
+    # The pattern to match is an array from 0-9
+    window_size = 10
 
     if mod_vals.size < window_size:
         logger.warning(
@@ -359,7 +359,7 @@ def find_complete_mod10_sets(mod_vals: np.ndarray) -> np.ndarray:
         return np.array([], dtype=int)
     # Use sliding windows to find pattern matches
     sw_view = np.lib.stride_tricks.sliding_window_view(mod_vals, window_size)
-    matches = np.all(sw_view == MOD_10_PATTERN, axis=1)
+    matches = np.all(sw_view == np.arange(window_size), axis=1)
     return np.where(matches)[0]
 
 
@@ -397,7 +397,11 @@ def subset_sectored_counts(
     # epoch dimension is filtered for complete sets.
     sectored_counts_dataset = update_livetime_coord(sectored_counts_dataset)
 
-    # Identify 10-minute intervals of complete sectored counts.
+    # Identify 10-minute intervals of complete sectored counts
+    # by using the mod 10 values of the header minute counts.
+    # Mod 10 determines the species and energy bin the data belongs
+    # to. A mapping of mod 10 values to species and energy bins is
+    # provided in l0/constants.py for reference.
     bin_size = 10
     mod_10: np.ndarray = sectored_counts_dataset.hdr_minute_cnt.values % 10
     start_indices = find_complete_mod10_sets(mod_10)
@@ -435,7 +439,7 @@ def subset_sectored_counts(
 
     # Trim the sectored data to epoch_per_complete_set values in the processing day
     filtered_dataset = filter_dataset_to_processing_day(
-        complete_sectored_counts_dataset, packet_date, epoch_per_complete_set
+        complete_sectored_counts_dataset, packet_date, epoch_vals=epoch_per_complete_set
     )
 
     # Trim livetime to the size of the sectored data but shifted 10 minutes earlier.
@@ -528,7 +532,7 @@ def subset_livetime(dataset: xr.Dataset) -> xr.Dataset:
 def filter_dataset_to_processing_day(
     dataset: xr.Dataset,
     packet_date: str,
-    epoch_array: Optional[np.ndarray] = None,
+    epoch_vals: np.ndarray,
     sc_tick: bool = False,
 ) -> xr.Dataset:
     """
@@ -540,13 +544,13 @@ def filter_dataset_to_processing_day(
         The dataset to filter.
     packet_date : str
         The date of the packet data in 'YYYYMMDD' format.
-    epoch_array : np.ndarray
-        An array of epoch values to filter by. If not provided,
-        the dataset's epoch will be used. This is used for sectored
-        counts data where an array of mean epoch values for major frames
-        (10 minute intervals) is used to filter the dataset to ensure
-        that major frames that span midnight, but belong to the processing
-        day, are included.
+    epoch_vals : np.ndarray
+        An array of epoch values. Used to identify indices of data that
+        belong in the processing day. For sectored counts data, an
+        array of mean epoch values for major frames (10 min. intervals)
+        is used to filter the dataset to ensure that major frames that span
+        midnight, but belong to the processing day, are included. For other
+        datasets, the dataset's epoch coordinate values will be used.
     sc_tick : bool
         If true, the dataset's sc_tick will be used to filter data as well.
         This ensures that the ccsds headers that use sc_tick as a coordinate,
@@ -559,13 +563,12 @@ def filter_dataset_to_processing_day(
     """
     processing_day = datetime.strptime(packet_date, "%Y%m%d").strftime("%Y-%m-%d")
 
-    # Filter dataset by epoch
-    epoch = dataset["epoch"].values if epoch_array is None else epoch_array
-    epoch_dt = et_to_datetime64(ttj2000ns_to_et(epoch))
-    epochs_in_processing_day = np.where(
+    # Filter dataset by epoch indices in processing day
+    epoch_dt = et_to_datetime64(ttj2000ns_to_et(epoch_vals))
+    epoch_indices_in_processing_day = np.where(
         epoch_dt.astype("datetime64[D]") == np.datetime64(processing_day)
     )[0]
-    dataset = dataset.isel(epoch=epochs_in_processing_day)
+    dataset = dataset.isel(epoch=epoch_indices_in_processing_day)
 
     # If sc_tick is provided (coord for ccsds headers), filter by sc_tick too
     if sc_tick:
@@ -623,7 +626,7 @@ def process_science(
 
     # Filter the science dataset to only include data from the processing day
     sci_dataset = filter_dataset_to_processing_day(
-        sci_dataset, packet_date, sc_tick=True
+        sci_dataset, packet_date, epoch_vals=sci_dataset["epoch"].values, sc_tick=True
     )
 
     # Split the science data into count rates and event datasets

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import xarray as xr
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 fillval = -9223372036854775808
 
 
-def hit_l1a(packet_file: Path, packet_date: Optional[str]) -> list[xr.Dataset]:
+def hit_l1a(packet_file: Path, packet_date: Union[str, Path]) -> list[xr.Dataset]:
     """
     Will process HIT L0 data into L1A data products.
 
@@ -73,7 +73,7 @@ def hit_l1a(packet_file: Path, packet_date: Optional[str]) -> list[xr.Dataset]:
                 datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1a_hk"
             )
             # filter the housekeeping dataset to the processing day
-            hk_dataset = filter_dataset_to_processing_day(hk_dataset, packet_date)
+            hk_dataset = filter_dataset_to_processing_day(hk_dataset, str(packet_date))
             l1a_datasets.append(hk_dataset)
         if HitAPID.HIT_SCIENCE in datasets_by_apid:
             l1a_datasets.extend(

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -18,6 +18,7 @@ from imap_processing.hit.hit_utils import (
 from imap_processing.hit.l0.constants import (
     AZIMUTH_ANGLES,
     MOD_10_MAPPING,
+    MOD_10_PATTERN,
     ZENITH_ANGLES,
 )
 from imap_processing.hit.l0.decom_hit import decom_hit
@@ -128,6 +129,7 @@ def subcom_sectorates(sci_dataset: xr.Dataset) -> xr.Dataset:
             "sectorates": sci_dataset["sectorates"],
             "hdr_minute_cnt": sci_dataset["hdr_minute_cnt"],
             "livetime_counter": sci_dataset["livetime_counter"],
+            "hdr_dynamic_threshold_state": sci_dataset["hdr_dynamic_threshold_state"],
         },
         coords={"epoch": sci_dataset["epoch"]},
     )
@@ -336,7 +338,7 @@ def add_cdf_attributes(
     return dataset
 
 
-def find_complete_mod10_sets(mod_vals: np.ndarray, window_size: int = 10) -> np.ndarray:
+def find_complete_mod10_sets(mod_vals: np.ndarray) -> np.ndarray:
     """
     Find start indices where mod_vals matches [0,1,...,9] pattern.
 
@@ -344,24 +346,29 @@ def find_complete_mod10_sets(mod_vals: np.ndarray, window_size: int = 10) -> np.
     ----------
     mod_vals : np.ndarray
         1D array of mod 10 values from the hdr_minute_cnt field in the L1A counts data.
-    window_size : int, optional
-        The size of the sliding window to match the pattern. Default is 10.
 
     Returns
     -------
     np.ndarray
         Indices in mod_vals where the complete pattern [0, 1, ..., 9] starts.
     """
-    pattern = np.arange(window_size)
+    window_size = len(MOD_10_PATTERN)
+
+    if mod_vals.size < window_size:
+        logger.warning(
+            "Mod 10 array is smaller than the required window size for "
+            "pattern matching."
+        )
+        return np.array([], dtype=int)
     # Use sliding windows to find pattern matches
     sw_view = np.lib.stride_tricks.sliding_window_view(mod_vals, window_size)
-    matches = np.all(sw_view == pattern, axis=1)
+    matches = np.all(sw_view == MOD_10_PATTERN, axis=1)
     return np.where(matches)[0]
 
 
 def subset_sectored_counts(
     sectored_counts_dataset: xr.Dataset, packet_date: str
-) -> tuple[xr.Dataset, np.ndarray]:
+) -> xr.Dataset:
     """
     Subset data for complete sets of sectored counts and corresponding livetime values.
 
@@ -381,9 +388,9 @@ def subset_sectored_counts(
 
     Returns
     -------
-    tuple[xr.Dataset, np.ndarray]
-        Dataset of complete sectored counts and mean epoch values
-        for the complete sets of sectored counts.
+    xr.Dataset
+        A dataset of complete sectored counts and corresponding livetime values
+        for the processing day.
     """
     # TODO: Update to use fill values for partial frames rather than drop them
 
@@ -395,7 +402,7 @@ def subset_sectored_counts(
 
     # Identify 10-minute intervals of complete sectored counts.
     bin_size = 10
-    mod_10 = sectored_counts_dataset.hdr_minute_cnt.values % 10
+    mod_10: np.ndarray = sectored_counts_dataset.hdr_minute_cnt.values % 10
     start_indices = find_complete_mod10_sets(mod_10)
 
     # Filter out start indices that are less than or equal to the bin size
@@ -428,13 +435,17 @@ def subset_sectored_counts(
         bin_size,
     )
 
+    # Filter dataset for data in the processing day
+
+    # Trim the sectored data to epoch_per_complete_set values in the processing day
     filtered_dataset = filter_dataset_to_processing_day(
         complete_sectored_counts_dataset, packet_date, epoch_per_complete_set
     )
 
-    # Trim livetime to the size of the filtered dataset but shifted 10 minutes earlier.
+    # Trim livetime to the size of the sectored data but shifted 10 minutes earlier.
     filtered_dataset = subset_livetime(filtered_dataset)
-    return filtered_dataset, epoch_per_complete_set
+
+    return filtered_dataset
 
 
 def update_livetime_coord(sectored_dataset: xr.Dataset) -> xr.Dataset:
@@ -486,12 +497,23 @@ def subset_livetime(dataset: xr.Dataset) -> xr.Dataset:
     xarray.Dataset
         The updated dataset with trimmed livetime data.
     """
-    # Get index positions of epoch[0] and epoch[-1] in epoch_livetime
     epoch_vals = dataset["epoch"].values
-    livetime_vals = dataset["epoch_livetime"].values
+    epoch_livetime_vals = dataset["epoch_livetime"].values
 
-    start_idx = np.where(livetime_vals == epoch_vals[0])[0][0]
-    end_idx = np.where(livetime_vals == epoch_vals[-1])[0][0]
+    if not epoch_vals.size:
+        logger.error("Epoch values are empty. Cannot proceed with livetime subsetting.")
+        raise ValueError("Epoch values are empty.")
+
+    # Get index positions of epoch[0] and epoch[-1] in epoch_livetime
+    start_idx = np.where(epoch_livetime_vals == epoch_vals[0])[0][0]
+    end_idx = np.where(epoch_livetime_vals == epoch_vals[-1])[0][0]
+
+    if start_idx < 10:
+        logger.error(
+            "Start or end indices for livetime are less than 10. "
+            "This indicates that the dataset is too small to shift livetime correctly."
+        )
+        raise ValueError("Start or end indices for livetime are out of range.")
 
     # Compute shifted indices
     start_trimmed = max(start_idx - 10, 0)
@@ -587,17 +609,16 @@ def process_science(
     sectored_dataset = subcom_sectorates(sci_dataset)
 
     # Subset sectored data for complete sets (10 min intervals covering all species)
-    sectored_dataset, major_frame_epochs = subset_sectored_counts(
-        sectored_dataset, packet_date
-    )
+    sectored_dataset = subset_sectored_counts(sectored_dataset, packet_date)
 
     # TODO:
     #  - headers are values per packet rather than frame. Do these need to align
     #    with the science frames?
-    #    For instance, the mean epoch for a frame that spans midngight might contain
-    #    packets from the previous day and filtering sc_tick by processing day will
+    #    For instance, the mean epoch for a frame that spans midnight might contain
+    #    packets from the previous day but filtering sc_tick by processing day will
     #    exclude those packets. Is this an issue?
-    #  - add headers to sectored dataset?
+    #  - include ccsds headers in sectored dataset?
+    #  - drop sectorates from standard dataset?
 
     # Filter the science dataset to only include data from the processing day
     sci_dataset = filter_dataset_to_processing_day(

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -45,7 +45,7 @@ def hit_l1a(packet_file: Path, packet_date: Union[str, Path]) -> list[xr.Dataset
     ----------
     packet_file : str
         Path to the CCSDS data packet file.
-    packet_date : str, optional
+    packet_date : str
         The date of the packet data in 'YYYYMMDD' format. This is used to filter
         data to the correct processing day since L0 will have a buffer around midnight.
 

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -636,7 +636,7 @@ def process_science(
     sectored_count_rates_dataset = calculate_uncertainties(sectored_dataset)
 
     l1a_datasets: dict = {
-        "imap_hit_l1a_counts": count_rates_dataset,
+        "imap_hit_l1a_counts_standard": count_rates_dataset,
         "imap_hit_l1a_counts_sectored": sectored_count_rates_dataset,
         "imap_hit_l1a_direct-events": pha_raw_dataset,
     }

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -55,8 +55,7 @@ def hit_l1a(packet_file: Path, packet_date: Union[str, Path]) -> list[xr.Dataset
         List of Datasets of L1A processed data.
     """
     if not packet_date:
-        logger.error("Packet date is required for processing L1A data.")
-        raise ValueError("Packet date cannot be None.")
+        raise ValueError("Packet date is required for processing L1A data.")
     else:
         # Unpack ccsds file to xarray datasets
         datasets_by_apid = get_datasets_by_apid(str(packet_file))
@@ -406,11 +405,10 @@ def subset_sectored_counts(
     # Filter out start indices that are less than or equal to the bin size
     # since the previous 10 minutes are needed for calculating rates
     if start_indices.size == 0:
-        logger.error(
+        raise ValueError(
             "No data to process - valid start indices not found for "
             "complete sectored counts."
         )
-        raise ValueError("No valid start indices found for complete sectored counts.")
     else:
         start_indices = start_indices[start_indices >= bin_size]
 
@@ -450,10 +448,16 @@ def update_livetime_coord(sectored_dataset: xr.Dataset) -> xr.Dataset:
     """
     Update livetime_counter to use a new epoch coordinate.
 
+    Assign a new epoch coordinate to the `livetime_counter` variable.
+    This new coordinate is aligned with the original `epoch` dimension,
+    ensuring that `livetime_counter` remains unaffected when the original
+    `epoch` dimension is filtered for complete sets in `subset_sectored_counts`
+    function.
+
     Parameters
     ----------
     sectored_dataset : xarray.Dataset
-        The dataset containing sectored counts and livetime data.
+        The dataset containing sectored counts and livetime_counter data.
 
     Returns
     -------
@@ -495,25 +499,26 @@ def subset_livetime(dataset: xr.Dataset) -> xr.Dataset:
     xarray.Dataset
         The updated dataset with trimmed livetime data.
     """
+    # epoch values are per science frame which is 1 minute
     epoch_vals = dataset["epoch"].values
     epoch_livetime_vals = dataset["epoch_livetime"].values
 
     if not epoch_vals.size:
-        logger.error("Epoch values are empty. Cannot proceed with livetime subsetting.")
-        raise ValueError("Epoch values are empty.")
+        raise ValueError(
+            "Epoch values are empty. Cannot proceed with livetime subsetting."
+        )
 
     # Get index positions of epoch[0] and epoch[-1] in epoch_livetime
     start_idx = np.where(epoch_livetime_vals == epoch_vals[0])[0][0]
     end_idx = np.where(epoch_livetime_vals == epoch_vals[-1])[0][0]
 
     if start_idx < 10:
-        logger.error(
-            "Start or end indices for livetime are less than 10. "
-            "This indicates that the dataset is too small to shift livetime correctly."
+        raise ValueError(
+            "Start index for livetime is less than 10. This indicates that the "
+            "dataset is too small to shift livetime correctly."
         )
-        raise ValueError("Start or end indices for livetime are out of range.")
 
-    # Compute shifted indices
+    # Compute shifted indices by 10 minutes
     start_trimmed = max(start_idx - 10, 0)
     end_trimmed = max(end_idx - 10, 0)
 

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -637,8 +637,8 @@ def process_science(
     sectored_count_rates_dataset = calculate_uncertainties(sectored_dataset)
 
     l1a_datasets: dict = {
-        "imap_hit_l1a_counts_standard": count_rates_dataset,
-        "imap_hit_l1a_counts_sectored": sectored_count_rates_dataset,
+        "imap_hit_l1a_counts-standard": count_rates_dataset,
+        "imap_hit_l1a_counts-sectored": sectored_count_rates_dataset,
         "imap_hit_l1a_direct-events": pha_raw_dataset,
     }
 

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -378,7 +378,7 @@ def subset_sectored_counts(
 
     Parameters
     ----------
-    sectored_counts_dataset : xr.Dataset
+    sectored_counts_dataset : xarray.Dataset
         The sectored counts dataset.
 
     packet_date : str
@@ -386,7 +386,7 @@ def subset_sectored_counts(
 
     Returns
     -------
-    xr.Dataset
+    xarray.Dataset
         A dataset of complete sectored counts and corresponding livetime values
         for the processing day.
     """
@@ -535,14 +535,14 @@ def filter_dataset_to_processing_day(
         The dataset to filter.
     packet_date : str
         The date of the packet data in 'YYYYMMDD' format.
-    epoch_array : np.ndarray, optional
+    epoch_array : np.ndarray
         An array of epoch values to filter by. If not provided,
         the dataset's epoch will be used. This is used for sectored
         counts data where an array of mean epoch values for major frames
         (10 minute intervals) is used to filter the dataset to ensure
         that major frames that span midnight, but belong to the processing
         day, are included.
-    sc_tick : bool, optional
+    sc_tick : bool
         If true, the dataset's sc_tick will be used to filter data as well.
         This ensures that the ccsds headers that use sc_tick as a coordinate,
         instead of epoch, also corresponds to the processing day.

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -63,15 +63,15 @@ def hit_l1b(dependencies: dict) -> list[xr.Dataset]:
                 )
             )
             logger.info("HIT L1B housekeeping dataset created")
-    if "imap_hit_l1a_counts_standard" in dependencies:
+    if "imap_hit_l1a_counts-standard" in dependencies:
         # Process science data to L1B datasets
-        l1a_counts_dataset = dependencies["imap_hit_l1a_counts_standard"]
+        l1a_counts_dataset = dependencies["imap_hit_l1a_counts-standard"]
         l1b_datasets.extend(process_science_data(l1a_counts_dataset, attr_mgr))
         logger.info("HIT L1B science datasets created")
 
-    if "imap_hit_l1a_counts_sectored" in dependencies:
+    if "imap_hit_l1a_counts-sectored" in dependencies:
         # Process science data to L1B datasets
-        l1a_counts_dataset = dependencies["imap_hit_l1a_counts_sectored"]
+        l1a_counts_dataset = dependencies["imap_hit_l1a_counts-sectored"]
         l1b_datasets.extend(process_science_data(l1a_counts_dataset, attr_mgr))
         logger.info("HIT L1B science datasets created")
 
@@ -114,7 +114,7 @@ def process_science_data(
 
     l1b_datasets = {}
 
-    if "imap_hit_l1a_counts_standard" in l1a_counts_dataset.attrs["Logical_source"]:
+    if "imap_hit_l1a_counts-standard" in l1a_counts_dataset.attrs["Logical_source"]:
         # Process counts data to L1B datasets
         l1b_datasets.update(
             {
@@ -126,7 +126,7 @@ def process_science_data(
                 ),
             }
         )
-    elif "imap_hit_l1a_counts_sectored" in l1a_counts_dataset.attrs["Logical_source"]:
+    elif "imap_hit_l1a_counts-sectored" in l1a_counts_dataset.attrs["Logical_source"]:
         # Process counts data to L1B datasets
         l1b_datasets.update(
             {

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -63,9 +63,15 @@ def hit_l1b(dependencies: dict) -> list[xr.Dataset]:
                 )
             )
             logger.info("HIT L1B housekeeping dataset created")
-    if "imap_hit_l1a_counts" in dependencies:
+    if "imap_hit_l1a_counts_standard" in dependencies:
         # Process science data to L1B datasets
-        l1a_counts_dataset = dependencies["imap_hit_l1a_counts"]
+        l1a_counts_dataset = dependencies["imap_hit_l1a_counts_standard"]
+        l1b_datasets.extend(process_science_data(l1a_counts_dataset, attr_mgr))
+        logger.info("HIT L1B science datasets created")
+
+    if "imap_hit_l1a_counts_sectored" in dependencies:
+        # Process science data to L1B datasets
+        l1a_counts_dataset = dependencies["imap_hit_l1a_counts_sectored"]
         l1b_datasets.extend(process_science_data(l1a_counts_dataset, attr_mgr))
         logger.info("HIT L1B science datasets created")
 
@@ -106,18 +112,29 @@ def process_science_data(
     livetime = l1a_counts_dataset["livetime_counter"] / LIVESTIM_PULSES
     livetime = livetime.rename("livetime")
 
-    # Process counts data to L1B datasets
-    l1b_datasets: dict = {
-        "imap_hit_l1b_standard-rates": process_standard_rates_data(
-            l1a_counts_dataset, livetime
-        ),
-        "imap_hit_l1b_summed-rates": process_summed_rates_data(
-            l1a_counts_dataset, livetime
-        ),
-        "imap_hit_l1b_sectored-rates": process_sectored_rates_data(
-            l1a_counts_dataset, livetime
-        ),
-    }
+    l1b_datasets = {}
+
+    if "imap_hit_l1a_counts_standard" in l1a_counts_dataset.attrs["Logical_source"]:
+        # Process counts data to L1B datasets
+        l1b_datasets.update(
+            {
+                "imap_hit_l1b_standard-rates": process_standard_rates_data(
+                    l1a_counts_dataset, livetime
+                ),
+                "imap_hit_l1b_summed-rates": process_summed_rates_data(
+                    l1a_counts_dataset, livetime
+                ),
+            }
+        )
+    elif "imap_hit_l1a_counts_sectored" in l1a_counts_dataset.attrs["Logical_source"]:
+        # Process counts data to L1B datasets
+        l1b_datasets.update(
+            {
+                "imap_hit_l1b_sectored-rates": process_sectored_rates_data(
+                    l1a_counts_dataset, livetime
+                )
+            }
+        )
 
     # Update attributes and dimensions
     for logical_source, dataset in l1b_datasets.items():
@@ -359,79 +376,11 @@ def process_summed_rates_data(
     return l1b_summed_rates_dataset
 
 
-def subset_data_for_sectored_counts(
-    l1a_counts_dataset: xr.Dataset, livetime: xr.DataArray
-) -> tuple[xr.Dataset, xr.DataArray]:
-    """
-    Subset data for complete sets of sectored counts and corresponding livetime values.
-
-    A set of sectored data starts with hydrogen and ends with iron and correspond to
-    the mod 10 values 0-9. The livetime values from the previous 10 minutes are used
-    to calculate the rates for each set since those counts are transmitted 10 minutes
-    after they were collected. Therefore, only complete sets of sectored counts where
-    livetime from the previous 10 minutes are available are included in the output.
-
-    Parameters
-    ----------
-    l1a_counts_dataset : xr.Dataset
-        The L1A counts dataset.
-    livetime : xr.DataArray
-        1D array of livetime values calculated from the livetime counter.
-
-    Returns
-    -------
-    tuple[xr.Dataset, xr.DataArray]
-        Dataset of complete sectored counts and corresponding livetime values.
-    """
-    # Identify 10-minute intervals of complete sectored counts.
-    bin_size = 10
-    mod_10 = l1a_counts_dataset.hdr_minute_cnt.values % 10
-    pattern = np.arange(bin_size)
-
-    # Use sliding windows to find pattern matches
-    matches = np.all(
-        np.lib.stride_tricks.sliding_window_view(mod_10, bin_size) == pattern, axis=1
-    )
-    start_indices = np.where(matches)[0]
-
-    # Filter out start indices that are less than or equal to the bin size
-    # since the previous 10 minutes are needed for calculating rates
-    if start_indices.size == 0:
-        logger.error(
-            "No data to process - valid start indices not found for "
-            "complete sectored counts."
-        )
-        raise ValueError("No valid start indices found for complete sectored counts.")
-    else:
-        start_indices = start_indices[start_indices >= bin_size]
-
-    # Subset data for complete sets of sectored counts.
-    # Each set of sectored counts is 10 minutes long, so we take the indices
-    # starting from the start indices and extend to the bin size of 10.
-    # This creates a 1D array of indices that correspond to the complete
-    # sets of sectored counts which is used to filter the L1A dataset and
-    # create the L1B sectored rates dataset.
-    data_indices = np.concatenate(
-        [np.arange(idx, idx + bin_size) for idx in start_indices]
-    )
-    l1b_sectored_rates_dataset = l1a_counts_dataset.isel(epoch=data_indices)
-
-    # Subset livetime values corresponding to the previous 10 minutes
-    # for each start index. This ensures the livetime data aligns correctly
-    # with the sectored counts for rate calculations.
-    livetime_indices = np.concatenate(
-        [np.arange(idx - bin_size, idx) for idx in start_indices]
-    )
-    livetime = livetime.isel(epoch=livetime_indices)
-
-    return l1b_sectored_rates_dataset, livetime
-
-
 def process_sectored_rates_data(
     l1a_counts_dataset: xr.Dataset, livetime: xr.DataArray
 ) -> xr.Dataset:
     """
-    Will process L1B sectored rates data from L1A raw counts data.
+    Will process L1A raw counts data into L1B sectored rates.
 
     A complete set of sectored counts is taken over 10 science frames (10 minutes)
     where each science frame contains counts for one species and energy range.
@@ -451,10 +400,13 @@ def process_sectored_rates_data(
     rotation is split into 15 inclination ranges). See equation 11 in the algorithm
     document.
 
+    NOTE: The L1A counts dataset has complete sets of sectored counts and livetime is
+    already shifted to 10 minutes before the counts. This was handled in L1A processing.
+
     Parameters
     ----------
     l1a_counts_dataset : xr.Dataset
-        The L1A counts dataset.
+        The L1A counts dataset containing sectored counts.
 
     livetime : xr.DataArray
         1D array of livetime values calculated from the livetime counter.
@@ -476,11 +428,6 @@ def process_sectored_rates_data(
         for var in l1a_counts_dataset.data_vars
         if any(str(var).startswith(f"{p}_") for p in particles)
     ]
-
-    # Subset data for complete sets of sectored counts and corresponding livetime values
-    l1a_counts_dataset, livetime = subset_data_for_sectored_counts(
-        l1a_counts_dataset, livetime
-    )
 
     # Sum livetime over 10 minute intervals
     livetime_10min = sum_livetime_10min(livetime)

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -116,24 +116,17 @@ def process_science_data(
 
     if "imap_hit_l1a_counts-standard" in l1a_counts_dataset.attrs["Logical_source"]:
         # Process counts data to L1B datasets
-        l1b_datasets.update(
-            {
-                "imap_hit_l1b_standard-rates": process_standard_rates_data(
-                    l1a_counts_dataset, livetime
-                ),
-                "imap_hit_l1b_summed-rates": process_summed_rates_data(
-                    l1a_counts_dataset, livetime
-                ),
-            }
+        l1b_datasets["imap_hit_l1b_standard-rates"] = process_standard_rates_data(
+            l1a_counts_dataset, livetime
+        )
+
+        l1b_datasets["imap_hit_l1b_summed-rates"] = process_summed_rates_data(
+            l1a_counts_dataset, livetime
         )
     elif "imap_hit_l1a_counts-sectored" in l1a_counts_dataset.attrs["Logical_source"]:
         # Process counts data to L1B datasets
-        l1b_datasets.update(
-            {
-                "imap_hit_l1b_sectored-rates": process_sectored_rates_data(
-                    l1a_counts_dataset, livetime
-                )
-            }
+        l1b_datasets["imap_hit_l1b_sectored-rates"] = process_sectored_rates_data(
+            l1a_counts_dataset, livetime
         )
 
     # Update attributes and dimensions

--- a/imap_processing/tests/hit/helpers/l1_validation.py
+++ b/imap_processing/tests/hit/helpers/l1_validation.py
@@ -318,6 +318,41 @@ def add_species_energy(data: pd.DataFrame) -> pd.DataFrame:
     return data
 
 
+def compare_sectored_data(frame, species, energy_bin, actual_data, expected_data):
+    """Compare sectored data for a specific frame, species, and energy bin."""
+    if "sectorates_stat_uncert_plus" in expected_data.columns:
+        np.testing.assert_allclose(
+            actual_data[f"{species}_sectored_counts_stat_uncert_plus"][frame][
+                energy_bin
+            ].data,
+            expected_data["sectorates_stat_uncert_plus"][frame],
+            rtol=1e-7,
+            atol=1e-8,
+            err_msg=f"Mismatch in {species}_sectored_counts_stat_uncert_plus "
+            f"at frame {frame}, energy_bin {energy_bin}",
+        )
+    if "sectorates_stat_uncert_minus" in expected_data.columns:
+        np.testing.assert_allclose(
+            actual_data[f"{species}_sectored_counts_stat_uncert_minus"][frame][
+                energy_bin
+            ].data,
+            expected_data["sectorates_stat_uncert_minus"][frame],
+            rtol=1e-7,
+            atol=1e-8,
+            err_msg=f"Mismatch in {species}_sectored_counts_stat_uncert_minus at "
+            f"frame {frame}, energy_bin {energy_bin}",
+        )
+    else:
+        np.testing.assert_allclose(
+            actual_data[f"{species}_sectored_counts"][frame][energy_bin].data,
+            expected_data["sectorates"][frame],
+            rtol=1e-7,
+            atol=1e-8,
+            err_msg=f"Mismatch in {species}_sectored_counts at frame {frame}, "
+            f"energy_bin {energy_bin}",
+        )
+
+
 def compare_data(
     expected_data: pd.DataFrame, actual_data: xr.Dataset, skip: list[str]
 ) -> None:
@@ -331,74 +366,44 @@ def compare_data(
     actual_data : xr.Dataset
         Processed counts data from l1a processing
     skip : list
-        Fields to skip in comparison
+        Data variables to skip in comparison
     """
-    for field in expected_data.columns:
-        if field not in skip:
-            # Check if the field is in the expected data
-            if field not in ["sc_tick_by_frame", "species"]:
-                assert field in actual_data.data_vars.keys(), (
-                    f"Field {field} not found in actual data variables"
+    for var in expected_data.columns:
+        if var not in skip:
+            if var not in ["sc_tick_by_frame", "species"]:
+                # Check if the var is in the processed dataset
+                assert var in actual_data.data_vars.keys(), (
+                    f"Field {var} not found in actual data variables"
                 )
-            if field == "sc_tick_by_frame":
+                # Compare data arrays
+                np.testing.assert_allclose(
+                    actual_data[var].values,
+                    np.stack(expected_data[var].values),
+                    rtol=1e-7,
+                    atol=1e-8,
+                    err_msg=f"Mismatch in {var}",
+                )
+            if var == "sc_tick_by_frame":
                 # Get the sc_tick values for each frame in the actual data
-                # to compare with the validation data
+                # to compare with the expected data
                 sc_tick = actual_data.sc_tick.values
                 sc_tick_by_frame = sc_tick[::20]
-                assert np.array_equal(sc_tick_by_frame, expected_data[field].values), (
-                    f"Mismatch in {field}"
+                assert np.array_equal(sc_tick_by_frame, expected_data[var].values), (
+                    f"Mismatch in {var}"
                 )
-            if field == "species" and "sectored" in actual_data.Logical_source:
-                # Compare sectored rates data using species and energy index.
+            if var == "species" and "sectored" in actual_data.Logical_source:
+                # Compare sectored rates data using species and energy bin,
                 # which are only present in the validation data. In the actual
                 # data, sectored rates are organized by species in 4D arrays.
                 #    i.e. h_sectored_counts has shape
                 #         (epoch, h_energy_index, azimuth, zenith).
-                # species and energy index are used to find the correct
+                # species and energy bin are used to find the correct
                 # array of sectored rate data from the actual data for comparison.
-                # Check frame by frame
+                # Check science frame by science frame. A science frame is a row in
+                # the validation data.
                 for frame in range(expected_data.shape[0]):
-                    species = expected_data[field][frame]
+                    species = expected_data[var][frame]
                     energy_bin = expected_data["energy_bin"][frame]
-                    if "sectorates_stat_uncert_plus" in expected_data.columns:
-                        np.testing.assert_allclose(
-                            actual_data[f"{species}_sectored_counts_stat_uncert_plus"][
-                                frame
-                            ][energy_bin].data,
-                            expected_data["sectorates_stat_uncert_plus"][frame],
-                            rtol=1e-7,  # relative tolerance
-                            atol=1e-8,  # absolute tolerance
-                            err_msg=f"Mismatch in {species}_sectored_counts_stat_uncert"
-                            f"_plus at frame {frame}, energy_bin {energy_bin}",
-                        )
-                    if "sectorates_stat_uncert_minus" in expected_data.columns:
-                        np.testing.assert_allclose(
-                            actual_data[f"{species}_sectored_counts_stat_uncert_minus"][
-                                frame
-                            ][energy_bin].data,
-                            expected_data["sectorates_stat_uncert_minus"][frame],
-                            rtol=1e-7,
-                            atol=1e-8,
-                            err_msg=f"Mismatch in {species}_sectored_counts_stat_uncert"
-                            f"_minus at frame {frame}, energy_bin {energy_bin}",
-                        )
-                    else:
-                        np.testing.assert_allclose(
-                            actual_data[f"{species}_sectored_counts"][frame][
-                                energy_bin
-                            ].data,
-                            expected_data["sectorates"][frame],
-                            rtol=1e-7,
-                            atol=1e-8,
-                            err_msg=f"Mismatch in {species}_sectored_counts at"
-                            f"frame {frame}, energy_bin {energy_bin}",
-                        )
-                # For all other fields, compare the data arrays directly
-                if field != "species":
-                    np.testing.assert_allclose(
-                        actual_data[field].values,
-                        expected_data[field].values,
-                        rtol=1e-7,
-                        atol=1e-8,
-                        err_msg=f"Mismatch in {field}",
+                    compare_sectored_data(
+                        frame, species, energy_bin, actual_data, expected_data
                     )

--- a/imap_processing/tests/hit/helpers/l1_validation.py
+++ b/imap_processing/tests/hit/helpers/l1_validation.py
@@ -334,24 +334,30 @@ def compare_data(
         Fields to skip in comparison
     """
     for field in expected_data.columns:
-        if field not in [
-            "sc_tick_by_frame",
-            "species",
-            "energy_bin",
-        ]:
-            assert field in actual_data.data_vars.keys(), (
-                f"Field {field} not found in actual data variables"
-            )
         if field not in skip:
-            for frame in range(expected_data.shape[0]):
-                if field == "species":
-                    # Compare sectored rates data using species and energy index.
-                    # which are only present in the validation data. In the actual
-                    # data, sectored rates are organized by species in 4D arrays.
-                    #    i.e. h_sectored_counts has shape
-                    #         (epoch, h_energy_index, azimuth, zenith).
-                    # species and energy index are used to find the correct
-                    # array of sectored rate data from the actual data for comparison.
+            # Check if the field is in the expected data
+            if field not in ["sc_tick_by_frame", "species"]:
+                assert field in actual_data.data_vars.keys(), (
+                    f"Field {field} not found in actual data variables"
+                )
+            if field == "sc_tick_by_frame":
+                # Get the sc_tick values for each frame in the actual data
+                # to compare with the validation data
+                sc_tick = actual_data.sc_tick.values
+                sc_tick_by_frame = sc_tick[::20]
+                assert np.array_equal(sc_tick_by_frame, expected_data[field].values), (
+                    f"Mismatch in {field}"
+                )
+            if field == "species" and "sectored" in actual_data.Logical_source:
+                # Compare sectored rates data using species and energy index.
+                # which are only present in the validation data. In the actual
+                # data, sectored rates are organized by species in 4D arrays.
+                #    i.e. h_sectored_counts has shape
+                #         (epoch, h_energy_index, azimuth, zenith).
+                # species and energy index are used to find the correct
+                # array of sectored rate data from the actual data for comparison.
+                # Check frame by frame
+                for frame in range(expected_data.shape[0]):
                     species = expected_data[field][frame]
                     energy_bin = expected_data["energy_bin"][frame]
                     if "sectorates_stat_uncert_plus" in expected_data.columns:
@@ -387,20 +393,12 @@ def compare_data(
                             err_msg=f"Mismatch in {species}_sectored_counts at"
                             f"frame {frame}, energy_bin {energy_bin}",
                         )
-                elif field == "sc_tick_by_frame":
-                    # Get the sc_tick values for each frame in the actual data
-                    # to compare with the validation data
-                    sc_tick = actual_data.sc_tick.values
-                    sc_tick_by_frame = sc_tick[::20]
-                    assert np.array_equal(
-                        sc_tick_by_frame[frame], expected_data[field][frame]
-                    ), f"Mismatch in {field} at frame {frame}"
-
-                else:
+                # For all other fields, compare the data arrays directly
+                if field != "species":
                     np.testing.assert_allclose(
-                        actual_data[field][frame].data,
-                        expected_data[field][frame],
+                        actual_data[field].values,
+                        expected_data[field].values,
                         rtol=1e-7,
                         atol=1e-8,
-                        err_msg=f"Mismatch in {field} at frame {frame}",
+                        err_msg=f"Mismatch in {field}",
                     )

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -748,6 +748,9 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
 
     skip_sectored_fields = [
         *skip_fields,
+        "sectorates",
+        "sectorates_stat_uncert_plus",
+        "sectorates_stat_uncert_minus",
         "h_sectored_counts",
         "h_energy_delta_minus",
         "h_energy_delta_plus",
@@ -780,9 +783,6 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
         *skip_standard_fields,
         *skip_sectored_fields,
         "hdr_minute_cnt",
-        "sectorates",
-        "sectorates_stat_uncert_plus",
-        "sectorates_stat_uncert_minus",
     ]
 
     # drop livetime counter from skip_livetime list

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -362,7 +362,7 @@ def test_filter_dataset_to_processing_day():
 
     # Call the function
     filtered_dataset = filter_dataset_to_processing_day(
-        dataset, packet_date, sc_tick=True
+        dataset, packet_date, epoch_vals=epoch_values, sc_tick=True
     )
 
     # Assert the filtered dataset contains only data within the processing day

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -830,7 +830,8 @@ def test_hit_l1a(hk_packet_filepath, sci_packet_filepath):
         else:
             assert len(processed_datasets) == 3
             assert (
-                processed_datasets[0].attrs["Logical_source"] == "imap_hit_l1a_counts"
+                processed_datasets[0].attrs["Logical_source"]
+                == "imap_hit_l1a_counts_standard"
             )
             assert (
                 processed_datasets[1].attrs["Logical_source"]

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -183,7 +183,10 @@ def test_subset_livetime():
             "epoch_livetime": np.array([0, 1, 2]),
         },
     )
-    with pytest.raises(ValueError, match="Epoch values are empty."):
+    with pytest.raises(
+        ValueError,
+        match="Epoch values are empty. Cannot proceed with livetime subsetting.",
+    ):
         subset_livetime(dataset)
 
     # Test case 3: Not enough livetime values, the function should raise a ValueError
@@ -197,7 +200,9 @@ def test_subset_livetime():
         },
     )
     with pytest.raises(
-        ValueError, match="Start or end indices for livetime are out of range."
+        ValueError,
+        match="Start index for livetime is less than 10. This indicates that the "
+        "dataset is too small to shift livetime correctly.",
     ):
         subset_livetime(dataset)
 
@@ -486,7 +491,9 @@ def test_subset_sectored_counts():
     # Test with only partial data in the dataset
     l1a_counts_dataset = create_l1a_counts_dataset(np.arange(100, 160, 2))
     with pytest.raises(
-        ValueError, match="No valid start indices found for complete sectored counts."
+        ValueError,
+        match="No data to process - valid start indices not found for "
+        "complete sectored counts.",
     ):
         subset_sectored_counts(l1a_counts_dataset, packet_date="20100106")
 
@@ -593,27 +600,40 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
     validation_data : pd.DataFrame
         Preloaded validation data
     """
+    # TODO: consider parameterization to test both the instrument
+    #  file and fake data file
+
     # Prepare validation data for comparison with processed data
     validation_data = prepare_counts_validation_data(validation_data)
 
-    # Copy the validation data for sectored and livetime validation
+    # Copy the validation data for sectored data validation.
     # The first complete set of sectored data with sufficient livetime
-    # data available is from the index 17 to -4.
+    # data available is from index 17 to -4. Slice the validation data.
     sectored_validation_data = validation_data.iloc[17:-4].copy().reset_index(drop=True)
 
     # The corresponding livetime values for the sectored data is from index 7 to -14
     # (i.e. 10 minutes before the first complete set of sectored data).
-    livetime_validation_data = validation_data.iloc[7:-14].copy().reset_index(drop=True)
+    livetime_validation_data = (
+        validation_data[["livetime_counter"]].iloc[7:-14].copy().reset_index(drop=True)
+    )
+
+    # NOTE: slicing indices are specific to the sci_sample_raw.csv validation file
 
     # Process the sample data into datasets to be validated
     processed_datasets = hit_l1a(sci_packet_filepath, packet_date="20100105")
     standard_counts_data = processed_datasets[0]
     sectored_counts_data = processed_datasets[1]
 
-    # Fields to skip in comparison. CCSDS headers plus others.
-    # The CCSDS header fields contain data per packet in the dataset, but the
-    # validation data has one value per science frame.
-    skip_fields = [
+    # The validation data contains all science data variables for both
+    # standard and sectored datasets. When comparing each dataset to the
+    # validation data, a list of variables to skip in the comparison is
+    # provided. This is to avoid comparing variables that are not present
+    # in the dataset or are not relevant for the comparison. Variables to
+    # skip in comparison also includes CCSDS headers the datasets contain
+    # data per packet, but the validation data contains one value per
+    # science frame (20 packets)
+
+    skip_vars = [
         "version",
         "type",
         "sec_hdr_flg",
@@ -624,8 +644,7 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
         "energy_bin",
     ]
 
-    skip_standard_fields = [
-        *skip_fields,
+    skip_standard_vars = [
         "hdr_unit_num",
         "hdr_frame_version",
         "hdr_leak_conv",
@@ -746,8 +765,7 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
         "sc_tick_by_frame",
     ]
 
-    skip_sectored_fields = [
-        *skip_fields,
+    skip_sectored_vars = [
         "sectorates",
         "sectorates_stat_uncert_plus",
         "sectorates_stat_uncert_minus",
@@ -779,34 +797,27 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
         "species",
     ]
 
-    skip_combined_fields = [
-        *skip_standard_fields,
-        *skip_sectored_fields,
-        "hdr_minute_cnt",
-    ]
-
-    # drop livetime counter from skip_livetime list
-    skip_combined_fields.remove("livetime_counter")
-
-    # Compare processed standard data to validation data
+    # Compare processed standard data to validation data skipping
+    # ccsds headers and sectored data vars
     compare_data(
         expected_data=validation_data,
         actual_data=standard_counts_data,
-        skip=skip_sectored_fields,
+        skip=[*skip_vars, *skip_sectored_vars],
     )
 
-    # Compare processed sectored data to validation data
+    # Compare processed sectored data to validation data skipping
+    # ccsds headers and standard data vars
     compare_data(
         expected_data=sectored_validation_data,
         actual_data=sectored_counts_data,
-        skip=skip_standard_fields,
+        skip=[*skip_vars, *skip_standard_vars],
     )
 
-    # Compare processed sectored livetime data to validation data
+    # Compare processed livetime data for sectored data to validation data
     compare_data(
         expected_data=livetime_validation_data,
         actual_data=sectored_counts_data,
-        skip=skip_combined_fields,
+        skip=[],
     )
 
 

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -14,6 +14,7 @@ from imap_processing.hit.l1a.hit_l1a import (
     add_cdf_attributes,
     calculate_uncertainties,
     decom_hit,
+    filter_dataset_to_processing_day,
     hit_l1a,
     subcom_sectorates,
 )
@@ -172,6 +173,59 @@ def test_add_cdf_attributes():
         assert list(result[f"{dim}_label"].dims) == [f"{dim}"]
 
 
+def test_filter_dataset_to_processing_day():
+    # Create a mock dataset
+    epoch_values = np.array(
+        [
+            316008024684000000,  # 2010-01-05T23:59:18.500
+            316008084684000000,  # 2010-01-06T00:10:18.500
+            316094424684000000,  # 2010-01-06T23:59:18.500
+            316094484684000000,  # 2010-01-07T00:10:18.500
+        ]
+    )
+
+    sc_tick_values = np.array(
+        [
+            431999,  # 2010-01-05T23:59:59.000000000
+            432002,  # 2010-01-06T00:00:02.000000000
+            518399,  # 2010-01-06T23:59:59.000000000
+            518402,  # 2010-01-07T00:00:02.000000000
+        ]
+    )
+
+    dataset = xr.Dataset(
+        {
+            "var1": (["epoch"], np.arange(len(epoch_values))),
+            "var2": (["sc_tick"], np.arange(len(sc_tick_values)) * 2),
+        },
+        coords={
+            "epoch": epoch_values,
+            "sc_tick": sc_tick_values,
+        },
+    )
+
+    # Define the packet date
+    packet_date = "20100106"
+
+    # Call the function
+    filtered_dataset = filter_dataset_to_processing_day(
+        dataset, packet_date, sc_tick=True
+    )
+
+    # Assert the filtered dataset contains only data within the processing day
+    expected_epochs = np.array(
+        [
+            316008084684000000,  # 2010-01-06T00:10:18.500
+            316094424684000000,  # 2010-01-06T23:59:18.500
+        ]
+    )
+    assert np.array_equal(filtered_dataset["epoch"].values, expected_epochs)
+
+    # Assert the sc_tick values are filtered correctly
+    expected_sc_ticks = np.array([432002, 518399])
+    assert np.array_equal(filtered_dataset["sc_tick"].values, expected_sc_ticks)
+
+
 def test_validate_l1a_housekeeping_data(hk_packet_filepath):
     """Validate the housekeeping dataset created by the L1A processing.
 
@@ -183,7 +237,7 @@ def test_validate_l1a_housekeeping_data(hk_packet_filepath):
     hk_packet_filepath : str
         File path to housekeeping ccsds file
     """
-    datasets = hit_l1a(hk_packet_filepath)
+    datasets = hit_l1a(hk_packet_filepath, "20100105")
     hk_dataset = None
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1a_hk":
@@ -269,7 +323,7 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
     """
 
     # Process the sample data
-    processed_datasets = hit_l1a(sci_packet_filepath)
+    processed_datasets = hit_l1a(sci_packet_filepath, packet_date="20100105")
     l1a_counts_data = processed_datasets[0]
 
     # Prepare validation data for comparison with processed data
@@ -306,18 +360,22 @@ def test_hit_l1a(hk_packet_filepath, sci_packet_filepath):
         Path to ccsds file for science data
     """
     for packet_filepath in [hk_packet_filepath, sci_packet_filepath]:
-        processed_datasets = hit_l1a(packet_filepath)
+        processed_datasets = hit_l1a(packet_filepath, packet_date="20100105")
         assert isinstance(processed_datasets, list)
         assert all(isinstance(ds, xr.Dataset) for ds in processed_datasets)
         if packet_filepath == hk_packet_filepath:
             assert len(processed_datasets) == 1
             assert processed_datasets[0].attrs["Logical_source"] == "imap_hit_l1a_hk"
         else:
-            assert len(processed_datasets) == 2
+            assert len(processed_datasets) == 3
             assert (
                 processed_datasets[0].attrs["Logical_source"] == "imap_hit_l1a_counts"
             )
             assert (
                 processed_datasets[1].attrs["Logical_source"]
+                == "imap_hit_l1a_counts_sectored"
+            )
+            assert (
+                processed_datasets[2].attrs["Logical_source"]
                 == "imap_hit_l1a_direct-events"
             )

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -15,8 +15,12 @@ from imap_processing.hit.l1a.hit_l1a import (
     calculate_uncertainties,
     decom_hit,
     filter_dataset_to_processing_day,
+    find_complete_mod10_sets,
     hit_l1a,
     subcom_sectorates,
+    subset_livetime,
+    subset_sectored_counts,
+    update_livetime_coord,
 )
 from imap_processing.tests.hit.helpers.l1_validation import (
     compare_data,
@@ -91,6 +95,147 @@ def test_subcom_sectorates(sci_packet_filepath):
         assert sci_dataset[f"{species}_energy_mean"].shape == (shape[0],)
         assert sci_dataset[f"{species}_energy_delta_minus"].shape == (shape[0],)
         assert sci_dataset[f"{species}_energy_delta_plus"].shape == (shape[0],)
+
+
+def test_update_livetime_coord():
+    """Test the update_livetime_coord function."""
+
+    # Create a mock dataset with livetime_counter and epoch
+    epoch_values = np.array([1, 2, 3, 4, 5])
+    livetime_values = np.array([10, 20, 30, 40, 50])
+
+    sectored_dataset = xr.Dataset(
+        {
+            "livetime_counter": ("epoch", livetime_values),
+        },
+        coords={
+            "epoch": epoch_values,
+        },
+    )
+
+    # Call the function
+    updated_dataset = update_livetime_coord(sectored_dataset)
+
+    # Assert the new coordinate 'epoch_livetime' exists
+    assert "epoch_livetime" in updated_dataset.coords
+
+    # Assert the values of 'epoch_livetime' match the original epoch values
+    np.testing.assert_array_equal(
+        updated_dataset["epoch_livetime"].values, epoch_values
+    )
+
+    # Assert the dimension of 'livetime_counter' is swapped to 'epoch_livetime'
+    assert updated_dataset["livetime_counter"].dims == ("epoch_livetime",)
+
+    # Assert the values of 'livetime_counter' remain unchanged
+    np.testing.assert_array_equal(
+        updated_dataset["livetime_counter"].values, livetime_values
+    )
+
+    # Assert the original 'epoch' coordinate is still present
+    assert "epoch" in updated_dataset.coords
+
+
+def test_subset_livetime():
+    """Test the subset_livetime function."""
+
+    # Test case 1: Normal case with valid epoch and epoch_livetime sizes
+
+    # epoch_livetime goes from 0 to 59 (simulates 60 minutes)
+    epoch_livetime = np.arange(60)
+
+    # epoch is 30 minute subset of epoch_livetime
+    epoch = epoch_livetime[10:40]
+
+    dataset = xr.Dataset(
+        {
+            "livetime_counter": xr.DataArray(
+                np.arange(60),
+                dims=["epoch_livetime"],
+                coords={"epoch_livetime": epoch_livetime},
+            )
+        },
+        coords={"epoch": epoch, "epoch_livetime": epoch_livetime},
+    )
+
+    # Call the function
+    trimmed = subset_livetime(dataset)
+
+    # The trimmed livetime should match the slice from index 0 to 29 (inclusive)
+    expected_indices = slice(0, 30)
+    expected_livetime = dataset.isel(epoch_livetime=expected_indices)
+
+    # Validate the result
+    np.testing.assert_array_equal(
+        trimmed["epoch_livetime"].values, expected_livetime["epoch_livetime"].values
+    )
+    np.testing.assert_array_equal(
+        trimmed["livetime_counter"].values, expected_livetime.livetime_counter.values
+    )
+
+    # Test case 2: epoch is empty, the function should raise a ValueError
+    dataset = xr.Dataset(
+        {
+            "livetime_counter": ("epoch_livetime", np.array([10, 20, 30])),
+        },
+        coords={
+            "epoch": np.array([]),
+            "epoch_livetime": np.array([0, 1, 2]),
+        },
+    )
+    with pytest.raises(ValueError, match="Epoch values are empty."):
+        subset_livetime(dataset)
+
+    # Test case 3: Not enough livetime values, the function should raise a ValueError
+    dataset = xr.Dataset(
+        {
+            "livetime_counter": ("epoch_livetime", np.array([10, 20, 30, 40, 50])),
+        },
+        coords={
+            "epoch": np.array([1, 2, 3]),
+            "epoch_livetime": np.array([0, 1, 2, 3, 4]),
+        },
+    )
+    with pytest.raises(
+        ValueError, match="Start or end indices for livetime are out of range."
+    ):
+        subset_livetime(dataset)
+
+
+def test_find_complete_mod10_sets():
+    """Test the find_complete_mod10_sets function."""
+
+    # Test case 1: Valid pattern exists throughout
+    mod_vals = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expected_indices = np.array([0, 10])
+    result = find_complete_mod10_sets(mod_vals)
+    assert np.array_equal(result, expected_indices), (
+        f"Expected {expected_indices}, got {result}"
+    )
+
+    # Test case 2: No valid pattern
+    mod_vals = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6])
+    expected_indices = np.array([])
+    result = find_complete_mod10_sets(mod_vals)
+    assert np.array_equal(result, expected_indices), (
+        f"Expected {expected_indices}, got {result}"
+    )
+
+    # Test case 3: Pattern in the middle
+    mod_vals = np.array([5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4])
+    expected_indices = np.array([5])
+    result = find_complete_mod10_sets(mod_vals)
+    assert np.array_equal(result, expected_indices), (
+        f"Expected {expected_indices}, got {result}"
+    )
+
+    # Test case 4: Empty input
+    mod_vals = np.array([])
+    expected_indices = np.array([])
+    result = find_complete_mod10_sets(mod_vals)
+    assert np.array_equal(result, expected_indices), (
+        f"Expected {expected_indices}, got {result}"
+    )
 
 
 def test_calculate_uncertainties():
@@ -174,6 +319,8 @@ def test_add_cdf_attributes():
 
 
 def test_filter_dataset_to_processing_day():
+    """Test the filter_dataset_to_processing_day function."""
+
     # Create a mock dataset
     epoch_values = np.array(
         [
@@ -224,6 +371,124 @@ def test_filter_dataset_to_processing_day():
     # Assert the sc_tick values are filtered correctly
     expected_sc_ticks = np.array([432002, 518399])
     assert np.array_equal(filtered_dataset["sc_tick"].values, expected_sc_ticks)
+
+
+def test_subset_sectored_counts():
+    """Test the subset_sectored_counts function."""
+
+    def create_l1a_counts_dataset(hdr_minute_cnt_values):
+        """Helper to create L1A counts dataset."""
+        return xr.Dataset(
+            {
+                "hdr_minute_cnt": ("epoch", hdr_minute_cnt_values),
+                "h_sectored_counts": ("epoch", np.arange(len(hdr_minute_cnt_values))),
+                "he4_sectored_counts": ("epoch", np.arange(len(hdr_minute_cnt_values))),
+                "livetime_counter": ("epoch", np.arange(len(hdr_minute_cnt_values))),
+            },
+            coords={
+                "epoch": np.arange(
+                    316008084684000000, 316008084684000000 + len(hdr_minute_cnt_values)
+                ),
+            },
+        )
+
+    def validate_subset(l1a_counts_dataset):
+        """Helper to validate the subset results."""
+        # Define the packet date
+        packet_date = "20100106"
+        subset_dataset = subset_sectored_counts(l1a_counts_dataset, packet_date)
+        assert subset_dataset.sizes["epoch"] == 10
+        assert subset_dataset.sizes["epoch_livetime"] == 10
+        assert np.all(subset_dataset["hdr_minute_cnt"].values % 10 == np.arange(10))
+        assert np.all(
+            subset_dataset["epoch_livetime"].values
+            == subset_dataset["epoch"].values - 10
+        ), "epoch_livetime values are not shifted by 10 from epoch values"
+
+    # Test with partial data at the start and end of the dataset
+    l1a_counts_dataset = create_l1a_counts_dataset(np.arange(105, 135))
+    validate_subset(l1a_counts_dataset)
+
+    # Test with partial data in the middle of the dataset
+    l1a_counts_dataset = create_l1a_counts_dataset(
+        [
+            100,
+            101,
+            102,
+            103,
+            104,
+            105,
+            106,
+            107,
+            108,
+            109,
+            110,
+            111,
+            112,
+            113,
+            114,
+            120,
+            121,
+            122,
+            123,
+            124,
+            130,
+            131,
+            132,
+            133,
+            134,
+            135,
+            136,
+            137,
+            138,
+            139,
+        ]
+    )
+    validate_subset(l1a_counts_dataset)
+
+    # Test with partial data at the start, middle, and end of the dataset
+    l1a_counts_dataset = create_l1a_counts_dataset(
+        [
+            105,
+            106,
+            107,
+            108,
+            109,
+            110,
+            111,
+            112,
+            113,
+            114,
+            115,
+            116,
+            117,
+            118,
+            119,
+            120,
+            121,
+            122,
+            130,
+            131,
+            132,
+            133,
+            134,
+            135,
+            136,
+            137,
+            138,
+            139,
+            140,
+            141,
+        ]
+    )
+    validate_subset(l1a_counts_dataset)
+
+    # Test with only partial data in the dataset
+    l1a_counts_dataset = create_l1a_counts_dataset(np.arange(100, 160, 2))
+    with pytest.raises(
+        ValueError, match="No valid start indices found for complete sectored counts."
+    ):
+        subset_sectored_counts(l1a_counts_dataset, packet_date="20100106")
 
 
 def test_validate_l1a_housekeeping_data(hk_packet_filepath):
@@ -306,13 +571,20 @@ def test_validate_l1a_housekeeping_data(hk_packet_filepath):
 def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
     """Compare the output of the L1A processing to the validation data.
 
-    This test compares the counts data product with the validation data.
+    This test compares the counts data products with the validation data.
     The PHA data product is not validated since it's not being decommutated.
 
     Since the validation data is structured differently than the processed data,
     This test prepares the validation data for comparison by calling helper
     functions to consolidate the data into arrays and rename columns to match
     the processed data.
+
+    Additionally, since standard counts, sectored counts, and the livetime values
+    related to the sectored counts all have different time ranges, validation data
+    is further split into three parts:
+        - Standard counts validation
+        - Sectored counts validation
+        - Livetime validation
 
     Parameters
     ----------
@@ -321,15 +593,24 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
     validation_data : pd.DataFrame
         Preloaded validation data
     """
-
-    # Process the sample data
-    processed_datasets = hit_l1a(sci_packet_filepath, packet_date="20100105")
-    l1a_counts_data = processed_datasets[0]
-
     # Prepare validation data for comparison with processed data
     validation_data = prepare_counts_validation_data(validation_data)
 
-    # Fields to skip in comparison. CCSDS headers plus a few others.
+    # Copy the validation data for sectored and livetime validation
+    # The first complete set of sectored data with sufficient livetime
+    # data available is from the index 17 to -4.
+    sectored_validation_data = validation_data.iloc[17:-4].copy().reset_index(drop=True)
+
+    # The corresponding livetime values for the sectored data is from index 7 to -14
+    # (i.e. 10 minutes before the first complete set of sectored data).
+    livetime_validation_data = validation_data.iloc[7:-14].copy().reset_index(drop=True)
+
+    # Process the sample data into datasets to be validated
+    processed_datasets = hit_l1a(sci_packet_filepath, packet_date="20100105")
+    standard_counts_data = processed_datasets[0]
+    sectored_counts_data = processed_datasets[1]
+
+    # Fields to skip in comparison. CCSDS headers plus others.
     # The CCSDS header fields contain data per packet in the dataset, but the
     # validation data has one value per science frame.
     skip_fields = [
@@ -343,9 +624,189 @@ def test_validate_l1a_counts_data(sci_packet_filepath, validation_data):
         "energy_bin",
     ]
 
-    # Compare processed data to validation data
+    skip_standard_fields = [
+        *skip_fields,
+        "hdr_unit_num",
+        "hdr_frame_version",
+        "hdr_leak_conv",
+        "hdr_heater_duty_cycle",
+        "hdr_code_ok",
+        "livetime_counter",
+        "num_trig",
+        "num_reject",
+        "num_acc_w_pha",
+        "num_acc_no_pha",
+        "num_haz_trig",
+        "num_haz_reject",
+        "num_haz_acc_w_pha",
+        "num_haz_acc_no_pha",
+        "sngrates",
+        "nread",
+        "nhazard",
+        "nadcstim",
+        "nodd",
+        "noddfix",
+        "nmulti",
+        "nmultifix",
+        "nbadtraj",
+        "nl2",
+        "nl3",
+        "nl4",
+        "npen",
+        "nformat",
+        "naside",
+        "nbside",
+        "nerror",
+        "nbadtags",
+        "coinrates",
+        "pbufrates",
+        "l2fgrates",
+        "l2bgrates",
+        "l3fgrates",
+        "l3bgrates",
+        "penfgrates",
+        "penbgrates",
+        "ialirtrates",
+        "l4fgrates",
+        "l4bgrates",
+        "nbside_stat_uncert_plus",
+        "nbside_stat_uncert_minus",
+        "l2fgrates_stat_uncert_plus",
+        "l2fgrates_stat_uncert_minus",
+        "noddfix_stat_uncert_plus",
+        "noddfix_stat_uncert_minus",
+        "num_haz_acc_no_pha_stat_uncert_plus",
+        "num_haz_acc_no_pha_stat_uncert_minus",
+        "ialirtrates_stat_uncert_plus",
+        "ialirtrates_stat_uncert_minus",
+        "num_acc_no_pha_stat_uncert_plus",
+        "num_acc_no_pha_stat_uncert_minus",
+        "coinrates_stat_uncert_plus",
+        "coinrates_stat_uncert_minus",
+        "penbgrates_stat_uncert_plus",
+        "penbgrates_stat_uncert_minus",
+        "nmulti_stat_uncert_plus",
+        "nmulti_stat_uncert_minus",
+        "nmultifix_stat_uncert_plus",
+        "nmultifix_stat_uncert_minus",
+        "nodd_stat_uncert_plus",
+        "nodd_stat_uncert_minus",
+        "num_reject_stat_uncert_plus",
+        "num_reject_stat_uncert_minus",
+        "nhazard_stat_uncert_plus",
+        "nhazard_stat_uncert_minus",
+        "nl4_stat_uncert_plus",
+        "nl4_stat_uncert_minus",
+        "npen_stat_uncert_plus",
+        "npen_stat_uncert_minus",
+        "sngrates_stat_uncert_plus",
+        "sngrates_stat_uncert_minus",
+        "num_haz_reject_stat_uncert_plus",
+        "num_haz_reject_stat_uncert_minus",
+        "nformat_stat_uncert_plus",
+        "nformat_stat_uncert_minus",
+        "l4fgrates_stat_uncert_plus",
+        "l4fgrates_stat_uncert_minus",
+        "num_trig_stat_uncert_plus",
+        "num_trig_stat_uncert_minus",
+        "nl2_stat_uncert_plus",
+        "nl2_stat_uncert_minus",
+        "l2bgrates_stat_uncert_plus",
+        "l2bgrates_stat_uncert_minus",
+        "penfgrates_stat_uncert_plus",
+        "penfgrates_stat_uncert_minus",
+        "nl3_stat_uncert_plus",
+        "nl3_stat_uncert_minus",
+        "nerror_stat_uncert_plus",
+        "nerror_stat_uncert_minus",
+        "l3fgrates_stat_uncert_plus",
+        "l3fgrates_stat_uncert_minus",
+        "num_acc_w_pha_stat_uncert_plus",
+        "num_acc_w_pha_stat_uncert_minus",
+        "naside_stat_uncert_plus",
+        "naside_stat_uncert_minus",
+        "l3bgrates_stat_uncert_plus",
+        "l3bgrates_stat_uncert_minus",
+        "num_haz_acc_w_pha_stat_uncert_plus",
+        "num_haz_acc_w_pha_stat_uncert_minus",
+        "nread_stat_uncert_plus",
+        "nread_stat_uncert_minus",
+        "pbufrates_stat_uncert_plus",
+        "pbufrates_stat_uncert_minus",
+        "nbadtags_stat_uncert_plus",
+        "nbadtags_stat_uncert_minus",
+        "l4bgrates_stat_uncert_plus",
+        "l4bgrates_stat_uncert_minus",
+        "nadcstim_stat_uncert_plus",
+        "nadcstim_stat_uncert_minus",
+        "nbadtraj_stat_uncert_plus",
+        "nbadtraj_stat_uncert_minus",
+        "num_haz_trig_stat_uncert_plus",
+        "num_haz_trig_stat_uncert_minus",
+        "sc_tick_by_frame",
+    ]
+
+    skip_sectored_fields = [
+        *skip_fields,
+        "h_sectored_counts",
+        "h_energy_delta_minus",
+        "h_energy_delta_plus",
+        "he4_sectored_counts",
+        "he4_energy_delta_minus",
+        "he4_energy_delta_plus",
+        "cno_sectored_counts",
+        "cno_energy_delta_minus",
+        "cno_energy_delta_plus",
+        "nemgsi_sectored_counts",
+        "nemgsi_energy_delta_minus",
+        "nemgsi_energy_delta_plus",
+        "fe_sectored_counts",
+        "fe_energy_delta_minus",
+        "fe_energy_delta_plus",
+        "he4_sectored_counts_stat_uncert_plus",
+        "he4_sectored_counts_stat_uncert_minus",
+        "nemgsi_sectored_counts_stat_uncert_plus",
+        "nemgsi_sectored_counts_stat_uncert_minus",
+        "fe_sectored_counts_stat_uncert_plus",
+        "fe_sectored_counts_stat_uncert_minus",
+        "cno_sectored_counts_stat_uncert_plus",
+        "cno_sectored_counts_stat_uncert_minus",
+        "h_sectored_counts_stat_uncert_plus",
+        "h_sectored_counts_stat_uncert_minus",
+        "species",
+    ]
+
+    skip_combined_fields = [
+        *skip_standard_fields,
+        *skip_sectored_fields,
+        "hdr_minute_cnt",
+        "sectorates",
+        "sectorates_stat_uncert_plus",
+        "sectorates_stat_uncert_minus",
+    ]
+
+    # drop livetime counter from skip_livetime list
+    skip_combined_fields.remove("livetime_counter")
+
+    # Compare processed standard data to validation data
     compare_data(
-        expected_data=validation_data, actual_data=l1a_counts_data, skip=skip_fields
+        expected_data=validation_data,
+        actual_data=standard_counts_data,
+        skip=skip_sectored_fields,
+    )
+
+    # Compare processed sectored data to validation data
+    compare_data(
+        expected_data=sectored_validation_data,
+        actual_data=sectored_counts_data,
+        skip=skip_standard_fields,
+    )
+
+    # Compare processed sectored livetime data to validation data
+    compare_data(
+        expected_data=livetime_validation_data,
+        actual_data=sectored_counts_data,
+        skip=skip_combined_fields,
     )
 
 

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import Mock
 
 import numpy as np
@@ -35,13 +36,13 @@ from imap_processing.tests.hit.helpers.l1_validation import (
 @pytest.fixture(scope="module")
 def hk_packet_filepath():
     """Set path to test data file"""
-    return imap_module_directory / "tests/hit/test_data/hskp_sample.ccsds"
+    return Path(imap_module_directory / "tests/hit/test_data/hskp_sample.ccsds")
 
 
 @pytest.fixture(scope="module")
 def sci_packet_filepath():
     """Set path to test data file"""
-    return imap_module_directory / "tests/hit/test_data/sci_sample.ccsds"
+    return Path(imap_module_directory / "tests/hit/test_data/sci_sample.ccsds")
 
 
 @pytest.fixture(scope="module")
@@ -826,10 +827,10 @@ def test_hit_l1a(hk_packet_filepath, sci_packet_filepath):
 
     Parameters
     ----------
-    hk_packet_filepath : str
-        Path to ccsds file for housekeeping data
-    sci_packet_filepath : str
-        Path to ccsds file for science data
+    hk_packet_filepath : Path
+        File path to ccsds file for housekeeping data
+    sci_packet_filepath : Path
+        File path to ccsds file for science data
     """
     for packet_filepath in [hk_packet_filepath, sci_packet_filepath]:
         processed_datasets = hit_l1a(packet_filepath, packet_date="20100105")
@@ -852,3 +853,9 @@ def test_hit_l1a(hk_packet_filepath, sci_packet_filepath):
                 processed_datasets[2].attrs["Logical_source"]
                 == "imap_hit_l1a_direct-events"
             )
+
+    # Assert that ValueError is raised when packet_date is None
+    with pytest.raises(
+        ValueError, match="Packet date is required for processing L1A data."
+    ):
+        hit_l1a(packet_filepath, "")

--- a/imap_processing/tests/hit/test_hit_l1a.py
+++ b/imap_processing/tests/hit/test_hit_l1a.py
@@ -831,11 +831,11 @@ def test_hit_l1a(hk_packet_filepath, sci_packet_filepath):
             assert len(processed_datasets) == 3
             assert (
                 processed_datasets[0].attrs["Logical_source"]
-                == "imap_hit_l1a_counts_standard"
+                == "imap_hit_l1a_counts-standard"
             )
             assert (
                 processed_datasets[1].attrs["Logical_source"]
-                == "imap_hit_l1a_counts_sectored"
+                == "imap_hit_l1a_counts-sectored"
             )
             assert (
                 processed_datasets[2].attrs["Logical_source"]

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -141,7 +141,7 @@ def test_sum_livetime_10min():
 def test_process_summed_rates_data(dependencies):
     """Test the variables in the summed rates dataset"""
 
-    l1a_counts_dataset = dependencies["imap_hit_l1a_counts_standard"]
+    l1a_counts_dataset = dependencies["imap_hit_l1a_counts-standard"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_summed_rates_dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
 
@@ -185,7 +185,7 @@ def test_process_summed_rates_data(dependencies):
 def test_process_standard_rates_data(dependencies):
     """Test the variables in the standard rates dataset"""
 
-    l1a_counts_dataset = dependencies["imap_hit_l1a_counts_standard"]
+    l1a_counts_dataset = dependencies["imap_hit_l1a_counts-standard"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_standard_rates_dataset = process_standard_rates_data(
         l1a_counts_dataset, livetime
@@ -277,7 +277,7 @@ def test_process_standard_rates_data(dependencies):
 def test_process_sectored_rates_data(dependencies):
     """Test the variables in the sectored rates dataset"""
 
-    l1a_counts_dataset = dependencies["imap_hit_l1a_counts_sectored"]
+    l1a_counts_dataset = dependencies["imap_hit_l1a_counts-sectored"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_sectored_rates_dataset = process_sectored_rates_data(
         l1a_counts_dataset, livetime

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -12,7 +12,6 @@ from imap_processing.hit.l1b.hit_l1b import (
     process_sectored_rates_data,
     process_standard_rates_data,
     process_summed_rates_data,
-    subset_data_for_sectored_counts,
     sum_livetime_10min,
 )
 from imap_processing.tests.hit.helpers.l1_validation import (
@@ -41,14 +40,20 @@ def sci_packet_filepath():
 
 
 @pytest.fixture
-def dependencies(packet_filepath, sci_packet_filepath):
+def packet_date():
+    """Get the date of the packet file"""
+    return "20100105"
+
+
+@pytest.fixture
+def dependencies(packet_filepath, sci_packet_filepath, packet_date):
     """Get dependencies for L1B processing"""
     # Create dictionary of dependencies and add CCSDS packet file
     data_dict = {"imap_hit_l0_raw": packet_filepath}
     # Add L1A datasets
-    l1a_datasets = hit_l1a.hit_l1a(packet_filepath)
+    l1a_datasets = hit_l1a.hit_l1a(packet_filepath, packet_date)
     # TODO: Remove this when HIT provides a packet file with all apids.
-    l1a_datasets.extend(hit_l1a.hit_l1a(sci_packet_filepath))
+    l1a_datasets.extend(hit_l1a.hit_l1a(sci_packet_filepath, packet_date))
     for dataset in l1a_datasets:
         data_dict[dataset.attrs["Logical_source"]] = dataset
     return data_dict
@@ -70,21 +75,6 @@ def l1b_standard_rates_dataset(dependencies):
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_standard-rates":
             return dataset
-
-
-@pytest.fixture
-def l1a_counts_dataset(sci_packet_filepath):
-    """Get L1A counts dataset to test l1b processing functions"""
-    l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath)
-    for dataset in l1a_datasets:
-        if dataset.attrs["Logical_source"] == "imap_hit_l1a_counts":
-            return dataset
-
-
-@pytest.fixture
-def livetime(l1a_counts_dataset: xr.Dataset) -> xr.DataArray:
-    """Calculate livetime for L1A counts dataset"""
-    return xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
 
 
 def test_calculate_rates():
@@ -148,120 +138,11 @@ def test_sum_livetime_10min():
     xr.testing.assert_equal(result, expected_livetime)
 
 
-def test_subset_data_for_sectored_counts():
-    """Test the subset_data_for_sectored_counts function."""
-
-    def create_l1a_counts_dataset(hdr_minute_cnt_values):
-        """Helper to create L1A counts dataset."""
-        return xr.Dataset(
-            {
-                "hdr_minute_cnt": ("epoch", hdr_minute_cnt_values),
-                "h_sectored_counts": ("epoch", np.arange(len(hdr_minute_cnt_values))),
-                "he4_sectored_counts": ("epoch", np.arange(len(hdr_minute_cnt_values))),
-            },
-        )
-
-    def validate_subset(l1a_counts_dataset, livetime):
-        """Helper to validate the subset results."""
-        subset_dataset, subset_livetime = subset_data_for_sectored_counts(
-            l1a_counts_dataset, livetime
-        )
-        assert subset_dataset.sizes["epoch"] == 10
-        assert len(subset_livetime["epoch"]) == 10
-        assert np.all(subset_dataset["hdr_minute_cnt"].values % 10 == np.arange(10))
-
-    # Create a sample livetime data array
-    livetime = xr.DataArray(np.arange(1.0, 31.0, dtype=np.float32), dims=["epoch"])
-
-    # Test with partial data at the start and end of the dataset
-    l1a_counts_dataset = create_l1a_counts_dataset(np.arange(105, 135))
-    validate_subset(l1a_counts_dataset, livetime)
-
-    # Test with partial data in the middle of the dataset
-    l1a_counts_dataset = create_l1a_counts_dataset(
-        [
-            100,
-            101,
-            102,
-            103,
-            104,
-            105,
-            106,
-            107,
-            108,
-            109,
-            110,
-            111,
-            112,
-            113,
-            114,
-            120,
-            121,
-            122,
-            123,
-            124,
-            130,
-            131,
-            132,
-            133,
-            134,
-            135,
-            136,
-            137,
-            138,
-            139,
-        ]
-    )
-    validate_subset(l1a_counts_dataset, livetime)
-
-    # Test with partial data at the start, middle, and end of the dataset
-    l1a_counts_dataset = create_l1a_counts_dataset(
-        [
-            105,
-            106,
-            107,
-            108,
-            109,
-            110,
-            111,
-            112,
-            113,
-            114,
-            115,
-            116,
-            117,
-            118,
-            119,
-            120,
-            121,
-            122,
-            130,
-            131,
-            132,
-            133,
-            134,
-            135,
-            136,
-            137,
-            138,
-            139,
-            140,
-            141,
-        ]
-    )
-    validate_subset(l1a_counts_dataset, livetime)
-
-    # Test with only partial data in the dataset
-    l1a_counts_dataset = create_l1a_counts_dataset(np.arange(100, 160, 2))
-    with pytest.raises(
-        ValueError, match="No valid start indices found for complete sectored counts."
-    ):
-        subset_data_for_sectored_counts(l1a_counts_dataset, livetime)
-
-
-def test_process_summed_rates_data(l1a_counts_dataset, livetime):
+def test_process_summed_rates_data(dependencies):
     """Test the variables in the summed rates dataset"""
 
+    l1a_counts_dataset = dependencies["imap_hit_l1a_counts_standard"]
+    livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_summed_rates_dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
 
     # Check that a xarray dataset is returned
@@ -301,8 +182,11 @@ def test_process_summed_rates_data(l1a_counts_dataset, livetime):
         assert f"{particle}_energy_delta_plus" in l1b_summed_rates_dataset.data_vars
 
 
-def test_process_standard_rates_data(l1a_counts_dataset, livetime):
+def test_process_standard_rates_data(dependencies):
     """Test the variables in the standard rates dataset"""
+
+    l1a_counts_dataset = dependencies["imap_hit_l1a_counts_standard"]
+    livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_standard_rates_dataset = process_standard_rates_data(
         l1a_counts_dataset, livetime
     )
@@ -390,9 +274,11 @@ def test_process_standard_rates_data(l1a_counts_dataset, livetime):
     )
 
 
-def test_process_sectored_rates_data(l1a_counts_dataset, livetime):
+def test_process_sectored_rates_data(dependencies):
     """Test the variables in the sectored rates dataset"""
 
+    l1a_counts_dataset = dependencies["imap_hit_l1a_counts_sectored"]
+    livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_sectored_rates_dataset = process_sectored_rates_data(
         l1a_counts_dataset, livetime
     )
@@ -667,7 +553,6 @@ def test_hit_l1b(dependencies):
     dependencies : dict
         Dictionary of L1A datasets and CCSDS packet file path
     """
-    # TODO: update assertions after science data processing is completed
     datasets = hit_l1b(dependencies)
 
     assert len(datasets) == 4

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -42,18 +42,27 @@ def sci_packet_filepath():
 
 
 @pytest.fixture
-def dependencies(sci_packet_filepath):
+def packet_date():
+    """Get the date of the packet file"""
+    return "20100105"
+
+
+@pytest.fixture
+def dependencies(sci_packet_filepath, packet_date):
     """Get dependencies for L2 processing"""
     # Create dictionary of dependencies
     data_dict = {}
-    l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath)
+    l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath, packet_date)
     for l1a_dataset in l1a_datasets:
         l1a_data_dict = {}
-        if l1a_dataset.attrs["Logical_source"] == "imap_hit_l1a_counts":
-            l1a_data_dict["imap_hit_l1a_counts"] = l1a_dataset
-            l1b_datasets = hit_l1b(l1a_data_dict)
-            for l1b_dataset in l1b_datasets:
-                data_dict[l1b_dataset.attrs["Logical_source"]] = l1b_dataset
+        if l1a_dataset.attrs["Logical_source"] in [
+            "imap_hit_l1a_counts_standard",
+            "imap_hit_l1a_counts_sectored",
+        ]:
+            l1a_data_dict[l1a_dataset.attrs["Logical_source"]] = l1a_dataset
+        l1b_datasets = hit_l1b(l1a_data_dict)
+        for l1b_dataset in l1b_datasets:
+            data_dict[l1b_dataset.attrs["Logical_source"]] = l1b_dataset
     return data_dict
 
 
@@ -833,8 +842,26 @@ def test_process_standard_intensity(l1b_standard_rates_dataset, ancillary_depend
         )
 
 
-def test_hit_l2(dependencies, ancillary_dependencies):
-    """Test creating L2 datasets ready for CDF output
+@pytest.mark.parametrize(
+    "dataset_key, ancillary_key, expected_logical_source",
+    [
+        ("imap_hit_l1b_summed-rates", "summed", "imap_hit_l2_summed-intensity"),
+        ("imap_hit_l1b_standard-rates", "standard", "imap_hit_l2_standard-intensity"),
+        (
+            "imap_hit_l1b_sectored-rates",
+            "macropixel",
+            "imap_hit_l2_macropixel-intensity",
+        ),
+    ],
+)
+def test_hit_l2(
+    dependencies,
+    ancillary_dependencies,
+    dataset_key,
+    ancillary_key,
+    expected_logical_source,
+):
+    """Test creating L2 datasets ready for CDF output.
 
     Creates a list of xarray datasets for L2 products.
 
@@ -846,21 +873,9 @@ def test_hit_l2(dependencies, ancillary_dependencies):
     ancillary_dependencies : dict
         Dictionary of ancillary file paths
     """
-    l2_datasets = hit_l2(
-        dependencies["imap_hit_l1b_summed-rates"], ancillary_dependencies["summed"]
-    )
-    assert len(l2_datasets) == 1
-    assert l2_datasets[0].attrs["Logical_source"] == "imap_hit_l2_summed-intensity"
 
     l2_datasets = hit_l2(
-        dependencies["imap_hit_l1b_standard-rates"], ancillary_dependencies["standard"]
+        dependencies[dataset_key], ancillary_dependencies[ancillary_key]
     )
     assert len(l2_datasets) == 1
-    assert l2_datasets[0].attrs["Logical_source"] == "imap_hit_l2_standard-intensity"
-
-    l2_datasets = hit_l2(
-        dependencies["imap_hit_l1b_sectored-rates"],
-        ancillary_dependencies["macropixel"],
-    )
-    assert len(l2_datasets) == 1
-    assert l2_datasets[0].attrs["Logical_source"] == "imap_hit_l2_macropixel-intensity"
+    assert l2_datasets[0].attrs["Logical_source"] == expected_logical_source

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -56,8 +56,8 @@ def dependencies(sci_packet_filepath, packet_date):
     for l1a_dataset in l1a_datasets:
         l1a_data_dict = {}
         if l1a_dataset.attrs["Logical_source"] in [
-            "imap_hit_l1a_counts_standard",
-            "imap_hit_l1a_counts_sectored",
+            "imap_hit_l1a_counts-standard",
+            "imap_hit_l1a_counts-sectored",
         ]:
             l1a_data_dict[l1a_dataset.attrs["Logical_source"]] = l1a_dataset
         l1b_datasets = hit_l1b(l1a_data_dict)


### PR DESCRIPTION
This PR implements handling for data spanning midnight. HIT has data that spans midnight in three ways:

1.  A science frame consists of 20 packets that could span midnight. A frame is 1 minute of data
2. A major frame consists of 10 science frames that could span midnight. A major frame is 10 minutes and represents a complete set of sectored rates data.
3. Livetime data associated with the sectored data is 10 minutes before the sectored data's epoch values because sectored data is transmitted 10 minutes after it's collected.

This PR uses mean epoch values for the science frames and major frames to determine which day they belong to for processing. Livetime for sectored data is taken by shifting the epoch range by 10 minutes earlier. 

To reduce the number of epoch ranges being tracked in the L1A counts data product, this product has been split into two.

1. One for standard data which only consists of science frames and therefore can only span midnight by up to a minute
2. One for sectored data which consists of major frames and could span midnight by 10 minutes but also needs the livetime values from the previous 10 minutes to properly calculate rates in L1B. Thus, the sectored product can span midnight by up to 20 minutes. 

Splitting the L1A counts product into two required some updates to L1B to expect two science files instead of one. It also required updating a validation unit test for L1A science data.

Processing expects an L0 file with a 20 minute buffer to capture all these cases and outputs two science products trimmed to their appropriate time ranges that belong in the day being processed.

Closes #1070 
Closes #1867 