### PR TITLE
Update default validmin/validmax attrs for epoch

### DIFF
--- a/imap_processing/cdf/config/imap_constant_attrs.yaml
+++ b/imap_processing/cdf/config/imap_constant_attrs.yaml
@@ -9,7 +9,7 @@ epoch:
   LABLAXIS: epoch
   FILLVAL: -9223372036854775808
   FORMAT: " " # Supposedly not required, fails in xarray_to_cdf
-  VALIDMIN: 315576066184000000   # 2010-01-01T00:00:00 mission start (APL 0 epoch)
+  VALIDMIN: 811857669184000000   # 2025-09-23T00:00:00 mission launch
   VALIDMAX: 3155716869184000000  # 2100-01-01T00:00:00 mission end
   UNITS: ns
   VAR_TYPE: support_data
@@ -20,6 +20,7 @@ epoch:
   REFERENCE_POSITION: Rotating Earth Geoid
   RESOLUTION: ' '
   DICT_KEY: "SPASE>Support>SupportQantity:Temporal"
+
 
 # <=== Data Variables ===>
 # Default Attrs for all metadata variables unless overridden

--- a/imap_processing/cdf/config/imap_constant_attrs.yaml
+++ b/imap_processing/cdf/config/imap_constant_attrs.yaml
@@ -9,7 +9,7 @@ epoch:
   LABLAXIS: epoch
   FILLVAL: -9223372036854775808
   FORMAT: " " # Supposedly not required, fails in xarray_to_cdf
-  VALIDMIN: 811857669184000000   # 2025-09-23T00:00:00 mission launch
+  VALIDMIN: 315576066184000000   # 2010-01-01T00:00:00 mission start (APL 0 epoch)
   VALIDMAX: 3155716869184000000  # 2100-01-01T00:00:00 mission end
   UNITS: ns
   VAR_TYPE: support_data

--- a/imap_processing/cdf/config/imap_constant_attrs.yaml
+++ b/imap_processing/cdf/config/imap_constant_attrs.yaml
@@ -2,14 +2,15 @@
 # center of accumulation/measurement period. But if, for some good reason,
 # time corresponds to the beginning or end or any other part of
 # accumulation/measurement period, that has to be stated in CATDESC.
+
 epoch:
   CATDESC: Time, number of nanoseconds since J2000 with leap seconds included
   FIELDNAM: epoch
   LABLAXIS: epoch
   FILLVAL: -9223372036854775808
   FORMAT: " " # Supposedly not required, fails in xarray_to_cdf
-  VALIDMIN: -9223372036854775808
-  VALIDMAX: 9223372036854775807
+  VALIDMIN: 315576066184000000   # 2010-01-01T00:00:00 mission start (APL 0 epoch)
+  VALIDMAX: 3155716869184000000  # 2100-01-01T00:00:00 mission end
   UNITS: ns
   VAR_TYPE: support_data
   SCALETYP: linear


### PR DESCRIPTION
This PR updates the default VALIDMIN and VALIDMAX attribute values for EPOCH to represent the lifetime of the mission (per ISTP requirements) instead of the min and max of the int64 datatype. 

The j2000ns values used correspond to 2010-01-01 to 2100-01-01.

Closes #1934 