### PR TITLE
779 hi l1b   function to convert hi esa step to esa energy step

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -737,10 +737,18 @@ class Hi(ProcessInstrument):
         elif self.data_level == "l1b":
             l0_files = dependencies.get_file_paths(source="hi", descriptor="raw")
             if l0_files:
-                datasets = hi_l1b.hi_l1b(l0_files[0])
+                datasets = hi_l1b.housekeeping(l0_files[0])
             else:
-                l1a_files = dependencies.get_file_paths(source="hi", data_type="l1a")
-                datasets = hi_l1b.hi_l1b(load_cdf(l1a_files[0]))
+                l1a_de_file = dependencies.get_file_paths(
+                    source="hi", data_type="l1a", descriptor="de"
+                )[0]
+                l1b_hk_file = dependencies.get_file_paths(
+                    source="hi", data_type="l1b", descriptor="hk"
+                )[0]
+                esa_energies_csv = dependencies.get_file_paths(data_type="ancillary")[0]
+                datasets = hi_l1b.annotate_direct_events(
+                    load_cdf(l1a_de_file), load_cdf(l1b_hk_file), esa_energies_csv
+                )
         elif self.data_level == "l1c":
             science_paths = dependencies.get_file_paths(source="hi", data_type="l1b")
             if len(science_paths) != 1:

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -107,7 +107,7 @@ def annotate_direct_events(
         L1A direct event data.
     l1b_hk_dataset : xarray.Dataset
         L1B housekeeping data coincident with the L1A DE data.
-    esa_energies_anc : Path
+    esa_energies_anc : pathlib.Path
         Location of the esa-energies ancillary csv file.
 
     Returns
@@ -375,7 +375,7 @@ def de_esa_energy_step(
         The partial L1B dataset.
     l1b_hk_ds : xarray.Dataset
         L1B housekeeping data coincident with the L1A DE data.
-    esa_energies_anc : Path
+    esa_energies_anc : pathlib.Path
         Location of the esa-energies ancillary csv file.
 
     Returns

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -47,51 +47,6 @@ ATTR_MGR.add_instrument_global_attrs("hi")
 ATTR_MGR.add_instrument_variable_attrs(instrument="hi", level=None)
 
 
-def hi_l1b(dependency: Union[str, Path, xr.Dataset]) -> list[xr.Dataset]:
-    """
-    High level IMAP-HI L1B processing function.
-
-    Parameters
-    ----------
-    dependency : str or xarray.Dataset
-        Path to L0 file or L1A dataset to process.
-
-    Returns
-    -------
-    l1b_dataset : list[xarray.Dataset]
-        Processed xarray datasets.
-    """
-    # Housekeeping processing
-    if isinstance(dependency, (Path, str)):
-        logger.info(f"Running Hi L1B processing on file: {dependency}")
-        l1b_datasets = housekeeping(dependency)
-    elif isinstance(dependency, xr.Dataset):
-        l1a_dataset = dependency
-        logger.info(
-            f"Running Hi L1B processing on dataset: "
-            f"{l1a_dataset.attrs['Logical_source']}"
-        )
-        logical_source_parts = parse_filename_like(l1a_dataset.attrs["Logical_source"])
-        # TODO: apid is not currently stored in all L1A data but should be.
-        #    Use apid to determine what L1B processing function to call
-
-        # DE processing
-        if logical_source_parts["descriptor"].endswith("de"):
-            l1b_datasets = [annotate_direct_events(l1a_dataset)]
-            l1b_datasets[0].attrs["Logical_source"] = (
-                l1b_datasets[0]
-                .attrs["Logical_source"]
-                .format(sensor=logical_source_parts["sensor"])
-            )
-        else:
-            raise NotImplementedError(
-                f"No Hi L1B processing defined for file type: "
-                f"{l1a_dataset.attrs['Logical_source']}"
-            )
-
-    return l1b_datasets
-
-
 def housekeeping(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
     """
     Will process IMAP raw data to l1b housekeeping dataset.
@@ -110,6 +65,7 @@ def housekeeping(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
     processed_data : list[xarray.Dataset]
         Housekeeping datasets with engineering units.
     """
+    logger.info(f"Running Hi L1B processing on file: {packet_file_path}")
     packet_def_file = (
         imap_module_directory / "hi/packet_definitions/TLM_HI_COMBINED_SCI.xml"
     )
@@ -139,33 +95,46 @@ def housekeeping(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
     return datasets
 
 
-def annotate_direct_events(l1a_dataset: xr.Dataset) -> xr.Dataset:
+def annotate_direct_events(
+    l1a_de_dataset: xr.Dataset, l1b_hk_dataset: xr.Dataset, esa_energies_anc: Path
+) -> list[xr.Dataset]:
     """
     Perform Hi L1B processing on direct event data.
 
     Parameters
     ----------
-    l1a_dataset : xarray.Dataset
+    l1a_de_dataset : xarray.Dataset
         L1A direct event data.
+    l1b_hk_dataset : xarray.Dataset
+        L1B housekeeping data coincident with the L1A DE data.
+    esa_energies_anc : Path
+        Location of the esa-energies ancillary csv file.
 
     Returns
     -------
-    l1b_dataset : xarray.Dataset
-        L1B direct event data.
+    l1b_datasets : list[xarray.Dataset]
+        List containing exactly one L1B direct event dataset.
     """
-    l1b_dataset = l1a_dataset.copy()
-    l1b_dataset.update(de_esa_energy_step(l1b_dataset))
-    l1b_dataset.update(compute_coincidence_type_and_tofs(l1b_dataset))
-    l1b_dataset.update(de_nominal_bin_and_spin_phase(l1b_dataset))
-    l1b_dataset.update(compute_hae_coordinates(l1b_dataset))
-    l1b_dataset.update(
+    logger.info(
+        f"Running Hi L1B processing on dataset: "
+        f"{l1a_de_dataset.attrs['Logical_source']}"
+    )
+
+    l1b_de_dataset = l1a_de_dataset.copy()
+    l1b_de_dataset.update(
+        de_esa_energy_step(l1b_de_dataset, l1b_hk_dataset, esa_energies_anc)
+    )
+    l1b_de_dataset.update(compute_coincidence_type_and_tofs(l1b_de_dataset))
+    l1b_de_dataset.update(de_nominal_bin_and_spin_phase(l1b_de_dataset))
+    l1b_de_dataset.update(compute_hae_coordinates(l1b_de_dataset))
+    l1b_de_dataset.update(
         create_dataset_variables(
             ["quality_flag"],
-            l1b_dataset["event_met"].size,
+            l1b_de_dataset["event_met"].size,
             att_manager_lookup_str="hi_de_{0}",
         )
     )
-    l1b_dataset = l1b_dataset.drop_vars(
+    l1b_de_dataset = l1b_de_dataset.drop_vars(
         [
             "src_seq_ctr",
             "pkt_len",
@@ -181,8 +150,13 @@ def annotate_direct_events(l1a_dataset: xr.Dataset) -> xr.Dataset:
     )
 
     de_global_attrs = ATTR_MGR.get_global_attributes("imap_hi_l1b_de_attrs")
-    l1b_dataset.attrs.update(**de_global_attrs)
-    return l1b_dataset
+    l1b_de_dataset.attrs.update(**de_global_attrs)
+
+    logical_source_parts = parse_filename_like(l1a_de_dataset.attrs["Logical_source"])
+    l1b_de_dataset.attrs["Logical_source"] = l1b_de_dataset.attrs[
+        "Logical_source"
+    ].format(sensor=logical_source_parts["sensor"])
+    return [l1b_de_dataset]
 
 
 def compute_coincidence_type_and_tofs(
@@ -389,7 +363,9 @@ def compute_hae_coordinates(dataset: xr.Dataset) -> dict[str, xr.DataArray]:
     return new_vars
 
 
-def de_esa_energy_step(l1b_de_ds: xr.Dataset) -> dict[str, xr.DataArray]:
+def de_esa_energy_step(
+    l1b_de_ds: xr.Dataset, l1b_hk_ds: xr.Dataset, esa_energies_anc: Path
+) -> dict[str, xr.DataArray]:
     """
     Compute esa_energy_step for each direct event.
 
@@ -401,6 +377,10 @@ def de_esa_energy_step(l1b_de_ds: xr.Dataset) -> dict[str, xr.DataArray]:
     ----------
     l1b_de_ds : xarray.Dataset
         The partial L1B dataset.
+    l1b_hk_ds : xarray.Dataset
+        L1B housekeeping data coincident with the L1A DE data.
+    esa_energies_anc : Path
+        Location of the esa-energies ancillary csv file.
 
     Returns
     -------
@@ -413,8 +393,14 @@ def de_esa_energy_step(l1b_de_ds: xr.Dataset) -> dict[str, xr.DataArray]:
         att_manager_lookup_str="hi_de_{0}",
     )
 
-    # TODO: Implement this algorithm
-    new_vars["esa_energy_step"].values = l1b_de_ds.esa_step.values
+    # Get the LUT object using the HK data and esa-energies ancillary csv
+    esa_energies_lut = pd.read_csv(esa_energies_anc, comment="#")
+    esa_to_esa_energy_step_lut = get_esa_to_esa_energy_step_lut(
+        l1b_hk_ds, esa_energies_lut
+    )
+    new_vars["esa_energy_step"].values = esa_to_esa_energy_step_lut.query(
+        l1b_de_ds["ccsds_met"].data, l1b_de_ds["esa_step"].data
+    )
 
     return new_vars
 

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -369,10 +369,6 @@ def de_esa_energy_step(
     """
     Compute esa_energy_step for each direct event.
 
-    TODO: For now this function just returns the esa_step from the input dataset.
-        Eventually, it will take L1B housekeeping data and determine the esa
-        energy steps from that data.
-
     Parameters
     ----------
     l1b_de_ds : xarray.Dataset
@@ -457,7 +453,12 @@ def get_esa_to_esa_energy_step_lut(
                     f"({met_to_utc(contiguous_hvsci_ds['shcoarse'].data[[0, -1]])})"
                 )
                 continue
-            median_inner_esa = np.median(single_esa_ds["inner_esa_hi"].data)
+            inner_esa_voltage = np.where(
+                single_esa_ds["inner_esa_state"].data == "LO",
+                single_esa_ds["inner_esa_lo"].data,
+                single_esa_ds["inner_esa_hi"].data,
+            )
+            median_inner_esa = np.median(inner_esa_voltage)
             median_outer_esa = np.median(single_esa_ds["outer_esa"].data)
             # Match median voltages to ESA Energies LUT
             inner_voltage_match = (

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -52,6 +52,8 @@ EXTERNAL_TEST_DATA = [
     # Hi
     ("imap_hi_l1a_45sensor-de_20250415_v999.cdf", "hi/data/l1/"),
     ("imap_hi_l1b_45sensor-de_20250415_v999.cdf", "hi/data/l1/"),
+    ("imap_hi_l1b_90sensor-hk_20241105-repoint00099_v001.cdf", "hi/data/l1/"),
+    ("imap_hi_l1a_90sensor-de_20241105-repoint00099_v001.cdf", "hi/data/l1/"),
     ("imap_hi_l1c_45sensor-pset_20250415_v999.cdf", "hi/data/l1/"),
 
     # I-ALiRT

--- a/imap_processing/tests/hi/data/l1/imap_hi_90sensor-esa-energies_20240101_v001.csv
+++ b/imap_processing/tests/hi/data/l1/imap_hi_90sensor-esa-energies_20240101_v001.csv
@@ -1,0 +1,22 @@
+# ESA Energies table
+# Valid start date: 2024-01-01 (from filename)
+# This file will be used in processing until a new calibration file is uploaded
+# to the SDC with either a higher version number or new date in the filename.
+# For details on how the SDC selects ancillary files for processing, see:
+# https://imap-processing.readthedocs.io/en/latest/data-access/calibration-files.html
+#
+# This file will be used twice in Hi processing:
+#   - To generate a mapping from ESA Step to ESA Energy Step for each contiguous HVSCI
+#     interval. This is used in L1B DE processing.
+#   - In L2 processing to associate an ESA Energy Step to an Energy band.
+esa_energy_step,nominal_central_energy,inner_esa_voltage,inner_esa_delta_v,outer_esa_voltage,outer_esa_delta_v
+0,,0,25,0,25
+1,0.50,-472,25,122,25
+2,0.75,-713,25,164,25
+3,1.10,-1047,25,213,25
+4,1.65,-1564,25,270,25
+5,2.50,-2089,25,718,25
+6,3.75,-2893,25,1232,25
+7,5.70,-4147,25,2034,25
+8,8.52,-5948,25,3185,25
+9,12.8,-8650,25,4911,25

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -9,12 +9,13 @@ import xarray as xr
 
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.hi.hi_l1b import (
+    annotate_direct_events,
     compute_coincidence_type_and_tofs,
     compute_hae_coordinates,
     de_esa_energy_step,
     de_nominal_bin_and_spin_phase,
     get_esa_to_esa_energy_step_lut,
-    hi_l1b,
+    housekeeping,
 )
 from imap_processing.hi.utils import (
     CoincidenceBitmap,
@@ -29,14 +30,16 @@ def test_hi_l1b_hk(hi_l0_test_data_path):
     housekeeping L1A as input"""
     bin_data_path = hi_l0_test_data_path / "H90_NHK_20241104.bin"
 
-    l1b_datasets = hi_l1b(bin_data_path)
+    l1b_datasets = housekeeping(bin_data_path)
     assert len(l1b_datasets) == 1
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_90sensor-hk"
 
 
 @pytest.mark.external_kernel
 @pytest.mark.external_test_data
+@mock.patch("imap_processing.hi.hi_l1b.get_esa_to_esa_energy_step_lut")
 def test_hi_l1b_de(
+    mock_get_esa_lut,
     hi_l1_test_data_path,
     spice_test_data_path,
     use_fake_spin_data_for_time,
@@ -44,15 +47,23 @@ def test_hi_l1b_de(
 ):
     """Test coverage for imap_processing.hi_l1b.hi_l1b() with
     direct events L1A as input"""
+    # Mock the esa LUT object to map esa_step to the same esa_energy_step value
+    mock_esa_lut = mock.MagicMock(spec=EsaEnergyStepLookupTable())
+    mock_esa_lut.query.side_effect = lambda a, b: b
+    mock_get_esa_lut.return_value = mock_esa_lut
+
     # Start MET time of spin for simulated input data is 482372988
     use_fake_spin_data_for_time(482372987.999)
     l1a_test_file_path = (
         hi_l1_test_data_path / "imap_hi_l1a_45sensor-de_20250415_v999.cdf"
     )
+    esa_energies_csv = (
+        hi_l1_test_data_path / "imap_hi_90sensor-esa-energies_20240101_v001.csv"
+    )
     # Process using test data
     l1a_dataset = load_cdf(l1a_test_file_path)
 
-    l1b_datasets = hi_l1b(l1a_dataset)
+    l1b_datasets = annotate_direct_events(l1a_dataset, xr.Dataset(), esa_energies_csv)
     assert len(l1b_datasets) == 1
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_45sensor-de"
     assert len(l1b_datasets[0].data_vars) == 15
@@ -245,20 +256,28 @@ def test_compute_hae_coordinates(mock_instrument_pointing, sensor_number):
     np.testing.assert_allclose(new_vars["hae_longitude"].values, sensor_number)
 
 
-def test_de_esa_energy_step():
+@mock.patch("imap_processing.hi.hi_l1b.pd.read_csv")
+@mock.patch("imap_processing.hi.hi_l1b.get_esa_to_esa_energy_step_lut")
+def test_de_esa_energy_step(mock_get_esa_lut, mock_read_csv):
     """Test coverage for de_esa_energy_step function."""
+    mock_esa_lut = mock.MagicMock(spec=EsaEnergyStepLookupTable())
+    mock_esa_lut.query.side_effect = lambda a, b: np.arange(len(a))[::-1] % 9
+    mock_get_esa_lut.return_value = mock_esa_lut
+
     n_epoch = 20
     fake_dataset = xr.Dataset(
         coords={
             "epoch": xr.DataArray(np.arange(n_epoch), name="epoch", dims=["epoch"])
         },
-        data_vars={"esa_step": xr.DataArray(np.arange(n_epoch) % 9, dims=["epoch"])},
+        data_vars={
+            "ccsds_met": xr.DataArray(np.arange(n_epoch) % 9, dims=["epoch"]),
+            "esa_step": xr.DataArray(np.arange(n_epoch), dims=["epoch"]),
+        },
     )
-    esa_energy_step_var = de_esa_energy_step(fake_dataset)
-    # TODO: The below check is for the temporary implementation and should be
-    #    removed when the function is update.
+    esa_energy_step_var = de_esa_energy_step(fake_dataset, xr.Dataset(), "Fake path")
+
     np.testing.assert_array_equal(
-        esa_energy_step_var["esa_energy_step"].values, fake_dataset.esa_step.values
+        esa_energy_step_var["esa_energy_step"].values, np.arange(n_epoch)[::-1] % 9
     )
 
 

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -38,15 +38,14 @@ def test_hi_l1b_hk(hi_l0_test_data_path):
 @pytest.mark.external_kernel
 @pytest.mark.external_test_data
 @mock.patch("imap_processing.hi.hi_l1b.get_esa_to_esa_energy_step_lut")
-def test_hi_l1b_de(
+def test_hi_annotate_direct_events(
     mock_get_esa_lut,
     hi_l1_test_data_path,
-    spice_test_data_path,
     use_fake_spin_data_for_time,
     imap_ena_sim_metakernel,
 ):
-    """Test coverage for imap_processing.hi_l1b.hi_l1b() with
-    direct events L1A as input"""
+    """Test coverage for imap_processing.hi_l1b.annotate_direct_events() with
+    direct events L1A as input and spice kernel coverage."""
     # Mock the esa LUT object to map esa_step to the same esa_energy_step value
     mock_esa_lut = mock.MagicMock(spec=EsaEnergyStepLookupTable())
     mock_esa_lut.query.side_effect = lambda a, b: b
@@ -66,6 +65,44 @@ def test_hi_l1b_de(
     l1b_datasets = annotate_direct_events(l1a_dataset, xr.Dataset(), esa_energies_csv)
     assert len(l1b_datasets) == 1
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_45sensor-de"
+    assert len(l1b_datasets[0].data_vars) == 15
+
+
+@mock.patch("imap_processing.hi.hi_l1b.instrument_pointing")
+def test_hi_l1b_with_hk(
+    mock_instrument_pointing, hi_l1_test_data_path, use_fake_spin_data_for_time
+):
+    """Test imap_processing.hi_l1b.annotate_direct_events() with a
+    coincident de and hk dataset but mocked spice."""
+    # Mock instrument pointing to return zeros since we don't have spice kernels
+    # for this time.
+    mock_instrument_pointing.side_effect = lambda et, frame_a, frame_b: np.zeros(
+        (len(et), 3)
+    )
+
+    l1a_de_file_path = (
+        hi_l1_test_data_path / "imap_hi_l1a_90sensor-de_20241105-repoint00099_v001.cdf"
+    )
+    l1b_hk_file_path = (
+        hi_l1_test_data_path / "imap_hi_l1b_90sensor-hk_20241105-repoint00099_v001.cdf"
+    )
+    esa_energies_csv = (
+        hi_l1_test_data_path / "imap_hi_90sensor-esa-energies_20240101_v001.csv"
+    )
+    # Process using test data
+    l1a_dataset = load_cdf(l1a_de_file_path)
+    hk_dataset = load_cdf(l1b_hk_file_path)
+    # Cross-cal data used a 15 second spin period. Calculate start time of first
+    # spin
+    spin_start_met = (
+        l1a_dataset["esa_step_seconds"].data[0].astype(float)
+        + l1a_dataset["esa_step_milliseconds"].data[0].astype(float) / 1000
+    )
+    use_fake_spin_data_for_time(spin_start_met)
+
+    l1b_datasets = annotate_direct_events(l1a_dataset, hk_dataset, esa_energies_csv)
+    assert len(l1b_datasets) == 1
+    assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_90sensor-de"
     assert len(l1b_datasets[0].data_vars) == 15
 
 
@@ -301,14 +338,23 @@ class TestGetEsaToEsaEnergyStepLut:
         )
 
     def create_mock_dataset(
-        self, op_modes, esa_steps, inner_esa_values, outer_esa_values, shcoarse_values
+        self,
+        op_modes,
+        esa_steps,
+        inner_esa_state,
+        inner_esa_hi,
+        inner_esa_lo,
+        outer_esa_values,
+        shcoarse_values,
     ):
         """Helper method to create mock L1B housekeeping dataset."""
         return xr.Dataset(
             {
                 "op_mode": (["epoch"], op_modes),
                 "sci_esa_step": (["epoch"], esa_steps),
-                "inner_esa_hi": (["epoch"], inner_esa_values),
+                "inner_esa_state": (["epoch"], inner_esa_state),
+                "inner_esa_hi": (["epoch"], inner_esa_hi),
+                "inner_esa_lo": (["epoch"], inner_esa_lo),
                 "outer_esa": (["epoch"], outer_esa_values),
                 "shcoarse": (["epoch"], shcoarse_values),
             }
@@ -323,12 +369,14 @@ class TestGetEsaToEsaEnergyStepLut:
         l1b_hk_ds = self.create_mock_dataset(
             op_modes=["HVSCI", "HVSCI", "HVSCI", "HVSCI"],
             esa_steps=[1, 1, 2, 2],
-            inner_esa_values=[
+            inner_esa_state=["HI", "HI", "HI", "HI"],
+            inner_esa_hi=[
                 -98.0,
                 -102.0,
                 -198.0,
                 -202.0,
             ],  # Should match steps 1 and 2
+            inner_esa_lo=[0, 0, 0, 0],
             outer_esa_values=[49.0, 51.0, 99.0, 101.0],
             shcoarse_values=[1000, 1001, 1002, 1003],
         )
@@ -365,7 +413,9 @@ class TestGetEsaToEsaEnergyStepLut:
         l1b_hk_ds = self.create_mock_dataset(
             op_modes=["OTHER", "HVSCI", "HVSCI", "OTHER", "HVSCI", "HVSCI"],
             esa_steps=[1, 1, 1, 2, 2, 2],
-            inner_esa_values=[-100.0, -98.0, -102.0, -200.0, -198.0, -202.0],
+            inner_esa_state=["LO", "LO", "LO", "LO", "LO", "LO"],
+            inner_esa_hi=[0, 0, 0, 0, 0, 0],
+            inner_esa_lo=[-100.0, -98.0, -102.0, -200.0, -198.0, -202.0],
             outer_esa_values=[50.0, 49.0, 51.0, 100.0, 99.0, 101.0],
             shcoarse_values=[1000, 1001, 1002, 1003, 1004, 1005],
         )
@@ -389,7 +439,9 @@ class TestGetEsaToEsaEnergyStepLut:
         l1b_hk_ds = self.create_mock_dataset(
             op_modes=["OTHER", "LVSCI", "LVSCI"],
             esa_steps=[1, 2, 3],
-            inner_esa_values=[-100.0, -200.0, -300.0],
+            inner_esa_state=["HI", "HI", "HI"],
+            inner_esa_hi=[-100.0, -200.0, -300.0],
+            inner_esa_lo=[-100.0, -200.0, -300.0],
             outer_esa_values=[50.0, 100.0, 150.0],
             shcoarse_values=[1000, 1001, 1002],
         )
@@ -409,7 +461,9 @@ class TestGetEsaToEsaEnergyStepLut:
         l1b_hk_ds = self.create_mock_dataset(
             op_modes=["HVSCI", "HVSCI"],
             esa_steps=[1, 1],
-            inner_esa_values=[-500.0, -500.0],  # No match in lookup table
+            inner_esa_state=["HI", "LO"],
+            inner_esa_hi=[-500.0, -500.0],  # No match in lookup table
+            inner_esa_lo=[-500.0, -500.0],
             outer_esa_values=[500.0, 500.0],
             shcoarse_values=[1000, 1001],
         )
@@ -445,7 +499,9 @@ class TestGetEsaToEsaEnergyStepLut:
         l1b_hk_ds = self.create_mock_dataset(
             op_modes=["HVSCI", "HVSCI"],
             esa_steps=[1, 1],
-            inner_esa_values=[-101.0, -101.0],  # Matches both rows
+            inner_esa_state=["HI", "LO"],
+            inner_esa_hi=[-101.0, 0],  # Matches both rows
+            inner_esa_lo=[0, -101.0],  # Matches both rows
             outer_esa_values=[51.0, 51.0],
             shcoarse_values=[1000, 1001],
         )
@@ -470,7 +526,9 @@ class TestGetEsaToEsaEnergyStepLut:
         l1b_hk_ds = self.create_mock_dataset(
             op_modes=["HVSCI"],
             esa_steps=[1],
-            inner_esa_values=[-100.0],
+            inner_esa_state=["HI"],
+            inner_esa_hi=[-100.0],
+            inner_esa_lo=[-100.0],
             outer_esa_values=[50.0],
             shcoarse_values=[1000],
         )
@@ -488,7 +546,9 @@ class TestGetEsaToEsaEnergyStepLut:
         l1b_hk_ds = self.create_mock_dataset(
             op_modes=["OTHER", "HVSCI", "HVSCI", "OTHER"],
             esa_steps=[1, 2, 2, 1],  # ESA step 1 not in HVSCI segment
-            inner_esa_values=[-100.0, -198.0, -202.0, -100.0],
+            inner_esa_state=["HI", "HI", "HI", "HI"],
+            inner_esa_hi=[-100.0, -198.0, -202.0, -100.0],
+            inner_esa_lo=[0, 0, 0, 0],
             outer_esa_values=[50.0, 99.0, 101.0, 50.0],
             shcoarse_values=[1000, 1001, 1002, 1003],
         )

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -69,7 +69,7 @@ def test_hi_annotate_direct_events(
 
 
 @mock.patch("imap_processing.hi.hi_l1b.instrument_pointing")
-def test_hi_l1b_with_hk(
+def test_annotate_direct_events_with_hk(
     mock_instrument_pointing, hi_l1_test_data_path, use_fake_spin_data_for_time
 ):
     """Test imap_processing.hi_l1b.annotate_direct_events() with a

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -557,3 +557,49 @@ class TestGetEsaToEsaEnergyStepLut:
 
         # Only ESA step 2 should be processed (it's the only one in HVSCI segment)
         self.mock_lut.add_entry.assert_called_once_with(1001, 1002, 2, 2)
+
+    @pytest.mark.external_test_data
+    def test_cal_data(self, hi_l1_test_data_path):
+        """Test with calibration data."""
+        l1b_hk_ds = load_cdf(
+            hi_l1_test_data_path
+            / "imap_hi_l1b_90sensor-hk_20241105-repoint00099_v001.cdf"
+        )
+        # Create a esa energies pandas DataFrame
+        esa_energies_lut_data = {
+            "esa_energy_step": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "nominal_central_energy": [
+                np.nan,
+                0.50,
+                0.75,
+                1.10,
+                1.65,
+                2.50,
+                3.75,
+                5.70,
+                8.52,
+                12.8,
+            ],
+            "inner_esa_voltage": [
+                0,
+                -472,
+                -713,
+                -1010,
+                -1524,
+                -2060,
+                -2870,
+                -4107,
+                -5908,
+                -8625,
+            ],
+            "inner_esa_delta_v": [25, 25, 25, 25, 25, 25, 25, 25, 25, 25],
+            "outer_esa_voltage": [0, 122, 164, 213, 270, 718, 1232, 2034, 3185, 4911],
+            "outer_esa_delta_v": [25, 25, 25, 25, 25, 25, 25, 25, 25, 25],
+        }
+        esa_energies_lut = pd.DataFrame(esa_energies_lut_data)
+
+        lut = get_esa_to_esa_energy_step_lut(l1b_hk_ds, esa_energies_lut)
+
+        # Check the generated lookup table
+        # We expect 1 dataframe entry per esa step in the range [1, 9]
+        np.testing.assert_array_equal(lut.df["esa_step"].values, np.arange(9) + 1)

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -68,6 +68,7 @@ def test_hi_annotate_direct_events(
     assert len(l1b_datasets[0].data_vars) == 15
 
 
+@pytest.mark.external_test_data
 @mock.patch("imap_processing.hi.hi_l1b.instrument_pointing")
 def test_annotate_direct_events_with_hk(
     mock_instrument_pointing, hi_l1_test_data_path, use_fake_spin_data_for_time

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -279,19 +279,30 @@ def test_post_processing_returns_empty_list_if_invoked_with_no_data(
 
 
 @pytest.mark.parametrize(
-    "data_level, science_input, anc_input, n_prods",
+    "data_level, function_name, science_input, anc_input, n_prods",
     [
-        ("l1a", ["imap_hi_l0_raw_20231212_v001.pkts"], [], 2),
-        ("l1b", ["imap_hi_l1a_90sensor-de_20241105_v001.cdf"], [], 1),
-        ("l1b", ["imap_hi_l0_raw_20231212_v001.pkts"], [], 2),
+        ("l1a", "hi_l1a", ["imap_hi_l0_raw_20231212_v001.pkts"], [], 2),
+        (
+            "l1b",
+            "annotate_direct_events",
+            [
+                "imap_hi_l1a_90sensor-de_20241105_v001.cdf",
+                "imap_hi_l1b_90sensor-hk_20241105_v001.cdf",
+            ],
+            ["imap_hi_90sensor-esa-energies_20240101_v001.csv"],
+            1,
+        ),
+        ("l1b", "housekeeping", ["imap_hi_l0_raw_20231212_v001.pkts"], [], 2),
         (
             "l1c",
+            "hi_l1c",
             ["imap_hi_l1b_45sensor-de_20250415_v001.cdf"],
             ["imap_hi_calibration-prod-config_20240101_v001.csv"],
             1,
         ),
         (
             "l2",
+            "hi_l2",
             [
                 "imap_hi_l1c_90sensor-pset_20250415_v001.cdf",
                 "imap_hi_l1c_90sensor-pset_20250416_v001.cdf",
@@ -302,7 +313,12 @@ def test_post_processing_returns_empty_list_if_invoked_with_no_data(
     ],
 )
 def test_hi(
-    mock_instrument_dependencies, data_level, science_input, anc_input, n_prods
+    mock_instrument_dependencies,
+    data_level,
+    function_name,
+    science_input,
+    anc_input,
+    n_prods,
 ):
     """Test coverage for cli.Hi class"""
     mocks = mock_instrument_dependencies
@@ -317,7 +333,7 @@ def test_hi(
     # patch autospec=True makes this test confirm that the function call in cli.py
     # matches the mocked function signature.
     with mock.patch(
-        f"imap_processing.cli.hi_{data_level}.hi_{data_level}", autospec=True
+        f"imap_processing.cli.hi_{data_level}.{function_name}", autospec=True
     ) as mock_hi:
         mock_hi.return_value = [xr.Dataset()] * n_prods
         dependency_str = (


### PR DESCRIPTION
# Change Summary

## Overview
This PR integrates the use of the `EsaEnergyStepLookupTable` class from #2004 into the Hi L1B pipeline. It adds the new upstream dependencies to the Hi `do_processing` method and changes how that method calls the L1B DE and HK processing. I also had to update how the median inner esa voltage was calculated by reading the correct HI/LO telemetry item based on the inner_esa_state.

## New Files
- imap_processing/tests/hi/data/l1/imap_hi_90sensor-esa-energies_20240101_v001.csv
   - Template ancillary file with the esa_step to energies and voltages LUT.
- imap_hi_l1b_90sensor-hk_20241105-repoint00099_v001.cdf
   - External test file
- imap_hi_l1a_90sensor-de_20241105-repoint00099_v001.cdf
   - External test file

## Updated Files
- imap_processing/cli.py
   - Add gathering of new upstream dependencies for Hi L1B DE processing
   - Directly call housekeeping or annotate_direct_event functions rather than having duplicate logic in hi_l1b.py to figure out which product is being processed.
- imap_processing/hi/hi_l1b.py
   - Remove hi_l1b function as this is now done in cli.py
   - Add dependencies for DE processing
   - Use esa_step to esa_energy_step LUT in processing
   - Read the correct inner esa voltage based on inner_esa_state
- imap_processing/tests/external_test_data_config.py
   - Add external files to download
- imap_processing/tests/hi/test_hi_l1b.py
   - Add test for getting esa_energy_step using calibration data
   - Add test coverage for new calculation of medain inner esa voltage
- imap_processing/tests/test_cli.py
   - Update test with new upstream dependencies


Closes: #779
