### PR TITLE
Minimal updates to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,18 @@ cython_debug/
 # Data that is downloaded
 data/
 test_data/
+/imap_processing/tests/mag/validation/L1c/T013/mag-l1b-l1c-t013-magi-burst-in.csv
+/imap_processing/tests/mag/validation/L1c/T013/mag-l1b-l1c-t013-mago-burst-in.csv
+/imap_processing/tests/mag/validation/L1c/T014/mag-l1b-l1c-t014-magi-burst-in.csv
+/imap_processing/tests/mag/validation/L1c/T014/mag-l1b-l1c-t014-mago-burst-in.csv
+/imap_processing/tests/mag/validation/L1c/T015/mag-l1b-l1c-t015-mago-burst-in.csv
+/imap_processing/tests/mag/validation/L1c/T016/mag-l1b-l1c-t016-mago-burst-in.csv
+/imap_processing/tests/mag/validation/L2/T021/imap_mag_l2_burst-offsets_20250506_v006.cdf
+/imap_processing/tests/mag/validation/L2/T021/imap_mag_l2_burst_20250506_v007.csv
+/imap_processing/tests/mag/validation/L2/T021/mag-l1bc-l2-t021-magi-burst-in.csv
+/imap_processing/tests/mag/validation/L2/T021/mag-l1bc-l2-t021-mago-burst-in.csv
+/imap_processing/tests/swe/l1_validation/
+/imap_processing/tests/swe/l2_validation/
 
 # Ignore specific SPICE kernels that get downloaded from NAIF automatically for tests
 # marked with @pytest.mark.external_kernel


### PR DESCRIPTION
# Change Summary
Exclude downloaded SWE and MAG tests from git. 

I also investigated specifying downloaded test files by adding "downloaded_" as a prefix on the file names, but unfortunately, even with Claude there were way too many places to update for it to be a reasonable change.

I still strongly prefer specifically listing excluded files such as in #2012 and feel that bulk-excluding folders with mixed downloaded and tracked files is confusing. I also think it would be a good idea to indicate that a file is downloaded in the file name or file location. 

