### PR TITLE
Temporary fix for the external_kernel pytest marker

### DIFF
--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -515,3 +515,4 @@ if __name__ == "__main__":
     # This is to enable downloading files easier by letting us
     # run this file directly
     _download_external_data()
+    _download_external_kernels(spice_test_data_path)

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -43,6 +43,10 @@ def clear_spin_and_repoint_paths(monkeypatch):
 
 
 @pytest.fixture(scope="session")
+def _download_kernels(spice_test_data_path):
+    _download_external_kernels(spice_test_data_path)
+
+
 def _download_external_kernels(spice_test_data_path):
     """This fixture downloads externally-located kernels into the tests/spice/test_data
     directory if they do not already exist there. The fixture is not intended to be
@@ -136,7 +140,7 @@ def pytest_collection_modifyitems(items):
     +---------------------+----------------------------+
     | pytest mark         | fixture added              |
     +=====================+============================+
-    | external_kernel     | _download_external_kernels |
+    | external_kernel     | _download_kernels          |
     | external_test_data  | _download_test_data        |
     +---------------------+----------------------------+
 
@@ -148,7 +152,7 @@ def pytest_collection_modifyitems(items):
     pytest.hookspec.pytest_collection_modifyitems
     """
     markers_to_fixtures = {
-        "external_kernel": "_download_external_kernels",
+        "external_kernel": "_download_kernels",
         "external_test_data": "_download_test_data",
     }
 
@@ -462,7 +466,7 @@ def use_fake_repoint_data_for_time(use_test_repoint_data_csv, tmp_path):
 
 
 @pytest.fixture
-def imap_ena_sim_metakernel(furnish_kernels, _download_external_kernels):
+def imap_ena_sim_metakernel(furnish_kernels, _download_kernels):
     kernels = [
         "imap_sclk_0000.tsc",
         "naif0012.tls",
@@ -515,4 +519,4 @@ if __name__ == "__main__":
     # This is to enable downloading files easier by letting us
     # run this file directly
     _download_external_data()
-    _download_external_kernels(spice_test_data_path)
+    _download_external_kernels(imap_module_directory / "tests" / "spice" / "test_data")

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -462,7 +462,7 @@ def use_fake_repoint_data_for_time(use_test_repoint_data_csv, tmp_path):
 
 
 @pytest.fixture
-def imap_ena_sim_metakernel(furnish_kernels):
+def imap_ena_sim_metakernel(furnish_kernels, _download_external_kernels):
     kernels = [
         "imap_sclk_0000.tsc",
         "naif0012.tls",

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -221,8 +221,10 @@ def lo_pset_cdf_path(imap_tests_path):
     return imap_tests_path / "hi/data/l1/imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
 
 
+# TODO remove _download_external_kernels when marker is fixed
 @pytest.mark.external_kernel
 @pytest.mark.usefixtures("imap_ena_sim_metakernel")
+@pytest.mark.usefixtures("_download_external_kernels")
 class TestLoPointingSet:
     """Test suite for LoPointingSet class."""
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -221,6 +221,7 @@ def lo_pset_cdf_path(imap_tests_path):
     return imap_tests_path / "hi/data/l1/imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
 
 
+@pytest.mark.external_kernel
 @pytest.mark.usefixtures("imap_ena_sim_metakernel")
 class TestLoPointingSet:
     """Test suite for LoPointingSet class."""

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -221,10 +221,7 @@ def lo_pset_cdf_path(imap_tests_path):
     return imap_tests_path / "hi/data/l1/imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
 
 
-# TODO remove _download_external_kernels fixture when marker is fixed
-@pytest.mark.external_kernel
 @pytest.mark.usefixtures("imap_ena_sim_metakernel")
-@pytest.mark.usefixtures("_download_external_kernels")
 class TestLoPointingSet:
     """Test suite for LoPointingSet class."""
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -221,7 +221,7 @@ def lo_pset_cdf_path(imap_tests_path):
     return imap_tests_path / "hi/data/l1/imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
 
 
-# TODO remove _download_external_kernels when marker is fixed
+# TODO remove _download_external_kernels fixture when marker is fixed
 @pytest.mark.external_kernel
 @pytest.mark.usefixtures("imap_ena_sim_metakernel")
 @pytest.mark.usefixtures("_download_external_kernels")

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -28,6 +28,7 @@ def test_hi_l1b_hk(hi_l0_test_data_path):
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_90sensor-hk"
 
 
+@pytest.mark.external_kernel
 @pytest.mark.external_test_data
 def test_hi_l1b_de(
     hi_l1_test_data_path,

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -28,9 +28,6 @@ def test_hi_l1b_hk(hi_l0_test_data_path):
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_90sensor-hk"
 
 
-# TODO remove _download_external_kernels when marker is fixed
-@pytest.mark.external_kernel
-@pytest.mark.usefixtures("_download_external_kernels")
 @pytest.mark.external_test_data
 def test_hi_l1b_de(
     hi_l1_test_data_path,

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -29,7 +29,7 @@ def test_hi_l1b_hk(hi_l0_test_data_path):
 
 
 # TODO remove _download_external_kernels when marker is fixed
-# @pytest.mark.external_kernel
+@pytest.mark.external_kernel
 @pytest.mark.usefixtures("_download_external_kernels")
 @pytest.mark.external_test_data
 def test_hi_l1b_de(

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -28,8 +28,10 @@ def test_hi_l1b_hk(hi_l0_test_data_path):
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_90sensor-hk"
 
 
+# TODO remove _download_external_kernels when marker is fixed
+# @pytest.mark.external_kernel
+@pytest.mark.usefixtures("_download_external_kernels")
 @pytest.mark.external_test_data
-@pytest.mark.external_kernel
 def test_hi_l1b_de(
     hi_l1_test_data_path,
     spice_test_data_path,

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -32,7 +32,7 @@ def test_hi_l1c(mock_generate_pset_dataset, hi_test_cal_prod_config_path):
 
 
 # TODO remove _download_external_kernels when marker is fixed
-# @pytest.mark.external_kernel
+@pytest.mark.external_kernel
 @pytest.mark.usefixtures("_download_external_kernels")
 @pytest.mark.external_test_data
 def test_generate_pset_dataset(

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -31,9 +31,6 @@ def test_hi_l1c(mock_generate_pset_dataset, hi_test_cal_prod_config_path):
     assert pset.attrs == {}
 
 
-# TODO remove _download_external_kernels when marker is fixed
-@pytest.mark.external_kernel
-@pytest.mark.usefixtures("_download_external_kernels")
 @pytest.mark.external_test_data
 def test_generate_pset_dataset(
     hi_l1_test_data_path,

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -31,8 +31,10 @@ def test_hi_l1c(mock_generate_pset_dataset, hi_test_cal_prod_config_path):
     assert pset.attrs == {}
 
 
+# TODO remove _download_external_kernels when marker is fixed
+# @pytest.mark.external_kernel
+@pytest.mark.usefixtures("_download_external_kernels")
 @pytest.mark.external_test_data
-@pytest.mark.external_kernel
 def test_generate_pset_dataset(
     hi_l1_test_data_path,
     hi_test_cal_prod_config_path,

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -31,6 +31,7 @@ def test_hi_l1c(mock_generate_pset_dataset, hi_test_cal_prod_config_path):
     assert pset.attrs == {}
 
 
+@pytest.mark.external_kernel
 @pytest.mark.external_test_data
 def test_generate_pset_dataset(
     hi_l1_test_data_path,


### PR DESCRIPTION
# Change Summary

## Overview
The 'external_kernel' pytest marker assigns the fixture _download_external_kernels. This is failing when another fixture that expects local kernels is also assigned with the test. Im not sure what the benefits of using the marker vs pytest.uses_fixture are. That is why I am adding some temporary TODOs instead of removing them. I think @subagonsouth will know more. 

## Updated Files
All fixes are the same. 
- Add this fixture @pytest.mark.usefixtures("_download_external_kernels")

## Testing
