### PR TITLE
Add spin-phase filtering to Hi L2

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -590,12 +590,30 @@ class HiPointingSet(PointingSet):
 
     Parameters
     ----------
-    dataset : xarray.Dataset
-        Hi L1C pointing set data loaded in an xarray.DataArray.
+    dataset : xarray.Dataset | str | Path
+        Hi L1C pointing set data loaded in a xarray.DataArray.
+    spin_phase : str
+        Include ENAs from "full", "ram" or "anti-ram" phases of the spin.
     """
 
-    def __init__(self, dataset: xr.Dataset):
+    def __init__(self, dataset: xr.Dataset | str | Path, spin_phase: str):
         super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.ECLIPJ2000)
+
+        # Filter out ENAs from non-selected portions of the spin.
+        if spin_phase not in ["full", "ram", "anti-ram"]:
+            raise ValueError(f"Unrecognized spin_phase value: {spin_phase}.")
+        # ram only includes spin-phase interval [0, 0.5)
+        # which is the first half of the spin_angle_bins
+        elif spin_phase == "ram":
+            self.data = self.data.isel(
+                spin_angle_bin=slice(0, self.data["spin_angle_bin"].data.size // 2)
+            )
+        # anti-ram includes spin-phase interval [0.5, 1)
+        # which is the second half of the spin_angle_bins
+        elif spin_phase == "anti-ram":
+            self.data = self.data.isel(
+                spin_angle_bin=slice(self.data["spin_angle_bin"].data.size // 2, None)
+            )
 
         # Rename some PSET vars to match L2 variables
         self.data = self.data.rename(

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -2,7 +2,6 @@
 
 import logging
 from pathlib import Path
-from typing import Literal
 
 import numpy as np
 import xarray as xr
@@ -86,7 +85,7 @@ def generate_hi_map(
     esa_energies_path: str | Path,
     output_map: AbstractSkyMap,
     cg_corrected: bool = False,
-    spin_phase: Literal["ram", "anti-ram", "full"] = "full",
+    spin_phase: str = "full",
 ) -> AbstractSkyMap:
     """
     Project Hi PSET data into a sky map.

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -46,8 +46,6 @@ def hi_l2(
     l2_dataset : list[xarray.Dataset]
         Level 2 IMAP-Hi dataset ready to be written to a CDF file.
     """
-    # TODO: parse descriptor to determine map configuration
-    direction: Literal["full"] = "full"
     cg_corrected = False
     map_descriptor = MapDescriptor.from_string(descriptor)
 
@@ -55,7 +53,7 @@ def hi_l2(
         psets,
         geometric_factors_path,
         esa_energies_path,
-        direction=direction,
+        spin_phase=map_descriptor.spin_phase,
         output_map=map_descriptor.to_empty_map(),
         cg_corrected=cg_corrected,
     )
@@ -88,7 +86,7 @@ def generate_hi_map(
     esa_energies_path: str | Path,
     output_map: AbstractSkyMap,
     cg_corrected: bool = False,
-    direction: Literal["ram", "anti-ram", "full"] = "full",
+    spin_phase: Literal["ram", "anti-ram", "full"] = "full",
 ) -> AbstractSkyMap:
     """
     Project Hi PSET data into a sky map.
@@ -107,7 +105,7 @@ def generate_hi_map(
     cg_corrected : bool, Optional
         Whether to apply Compton-Getting correction to the energies. Defaults to
         False.
-    direction : str, Optional
+    spin_phase : str, Optional
         Apply filtering to PSET data include ram or anti-ram or full spin data.
         Defaults to "full".
 
@@ -119,13 +117,10 @@ def generate_hi_map(
     # TODO: Implement Compton-Getting correction
     if cg_corrected:
         raise NotImplementedError
-    # TODO: Implement directional filtering
-    if direction != "full":
-        raise NotImplementedError
 
     for pset_path in psets:
         logger.info(f"Processing {pset_path}")
-        pset = HiPointingSet(pset_path)
+        pset = HiPointingSet(pset_path, spin_phase=spin_phase)
 
         # Background rate and uncertainty are exposure time weighted means in
         # the map.

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -185,7 +185,7 @@ class TestHiPointingSet:
 
     def test_plays_nice_with_rectangular_sky_map(self, hi_pset_cdf_path):
         """Test that HiPointingSet works with RectangularSkyMap"""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path)
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
         rect_map = ena_maps.RectangularSkyMap(
             spacing_deg=2, spice_frame=geometry.SpiceFrame.ECLIPJ2000
         )

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -147,7 +147,7 @@ class TestHiPointingSet:
     def test_init(self, hi_pset_cdf_path):
         """Test coverage for __init__ method."""
         pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds)
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
         assert isinstance(hi_pset, ena_maps.HiPointingSet)
         assert hi_pset.spice_reference_frame == geometry.SpiceFrame.ECLIPJ2000
         assert hi_pset.num_points == 3600
@@ -157,9 +157,31 @@ class TestHiPointingSet:
             assert var_name in hi_pset.data
 
     def test_from_cdf(self, hi_pset_cdf_path):
-        """Test coverage for from_cdf method."""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path)
+        """Test coverage for instantiating HiPointingSet from cdf."""
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
         assert isinstance(hi_pset, ena_maps.HiPointingSet)
+
+    def test_spin_phase_filtering(self, hi_pset_cdf_path):
+        """Test coverage for filtering pset data by ram or anti-ram directions."""
+        pset_ds = load_cdf(hi_pset_cdf_path)
+
+        # Test ram only direction
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="ram")
+        assert hi_pset.num_points == 1800
+        np.testing.assert_array_equal(
+            hi_pset.data["spin_angle_bin"].data, np.arange(1800)
+        )
+
+        # Test anti-ram direction
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="anti-ram")
+        assert hi_pset.num_points == 1800
+        np.testing.assert_array_equal(
+            hi_pset.data["spin_angle_bin"].data, np.arange(1800) + 1800
+        )
+
+        # Test value error
+        with pytest.raises(ValueError, match="Unrecognized spin_phase value:"):
+            _ = ena_maps.HiPointingSet(pset_ds, spin_phase="foo-phase")
 
     def test_plays_nice_with_rectangular_sky_map(self, hi_pset_cdf_path):
         """Test that HiPointingSet works with RectangularSkyMap"""

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -102,7 +102,7 @@ def test_genarate_hi_map(hi_l1_test_data_path, furnish_kernels):
             None,
             rectangular_sky_map,
             cg_corrected=False,
-            direction="full",
+            spin_phase="full",
         )
     assert isinstance(sky_map, RectangularSkyMap)
     assert sky_map.spacing_deg == 6

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -72,7 +72,7 @@ def test_hi_l2_uses_descriptor_to_setup_map(
 
     assert output_map.spice_reference_frame == SpiceFrame.IMAP_HNU
     assert output_map.spacing_deg == 2.0
-    assert mock_generate_hi_map.call_args.kwargs["direction"] == "full"
+    assert mock_generate_hi_map.call_args.kwargs["spin_phase"] == "full"
     assert not mock_generate_hi_map.call_args.kwargs["cg_corrected"]
 
     rect_map.build_cdf_dataset.assert_called_with(


### PR DESCRIPTION
# Change Summary

## Overview
For Hi PSETs, filtering by ram or anti-ram is easy. Just keep the appropriate indices for the `spin_angle_bin` coordinate. This implements that filtering.


## Updated Files
- imap_processing/ena_maps/ena_maps.py
   - Add `spin_phase` parameter to the `HiPointingSet._init_()` method.
   - Filter the xarray.Dataset based on input `spin_phase`
- imap_processing/hi/hi_l2.py
   - Rename `direction` to `spin_phase` to be consistent with the `MapDescriptor` class.
   - Pass `spin_phase` from the map_descriptor into the HiPointingSet instantiation call.
- imap_processing/tests/ena_maps/test_ena_maps.py
   - Add test coverage for `spin_phase` options.
- imap_processing/tests/hi/test_hi_l2.py
   - Update tests with new `generate_hi_map` signature


Closes: #1690 