### PR TITLE
2003 hi l1b   function to generate esa step to esa energy step lut

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,9 +108,7 @@ nitpick_ignore_regex = [
     (r"py:.*", r".*RectangularSkyMap.*"),
     (r"py:.*", r".*.lo.l0.utils.*"),
     (r"py:.*", r".*.lo.l0.data_classes.*"),
-    (r"py:.*", r".*.hi.*.CoincidenceBitmap.*"),
-    (r"py:.*", r".*.hi.hi_l1b.TriggerId.*"),
-    (r"py:.*", r".*.hi.hi_l1c.CalibrationProductConfig.*"),
+    (r"py:.*", r".*.hi.*.[A-Z][a-zA-Z]*.*"),  # match any hi CamelCase class
     (r"py:.*", r".*.hit.l0.utils.*"),
     (r"py:.*", r".*.hit.l0.data_classes.*"),
     (r"py:.*", r".*.hit.l1a.*"),

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -447,6 +447,10 @@ def get_esa_to_esa_energy_step_lut(
     # Get the set of esa_steps visited
     esa_steps = list(sorted(set(l1b_hk_ds["sci_esa_step"].data)))
     # Break into contiguous segments where op_mode == "HVSCI"
+    # Pad the boolean array `op_mode == HVSCI` with False values on each end.
+    # This treats starting or ending in HVSCI mode as a transition in the next
+    # step where np.diff is used to find op_mode transitions into and out of
+    # HVSCI
     padded_mask = np.pad(
         l1b_hk_ds["op_mode"].data == "HVSCI", (1, 1), constant_values=False
     )

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from imap_processing import imap_module_directory
@@ -15,6 +16,7 @@ from imap_processing.hi.hi_l1a import HALF_CLOCK_TICK_S
 from imap_processing.hi.utils import (
     HIAPID,
     CoincidenceBitmap,
+    EsaEnergyStepLookupTable,
     HiConstants,
     create_dataset_variables,
     parse_sensor_number,
@@ -27,7 +29,7 @@ from imap_processing.spice.spin import (
     get_instrument_spin_phase,
     get_spacecraft_spin_phase,
 )
-from imap_processing.spice.time import met_to_sclkticks, sct_to_et
+from imap_processing.spice.time import met_to_sclkticks, met_to_utc, sct_to_et
 from imap_processing.utils import packet_file_to_datasets
 
 
@@ -387,7 +389,7 @@ def compute_hae_coordinates(dataset: xr.Dataset) -> dict[str, xr.DataArray]:
     return new_vars
 
 
-def de_esa_energy_step(dataset: xr.Dataset) -> dict[str, xr.DataArray]:
+def de_esa_energy_step(l1b_de_ds: xr.Dataset) -> dict[str, xr.DataArray]:
     """
     Compute esa_energy_step for each direct event.
 
@@ -397,7 +399,7 @@ def de_esa_energy_step(dataset: xr.Dataset) -> dict[str, xr.DataArray]:
 
     Parameters
     ----------
-    dataset : xarray.Dataset
+    l1b_de_ds : xarray.Dataset
         The partial L1B dataset.
 
     Returns
@@ -407,10 +409,101 @@ def de_esa_energy_step(dataset: xr.Dataset) -> dict[str, xr.DataArray]:
     """
     new_vars = create_dataset_variables(
         ["esa_energy_step"],
-        len(dataset.epoch),
+        len(l1b_de_ds.epoch),
         att_manager_lookup_str="hi_de_{0}",
     )
+
     # TODO: Implement this algorithm
-    new_vars["esa_energy_step"].values = dataset.esa_step.values
+    new_vars["esa_energy_step"].values = l1b_de_ds.esa_step.values
 
     return new_vars
+
+
+def get_esa_to_esa_energy_step_lut(
+    l1b_hk_ds: xr.Dataset, esa_energies_lut: pd.DataFrame
+) -> EsaEnergyStepLookupTable:
+    """
+    Generate a lookup table that associates an esa_step to an esa_energy_step.
+
+    Parameters
+    ----------
+    l1b_hk_ds : xarray.Dataset
+        L1B housekeeping dataset.
+    esa_energies_lut : pandas.DataFrame
+        Esa energies lookup table derived from ancillary file.
+
+    Returns
+    -------
+    esa_energy_step_lut : EsaEnergyStepLookupTable
+        A lookup table object that can be used to query by MET time and esa_step
+        for the associated esa_energy_step values.
+
+    Notes
+    -----
+    Algorithm definition in section 2.1.2 of IMAP Hi Algorithm Document.
+    """
+    # Instantiate a lookup table object
+    esa_energy_step_lut = EsaEnergyStepLookupTable()
+    # Get the set of esa_steps visited
+    esa_steps = list(sorted(set(l1b_hk_ds["sci_esa_step"].data)))
+    # Break into contiguous segments where op_mode == "HVSCI"
+    padded_mask = np.pad(
+        l1b_hk_ds["op_mode"].data == "HVSCI", (1, 1), constant_values=False
+    )
+    mode_changes = np.diff(padded_mask.astype(int))
+    hsvsci_starts = np.nonzero(mode_changes == 1)[0]
+    hsvsci_ends = np.nonzero(mode_changes == -1)[0]
+    for i_start, i_end in zip(hsvsci_starts, hsvsci_ends):
+        contiguous_hvsci_ds = l1b_hk_ds.isel(dict(epoch=slice(i_start, i_end)))
+        # Find median inner and outer ESA voltages for each ESA step
+        for esa_step in esa_steps:
+            single_esa_ds = contiguous_hvsci_ds.where(
+                contiguous_hvsci_ds["sci_esa_step"] == esa_step, drop=True
+            )
+            if len(single_esa_ds["epoch"].data) == 0:
+                logger.debug(
+                    f"No instances of sci_esa_step == {esa_step} "
+                    f"present in contiguous HVSCI block with interval: "
+                    f"({met_to_utc(contiguous_hvsci_ds['shcoarse'].data[[0, -1]])})"
+                )
+                continue
+            median_inner_esa = np.median(single_esa_ds["inner_esa_hi"].data)
+            median_outer_esa = np.median(single_esa_ds["outer_esa"].data)
+            # Match median voltages to ESA Energies LUT
+            inner_voltage_match = (
+                np.abs(median_inner_esa - esa_energies_lut["inner_esa_voltage"])
+                <= esa_energies_lut["inner_esa_delta_v"]
+            )
+            outer_voltage_match = (
+                np.abs(median_outer_esa - esa_energies_lut["outer_esa_voltage"])
+                <= esa_energies_lut["outer_esa_delta_v"]
+            )
+            matching_esa_energy = esa_energies_lut[
+                np.logical_and(inner_voltage_match, outer_voltage_match)
+            ]
+            if len(matching_esa_energy) != 1:
+                if len(matching_esa_energy) == 0:
+                    logger.critical(
+                        f"No esa_energy_step matches found for esa_step "
+                        f"{esa_step} during interval: "
+                        f"({met_to_utc(single_esa_ds['shcoarse'].data[[0, -1]])}) "
+                        f"with median esa voltages: "
+                        f"{median_inner_esa}, {median_outer_esa}."
+                    )
+                if len(matching_esa_energy) > 1:
+                    logger.critical(
+                        f"Multiple esa_energy_step matches found for esa_step "
+                        f"{esa_step} during interval: "
+                        f"({met_to_utc(single_esa_ds['shcoarse'].data[[0, -1]])}) "
+                        f"with median esa voltages: "
+                        f"{median_inner_esa}, {median_outer_esa}."
+                    )
+                continue
+            # Set LUT to matching esa_energy_step for time range
+            esa_energy_step_lut.add_entry(
+                contiguous_hvsci_ds["shcoarse"].data[0],
+                contiguous_hvsci_ds["shcoarse"].data[-1],
+                esa_step,
+                matching_esa_energy["esa_energy_step"].values[0],
+            )
+    return esa_energy_step_lut

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -1,12 +1,13 @@
 """IMAP-Hi utils functions."""
 
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import IntEnum
 from typing import Optional, Union
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
@@ -247,3 +248,146 @@ class CoincidenceBitmap(IntEnum):
         matches = re.findall(pattern, detector_hit_str)
         # Sum the integer value assigned to the detector name for each match
         return sum(CoincidenceBitmap[m] for m in matches)
+
+
+class EsaEnergyStepLookupTable:
+    """Class for holding a esa_step to esa_energy lookup table."""
+
+    def __init__(self) -> None:
+        self.df = pd.DataFrame(
+            columns=["start_met", "end_met", "esa_step", "esa_energy_step"]
+        )
+        self._indexed = False
+
+        # Get the FILLVAL from the CDF attribute manager that will be returned
+        # for queries without matches
+        attr_mgr = ImapCdfAttributes()
+        attr_mgr.add_instrument_global_attrs("hi")
+        attr_mgr.add_instrument_variable_attrs(instrument="hi", level=None)
+        var_attrs = attr_mgr.get_variable_attributes(
+            "hi_de_esa_energy_step", check_schema=False
+        )
+        self._fillval = var_attrs["FILLVAL"]
+        self._esa_energy_step_dtype = var_attrs["dtype"]
+
+    def add_entry(
+        self, start_met: float, end_met: float, esa_step: int, esa_energy_step: int
+    ) -> None:
+        """
+        Add a single entry to the lookup table.
+
+        Parameters
+        ----------
+        start_met : float
+            Start mission elapsed time of the time range.
+        end_met : float
+            End mission elapsed time of the time range.
+        esa_step : int
+            ESA step value.
+        esa_energy_step : int
+            ESA energy step value to be stored.
+        """
+        new_row = pd.DataFrame(
+            {
+                "start_met": [start_met],
+                "end_met": [end_met],
+                "esa_step": [esa_step],
+                "esa_energy_step": [esa_energy_step],
+            }
+        )
+        self.df = pd.concat([self.df, new_row], ignore_index=True)
+        self._indexed = False
+
+    def _ensure_indexed(self) -> None:
+        """
+        Create index for faster queries if not already done.
+
+        Notes
+        -----
+        This method sorts the internal DataFrame by start_met and esa_step
+        for improved query performance.
+        """
+        if not self._indexed:
+            # Sort by start_met and esa_step for better query performance
+            self.df = self.df.sort_values(["start_met", "esa_step"]).reset_index(
+                drop=True
+            )
+            self._indexed = True
+
+    def query(
+        self,
+        query_met: Union[float, Iterable[float]],
+        esa_step: Union[int, Iterable[float]],
+    ) -> Union[float, np.ndarray]:
+        """
+        Query MET(s) and esa_step(s) to retrieve esa_energy_step(s).
+
+        Parameters
+        ----------
+        query_met : float or array_like
+            Mission elapsed time value(s) to query.
+            Can be a single float or array-like of floats.
+        esa_step : int or array_like
+            ESA step value(s) to match. Can be a single int or array-like of ints.
+            Must be same type (scalar or array-like) as query_met.
+
+        Returns
+        -------
+        float or numpy.ndarray
+            - If inputs are scalars: returns float (esa_energy_step)
+            - If inputs are array-like: returns numpy array of esa_energy_steps
+              with same length as inputs.
+              Contains FILLVAL for queries with no matches.
+
+        Raises
+        ------
+        ValueError
+            If one input is scalar and the other is array-like, or if both are
+            array-like but have different lengths.
+
+        Notes
+        -----
+        If multiple entries match a query, returns the first match found.
+        """
+        self._ensure_indexed()
+
+        # Check if inputs are scalars
+        is_scalar_met = np.isscalar(query_met)
+        is_scalar_step = np.isscalar(esa_step)
+
+        # Check for mismatched input types
+        if is_scalar_met != is_scalar_step:
+            raise ValueError(
+                "query_met and esa_step must both be scalars or both be array-like"
+            )
+
+        # Convert to arrays for uniform processing
+        query_mets = np.atleast_1d(query_met)
+        esa_steps = np.atleast_1d(esa_step)
+
+        # Ensure both arrays have the same shape
+        if query_mets.shape != esa_steps.shape:
+            raise ValueError(
+                "query_met and esa_step must have the same "
+                "length when both are array-like"
+            )
+
+        results = np.full_like(query_mets, self._fillval)
+
+        # Lookup esa_energy_steps for queries
+        for i, (qm, es) in enumerate(zip(query_mets, esa_steps)):
+            mask = (
+                (self.df["start_met"] <= qm)
+                & (self.df["end_met"] >= qm)
+                & (self.df["esa_step"] == es)
+            )
+
+            matches = self.df[mask]
+            if not matches.empty:
+                results[i] = matches["esa_energy_step"].iloc[0]
+
+        # Return scalar for scalar inputs, array for array inputs
+        if is_scalar_met and is_scalar_step:
+            return results.astype(self._esa_energy_step_dtype)[0]
+        else:
+            return results.astype(self._esa_energy_step_dtype)

--- a/imap_processing/tests/hi/data/l1/imap_hi_90sensor-cal-prod_20240101_v001.csv
+++ b/imap_processing/tests/hi/data/l1/imap_hi_90sensor-cal-prod_20240101_v001.csv
@@ -6,7 +6,7 @@
 # https://imap-processing.readthedocs.io/en/latest/data-access/calibration-files.html
 #
 # When creating PSET products, the following table will be used to filter the list
-# of DEs into the into calibration product categories at each ESA energy step. Only
+# of DEs into calibration product categories at each ESA energy step. Only
 # DEs with coincidence type contained in the `coincidence_type_list` and time-of-flight
 # values that are in the inclusive range specified by the low and high entries for each
 # energy step are included in the angular pset bins.

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 
@@ -12,9 +13,14 @@ from imap_processing.hi.hi_l1b import (
     compute_hae_coordinates,
     de_esa_energy_step,
     de_nominal_bin_and_spin_phase,
+    get_esa_to_esa_energy_step_lut,
     hi_l1b,
 )
-from imap_processing.hi.utils import CoincidenceBitmap, HiConstants
+from imap_processing.hi.utils import (
+    CoincidenceBitmap,
+    EsaEnergyStepLookupTable,
+    HiConstants,
+)
 from imap_processing.spice.geometry import SpiceFrame
 
 
@@ -254,3 +260,221 @@ def test_de_esa_energy_step():
     np.testing.assert_array_equal(
         esa_energy_step_var["esa_energy_step"].values, fake_dataset.esa_step.values
     )
+
+
+class TestGetEsaToEsaEnergyStepLut:
+    """Test suite for get_esa_to_esa_energy_step_lut function."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        # Mock the EsaEnergyStepLookupTable class
+        self.mock_lut = mock.Mock(spec=EsaEnergyStepLookupTable())
+
+        # Sample ESA energies lookup table
+        self.esa_energies_lut = pd.DataFrame(
+            {
+                "inner_esa_voltage": [-100.0, -200.0, -300.0],
+                "outer_esa_voltage": [50.0, 100.0, 150.0],
+                "inner_esa_delta_v": [5.0, 5.0, 5.0],
+                "outer_esa_delta_v": [2.5, 2.5, 2.5],
+                "esa_energy_step": [1, 2, 3],
+            }
+        )
+
+    def create_mock_dataset(
+        self, op_modes, esa_steps, inner_esa_values, outer_esa_values, shcoarse_values
+    ):
+        """Helper method to create mock L1B housekeeping dataset."""
+        return xr.Dataset(
+            {
+                "op_mode": (["epoch"], op_modes),
+                "sci_esa_step": (["epoch"], esa_steps),
+                "inner_esa_hi": (["epoch"], inner_esa_values),
+                "outer_esa": (["epoch"], outer_esa_values),
+                "shcoarse": (["epoch"], shcoarse_values),
+            }
+        )
+
+    @mock.patch("imap_processing.hi.hi_l1b.EsaEnergyStepLookupTable")
+    def test_basic_functionality_single_hvsci_segment(self, mock_lut_class):
+        """Test basic functionality with a single HVSCI segment."""
+        mock_lut_class.return_value = self.mock_lut
+
+        # Create test data with single HVSCI segment
+        l1b_hk_ds = self.create_mock_dataset(
+            op_modes=["HVSCI", "HVSCI", "HVSCI", "HVSCI"],
+            esa_steps=[1, 1, 2, 2],
+            inner_esa_values=[
+                -98.0,
+                -102.0,
+                -198.0,
+                -202.0,
+            ],  # Should match steps 1 and 2
+            outer_esa_values=[49.0, 51.0, 99.0, 101.0],
+            shcoarse_values=[1000, 1001, 1002, 1003],
+        )
+
+        result = get_esa_to_esa_energy_step_lut(l1b_hk_ds, self.esa_energies_lut)
+
+        # Verify LUT was instantiated
+        mock_lut_class.assert_called_once()
+
+        # Verify add_entry was called for each ESA step
+        assert self.mock_lut.add_entry.call_count == 2
+
+        # Check the calls made to add_entry
+        calls = self.mock_lut.add_entry.call_args_list
+
+        # First call should be for esa_step 1
+        assert calls[0][0] == (
+            1000,
+            1003,
+            1,
+            1,
+        )  # start_time, end_time, esa_step, esa_energy_step
+
+        # Second call should be for esa_step 2
+        assert calls[1][0] == (1000, 1003, 2, 2)
+
+        assert result == self.mock_lut
+
+    @mock.patch("imap_processing.hi.hi_l1b.EsaEnergyStepLookupTable")
+    def test_multiple_hvsci_segments(self, mock_lut_class):
+        """Test with multiple separate HVSCI segments."""
+        mock_lut_class.return_value = self.mock_lut
+
+        l1b_hk_ds = self.create_mock_dataset(
+            op_modes=["OTHER", "HVSCI", "HVSCI", "OTHER", "HVSCI", "HVSCI"],
+            esa_steps=[1, 1, 1, 2, 2, 2],
+            inner_esa_values=[-100.0, -98.0, -102.0, -200.0, -198.0, -202.0],
+            outer_esa_values=[50.0, 49.0, 51.0, 100.0, 99.0, 101.0],
+            shcoarse_values=[1000, 1001, 1002, 1003, 1004, 1005],
+        )
+
+        _ = get_esa_to_esa_energy_step_lut(l1b_hk_ds, self.esa_energies_lut)
+
+        # Should have 2 calls to add_entry (one for each segment)
+        assert self.mock_lut.add_entry.call_count == 2
+
+        calls = self.mock_lut.add_entry.call_args_list
+        # First segment: indices 1-2, esa_step 1
+        assert calls[0][0] == (1001, 1002, 1, 1)
+        # Second segment: indices 4-5, esa_step 2
+        assert calls[1][0] == (1004, 1005, 2, 2)
+
+    @mock.patch("imap_processing.hi.hi_l1b.EsaEnergyStepLookupTable")
+    def test_no_hvsci_segments(self, mock_lut_class):
+        """Test with no HVSCI segments."""
+        mock_lut_class.return_value = self.mock_lut
+
+        l1b_hk_ds = self.create_mock_dataset(
+            op_modes=["OTHER", "LVSCI", "LVSCI"],
+            esa_steps=[1, 2, 3],
+            inner_esa_values=[-100.0, -200.0, -300.0],
+            outer_esa_values=[50.0, 100.0, 150.0],
+            shcoarse_values=[1000, 1001, 1002],
+        )
+
+        result = get_esa_to_esa_energy_step_lut(l1b_hk_ds, self.esa_energies_lut)
+
+        # No add_entry calls should be made
+        self.mock_lut.add_entry.assert_not_called()
+        assert result == self.mock_lut
+
+    @mock.patch("imap_processing.hi.hi_l1b.EsaEnergyStepLookupTable")
+    @mock.patch("imap_processing.hi.hi_l1b.logger")
+    def test_no_voltage_match_found(self, mock_logger, mock_lut_class):
+        """Test when no matching ESA energy is found."""
+        mock_lut_class.return_value = self.mock_lut
+
+        l1b_hk_ds = self.create_mock_dataset(
+            op_modes=["HVSCI", "HVSCI"],
+            esa_steps=[1, 1],
+            inner_esa_values=[-500.0, -500.0],  # No match in lookup table
+            outer_esa_values=[500.0, 500.0],
+            shcoarse_values=[1000, 1001],
+        )
+
+        _ = get_esa_to_esa_energy_step_lut(l1b_hk_ds, self.esa_energies_lut)
+
+        # Should log critical error
+        mock_logger.critical.assert_called_once()
+        assert (
+            "No esa_energy_step matches found" in mock_logger.critical.call_args[0][0]
+        )
+
+        # No add_entry should be called
+        self.mock_lut.add_entry.assert_not_called()
+
+    @mock.patch("imap_processing.hi.hi_l1b.EsaEnergyStepLookupTable")
+    @mock.patch("imap_processing.hi.hi_l1b.logger")
+    def test_multiple_voltage_matches_found(self, mock_logger, mock_lut_class):
+        """Test when multiple matching ESA energies are found."""
+        mock_lut_class.return_value = self.mock_lut
+
+        # Create lookup table with overlapping voltage ranges
+        overlapping_lut = pd.DataFrame(
+            {
+                "inner_esa_voltage": [-100.0, -102.0],  # Overlapping ranges
+                "outer_esa_voltage": [50.0, 52.0],
+                "inner_esa_delta_v": [10.0, 10.0],  # Large deltas create overlap
+                "outer_esa_delta_v": [10.0, 10.0],
+                "esa_energy_step": [1, 2],
+            }
+        )
+
+        l1b_hk_ds = self.create_mock_dataset(
+            op_modes=["HVSCI", "HVSCI"],
+            esa_steps=[1, 1],
+            inner_esa_values=[-101.0, -101.0],  # Matches both rows
+            outer_esa_values=[51.0, 51.0],
+            shcoarse_values=[1000, 1001],
+        )
+
+        _ = get_esa_to_esa_energy_step_lut(l1b_hk_ds, overlapping_lut)
+
+        # Should log critical error for multiple matches
+        mock_logger.critical.assert_called_once()
+        assert (
+            "Multiple esa_energy_step matches found"
+            in mock_logger.critical.call_args[0][0]
+        )
+
+        # No add_entry should be called
+        self.mock_lut.add_entry.assert_not_called()
+
+    @mock.patch("imap_processing.hi.hi_l1b.EsaEnergyStepLookupTable")
+    def test_single_data_point_segment(self, mock_lut_class):
+        """Test with HVSCI segment containing only one data point."""
+        mock_lut_class.return_value = self.mock_lut
+
+        l1b_hk_ds = self.create_mock_dataset(
+            op_modes=["HVSCI"],
+            esa_steps=[1],
+            inner_esa_values=[-100.0],
+            outer_esa_values=[50.0],
+            shcoarse_values=[1000],
+        )
+
+        _ = get_esa_to_esa_energy_step_lut(l1b_hk_ds, self.esa_energies_lut)
+
+        # Should still work with single data point
+        self.mock_lut.add_entry.assert_called_once_with(1000, 1000, 1, 1)
+
+    @mock.patch("imap_processing.hi.hi_l1b.EsaEnergyStepLookupTable")
+    def test_esa_step_not_in_segment(self, mock_lut_class):
+        """Test when an ESA step doesn't appear in a particular HVSCI segment."""
+        mock_lut_class.return_value = self.mock_lut
+
+        l1b_hk_ds = self.create_mock_dataset(
+            op_modes=["OTHER", "HVSCI", "HVSCI", "OTHER"],
+            esa_steps=[1, 2, 2, 1],  # ESA step 1 not in HVSCI segment
+            inner_esa_values=[-100.0, -198.0, -202.0, -100.0],
+            outer_esa_values=[50.0, 99.0, 101.0, 50.0],
+            shcoarse_values=[1000, 1001, 1002, 1003],
+        )
+
+        _ = get_esa_to_esa_energy_step_lut(l1b_hk_ds, self.esa_energies_lut)
+
+        # Only ESA step 2 should be processed (it's the only one in HVSCI segment)
+        self.mock_lut.add_entry.assert_called_once_with(1001, 1002, 2, 2)

--- a/imap_processing/tests/hi/test_utils.py
+++ b/imap_processing/tests/hi/test_utils.py
@@ -8,6 +8,7 @@ from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.hi.utils import (
     HIAPID,
     CoincidenceBitmap,
+    EsaEnergyStepLookupTable,
     create_dataset_variables,
     full_dataarray,
     parse_sensor_number,
@@ -122,3 +123,207 @@ def test_create_dataset_variables(var_names, shape, fill_value, lookup_str):
 def test_coincidence_type_string_to_int(sensor_hit_str, expected_val):
     """Test coverage for coincidence_type_string_to_int function"""
     assert CoincidenceBitmap.detector_hit_str_to_int(sensor_hit_str) == expected_val
+
+
+class TestEsaEnergyStepLookupTable:
+    """Test suite for EsaEnergyStepLookupTable class."""
+
+    @pytest.fixture
+    def empty_lookup(self):
+        """Create an empty lookup table for testing."""
+        return EsaEnergyStepLookupTable()
+
+    @pytest.fixture
+    def populated_lookup(self):
+        """Create a lookup table with test data."""
+        lookup = EsaEnergyStepLookupTable()
+        # Columns are: [start_met, end_met, esa_step, esa_energy_step]
+        entries = [
+            (0.0, 10.0, 1, 100.0),
+            (0.0, 10.0, 2, 200.0),
+            (10.0, 20.0, 1, 150.0),
+            (10.0, 20.0, 2, 250.0),
+        ]
+        for entry in entries:
+            lookup.add_entry(*entry)
+        return lookup
+
+    def test_init(self, empty_lookup):
+        """Test initialization of lookup table."""
+        assert len(empty_lookup.df) == 0
+        assert list(empty_lookup.df.columns) == [
+            "start_met",
+            "end_met",
+            "esa_step",
+            "esa_energy_step",
+        ]
+        assert empty_lookup._indexed is False
+
+    def test_add_entry_single(self, empty_lookup):
+        """Test adding a single entry."""
+        empty_lookup.add_entry(0.0, 10.0, 1, 100.0)
+
+        assert len(empty_lookup.df) == 1
+        assert empty_lookup.df.iloc[0]["start_met"] == 0.0
+        assert empty_lookup.df.iloc[0]["end_met"] == 10.0
+        assert empty_lookup.df.iloc[0]["esa_step"] == 1
+        assert empty_lookup.df.iloc[0]["esa_energy_step"] == 100.0
+        assert empty_lookup._indexed is False
+
+    def test_add_entry_multiple(self, empty_lookup):
+        """Test adding multiple entries one by one."""
+        empty_lookup.add_entry(0.0, 10.0, 1, 100.0)
+        empty_lookup.add_entry(10.0, 20.0, 2, 200.0)
+
+        assert len(empty_lookup.df) == 2
+        assert empty_lookup._indexed is False
+
+    def test_ensure_indexed(self, populated_lookup):
+        """Test the indexing functionality."""
+        # Initially not indexed
+        assert populated_lookup._indexed is False
+
+        # Call _ensure_indexed
+        populated_lookup._ensure_indexed()
+        assert populated_lookup._indexed is True
+
+        # Check that data is sorted by start_met, then esa_step
+        df = populated_lookup.df
+        # np.lexsort uses the last key as the primary sort order
+        np.testing.assert_array_equal(
+            np.lexsort((df["esa_step"].values, df["start_met"].values)),
+            np.arange(len(df)),
+        )
+
+    def test_query_scalar_found(self, populated_lookup):
+        """Test scalar query that finds a match."""
+        result = populated_lookup.query(5.0, 1)
+        assert result == 100.0
+
+        result = populated_lookup.query(12.0, 2)
+        assert result == 250.0
+
+    def test_query_scalar_not_found(self, populated_lookup):
+        """Test scalar query that doesn't find a match."""
+        # Query outside time range
+        result = populated_lookup.query(25.0, 1)
+        assert result == 255
+
+        # Query with non-existent esa_step
+        result = populated_lookup.query(5.0, 99)
+        assert result == 255
+
+    def test_query_array_found(self, populated_lookup):
+        """Test array query with matches."""
+        mets = [5.0, 12.0, 8.0]
+        steps = [1, 2, 3]
+        results = populated_lookup.query(mets, steps)
+
+        assert isinstance(results, np.ndarray)
+        assert len(results) == 3
+        assert results[0] == 100  # MET=5.0, step=1
+        assert results[1] == 250  # MET=12.0, step=2
+        assert results[2] == 255  # MET=8.0, step=3
+
+    def test_query_array_all_not_found(self, populated_lookup):
+        """Test array query where no entries are found."""
+        mets = [25.0, 30.0]
+        steps = [1, 2]
+        results = populated_lookup.query(mets, steps)
+
+        assert isinstance(results, np.ndarray)
+        assert len(results) == 2
+        assert results[0] == 255
+        assert results[1] == 255
+
+    def test_query_numpy_arrays(self, populated_lookup):
+        """Test query with numpy arrays as input."""
+        mets = np.array([5.0, 12.0])
+        steps = np.array([1, 2])
+        results = populated_lookup.query(mets, steps)
+
+        assert isinstance(results, np.ndarray)
+        assert len(results) == 2
+        assert results[0] == 100.0
+        assert results[1] == 250.0
+
+    def test_query_mixed_scalar_array_raises_error(self, populated_lookup):
+        """Test that mixing scalar and array inputs raises ValueError."""
+        with pytest.raises(
+            ValueError,
+            match="query_met and esa_step must both be scalars or both be array-like",
+        ):
+            populated_lookup.query(5.0, [1, 2])
+
+        with pytest.raises(
+            ValueError,
+            match="query_met and esa_step must both be scalars or both be array-like",
+        ):
+            populated_lookup.query([5.0, 12.0], 1)
+
+    def test_query_different_length_arrays_raises_error(self, populated_lookup):
+        """Test that arrays of different lengths raise ValueError."""
+        with pytest.raises(
+            ValueError,
+            match="query_met and esa_step must have the same length "
+            "when both are array-like",
+        ):
+            populated_lookup.query([5.0, 12.0], [1, 2, 3])
+
+        with pytest.raises(
+            ValueError,
+            match="query_met and esa_step must have the same length "
+            "when both are array-like",
+        ):
+            populated_lookup.query([5.0, 12.0, 8.0], [1, 2])
+
+    def test_query_different_shape_arrays_raises_error(self, populated_lookup):
+        """Test that arrays of different shapes raise ValueError."""
+        mets = np.array([[5.0, 12.0]])  # Shape (1, 2)
+        steps = np.array([1, 2])  # Shape (2,)
+
+        with pytest.raises(
+            ValueError,
+            match="query_met and esa_step must have the same "
+            "length when both are array-like",
+        ):
+            populated_lookup.query(mets, steps)
+
+    def test_query_single_element_arrays(self, populated_lookup):
+        """Test query with single-element arrays."""
+        results = populated_lookup.query([5.0], [1])
+        assert isinstance(results, np.ndarray)
+        assert len(results) == 1
+        assert results[0] == 100.0
+
+    def test_query_calls_ensure_indexed(self, populated_lookup):
+        """Test that query calls _ensure_indexed."""
+        # Reset indexed flag
+        populated_lookup._indexed = False
+
+        # Call query
+        populated_lookup.query(5.0, 1)
+
+        # Check that indexing was performed
+        assert populated_lookup._indexed is True
+
+    def test_add_entry_resets_indexed_flag(self, populated_lookup):
+        """Test that adding entries resets the indexed flag."""
+        # Ensure it's indexed first
+        populated_lookup._ensure_indexed()
+        assert populated_lookup._indexed is True
+
+        # Add entry
+        populated_lookup.add_entry(20.0, 30.0, 4, 400.0)
+        assert populated_lookup._indexed is False
+
+    def test_edge_case_boundary_values(self, populated_lookup):
+        """Test queries at exact boundary values."""
+        # Test exact start time
+        result = populated_lookup.query(0.0, 1)
+        assert result == 100.0
+
+        # Test exact end time
+        result = populated_lookup.query(10.0, 1)
+        # Should match both (0.0, 10.0, 1, 100.0) and (10.0, 20.0, 1, 150.0)
+        assert result in [100.0, 150.0]


### PR DESCRIPTION
# Change Summary

## Overview
Includes functionality to use a housekeeping dataset along with a pandas dataframe to generate a lookup table for converting esa_step to esa_energy_step. Voltages for an esa_step are dependent on what table is loaded to the instrument where esa_energy_step is an index associate with a fixed energy range.

A later PR will include the changes to add the dataframe that maps inner and outer esa voltages to an esa_energy_step and modifies the cli to add this new upstream dependency for Hi L1B DE processing.

## Updated Files
- imap_processing/hi/hi_l1b.py
   - Add `get_esa_to_esa_energy_step_lut()` function that generates the LUT object given a housekeeping dataset and pd.DataFrame that maps ESA voltages to energies.
- imap_processing/hi/utils.py
   - Add `EsaEnergyStepLookupTable` class that acts as the esa_step to esa_energy_step lookup table.
- imap_processing/tests/hi/data/l1/imap_hi_90sensor-cal-prod_20240101_v001.csv
   - Fix typo in comment section
- imap_processing/tests/hi/test_hi_l1b.py
   - Test coverage for new `get_esa_to_esa_energy_step_lut` function (AI aided in writing tests)
- imap_processing/tests/hi/test_utils.py
   - Test coverage for LUT object (AI aided)

Closes: #2003 
