### PR TITLE
MNT: Add validation folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,7 @@ cython_debug/
 # Data that is downloaded
 data/
 test_data/
+*validation/
 
 # Ignore specific SPICE kernels that get downloaded from NAIF automatically for tests
 # marked with @pytest.mark.external_kernel


### PR DESCRIPTION
# Change Summary

## Overview

I was running the latest test suite locally and there were remote files that were added to my repository history when downloaded. This adds a general gitignore line for any validation files. The updates were to ignore: `mag/validiation` and `swe/l1_validation` and `swe/l2_validation` folders.