### PR TITLE
I-ALiRT - MAG frame transformation to ECLIPJ2000 using Spacecraft Packet

### DIFF
--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -48,7 +48,15 @@ class StationProperties(NamedTuple):
     min_elevation_deg: float  # minimum elevation angle in degrees
 
 
-# Verified by Kiel Observatory staff.
+# Verified by Kiel and KSWC Observatory staff.
+# Notes: the KSWC station is not yet operational,
+# but will have the following properties:
+# "KSWC": StationProperties(
+#     longitude=126.2958,  # degrees East
+#     latitude=33.4273,  # degrees North
+#     altitude=0.1,  # approx 100 meters
+#     min_elevation_deg=5,  # 5 degrees is the requirement
+# ),
 STATIONS = {
     "Kiel": StationProperties(
         longitude=10.1808,  # degrees East

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -27,11 +27,6 @@ from imap_processing.mag.l1d.mag_l1d_data import MagL1d
 from imap_processing.mag.l2.mag_l2_data import MagL2L1dBase
 from imap_processing.spice.time import met_to_ttj2000ns, met_to_utc
 
-# Range values (mago is 0 to 1, magi is 2 to 3)
-# Range values (0 to 3) represent MAG gain setting
-MAGO_RANGE = np.array([0, 1])
-MAGI_RANGE = np.array([2, 3])
-
 logger = logging.getLogger(__name__)
 
 
@@ -298,6 +293,7 @@ def calculate_l1b(
 
 def calibrate_and_offset_vectors(
     vectors: np.ndarray,
+    range_vals: np.ndarray,
     calibration: np.ndarray,
     offsets: np.ndarray,
     is_magi: bool = False,
@@ -309,6 +305,8 @@ def calibrate_and_offset_vectors(
     ----------
     vectors : np.ndarray
         Raw magnetic vectors, shape (n, 3).
+    range_vals : np.ndarray
+        Range indices for each vector, shape (n). Values 0–3.
     calibration : np.ndarray
         Calibration matrix, shape (3, 3, 4).
     offsets : np.ndarray
@@ -324,11 +322,6 @@ def calibrate_and_offset_vectors(
     calibrated_and_offset_vectors : np.ndarray
         Calibrated and offset vectors, shape (n, 3).
     """
-    if is_magi:
-        range_vals = MAGI_RANGE
-    else:
-        range_vals = MAGO_RANGE
-
     # Append range as 4th column
     vec_plus_range = np.concatenate((vectors, range_vals[:, np.newaxis]), axis=1)
 

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -20,9 +20,16 @@ from imap_processing.mag.l1b.mag_l1b import (
     calibrate_vector,
     shift_time,
 )
+from imap_processing.mag.l1c.interpolation_methods import linear
 from imap_processing.mag.l1d.mag_l1d_data import MagL1d
 from imap_processing.mag.l2.mag_l2_data import MagL2L1dBase
+from imap_processing.spice.geometry import SpiceFrame, frame_transform
 from imap_processing.spice.time import met_to_ttj2000ns, met_to_utc
+
+# Range values (mago is 0 to 1, magi is 2 to 3)
+# Range values (0 to 3) represent MAG gain setting
+MAGO_RANGE = np.array([0, 1])
+MAGI_RANGE = np.array([2, 3])
 
 logger = logging.getLogger(__name__)
 
@@ -290,7 +297,6 @@ def calculate_l1b(
 
 def calibrate_and_offset_vectors(
     vectors: np.ndarray,
-    range_vals: np.ndarray,
     calibration: np.ndarray,
     offsets: np.ndarray,
     is_magi: bool = False,
@@ -302,8 +308,6 @@ def calibrate_and_offset_vectors(
     ----------
     vectors : np.ndarray
         Raw magnetic vectors, shape (n, 3).
-    range_vals : np.ndarray
-        Range indices for each vector, shape (n). Values 0–3.
     calibration : np.ndarray
         Calibration matrix, shape (3, 3, 4).
     offsets : np.ndarray
@@ -319,6 +323,11 @@ def calibrate_and_offset_vectors(
     calibrated_and_offset_vectors : np.ndarray
         Calibrated and offset vectors, shape (n, 3).
     """
+    if is_magi:
+        range_vals = MAGI_RANGE
+    else:
+        range_vals = MAGO_RANGE
+
     # Append range as 4th column
     vec_plus_range = np.concatenate((vectors, range_vals[:, np.newaxis]), axis=1)
 
@@ -374,6 +383,95 @@ def apply_gradiometry_correction(
     mago_corrected = MagL1d.apply_gradiometry_offsets(
         gradiometry_offsets, mago_vector_eclipj2000, gradiometer_factor
     )
+    magnitude = np.linalg.norm(mago_corrected, axis=1)
+
+    return mago_corrected, magnitude
+
+
+def calculate_l1d(
+    time_data,
+    vector_mago: np.ndarray,
+    vector_magi: np.ndarray,
+    calibration: np.ndarray,
+    offsets: np.ndarray,
+    gradiometer_factor: np.ndarray,
+):
+    """
+    Apply calibration and offsets to magnetic vectors.
+
+    Parameters
+    ----------
+    time_data : dict
+        Coarse and fine time for Primary and Secondary Sensors.
+    vector_mago : numpy.ndarray
+        Mago vector, shape (n, 3).
+    vector_magi : numpy.ndarray
+        Magi vector, shape (n, 3).
+    calibration : np.ndarray
+        Calibration matrix, shape (3, 3, 4).
+    offsets : np.ndarray
+        Offsets array, shape (2, 4, 3) where:
+        - index 0 = MAGo, 1 = MAGi
+        - second index = range (0–3)
+        - third index = axis (x, y, z)
+    gradiometer_factor : np.ndarray
+            A (3,3) element matrix to scale and rotate the gradiometer offsets.
+    is_magi : bool, optional
+        True if applying to MAGi data, False for MAGo.
+
+    Returns
+    -------
+    mago_corrected : np.ndarray
+        The output vectors with gradiometry offsets applied, shape (N, 3).
+    magnitude : np.ndarray
+        The magnitude of the corrected MAGo vectors, shape (N,).
+    """
+    # Apply calibration and offsets.
+    mago_calibrate_and_offset = calibrate_and_offset_vectors(
+        vector_mago, calibration, offsets, is_magi=False
+    )
+    magi_calibrate_and_offset = calibrate_and_offset_vectors(
+        vector_magi, calibration, offsets, is_magi=True
+    )
+
+    # Transform to DSRF (IMAP_DPS) frame.
+    mago_vector_dsrf = frame_transform(
+        time_data["primary_epoch"],
+        mago_calibrate_and_offset,
+        from_frame=SpiceFrame.IMAP_MAG,  # SRF
+        to_frame=SpiceFrame.IMAP_DPS,  # DSRF
+    )
+
+    magi_vector_dsrf = frame_transform(
+        time_data["secondary_epoch"],
+        magi_calibrate_and_offset,
+        from_frame=SpiceFrame.IMAP_MAG,  # SRF
+        to_frame=SpiceFrame.IMAP_DPS,  # DSRF
+    )
+
+    # Use linear interpolation to align the MAGi data to the MAGo timestamps,
+    # then calculate the difference between the two sensors on each axis.
+    aligned_magi_dsrf = linear(
+        magi_vector_dsrf,
+        time_data["secondary_epoch"],
+        time_data["primary_epoch"],
+    )
+
+    # Compute gradiometry offset (MAGi - MAGo)
+    offset_value = aligned_magi_dsrf - mago_vector_dsrf
+
+    # Apply gradiometer factor
+    offset_value = np.apply_along_axis(
+        np.dot,
+        1,
+        offset_value,
+        gradiometer_factor,
+    )
+
+    # Subtract offsets from MAGo data
+    mago_corrected = mago_vector_dsrf - offset_value
+
+    # Compute magnitude
     magnitude = np.linalg.norm(mago_corrected, axis=1)
 
     return mago_corrected, magnitude

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -307,6 +307,7 @@ def calibrate_and_offset_vectors(
         Raw magnetic vectors, shape (n, 3).
     range_vals : np.ndarray
         Range indices for each vector, shape (n). Values 0–3.
+        Expected value for mago will be [0,1] and magi will be [2,3].
     calibration : np.ndarray
         Calibration matrix, shape (3, 3, 4).
     offsets : np.ndarray

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -395,6 +395,8 @@ def transform_to_inertial(
     sc_spin_phase_rad: np.ndarray,
     sc_inertial_right: np.ndarray,
     sc_inertial_decline: np.ndarray,
+    attitude_time: np.ndarray,
+    target_time: float,
     mag_vector: np.ndarray,
 ) -> np.ndarray:
     """
@@ -408,13 +410,22 @@ def transform_to_inertial(
         Inertial right ascension for 4 packets 0 to 2π radians, shape (4).
     sc_inertial_decline : numpy.ndarray
         Inertial declination for 4 packets -π/2 to π/2 radians, shape (4).
+    attitude_time : np.ndarray
+        Timestamps for the 4 packets.
+        Example: test_met = grouped_data["met"][
+                 (grouped_data["group"] == group).values].
+        ttj2000ns = met_to_ttj2000ns(test_met.values).
+    target_time : float
+        Time at which to apply the transformation.
+        Will be primary_epoch (mago vector) or secondary_epoch (magi vector).
+        Example: time_data['primary_epoch'].
     mag_vector : numpy.ndarray
         Vector, shape (3).
 
     Returns
     -------
-    mean_vector : np.ndarray
-        Average rotated vector in ECLIPJ2000 frame, shape (3,).
+    inertial_vector : np.ndarray
+        Transformed vector in the ECLIPJ2000 frame, shape (3,).
 
     Notes
     -----
@@ -422,20 +433,22 @@ def transform_to_inertial(
     each of which contains its own spin phase,
     inertial right ascension, and inertial decline.
     """
-    # Expand to shape (4, 3) to match spin phase samples
-    v_stack = np.tile(mag_vector, (len(sc_spin_phase_rad), 1))
+    # Interpolate spin phase, RA, and Dec at target_time
+    spin_phase_deg = np.degrees(
+        np.interp(target_time, attitude_time, sc_spin_phase_rad)
+    )
+    ra_deg = np.degrees(np.interp(target_time, attitude_time, sc_inertial_right))
+    dec_deg = np.degrees(np.interp(target_time, attitude_time, sc_inertial_decline))
 
     # Transform each into ECLIPJ2000
-    vector_inertial = transform_instrument_vectors_to_inertial(
-        v_stack,
-        spin_phase=np.degrees(sc_spin_phase_rad),  # shape (4,)
-        sc_inertial_right=np.degrees(sc_inertial_right),  # shape (4,)
-        sc_inertial_decline=np.degrees(sc_inertial_decline),  # shape (4,)
-    )
+    inertial_vector = transform_instrument_vectors_to_inertial(
+        np.asarray(mag_vector).reshape(1, 3),
+        np.array([spin_phase_deg]),
+        np.array([ra_deg]),
+        np.array([dec_deg]),
+    )[0]
 
-    mean_vector = np.mean(vector_inertial, axis=0)
-
-    return mean_vector
+    return inertial_vector
 
 
 def process_packet(

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -383,14 +383,6 @@ def apply_gradiometry_correction(
     return mago_corrected, magnitude
 
 
-def calculate_l1d(
-    time_data,
-    vector_mago: np.ndarray,
-    vector_magi: np.ndarray,
-    calibration: np.ndarray,
-    offsets: np.ndarray,
-    gradiometer_factor: np.ndarray,
-):
 def transform_to_inertial(
     sc_spin_phase_rad: np.ndarray,
     sc_inertial_right: np.ndarray,

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -406,7 +406,7 @@ def transform_to_inertial(
     sc_inertial_right : numpy.ndarray
         Inertial right ascension for 4 packets 0 to 2π radians, shape (4).
     sc_inertial_decline : numpy.ndarray
-        Inertial right ascension for 4 packets -π/2 to π/2 radians, shape (4).
+        Inertial declination for 4 packets -π/2 to π/2 radians, shape (4).
     mag_vector : numpy.ndarray
         Vector, shape (3).
 

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -25,6 +25,10 @@ from imap_processing.mag.l1b.mag_l1b import (
 )
 from imap_processing.mag.l1d.mag_l1d_data import MagL1d
 from imap_processing.mag.l2.mag_l2_data import MagL2L1dBase
+from imap_processing.spice.geometry import (
+    cartesian_to_spherical,
+    spherical_to_cartesian,
+)
 from imap_processing.spice.time import met_to_ttj2000ns, met_to_utc
 
 logger = logging.getLogger(__name__)
@@ -425,12 +429,50 @@ def transform_to_inertial(
     each of which contains its own spin phase,
     inertial right ascension, and inertial decline.
     """
+    if target_time < attitude_time.min() or target_time > attitude_time.max():
+        logger.warning(
+            f"target_time {target_time} is outside attitude_time bounds "
+            f"[{attitude_time.min()}, {attitude_time.max()}]; using edge values."
+        )
+
+    # Get sort order based on attitude_time
+    sort_idx = np.argsort(attitude_time)
+
+    # Sort all arrays accordingly
+    attitude_time = attitude_time[sort_idx]
+    sc_spin_phase_rad = sc_spin_phase_rad[sort_idx]
+    sc_inertial_right = sc_inertial_right[sort_idx]
+    sc_inertial_decline = sc_inertial_decline[sort_idx]
+
     # Interpolate spin phase, RA, and Dec at target_time
-    spin_phase_deg = np.degrees(
-        np.interp(target_time, attitude_time, sc_spin_phase_rad)
+    # Convert RA/Dec to unit cartesian vectors
+    spherical_coords = np.stack(
+        [
+            np.ones_like(sc_inertial_right),
+            np.degrees(sc_inertial_right),
+            np.degrees(sc_inertial_decline),
+        ],
+        axis=-1,
     )
-    ra_deg = np.degrees(np.interp(target_time, attitude_time, sc_inertial_right))
-    dec_deg = np.degrees(np.interp(target_time, attitude_time, sc_inertial_decline))
+    vecs = spherical_to_cartesian(spherical_coords)
+
+    # Interpolate in Cartesian space
+    vx = np.interp(target_time, attitude_time, vecs[:, 0])
+    vy = np.interp(target_time, attitude_time, vecs[:, 1])
+    vz = np.interp(target_time, attitude_time, vecs[:, 2])
+    v_interp = np.array([vx, vy, vz])
+    # Normalize vector so that its magnitude is 1.
+    v_interp /= np.linalg.norm(v_interp)
+
+    # Convert back to spherical
+    ra_dec = cartesian_to_spherical(v_interp)
+    ra_deg = ra_dec[1]
+    dec_deg = ra_dec[2]
+
+    # Account for discontinuities in spin phase.
+    spin_phase_unwrapped = np.unwrap(sc_spin_phase_rad)
+    spin_phase_interp = np.interp(target_time, attitude_time, spin_phase_unwrapped)
+    spin_phase_deg = np.degrees(spin_phase_interp) % 360
 
     # Transform each into ECLIPJ2000
     inertial_vector = transform_instrument_vectors_to_inertial(

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -7,6 +7,9 @@ from typing import Union
 import numpy as np
 import xarray as xr
 
+from imap_processing.ialirt.l0.ialirt_spice import (
+    transform_instrument_vectors_to_inertial,
+)
 from imap_processing.ialirt.l0.mag_l0_ialirt_data import (
     Packet0,
     Packet1,
@@ -20,10 +23,8 @@ from imap_processing.mag.l1b.mag_l1b import (
     calibrate_vector,
     shift_time,
 )
-from imap_processing.mag.l1c.interpolation_methods import linear
 from imap_processing.mag.l1d.mag_l1d_data import MagL1d
 from imap_processing.mag.l2.mag_l2_data import MagL2L1dBase
-from imap_processing.spice.geometry import SpiceFrame, frame_transform
 from imap_processing.spice.time import met_to_ttj2000ns, met_to_utc
 
 # Range values (mago is 0 to 1, magi is 2 to 3)
@@ -396,85 +397,51 @@ def calculate_l1d(
     offsets: np.ndarray,
     gradiometer_factor: np.ndarray,
 ):
+def transform_to_inertial(
+    sc_spin_phase_rad: np.ndarray,
+    sc_inertial_right: np.ndarray,
+    sc_inertial_decline: np.ndarray,
+    mag_vector: np.ndarray,
+) -> np.ndarray:
     """
-    Apply calibration and offsets to magnetic vectors.
+    Transform vector to ECLIPJ2000.
 
     Parameters
     ----------
-    time_data : dict
-        Coarse and fine time for Primary and Secondary Sensors.
-    vector_mago : numpy.ndarray
-        Mago vector, shape (n, 3).
-    vector_magi : numpy.ndarray
-        Magi vector, shape (n, 3).
-    calibration : np.ndarray
-        Calibration matrix, shape (3, 3, 4).
-    offsets : np.ndarray
-        Offsets array, shape (2, 4, 3) where:
-        - index 0 = MAGo, 1 = MAGi
-        - second index = range (0–3)
-        - third index = axis (x, y, z)
-    gradiometer_factor : np.ndarray
-            A (3,3) element matrix to scale and rotate the gradiometer offsets.
-    is_magi : bool, optional
-        True if applying to MAGi data, False for MAGo.
+    sc_spin_phase_rad : numpy.ndarray
+        Spin phase for 4 packets 0 to 2π radians, shape (4).
+    sc_inertial_right : numpy.ndarray
+        Inertial right ascension for 4 packets 0 to 2π radians, shape (4).
+    sc_inertial_decline : numpy.ndarray
+        Inertial right ascension for 4 packets -π/2 to π/2 radians, shape (4).
+    mag_vector : numpy.ndarray
+        Vector, shape (3).
 
     Returns
     -------
-    mago_corrected : np.ndarray
-        The output vectors with gradiometry offsets applied, shape (N, 3).
-    magnitude : np.ndarray
-        The magnitude of the corrected MAGo vectors, shape (N,).
+    mean_vector : np.ndarray
+        Average rotated vector in ECLIPJ2000 frame, shape (3,).
+
+    Notes
+    -----
+    The MAG vectors are calculated based on 4 packets,
+    each of which contains its own spin phase,
+    inertial right ascension, and inertial decline.
     """
-    # Apply calibration and offsets.
-    mago_calibrate_and_offset = calibrate_and_offset_vectors(
-        vector_mago, calibration, offsets, is_magi=False
-    )
-    magi_calibrate_and_offset = calibrate_and_offset_vectors(
-        vector_magi, calibration, offsets, is_magi=True
-    )
+    # Expand to shape (4, 3) to match spin phase samples
+    v_stack = np.tile(mag_vector, (len(sc_spin_phase_rad), 1))
 
-    # Transform to DSRF (IMAP_DPS) frame.
-    mago_vector_dsrf = frame_transform(
-        time_data["primary_epoch"],
-        mago_calibrate_and_offset,
-        from_frame=SpiceFrame.IMAP_MAG,  # SRF
-        to_frame=SpiceFrame.IMAP_DPS,  # DSRF
+    # Transform each into ECLIPJ2000
+    vector_inertial = transform_instrument_vectors_to_inertial(
+        v_stack,
+        spin_phase=np.degrees(sc_spin_phase_rad),  # shape (4,)
+        sc_inertial_right=np.degrees(sc_inertial_right),  # shape (4,)
+        sc_inertial_decline=np.degrees(sc_inertial_decline),  # shape (4,)
     )
 
-    magi_vector_dsrf = frame_transform(
-        time_data["secondary_epoch"],
-        magi_calibrate_and_offset,
-        from_frame=SpiceFrame.IMAP_MAG,  # SRF
-        to_frame=SpiceFrame.IMAP_DPS,  # DSRF
-    )
+    mean_vector = np.mean(vector_inertial, axis=0)
 
-    # Use linear interpolation to align the MAGi data to the MAGo timestamps,
-    # then calculate the difference between the two sensors on each axis.
-    aligned_magi_dsrf = linear(
-        magi_vector_dsrf,
-        time_data["secondary_epoch"],
-        time_data["primary_epoch"],
-    )
-
-    # Compute gradiometry offset (MAGi - MAGo)
-    offset_value = aligned_magi_dsrf - mago_vector_dsrf
-
-    # Apply gradiometer factor
-    offset_value = np.apply_along_axis(
-        np.dot,
-        1,
-        offset_value,
-        gradiometer_factor,
-    )
-
-    # Subtract offsets from MAGo data
-    mago_corrected = mago_vector_dsrf - offset_value
-
-    # Compute magnitude
-    magnitude = np.linalg.norm(mago_corrected, axis=1)
-
-    return mago_corrected, magnitude
+    return mean_vector
 
 
 def process_packet(

--- a/imap_processing/tests/ialirt/unit/test_parse_mag.py
+++ b/imap_processing/tests/ialirt/unit/test_parse_mag.py
@@ -393,10 +393,10 @@ def test_transform_to_inertial(furnish_kernels, spice_test_data_path):
 
     with furnish_kernels(kernels):
         v_avg = transform_to_inertial(
-            sc_spin_phase_deg=spin_phase,
-            sc_inertial_right=ra,
-            sc_inertial_decline=dec,
-            mag_vector=mag_vector,
+            np.radians(spin_phase),
+            ra,
+            dec,
+            mag_vector,
         )
 
     # Near zero vector in X and Y since it spans a full rotation.

--- a/imap_processing/tests/ialirt/unit/test_parse_mag.py
+++ b/imap_processing/tests/ialirt/unit/test_parse_mag.py
@@ -18,6 +18,7 @@ from imap_processing.ialirt.l0.parse_mag import (
     get_time,
     process_packet,
     retrieve_matrix_from_single_l1b_calibration,
+    transform_to_inertial,
 )
 from imap_processing.mag.constants import MAX_FINE_TIME
 from imap_processing.spice.time import met_to_ttj2000ns
@@ -368,3 +369,30 @@ def test_apply_gradiometry_correction(ialirt_mag_test_l1d_data):
 
     expected_magnitude = np.sqrt(np.sum(mago_corrected**2, axis=1))
     np.testing.assert_array_equal(magnitude, expected_magnitude)
+
+
+@pytest.mark.external_kernel
+@pytest.mark.usefixtures("_unset_metakernel_path")
+def test_transform_to_inertial(furnish_kernels, spice_test_data_path):
+    """Test transform_to_inertial over multiple spin phases."""
+
+    kernels = ["imap_wkcp.tf"]
+
+    # Use a fixed spin axis pointing at +Z (RA=0, Dec=90)
+    ra = np.array([0.0, 0.0, 0.0, 0.0])
+    dec = np.array([90.0, 90.0, 90.0, 90.0])
+    spin_phase = np.array([0.0, 90.0, 180.0, 270.0])  # degrees
+
+    # Unit vector pointing along +X in instrument frame
+    mag_vector = np.array([1.0, 0.0, 0.0])
+
+    with furnish_kernels(kernels):
+        v_avg = transform_to_inertial(
+            sc_spin_phase_deg=spin_phase,
+            sc_inertial_right=ra,
+            sc_inertial_decline=dec,
+            mag_vector=mag_vector,
+        )
+
+    # Near zero vector in X and Y since it spans a full rotation.
+    np.testing.assert_allclose(v_avg, np.zeros(3), atol=1e-8)

--- a/imap_processing/tests/ialirt/unit/test_parse_mag.py
+++ b/imap_processing/tests/ialirt/unit/test_parse_mag.py
@@ -391,13 +391,19 @@ def test_transform_to_inertial(furnish_kernels, spice_test_data_path):
     # Unit vector pointing along +X in instrument frame
     mag_vector = np.array([1.0, 0.0, 0.0])
 
+    attitude_time = np.array([1000.0, 1010.0, 1020.0, 1030.0])
+    target_time = 1015.0  # halfway between 90° and 180° spin phase
+
     with furnish_kernels(kernels):
-        v_avg = transform_to_inertial(
+        result = transform_to_inertial(
             np.radians(spin_phase),
-            ra,
-            dec,
+            np.radians(ra),
+            np.radians(dec),
+            attitude_time,
+            target_time,
             mag_vector,
         )
 
-    # Near zero vector in X and Y since it spans a full rotation.
-    np.testing.assert_allclose(v_avg, np.zeros(3), atol=1e-8)
+    # With spin phase halfway between 90 and 180, vector should be pointing at 135.
+    expected_vector = np.array([-np.sqrt(2) / 2, np.sqrt(2) / 2, 0.0])
+    np.testing.assert_allclose(result, expected_vector, atol=1e-05)

--- a/imap_processing/tests/ialirt/unit/test_parse_mag.py
+++ b/imap_processing/tests/ialirt/unit/test_parse_mag.py
@@ -311,16 +311,21 @@ def test_calibrate_and_offset_vectors(ialirt_mag_test_l1d_data):
     mago_vectors = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     magi_vectors = np.array([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]])
 
+    # Range values (mago is 0 to 1, magi is 2 to 3)
+    # Range values (0 to 3) represent MAG gain setting
+    mago_range = np.array([0, 1])
+    magi_range = np.array([2, 3])
+
     # Calibration and offsets from ancillary cdf
     mago_calibration = ialirt_mag_test_l1d_data["URFTOORFO"][0]
     magi_calibration = ialirt_mag_test_l1d_data["URFTOORFI"][0]
     offsets = ialirt_mag_test_l1d_data["offsets"][0]
 
     mago_out = calibrate_and_offset_vectors(
-        mago_vectors, mago_calibration, offsets, is_magi=False
+        mago_vectors, mago_range, mago_calibration, offsets, is_magi=False
     )
     magi_out = calibrate_and_offset_vectors(
-        magi_vectors, magi_calibration, offsets, is_magi=True
+        magi_vectors, magi_range, magi_calibration, offsets, is_magi=True
     )
 
     # Every offset is zero.

--- a/imap_processing/tests/ialirt/unit/test_parse_mag.py
+++ b/imap_processing/tests/ialirt/unit/test_parse_mag.py
@@ -377,7 +377,6 @@ def test_apply_gradiometry_correction(ialirt_mag_test_l1d_data):
 
 
 @pytest.mark.external_kernel
-@pytest.mark.usefixtures("_unset_metakernel_path")
 def test_transform_to_inertial(furnish_kernels, spice_test_data_path):
     """Test transform_to_inertial over multiple spin phases."""
 

--- a/imap_processing/tests/ialirt/unit/test_parse_mag.py
+++ b/imap_processing/tests/ialirt/unit/test_parse_mag.py
@@ -310,21 +310,16 @@ def test_calibrate_and_offset_vectors(ialirt_mag_test_l1d_data):
     mago_vectors = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     magi_vectors = np.array([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]])
 
-    # Range values (mago is 0 to 1, magi is 2 to 3)
-    # Range values (0 to 3) represent MAG gain setting
-    mago_range = np.array([0, 1])
-    magi_range = np.array([2, 3])
-
     # Calibration and offsets from ancillary cdf
     mago_calibration = ialirt_mag_test_l1d_data["URFTOORFO"][0]
     magi_calibration = ialirt_mag_test_l1d_data["URFTOORFI"][0]
     offsets = ialirt_mag_test_l1d_data["offsets"][0]
 
     mago_out = calibrate_and_offset_vectors(
-        mago_vectors, mago_range, mago_calibration, offsets, is_magi=False
+        mago_vectors, mago_calibration, offsets, is_magi=False
     )
     magi_out = calibrate_and_offset_vectors(
-        magi_vectors, magi_range, magi_calibration, offsets, is_magi=True
+        magi_vectors, magi_calibration, offsets, is_magi=True
     )
 
     # Every offset is zero.


### PR DESCRIPTION
# Change Summary

## Overview
The MAG vectors are calculated based on 4 packets, each of which contains its own spin phase, inertial right ascension, and inertial decline. This PR addresses that issue and performs a frame transformation from the MAG instrument frame to the ECLIPJ2000.

I also updated the docstring to include constants for KSWC (our future ground station partner).

## Updated Files
- parse_mag.py
   - Transform vector to ECLIPJ2000.
- constants.py
   - Add KSWC to the docstring

## Testing
test_parse_mag.py
