### PR TITLE
Replace earth pck spice kernel

### DIFF
--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -52,7 +52,6 @@ def _download_external_kernels(spice_test_data_path):
     kernel_urls = [
         "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp",
         "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/pck00011.tpc",
-        "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/",
         "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_latest_high_prec.bpc",
     ]
 

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -52,8 +52,8 @@ def _download_external_kernels(spice_test_data_path):
     kernel_urls = [
         "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp",
         "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/pck00011.tpc",
-        "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/"
-        "earth_1962_240827_2124_combined.bpc",
+        "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/",
+        "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_latest_high_prec.bpc",
     ]
 
     for kernel_url in kernel_urls:

--- a/imap_processing/tests/ialirt/unit/test_process_ephemeris.py
+++ b/imap_processing/tests/ialirt/unit/test_process_ephemeris.py
@@ -16,14 +16,14 @@ def test_calculate_doppler(furnish_kernels):
     latitude = -33.94  # latitude in degrees
     altitude = 0.157  # altitude in kilometers
     # test single observation time
-    observation_time = 843307269.1823885  # "2026-09-22T00:00:00.000"
+    observation_time = 811771269.1823868  # "2025-09-22T00:00:00.000"
 
     kernels = [
         "naif0012.tls",
         "pck00011.tpc",
         "imap_spk_demo.bsp",
         "de440s.bsp",
-        "earth_1962_240827_2124_combined.bpc",
+        "earth_latest_high_prec.bpc",
     ]
     with furnish_kernels(kernels):
         doppler_result = process_ephemeris.calculate_doppler(
@@ -32,7 +32,7 @@ def test_calculate_doppler(furnish_kernels):
         assert doppler_result is not None
 
         # test array of observation times
-        time_endpoints = ("2026 SEP 22 00:00:00", "2026 SEP 22 23:59:59")
+        time_endpoints = ("2025 SEP 22 00:00:00", "2025 SEP 22 23:59:59")
         time_interval = int(1e3)  # seconds between data points
         observation_time = np.arange(
             str_to_et(time_endpoints[0]), str_to_et(time_endpoints[1]), time_interval
@@ -114,7 +114,7 @@ def test_build_output(furnish_kernels):
     longitude = -71.41  # longitude in degrees
     latitude = -33.94  # latitude in degrees
     altitude = 0.157  # altitude in kilometers
-    time_endpoints = ("2026 SEP 22 00:00:00", "2026 SEP 22 23:59:59")
+    time_endpoints = ("2025 SEP 22 00:00:00", "2025 SEP 22 23:59:59")
     time_interval = int(1e3)  # seconds between data points
 
     kernels = [
@@ -122,7 +122,7 @@ def test_build_output(furnish_kernels):
         "pck00011.tpc",
         "de440s.bsp",
         "imap_spk_demo.bsp",
-        "earth_1962_240827_2124_combined.bpc",
+        "earth_latest_high_prec.bpc",
     ]
     with furnish_kernels(kernels):
         output_dict = process_ephemeris.build_output(

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_culling.py
@@ -56,7 +56,7 @@ def test_compare_sincpt_with_culling_mask_deterministic(furnish_kernels):
             "imap_sclk_0000.tsc",
             "sim_1yr_imap_pointing_frame.bc",
             "imap_spk_demo.bsp",
-            "earth_1962_240827_2124_combined.bpc",
+            "earth_latest_high_prec.bpc",
             "pck00011.tpc",
             "naif0012.tls",
             "de440s.bsp",


### PR DESCRIPTION
# Change Summary
Replace the large `earth_1962_240827_2124_combined.bpc` kernel with the smaller `earth_latest_high_prec.bpc` kernel.

## Overview
I've replaced the old kernel name with the new one in every place it was mentioned, and updated the date ranges within a few tests due to the shorter span of time that the new kernel covers.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/tests/conftest.py
   - Replace kernel
- imap_processing/tests/ialirt/unit/test_process_ephemeris.py
   - Replace kernel
   - Update time range 
- imap_processing/tests/ultra/unit/test_ultra_l1c_culling.py
   - Replace kernel
