### PR TITLE
ULTRA L1C Dead time correction function 

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -224,7 +224,7 @@ def test_get_deadtime_interpolator():
             deadtime_ratios, np.ones_like(deadtime_ratios)
         )
     assert callable(interpolator)
-    deadtime = interpolator(0.9)
+    deadtime = interpolator(180)
     assert (deadtime >= 0) & (deadtime < 1)
 
     # Assert value error is raised for NaN values

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -168,6 +168,17 @@ def test_get_sectored_rates():
         np.hstack([np.arange(10, 20), np.arange(30, 40), np.arange(50, 60)]),
     )
 
+    # Test with one mode shift in the middle of the dataset.
+    modes = np.array([1, 3, 1])
+    test_l1a_params_dataset = xr.Dataset(
+        {
+            "imageratescadence": (["epoch"], modes),
+        },
+        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
+    )
+    sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
+    np.testing.assert_array_equal(sectored_rates["test_data"].data, np.arange(20, 40))
+
 
 def test_get_deadtime_ratios():
     """Tests get_deadtime_correction_factors function."""

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -164,16 +164,6 @@ def test_get_sectored_rates():
         sectored_rates["test_data"].data,
         np.hstack([np.arange(10, 20), np.arange(30, 40), np.arange(50, 60)]),
     )
-    # Test with one mode shift in the middle of the dataset.
-    modes = np.array([1, 3, 1])
-    test_l1a_params_dataset = xr.Dataset(
-        {
-            "imageratescadence": (["epoch"], modes),
-        },
-        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
-    )
-    sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
-    np.testing.assert_array_equal(sectored_rates["test_data"].data, np.arange(20, 40))
 
 
 def test_get_deadtime_correction_factors():
@@ -195,7 +185,9 @@ def test_get_deadtime_correction_factors():
     )
     deadtime_correction_factors = get_deadtime_correction_factors(sectored_rates_ds)
     assert deadtime_correction_factors.shape == (sectored_rates_ds.sizes["epoch"],)
-    assert np.all(deadtime_correction_factors >= 0)
+    assert np.all(
+        (deadtime_correction_factors >= 0) & (deadtime_correction_factors <= 1)
+    )
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -204,25 +204,26 @@ def test_get_deadtime_interpolator():
     deadtime_ratios = xr.DataArray(
         np.random.uniform(0.1, 1.0, num_deadtimes), dims=["epoch"]
     )
+    spin_phases = np.random.random(deadtime_ratios.shape)
     with mock.patch(
-        "imap_processing.ultra.l1c.ultra_l1c_pset_bins.spice.spin.get_spacecraft_spin_phase"
+        "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_spacecraft_spin_phase"
     ) as mock_spin_phases:
-        mock_spin_phases.return_value = np.random.randint(0, 360, deadtime_ratios.shape)
+        mock_spin_phases.return_value = spin_phases
         interpolator = get_deadtime_interpolator(
             deadtime_ratios, np.ones_like(deadtime_ratios)
         )
     assert callable(interpolator)
-    deadtime = interpolator(359)
+    deadtime = interpolator(0.9)
     assert (deadtime >= 0) & (deadtime < 1)
 
+    # Assert value error is raised for NaN values
     with mock.patch(
-        "imap_processing.ultra.l1c.ultra_l1c_pset_bins.spice.spin.get_spacecraft_spin_phase"
+        "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_spacecraft_spin_phase"
     ) as mock_spin_phases:
-        mock_spin_phases.return_value = np.random.randint(0, 360, deadtime_ratios.shape)
-        # Test with nans
+        mock_spin_phases.return_value = spin_phases
         with pytest.raises(
             ValueError,
-            "Dead time ratios contain NaN values, cannot create interpolator.",
+            match="Dead time ratios contain NaN values, cannot create interpolator.",
         ):
             get_deadtime_interpolator(
                 np.nan * deadtime_ratios, np.ones_like(deadtime_ratios)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -1,5 +1,7 @@
 "Tests pointing sets"
 
+from unittest import mock
+
 import astropy_healpix.healpy as hp
 import numpy as np
 import pandas as pd
@@ -10,7 +12,8 @@ from imap_processing import imap_module_directory
 from imap_processing.ultra.l1c import ultra_l1c_pset_bins
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
-    get_deadtime_correction_factors,
+    get_deadtime_interpolator,
+    get_deadtime_ratios,
     get_energy_delta_minus_plus,
     get_helio_background_rates,
     get_helio_exposure_times,
@@ -166,7 +169,7 @@ def test_get_sectored_rates():
     )
 
 
-def test_get_deadtime_correction_factors():
+def test_get_deadtime_ratios():
     """Tests get_deadtime_correction_factors function."""
     # Simulate a test sectored rates dataset.
     epoch = 10
@@ -183,9 +186,47 @@ def test_get_deadtime_correction_factors():
             "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
         }
     )
-    deadtime_correction_factors = get_deadtime_correction_factors(sectored_rates_ds)
+    deadtime_correction_factors = get_deadtime_ratios(sectored_rates_ds)
     assert deadtime_correction_factors.shape == (sectored_rates_ds.sizes["epoch"],)
     assert np.all(deadtime_correction_factors >= 0)
+
+
+def test_get_deadtime_interpolator():
+    """Tests get_deadtime_correction_factors function."""
+
+    sector_rate_seconds = 20 * 60  # 20 minutes in seconds
+    num_sectors = 3  # Number of sectors per pointing
+    num_spins = sector_rate_seconds * num_sectors / 15  # 15 seconds per spin
+    num_deadtimes = int(
+        num_spins * 15
+    )  # 15 sectors per spin. One deadtime ratio per sector
+
+    deadtime_ratios = xr.DataArray(
+        np.random.uniform(0.1, 1.0, num_deadtimes), dims=["epoch"]
+    )
+    with mock.patch(
+        "imap_processing.ultra.l1c.ultra_l1c_pset_bins.spice.spin.get_spacecraft_spin_phase"
+    ) as mock_spin_phases:
+        mock_spin_phases.return_value = np.random.randint(0, 360, deadtime_ratios.shape)
+        interpolator = get_deadtime_interpolator(
+            deadtime_ratios, np.ones_like(deadtime_ratios)
+        )
+    assert callable(interpolator)
+    deadtime = interpolator(359)
+    assert (deadtime >= 0) & (deadtime < 1)
+
+    with mock.patch(
+        "imap_processing.ultra.l1c.ultra_l1c_pset_bins.spice.spin.get_spacecraft_spin_phase"
+    ) as mock_spin_phases:
+        mock_spin_phases.return_value = np.random.randint(0, 360, deadtime_ratios.shape)
+        # Test with nans
+        with pytest.raises(
+            ValueError,
+            "Dead time ratios contain NaN values, cannot create interpolator.",
+        ):
+            get_deadtime_interpolator(
+                np.nan * deadtime_ratios, np.ones_like(deadtime_ratios)
+            )
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -185,9 +185,7 @@ def test_get_deadtime_correction_factors():
     )
     deadtime_correction_factors = get_deadtime_correction_factors(sectored_rates_ds)
     assert deadtime_correction_factors.shape == (sectored_rates_ds.sizes["epoch"],)
-    assert np.all(
-        (deadtime_correction_factors >= 0) & (deadtime_correction_factors <= 1)
-    )
+    assert np.all(deadtime_correction_factors >= 0)
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -220,7 +220,7 @@ def get_deadtime_correction_factors(sectored_rates_ds: xr.Dataset) -> xr.DataArr
 
     Returns
     -------
-    dead_time_ratio : numpy.ndarray
+    dead_time_ratio : xarray.DataArray
         Dead time correction factor for each sector.
     """
     # Compute the correction factor at each sector

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -317,8 +317,8 @@ def get_deadtime_interpolator(
         Interpolating function for dead time ratios.
     """
     # Get the spin phase at the start of each sector rate measurement
-    spin_phases = get_spin_angle(
-        get_spacecraft_spin_phase(np.array(timestamps)), degrees=True
+    spin_phases = np.asarray(
+        get_spin_angle(get_spacecraft_spin_phase(np.array(timestamps)), degrees=True)
     )
     # Assume the sectored rate data is evenly spaced in time, and find the middle spin
     # phase value for each sector.

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -325,7 +325,7 @@ def get_deadtime_interpolator(
     # the spin phase at the end of the last sector.
     # TODO: is this assumption valid?
     # Add the last spin phase value + half of a nominal sector.
-    spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + (1 / 180))
+    spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + (1 / 30))
     # Create a dataset with spin phases and dead time ratios
     deadtime_by_spin_phase = xr.Dataset(
         {"deadtime_ratio": deadtime_ratios},

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -337,7 +337,6 @@ def get_deadtime_interpolator(
     # Sort the dataset by spin phase (ascending order)
     deadtime_by_spin_phase = deadtime_by_spin_phase.sortby("spin_phase")
     # Group by spin phase and calculate the median dead time ratio for each phase
-    # TODO: skip NaN values in the median calculation?
     deadtime_medians = deadtime_by_spin_phase.groupby("spin_phase").median(skipna=True)
 
     if np.any(np.isnan(deadtime_medians["deadtime_ratio"].values)):

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -220,7 +220,7 @@ def get_deadtime_correction_factors(sectored_rates_ds: xr.Dataset) -> xr.DataArr
 
     Returns
     -------
-    dead_time_ratio : xarray.DataArray
+    dead_time_ratio : numpy.ndarray
         Dead time correction factor for each sector.
     """
     # Compute the correction factor at each sector
@@ -230,7 +230,7 @@ def get_deadtime_correction_factors(sectored_rates_ds: xr.Dataset) -> xr.DataArr
     )
 
     start_full = sectored_rates_ds.start_rf + sectored_rates_ds.start_lf
-    b = a * np.exp(start_full * 1e-7 * 5)
+    b = a * np.exp((start_full) * 1e-7 * 5)
 
     coin_stop_nd = (
         sectored_rates_ds.coin_tn
@@ -267,8 +267,8 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
     # sector mode. At the normal 15-second spin period, each 24° sector takes ~1 second.
 
     # This means that data was collected as a function of spin allowing for fine grained
-    # rate analysis.
-    sector_mode_start_inds = np.where(params_ds["imageratescadence"] == 3)[0]
+    # rate analysis at different spin phases.
+    sector_mode_start_inds = np.where(params_ds.imageratescadence == 3)[0]
     # get the sector mode start and stop indices
     sector_mode_stop_inds = sector_mode_start_inds + 1
     # get the sector mode start and stop times

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -6,8 +6,10 @@ import pandas
 import pandas as pd
 import xarray as xr
 from numpy.typing import NDArray
-from scipy.interpolate import interp1d
+from scipy import interpolate
+from scipy.interpolate import PchipInterpolator, interp1d
 
+from imap_processing.spice import spin
 from imap_processing.spice.geometry import (
     SpiceFrame,
     cartesian_to_spherical,
@@ -206,12 +208,15 @@ def get_helio_background_rates(
     return background
 
 
-def get_deadtime_correction_factors(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
+def get_deadtime_ratios(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
     """
-    Compute the dead time correction factor at each sector.
+    Compute the dead time ratio at each sector.
 
-    Further description is available in section 3.4.3 of the IMAP-Ultra Algorithm
-    Document.
+    A reduction in exposure time (duty cycle) is caused by the flight hardware listening
+    for coincidence events that never occur, due to singles starts predominantly from UV
+    radiation. The static exposure time for a given Pointing should be reduced by this
+    spatially dependent exposure time reduction factor (the dead time). Further
+    description is available in section 3.4.3 of the IMAP-Ultra Algorithm Document.
 
     Parameters
     ----------
@@ -291,6 +296,60 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
 
     sector_mode_mask = np.logical_or.reduce(conditions)
     return rates_ds.isel(epoch=sector_mode_mask)
+
+
+def get_deadtime_interpolator(
+    deadtime_ratios: xr.DataArray, timestamps: xr.DataArray
+) -> PchipInterpolator:
+    """
+    Create PCHIP function for dead time ratio vs spin phase.
+
+    Parameters
+    ----------
+    deadtime_ratios : xarray.DataArray
+        Dead time ratios for each sector.
+    timestamps : xarray.DataArray
+        Epoch values corresponding to the dead time ratios.
+
+    Returns
+    -------
+    scipy.interpolate.PchipInterpolator
+        Interpolating function for dead time ratios.
+    """
+    # Get the spin phase at the middle time of each sector, corresponding to the dead
+    # time ratio.
+    middle_sector_query_mets = []
+    for i in range(len(timestamps)):
+        if i == len(timestamps) - 1:
+            # If we are at the last timestamp, we cannot calculate the middle time
+            # TODO: handle this case properly
+            middle_sector_query_mets.append(timestamps[i])
+        else:
+            middle_sector_query_mets.append(timestamps[i] + timestamps[i + 1] / 2)
+
+    spin_phases = spin.get_spacecraft_spin_phase(np.array(middle_sector_query_mets))
+
+    # Create a dataset with spin phases and dead time ratios
+    deadtime_by_spin_phase = xr.Dataset(
+        {"deadtime_ratio": deadtime_ratios},
+        coords={"spin_phase": xr.DataArray(np.array(spin_phases), dims="epoch")},
+    )
+
+    # Sort the dataset by spin phase (ascending order)
+    deadtime_by_spin_phase = deadtime_by_spin_phase.sortby("spin_phase")
+    # Group by spin phase and calculate the median dead time ratio for each phase
+    # TODO: skip NaN values in the median calculation?
+    deadtime_medians = deadtime_by_spin_phase.groupby("spin_phase").median(skipna=True)
+
+    # TODO: handle NaN values in the dead time ratios. DO we raise error?
+    if np.any(np.isnan(deadtime_medians["deadtime_ratio"].values)):
+        raise ValueError(
+            "Dead time ratios contain NaN values, cannot create interpolator."
+        )
+    # Return a PCHIP interpolator for the dead time ratios
+    return interpolate.PchipInterpolator(
+        deadtime_medians["spin_phase"].values, deadtime_medians["deadtime_ratio"].values
+    )
 
 
 def get_spacecraft_exposure_times(

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -14,7 +14,7 @@ from imap_processing.spice.geometry import (
     cartesian_to_spherical,
     imap_state,
 )
-from imap_processing.spice.spin import get_spacecraft_spin_phase
+from imap_processing.spice.spin import get_spacecraft_spin_phase, get_spin_angle
 from imap_processing.ultra.constants import UltraConstants
 
 # TODO: add species binning.
@@ -317,15 +317,22 @@ def get_deadtime_interpolator(
         Interpolating function for dead time ratios.
     """
     # Get the spin phase at the start of each sector rate measurement
-    spin_phases = get_spacecraft_spin_phase(np.array(timestamps))
+    spin_phases = get_spin_angle(
+        get_spacecraft_spin_phase(np.array(timestamps)), degrees=True
+    )
     # Assume the sectored rate data is evenly spaced in time, and find the middle spin
     # phase value for each sector.
+    # The center spin phase is the closest / most accurate spin phase.
+    # There are 24 spin phases per sector so the nominal middle sector spin phases
+    # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.
     spin_phases_centered = (spin_phases[:-1] + spin_phases[1:]) / 2
     # Assume the last sector is nominal because we dont have enough data to determine
     # the spin phase at the end of the last sector.
     # TODO: is this assumption valid?
     # Add the last spin phase value + half of a nominal sector.
-    spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + (1 / 30))
+    spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + 12)
+    # Wrap any spin phases > 360 back to [0, 360]
+    spin_phases_centered = spin_phases_centered % 360
     # Create a dataset with spin phases and dead time ratios
     deadtime_by_spin_phase = xr.Dataset(
         {"deadtime_ratio": deadtime_ratios},

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -230,7 +230,7 @@ def get_deadtime_correction_factors(sectored_rates_ds: xr.Dataset) -> xr.DataArr
     )
 
     start_full = sectored_rates_ds.start_rf + sectored_rates_ds.start_lf
-    b = a * np.exp((start_full) * 1e-7 * 5)
+    b = a * np.exp(start_full * 1e-7 * 5)
 
     coin_stop_nd = (
         sectored_rates_ds.coin_tn
@@ -267,8 +267,8 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
     # sector mode. At the normal 15-second spin period, each 24° sector takes ~1 second.
 
     # This means that data was collected as a function of spin allowing for fine grained
-    # rate analysis at different spin phases.
-    sector_mode_start_inds = np.where(params_ds.imageratescadence == 3)[0]
+    # rate analysis.
+    sector_mode_start_inds = np.where(params_ds["imageratescadence"] == 3)[0]
     # get the sector mode start and stop indices
     sector_mode_stop_inds = sector_mode_start_inds + 1
     # get the sector mode start and stop times

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -9,12 +9,12 @@ from numpy.typing import NDArray
 from scipy import interpolate
 from scipy.interpolate import PchipInterpolator, interp1d
 
-from imap_processing.spice import spin
 from imap_processing.spice.geometry import (
     SpiceFrame,
     cartesian_to_spherical,
     imap_state,
 )
+from imap_processing.spice.spin import get_spacecraft_spin_phase
 from imap_processing.ultra.constants import UltraConstants
 
 # TODO: add species binning.
@@ -316,23 +316,22 @@ def get_deadtime_interpolator(
     scipy.interpolate.PchipInterpolator
         Interpolating function for dead time ratios.
     """
-    # Get the spin phase at the middle time of each sector, corresponding to the dead
-    # time ratio.
-    middle_sector_query_mets = []
-    for i in range(len(timestamps)):
-        if i == len(timestamps) - 1:
-            # If we are at the last timestamp, we cannot calculate the middle time
-            # TODO: handle this case properly
-            middle_sector_query_mets.append(timestamps[i])
-        else:
-            middle_sector_query_mets.append(timestamps[i] + timestamps[i + 1] / 2)
-
-    spin_phases = spin.get_spacecraft_spin_phase(np.array(middle_sector_query_mets))
-
+    # Get the spin phase at the start of each sector rate measurement
+    spin_phases = get_spacecraft_spin_phase(np.array(timestamps))
+    # Assume the sectored rate data is evenly spaced in time, and find the middle spin
+    # phase value for each sector.
+    spin_phases_centered = (spin_phases[:-1] + spin_phases[1:]) / 2
+    # Assume the last sector is nominal because we dont have enough data to determine
+    # the spin phase at the end of the last sector.
+    # TODO: is this assumption valid?
+    # Add the last spin phase value + half of a nominal sector.
+    spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + (1 / 180))
     # Create a dataset with spin phases and dead time ratios
     deadtime_by_spin_phase = xr.Dataset(
         {"deadtime_ratio": deadtime_ratios},
-        coords={"spin_phase": xr.DataArray(np.array(spin_phases), dims="epoch")},
+        coords={
+            "spin_phase": xr.DataArray(np.array(spin_phases_centered), dims="epoch")
+        },
     )
 
     # Sort the dataset by spin phase (ascending order)
@@ -341,7 +340,6 @@ def get_deadtime_interpolator(
     # TODO: skip NaN values in the median calculation?
     deadtime_medians = deadtime_by_spin_phase.groupby("spin_phase").median(skipna=True)
 
-    # TODO: handle NaN values in the dead time ratios. DO we raise error?
     if np.any(np.isnan(deadtime_medians["deadtime_ratio"].values)):
         raise ValueError(
             "Dead time ratios contain NaN values, cannot create interpolator."


### PR DESCRIPTION
# Change Summary

closes #1975
## Overview
Create a pchip interpolation function for dead time ratios v spin phase. This will eventually be used to adjust each pixels exposure time in the pset. 


## Updated Files
- imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
   - Add interpolation function 

## Testing
Test for the new function 
