### PR TITLE
Add scattering calibration data LUT

### DIFF
--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -100,6 +100,7 @@ EXTERNAL_TEST_DATA = [
     ("imap_ultra_l1b-45sensor-spbtphcorr_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b-90sensor-sptpphcorr_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b-90sensor-spbtphcorr_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1b-90sensor-scattering-calibration-data_20250101_v000.csv", "ultra/data/l1/"),
     ("ultra45_raw_sc_ultrarawimg_withFSWccs_FM45_40P_Phi28p5_BeamCal_LinearScan_"
      "phi2850_theta-000_20240207T102740_revised20250724.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b-45sensor-tofxeflat_20250101_v000.pgm", "ultra/data/l1/"),

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -526,8 +526,8 @@ def ancillary_files():
         "l1b-90sensor-tofxesteep": path
         / "imap_ultra_l1b-90sensor-tofxesteep_20250101_v000.pgm",
         "l1b-tofxph": path / "imap_ultra_l1b-tofxph_20250101_v000.pgm",
-        "l1b-90sensor-scattering-calibration": "/Users/luco3133/Downloads/"
-        "fm90_scattering_power_law_data.csv",
+        "l1b-90sensor-scattering-calibration": path
+        / "imap_ultra_l1b-90sensor-scattering-calibration-data_20250101_v000.csv",
     }
 
 

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -526,6 +526,8 @@ def ancillary_files():
         "l1b-90sensor-tofxesteep": path
         / "imap_ultra_l1b-90sensor-tofxesteep_20250101_v000.pgm",
         "l1b-tofxph": path / "imap_ultra_l1b-tofxph_20250101_v000.pgm",
+        "l1b-90sensor-scattering-calibration": "/Users/luco3133/Downloads/"
+        "fm90_scattering_power_law_data.csv",
     }
 
 

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -16,6 +16,7 @@ from imap_processing.ultra.l1b.lookup_utils import (
     get_image_params,
     get_norm,
     get_ph_corrected,
+    get_scattering_calibration_data,
     get_y_adjust,
 )
 
@@ -166,3 +167,17 @@ def test_get_ebins(ancillary_files):
     ebins = get_ebins("l1b-tofxph", energy, ctof, ebins, ancillary_files)
 
     np.testing.assert_array_equal(ebins, np.array([15, 19]))
+
+
+@pytest.mark.external_test_data
+def test_get_scattering_data(ancillary_files):
+    """Tests function get_scattering_data."""
+
+    (a_theta_val, g_theta_val, a_phi_val, g_phi_val) = get_scattering_calibration_data(
+        ancillary_files,
+        "l1b-90sensor-scattering-calibration",
+        np.array([47, 43]),
+        np.array([43, 42]),
+    )
+    np.testing.assert_array_equal(a_theta_val, np.array([np.nan, 35.23100]))
+    np.testing.assert_array_equal(g_theta_val, np.array([np.nan, -0.72148]))

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -16,8 +16,9 @@ from imap_processing.ultra.l1b.lookup_utils import (
     get_image_params,
     get_norm,
     get_ph_corrected,
-    get_scattering_calibration_data,
+    get_scattering_coefficients,
     get_y_adjust,
+    pixels_below_fwhm_scattering_threshold,
 )
 
 BASE_PATH = imap_module_directory / "ultra" / "lookup_tables"
@@ -170,14 +171,48 @@ def test_get_ebins(ancillary_files):
 
 
 @pytest.mark.external_test_data
-def test_get_scattering_data(ancillary_files):
+def test_get_scattering_coefficients(ancillary_files):
     """Tests function get_scattering_data."""
 
-    (a_theta_val, g_theta_val, a_phi_val, g_phi_val) = get_scattering_calibration_data(
+    theta_coeffs, phi_coeffs = get_scattering_coefficients(
         ancillary_files,
-        "l1b-90sensor-scattering-calibration",
+        90,
         np.array([47, 43]),
         np.array([43, 42]),
     )
-    np.testing.assert_array_equal(a_theta_val, np.array([np.nan, 35.23100]))
-    np.testing.assert_array_equal(g_theta_val, np.array([np.nan, -0.72148]))
+    # Test a theta coefficients
+    np.testing.assert_array_equal(theta_coeffs[:, 0], np.array([np.nan, 35.23100]))
+    # Test b theta coefficients
+    np.testing.assert_array_equal(theta_coeffs[:, 1], np.array([np.nan, -0.72148]))
+    # Test a phi coefficients
+    np.testing.assert_array_equal(phi_coeffs[:, 0], np.array([np.nan, 168.3100]))
+    # Test b phi coefficients
+    np.testing.assert_array_equal(phi_coeffs[:, 1], np.array([np.nan, -1.0752]))
+
+
+@pytest.mark.external_test_data
+def test_get_pixels_below_fwhm_scattering_threshold(ancillary_files):
+    """Tests function get_pixels_below_fwhm_scattering_threshold."""
+    energy = 5  # At energy 5, the FWHM threshold is 10
+    theta_coeffs = np.array(
+        [
+            [np.nan, 10],  # This will result in a NaN value (False)
+            [5, -0.1],  # FWHM value below the threshold (True)
+            [4, -0.1],
+        ]
+    )  # FWHM value below the threshold (True)
+    phi_coeffs = np.array(
+        [
+            [3, -0.1],  # FWHM value below the threshold (True)
+            [5, -0.1],  # FWHM value below the threshold (True)
+            [15, -0.1],
+        ]
+    )  # FWHM value above the threshold (False)
+    # Only pixels where both the theta and phi coefficients are below the FWHM
+    # threshold should be True.
+    expected_pixel_mask = np.array([False, True, False])
+    pixel_mask = pixels_below_fwhm_scattering_threshold(
+        theta_coeffs, phi_coeffs, energy
+    )
+    assert pixel_mask.shape == (3,)
+    np.testing.assert_array_equal(pixel_mask, expected_pixel_mask)

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -198,16 +198,16 @@ def test_get_pixels_below_fwhm_scattering_threshold(ancillary_files):
         [
             [np.nan, 10],  # This will result in a NaN value (False)
             [5, -0.1],  # FWHM value below the threshold (True)
-            [4, -0.1],
+            [4, -0.1],  # FWHM value below the threshold (True)
         ]
-    )  # FWHM value below the threshold (True)
+    )
     phi_coeffs = np.array(
         [
             [3, -0.1],  # FWHM value below the threshold (True)
             [5, -0.1],  # FWHM value below the threshold (True)
-            [15, -0.1],
+            [15, -0.1],  # FWHM value above the threshold (False)
         ]
-    )  # FWHM value above the threshold (False)
+    )
     # Only pixels where both the theta and phi coefficients are below the FWHM
     # threshold should be True.
     expected_pixel_mask = np.array([False, True, False])

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -18,7 +18,7 @@ from imap_processing.ultra.l1b.lookup_utils import (
     get_ph_corrected,
     get_scattering_coefficients,
     get_y_adjust,
-    pixels_below_fwhm_scattering_threshold,
+    mask_below_fwhm_scattering_threshold,
 )
 
 BASE_PATH = imap_module_directory / "ultra" / "lookup_tables"
@@ -176,7 +176,7 @@ def test_get_scattering_coefficients(ancillary_files):
 
     theta_coeffs, phi_coeffs = get_scattering_coefficients(
         ancillary_files,
-        90,
+        45,
         np.array([47, 43]),
         np.array([43, 42]),
     )
@@ -191,8 +191,8 @@ def test_get_scattering_coefficients(ancillary_files):
 
 
 @pytest.mark.external_test_data
-def test_get_pixels_below_fwhm_scattering_threshold(ancillary_files):
-    """Tests function get_pixels_below_fwhm_scattering_threshold."""
+def test_get_mask_below_fwhm_scattering_threshold(ancillary_files):
+    """Tests function get_mask_below_fwhm_scattering_threshold."""
     energy = 5  # At energy 5, the FWHM threshold is 10
     theta_coeffs = np.array(
         [
@@ -208,11 +208,9 @@ def test_get_pixels_below_fwhm_scattering_threshold(ancillary_files):
             [15, -0.1],  # FWHM value above the threshold (False)
         ]
     )
-    # Only pixels where both the theta and phi coefficients are below the FWHM
+    # Only indices where both the theta and phi coefficients are below the FWHM
     # threshold should be True.
     expected_pixel_mask = np.array([False, True, False])
-    pixel_mask = pixels_below_fwhm_scattering_threshold(
-        theta_coeffs, phi_coeffs, energy
-    )
-    assert pixel_mask.shape == (3,)
+    pixel_mask = mask_below_fwhm_scattering_threshold(theta_coeffs, phi_coeffs, energy)
+    np.testing.assert_array_equal(pixel_mask.shape, (3,))
     np.testing.assert_array_equal(pixel_mask, expected_pixel_mask)

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -22,6 +22,7 @@ from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 
+@pytest.mark.external_test_data
 @pytest.mark.external_kernel
 def test_calculate_spacecraft_pset(deadtime_datasets, imap_ena_sim_metakernel):
     """Tests calculate_spacecraft_pset function."""

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -64,31 +64,6 @@ def test_calculate_spacecraft_pset(deadtime_datasets, imap_ena_sim_metakernel):
             "component": ("component", ["vx", "vy", "vz"]),
         },
     )
-    # Simulate a test rates dataset.
-    epoch = 200
-    test_l1a_rates_dataset = xr.Dataset(
-        {
-            "fifo_valid_events": (["epoch"], np.random.randint(100, 200, epoch)),
-            "event_active_time": (["epoch"], np.random.uniform(0, 10, epoch)),
-            "start_pos": (["epoch"], np.random.randint(0, 5, epoch)),
-            "start_rf": (["epoch"], np.random.randint(0, 5, epoch)),
-            "start_lf": (["epoch"], np.random.randint(0, 5, epoch)),
-            "coin_tn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "coin_bn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "stop_tn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
-        }
-    )
-    # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).
-    # each time the mode changes, it is recorded in the params packet.
-    # Create a test params dataset that simulates the mode changing to 3, 3 times.
-    modes = np.tile(np.arange(4), 3)
-    test_l1a_params_dataset = xr.Dataset(
-        {
-            "imageratescadence": (["epoch"], modes),
-        },
-        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
-    )
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary = {

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -63,6 +63,31 @@ def test_calculate_spacecraft_pset(deadtime_datasets, imap_ena_sim_metakernel):
             "component": ("component", ["vx", "vy", "vz"]),
         },
     )
+    # Simulate a test rates dataset.
+    epoch = 200
+    test_l1a_rates_dataset = xr.Dataset(
+        {
+            "fifo_valid_events": (["epoch"], np.random.randint(100, 200, epoch)),
+            "event_active_time": (["epoch"], np.random.uniform(0, 10, epoch)),
+            "start_pos": (["epoch"], np.random.randint(0, 5, epoch)),
+            "start_rf": (["epoch"], np.random.randint(0, 5, epoch)),
+            "start_lf": (["epoch"], np.random.randint(0, 5, epoch)),
+            "coin_tn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "coin_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "stop_tn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+        }
+    )
+    # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).
+    # each time the mode changes, it is recorded in the params packet.
+    # Create a test params dataset that simulates the mode changing to 3, 3 times.
+    modes = np.tile(np.arange(4), 3)
+    test_l1a_params_dataset = xr.Dataset(
+        {
+            "imageratescadence": (["epoch"], modes),
+        },
+        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
+    )
 
     path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
     ancillary = {

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -167,6 +167,16 @@ def test_get_sectored_rates():
         sectored_rates["test_data"].data,
         np.hstack([np.arange(10, 20), np.arange(30, 40), np.arange(50, 60)]),
     )
+    # Test with one mode shift in the middle of the dataset.
+    modes = np.array([1, 3, 1])
+    test_l1a_params_dataset = xr.Dataset(
+        {
+            "imageratescadence": (["epoch"], modes),
+        },
+        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
+    )
+    sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
+    np.testing.assert_array_equal(sectored_rates["test_data"].data, np.arange(20, 40))
 
     # Test with one mode shift in the middle of the dataset.
     modes = np.array([1, 3, 1])

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import ClassVar
 
+import numpy as np
+
 
 @dataclass(frozen=True)
 class UltraConstants:
@@ -51,7 +53,6 @@ class UltraConstants:
     Z_DSTOP: float = 2.6 / 2  # Position of stop foil on Z axis [mm]
     Z_DS: float = 46.19 - (2.6 / 2)  # Position of slit on Z axis [mm]
     DF: float = 3.39  # Distance from slit to foil [mm]
-
     # Derived constants
     DMIN_PH_CTOF: float = (
         Z_DS - (2**0.5) * DF
@@ -129,3 +130,11 @@ class UltraConstants:
         341.989454569026,
         1e5,
     ]
+
+    ULTRA_FWHM_SCATTERING_CULLING_THRESHOLDS: ClassVar[dict] = {
+        (1, 5): 12,
+        (5, 8): 10,
+        (8, 10): 8,
+        (10, 20): 6,
+        (20, np.inf): 4,
+    }

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -130,7 +130,9 @@ class UltraConstants:
         341.989454569026,
         1e5,
     ]
-
+    # Culling FWHM Scattering values as a function of energy.
+    # The tuple represents the energy range (min, max) in keV, and the value is the
+    # FWHM scattering threshold in degrees.
     ULTRA_FWHM_SCATTERING_CULLING_THRESHOLDS: ClassVar[dict] = {
         (1, 5): 12,
         (5, 8): 10,

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -313,24 +313,27 @@ def get_scattering_coefficients(
     tuple
         Scattering a and g values corresponding to the given theta and phi values.
     """
-    filename = f"l1b-{instrument_id}sensor-scattering-calibration"
+    # TODO remove the line below when the 45 sensor scattering coefficients are
+    #   delivered.
+    instrument_id = 90
+    descriptor = f"l1b-{instrument_id}sensor-scattering-calibration"
     theta_grid = pd.read_csv(
-        ancillary_files[filename], header=None, skiprows=7, nrows=241
+        ancillary_files[descriptor], header=None, skiprows=7, nrows=241
     ).to_numpy(dtype=float)
     phi_grid = pd.read_csv(
-        ancillary_files[filename], header=None, skiprows=249, nrows=241
+        ancillary_files[descriptor], header=None, skiprows=249, nrows=241
     ).to_numpy(dtype=float)
     a_theta = pd.read_csv(
-        ancillary_files[filename], header=None, skiprows=491, nrows=241
+        ancillary_files[descriptor], header=None, skiprows=491, nrows=241
     ).to_numpy(dtype=float)
     g_theta = pd.read_csv(
-        ancillary_files[filename], header=None, skiprows=733, nrows=241
+        ancillary_files[descriptor], header=None, skiprows=733, nrows=241
     ).to_numpy(dtype=float)
     a_phi = pd.read_csv(
-        ancillary_files[filename], header=None, skiprows=975, nrows=241
+        ancillary_files[descriptor], header=None, skiprows=975, nrows=241
     ).to_numpy(dtype=float)
     g_phi = pd.read_csv(
-        ancillary_files[filename], header=None, skiprows=1217, nrows=241
+        ancillary_files[descriptor], header=None, skiprows=1217, nrows=241
     ).to_numpy(dtype=float)
 
     # Assume uniform grids: extract 1D arrays from first row/col
@@ -352,13 +355,13 @@ def get_scattering_coefficients(
     )
 
 
-def pixels_below_fwhm_scattering_threshold(
+def mask_below_fwhm_scattering_threshold(
     theta_coeffs: np.ndarray,
     phi_coeffs: np.ndarray,
     energy: int,
 ) -> np.ndarray:
     """
-    Determine pixels below the FWHM scattering threshold.
+    Determine indices of theta and phi values below the FWHM scattering threshold.
 
     For each phi and theta, calculate the FWHM using the formula:
     FWHM = A*E^g
@@ -377,7 +380,7 @@ def pixels_below_fwhm_scattering_threshold(
     Returns
     -------
     numpy.ndarray
-        Boolean array indicating pixels below the scattering threshold.
+        Boolean array indicating incides below the scattering threshold.
     """
     scattering_thresholds = UltraConstants.ULTRA_FWHM_SCATTERING_CULLING_THRESHOLDS
     # Calculate FWHM for theta and phi
@@ -398,8 +401,10 @@ def is_inside_fov(phi: np.ndarray, theta: np.ndarray) -> np.ndarray:
     """
     Determine angles in the field of view (FOV).
 
-    More information can be found by looking at equation 19 in the Ultra Algorithm
-    Document.
+    This function is used in the deadtime correction to determine whether a given
+    (theta, phi) angle is within the instrument's Field of View (FOV).
+    Only pixels inside the FOV are considered for time accumulation. The FOV boundary
+    is defined by equation 19 in the Ultra Algorithm Document.
 
     Parameters
     ----------

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -281,17 +281,142 @@ def get_geometric_factor(
     # Fetch geometric factor values at nearest (phi, theta) pairs
     geometric_factor = gf_table[phi_idx, theta_idx]
 
-    phi_rad = np.deg2rad(phi)
-    numerator = 5.0 * np.cos(phi_rad)
-    denominator = 1 + 2.80 * np.cos(phi_rad)
-    # Equation 19 in the Ultra Algorithm Document.
-    theta_nom = np.arctan(numerator / denominator)
-    theta_nom = np.rad2deg(theta_nom)
-
-    outside_fov = np.abs(theta) > theta_nom
+    outside_fov = ~is_inside_fov(np.deg2rad(phi), np.deg2rad(theta))
     quality_flag[outside_fov] |= ImapDEUltraFlags.FOV.value
 
     return geometric_factor
+
+
+def get_scattering_coefficients(
+    ancillary_files: dict,
+    instrument_id: int,
+    theta: NDArray,
+    phi: NDArray,
+) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+    """
+    Get a and g coefficients for theta and phi to compute scattering FWHM.
+
+    Parameters
+    ----------
+    ancillary_files : dict[Path]
+        Ancillary files.
+    instrument_id : str
+        Instrument ID, either 45 or 90.
+    theta : NDArray
+        Elevation angles in degrees.
+    phi : NDArray
+        Azimuth angles in degrees.
+
+    Returns
+    -------
+    tuple
+        Scattering a and g values corresponding to the given theta and phi values.
+    """
+    filename = f"l1b-{instrument_id}sensor-scattering-calibration"
+    theta_grid = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=7, nrows=241
+    ).to_numpy(dtype=float)
+    phi_grid = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=249, nrows=241
+    ).to_numpy(dtype=float)
+    a_theta = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=491, nrows=241
+    ).to_numpy(dtype=float)
+    g_theta = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=733, nrows=241
+    ).to_numpy(dtype=float)
+    a_phi = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=975, nrows=241
+    ).to_numpy(dtype=float)
+    g_phi = pd.read_csv(
+        ancillary_files[filename], header=None, skiprows=1217, nrows=241
+    ).to_numpy(dtype=float)
+
+    # Assume uniform grids: extract 1D arrays from first row/col
+    theta_vals = theta_grid[0, :]  # columns represent theta
+    phi_vals = phi_grid[:, 0]  # rows represent phi
+
+    # Find nearest index in table for each input value
+    phi_idx = np.abs(phi_vals[:, None] - phi).argmin(axis=0)
+    theta_idx = np.abs(theta_vals[:, None] - theta).argmin(axis=0)
+
+    # Fetch a and g values at nearest (phi, theta) pairs
+    a_theta_val = a_theta[phi_idx, theta_idx]
+    g_theta_val = g_theta[phi_idx, theta_idx]
+    a_phi_val = a_phi[phi_idx, theta_idx]
+    g_phi_val = g_phi[phi_idx, theta_idx]
+
+    return a_theta_val, g_theta_val, a_phi_val, g_phi_val
+
+
+def pixels_below_fwhm_scattering_threshold(
+    theta: np.ndarray,
+    phi: np.ndarray,
+    energy: int,
+    ancillary_files: dict,
+    instrument_id: int,
+) -> np.ndarray:
+    """
+    Determine pixels below the FWHM scattering threshold.
+
+    For each phi and theta, calculate the FWHM using the formula:
+    FWHM = A*E^g
+    If Phi FWHM or Theta FWHM > the scattering requirements from the table above,
+    mask the instrument frame pixel.
+
+    Parameters
+    ----------
+    theta : NDArray
+        Elevation angles in degrees.
+    phi : NDArray
+        Azimuth angles in degrees.
+    energy : NDArray
+        Energy in keV.
+    ancillary_files : dict[Path]
+        Ancillary files containing the lookup tables.
+    instrument_id : int
+        Instrument ID, either 45 or 90.
+
+    Returns
+    -------
+    numpy.ndarray
+        Boolean array indicating pixels below the scattering threshold.
+    """
+    # Get scattering coefficients
+    a_theta_val, g_theta_val, a_phi_val, g_phi_val = get_scattering_coefficients(
+        ancillary_files, instrument_id, theta, phi
+    )
+    # Calculate FWHM for theta and phi
+    fwhm_theta = a_theta_val * energy**g_theta_val
+    fwhm_phi = a_phi_val * energy**g_phi_val
+    pixels_below_scattering_threshold = np.array(fwhm_theta) + np.ndarray(fwhm_phi)
+    return pixels_below_scattering_threshold
+
+
+def is_inside_fov(phi: np.ndarray, theta: np.ndarray) -> np.ndarray:
+    """
+    Determine angles in the field of view (FOV).
+
+    More information can be found by looking at equation 19 in the Ultra Algorithm
+    Document.
+
+    Parameters
+    ----------
+    phi : np.ndarray
+        Azimuth angles in radians.
+    theta : np.ndarray
+        Elevation angles in radians.
+
+    Returns
+    -------
+    numpy.ndarray
+        Boolean array indicating if the angle is in the FOV, False otherwise.
+    """
+    numerator = 5.0 * np.cos(phi)
+    denominator = 1 + 2.80 * np.cos(phi)
+    # Equation 19 in the Ultra Algorithm Document.
+    theta_nom = np.arctan(numerator / denominator)
+    return np.abs(theta) <= theta_nom
 
 
 def get_ph_corrected(

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -293,7 +293,7 @@ def get_scattering_coefficients(
     instrument_id: int,
     theta: NDArray,
     phi: NDArray,
-) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+) -> tuple[NDArray, NDArray]:
     """
     Get a and g coefficients for theta and phi to compute scattering FWHM.
 
@@ -301,7 +301,7 @@ def get_scattering_coefficients(
     ----------
     ancillary_files : dict[Path]
         Ancillary files.
-    instrument_id : str
+    instrument_id : int
         Instrument ID, either 45 or 90.
     theta : NDArray
         Elevation angles in degrees.
@@ -347,15 +347,15 @@ def get_scattering_coefficients(
     a_phi_val = a_phi[phi_idx, theta_idx]
     g_phi_val = g_phi[phi_idx, theta_idx]
 
-    return a_theta_val, g_theta_val, a_phi_val, g_phi_val
+    return np.column_stack([a_theta_val, g_theta_val]), np.column_stack(
+        [a_phi_val, g_phi_val]
+    )
 
 
 def pixels_below_fwhm_scattering_threshold(
-    theta: np.ndarray,
-    phi: np.ndarray,
+    theta_coeffs: np.ndarray,
+    phi_coeffs: np.ndarray,
     energy: int,
-    ancillary_files: dict,
-    instrument_id: int,
 ) -> np.ndarray:
     """
     Determine pixels below the FWHM scattering threshold.
@@ -367,16 +367,12 @@ def pixels_below_fwhm_scattering_threshold(
 
     Parameters
     ----------
-    theta : NDArray
-        Elevation angles in degrees.
-    phi : NDArray
-        Azimuth angles in degrees.
-    energy : NDArray
+    theta_coeffs : NDArray
+        Coefficients for theta FWHM calculation (a and g) for each pixel.
+    phi_coeffs : NDArray
+        Coefficients for phi FWHM calculation (a and g) for each pixel.
+    energy : int
         Energy in keV.
-    ancillary_files : dict[Path]
-        Ancillary files containing the lookup tables.
-    instrument_id : int
-        Instrument ID, either 45 or 90.
 
     Returns
     -------
@@ -384,18 +380,15 @@ def pixels_below_fwhm_scattering_threshold(
         Boolean array indicating pixels below the scattering threshold.
     """
     scattering_thresholds = UltraConstants.ULTRA_FWHM_SCATTERING_CULLING_THRESHOLDS
-    # Get scattering coefficients
-    a_theta_val, g_theta_val, a_phi_val, g_phi_val = get_scattering_coefficients(
-        ancillary_files, instrument_id, theta, phi
-    )
     # Calculate FWHM for theta and phi
-    fwhm_theta = a_theta_val * energy**g_theta_val
-    fwhm_phi = a_phi_val * energy**g_phi_val
+    fwhm_theta = theta_coeffs[:, 0] * energy ** theta_coeffs[:, 1]
+    fwhm_phi = phi_coeffs[:, 0] * energy ** phi_coeffs[:, 1]
 
+    # Get the scattering threshold based on the energy
     threshold = next(
         threshold
         for energy_range, threshold in scattering_thresholds.items()
-        if energy_range[0] <= energy <= energy_range[1]
+        if energy_range[0] <= energy < energy_range[1]
     )
     # Combine conditions for both theta and phi
     return np.logical_and(fwhm_theta <= threshold, fwhm_phi <= threshold)

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -7,6 +7,7 @@ import xarray as xr
 from numpy.typing import NDArray
 
 from imap_processing.quality_flags import ImapDEUltraFlags
+from imap_processing.ultra.constants import UltraConstants
 
 
 def get_y_adjust(dy_lut: np.ndarray, ancillary_files: dict) -> npt.NDArray:
@@ -382,6 +383,7 @@ def pixels_below_fwhm_scattering_threshold(
     numpy.ndarray
         Boolean array indicating pixels below the scattering threshold.
     """
+    scattering_thresholds = UltraConstants.ULTRA_FWHM_SCATTERING_CULLING_THRESHOLDS
     # Get scattering coefficients
     a_theta_val, g_theta_val, a_phi_val, g_phi_val = get_scattering_coefficients(
         ancillary_files, instrument_id, theta, phi
@@ -389,8 +391,14 @@ def pixels_below_fwhm_scattering_threshold(
     # Calculate FWHM for theta and phi
     fwhm_theta = a_theta_val * energy**g_theta_val
     fwhm_phi = a_phi_val * energy**g_phi_val
-    pixels_below_scattering_threshold = np.array(fwhm_theta) + np.ndarray(fwhm_phi)
-    return pixels_below_scattering_threshold
+
+    threshold = next(
+        threshold
+        for energy_range, threshold in scattering_thresholds.items()
+        if energy_range[0] <= energy <= energy_range[1]
+    )
+    # Combine conditions for both theta and phi
+    return np.logical_and(fwhm_theta <= threshold, fwhm_phi <= threshold)
 
 
 def is_inside_fov(phi: np.ndarray, theta: np.ndarray) -> np.ndarray:

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -380,18 +380,16 @@ def get_spacecraft_exposure_times(
         Healpix tessellation of the sky
         in the pointing (dps) frame.
     """
-    # TODO: uncomment these lines when the deadtime correction is implemented
-    # sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
-    # get_deadtime_correction_factors(sectored_rates)
-    # TODO: calculate the deadtime correction function
-    # TODO: Apply the deadtime correction to the exposure times
     # TODO: use the universal spin table and
     #  universal pointing table here to determine actual number of spins
     exposure_pointing = (
         constant_exposure["Exposure Time"] * 5760
     )  # 5760 spins per pointing (for now)
 
-    return exposure_pointing
+    exposure_pointing_adjusted = apply_deadtime_correction(
+        exposure_pointing, rates_dataset, params_dataset
+    )
+    return exposure_pointing_adjusted
 
 
 def get_helio_exposure_times(

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -386,10 +386,11 @@ def get_spacecraft_exposure_times(
         constant_exposure["Exposure Time"] * 5760
     )  # 5760 spins per pointing (for now)
 
-    exposure_pointing_adjusted = apply_deadtime_correction(
-        exposure_pointing, rates_dataset, params_dataset
-    )
-    return exposure_pointing_adjusted
+    # TODO uncomment the line below when implemented
+    # exposure_pointing_adjusted = apply_deadtime_correction(
+    #     exposure_pointing, rates_dataset, params_dataset
+    # )
+    return exposure_pointing
 
 
 def get_helio_exposure_times(


### PR DESCRIPTION
# Change Summary

## Overview
Add the scattering calibration LUT containing phi and theta values in the instrument frame and their corresponding coefficients for the FWHM scattering equation. Add relevant functions to extract the data from the csv and calculate which pixels are below the scattering threshold. 


These functions are needed for the l1b scattering culling and the l1c deadtime correction. For more info see: [ultra_scattering_algo_update.pptx](https://github.com/user-attachments/files/21800812/ultra_scattering_algo_update.pptx)

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## Updated Files
- imap_processing/ultra/l1b/lookup_utils.py
   - Add function to extract the relevant data from the LUT and find the a and g coefficient values corresponding to the nearest phi and theta values given. 
   - Add function to determine, whether the pixel's scattering value is below the corresponding threshold. 

## Testing
Add tests relating to the FWHM scattering LUT and threshold culling. 
