### PR TITLE
HIT L1B - Update dependency handling

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -815,15 +815,15 @@ class Hit(ProcessInstrument):
             datasets = hit_l1a(science_files[0], self.start_date)
 
         elif self.data_level == "l1b":
-            data_dict = {}
+            dependency_dict = {}
             l0_files = dependencies.get_file_paths(source="hit", descriptor="raw")
             l1a_files = dependencies.get_file_paths(source="hit", data_type="l1a")
             if len(l0_files) == 1:
                 # Add path to CCSDS file to process housekeeping
-                data_dict = {
-                    "logical_source": "imap_hit_l0_raw",
+                dependency_dict = {
                     "data": l0_files[0],
-                    "descriptor": self.descriptor,
+                    "logical_source": "imap_hit_l0_raw",
+                    "output_descriptor": self.descriptor,
                 }
             else:
                 # 1 science file
@@ -834,16 +834,14 @@ class Hit(ProcessInstrument):
                     )
                 # Add L1A dataset to process science data
                 l1a_dataset = load_cdf(l1a_files[0])
-                data_dict = {
-                    "logical_source": l1a_dataset.attrs["Logical_source"],
+                dependency_dict = {
                     "data": l1a_dataset,
-                    "descriptor": self.descriptor,
+                    "logical_source": l1a_dataset.attrs["Logical_source"],
+                    "output_descriptor": self.descriptor,
                 }
-            print(self.descriptor)
-            print(data_dict)
-
             # process data to L1B products
-            datasets = hit_l1b(data_dict)
+            datasets = hit_l1b(dependency_dict)
+
         elif self.data_level == "l2":
             # 1 science files and 4 ancillary files
             if len(dependency_list) != 5:

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -830,7 +830,7 @@ class Hit(ProcessInstrument):
                 # Add L1A dataset to process science data
                 dependency = load_cdf(l1a_files[0])
             # process data to L1B products
-            datasets = hit_l1b(dependency, self.descriptor)
+            datasets = [hit_l1b(dependency, self.descriptor)]
 
         elif self.data_level == "l2":
             # 1 science files and 4 ancillary files
@@ -857,7 +857,7 @@ class Hit(ProcessInstrument):
                 )
             l1b_dataset = load_cdf(science_files[0])
             # process data to L2 products
-            datasets = hit_l2(l1b_dataset, ancillary_files)
+            datasets = [hit_l2(l1b_dataset, ancillary_files)]
 
         return datasets
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -815,16 +815,11 @@ class Hit(ProcessInstrument):
             datasets = hit_l1a(science_files[0], self.start_date)
 
         elif self.data_level == "l1b":
-            dependency_dict = {}
             l0_files = dependencies.get_file_paths(source="hit", descriptor="raw")
             l1a_files = dependencies.get_file_paths(source="hit", data_type="l1a")
             if len(l0_files) == 1:
-                # Add path to CCSDS file to process housekeeping
-                dependency_dict = {
-                    "data": l0_files[0],
-                    "logical_source": "imap_hit_l0_raw",
-                    "output_descriptor": self.descriptor,
-                }
+                # Path to CCSDS file to process housekeeping
+                dependency = l0_files[0]
             else:
                 # 1 science file
                 if len(l1a_files) > 1:
@@ -833,14 +828,9 @@ class Hit(ProcessInstrument):
                         f"{l1a_files}. Expected only one dependency."
                     )
                 # Add L1A dataset to process science data
-                l1a_dataset = load_cdf(l1a_files[0])
-                dependency_dict = {
-                    "data": l1a_dataset,
-                    "logical_source": l1a_dataset.attrs["Logical_source"],
-                    "output_descriptor": self.descriptor,
-                }
+                dependency = load_cdf(l1a_files[0])
             # process data to L1B products
-            datasets = hit_l1b(dependency_dict)
+            datasets = hit_l1b(dependency, self.descriptor)
 
         elif self.data_level == "l2":
             # 1 science files and 4 ancillary files

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -820,7 +820,11 @@ class Hit(ProcessInstrument):
             l1a_files = dependencies.get_file_paths(source="hit", data_type="l1a")
             if len(l0_files) == 1:
                 # Add path to CCSDS file to process housekeeping
-                data_dict["imap_hit_l0_raw"] = l0_files[0]
+                data_dict = {
+                    "logical_source": "imap_hit_l0_raw",
+                    "data": l0_files[0],
+                    "descriptor": self.descriptor,
+                }
             else:
                 # 1 science file
                 if len(l1a_files) > 1:
@@ -830,7 +834,14 @@ class Hit(ProcessInstrument):
                     )
                 # Add L1A dataset to process science data
                 l1a_dataset = load_cdf(l1a_files[0])
-                data_dict[l1a_dataset.attrs["Logical_source"]] = l1a_dataset
+                data_dict = {
+                    "logical_source": l1a_dataset.attrs["Logical_source"],
+                    "data": l1a_dataset,
+                    "descriptor": self.descriptor,
+                }
+            print(self.descriptor)
+            print(data_dict)
+
             # process data to L1B products
             datasets = hit_l1b(data_dict)
         elif self.data_level == "l2":

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -105,50 +105,47 @@ def process_science_data(
     """
     logger.info("Creating HIT L1B science datasets")
 
+    dataset = None
+    logical_source = None
+
     # Calculate fractional livetime from the livetime counter
     livetime = l1a_counts_dataset["livetime_counter"] / LIVESTIM_PULSES
     livetime = livetime.rename("livetime")
 
-    try:
-        # Process counts data to an L1B dataset based on the descriptor
-        if descriptor == "standard-rates":
-            dataset = process_standard_rates_data(l1a_counts_dataset, livetime)
-            logical_source = "imap_hit_l1b_standard-rates"
-        elif descriptor == "summed-rates":
-            dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
-            logical_source = "imap_hit_l1b_summed-rates"
-        elif descriptor == "sectored-rates":
-            dataset = process_sectored_rates_data(l1a_counts_dataset, livetime)
-            logical_source = "imap_hit_l1b_sectored-rates"
-        else:
-            raise ValueError(f"Unsupported descriptor: {descriptor}")
-    except KeyError as e:
-        logger.error(
-            f"Failed to create L1B dataset for descriptor {descriptor} with input data"
-            f" {l1a_counts_dataset.attrs['Logical_source']}: {e}"
-        )
-        raise
+    # Process counts data to an L1B dataset based on the descriptor
+    if descriptor == "standard-rates":
+        dataset = process_standard_rates_data(l1a_counts_dataset, livetime)
+        logical_source = "imap_hit_l1b_standard-rates"
+    elif descriptor == "summed-rates":
+        dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
+        logical_source = "imap_hit_l1b_summed-rates"
+    elif descriptor == "sectored-rates":
+        dataset = process_sectored_rates_data(l1a_counts_dataset, livetime)
+        logical_source = "imap_hit_l1b_sectored-rates"
 
     # Update attributes and dimensions
-    dataset.attrs = attr_mgr.get_global_attributes(logical_source)
-    # TODO: Add CDF attributes to yaml
-    for field in dataset.data_vars.keys():
-        try:
-            # Create a dict of dimensions using the DEPEND_I keys in the attributes
-            dims = {
-                key: value
-                for key, value in attr_mgr.get_variable_attributes(field).items()
-                if "DEPEND" in key
-            }
-            dataset[field].attrs = attr_mgr.get_variable_attributes(field)
-            dataset[field].assign_coords(dims)
-        except KeyError:
-            logger.warning(f"Field {field} not found in attribute manager.")
+    if dataset and logical_source:
+        dataset.attrs = attr_mgr.get_global_attributes(logical_source)
+        # TODO: Add CDF attributes to yaml
+        for field in dataset.data_vars.keys():
+            try:
+                # Create a dict of dimensions using the DEPEND_I keys in the attributes
+                dims = {
+                    key: value
+                    for key, value in attr_mgr.get_variable_attributes(field).items()
+                    if "DEPEND" in key
+                }
+                dataset[field].attrs = attr_mgr.get_variable_attributes(field)
+                dataset[field].assign_coords(dims)
+            except KeyError:
+                logger.warning(f"Field {field} not found in attribute manager.")
 
-    # Skip schema check for epoch to prevent attr_mgr from adding the
-    # DEPEND_0 attribute which isn't required for epoch
-    dataset.epoch.attrs = attr_mgr.get_variable_attributes("epoch", check_schema=False)
-    logger.info(f"HIT L1B dataset created for {logical_source}")
+        # Skip schema check for epoch to prevent attr_mgr from adding the
+        # DEPEND_0 attribute which isn't required for epoch
+        dataset.epoch.attrs = attr_mgr.get_variable_attributes(
+            "epoch", check_schema=False
+        )
+        logger.info(f"HIT L1B dataset created for {logical_source}")
 
     return dataset
 

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # TODO review logging levels to use (debug vs. info)
 
 
-def hit_l1b(dependencies: dict) -> list[xr.Dataset]:
+def hit_l1b(dependency: dict) -> list[xr.Dataset]:
     """
     Will process HIT data to L1B.
 
@@ -34,24 +34,34 @@ def hit_l1b(dependencies: dict) -> list[xr.Dataset]:
 
     Parameters
     ----------
-    dependencies : dict
-        Dictionary of dependencies that are L1A xarray datasets
-        for science data and a file path string to an L0 file
-        for housekeeping data.
+    dependency : dict
+        A dictionary of dependency info that contains logical source,
+        data and the l1b data descriptor. Data is either an L1A xarray
+        dataset for science data or a file path string to an L0 file to
+        process housekeeping data.
+            {
+                logical_source: str
+                data: xarray.Dataset or str,
+                descriptor: str
+            }
 
     Returns
     -------
     processed_data : list[xarray.Dataset]
-        List of four L1B datasets.
+        List containing one L1B dataset. While there are a total of four l1b datasets,
+        Only one is passed in by cli to be processed at a time.
     """
     # Create the attribute manager for this data level
     attr_mgr = get_attribute_manager("l1b")
 
+    # Get the descriptor of the L1B product to create from the dependency dict.
+    descriptor = dependency["descriptor"]
+
     # Create L1B datasets
     l1b_datasets: list = []
-    if "imap_hit_l0_raw" in dependencies:
+    if descriptor == "hk":
         # Unpack ccsds file to xarray datasets
-        packet_file = dependencies["imap_hit_l0_raw"]
+        packet_file = dependency["data"]
         datasets_by_apid = get_datasets_by_apid(packet_file, derived=True)
         # TODO: update to raise error after all APIDs are included in the same
         #  raw files. currently science and housekeeping are in separate files.
@@ -63,23 +73,20 @@ def hit_l1b(dependencies: dict) -> list[xr.Dataset]:
                 )
             )
             logger.info("HIT L1B housekeeping dataset created")
-    if "imap_hit_l1a_counts-standard" in dependencies:
-        # Process science data to L1B datasets
-        l1a_counts_dataset = dependencies["imap_hit_l1a_counts-standard"]
-        l1b_datasets.extend(process_science_data(l1a_counts_dataset, attr_mgr))
-        logger.info("HIT L1B science datasets created")
 
-    if "imap_hit_l1a_counts-sectored" in dependencies:
+    if descriptor in ["standard-rates", "summed-rates", "sectored-rates"]:
         # Process science data to L1B datasets
-        l1a_counts_dataset = dependencies["imap_hit_l1a_counts-sectored"]
-        l1b_datasets.extend(process_science_data(l1a_counts_dataset, attr_mgr))
+        l1a_counts_dataset = dependency["data"]
+        l1b_datasets.append(
+            process_science_data(l1a_counts_dataset, descriptor, attr_mgr)
+        )
         logger.info("HIT L1B science datasets created")
 
     return l1b_datasets
 
 
 def process_science_data(
-    l1a_counts_dataset: xr.Dataset, attr_mgr: ImapCdfAttributes
+    l1a_counts_dataset: xr.Dataset, descriptor: str, attr_mgr: ImapCdfAttributes
 ) -> list[xr.Dataset]:
     """
     Will create L1B science datasets for CDF products.
@@ -95,6 +102,9 @@ def process_science_data(
     ----------
     l1a_counts_dataset : xr.Dataset
         The L1A counts dataset.
+    descriptor : str
+        The descriptor for the L1B dataset to create
+        (e.g., "standard-rates", "summed-rates", "sectored-rates").
     attr_mgr : AttributeManager
         The attribute manager for the L1B data level.
 
@@ -105,26 +115,22 @@ def process_science_data(
     """
     logger.info("Creating HIT L1B science datasets")
 
-    # TODO: Write functions to create the following datasets
-    #  Process sectored rates dataset
-
     # Calculate fractional livetime from the livetime counter
     livetime = l1a_counts_dataset["livetime_counter"] / LIVESTIM_PULSES
     livetime = livetime.rename("livetime")
 
     l1b_datasets = {}
 
-    if "imap_hit_l1a_counts-standard" in l1a_counts_dataset.attrs["Logical_source"]:
-        # Process counts data to L1B datasets
+    # Process counts data to an L1B dataset based on the descriptor
+    if descriptor == "standard-rates":
         l1b_datasets["imap_hit_l1b_standard-rates"] = process_standard_rates_data(
             l1a_counts_dataset, livetime
         )
-
+    elif descriptor == "summed-rates":
         l1b_datasets["imap_hit_l1b_summed-rates"] = process_summed_rates_data(
             l1a_counts_dataset, livetime
         )
-    elif "imap_hit_l1a_counts-sectored" in l1a_counts_dataset.attrs["Logical_source"]:
-        # Process counts data to L1B datasets
+    elif descriptor == "sectored-rates":
         l1b_datasets["imap_hit_l1b_sectored-rates"] = process_sectored_rates_data(
             l1a_counts_dataset, livetime
         )

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -40,9 +40,9 @@ def hit_l1b(dependency: dict) -> list[xr.Dataset]:
         dataset for science data or a file path string to an L0 file to
         process housekeeping data.
             {
-                logical_source: str
-                data: xarray.Dataset or str,
-                descriptor: str
+                logical_source: str, dependency logical source,
+                data: xarray dataset for L1A data or file path for L0 data,
+                output_descriptor: str, descriptor for the L1B dataset to create,
             }
 
     Returns
@@ -55,46 +55,45 @@ def hit_l1b(dependency: dict) -> list[xr.Dataset]:
     attr_mgr = get_attribute_manager("l1b")
 
     # Get the descriptor of the L1B product to create from the dependency dict.
-    descriptor = dependency["descriptor"]
+    l1b_descriptor = dependency["output_descriptor"]
+
+    l1b_dataset = None
 
     # Create L1B datasets
-    l1b_datasets: list = []
-    if descriptor == "hk":
+    if l1b_descriptor == "hk":
         # Unpack ccsds file to xarray datasets
         packet_file = dependency["data"]
         datasets_by_apid = get_datasets_by_apid(packet_file, derived=True)
-        # TODO: update to raise error after all APIDs are included in the same
-        #  raw files. currently science and housekeeping are in separate files.
         if HitAPID.HIT_HSKP in datasets_by_apid:
             # Process housekeeping to L1B.
-            l1b_datasets.append(
-                process_housekeeping_data(
-                    datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1b_hk"
-                )
+            l1b_dataset = process_housekeeping_data(
+                datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1b_hk"
             )
             logger.info("HIT L1B housekeeping dataset created")
 
-    if descriptor in ["standard-rates", "summed-rates", "sectored-rates"]:
+    elif l1b_descriptor in ["standard-rates", "summed-rates", "sectored-rates"]:
         # Process science data to L1B datasets
         l1a_counts_dataset = dependency["data"]
-        l1b_datasets.append(
-            process_science_data(l1a_counts_dataset, descriptor, attr_mgr)
-        )
-        logger.info("HIT L1B science datasets created")
+        l1b_dataset = process_science_data(l1a_counts_dataset, l1b_descriptor, attr_mgr)
+        logger.info("HIT L1B science dataset created")
+    else:
+        logger.error(f"Unsupported descriptor for L1B processing: {l1b_descriptor}")
+        raise ValueError(f"Unsupported descriptor: {l1b_descriptor}")
 
-    return l1b_datasets
+    return [l1b_dataset] if l1b_dataset is not None else []
 
 
 def process_science_data(
     l1a_counts_dataset: xr.Dataset, descriptor: str, attr_mgr: ImapCdfAttributes
-) -> list[xr.Dataset]:
+) -> xr.Dataset:
     """
     Will create L1B science datasets for CDF products.
 
-    Process L1A raw counts data to create L1B science data for
-    CDF creation. This function will create three L1B science
+    This function processes L1A counts data to L1B science
+    data for CDF creation. There are three L1B science
     datasets: standard rates, summed rates, and sectored rates.
-    It will also update dataset attributes, coordinates and
+    This function creates one dataset based on the descriptor
+    provided. It will also update dataset attributes, coordinates and
     data variable dimensions according to specifications in
     a CDF yaml file.
 
@@ -110,8 +109,8 @@ def process_science_data(
 
     Returns
     -------
-    dataset : list
-        The processed L1B science datasets as xarray datasets.
+    dataset : xarray.Dataset
+        A processed L1B science dataset.
     """
     logger.info("Creating HIT L1B science datasets")
 
@@ -119,52 +118,48 @@ def process_science_data(
     livetime = l1a_counts_dataset["livetime_counter"] / LIVESTIM_PULSES
     livetime = livetime.rename("livetime")
 
-    l1b_datasets = {}
-
-    # Process counts data to an L1B dataset based on the descriptor
-    if descriptor == "standard-rates":
-        l1b_datasets["imap_hit_l1b_standard-rates"] = process_standard_rates_data(
-            l1a_counts_dataset, livetime
+    try:
+        # Process counts data to an L1B dataset based on the descriptor
+        if descriptor == "standard-rates":
+            dataset = process_standard_rates_data(l1a_counts_dataset, livetime)
+            logical_source = "imap_hit_l1b_standard-rates"
+        elif descriptor == "summed-rates":
+            dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
+            logical_source = "imap_hit_l1b_summed-rates"
+        elif descriptor == "sectored-rates":
+            dataset = process_sectored_rates_data(l1a_counts_dataset, livetime)
+            logical_source = "imap_hit_l1b_sectored-rates"
+        else:
+            raise ValueError(f"Unsupported descriptor: {descriptor}")
+    except KeyError as e:
+        logger.error(
+            f"Failed to create L1B dataset for descriptor {descriptor} with input data"
+            f" {l1a_counts_dataset.attrs['Logical_source']}: {e}"
         )
-    elif descriptor == "summed-rates":
-        l1b_datasets["imap_hit_l1b_summed-rates"] = process_summed_rates_data(
-            l1a_counts_dataset, livetime
-        )
-    elif descriptor == "sectored-rates":
-        l1b_datasets["imap_hit_l1b_sectored-rates"] = process_sectored_rates_data(
-            l1a_counts_dataset, livetime
-        )
+        raise
 
     # Update attributes and dimensions
-    for logical_source, dataset in l1b_datasets.items():
-        dataset.attrs = attr_mgr.get_global_attributes(logical_source)
+    dataset.attrs = attr_mgr.get_global_attributes(logical_source)
+    # TODO: Add CDF attributes to yaml
+    for field in dataset.data_vars.keys():
+        try:
+            # Create a dict of dimensions using the DEPEND_I keys in the attributes
+            dims = {
+                key: value
+                for key, value in attr_mgr.get_variable_attributes(field).items()
+                if "DEPEND" in key
+            }
+            dataset[field].attrs = attr_mgr.get_variable_attributes(field)
+            dataset[field].assign_coords(dims)
+        except KeyError:
+            logger.warning(f"Field {field} not found in attribute manager.")
 
-        # TODO: Add CDF attributes to yaml once they're defined for L1B science data
-        # Assign attributes and dimensions to each data array in the Dataset
-        for field in dataset.data_vars.keys():
-            try:
-                # Create a dict of dimensions using the DEPEND_I keys in the
-                # attributes
-                dims = {
-                    key: value
-                    for key, value in attr_mgr.get_variable_attributes(field).items()
-                    if "DEPEND" in key
-                }
-                dataset[field].attrs = attr_mgr.get_variable_attributes(field)
-                dataset[field].assign_coords(dims)
-            except KeyError:
-                print(f"Field {field} not found in attribute manager.")
-                logger.warning(f"Field {field} not found in attribute manager.")
+    # Skip schema check for epoch to prevent attr_mgr from adding the
+    # DEPEND_0 attribute which isn't required for epoch
+    dataset.epoch.attrs = attr_mgr.get_variable_attributes("epoch", check_schema=False)
+    logger.info(f"HIT L1B dataset created for {logical_source}")
 
-        # Skip schema check for epoch to prevent attr_mgr from adding the
-        # DEPEND_0 attribute which isn't required for epoch
-        dataset.epoch.attrs = attr_mgr.get_variable_attributes(
-            "epoch", check_schema=False
-        )
-
-        logger.info(f"HIT L1B dataset created for {logical_source}")
-
-    return list(l1b_datasets.values())
+    return dataset
 
 
 def initialize_l1b_dataset(l1a_counts_dataset: xr.Dataset, coords: list) -> xr.Dataset:

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -1,6 +1,7 @@
 """IMAP-HIT L1B data processing."""
 
 import logging
+from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -26,7 +27,9 @@ logger = logging.getLogger(__name__)
 # TODO review logging levels to use (debug vs. info)
 
 
-def hit_l1b(dependency: dict) -> list[xr.Dataset]:
+def hit_l1b(
+    dependency: Union[str, xr.Dataset], l1b_descriptor: str
+) -> list[xr.Dataset]:
     """
     Will process HIT data to L1B.
 
@@ -34,35 +37,28 @@ def hit_l1b(dependency: dict) -> list[xr.Dataset]:
 
     Parameters
     ----------
-    dependency : dict
-        A dictionary of dependency info that contains logical source,
-        data and the l1b data descriptor. Data is either an L1A xarray
-        dataset for science data or a file path string to an L0 file to
+    dependency : Union[str, xr.Dataset]
+        Dependency is either an L1A xarray dataset to process
+        science data or a file path string to an L0 file to
         process housekeeping data.
-            {
-                logical_source: str, dependency logical source,
-                data: xarray dataset for L1A data or file path for L0 data,
-                output_descriptor: str, descriptor for the L1B dataset to create,
-            }
+    l1b_descriptor : str
+        The descriptor for the L1B dataset to create.
 
     Returns
     -------
     processed_data : list[xarray.Dataset]
-        List containing one L1B dataset. While there are a total of four l1b datasets,
-        Only one is passed in by cli to be processed at a time.
+        List containing one L1B dataset. While there are a
+        total of four L1B datasets, only one is processed at a time.
     """
     # Create the attribute manager for this data level
     attr_mgr = get_attribute_manager("l1b")
-
-    # Get the descriptor of the L1B product to create from the dependency dict.
-    l1b_descriptor = dependency["output_descriptor"]
 
     l1b_dataset = None
 
     # Create L1B datasets
     if l1b_descriptor == "hk":
         # Unpack ccsds file to xarray datasets
-        packet_file = dependency["data"]
+        packet_file = dependency
         datasets_by_apid = get_datasets_by_apid(packet_file, derived=True)
         if HitAPID.HIT_HSKP in datasets_by_apid:
             # Process housekeeping to L1B.
@@ -70,11 +66,9 @@ def hit_l1b(dependency: dict) -> list[xr.Dataset]:
                 datasets_by_apid[HitAPID.HIT_HSKP], attr_mgr, "imap_hit_l1b_hk"
             )
             logger.info("HIT L1B housekeeping dataset created")
-
     elif l1b_descriptor in ["standard-rates", "summed-rates", "sectored-rates"]:
         # Process science data to L1B datasets
-        l1a_counts_dataset = dependency["data"]
-        l1b_dataset = process_science_data(l1a_counts_dataset, l1b_descriptor, attr_mgr)
+        l1b_dataset = process_science_data(dependency, l1b_descriptor, attr_mgr)
         logger.info("HIT L1B science dataset created")
     else:
         logger.error(f"Unsupported descriptor for L1B processing: {l1b_descriptor}")

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -27,9 +27,7 @@ logger = logging.getLogger(__name__)
 # TODO review logging levels to use (debug vs. info)
 
 
-def hit_l1b(
-    dependency: Union[str, xr.Dataset], l1b_descriptor: str
-) -> list[xr.Dataset]:
+def hit_l1b(dependency: Union[str, xr.Dataset], l1b_descriptor: str) -> xr.Dataset:
     """
     Will process HIT data to L1B.
 
@@ -46,9 +44,8 @@ def hit_l1b(
 
     Returns
     -------
-    processed_data : list[xarray.Dataset]
-        List containing one L1B dataset. While there are a
-        total of four L1B datasets, only one is processed at a time.
+    l1b_dataset : xarray.Dataset
+        The processed L1B dataset.
     """
     # Create the attribute manager for this data level
     attr_mgr = get_attribute_manager("l1b")
@@ -74,7 +71,7 @@ def hit_l1b(
         logger.error(f"Unsupported descriptor for L1B processing: {l1b_descriptor}")
         raise ValueError(f"Unsupported descriptor: {l1b_descriptor}")
 
-    return [l1b_dataset] if l1b_dataset is not None else []
+    return l1b_dataset
 
 
 def process_science_data(

--- a/imap_processing/hit/l2/hit_l2.py
+++ b/imap_processing/hit/l2/hit_l2.py
@@ -27,16 +27,16 @@ logger = logging.getLogger(__name__)
 #  - review logging levels to use (debug vs. info)
 
 
-def hit_l2(dependency_sci: xr.Dataset, dependencies_anc: list) -> list[xr.Dataset]:
+def hit_l2(dependency_sci: xr.Dataset, dependencies_anc: list) -> xr.Dataset:
     """
-    Will process HIT data to L2.
+    Will process HIT L1B data to L2.
 
     Processes dependencies needed to create L2 data products.
 
     Parameters
     ----------
     dependency_sci : xr.Dataset
-        L1B xarray science dataset that is either summed rates
+        L1B dataset that is either summed rates
         standard rates or sector rates.
 
     dependencies_anc : list
@@ -44,8 +44,8 @@ def hit_l2(dependency_sci: xr.Dataset, dependencies_anc: list) -> list[xr.Datase
 
     Returns
     -------
-    processed_data : list[xarray.Dataset]
-        List of one L2 dataset.
+    l2_dataset : xarray.Dataset
+        The processed L2 dataset from the dependency dataset provided.
     """
     logger.info("Creating HIT L2 science dataset")
 
@@ -74,7 +74,7 @@ def hit_l2(dependency_sci: xr.Dataset, dependencies_anc: list) -> list[xr.Datase
 
         logger.info(f"HIT L2 dataset created for {logical_source}")
 
-    return [l2_dataset]
+    return l2_dataset
 
 
 def add_cdf_attributes(

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -27,7 +27,7 @@ from imap_processing.tests.hit.helpers.l1_validation import (
 def packet_filepath():
     """Set path to test data file"""
     # TODO: Update this path when HIT provides a packet file with all apids.
-    #  Current test file only has the housekeeping apid is available.
+    #  Current test file only has the housekeeping apid.
     return (
         imap_module_directory / "tests/hit/test_data/imap_hit_l0_raw_20100105_v001.pkts"
     )
@@ -48,45 +48,35 @@ def packet_date():
 @pytest.fixture
 def dependencies(packet_filepath, sci_packet_filepath, packet_date):
     """Get dependencies for L1B processing"""
-    # Create dictionary of dependencies and add CCSDS packet file
-    dependency_dict = {
-        "hk": {
-            "logical_source": "imap_hit_l0_raw",
-            "data": packet_filepath,
-            "output_descriptor": "hk",
-        }
-    }
-    # Add L1A datasets
-    l1a_datasets = hit_l1a.hit_l1a(packet_filepath, packet_date)
-    # TODO: Remove this when HIT provides a packet file with all apids.
-    l1a_datasets.extend(hit_l1a.hit_l1a(sci_packet_filepath, packet_date))
-    # Add L1A datasets to the data_dict
-    for dataset in l1a_datasets:
-        if dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-standard":
-            dependency_dict["standard-rates"] = {
-                "logical_source": dataset.attrs["Logical_source"],
-                "data": dataset,
-                "output_descriptor": "standard-rates",
-            }
-            dependency_dict["summed-rates"] = {
-                "logical_source": dataset.attrs["Logical_source"],
-                "data": dataset,
-                "output_descriptor": "summed-rates",
-            }
-        elif dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-sectored":
-            dependency_dict["sectored-rates"] = {
-                "data": dataset,
-                "output_descriptor": "sectored-rates",
-                "logical_source": dataset.attrs["Logical_source"],
-            }
+    # Get the L1A datasets from the housekeeping and science packet files
+    l1a_datasets = hit_l1a.hit_l1a(packet_filepath, packet_date) + hit_l1a.hit_l1a(
+        sci_packet_filepath, packet_date
+    )
 
-    return dependency_dict
+    return {
+        "hk": packet_filepath,
+        "standard-rates": next(
+            ds
+            for ds in l1a_datasets
+            if ds.attrs["Logical_source"] == "imap_hit_l1a_counts-standard"
+        ),
+        "summed-rates": next(
+            ds
+            for ds in l1a_datasets
+            if ds.attrs["Logical_source"] == "imap_hit_l1a_counts-standard"
+        ),
+        "sectored-rates": next(
+            ds
+            for ds in l1a_datasets
+            if ds.attrs["Logical_source"] == "imap_hit_l1a_counts-sectored"
+        ),
+    }
 
 
 @pytest.fixture
 def l1b_hk_dataset(dependencies):
     """Get the housekeeping dataset"""
-    datasets = hit_l1b(dependencies["hk"])
+    datasets = hit_l1b(dependencies["hk"], "hk")
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_hk":
             return dataset
@@ -95,7 +85,7 @@ def l1b_hk_dataset(dependencies):
 @pytest.fixture
 def l1b_standard_rates_dataset(dependencies):
     """Get the standard rates dataset"""
-    datasets = hit_l1b(dependencies["standard-rates"])
+    datasets = hit_l1b(dependencies["standard-rates"], "standard-rates")
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_standard-rates":
             return dataset
@@ -165,7 +155,7 @@ def test_sum_livetime_10min():
 def test_process_summed_rates_data(dependencies):
     """Test the variables in the summed rates dataset"""
 
-    l1a_counts_dataset = dependencies["summed-rates"]["data"]
+    l1a_counts_dataset = dependencies["summed-rates"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_summed_rates_dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
 
@@ -209,7 +199,7 @@ def test_process_summed_rates_data(dependencies):
 def test_process_standard_rates_data(dependencies):
     """Test the variables in the standard rates dataset"""
 
-    l1a_counts_dataset = dependencies["standard-rates"]["data"]
+    l1a_counts_dataset = dependencies["standard-rates"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_standard_rates_dataset = process_standard_rates_data(
         l1a_counts_dataset, livetime
@@ -301,7 +291,7 @@ def test_process_standard_rates_data(dependencies):
 def test_process_sectored_rates_data(dependencies):
     """Test the variables in the sectored rates dataset"""
 
-    l1a_counts_dataset = dependencies["sectored-rates"]["data"]
+    l1a_counts_dataset = dependencies["sectored-rates"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_sectored_rates_dataset = process_sectored_rates_data(
         l1a_counts_dataset, livetime
@@ -560,15 +550,7 @@ def test_hit_l1b_missing_apid(sci_packet_filepath):
         Science CCSDS packet file path. Only contains science APID and is
         missing the housekeeping APID.
     """
-    # Create a dependency dictionary with a science CCSDS packet file
-    # excluding the housekeeping apid
-    dependency = {
-        "data": sci_packet_filepath,
-        "output_descriptor": "hk",
-        "logical_source": "imap_hit_l0_raw",
-    }
-
-    dataset = hit_l1b(dependency)
+    dataset = hit_l1b(sci_packet_filepath, "hk")
     assert len(dataset) == 0
 
 
@@ -589,6 +571,9 @@ def test_hit_l1b(dependencies, dependency_key, expected_logical_source):
     dependencies : dict
         Dictionary of L1B products and their dependencies.
     """
-    dataset = hit_l1b(dependencies.get(dependency_key))
+    # Check that the dataset is created and has the correct logical source
+    dependency = dependencies.get(dependency_key)
+    l1b_descriptor = dependency_key
+    dataset = hit_l1b(dependency, l1b_descriptor)
     assert isinstance(dataset[0], xr.Dataset)
     assert dataset[0].attrs["Logical_source"] == expected_logical_source

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -554,6 +554,17 @@ def test_hit_l1b_missing_apid(sci_packet_filepath):
     assert dataset is None
 
 
+def test_hit_l1b_unsupported_descriptor():
+    # Arrange
+    dependency = xr.Dataset()  # Mock dependency
+    unsupported_descriptor = "invalid-descriptor"
+
+    with pytest.raises(
+        ValueError, match=f"Unsupported descriptor: {unsupported_descriptor}"
+    ):
+        hit_l1b(dependency, unsupported_descriptor)
+
+
 @pytest.mark.parametrize(
     "dependency_key, expected_logical_source",
     [

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -49,20 +49,44 @@ def packet_date():
 def dependencies(packet_filepath, sci_packet_filepath, packet_date):
     """Get dependencies for L1B processing"""
     # Create dictionary of dependencies and add CCSDS packet file
-    data_dict = {"imap_hit_l0_raw": packet_filepath}
+    dependency_dict = {
+        "hk": {
+            "logical_source": "imap_hit_l0_raw",
+            "data": packet_filepath,
+            "output_descriptor": "hk",
+        }
+    }
     # Add L1A datasets
     l1a_datasets = hit_l1a.hit_l1a(packet_filepath, packet_date)
     # TODO: Remove this when HIT provides a packet file with all apids.
     l1a_datasets.extend(hit_l1a.hit_l1a(sci_packet_filepath, packet_date))
+    # Add L1A datasets to the data_dict
     for dataset in l1a_datasets:
-        data_dict[dataset.attrs["Logical_source"]] = dataset
-    return data_dict
+        if dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-standard":
+            dependency_dict["standard-rates"] = {
+                "logical_source": dataset.attrs["Logical_source"],
+                "data": dataset,
+                "output_descriptor": "standard-rates",
+            }
+            dependency_dict["summed-rates"] = {
+                "logical_source": dataset.attrs["Logical_source"],
+                "data": dataset,
+                "output_descriptor": "summed-rates",
+            }
+        elif dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-sectored":
+            dependency_dict["sectored-rates"] = {
+                "data": dataset,
+                "output_descriptor": "sectored-rates",
+                "logical_source": dataset.attrs["Logical_source"],
+            }
+
+    return dependency_dict
 
 
 @pytest.fixture
 def l1b_hk_dataset(dependencies):
     """Get the housekeeping dataset"""
-    datasets = hit_l1b(dependencies)
+    datasets = hit_l1b(dependencies["hk"])
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_hk":
             return dataset
@@ -71,7 +95,7 @@ def l1b_hk_dataset(dependencies):
 @pytest.fixture
 def l1b_standard_rates_dataset(dependencies):
     """Get the standard rates dataset"""
-    datasets = hit_l1b(dependencies)
+    datasets = hit_l1b(dependencies["standard-rates"])
     for dataset in datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1b_standard-rates":
             return dataset
@@ -141,7 +165,7 @@ def test_sum_livetime_10min():
 def test_process_summed_rates_data(dependencies):
     """Test the variables in the summed rates dataset"""
 
-    l1a_counts_dataset = dependencies["imap_hit_l1a_counts-standard"]
+    l1a_counts_dataset = dependencies["summed-rates"]["data"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_summed_rates_dataset = process_summed_rates_data(l1a_counts_dataset, livetime)
 
@@ -185,7 +209,7 @@ def test_process_summed_rates_data(dependencies):
 def test_process_standard_rates_data(dependencies):
     """Test the variables in the standard rates dataset"""
 
-    l1a_counts_dataset = dependencies["imap_hit_l1a_counts-standard"]
+    l1a_counts_dataset = dependencies["standard-rates"]["data"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_standard_rates_dataset = process_standard_rates_data(
         l1a_counts_dataset, livetime
@@ -277,7 +301,7 @@ def test_process_standard_rates_data(dependencies):
 def test_process_sectored_rates_data(dependencies):
     """Test the variables in the sectored rates dataset"""
 
-    l1a_counts_dataset = dependencies["imap_hit_l1a_counts-sectored"]
+    l1a_counts_dataset = dependencies["sectored-rates"]["data"]
     livetime = xr.DataArray(l1a_counts_dataset["livetime_counter"] / 270)
     l1b_sectored_rates_dataset = process_sectored_rates_data(
         l1a_counts_dataset, livetime
@@ -538,27 +562,33 @@ def test_hit_l1b_missing_apid(sci_packet_filepath):
     """
     # Create a dependency dictionary with a science CCSDS packet file
     # excluding the housekeeping apid
-    dependency = {"imap_hit_l0_raw": sci_packet_filepath}
-    datasets = hit_l1b(dependency)
-    assert len(datasets) == 0
+    dependency = {
+        "data": sci_packet_filepath,
+        "output_descriptor": "hk",
+        "logical_source": "imap_hit_l0_raw",
+    }
+
+    dataset = hit_l1b(dependency)
+    assert len(dataset) == 0
 
 
-def test_hit_l1b(dependencies):
+@pytest.mark.parametrize(
+    "dependency_key, expected_logical_source",
+    [
+        ("hk", "imap_hit_l1b_hk"),
+        ("standard-rates", "imap_hit_l1b_standard-rates"),
+        ("summed-rates", "imap_hit_l1b_summed-rates"),
+        ("sectored-rates", "imap_hit_l1b_sectored-rates"),
+    ],
+)
+def test_hit_l1b(dependencies, dependency_key, expected_logical_source):
     """Test creating L1B CDF files
-
-    Creates a list of xarray datasets for each L1B product
 
     Parameters
     ----------
     dependencies : dict
-        Dictionary of L1A datasets and CCSDS packet file path
+        Dictionary of L1B products and their dependencies.
     """
-    datasets = hit_l1b(dependencies)
-
-    assert len(datasets) == 4
-    for dataset in datasets:
-        assert isinstance(dataset, xr.Dataset)
-    assert datasets[0].attrs["Logical_source"] == "imap_hit_l1b_hk"
-    assert datasets[1].attrs["Logical_source"] == "imap_hit_l1b_standard-rates"
-    assert datasets[2].attrs["Logical_source"] == "imap_hit_l1b_summed-rates"
-    assert datasets[3].attrs["Logical_source"] == "imap_hit_l1b_sectored-rates"
+    dataset = hit_l1b(dependencies.get(dependency_key))
+    assert isinstance(dataset[0], xr.Dataset)
+    assert dataset[0].attrs["Logical_source"] == expected_logical_source

--- a/imap_processing/tests/hit/test_hit_l1b.py
+++ b/imap_processing/tests/hit/test_hit_l1b.py
@@ -76,19 +76,19 @@ def dependencies(packet_filepath, sci_packet_filepath, packet_date):
 @pytest.fixture
 def l1b_hk_dataset(dependencies):
     """Get the housekeeping dataset"""
-    datasets = hit_l1b(dependencies["hk"], "hk")
-    for dataset in datasets:
-        if dataset.attrs["Logical_source"] == "imap_hit_l1b_hk":
-            return dataset
+    return hit_l1b(dependencies["hk"], "hk")
+    # for dataset in datasets:
+    #     if dataset.attrs["Logical_source"] == "imap_hit_l1b_hk":
+    #         return dataset
 
 
 @pytest.fixture
 def l1b_standard_rates_dataset(dependencies):
     """Get the standard rates dataset"""
-    datasets = hit_l1b(dependencies["standard-rates"], "standard-rates")
-    for dataset in datasets:
-        if dataset.attrs["Logical_source"] == "imap_hit_l1b_standard-rates":
-            return dataset
+    return hit_l1b(dependencies["standard-rates"], "standard-rates")
+    # for dataset in datasets:
+    #     if dataset.attrs["Logical_source"] == "imap_hit_l1b_standard-rates":
+    #         return dataset
 
 
 def test_calculate_rates():
@@ -551,7 +551,7 @@ def test_hit_l1b_missing_apid(sci_packet_filepath):
         missing the housekeeping APID.
     """
     dataset = hit_l1b(sci_packet_filepath, "hk")
-    assert len(dataset) == 0
+    assert dataset is None
 
 
 @pytest.mark.parametrize(
@@ -575,5 +575,5 @@ def test_hit_l1b(dependencies, dependency_key, expected_logical_source):
     dependency = dependencies.get(dependency_key)
     l1b_descriptor = dependency_key
     dataset = hit_l1b(dependency, l1b_descriptor)
-    assert isinstance(dataset[0], xr.Dataset)
-    assert dataset[0].attrs["Logical_source"] == expected_logical_source
+    assert isinstance(dataset, xr.Dataset)
+    assert dataset.attrs["Logical_source"] == expected_logical_source

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -62,14 +62,12 @@ def dependencies(sci_packet_filepath, packet_date):
             # Standard and summed rates datasets are created from the same L1A dataset
             dependencies["imap_hit_l1b_standard-rates"] = hit_l1b(
                 dataset, "standard-rates"
-            )[0]
-            dependencies["imap_hit_l1b_summed-rates"] = hit_l1b(
-                dataset, "summed-rates"
-            )[0]
+            )
+            dependencies["imap_hit_l1b_summed-rates"] = hit_l1b(dataset, "summed-rates")
         elif dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-sectored":
             dependencies["imap_hit_l1b_sectored-rates"] = hit_l1b(
                 dataset, "sectored-rates"
-            )[0]
+            )
     return dependencies
 
 
@@ -881,8 +879,7 @@ def test_hit_l2(
         Dictionary of ancillary file paths
     """
 
-    l2_datasets = hit_l2(
+    l2_dataset = hit_l2(
         dependencies[dataset_key], ancillary_dependencies[ancillary_key]
     )
-    assert len(l2_datasets) == 1
-    assert l2_datasets[0].attrs["Logical_source"] == expected_logical_source
+    assert l2_dataset.attrs["Logical_source"] == expected_logical_source

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -51,41 +51,26 @@ def packet_date():
 def dependencies(sci_packet_filepath, packet_date):
     """Get dependencies for L2 processing"""
     # Create dictionary of dependencies
-    data_dict = {}
+    dependencies = {}
+
     # Get L1A datasets
     l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath, packet_date)
 
     # Get L1B datasets from L1A datasets
     for dataset in l1a_datasets:
         if dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-standard":
-            l1b_dataset = hit_l1b(
-                {
-                    "logical_source": dataset.attrs["Logical_source"],
-                    "data": dataset,
-                    "output_descriptor": "standard-rates",
-                }
-            )
-            data_dict[l1b_dataset[0].attrs["Logical_source"]] = l1b_dataset[0]
-
-            l1b_dataset = hit_l1b(
-                {
-                    "logical_source": dataset.attrs["Logical_source"],
-                    "data": dataset,
-                    "output_descriptor": "summed-rates",
-                }
-            )
-            data_dict[l1b_dataset[0].attrs["Logical_source"]] = l1b_dataset[0]
-
+            # Standard and summed rates datasets are created from the same L1A dataset
+            dependencies["imap_hit_l1b_standard-rates"] = hit_l1b(
+                dataset, "standard-rates"
+            )[0]
+            dependencies["imap_hit_l1b_summed-rates"] = hit_l1b(
+                dataset, "summed-rates"
+            )[0]
         elif dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-sectored":
-            l1b_dataset = hit_l1b(
-                {
-                    "logical_source": dataset.attrs["Logical_source"],
-                    "data": dataset,
-                    "output_descriptor": "sectored-rates",
-                }
-            )
-            data_dict[l1b_dataset[0].attrs["Logical_source"]] = l1b_dataset[0]
-    return data_dict
+            dependencies["imap_hit_l1b_sectored-rates"] = hit_l1b(
+                dataset, "sectored-rates"
+            )[0]
+    return dependencies
 
 
 @pytest.fixture

--- a/imap_processing/tests/hit/test_hit_l2.py
+++ b/imap_processing/tests/hit/test_hit_l2.py
@@ -52,17 +52,39 @@ def dependencies(sci_packet_filepath, packet_date):
     """Get dependencies for L2 processing"""
     # Create dictionary of dependencies
     data_dict = {}
+    # Get L1A datasets
     l1a_datasets = hit_l1a.hit_l1a(sci_packet_filepath, packet_date)
-    for l1a_dataset in l1a_datasets:
-        l1a_data_dict = {}
-        if l1a_dataset.attrs["Logical_source"] in [
-            "imap_hit_l1a_counts-standard",
-            "imap_hit_l1a_counts-sectored",
-        ]:
-            l1a_data_dict[l1a_dataset.attrs["Logical_source"]] = l1a_dataset
-        l1b_datasets = hit_l1b(l1a_data_dict)
-        for l1b_dataset in l1b_datasets:
-            data_dict[l1b_dataset.attrs["Logical_source"]] = l1b_dataset
+
+    # Get L1B datasets from L1A datasets
+    for dataset in l1a_datasets:
+        if dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-standard":
+            l1b_dataset = hit_l1b(
+                {
+                    "logical_source": dataset.attrs["Logical_source"],
+                    "data": dataset,
+                    "output_descriptor": "standard-rates",
+                }
+            )
+            data_dict[l1b_dataset[0].attrs["Logical_source"]] = l1b_dataset[0]
+
+            l1b_dataset = hit_l1b(
+                {
+                    "logical_source": dataset.attrs["Logical_source"],
+                    "data": dataset,
+                    "output_descriptor": "summed-rates",
+                }
+            )
+            data_dict[l1b_dataset[0].attrs["Logical_source"]] = l1b_dataset[0]
+
+        elif dataset.attrs["Logical_source"] == "imap_hit_l1a_counts-sectored":
+            l1b_dataset = hit_l1b(
+                {
+                    "logical_source": dataset.attrs["Logical_source"],
+                    "data": dataset,
+                    "output_descriptor": "sectored-rates",
+                }
+            )
+            data_dict[l1b_dataset[0].attrs["Logical_source"]] = l1b_dataset[0]
     return data_dict
 
 


### PR DESCRIPTION
This PR updates HIT L1B dependencies to match updates made to the dependency config in `sds-data-manager` for HIT. It used to be that one l1a dataset created three l1b science datasets. Now there are two l1a datasets, one that produces two l1b datasets and one that creates one dataset.  As a result, the dependency config went from:

```
hit, l1a, counts, hit, l1b, all, HARD, DOWNSTREAM
```
to

```
hit, l1a, counts-standard, hit, l1b, standard-rates, HARD, DOWNSTREAM
hit, l1a, counts-standard, hit, l1b, summed-rates, HARD, DOWNSTREAM
hit, l1a, counts-sectored, hit, l1b, sectored-rates, HARD, DOWNSTREAM
```

`cli.py` and `hit_l1b.py` were both updated, as well as relevant unit tests, to support this change

Closes #2035 
