### PR TITLE
MNT: Ruff target update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,9 @@ repos:
     - id: no-commit-to-branch
       args: [--branch, main, --branch, dev]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.12.2'
+    rev: 'v0.12.8'
     hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix]
     - id: ruff-format
   - repo: https://github.com/codespell-project/codespell

--- a/imap_processing/ancillary/ancillary_dataset_combiner.py
+++ b/imap_processing/ancillary/ancillary_dataset_combiner.py
@@ -174,14 +174,14 @@ class AncillaryCombiner:
         # For the lists, we specify the dimension names. For scalars, pass in [].
         data_vars = {}
         for key, value in json_data.items():
-            if isinstance(value, list | tuple):
+            if isinstance(value, (list, tuple)):
                 # Handle arrays/lists
                 data_vars[key] = ([f"dim_{key}"], value)
             elif isinstance(value, dict):
                 # Handle nested dictionaries by flattening with underscore
                 for subkey, subvalue in value.items():
                     flat_key = f"{key}_{subkey}"
-                    if isinstance(subvalue, list | tuple):
+                    if isinstance(subvalue, (list, tuple)):
                         data_vars[flat_key] = ([f"dim_{flat_key}"], subvalue)
                     else:
                         data_vars[flat_key] = ([], subvalue)

--- a/imap_processing/ancillary/ancillary_dataset_combiner.py
+++ b/imap_processing/ancillary/ancillary_dataset_combiner.py
@@ -174,14 +174,14 @@ class AncillaryCombiner:
         # For the lists, we specify the dimension names. For scalars, pass in [].
         data_vars = {}
         for key, value in json_data.items():
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, list | tuple):
                 # Handle arrays/lists
                 data_vars[key] = ([f"dim_{key}"], value)
             elif isinstance(value, dict):
                 # Handle nested dictionaries by flattening with underscore
                 for subkey, subvalue in value.items():
                     flat_key = f"{key}_{subkey}"
-                    if isinstance(subvalue, (list, tuple)):
+                    if isinstance(subvalue, list | tuple):
                         data_vars[flat_key] = ([f"dim_{flat_key}"], subvalue)
                     else:
                         data_vars[flat_key] = ([], subvalue)

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -191,7 +191,7 @@ class CoDICEL1aPipeline:
 
         else:
             for packet_data, byte_count in zip(
-                science_values, self.dataset.byte_count.data
+                science_values, self.dataset.byte_count.data, strict=False
             ):
                 # Convert from numpy array to byte object
                 values = packet_data[()]
@@ -326,7 +326,7 @@ class CoDICEL1aPipeline:
         # the num_counters dimension to isolate the data for each counter so
         # each counter's data can be placed in a separate CDF data variable.
         for counter, variable_name in zip(
-            range(all_data.shape[-1]), self.config["variable_names"]
+            range(all_data.shape[-1]), self.config["variable_names"], strict=False
         ):
             # Extract the counter data
             counter_data = all_data[..., counter]

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -191,7 +191,7 @@ class CoDICEL1aPipeline:
 
         else:
             for packet_data, byte_count in zip(
-                science_values, self.dataset.byte_count.data, strict=False
+                science_values, self.dataset.byte_count.data
             ):
                 # Convert from numpy array to byte object
                 values = packet_data[()]
@@ -326,7 +326,7 @@ class CoDICEL1aPipeline:
         # the num_counters dimension to isolate the data for each counter so
         # each counter's data can be placed in a separate CDF data variable.
         for counter, variable_name in zip(
-            range(all_data.shape[-1]), self.config["variable_names"], strict=False
+            range(all_data.shape[-1]), self.config["variable_names"]
         ):
             # Extract the counter data
             counter_data = all_data[..., counter]

--- a/imap_processing/decom.py
+++ b/imap_processing/decom.py
@@ -6,14 +6,11 @@ to decommutate CCSDS packet data using a given XTCE packet definition.
 """
 
 from pathlib import Path
-from typing import Union
 
 from space_packet_parser import definitions
 
 
-def decom_packets(
-    packet_file: Union[str, Path], xtce_packet_definition: Union[str, Path]
-) -> list:
+def decom_packets(packet_file: str | Path, xtce_packet_definition: str | Path) -> list:
     """
     Unpack CCSDS data packet.
 

--- a/imap_processing/decom.py
+++ b/imap_processing/decom.py
@@ -6,11 +6,14 @@ to decommutate CCSDS packet data using a given XTCE packet definition.
 """
 
 from pathlib import Path
+from typing import Union
 
 from space_packet_parser import definitions
 
 
-def decom_packets(packet_file: str | Path, xtce_packet_definition: str | Path) -> list:
+def decom_packets(
+    packet_file: Union[str, Path], xtce_packet_definition: Union[str, Path]
+) -> list:
     """
     Unpack CCSDS data packet.
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -412,6 +412,7 @@ class RectangularPointingSet(PointingSet):
         for dim, constructed_bins in zip(
             [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
             [self.sky_grid.az_bin_midpoints, self.sky_grid.el_bin_midpoints],
+            strict=False,
         ):
             if not np.allclose(
                 sorted(constructed_bins),
@@ -522,6 +523,7 @@ class UltraPointingSet(HealpixPointingSet):
         for dim, constructed_bins in zip(
             [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
             [azimuth_pixel_center, elevation_pixel_center],
+            strict=False,
         ):
             if not np.allclose(
                 self.data[dim],
@@ -1748,7 +1750,7 @@ class HealpixSkyMap(AbstractSkyMap):
             # into two lists, then convert both to numpy arrays
             # and move the pixel dim to the last dim of values
             interpolated_data_by_rect_pixel, subdiv_depth_of_value_by_pixel = zip(
-                *best_value_and_recursion_depth_by_pixel
+                *best_value_and_recursion_depth_by_pixel, strict=False
             )
             interpolated_data_by_rect_pixel = np.moveaxis(
                 np.array(interpolated_data_by_rect_pixel), 0, -1

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -252,7 +252,7 @@ class PointingSet(ABC):
         """Abstract method to initialize the pointing set object."""
         self.spice_reference_frame = spice_reference_frame
 
-        if isinstance(dataset, str | Path):
+        if isinstance(dataset, (str, Path)):
             dataset = load_cdf(dataset)
             self.data = dataset
         else:
@@ -412,7 +412,6 @@ class RectangularPointingSet(PointingSet):
         for dim, constructed_bins in zip(
             [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
             [self.sky_grid.az_bin_midpoints, self.sky_grid.el_bin_midpoints],
-            strict=False,
         ):
             if not np.allclose(
                 sorted(constructed_bins),
@@ -523,7 +522,6 @@ class UltraPointingSet(HealpixPointingSet):
         for dim, constructed_bins in zip(
             [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
             [azimuth_pixel_center, elevation_pixel_center],
-            strict=False,
         ):
             if not np.allclose(
                 self.data[dim],
@@ -1750,7 +1748,7 @@ class HealpixSkyMap(AbstractSkyMap):
             # into two lists, then convert both to numpy arrays
             # and move the pixel dim to the last dim of values
             interpolated_data_by_rect_pixel, subdiv_depth_of_value_by_pixel = zip(
-                *best_value_and_recursion_depth_by_pixel, strict=False
+                *best_value_and_recursion_depth_by_pixel
             )
             interpolated_data_by_rect_pixel = np.moveaxis(
                 np.array(interpolated_data_by_rect_pixel), 0, -1

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -252,7 +252,7 @@ class PointingSet(ABC):
         """Abstract method to initialize the pointing set object."""
         self.spice_reference_frame = spice_reference_frame
 
-        if isinstance(dataset, (str, Path)):
+        if isinstance(dataset, str | Path):
             dataset = load_cdf(dataset)
             self.data = dataset
         else:
@@ -412,6 +412,7 @@ class RectangularPointingSet(PointingSet):
         for dim, constructed_bins in zip(
             [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
             [self.sky_grid.az_bin_midpoints, self.sky_grid.el_bin_midpoints],
+            strict=False,
         ):
             if not np.allclose(
                 sorted(constructed_bins),
@@ -522,6 +523,7 @@ class UltraPointingSet(HealpixPointingSet):
         for dim, constructed_bins in zip(
             [CoordNames.AZIMUTH_L1C.value, CoordNames.ELEVATION_L1C.value],
             [azimuth_pixel_center, elevation_pixel_center],
+            strict=False,
         ):
             if not np.allclose(
                 self.data[dim],
@@ -1748,7 +1750,7 @@ class HealpixSkyMap(AbstractSkyMap):
             # into two lists, then convert both to numpy arrays
             # and move the pixel dim to the last dim of values
             interpolated_data_by_rect_pixel, subdiv_depth_of_value_by_pixel = zip(
-                *best_value_and_recursion_depth_by_pixel
+                *best_value_and_recursion_depth_by_pixel, strict=False
             )
             interpolated_data_by_rect_pixel = np.moveaxis(
                 np.array(interpolated_data_by_rect_pixel), 0, -1

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -4,7 +4,6 @@ import dataclasses
 import json
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -454,11 +453,11 @@ class DirectEventL1B:
     pulse_test_in_progress: InitVar[np.double]
     memory_error_detected: InitVar[np.double]
     # The following variables are created from the InitVar data
-    de_flags: Optional[np.ndarray] = field(init=False, default=None)
+    de_flags: np.ndarray | None = field(init=False, default=None)
     # TODO: First two values of DE are sec/subsec
-    direct_event_glows_times: Optional[np.ndarray] = field(init=False, default=None)
+    direct_event_glows_times: np.ndarray | None = field(init=False, default=None)
     # 3rd value is pulse length
-    direct_event_pulse_lengths: Optional[np.ndarray] = field(init=False, default=None)
+    direct_event_pulse_lengths: np.ndarray | None = field(init=False, default=None)
     # TODO: where does the multi-event flag go?
 
     def __post_init__(

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -4,6 +4,7 @@ import dataclasses
 import json
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -453,11 +454,11 @@ class DirectEventL1B:
     pulse_test_in_progress: InitVar[np.double]
     memory_error_detected: InitVar[np.double]
     # The following variables are created from the InitVar data
-    de_flags: np.ndarray | None = field(init=False, default=None)
+    de_flags: Optional[np.ndarray] = field(init=False, default=None)
     # TODO: First two values of DE are sec/subsec
-    direct_event_glows_times: np.ndarray | None = field(init=False, default=None)
+    direct_event_glows_times: Optional[np.ndarray] = field(init=False, default=None)
     # 3rd value is pulse length
-    direct_event_pulse_lengths: np.ndarray | None = field(init=False, default=None)
+    direct_event_pulse_lengths: Optional[np.ndarray] = field(init=False, default=None)
     # TODO: where does the multi-event flag go?
 
     def __post_init__(

--- a/imap_processing/hi/hi_l1a.py
+++ b/imap_processing/hi/hi_l1a.py
@@ -3,7 +3,6 @@
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -57,7 +56,7 @@ TOTAL_COUNTERS = ("a_total", "b_total", "c_total", "fee_de_recd", "fee_de_sent")
 logger = logging.getLogger(__name__)
 
 
-def hi_l1a(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
+def hi_l1a(packet_file_path: str | Path) -> list[xr.Dataset]:
     """
     Will process IMAP raw data to l1a.
 
@@ -111,7 +110,7 @@ def hi_l1a(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
 
 
 def hi_packet_file_to_datasets(
-    packet_file_path: Union[str, Path], use_derived_value: bool = False
+    packet_file_path: str | Path, use_derived_value: bool = False
 ) -> dict[int, xr.Dataset]:
     """
     Extract hi datasets from packet file.

--- a/imap_processing/hi/hi_l1a.py
+++ b/imap_processing/hi/hi_l1a.py
@@ -3,6 +3,7 @@
 import logging
 from collections import defaultdict
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -56,7 +57,7 @@ TOTAL_COUNTERS = ("a_total", "b_total", "c_total", "fee_de_recd", "fee_de_sent")
 logger = logging.getLogger(__name__)
 
 
-def hi_l1a(packet_file_path: str | Path) -> list[xr.Dataset]:
+def hi_l1a(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
     """
     Will process IMAP raw data to l1a.
 
@@ -110,7 +111,7 @@ def hi_l1a(packet_file_path: str | Path) -> list[xr.Dataset]:
 
 
 def hi_packet_file_to_datasets(
-    packet_file_path: str | Path, use_derived_value: bool = False
+    packet_file_path: Union[str, Path], use_derived_value: bool = False
 ) -> dict[int, xr.Dataset]:
     """
     Extract hi datasets from packet file.

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -3,7 +3,6 @@
 import logging
 from enum import IntEnum
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -47,7 +46,7 @@ ATTR_MGR.add_instrument_global_attrs("hi")
 ATTR_MGR.add_instrument_variable_attrs(instrument="hi", level=None)
 
 
-def housekeeping(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
+def housekeeping(packet_file_path: str | Path) -> list[xr.Dataset]:
     """
     Will process IMAP raw data to l1b housekeeping dataset.
 
@@ -439,7 +438,7 @@ def get_esa_to_esa_energy_step_lut(
     mode_changes = np.diff(padded_mask.astype(int))
     hsvsci_starts = np.nonzero(mode_changes == 1)[0]
     hsvsci_ends = np.nonzero(mode_changes == -1)[0]
-    for i_start, i_end in zip(hsvsci_starts, hsvsci_ends):
+    for i_start, i_end in zip(hsvsci_starts, hsvsci_ends, strict=False):
         contiguous_hvsci_ds = l1b_hk_ds.isel(dict(epoch=slice(i_start, i_end)))
         # Find median inner and outer ESA voltages for each ESA step
         for esa_step in esa_steps:

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -3,6 +3,7 @@
 import logging
 from enum import IntEnum
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -46,7 +47,7 @@ ATTR_MGR.add_instrument_global_attrs("hi")
 ATTR_MGR.add_instrument_variable_attrs(instrument="hi", level=None)
 
 
-def housekeeping(packet_file_path: str | Path) -> list[xr.Dataset]:
+def housekeeping(packet_file_path: Union[str, Path]) -> list[xr.Dataset]:
     """
     Will process IMAP raw data to l1b housekeeping dataset.
 
@@ -438,7 +439,7 @@ def get_esa_to_esa_energy_step_lut(
     mode_changes = np.diff(padded_mask.astype(int))
     hsvsci_starts = np.nonzero(mode_changes == 1)[0]
     hsvsci_ends = np.nonzero(mode_changes == -1)[0]
-    for i_start, i_end in zip(hsvsci_starts, hsvsci_ends, strict=False):
+    for i_start, i_end in zip(hsvsci_starts, hsvsci_ends):
         contiguous_hvsci_ds = l1b_hk_ds.isel(dict(epoch=slice(i_start, i_end)))
         # Find median inner and outer ESA voltages for each ESA step
         for esa_step in esa_steps:

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -4,7 +4,6 @@ import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -101,9 +100,9 @@ def parse_sensor_number(full_string: str) -> int:
 def full_dataarray(
     name: str,
     attrs: dict,
-    coords: Optional[dict[str, xr.DataArray]] = None,
-    shape: Optional[Union[int, Sequence[int]]] = None,
-    fill_value: Optional[float] = None,
+    coords: dict[str, xr.DataArray] | None = None,
+    shape: int | Sequence[int] | None = None,
+    fill_value: float | None = None,
 ) -> xr.DataArray:
     """
     Generate an empty xarray.DataArray with appropriate attributes.
@@ -159,9 +158,9 @@ def full_dataarray(
 
 def create_dataset_variables(
     variable_names: list[str],
-    variable_shape: Optional[Union[int, Sequence[int]]] = None,
-    coords: Optional[dict[str, xr.DataArray]] = None,
-    fill_value: Optional[float] = None,
+    variable_shape: int | Sequence[int] | None = None,
+    coords: dict[str, xr.DataArray] | None = None,
+    fill_value: float | None = None,
     att_manager_lookup_str: str = "{0}",
 ) -> dict[str, xr.DataArray]:
     """
@@ -316,9 +315,9 @@ class EsaEnergyStepLookupTable:
 
     def query(
         self,
-        query_met: Union[float, Iterable[float]],
-        esa_step: Union[int, Iterable[float]],
-    ) -> Union[float, np.ndarray]:
+        query_met: float | Iterable[float],
+        esa_step: int | Iterable[float],
+    ) -> float | np.ndarray:
         """
         Query MET(s) and esa_step(s) to retrieve esa_energy_step(s).
 
@@ -375,7 +374,7 @@ class EsaEnergyStepLookupTable:
         results = np.full_like(query_mets, self._fillval)
 
         # Lookup esa_energy_steps for queries
-        for i, (qm, es) in enumerate(zip(query_mets, esa_steps)):
+        for i, (qm, es) in enumerate(zip(query_mets, esa_steps, strict=False)):
             mask = (
                 (self.df["start_met"] <= qm)
                 & (self.df["end_met"] >= qm)

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -100,9 +101,9 @@ def parse_sensor_number(full_string: str) -> int:
 def full_dataarray(
     name: str,
     attrs: dict,
-    coords: dict[str, xr.DataArray] | None = None,
-    shape: int | Sequence[int] | None = None,
-    fill_value: float | None = None,
+    coords: Optional[dict[str, xr.DataArray]] = None,
+    shape: Optional[Union[int, Sequence[int]]] = None,
+    fill_value: Optional[float] = None,
 ) -> xr.DataArray:
     """
     Generate an empty xarray.DataArray with appropriate attributes.
@@ -158,9 +159,9 @@ def full_dataarray(
 
 def create_dataset_variables(
     variable_names: list[str],
-    variable_shape: int | Sequence[int] | None = None,
-    coords: dict[str, xr.DataArray] | None = None,
-    fill_value: float | None = None,
+    variable_shape: Optional[Union[int, Sequence[int]]] = None,
+    coords: Optional[dict[str, xr.DataArray]] = None,
+    fill_value: Optional[float] = None,
     att_manager_lookup_str: str = "{0}",
 ) -> dict[str, xr.DataArray]:
     """
@@ -315,9 +316,9 @@ class EsaEnergyStepLookupTable:
 
     def query(
         self,
-        query_met: float | Iterable[float],
-        esa_step: int | Iterable[float],
-    ) -> float | np.ndarray:
+        query_met: Union[float, Iterable[float]],
+        esa_step: Union[int, Iterable[float]],
+    ) -> Union[float, np.ndarray]:
         """
         Query MET(s) and esa_step(s) to retrieve esa_energy_step(s).
 
@@ -374,7 +375,7 @@ class EsaEnergyStepLookupTable:
         results = np.full_like(query_mets, self._fillval)
 
         # Lookup esa_energy_steps for queries
-        for i, (qm, es) in enumerate(zip(query_mets, esa_steps, strict=False)):
+        for i, (qm, es) in enumerate(zip(query_mets, esa_steps)):
             mask = (
                 (self.df["start_met"] <= qm)
                 & (self.df["end_met"] >= qm)

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -3,7 +3,6 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -36,7 +35,7 @@ logger = logging.getLogger(__name__)
 fillval = -9223372036854775808
 
 
-def hit_l1a(packet_file: Path, packet_date: Union[str, None]) -> list[xr.Dataset]:
+def hit_l1a(packet_file: Path, packet_date: str | None) -> list[xr.Dataset]:
     """
     Will process HIT L0 data into L1A data products.
 

--- a/imap_processing/hit/l1a/hit_l1a.py
+++ b/imap_processing/hit/l1a/hit_l1a.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 fillval = -9223372036854775808
 
 
-def hit_l1a(packet_file: Path, packet_date: str | None) -> list[xr.Dataset]:
+def hit_l1a(packet_file: Path, packet_date: Union[str, None]) -> list[xr.Dataset]:
     """
     Will process HIT L0 data into L1A data products.
 

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -1,7 +1,6 @@
 """IMAP-HIT L1B data processing."""
 
 import logging
-from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -27,7 +26,7 @@ logger = logging.getLogger(__name__)
 # TODO review logging levels to use (debug vs. info)
 
 
-def hit_l1b(dependency: Union[str, xr.Dataset], l1b_descriptor: str) -> xr.Dataset:
+def hit_l1b(dependency: str | xr.Dataset, l1b_descriptor: str) -> xr.Dataset:
     """
     Will process HIT data to L1B.
 

--- a/imap_processing/hit/l1b/hit_l1b.py
+++ b/imap_processing/hit/l1b/hit_l1b.py
@@ -1,6 +1,7 @@
 """IMAP-HIT L1B data processing."""
 
 import logging
+from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 # TODO review logging levels to use (debug vs. info)
 
 
-def hit_l1b(dependency: str | xr.Dataset, l1b_descriptor: str) -> xr.Dataset:
+def hit_l1b(dependency: Union[str, xr.Dataset], l1b_descriptor: str) -> xr.Dataset:
     """
     Will process HIT data to L1B.
 

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -56,7 +56,10 @@ def get_rotation_matrix(axis: NDArray, angle: NDArray) -> NDArray:
     """
     angle_rad = np.radians(angle)
     rot_matrices = np.array(
-        [spice.axisar(z, float(phase)) for z, phase in zip(axis, angle_rad)]
+        [
+            spice.axisar(z, float(phase))
+            for z, phase in zip(axis, angle_rad, strict=False)
+        ]
     )
 
     return rot_matrices
@@ -185,7 +188,7 @@ def transform_instrument_vectors_to_inertial(
     vectors = np.array(
         [
             spice.mxv(rot.T.copy(), vec)
-            for rot, vec in zip(total_rotations, instrument_vectors)
+            for rot, vec in zip(total_rotations, instrument_vectors, strict=False)
         ]
     )
 

--- a/imap_processing/ialirt/l0/ialirt_spice.py
+++ b/imap_processing/ialirt/l0/ialirt_spice.py
@@ -56,10 +56,7 @@ def get_rotation_matrix(axis: NDArray, angle: NDArray) -> NDArray:
     """
     angle_rad = np.radians(angle)
     rot_matrices = np.array(
-        [
-            spice.axisar(z, float(phase))
-            for z, phase in zip(axis, angle_rad, strict=False)
-        ]
+        [spice.axisar(z, float(phase)) for z, phase in zip(axis, angle_rad)]
     )
 
     return rot_matrices
@@ -188,7 +185,7 @@ def transform_instrument_vectors_to_inertial(
     vectors = np.array(
         [
             spice.mxv(rot.T.copy(), vec)
-            for rot, vec in zip(total_rotations, instrument_vectors, strict=False)
+            for rot, vec in zip(total_rotations, instrument_vectors)
         ]
     )
 

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -2,7 +2,6 @@
 
 import logging
 from decimal import Decimal
-from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -202,7 +201,7 @@ def get_time(
         (grouped_data["group"] == group).values
     ][pkt_counter == 2]
 
-    time_data: dict[str, Union[int, float]] = {
+    time_data: dict[str, int | float] = {
         "pri_coarsetm": int(pri_coarsetm.item()),
         "pri_fintm": int(pri_fintm.item()),
         "sec_coarsetm": int(sec_coarsetm.item()),

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -2,6 +2,7 @@
 
 import logging
 from decimal import Decimal
+from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -201,7 +202,7 @@ def get_time(
         (grouped_data["group"] == group).values
     ][pkt_counter == 2]
 
-    time_data: dict[str, int | float] = {
+    time_data: dict[str, Union[int, float]] = {
         "pri_coarsetm": int(pri_coarsetm.item()),
         "pri_fintm": int(pri_fintm.item()),
         "sec_coarsetm": int(sec_coarsetm.item()),

--- a/imap_processing/ialirt/l0/process_hit.py
+++ b/imap_processing/ialirt/l0/process_hit.py
@@ -91,18 +91,20 @@ def create_l1(
     fast_rate_1_dict = {
         prefix: value
         for prefix, value in zip(
-            HIT_PREFIX_TO_RATE_TYPE["FAST_RATE_1"], fast_rate_1.data
+            HIT_PREFIX_TO_RATE_TYPE["FAST_RATE_1"], fast_rate_1.data, strict=False
         )
     }
     fast_rate_2_dict = {
         prefix: value
         for prefix, value in zip(
-            HIT_PREFIX_TO_RATE_TYPE["FAST_RATE_2"], fast_rate_2.data
+            HIT_PREFIX_TO_RATE_TYPE["FAST_RATE_2"], fast_rate_2.data, strict=False
         )
     }
     slow_rate_dict = {
         prefix: value
-        for prefix, value in zip(HIT_PREFIX_TO_RATE_TYPE["SLOW_RATE"], slow_rate.data)
+        for prefix, value in zip(
+            HIT_PREFIX_TO_RATE_TYPE["SLOW_RATE"], slow_rate.data, strict=False
+        )
     }
 
     l1 = {**fast_rate_1_dict, **fast_rate_2_dict, **slow_rate_dict}

--- a/imap_processing/ialirt/l0/process_hit.py
+++ b/imap_processing/ialirt/l0/process_hit.py
@@ -91,20 +91,18 @@ def create_l1(
     fast_rate_1_dict = {
         prefix: value
         for prefix, value in zip(
-            HIT_PREFIX_TO_RATE_TYPE["FAST_RATE_1"], fast_rate_1.data, strict=False
+            HIT_PREFIX_TO_RATE_TYPE["FAST_RATE_1"], fast_rate_1.data
         )
     }
     fast_rate_2_dict = {
         prefix: value
         for prefix, value in zip(
-            HIT_PREFIX_TO_RATE_TYPE["FAST_RATE_2"], fast_rate_2.data, strict=False
+            HIT_PREFIX_TO_RATE_TYPE["FAST_RATE_2"], fast_rate_2.data
         )
     }
     slow_rate_dict = {
         prefix: value
-        for prefix, value in zip(
-            HIT_PREFIX_TO_RATE_TYPE["SLOW_RATE"], slow_rate.data, strict=False
-        )
+        for prefix, value in zip(HIT_PREFIX_TO_RATE_TYPE["SLOW_RATE"], slow_rate.data)
     }
 
     l1 = {**fast_rate_1_dict, **fast_rate_2_dict, **slow_rate_dict}

--- a/imap_processing/ialirt/l0/process_swapi.py
+++ b/imap_processing/ialirt/l0/process_swapi.py
@@ -2,7 +2,6 @@
 
 import logging
 from decimal import Decimal
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -70,7 +69,7 @@ def count_rate(
 def optimize_pseudo_parameters(
     count_rates: np.ndarray,
     count_rate_error: np.ndarray,
-    energy_passbands: Optional[np.ndarray] = None,
+    energy_passbands: np.ndarray | None = None,
 ) -> (dict)[str, list[float]]:
     """
     Find the pseudo speed (u), density (n) and temperature (T) of solar wind particles.

--- a/imap_processing/ialirt/l0/process_swapi.py
+++ b/imap_processing/ialirt/l0/process_swapi.py
@@ -2,6 +2,7 @@
 
 import logging
 from decimal import Decimal
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -69,7 +70,7 @@ def count_rate(
 def optimize_pseudo_parameters(
     count_rates: np.ndarray,
     count_rate_error: np.ndarray,
-    energy_passbands: np.ndarray | None = None,
+    energy_passbands: Optional[np.ndarray] = None,
 ) -> (dict)[str, list[float]]:
     """
     Find the pseudo speed (u), density (n) and temperature (T) of solar wind particles.

--- a/imap_processing/ialirt/process_ephemeris.py
+++ b/imap_processing/ialirt/process_ephemeris.py
@@ -8,7 +8,6 @@ Reference: https://spiceypy.readthedocs.io/en/main/documentation.html.
 
 import logging
 import typing
-from typing import Union
 
 import numpy as np
 import spiceypy
@@ -69,7 +68,7 @@ def calculate_azimuth_and_elevation(
     longitude: float,
     latitude: float,
     altitude: float,
-    observation_time: Union[float, np.ndarray],
+    observation_time: float | np.ndarray,
     target: str = SpiceBody.IMAP.name,
 ) -> tuple:
     """
@@ -133,8 +132,8 @@ def calculate_doppler(
     longitude: float,
     latitude: float,
     altitude: float,
-    observation_time: Union[float, np.ndarray],
-) -> Union[float, ndarray[float]]:
+    observation_time: float | np.ndarray,
+) -> float | ndarray[float]:
     """
     Calculate the doppler velocity.
 

--- a/imap_processing/ialirt/process_ephemeris.py
+++ b/imap_processing/ialirt/process_ephemeris.py
@@ -8,6 +8,7 @@ Reference: https://spiceypy.readthedocs.io/en/main/documentation.html.
 
 import logging
 import typing
+from typing import Union
 
 import numpy as np
 import spiceypy
@@ -68,7 +69,7 @@ def calculate_azimuth_and_elevation(
     longitude: float,
     latitude: float,
     altitude: float,
-    observation_time: float | np.ndarray,
+    observation_time: Union[float, np.ndarray],
     target: str = SpiceBody.IMAP.name,
 ) -> tuple:
     """
@@ -132,8 +133,8 @@ def calculate_doppler(
     longitude: float,
     latitude: float,
     altitude: float,
-    observation_time: float | np.ndarray,
-) -> float | ndarray[float]:
+    observation_time: Union[float, np.ndarray],
+) -> Union[float, ndarray[float]]:
     """
     Calculate the doppler velocity.
 

--- a/imap_processing/idex/idex_l0.py
+++ b/imap_processing/idex/idex_l0.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 from xarray import Dataset
 
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def decom_packets(
-    packet_file: Union[str, Path],
+    packet_file: str | Path,
 ) -> tuple[list[Any], dict[int, Dataset], dict[int, Dataset]]:
     """
     Decom IDEX data packets using IDEX packet definition.

--- a/imap_processing/idex/idex_l0.py
+++ b/imap_processing/idex/idex_l0.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 from xarray import Dataset
 
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def decom_packets(
-    packet_file: str | Path,
+    packet_file: Union[str, Path],
 ) -> tuple[list[Any], dict[int, Dataset], dict[int, Dataset]]:
     """
     Decom IDEX data packets using IDEX packet definition.

--- a/imap_processing/idex/idex_l1a.py
+++ b/imap_processing/idex/idex_l1a.py
@@ -17,7 +17,6 @@ Examples
 import logging
 from enum import IntEnum
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -61,7 +60,7 @@ class PacketParser:
         The path and filename to the L0 file to read.
     """
 
-    def __init__(self, packet_file: Union[str, Path]) -> None:
+    def __init__(self, packet_file: str | Path) -> None:
         """
         Read a L0 pkts file and perform all of the decom work.
 
@@ -250,7 +249,7 @@ def _read_waveform_bits(waveform_raw: str, high_sample: bool = True) -> list[int
 
 
 def calculate_idex_epoch_time(
-    shcoarse_time: Union[float, np.ndarray], shfine_time: Union[float, np.ndarray]
+    shcoarse_time: float | np.ndarray, shfine_time: float | np.ndarray
 ) -> npt.NDArray[np.int64]:
     """
     Calculate the epoch time from the FPGA header time variables.

--- a/imap_processing/idex/idex_l1a.py
+++ b/imap_processing/idex/idex_l1a.py
@@ -17,6 +17,7 @@ Examples
 import logging
 from enum import IntEnum
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -60,7 +61,7 @@ class PacketParser:
         The path and filename to the L0 file to read.
     """
 
-    def __init__(self, packet_file: str | Path) -> None:
+    def __init__(self, packet_file: Union[str, Path]) -> None:
         """
         Read a L0 pkts file and perform all of the decom work.
 
@@ -249,7 +250,7 @@ def _read_waveform_bits(waveform_raw: str, high_sample: bool = True) -> list[int
 
 
 def calculate_idex_epoch_time(
-    shcoarse_time: float | np.ndarray, shfine_time: float | np.ndarray
+    shcoarse_time: Union[float, np.ndarray], shfine_time: Union[float, np.ndarray]
 ) -> npt.NDArray[np.int64]:
     """
     Calculate the epoch time from the FPGA header time variables.

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -16,7 +16,6 @@ Examples
 
 import logging
 from enum import Enum
-from typing import Union
 
 import pandas as pd
 import xarray as xr
@@ -226,7 +225,7 @@ def convert_waveforms(
 
 def get_trigger_mode_and_level(
     l1a_dataset: xr.Dataset,
-) -> Union[dict[str, xr.DataArray], dict]:
+) -> dict[str, xr.DataArray] | dict:
     """
     Determine the trigger mode and threshold level for each event.
 
@@ -249,7 +248,7 @@ def get_trigger_mode_and_level(
 
     def compute_trigger_values(
         trigger_mode: int, trigger_controls: int, gain_channel: str
-    ) -> Union[tuple[str, Union[int, float]], tuple[None, None]]:
+    ) -> tuple[str, int | float] | tuple[None, None]:
         """
         Compute the trigger mode label and threshold level.
 

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -16,6 +16,7 @@ Examples
 
 import logging
 from enum import Enum
+from typing import Union
 
 import pandas as pd
 import xarray as xr
@@ -225,7 +226,7 @@ def convert_waveforms(
 
 def get_trigger_mode_and_level(
     l1a_dataset: xr.Dataset,
-) -> dict[str, xr.DataArray] | dict:
+) -> Union[dict[str, xr.DataArray], dict]:
     """
     Determine the trigger mode and threshold level for each event.
 
@@ -248,7 +249,7 @@ def get_trigger_mode_and_level(
 
     def compute_trigger_values(
         trigger_mode: int, trigger_controls: int, gain_channel: str
-    ) -> tuple[str, int | float] | tuple[None, None]:
+    ) -> Union[tuple[str, Union[int, float]], tuple[None, None]]:
         """
         Compute the trigger mode label and threshold level.
 

--- a/imap_processing/idex/idex_l2a.py
+++ b/imap_processing/idex/idex_l2a.py
@@ -399,7 +399,7 @@ def calculate_kappa(mass_scales: np.ndarray, peaks_2d: list) -> NDArray:
     kappas = np.asarray(
         [
             np.mean(mass_scale[peaks] - np.round(mass_scale[peaks]))
-            for mass_scale, peaks in zip(mass_scales, peaks_2d)
+            for mass_scale, peaks in zip(mass_scales, peaks_2d, strict=False)
         ]
     )
     return kappas

--- a/imap_processing/idex/idex_l2a.py
+++ b/imap_processing/idex/idex_l2a.py
@@ -399,7 +399,7 @@ def calculate_kappa(mass_scales: np.ndarray, peaks_2d: list) -> NDArray:
     kappas = np.asarray(
         [
             np.mean(mass_scale[peaks] - np.round(mass_scale[peaks]))
-            for mass_scale, peaks in zip(mass_scales, peaks_2d, strict=False)
+            for mass_scale, peaks in zip(mass_scales, peaks_2d)
         ]
     )
     return kappas

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -607,7 +607,7 @@ def get_science_acquisition_timestamps(
     epochs = evt_dataset["epoch"][sc_indices].data
     # Now the state change values and check if it is either a science
     # acquisition start or science acquisition stop event.
-    for v1, v2, epoch in zip(val1, val2, epochs):
+    for v1, v2, epoch in zip(val1, val2, epochs, strict=False):
         # An "acquire" start will have val1=ACQSETUP and val2=ACQ
         # An "acquire" stop will have val1=ACQ and val2=CHILL
         if (v1, v2) == (IDEXEvtAcquireCodes.ACQSETUP, IDEXEvtAcquireCodes.ACQ):

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -607,7 +607,7 @@ def get_science_acquisition_timestamps(
     epochs = evt_dataset["epoch"][sc_indices].data
     # Now the state change values and check if it is either a science
     # acquisition start or science acquisition stop event.
-    for v1, v2, epoch in zip(val1, val2, epochs, strict=False):
+    for v1, v2, epoch in zip(val1, val2, epochs):
         # An "acquire" start will have val1=ACQSETUP and val2=ACQ
         # An "acquire" stop will have val1=ACQ and val2=CHILL
         if (v1, v2) == (IDEXEvtAcquireCodes.ACQSETUP, IDEXEvtAcquireCodes.ACQ):

--- a/imap_processing/idex/idex_utils.py
+++ b/imap_processing/idex/idex_utils.py
@@ -1,7 +1,5 @@
 """Contains helper functions to support IDEX processing."""
 
-from typing import Optional
-
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
@@ -31,7 +29,7 @@ def setup_dataset(
     dataset: xr.Dataset,
     match_strings: list,
     idex_attrs: ImapCdfAttributes,
-    data_vars: Optional[dict] = None,
+    data_vars: dict | None = None,
 ) -> xr.Dataset:
     """
     Initialize a dataset and copy over any dataArrays.

--- a/imap_processing/idex/idex_utils.py
+++ b/imap_processing/idex/idex_utils.py
@@ -1,5 +1,7 @@
 """Contains helper functions to support IDEX processing."""
 
+from typing import Optional
+
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
@@ -29,7 +31,7 @@ def setup_dataset(
     dataset: xr.Dataset,
     match_strings: list,
     idex_attrs: ImapCdfAttributes,
-    data_vars: dict | None = None,
+    data_vars: Optional[dict] = None,
 ) -> xr.Dataset:
     """
     Initialize a dataset and copy over any dataArrays.

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -399,7 +399,7 @@ def combine_segmented_packets(dataset: xr.Dataset) -> xr.Dataset:
     # Combine the segmented packets into a single binary string
     dataset["events"] = [
         "".join(dataset["data"].values[start : end + 1])
-        for start, end in zip(seg_starts, seg_ends)
+        for start, end in zip(seg_starts, seg_ends, strict=False)
     ]
 
     # drop any group of segmented packets that aren't sequential
@@ -441,7 +441,8 @@ def find_valid_groups(
     """
     # Check if the sequence counters from the CCSDS header are sequential
     grouped_seq_ctrs = [
-        np.array(seq_ctrs[start : end + 1]) for start, end in zip(seg_starts, seg_ends)
+        np.array(seq_ctrs[start : end + 1])
+        for start, end in zip(seg_starts, seg_ends, strict=False)
     ]
     valid_groups = [is_sequential(seq_ctrs) for seq_ctrs in grouped_seq_ctrs]
     return valid_groups

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -399,7 +399,7 @@ def combine_segmented_packets(dataset: xr.Dataset) -> xr.Dataset:
     # Combine the segmented packets into a single binary string
     dataset["events"] = [
         "".join(dataset["data"].values[start : end + 1])
-        for start, end in zip(seg_starts, seg_ends, strict=False)
+        for start, end in zip(seg_starts, seg_ends)
     ]
 
     # drop any group of segmented packets that aren't sequential
@@ -441,8 +441,7 @@ def find_valid_groups(
     """
     # Check if the sequence counters from the CCSDS header are sequential
     grouped_seq_ctrs = [
-        np.array(seq_ctrs[start : end + 1])
-        for start, end in zip(seg_starts, seg_ends, strict=False)
+        np.array(seq_ctrs[start : end + 1]) for start, end in zip(seg_starts, seg_ends)
     ]
     valid_groups = [is_sequential(seq_ctrs) for seq_ctrs in grouped_seq_ctrs]
     return valid_groups

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -3,7 +3,7 @@
 import logging
 from dataclasses import Field
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 import xarray as xr
@@ -204,7 +204,7 @@ def get_avg_spin_durations_per_cycle(
     return avg_spin_durations_per_cycle
 
 
-def get_spin_angle(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
+def get_spin_angle(l1a_de: xr.Dataset) -> np.ndarray[np.float64] | Any:
     """
     Get the spin angle (0 - 360 degrees) for each DE.
 
@@ -587,7 +587,7 @@ def convert_tofs_to_eu(
     tof_conversions = [TOF0_CONV, TOF1_CONV, TOF2_CONV, TOF3_CONV]
 
     # Loop through the TOF fields and convert them to engineering units
-    for tof, conv in zip(tof_fields, tof_conversions):
+    for tof, conv in zip(tof_fields, tof_conversions, strict=False):
         # Get the fill value for the L1A and L1B TOF
         fillval_1a = attr_mgr_l1a.get_variable_attributes(tof)["FILLVAL"]
         fillval_1b = attr_mgr_l1b.get_variable_attributes(tof)["FILLVAL"]

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -3,7 +3,7 @@
 import logging
 from dataclasses import Field
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 import numpy as np
 import xarray as xr
@@ -204,7 +204,7 @@ def get_avg_spin_durations_per_cycle(
     return avg_spin_durations_per_cycle
 
 
-def get_spin_angle(l1a_de: xr.Dataset) -> np.ndarray[np.float64] | Any:
+def get_spin_angle(l1a_de: xr.Dataset) -> Union[np.ndarray[np.float64], Any]:
     """
     Get the spin angle (0 - 360 degrees) for each DE.
 
@@ -587,7 +587,7 @@ def convert_tofs_to_eu(
     tof_conversions = [TOF0_CONV, TOF1_CONV, TOF2_CONV, TOF3_CONV]
 
     # Loop through the TOF fields and convert them to engineering units
-    for tof, conv in zip(tof_fields, tof_conversions, strict=False):
+    for tof, conv in zip(tof_fields, tof_conversions):
         # Get the fill value for the L1A and L1B TOF
         fillval_1a = attr_mgr_l1a.get_variable_attributes(tof)["FILLVAL"]
         fillval_1b = attr_mgr_l1b.get_variable_attributes(tof)["FILLVAL"]

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -151,7 +151,7 @@ def filter_goodtimes(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
     goodtimes_mask = np.zeros_like(l1b_de["epoch"], dtype=bool)
 
     # Iterate over the good times and create a mask
-    for start, end in zip(goodtimes_start, goodtimes_end):
+    for start, end in zip(goodtimes_start, goodtimes_end, strict=False):
         goodtimes_mask |= (l1b_de["epoch"] >= start) & (l1b_de["epoch"] < end)
 
     # Filter the dataset using the mask

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -151,7 +151,7 @@ def filter_goodtimes(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
     goodtimes_mask = np.zeros_like(l1b_de["epoch"], dtype=bool)
 
     # Iterate over the good times and create a mask
-    for start, end in zip(goodtimes_start, goodtimes_end, strict=False):
+    for start, end in zip(goodtimes_start, goodtimes_end):
         goodtimes_mask |= (l1b_de["epoch"] >= start) & (l1b_de["epoch"] < end)
 
     # Filter the dataset using the mask

--- a/imap_processing/mag/l1c/interpolation_methods.py
+++ b/imap_processing/mag/l1c/interpolation_methods.py
@@ -3,7 +3,6 @@
 
 import logging
 from enum import Enum
-from typing import Optional
 
 import numpy as np
 from scipy.interpolate import make_interp_spline
@@ -44,8 +43,8 @@ def linear(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: Optional[VecSec] = None,
-    output_rate: Optional[VecSec] = None,
+    input_rate: VecSec | None = None,
+    output_rate: VecSec | None = None,
 ) -> np.ndarray:
     """
     Linear interpolation of input vectors to output timestamps.
@@ -80,8 +79,8 @@ def quadratic(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: Optional[VecSec] = None,
-    output_rate: Optional[VecSec] = None,
+    input_rate: VecSec | None = None,
+    output_rate: VecSec | None = None,
 ) -> np.ndarray:
     """
     Quadratic interpolation of input vectors to output timestamps.
@@ -115,8 +114,8 @@ def cubic(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: Optional[VecSec] = None,
-    output_rate: Optional[VecSec] = None,
+    input_rate: VecSec | None = None,
+    output_rate: VecSec | None = None,
 ) -> np.ndarray:
     """
     Cubic interpolation of input vectors to output timestamps.
@@ -175,8 +174,8 @@ def cic_filter(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: Optional[VecSec],
-    output_rate: Optional[VecSec],
+    input_rate: VecSec | None,
+    output_rate: VecSec | None,
 ):
     """
     Apply CIC filter to data before interpolating.
@@ -242,8 +241,8 @@ def linear_filtered(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: Optional[VecSec] = None,
-    output_rate: Optional[VecSec] = None,
+    input_rate: VecSec | None = None,
+    output_rate: VecSec | None = None,
 ) -> np.ndarray:
     """
     Linear filtered interpolation of input vectors to output timestamps.
@@ -281,8 +280,8 @@ def quadratic_filtered(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: Optional[VecSec] = None,
-    output_rate: Optional[VecSec] = None,
+    input_rate: VecSec | None = None,
+    output_rate: VecSec | None = None,
 ) -> np.ndarray:
     """
     Quadratic filtered interpolation of input vectors to output timestamps.
@@ -320,8 +319,8 @@ def cubic_filtered(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: Optional[VecSec] = None,
-    output_rate: Optional[VecSec] = None,
+    input_rate: VecSec | None = None,
+    output_rate: VecSec | None = None,
 ) -> np.ndarray:
     """
     Cubic filtered interpolation of input vectors to output timestamps.

--- a/imap_processing/mag/l1c/interpolation_methods.py
+++ b/imap_processing/mag/l1c/interpolation_methods.py
@@ -3,6 +3,7 @@
 
 import logging
 from enum import Enum
+from typing import Optional
 
 import numpy as np
 from scipy.interpolate import make_interp_spline
@@ -43,8 +44,8 @@ def linear(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: VecSec | None = None,
-    output_rate: VecSec | None = None,
+    input_rate: Optional[VecSec] = None,
+    output_rate: Optional[VecSec] = None,
 ) -> np.ndarray:
     """
     Linear interpolation of input vectors to output timestamps.
@@ -79,8 +80,8 @@ def quadratic(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: VecSec | None = None,
-    output_rate: VecSec | None = None,
+    input_rate: Optional[VecSec] = None,
+    output_rate: Optional[VecSec] = None,
 ) -> np.ndarray:
     """
     Quadratic interpolation of input vectors to output timestamps.
@@ -114,8 +115,8 @@ def cubic(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: VecSec | None = None,
-    output_rate: VecSec | None = None,
+    input_rate: Optional[VecSec] = None,
+    output_rate: Optional[VecSec] = None,
 ) -> np.ndarray:
     """
     Cubic interpolation of input vectors to output timestamps.
@@ -174,8 +175,8 @@ def cic_filter(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: VecSec | None,
-    output_rate: VecSec | None,
+    input_rate: Optional[VecSec],
+    output_rate: Optional[VecSec],
 ):
     """
     Apply CIC filter to data before interpolating.
@@ -241,8 +242,8 @@ def linear_filtered(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: VecSec | None = None,
-    output_rate: VecSec | None = None,
+    input_rate: Optional[VecSec] = None,
+    output_rate: Optional[VecSec] = None,
 ) -> np.ndarray:
     """
     Linear filtered interpolation of input vectors to output timestamps.
@@ -280,8 +281,8 @@ def quadratic_filtered(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: VecSec | None = None,
-    output_rate: VecSec | None = None,
+    input_rate: Optional[VecSec] = None,
+    output_rate: Optional[VecSec] = None,
 ) -> np.ndarray:
     """
     Quadratic filtered interpolation of input vectors to output timestamps.
@@ -319,8 +320,8 @@ def cubic_filtered(
     input_vectors: np.ndarray,
     input_timestamps: np.ndarray,
     output_timestamps: np.ndarray,
-    input_rate: VecSec | None = None,
-    output_rate: VecSec | None = None,
+    input_rate: Optional[VecSec] = None,
+    output_rate: Optional[VecSec] = None,
 ) -> np.ndarray:
     """
     Cubic filtered interpolation of input vectors to output timestamps.

--- a/imap_processing/mag/l1c/mag_l1c.py
+++ b/imap_processing/mag/l1c/mag_l1c.py
@@ -1,7 +1,6 @@
 """MAG L1C processing module."""
 
 import logging
-from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -183,7 +182,7 @@ def mag_l1c(
 
 
 def select_datasets(
-    first_input_dataset: xr.Dataset, second_input_dataset: Optional[xr.Dataset] = None
+    first_input_dataset: xr.Dataset, second_input_dataset: xr.Dataset | None = None
 ) -> tuple[xr.Dataset, xr.Dataset]:
     """
     Given one or two datasets, assign one to norm and one to burst.
@@ -503,7 +502,7 @@ def generate_timeline(epoch_data: np.ndarray, gaps: np.ndarray) -> np.ndarray:
 
 
 def find_all_gaps(
-    epoch_data: np.ndarray, vecsec_dict: Optional[dict] = None
+    epoch_data: np.ndarray, vecsec_dict: dict | None = None
 ) -> np.ndarray:
     """
     Find all the gaps in the epoch data.

--- a/imap_processing/mag/l1c/mag_l1c.py
+++ b/imap_processing/mag/l1c/mag_l1c.py
@@ -1,6 +1,7 @@
 """MAG L1C processing module."""
 
 import logging
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -182,7 +183,7 @@ def mag_l1c(
 
 
 def select_datasets(
-    first_input_dataset: xr.Dataset, second_input_dataset: xr.Dataset | None = None
+    first_input_dataset: xr.Dataset, second_input_dataset: Optional[xr.Dataset] = None
 ) -> tuple[xr.Dataset, xr.Dataset]:
     """
     Given one or two datasets, assign one to norm and one to burst.
@@ -502,7 +503,7 @@ def generate_timeline(epoch_data: np.ndarray, gaps: np.ndarray) -> np.ndarray:
 
 
 def find_all_gaps(
-    epoch_data: np.ndarray, vecsec_dict: dict | None = None
+    epoch_data: np.ndarray, vecsec_dict: Optional[dict] = None
 ) -> np.ndarray:
     """
     Find all the gaps in the epoch data.

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -11,7 +11,6 @@ Paradigms for developing this module:
 
 import typing
 from enum import IntEnum
-from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -99,7 +98,7 @@ BORESIGHT_LOOKUP = {
 
 
 def imap_state(
-    et: Union[np.ndarray, float],
+    et: np.ndarray | float,
     ref_frame: SpiceFrame = SpiceFrame.ECLIPJ2000,
     abcorr: str = "NONE",
     observer: SpiceBody = SpiceBody.SUN,
@@ -171,7 +170,7 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
 
 
 def frame_transform(
-    et: Union[float, npt.NDArray],
+    et: float | npt.NDArray,
     position: npt.NDArray,
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
@@ -245,7 +244,7 @@ def frame_transform(
 
 
 def frame_transform_az_el(
-    et: Union[float, npt.NDArray],
+    et: float | npt.NDArray,
     az_el: npt.NDArray,
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
@@ -295,7 +294,7 @@ def frame_transform_az_el(
 
 
 def get_rotation_matrix(
-    et: Union[float, npt.NDArray],
+    et: float | npt.NDArray,
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
 ) -> npt.NDArray:
@@ -333,7 +332,7 @@ def get_rotation_matrix(
 
 
 def instrument_pointing(
-    et: Union[float, npt.NDArray],
+    et: float | npt.NDArray,
     instrument: SpiceFrame,
     to_frame: SpiceFrame,
     cartesian: bool = False,
@@ -371,7 +370,7 @@ def instrument_pointing(
 
 
 def basis_vectors(
-    et: Union[float, npt.NDArray],
+    et: float | npt.NDArray,
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
 ) -> npt.NDArray:
@@ -544,9 +543,9 @@ def cartesian_to_latitudinal(coords: NDArray, degrees: bool = True) -> NDArray:
 
 
 def solar_longitude(
-    et: Union[np.ndarray, float],
+    et: np.ndarray | float,
     degrees: bool = True,
-) -> Union[float, npt.NDArray]:
+) -> float | npt.NDArray:
     """
     Compute the solar longitude of the Imap Spacecraft.
 

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -11,6 +11,7 @@ Paradigms for developing this module:
 
 import typing
 from enum import IntEnum
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -98,7 +99,7 @@ BORESIGHT_LOOKUP = {
 
 
 def imap_state(
-    et: np.ndarray | float,
+    et: Union[np.ndarray, float],
     ref_frame: SpiceFrame = SpiceFrame.ECLIPJ2000,
     abcorr: str = "NONE",
     observer: SpiceBody = SpiceBody.SUN,
@@ -170,7 +171,7 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
 
 
 def frame_transform(
-    et: float | npt.NDArray,
+    et: Union[float, npt.NDArray],
     position: npt.NDArray,
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
@@ -244,7 +245,7 @@ def frame_transform(
 
 
 def frame_transform_az_el(
-    et: float | npt.NDArray,
+    et: Union[float, npt.NDArray],
     az_el: npt.NDArray,
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
@@ -294,7 +295,7 @@ def frame_transform_az_el(
 
 
 def get_rotation_matrix(
-    et: float | npt.NDArray,
+    et: Union[float, npt.NDArray],
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
 ) -> npt.NDArray:
@@ -332,7 +333,7 @@ def get_rotation_matrix(
 
 
 def instrument_pointing(
-    et: float | npt.NDArray,
+    et: Union[float, npt.NDArray],
     instrument: SpiceFrame,
     to_frame: SpiceFrame,
     cartesian: bool = False,
@@ -370,7 +371,7 @@ def instrument_pointing(
 
 
 def basis_vectors(
-    et: float | npt.NDArray,
+    et: Union[float, npt.NDArray],
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
 ) -> npt.NDArray:
@@ -543,9 +544,9 @@ def cartesian_to_latitudinal(coords: NDArray, degrees: bool = True) -> NDArray:
 
 
 def solar_longitude(
-    et: np.ndarray | float,
+    et: Union[np.ndarray, float],
     degrees: bool = True,
-) -> float | npt.NDArray:
+) -> Union[float, npt.NDArray]:
     """
     Compute the solar longitude of the Imap Spacecraft.
 

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -3,7 +3,6 @@
 import functools
 import logging
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -113,7 +112,7 @@ def _load_repoint_data_with_cache(csv_path: Path) -> pd.DataFrame:
 
 
 def interpolate_repoint_data(
-    query_met_times: Union[float, npt.NDArray],
+    query_met_times: float | npt.NDArray,
 ) -> pd.DataFrame:
     """
     Interpolate repointing data to the queried MET times.

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -3,6 +3,7 @@
 import functools
 import logging
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -112,7 +113,7 @@ def _load_repoint_data_with_cache(csv_path: Path) -> pd.DataFrame:
 
 
 def interpolate_repoint_data(
-    query_met_times: float | npt.NDArray,
+    query_met_times: Union[float, npt.NDArray],
 ) -> pd.DataFrame:
     """
     Interpolate repointing data to the queried MET times.

--- a/imap_processing/spice/spin.py
+++ b/imap_processing/spice/spin.py
@@ -4,7 +4,6 @@ import functools
 import logging
 from functools import reduce
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -129,7 +128,7 @@ def _load_spin_data_with_cache(csv_paths: tuple[Path]) -> pd.DataFrame:
     return combined_df
 
 
-def interpolate_spin_data(query_met_times: Union[float, npt.NDArray]) -> pd.DataFrame:
+def interpolate_spin_data(query_met_times: float | npt.NDArray) -> pd.DataFrame:
     """
     Interpolate spin table data to the queried MET times.
 
@@ -214,9 +213,9 @@ def interpolate_spin_data(query_met_times: Union[float, npt.NDArray]) -> pd.Data
 
 
 def get_spin_angle(
-    spin_phases: Union[float, npt.NDArray],
+    spin_phases: float | npt.NDArray,
     degrees: bool = False,
-) -> Union[float, npt.NDArray]:
+) -> float | npt.NDArray:
     """
     Convert spin_phases to radians or degrees.
 
@@ -249,8 +248,8 @@ def get_spin_angle(
 
 
 def get_spacecraft_spin_phase(
-    query_met_times: Union[float, npt.NDArray],
-) -> Union[float, npt.NDArray]:
+    query_met_times: float | npt.NDArray,
+) -> float | npt.NDArray:
     """
     Get the spacecraft spin phase for the input query times.
 
@@ -274,8 +273,8 @@ def get_spacecraft_spin_phase(
 
 
 def get_instrument_spin_phase(
-    query_met_times: Union[float, npt.NDArray], instrument: SpiceFrame
-) -> Union[float, npt.NDArray]:
+    query_met_times: float | npt.NDArray, instrument: SpiceFrame
+) -> float | npt.NDArray:
     """
     Get the instrument spin phase for the input query times.
 

--- a/imap_processing/spice/spin.py
+++ b/imap_processing/spice/spin.py
@@ -4,6 +4,7 @@ import functools
 import logging
 from functools import reduce
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -128,7 +129,7 @@ def _load_spin_data_with_cache(csv_paths: tuple[Path]) -> pd.DataFrame:
     return combined_df
 
 
-def interpolate_spin_data(query_met_times: float | npt.NDArray) -> pd.DataFrame:
+def interpolate_spin_data(query_met_times: Union[float, npt.NDArray]) -> pd.DataFrame:
     """
     Interpolate spin table data to the queried MET times.
 
@@ -213,9 +214,9 @@ def interpolate_spin_data(query_met_times: float | npt.NDArray) -> pd.DataFrame:
 
 
 def get_spin_angle(
-    spin_phases: float | npt.NDArray,
+    spin_phases: Union[float, npt.NDArray],
     degrees: bool = False,
-) -> float | npt.NDArray:
+) -> Union[float, npt.NDArray]:
     """
     Convert spin_phases to radians or degrees.
 
@@ -248,8 +249,8 @@ def get_spin_angle(
 
 
 def get_spacecraft_spin_phase(
-    query_met_times: float | npt.NDArray,
-) -> float | npt.NDArray:
+    query_met_times: Union[float, npt.NDArray],
+) -> Union[float, npt.NDArray]:
     """
     Get the spacecraft spin phase for the input query times.
 
@@ -273,8 +274,8 @@ def get_spacecraft_spin_phase(
 
 
 def get_instrument_spin_phase(
-    query_met_times: float | npt.NDArray, instrument: SpiceFrame
-) -> float | npt.NDArray:
+    query_met_times: Union[float, npt.NDArray], instrument: SpiceFrame
+) -> Union[float, npt.NDArray]:
     """
     Get the instrument spin phase for the input query times.
 

--- a/imap_processing/spice/time.py
+++ b/imap_processing/spice/time.py
@@ -3,7 +3,6 @@
 import typing
 from collections.abc import Collection, Iterable
 from datetime import datetime
-from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -180,7 +179,7 @@ def met_to_utc(met: npt.ArrayLike, precision: int = 9) -> npt.NDArray[str]:
 
 def met_to_datetime64(
     met: npt.ArrayLike,
-) -> Union[np.datetime64, npt.NDArray[np.datetime64]]:
+) -> np.datetime64 | npt.NDArray[np.datetime64]:
     """
     Convert mission elapsed time (MET) to datetime.datetime.
 
@@ -199,7 +198,7 @@ def met_to_datetime64(
 
 def et_to_datetime64(
     et: npt.ArrayLike,
-) -> Union[np.datetime64, npt.NDArray[np.datetime64]]:
+) -> np.datetime64 | npt.NDArray[np.datetime64]:
     """
     Convert ET to numpy datetime64.
 
@@ -218,8 +217,8 @@ def et_to_datetime64(
 
 @typing.no_type_check
 def et_to_met(
-    et: Union[float, Collection[float]],
-) -> Union[float, np.ndarray]:
+    et: float | Collection[float],
+) -> float | np.ndarray:
     """
     Convert ephemeris time to mission elapsed time (MET).
 
@@ -268,8 +267,8 @@ def ttj2000ns_to_met(
 
 @typing.no_type_check
 def sct_to_et(
-    sclk_ticks: Union[float, Collection[float]],
-) -> Union[float, np.ndarray]:
+    sclk_ticks: float | Collection[float],
+) -> float | np.ndarray:
     """
     Convert encoded spacecraft clock "ticks" to ephemeris time.
 
@@ -293,8 +292,8 @@ def sct_to_et(
 
 @typing.no_type_check
 def sct_to_ttj2000s(
-    sclk_ticks: Union[float, Iterable[float]],
-) -> Union[float, np.ndarray]:
+    sclk_ticks: float | Iterable[float],
+) -> float | np.ndarray:
     """
     Convert encoded spacecraft clock "ticks" to terrestrial time (TT).
 
@@ -324,8 +323,8 @@ def sct_to_ttj2000s(
 
 @typing.no_type_check
 def str_to_et(
-    time_str: Union[str, Iterable[str]],
-) -> Union[float, np.ndarray]:
+    time_str: str | Iterable[str],
+) -> float | np.ndarray:
     """
     Convert string to ephemeris time.
 
@@ -349,11 +348,11 @@ def str_to_et(
 
 @typing.no_type_check
 def et_to_utc(
-    et: Union[float, Iterable[float]],
+    et: float | Iterable[float],
     format_str: str = "ISOC",
     precision: int = 3,
     utclen: int = 24,
-) -> Union[str, np.ndarray]:
+) -> str | np.ndarray:
     """
     Convert ephemeris time to UTC.
 

--- a/imap_processing/spice/time.py
+++ b/imap_processing/spice/time.py
@@ -3,6 +3,7 @@
 import typing
 from collections.abc import Collection, Iterable
 from datetime import datetime
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -179,7 +180,7 @@ def met_to_utc(met: npt.ArrayLike, precision: int = 9) -> npt.NDArray[str]:
 
 def met_to_datetime64(
     met: npt.ArrayLike,
-) -> np.datetime64 | npt.NDArray[np.datetime64]:
+) -> Union[np.datetime64, npt.NDArray[np.datetime64]]:
     """
     Convert mission elapsed time (MET) to datetime.datetime.
 
@@ -198,7 +199,7 @@ def met_to_datetime64(
 
 def et_to_datetime64(
     et: npt.ArrayLike,
-) -> np.datetime64 | npt.NDArray[np.datetime64]:
+) -> Union[np.datetime64, npt.NDArray[np.datetime64]]:
     """
     Convert ET to numpy datetime64.
 
@@ -217,8 +218,8 @@ def et_to_datetime64(
 
 @typing.no_type_check
 def et_to_met(
-    et: float | Collection[float],
-) -> float | np.ndarray:
+    et: Union[float, Collection[float]],
+) -> Union[float, np.ndarray]:
     """
     Convert ephemeris time to mission elapsed time (MET).
 
@@ -267,8 +268,8 @@ def ttj2000ns_to_met(
 
 @typing.no_type_check
 def sct_to_et(
-    sclk_ticks: float | Collection[float],
-) -> float | np.ndarray:
+    sclk_ticks: Union[float, Collection[float]],
+) -> Union[float, np.ndarray]:
     """
     Convert encoded spacecraft clock "ticks" to ephemeris time.
 
@@ -292,8 +293,8 @@ def sct_to_et(
 
 @typing.no_type_check
 def sct_to_ttj2000s(
-    sclk_ticks: float | Iterable[float],
-) -> float | np.ndarray:
+    sclk_ticks: Union[float, Iterable[float]],
+) -> Union[float, np.ndarray]:
     """
     Convert encoded spacecraft clock "ticks" to terrestrial time (TT).
 
@@ -323,8 +324,8 @@ def sct_to_ttj2000s(
 
 @typing.no_type_check
 def str_to_et(
-    time_str: str | Iterable[str],
-) -> float | np.ndarray:
+    time_str: Union[str, Iterable[str]],
+) -> Union[float, np.ndarray]:
     """
     Convert string to ephemeris time.
 
@@ -348,11 +349,11 @@ def str_to_et(
 
 @typing.no_type_check
 def et_to_utc(
-    et: float | Iterable[float],
+    et: Union[float, Iterable[float]],
     format_str: str = "ISOC",
     precision: int = 3,
     utclen: int = 24,
-) -> str | np.ndarray:
+) -> Union[str, np.ndarray]:
     """
     Convert ephemeris time to UTC.
 

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -66,7 +66,7 @@ def solve_full_sweep_energy(
 
     first_63_energies = []
 
-    for time, sweep_id in zip(data_time, sweep_table):
+    for time, sweep_id in zip(data_time, sweep_table, strict=False):
         # Find the sweep's ESA data for the given time and sweep_id
         subset = esa_table_df[
             (esa_table_df["timestamp"] <= time) & (esa_table_df["Sweep #"] == sweep_id)

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -66,7 +66,7 @@ def solve_full_sweep_energy(
 
     first_63_energies = []
 
-    for time, sweep_id in zip(data_time, sweep_table, strict=False):
+    for time, sweep_id in zip(data_time, sweep_table):
         # Find the sweep's ESA data for the given time and sweep_id
         subset = esa_table_df[
             (esa_table_df["timestamp"] <= time) & (esa_table_df["Sweep #"] == sweep_id)

--- a/imap_processing/swe/l1b/swe_l1b.py
+++ b/imap_processing/swe/l1b/swe_l1b.py
@@ -2,7 +2,6 @@
 
 import logging
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -51,7 +50,7 @@ def get_esa_dataframe(esa_table_number: int) -> pd.DataFrame:
 
 
 def deadtime_correction(
-    counts: np.ndarray, acq_duration: Union[int, npt.NDArray]
+    counts: np.ndarray, acq_duration: int | npt.NDArray
 ) -> npt.NDArray:
     """
     Calculate deadtime correction.

--- a/imap_processing/swe/l1b/swe_l1b.py
+++ b/imap_processing/swe/l1b/swe_l1b.py
@@ -2,6 +2,7 @@
 
 import logging
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -50,7 +51,7 @@ def get_esa_dataframe(esa_table_number: int) -> pd.DataFrame:
 
 
 def deadtime_correction(
-    counts: np.ndarray, acq_duration: int | npt.NDArray
+    counts: np.ndarray, acq_duration: Union[int, npt.NDArray]
 ) -> npt.NDArray:
     """
     Calculate deadtime correction.

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -44,7 +44,7 @@ def test_l1b_data(request) -> xr.Dataset:
 
 @pytest.mark.parametrize(
     "test_l1b_data, expected_logical_source",
-    list(zip(TEST_L1A_FILES, EXPECTED_LOGICAL_SOURCES)),
+    list(zip(TEST_L1A_FILES, EXPECTED_LOGICAL_SOURCES, strict=False)),
     indirect=["test_l1b_data"],
 )
 def test_l1b_logical_sources(test_l1b_data: xr.Dataset, expected_logical_source: str):

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -44,7 +44,7 @@ def test_l1b_data(request) -> xr.Dataset:
 
 @pytest.mark.parametrize(
     "test_l1b_data, expected_logical_source",
-    list(zip(TEST_L1A_FILES, EXPECTED_LOGICAL_SOURCES, strict=False)),
+    list(zip(TEST_L1A_FILES, EXPECTED_LOGICAL_SOURCES)),
     indirect=["test_l1b_data"],
 )
 def test_l1b_logical_sources(test_l1b_data: xr.Dataset, expected_logical_source: str):

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -30,7 +30,7 @@ def test_l2_data(request) -> xr.Dataset:
 
 @pytest.mark.parametrize(
     "test_l2_data, expected_logical_source",
-    list(zip(TEST_L2_FILES, EXPECTED_LOGICAL_SOURCES)),
+    list(zip(TEST_L2_FILES, EXPECTED_LOGICAL_SOURCES, strict=False)),
     indirect=["test_l2_data"],
 )
 def test_l2_logical_sources(test_l2_data: xr.Dataset, expected_logical_source: str):

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -30,7 +30,7 @@ def test_l2_data(request) -> xr.Dataset:
 
 @pytest.mark.parametrize(
     "test_l2_data, expected_logical_source",
-    list(zip(TEST_L2_FILES, EXPECTED_LOGICAL_SOURCES, strict=False)),
+    list(zip(TEST_L2_FILES, EXPECTED_LOGICAL_SOURCES)),
     indirect=["test_l2_data"],
 )
 def test_l2_logical_sources(test_l2_data: xr.Dataset, expected_logical_source: str):

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -4,7 +4,6 @@ import logging
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional, Union
 
 import cdflib
 import imap_data_access
@@ -239,8 +238,8 @@ def use_fake_spin_data_for_time(
 
     def wrapped_set_spin_data_filepath(
         start_met: float,
-        end_met: Optional[int] = None,
-        spin_period: Optional[float] = 15.0,
+        end_met: int | None = None,
+        spin_period: float | None = 15.0,
     ) -> pd.DataFrame:
         """
         Generate and use fake spin data for testing.
@@ -268,8 +267,8 @@ def use_fake_spin_data_for_time(
 def generate_spin_data():
     def make_data(
         start_met: float,
-        end_met: Optional[float] = None,
-        spin_period: Optional[float] = None,
+        end_met: float | None = None,
+        spin_period: float | None = None,
     ) -> pd.DataFrame:
         """
         Generate a spin table CSV covering one or more days.
@@ -371,9 +370,9 @@ def use_test_repoint_data_csv(monkeypatch):
 
 
 def generate_repoint_data(
-    repoint_start_met: Union[float, np.ndarray],
-    repoint_end_met: Optional[Union[float, np.ndarray]] = None,
-    repoint_id_start: Optional[int] = 0,
+    repoint_start_met: float | np.ndarray,
+    repoint_end_met: float | np.ndarray | None = None,
+    repoint_id_start: int | None = 0,
 ) -> pd.DataFrame:
     """
     Generate a repoint dataframe for the star/end times provided.
@@ -435,9 +434,9 @@ def use_fake_repoint_data_for_time(use_test_repoint_data_csv, tmp_path):
     """
 
     def wrapped_repoint_data_filepath(
-        repoint_start_met: Union[float, np.ndarray],
-        repoint_end_met: Optional[Union[float, np.ndarray]] = None,
-        repoint_id_start: Optional[int] = 0,
+        repoint_start_met: float | np.ndarray,
+        repoint_end_met: float | np.ndarray | None = None,
+        repoint_id_start: int | None = 0,
     ) -> pd.DataFrame:
         """
         Generate and use fake repoint data for testing.

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -4,6 +4,7 @@ import logging
 import time
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Optional, Union
 
 import cdflib
 import imap_data_access
@@ -238,8 +239,8 @@ def use_fake_spin_data_for_time(
 
     def wrapped_set_spin_data_filepath(
         start_met: float,
-        end_met: int | None = None,
-        spin_period: float | None = 15.0,
+        end_met: Optional[int] = None,
+        spin_period: Optional[float] = 15.0,
     ) -> pd.DataFrame:
         """
         Generate and use fake spin data for testing.
@@ -267,8 +268,8 @@ def use_fake_spin_data_for_time(
 def generate_spin_data():
     def make_data(
         start_met: float,
-        end_met: float | None = None,
-        spin_period: float | None = None,
+        end_met: Optional[float] = None,
+        spin_period: Optional[float] = None,
     ) -> pd.DataFrame:
         """
         Generate a spin table CSV covering one or more days.
@@ -370,9 +371,9 @@ def use_test_repoint_data_csv(monkeypatch):
 
 
 def generate_repoint_data(
-    repoint_start_met: float | np.ndarray,
-    repoint_end_met: float | np.ndarray | None = None,
-    repoint_id_start: int | None = 0,
+    repoint_start_met: Union[float, np.ndarray],
+    repoint_end_met: Optional[Union[float, np.ndarray]] = None,
+    repoint_id_start: Optional[int] = 0,
 ) -> pd.DataFrame:
     """
     Generate a repoint dataframe for the star/end times provided.
@@ -434,9 +435,9 @@ def use_fake_repoint_data_for_time(use_test_repoint_data_csv, tmp_path):
     """
 
     def wrapped_repoint_data_filepath(
-        repoint_start_met: float | np.ndarray,
-        repoint_end_met: float | np.ndarray | None = None,
-        repoint_id_start: int | None = 0,
+        repoint_start_met: Union[float, np.ndarray],
+        repoint_end_met: Optional[Union[float, np.ndarray]] = None,
+        repoint_id_start: Optional[int] = 0,
     ) -> pd.DataFrame:
         """
         Generate and use fake repoint data for testing.

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -90,7 +90,7 @@ class TestENAMapMappingUtils:
         # Create the expected projection values by summing the input values in a loop
         # This is different from the binning function, which uses np.bincount
         expected_projection_values = np.zeros((extra_axis_size, projection_grid_size))
-        for ii, ip in zip(input_indices, projection_indices):
+        for ii, ip in zip(input_indices, projection_indices, strict=False):
             expected_projection_values[:, ip] += value_array[:, ii]
 
         np.testing.assert_allclose(projection_values, expected_projection_values)
@@ -128,7 +128,7 @@ class TestENAMapMappingUtils:
         # Create the expected projection values by summing the input values in a loop
         # This is different from the binning function, which uses np.bincount
         expected_projection_values = np.zeros((*extra_axes_sizes, projection_grid_size))
-        for ii, ip in zip(input_indices, projection_indices):
+        for ii, ip in zip(input_indices, projection_indices, strict=False):
             expected_projection_values[..., ip] += value_array[..., ii]
 
         np.testing.assert_allclose(projection_values, expected_projection_values)

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -90,7 +90,7 @@ class TestENAMapMappingUtils:
         # Create the expected projection values by summing the input values in a loop
         # This is different from the binning function, which uses np.bincount
         expected_projection_values = np.zeros((extra_axis_size, projection_grid_size))
-        for ii, ip in zip(input_indices, projection_indices, strict=False):
+        for ii, ip in zip(input_indices, projection_indices):
             expected_projection_values[:, ip] += value_array[:, ii]
 
         np.testing.assert_allclose(projection_values, expected_projection_values)
@@ -128,7 +128,7 @@ class TestENAMapMappingUtils:
         # Create the expected projection values by summing the input values in a loop
         # This is different from the binning function, which uses np.bincount
         expected_projection_values = np.zeros((*extra_axes_sizes, projection_grid_size))
-        for ii, ip in zip(input_indices, projection_indices, strict=False):
+        for ii, ip in zip(input_indices, projection_indices):
             expected_projection_values[..., ip] += value_array[..., ii]
 
         np.testing.assert_allclose(projection_values, expected_projection_values)

--- a/imap_processing/tests/ena_maps/test_spatial_utils.py
+++ b/imap_processing/tests/ena_maps/test_spatial_utils.py
@@ -69,7 +69,8 @@ def test_build_solid_angle_map_equal_at_equal_el(spacing):
 
 
 @pytest.mark.parametrize(
-    "spacing, match_str", zip(invalid_spacings, invalid_spacings_match_str)
+    "spacing, match_str",
+    zip(invalid_spacings, invalid_spacings_match_str, strict=False),
 )
 def test_build_solid_angle_map_invalid_spacing(spacing, match_str):
     """Test build_solid_angle_map function raises error for invalid spacing."""

--- a/imap_processing/tests/ena_maps/test_spatial_utils.py
+++ b/imap_processing/tests/ena_maps/test_spatial_utils.py
@@ -69,8 +69,7 @@ def test_build_solid_angle_map_equal_at_equal_el(spacing):
 
 
 @pytest.mark.parametrize(
-    "spacing, match_str",
-    zip(invalid_spacings, invalid_spacings_match_str, strict=False),
+    "spacing, match_str", zip(invalid_spacings, invalid_spacings_match_str)
 )
 def test_build_solid_angle_map_invalid_spacing(spacing, match_str):
     """Test build_solid_angle_map function raises error for invalid spacing."""

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -149,7 +149,8 @@ def synthetic_trigger_id_and_tof_data():
     )
     data = [arr[good_inds] for arr in data]
     data_vars = {
-        n: xr.DataArray(arr, dims=["event_met"]) for n, arr in zip(var_names, data)
+        n: xr.DataArray(arr, dims=["event_met"])
+        for n, arr in zip(var_names, data, strict=False)
     }
     synthetic_l1a_ds = xr.Dataset(
         coords={

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -149,8 +149,7 @@ def synthetic_trigger_id_and_tof_data():
     )
     data = [arr[good_inds] for arr in data]
     data_vars = {
-        n: xr.DataArray(arr, dims=["event_met"])
-        for n, arr in zip(var_names, data, strict=False)
+        n: xr.DataArray(arr, dims=["event_met"]) for n, arr in zip(var_names, data)
     }
     synthetic_l1a_ds = xr.Dataset(
         coords={

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -397,7 +397,9 @@ class TestCalibrationProductConfig:
         assert "coincidence_type_values" in df.columns
         for _, row in df.iterrows():
             for detect_string, val in zip(
-                row["coincidence_type_list"], row["coincidence_type_values"]
+                row["coincidence_type_list"],
+                row["coincidence_type_values"],
+                strict=False,
             ):
                 assert val == CoincidenceBitmap.detector_hit_str_to_int(detect_string)
 

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -397,9 +397,7 @@ class TestCalibrationProductConfig:
         assert "coincidence_type_values" in df.columns
         for _, row in df.iterrows():
             for detect_string, val in zip(
-                row["coincidence_type_list"],
-                row["coincidence_type_values"],
-                strict=False,
+                row["coincidence_type_list"], row["coincidence_type_values"]
             ):
                 assert val == CoincidenceBitmap.detector_hit_str_to_int(detect_string)
 

--- a/imap_processing/tests/ialirt/unit/test_process_swe.py
+++ b/imap_processing/tests/ialirt/unit/test_process_swe.py
@@ -220,7 +220,7 @@ def test_phi_to_bin():
 
     expected_bins = np.arange(30)
 
-    for phi, expected_bin in zip(phis, expected_bins):
+    for phi, expected_bin in zip(phis, expected_bins, strict=False):
         assert phi_to_bin(phi) == expected_bin
 
 

--- a/imap_processing/tests/ialirt/unit/test_process_swe.py
+++ b/imap_processing/tests/ialirt/unit/test_process_swe.py
@@ -220,7 +220,7 @@ def test_phi_to_bin():
 
     expected_bins = np.arange(30)
 
-    for phi, expected_bin in zip(phis, expected_bins, strict=False):
+    for phi, expected_bin in zip(phis, expected_bins):
         assert phi_to_bin(phi) == expected_bin
 
 

--- a/imap_processing/tests/lo/test_lo_l1a.py
+++ b/imap_processing/tests/lo/test_lo_l1a.py
@@ -22,7 +22,9 @@ def test_lo_l1a():
 
     # Assert
     assert len(output_dataset) == len(expected_logical_source)
-    for dataset, logical_source in zip(output_dataset, expected_logical_source):
+    for dataset, logical_source in zip(
+        output_dataset, expected_logical_source, strict=False
+    ):
         assert logical_source == dataset.attrs["Logical_source"]
 
 

--- a/imap_processing/tests/lo/test_lo_l1a.py
+++ b/imap_processing/tests/lo/test_lo_l1a.py
@@ -22,9 +22,7 @@ def test_lo_l1a():
 
     # Assert
     assert len(output_dataset) == len(expected_logical_source)
-    for dataset, logical_source in zip(
-        output_dataset, expected_logical_source, strict=False
-    ):
+    for dataset, logical_source in zip(output_dataset, expected_logical_source):
         assert logical_source == dataset.attrs["Logical_source"]
 
 

--- a/imap_processing/tests/mag/test_mag_decom.py
+++ b/imap_processing/tests/mag/test_mag_decom.py
@@ -127,7 +127,7 @@ def test_mag_raw_cdf_generation(cdf_attrs):
 def test_comparison():
     l0_args = [f.name for f in fields(MagL0)][2:-1]
     values = np.zeros(len(l0_args), dtype=int)
-    attrs = dict(zip(l0_args, values))
+    attrs = dict(zip(l0_args, values, strict=False))
     attrs["VECTORS"] = np.array([1.0, 2.0, 3.0, 4.0])
     attrs["SHCOARSE"] = 1234
     l0_match = MagL0(

--- a/imap_processing/tests/mag/test_mag_decom.py
+++ b/imap_processing/tests/mag/test_mag_decom.py
@@ -127,7 +127,7 @@ def test_mag_raw_cdf_generation(cdf_attrs):
 def test_comparison():
     l0_args = [f.name for f in fields(MagL0)][2:-1]
     values = np.zeros(len(l0_args), dtype=int)
-    attrs = dict(zip(l0_args, values, strict=False))
+    attrs = dict(zip(l0_args, values))
     attrs["VECTORS"] = np.array([1.0, 2.0, 3.0, 4.0])
     attrs["SHCOARSE"] = 1234
     l0_match = MagL0(

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -143,7 +143,9 @@ def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_ker
         if position.ndim == 1:
             position = np.broadcast_to(position, (len(et), 3))
             result = np.broadcast_to(result, (len(et), 3))
-        for spice_et, spice_position, test_result in zip(et, position, result):
+        for spice_et, spice_position, test_result in zip(
+            et, position, result, strict=False
+        ):
             rotation_matrix = spiceypy.pxform(from_frame.name, to_frame.name, spice_et)
             spice_result = spiceypy.mxv(rotation_matrix, spice_position)
             np.testing.assert_allclose(test_result, spice_result, atol=1e-12)
@@ -308,7 +310,7 @@ def test_basis_vectors(imap_ena_sim_metakernel):
     sc_axes = basis_vectors(et_array, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000)
     assert sc_axes.shape == (10, 3, 3)
     # Verify that for each time, the basis vectors are correct
-    for et, basis_matrix in zip(et_array, sc_axes):
+    for et, basis_matrix in zip(et_array, sc_axes, strict=False):
         np.testing.assert_array_equal(
             basis_matrix,
             frame_transform(

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -143,9 +143,7 @@ def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_ker
         if position.ndim == 1:
             position = np.broadcast_to(position, (len(et), 3))
             result = np.broadcast_to(result, (len(et), 3))
-        for spice_et, spice_position, test_result in zip(
-            et, position, result, strict=False
-        ):
+        for spice_et, spice_position, test_result in zip(et, position, result):
             rotation_matrix = spiceypy.pxform(from_frame.name, to_frame.name, spice_et)
             spice_result = spiceypy.mxv(rotation_matrix, spice_position)
             np.testing.assert_allclose(test_result, spice_result, atol=1e-12)
@@ -310,7 +308,7 @@ def test_basis_vectors(imap_ena_sim_metakernel):
     sc_axes = basis_vectors(et_array, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.ECLIPJ2000)
     assert sc_axes.shape == (10, 3, 3)
     # Verify that for each time, the basis vectors are correct
-    for et, basis_matrix in zip(et_array, sc_axes, strict=False):
+    for et, basis_matrix in zip(et_array, sc_axes):
         np.testing.assert_array_equal(
             basis_matrix,
             frame_transform(

--- a/imap_processing/tests/ultra/unit/test_decom_apid_865.py
+++ b/imap_processing/tests/ultra/unit/test_decom_apid_865.py
@@ -30,7 +30,7 @@ def test_process_cmd_echo(decom_test_data, cmd_echo_test_path):
     np.testing.assert_array_equal(df.Opcode, decom_ultra["opcode"].values.flatten())
 
     for i, (row, opcode) in enumerate(
-        zip(decom_ultra["arguments"].values, decom_ultra["opcode"].values)
+        zip(decom_ultra["arguments"].values, decom_ultra["opcode"].values, strict=False)
     ):
         expected_arg = df.Arguments.values[i].strip()
         expected_len = len(expected_arg.split())

--- a/imap_processing/tests/ultra/unit/test_decom_apid_865.py
+++ b/imap_processing/tests/ultra/unit/test_decom_apid_865.py
@@ -30,7 +30,7 @@ def test_process_cmd_echo(decom_test_data, cmd_echo_test_path):
     np.testing.assert_array_equal(df.Opcode, decom_ultra["opcode"].values.flatten())
 
     for i, (row, opcode) in enumerate(
-        zip(decom_ultra["arguments"].values, decom_ultra["opcode"].values, strict=False)
+        zip(decom_ultra["arguments"].values, decom_ultra["opcode"].values)
     ):
         expected_arg = df.Arguments.values[i].strip()
         expected_len = len(expected_arg.split())

--- a/imap_processing/ultra/l0/ultra_utils.py
+++ b/imap_processing/ultra/l0/ultra_utils.py
@@ -1,6 +1,6 @@
 """Contains data classes to support Ultra L0 processing."""
 
-from typing import NamedTuple, Union
+from typing import NamedTuple
 
 
 class PacketProperties(NamedTuple):
@@ -9,23 +9,21 @@ class PacketProperties(NamedTuple):
     apid: list  # List of APIDs
     logical_source: list  # List of logical sources
     addition_to_logical_desc: str  # Description of the logical source
-    width: Union[int, None]  # Width of binary data (could be None).
+    width: int | None  # Width of binary data (could be None).
     # Block, image_planes, pixel_window_rows, and pixel_window_columns are important for
     # decompressing the images and a description is available on page 171 of IMAP-Ultra
     # Flight Software Specification document (7523-9009_Rev_-.pdf).
-    block: Union[int, None]  # Number of values in each block (could be None).
-    len_array: Union[
-        int, None
-    ]  # Length of the array to be decompressed (could be None).
-    mantissa_bit_length: Union[int, None]  # used to determine the level of
+    block: int | None  # Number of values in each block (could be None).
+    len_array: int | None  # Length of the array to be decompressed (could be None).
+    mantissa_bit_length: int | None  # used to determine the level of
     # precision that can be recovered from compressed data (could be None).
-    image_planes: Union[int, None] = None
+    image_planes: int | None = None
     # number of images. See table 11 in the FSSD.
-    pixel_window_rows: Union[int, None] = None
+    pixel_window_rows: int | None = None
     # number of rows in each image. See table 49 in the FSSD.
-    pixel_window_columns: Union[int, None] = None
+    pixel_window_columns: int | None = None
     # number of columns in each image. See table 49 in the FSSD.
-    image_planes_per_packet: Union[int, None] = None
+    image_planes_per_packet: int | None = None
     # number of image planes in each packet. See table 52 in the FSSD.
 
 

--- a/imap_processing/ultra/l0/ultra_utils.py
+++ b/imap_processing/ultra/l0/ultra_utils.py
@@ -1,6 +1,6 @@
 """Contains data classes to support Ultra L0 processing."""
 
-from typing import NamedTuple
+from typing import NamedTuple, Union
 
 
 class PacketProperties(NamedTuple):
@@ -9,21 +9,23 @@ class PacketProperties(NamedTuple):
     apid: list  # List of APIDs
     logical_source: list  # List of logical sources
     addition_to_logical_desc: str  # Description of the logical source
-    width: int | None  # Width of binary data (could be None).
+    width: Union[int, None]  # Width of binary data (could be None).
     # Block, image_planes, pixel_window_rows, and pixel_window_columns are important for
     # decompressing the images and a description is available on page 171 of IMAP-Ultra
     # Flight Software Specification document (7523-9009_Rev_-.pdf).
-    block: int | None  # Number of values in each block (could be None).
-    len_array: int | None  # Length of the array to be decompressed (could be None).
-    mantissa_bit_length: int | None  # used to determine the level of
+    block: Union[int, None]  # Number of values in each block (could be None).
+    len_array: Union[
+        int, None
+    ]  # Length of the array to be decompressed (could be None).
+    mantissa_bit_length: Union[int, None]  # used to determine the level of
     # precision that can be recovered from compressed data (could be None).
-    image_planes: int | None = None
+    image_planes: Union[int, None] = None
     # number of images. See table 11 in the FSSD.
-    pixel_window_rows: int | None = None
+    pixel_window_rows: Union[int, None] = None
     # number of rows in each image. See table 49 in the FSSD.
-    pixel_window_columns: int | None = None
+    pixel_window_columns: Union[int, None] = None
     # number of columns in each image. See table 49 in the FSSD.
-    image_planes_per_packet: int | None = None
+    image_planes_per_packet: Union[int, None] = None
     # number of image planes in each packet. See table 52 in the FSSD.
 
 

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -1,7 +1,6 @@
 """Generate ULTRA L1a CDFs."""
 
 import logging
-from typing import Optional
 
 import xarray as xr
 
@@ -44,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 def ultra_l1a(  # noqa: PLR0912
-    packet_file: str, apid_input: Optional[int] = None
+    packet_file: str, apid_input: int | None = None
 ) -> list[xr.Dataset]:
     """
     Will process ULTRA L0 data into L1A CDF files at output_filepath.

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -1,6 +1,7 @@
 """Generate ULTRA L1a CDFs."""
 
 import logging
+from typing import Optional
 
 import xarray as xr
 
@@ -43,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 
 def ultra_l1a(  # noqa: PLR0912
-    packet_file: str, apid_input: int | None = None
+    packet_file: str, apid_input: Optional[int] = None
 ) -> list[xr.Dataset]:
     """
     Will process ULTRA L0 data into L1A CDF files at output_filepath.

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -90,7 +90,10 @@ def calculate_de(
     ]
 
     de_dict.update(
-        {key: de_dataset[dataset_key] for key, dataset_key in zip(keys, dataset_keys)}
+        {
+            key: de_dataset[dataset_key]
+            for key, dataset_key in zip(keys, dataset_keys, strict=False)
+        }
     )
 
     valid_mask = de_dataset["start_type"].data != FILLVAL_UINT8

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -90,10 +90,7 @@ def calculate_de(
     ]
 
     de_dict.update(
-        {
-            key: de_dataset[dataset_key]
-            for key, dataset_key in zip(keys, dataset_keys, strict=False)
-        }
+        {key: de_dataset[dataset_key] for key, dataset_key in zip(keys, dataset_keys)}
     )
 
     valid_mask = de_dataset["start_type"].data != FILLVAL_UINT8

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -369,7 +369,7 @@ def get_spin_and_duration(met: NDArray, spin: NDArray) -> tuple[NDArray, NDArray
     possible_spins = spin_numbers & 0xFF
 
     # Assign each group based on time.
-    for start, end in zip(spin_start_indices, spin_end_indices):
+    for start, end in zip(spin_start_indices, spin_end_indices, strict=False):
         # Now that we have the possible spins from the Universal Spin Table,
         # we match the times of those spins to the nearest times in the DE data.
         possible_times = spin_start_mets[

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -369,7 +369,7 @@ def get_spin_and_duration(met: NDArray, spin: NDArray) -> tuple[NDArray, NDArray
     possible_spins = spin_numbers & 0xFF
 
     # Assign each group based on time.
-    for start, end in zip(spin_start_indices, spin_end_indices, strict=False):
+    for start, end in zip(spin_start_indices, spin_end_indices):
         # Now that we have the possible spins from the Universal Spin Table,
         # we match the times of those spins to the nearest times in the DE data.
         possible_times = spin_start_mets[

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -944,7 +944,7 @@ def get_spin_number(de_met: NDArray, de_spin: NDArray) -> NDArray:
     possible_spins = spin_numbers & 0xFF
 
     # Assign each group based on time.
-    for start, end in zip(spin_start_indices, spin_end_indices):
+    for start, end in zip(spin_start_indices, spin_end_indices, strict=False):
         # Now that we have the possible spins from the Universal Spin Table,
         # we match the times of those spins to the nearest times in the DE data.
         possible_times = spin_start_mets[possible_spins == de_spin_sorted[start]]

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -944,7 +944,7 @@ def get_spin_number(de_met: NDArray, de_spin: NDArray) -> NDArray:
     possible_spins = spin_numbers & 0xFF
 
     # Assign each group based on time.
-    for start, end in zip(spin_start_indices, spin_end_indices, strict=False):
+    for start, end in zip(spin_start_indices, spin_end_indices):
         # Now that we have the possible spins from the Universal Spin Table,
         # we match the times of those spins to the nearest times in the DE data.
         possible_times = spin_start_mets[possible_spins == de_spin_sorted[start]]

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -75,7 +75,7 @@ def get_energy_delta_minus_plus() -> tuple[NDArray, NDArray]:
     """
     bins, _, bin_geom_means = build_energy_bins()
     bins_energy_delta_plus, bins_energy_delta_minus = [], []
-    for bin_edges, bin_geom_mean in zip(bins, bin_geom_means):
+    for bin_edges, bin_geom_mean in zip(bins, bin_geom_means, strict=False):
         bins_energy_delta_plus.append(bin_edges[1] - bin_geom_mean)
         bins_energy_delta_minus.append(bin_geom_mean - bin_edges[0])
     return abs(np.array(bins_energy_delta_minus)), abs(np.array(bins_energy_delta_plus))
@@ -291,7 +291,7 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
     # Build a list of conditions for each sector mode time range
     conditions = [
         (rates_ds["epoch"] >= start) & (rates_ds["epoch"] < end)
-        for start, end in zip(mode_3_start, mode_3_end)
+        for start, end in zip(mode_3_start, mode_3_end, strict=False)
     ]
 
     sector_mode_mask = np.logical_or.reduce(conditions)

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -75,7 +75,7 @@ def get_energy_delta_minus_plus() -> tuple[NDArray, NDArray]:
     """
     bins, _, bin_geom_means = build_energy_bins()
     bins_energy_delta_plus, bins_energy_delta_minus = [], []
-    for bin_edges, bin_geom_mean in zip(bins, bin_geom_means, strict=False):
+    for bin_edges, bin_geom_mean in zip(bins, bin_geom_means):
         bins_energy_delta_plus.append(bin_edges[1] - bin_geom_mean)
         bins_energy_delta_minus.append(bin_geom_mean - bin_edges[0])
     return abs(np.array(bins_energy_delta_minus)), abs(np.array(bins_energy_delta_plus))
@@ -291,7 +291,7 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
     # Build a list of conditions for each sector mode time range
     conditions = [
         (rates_ds["epoch"] >= start) & (rates_ds["epoch"] < end)
-        for start, end in zip(mode_3_start, mode_3_end, strict=False)
+        for start, end in zip(mode_3_start, mode_3_end)
     ]
 
     sector_mode_mask = np.logical_or.reduce(conditions)

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -3,7 +3,6 @@
 import collections
 import logging
 from pathlib import Path
-from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -141,7 +140,7 @@ def _get_minimum_numpy_datatype(  # noqa: PLR0912 - Too many branches
     name: str,
     definition: definitions.XtcePacketDefinition,
     use_derived_value: bool = True,
-) -> Optional[str]:
+) -> str | None:
     """
     Get the minimum datatype for a given variable.
 
@@ -209,8 +208,8 @@ def _get_minimum_numpy_datatype(  # noqa: PLR0912 - Too many branches
 
 
 def packet_file_to_datasets(
-    packet_file: Union[str, Path],
-    xtce_packet_definition: Union[str, Path],
+    packet_file: str | Path,
+    xtce_packet_definition: str | Path,
     use_derived_value: bool = False,
 ) -> dict[int, xr.Dataset]:
     """

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -3,6 +3,7 @@
 import collections
 import logging
 from pathlib import Path
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -140,7 +141,7 @@ def _get_minimum_numpy_datatype(  # noqa: PLR0912 - Too many branches
     name: str,
     definition: definitions.XtcePacketDefinition,
     use_derived_value: bool = True,
-) -> str | None:
+) -> Optional[str]:
     """
     Get the minimum datatype for a given variable.
 
@@ -208,8 +209,8 @@ def _get_minimum_numpy_datatype(  # noqa: PLR0912 - Too many branches
 
 
 def packet_file_to_datasets(
-    packet_file: str | Path,
-    xtce_packet_definition: str | Path,
+    packet_file: Union[str, Path],
+    xtce_packet_definition: Union[str, Path],
     use_derived_value: bool = False,
 ) -> dict[int, xr.Dataset]:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ markers = [
 
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 lint.select = ["B", "D", "E", "F", "I", "N", "S", "W", "PL", "PT", "UP", "RUF"]
 lint.ignore = [
   "D104",  # Missing docstring in public package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ lint.ignore = [
   "RUF002",  # `−` (MINUS SIGN). Did you mean `-` (HYPHEN-MINUS) error
   "RUF200",  # pyproject missing field (poetry doesn't follow the spec)
   "S311",  # suspicious-non-cryptographic-random-usage
+  "UP038", # Deprecated
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tools/metadata_generation/metadata_generator.py
+++ b/tools/metadata_generation/metadata_generator.py
@@ -1,7 +1,6 @@
 """SWAPI metadata generator."""
 
 from pathlib import Path
-from typing import Optional, Union
 
 import pandas as pd
 import yaml
@@ -29,7 +28,7 @@ def get_global_attributes(sheet: pd.DataFrame) -> pd.DataFrame:
 
 
 def get_dataset_attributes(
-    sheet: pd.DataFrame, global_attrs: Optional[dict] = None
+    sheet: pd.DataFrame, global_attrs: dict | None = None
 ) -> dict:
     """
     Get the dataset attributes from a metadata spreadsheet.
@@ -67,7 +66,7 @@ def get_dataset_attributes(
 
 
 # Load all sheets
-def process_file(excel_path: Union[str, Path], output_folder: Path) -> None:
+def process_file(excel_path: str | Path, output_folder: Path) -> None:
     """
     Will process the metadata file and output the metadata to a JSON file.
 

--- a/tools/metadata_generation/metadata_generator.py
+++ b/tools/metadata_generation/metadata_generator.py
@@ -1,6 +1,7 @@
 """SWAPI metadata generator."""
 
 from pathlib import Path
+from typing import Optional, Union
 
 import pandas as pd
 import yaml
@@ -28,7 +29,7 @@ def get_global_attributes(sheet: pd.DataFrame) -> pd.DataFrame:
 
 
 def get_dataset_attributes(
-    sheet: pd.DataFrame, global_attrs: dict | None = None
+    sheet: pd.DataFrame, global_attrs: Optional[dict] = None
 ) -> dict:
     """
     Get the dataset attributes from a metadata spreadsheet.
@@ -66,7 +67,7 @@ def get_dataset_attributes(
 
 
 # Load all sheets
-def process_file(excel_path: str | Path, output_folder: Path) -> None:
+def process_file(excel_path: Union[str, Path], output_folder: Path) -> None:
     """
     Will process the metadata file and output the metadata to a JSON file.
 

--- a/tools/spice/spice_utils.py
+++ b/tools/spice/spice_utils.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-from typing import Optional
 
 import spiceypy
 
@@ -10,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def list_files_with_extensions(
-    directory: str, extensions: Optional[list[str]] = None
+    directory: str, extensions: list[str] | None = None
 ) -> list[str]:
     """
     List all files in a given directory that have the specified extensions.
@@ -44,7 +43,7 @@ def list_files_with_extensions(
     return matching_files
 
 
-def list_loaded_kernels(extensions: Optional[list[str]] = None) -> list:
+def list_loaded_kernels(extensions: list[str] | None = None) -> list:
     """
     List furnished spice kernels, optionally filtered by specific extensions.
 

--- a/tools/spice/spice_utils.py
+++ b/tools/spice/spice_utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from typing import Optional
 
 import spiceypy
 
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def list_files_with_extensions(
-    directory: str, extensions: list[str] | None = None
+    directory: str, extensions: Optional[list[str]] = None
 ) -> list[str]:
     """
     List all files in a given directory that have the specified extensions.
@@ -43,7 +44,7 @@ def list_files_with_extensions(
     return matching_files
 
 
-def list_loaded_kernels(extensions: list[str] | None = None) -> list:
+def list_loaded_kernels(extensions: Optional[list[str]] = None) -> list:
     """
     List furnished spice kernels, optionally filtered by specific extensions.
 


### PR DESCRIPTION
# Change Summary
Clean-up work to update ruff for Python 3.10 since we dropped 3.9 support. These updates did change a lot of files but they were entirely done by ruff's automatic formatter, so only the pyproject.toml and .pre-commit-config.yaml files need review. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
- Update ruff pre-commit checker version
- Update ruff standards to 3.10

I hit this issue in a MAG Pr but since it touches a lot of files I wanted to open a new PR. I would appreciate a quick review. 