### PR TITLE
Fix running tests on Windows

### DIFF
--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -265,7 +265,7 @@ def get_test_kernels_to_load(template_path, kernel_dir_path):
                     break
                 else:
                     slash_positions = np.array(
-                        [m.start() for m in re.finditer("/", kernel)]
+                        [m.start() for m in re.finditer(re.escape(os.path.sep), kernel)]
                     )
                     stop_idx = (
                         slash_positions[slash_positions < max_line_length - 1].max() + 1


### PR DESCRIPTION
## Overview

`get_test_kernels_to_load` failed to run on Windows because it assumed "/" for the path separator.

## Change Summary

Get the correct separator for the system using `os.path.sep`.

## New Dependencies

None

## New Files

None

## Deleted Files

None

## Updated Files
conftest.py: use (escaped) `os.path.sep` instead of a hardcoded "/".

## Testing
None