### PR TITLE
Lo L1C - Pointing Set pointing times and spin numbers

### DIFF
--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -10,7 +10,10 @@ from scipy.stats import binned_statistic_dd
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.spice.time import met_to_ttj2000ns
-
+from imap_processing.spice.spin import (
+    get_spin_data,
+)
+from imap_processing.spice.repoint import get_repoint_data
 
 class FilterType(str, Enum):
     """
@@ -56,6 +59,7 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         l1b_goodtimes_only = filter_goodtimes(l1b_de, anc_dependencies)
         pset = initialize_pset(l1b_goodtimes_only, attr_mgr, logical_source)
         full_counts = create_pset_counts(l1b_goodtimes_only)
+        start_spin_number, end_spin_number = get_spin_numbers(l1b_goodtimes_only)
         pset["triples_counts"] = create_pset_counts(
             l1b_goodtimes_only, FilterType.TRIPLES
         )
@@ -254,6 +258,27 @@ def create_pset_counts(
 
     return counts
 
+def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
+    """
+    Get the start and end spin numbers from the L1B Direct Event dataset.
+
+    The spin numbers are used to identify the start and end of the
+    pointing periods in the dataset.
+
+    Parameters
+    ----------
+    l1b_de : xarray.Dataset
+        L1B Direct Event dataset.
+
+    Returns
+    -------
+    tuple[int, int]
+        The start and end spin numbers.
+    """
+    repoint_df = get_repoint_data()
+    print(repoint_df.info())
+
+    #return start_spin_number, end_spin_number
 
 def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:
     """

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -279,9 +279,12 @@ def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
     spin_df = get_spin_data()
 
     # Convert repoint and spin MET to TTJ2000NS
-    repoint_df["repoint_end_ttj2000ns"] = met_to_ttj2000ns(repoint_df["repoint_end_met"])
+    repoint_df["repoint_end_ttj2000ns"] = met_to_ttj2000ns(
+        repoint_df["repoint_end_met"]
+    )
     repoint_df["repoint_start_ttj2000ns"] = met_to_ttj2000ns(
-        repoint_df["repoint_start_met"])
+        repoint_df["repoint_start_met"]
+    )
     spin_df["spin_start_ttj2000ns"] = met_to_ttj2000ns(spin_df["spin_start_met"])
 
     first_epoch = l1b_de["epoch"][0].item()
@@ -292,37 +295,75 @@ def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
     pointing_start_spin_idx = find_spin_idx(spin_df, pointing_start)
     pointing_end_spin_idx = find_spin_idx(spin_df, pointing_end, start=False)
 
-    start_spin_number = spin_df["spin_number"].iloc[
-        pointing_start_spin_idx] if pointing_start_spin_idx is not None else None
-    end_spin_number = spin_df["spin_number"].iloc[
-        pointing_end_spin_idx] if pointing_end_spin_idx is not None else None
+    start_spin_number = (
+        spin_df["spin_number"].iloc[pointing_start_spin_idx]
+        if pointing_start_spin_idx is not None
+        else None
+    )
+    end_spin_number = (
+        spin_df["spin_number"].iloc[pointing_end_spin_idx]
+        if pointing_end_spin_idx is not None
+        else None
+    )
 
     print(f"Start spin number: {start_spin_number}")
 
     return start_spin_number, end_spin_number
 
+
 def pointing_times(df, epoch):
+    """
+    Get the pointing start and end times for a given epoch.
+    The pointing start time is the end of the repointing period
+    and the pointing end time is the start of the next repointing period.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing the repointing data with columns:
+            - repoint_end_ttj2000ns
+            - repoint_start_ttj2000ns
+    epoch : int
+        The epoch time in TTJ2000NS to find the pointing start and end times for
+    Returns
+    -------
+    tuple[int, int]
+        The pointing start and end times in TTJ2000NS.
+        If no pointing times are found, both values will be None.
+    """
     mask_start = (df["repoint_end_ttj2000ns"] <= epoch) & (
-                df["repoint_start_ttj2000ns"].shift(-1) >= epoch)
+        df["repoint_start_ttj2000ns"].shift(-1) >= epoch
+    )
     mask_end = (df["repoint_end_ttj2000ns"] <= epoch) & (
-                df["repoint_start_ttj2000ns"].shift(-1) > epoch)
+        df["repoint_start_ttj2000ns"].shift(-1) > epoch
+    )
 
     if all(mask_start == mask_end):
         repoint_idx = mask_start.idxmax() if mask_start.any() else None
-        pointing_start = df["repoint_end_ttj2000ns"].iloc[
-            repoint_idx] if repoint_idx is not None else None
-        pointing_end = df["repoint_start_ttj2000ns"].iloc[
-            repoint_idx + 1] if repoint_idx is not None else None
+        pointing_start = (
+            df["repoint_end_ttj2000ns"].iloc[repoint_idx]
+            if repoint_idx is not None
+            else None
+        )
+        pointing_end = (
+            df["repoint_start_ttj2000ns"].iloc[repoint_idx + 1]
+            if repoint_idx is not None
+            else None
+        )
     return pointing_start, pointing_end
+
 
 def find_spin_idx(df, time, start=True):
     if start:
         mask = (df["spin_start_ttj2000ns"] <= time) & (
-                    df["spin_start_ttj2000ns"].shift(-1) > time)
+            df["spin_start_ttj2000ns"].shift(-1) > time
+        )
     else:
         mask = (df["spin_start_ttj2000ns"] <= time - 1) & (
-                    df["spin_start_ttj2000ns"].shift(-1) >= time - 1)
+            df["spin_start_ttj2000ns"].shift(-1) >= time - 1
+        )
     return mask.idxmax() if mask.any() else None
+
 
 def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:
     """

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -9,11 +9,10 @@ import xarray as xr
 from scipy.stats import binned_statistic_dd
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.spice.time import met_to_ttj2000ns
-from imap_processing.spice.spin import (
-    get_spin_data,
-)
 from imap_processing.spice.repoint import get_repoint_data
+from imap_processing.spice.spin import get_spin_data
+from imap_processing.spice.time import met_to_ttj2000ns
+
 
 class FilterType(str, Enum):
     """
@@ -258,6 +257,7 @@ def create_pset_counts(
 
     return counts
 
+
 def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
     """
     Get the start and end spin numbers from the L1B Direct Event dataset.
@@ -276,9 +276,42 @@ def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
         The start and end spin numbers.
     """
     repoint_df = get_repoint_data()
-    print(repoint_df.info())
+    spin_df = get_spin_data()
 
-    #return start_spin_number, end_spin_number
+    # Convert repoint end MET to TTJ2000NS
+    repoint_df["repoint_end_ttj2000ns"] = met_to_ttj2000ns(repoint_df["repoint_end_met"])
+    repoint_df["repoint_start_ttj2000ns"] = met_to_ttj2000ns(repoint_df["repoint_start_met"])
+    print()
+    print(repoint_df.head())
+    # Convert spin start MET to TTJ2000NS
+    spin_df["spin_start_ttj2000ns"] = met_to_ttj2000ns(spin_df["spin_start_met"])
+
+    first_epoch = l1b_de["epoch"][0].item()
+    last_epoch = l1b_de["epoch"][-1].item()
+    # Find the repoint interval that contains first_epoch
+    repoint_mask_first = (
+            (repoint_df["repoint_end_ttj2000ns"] <= first_epoch)
+            & (repoint_df["repoint_start_ttj2000ns"].shift(-1) >= first_epoch)
+    )
+    #TODO: getting first idx is confusing, should only have 1
+    repoint_first_idx = repoint_mask_first.idxmax() if repoint_mask_first.any() else None
+    repoint_end_time = repoint_df["repoint_end_ttj2000ns"].iloc[
+        repoint_first_idx] if repoint_first_idx is not None else None
+
+    print(f"Repoint end time: {repoint_end_time}")
+    print(f"First epoch: {first_epoch}")
+
+    spin_mask = (
+        (spin_df["spin_start_ttj2000ns"] <= repoint_end_time) &
+        (spin_df["spin_start_ttj2000ns"].shift(-1) > repoint_end_time)
+    )
+    spin_idx = spin_mask.idxmax() if spin_mask.any() else None
+    start_spin_number = spin_df["spin_number"].iloc[spin_idx] if spin_idx is not None else None
+
+    print(f"Start spin number: {start_spin_number}")
+
+    # return start_spin_number, end_spin_number
+
 
 def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:
     """

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -9,9 +9,9 @@ import xarray as xr
 from scipy.stats import binned_statistic_dd
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.spice.repoint import get_repoint_data
-from imap_processing.spice.spin import get_spin_data
-from imap_processing.spice.time import met_to_ttj2000ns
+from imap_processing.spice.repoint import get_pointing_start_time, get_repoint_data
+from imap_processing.spice.spin import get_spin_number
+from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_met
 
 
 class FilterType(str, Enum):
@@ -54,16 +54,26 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
     if "imap_lo_l1b_de" in sci_dependencies:
         logical_source = "imap_lo_l1c_pset"
         l1b_de = sci_dependencies["imap_lo_l1b_de"]
-
         l1b_goodtimes_only = filter_goodtimes(l1b_de, anc_dependencies)
         pset = initialize_pset(l1b_goodtimes_only, attr_mgr, logical_source)
         full_counts = create_pset_counts(l1b_goodtimes_only)
 
         # Set the pointing start and end times based on the first epoch
-        pset["pointing_start_met"], pset["pointing_end_met"] = get_pointing_times(
-            l1b_goodtimes_only["epoch"][0].item()
+        pointing_start_met = get_pointing_start_time(
+            ttj2000ns_to_met(l1b_goodtimes_only["epoch"][0].item())
+        )
+        pset["pointing_start_met"] = xr.DataArray(
+            np.array([pointing_start_met]),
+            dims="epoch",
+            # attrs=attr_mgr.get_variable_attributes("pointing_start_met)"
         )
 
+        # set the pointing end met as the start of the next repointing
+        pset["pointing_end_met"] = get_pointing_end_time(
+            pset["pointing_start_met"].item()
+        )
+
+        # pset["pointing_end_met"] = xr.DataArray(
         # Set the epoch to the start of the pointing
         pset["epoch"] = xr.DataArray(
             met_to_ttj2000ns(pset["pointing_start_met"].values),
@@ -71,8 +81,15 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         )
 
         # Get the start and end spin numbers based on the pointing start and end MET
-        pset["start_spin_number"], pset["end_spin_number"] = get_spin_numbers(
-            pset["pointing_start_met"].item(), pset["pointing_end_met"].item()
+        pset["start_spin_number"] = xr.DataArray(
+            np.array([get_spin_number(pset["pointing_start_met"].item())]),
+            dims="epoch",
+            # attrs=attr_mgr.get_variable_attributes("start_spin_number"),
+        )
+        pset["end_spin_number"] = xr.DataArray(
+            np.array([get_spin_number(pset["pointing_end_met"].item())]),
+            dims="epoch",
+            # attrs=attr_mgr.get_variable_attributes("end_spin_number"),
         )
 
         # Set the counts
@@ -278,111 +295,6 @@ def create_pset_counts(
     return counts
 
 
-def get_pointing_times(epoch: int) -> tuple[xr.DataArray, xr.DataArray]:
-    """
-    Get the pointing start and end times for a given epoch.
-
-    The pointing start time is the end of the repointing period
-    and the pointing end time is the start of the next repointing period.
-
-    Parameters
-    ----------
-    epoch : int
-        The first epoch time in the L1B Direct Events (TTJ2000NS).
-
-    Returns
-    -------
-    tuple[xarray.DataArray, xarray.DataArray]
-        The pointing start and end times in TTJ2000NS.
-        If no pointing times are found, both values will be None.
-    """
-    # Get the repoint table
-    repoint_df = get_repoint_data()
-
-    # Convert repoint and spin MET to TTJ2000NS to compare with the epoch
-    repoint_df["repoint_end_ttj2000ns"] = met_to_ttj2000ns(
-        repoint_df["repoint_end_met"]
-    )
-    repoint_df["repoint_start_ttj2000ns"] = met_to_ttj2000ns(
-        repoint_df["repoint_start_met"]
-    )
-
-    repoint_mask = (repoint_df["repoint_end_ttj2000ns"] <= epoch) & (
-        repoint_df["repoint_start_ttj2000ns"].shift(-1) >= epoch
-    )
-
-    # Get the repoint index that contains the epoch
-    repoint_idx = repoint_mask.idxmax() if repoint_mask.any() else None
-    # use the index to get the pointing start and end times
-    pointing_start = (
-        repoint_df["repoint_end_met"].iloc[repoint_idx]
-        if repoint_idx is not None
-        else None
-    )
-    pointing_end = (
-        repoint_df["repoint_start_met"].iloc[repoint_idx + 1]
-        if repoint_idx is not None
-        else None
-    )
-
-    return (
-        xr.DataArray(np.array([pointing_start]), dims=["epoch"]),
-        xr.DataArray(np.array([pointing_end]), dims=["epoch"]),
-    )
-
-
-def get_spin_numbers(
-    pointing_start: int, pointing_end: int
-) -> tuple[xr.DataArray, xr.DataArray]:
-    """
-    Get the start and end spin numbers from the L1B Direct Event dataset.
-
-    The spin numbers are used to identify the start and end of the
-    pointing periods in the dataset.
-
-    Parameters
-    ----------
-    pointing_start : int
-        The pointing start time in MET.
-    pointing_end : int
-        The pointing end time in MET.
-
-    Returns
-    -------
-    tuple[xarray.DataArray, xarray.DataArray]
-        The start and end spin numbers.
-    """
-    # Get the spin table
-    spin_df = get_spin_data()
-
-    # create a mask for the spin that contains the start of the pointing
-    mask_start = (spin_df["spin_start_met"] <= pointing_start) & (
-        spin_df["spin_start_met"].shift(-1) > pointing_start
-    )
-    # create a masks for the spin that contains the end of the pointing
-    mask_end = (spin_df["spin_start_met"] <= pointing_end) & (
-        spin_df["spin_start_met"].shift(-1) >= pointing_end
-    )
-    # get the index for the spin that contains the start and end of the pointing
-    spin_start_idx = mask_start.idxmax() if mask_start.any() else None
-    spin_end_idx = mask_end.idxmax() if mask_end.any() else None
-
-    # get the spin numbers for the start and end of the pointing
-    start_spin_number = (
-        spin_df["spin_number"].iloc[spin_start_idx]
-        if spin_start_idx is not None
-        else None
-    )
-    end_spin_number = (
-        spin_df["spin_number"].iloc[spin_end_idx] if spin_end_idx is not None else None
-    )
-
-    return (
-        xr.DataArray(np.array([start_spin_number]), dims=["epoch"]),
-        xr.DataArray(np.array([end_spin_number]), dims=["epoch"]),
-    )
-
-
 def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:
     """
     Calculate the exposure times for the L1B Direct Event dataset.
@@ -428,6 +340,34 @@ def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.Dat
     )
 
     return exposure_time
+
+
+def get_pointing_end_time(pointing_start_met: float) -> xr.DataArray:
+    """
+    Get the end of the current pointing in MET.
+
+    The pointing end MET time is set to the start of the next repointing.
+
+    Parameters
+    ----------
+    pointing_start_met : xr.DataArray
+        The start time of the pointing in MET.
+
+    Returns
+    -------
+    pointing_end_met : xr.DataArray
+        The pointing end MET time.
+    """
+    repoint_df = get_repoint_data()
+    pointing_idx = repoint_df.index[
+        repoint_df["repoint_end_met"] == pointing_start_met
+    ][0]
+    pointing_end_met = xr.DataArray(
+        np.array([repoint_df["repoint_start_met"].iloc[pointing_idx + 1]]),
+        dims="epoch",
+        # attrs=attr_mgr.get_variable_attributes("pointing_end_met")
+    )
+    return pointing_end_met
 
 
 def create_datasets(

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -277,6 +277,7 @@ def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
     """
     repoint_df = get_repoint_data()
     spin_df = get_spin_data()
+    print(spin_df.head(50))
 
     # Convert repoint end MET to TTJ2000NS
     repoint_df["repoint_end_ttj2000ns"] = met_to_ttj2000ns(repoint_df["repoint_end_met"])
@@ -293,24 +294,40 @@ def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
             (repoint_df["repoint_end_ttj2000ns"] <= first_epoch)
             & (repoint_df["repoint_start_ttj2000ns"].shift(-1) >= first_epoch)
     )
+    repoint_mask_last = (
+        (repoint_df["repoint_end_ttj2000ns"] <= last_epoch) &
+        (repoint_df["repoint_start_ttj2000ns"].shift(-1) > last_epoch)
+    )
     #TODO: getting first idx is confusing, should only have 1
     repoint_first_idx = repoint_mask_first.idxmax() if repoint_mask_first.any() else None
-    repoint_end_time = repoint_df["repoint_end_ttj2000ns"].iloc[
-        repoint_first_idx] if repoint_first_idx is not None else None
+    repoint_last_idx = repoint_mask_last.idxmax() if repoint_mask_last.any() else None
 
-    print(f"Repoint end time: {repoint_end_time}")
+    pointing_start = repoint_df["repoint_end_ttj2000ns"].iloc[
+        repoint_first_idx] if repoint_first_idx is not None else None
+    pointing_end = repoint_df["repoint_start_ttj2000ns"].iloc[
+        repoint_last_idx + 1] if repoint_last_idx is not None else None
+
+
+    print(f"Repoint end time: {pointing_start}")
     print(f"First epoch: {first_epoch}")
 
-    spin_mask = (
-        (spin_df["spin_start_ttj2000ns"] <= repoint_end_time) &
-        (spin_df["spin_start_ttj2000ns"].shift(-1) > repoint_end_time)
+    pointing_start_spin_mask = (
+        (spin_df["spin_start_ttj2000ns"] <= pointing_start) &
+        (spin_df["spin_start_ttj2000ns"].shift(-1) > pointing_start)
     )
-    spin_idx = spin_mask.idxmax() if spin_mask.any() else None
-    start_spin_number = spin_df["spin_number"].iloc[spin_idx] if spin_idx is not None else None
+    pointing_end_spin_mask = (
+        (spin_df["spin_start_ttj2000ns"] <= pointing_end - 1) &
+        (spin_df["spin_start_ttj2000ns"].shift(-1) >= pointing_end - 1)
+    )
+
+    pointing_start_spin_idx = pointing_start_spin_mask.idxmax() if pointing_start_spin_mask.any() else None
+    pointing_end_spin_idx = pointing_end_spin_mask.idxmax() if pointing_end_spin_mask.any() else None
+    start_spin_number = spin_df["spin_number"].iloc[pointing_start_spin_idx] if pointing_start_spin_idx is not None else None
+    end_spin_number = spin_df["spin_number"].iloc[pointing_end_spin_idx] if pointing_end_spin_idx is not None else None
 
     print(f"Start spin number: {start_spin_number}")
 
-    # return start_spin_number, end_spin_number
+    return start_spin_number, end_spin_number
 
 
 def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -277,58 +277,52 @@ def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
     """
     repoint_df = get_repoint_data()
     spin_df = get_spin_data()
-    print(spin_df.head(50))
 
-    # Convert repoint end MET to TTJ2000NS
+    # Convert repoint and spin MET to TTJ2000NS
     repoint_df["repoint_end_ttj2000ns"] = met_to_ttj2000ns(repoint_df["repoint_end_met"])
-    repoint_df["repoint_start_ttj2000ns"] = met_to_ttj2000ns(repoint_df["repoint_start_met"])
-    print()
-    print(repoint_df.head())
-    # Convert spin start MET to TTJ2000NS
+    repoint_df["repoint_start_ttj2000ns"] = met_to_ttj2000ns(
+        repoint_df["repoint_start_met"])
     spin_df["spin_start_ttj2000ns"] = met_to_ttj2000ns(spin_df["spin_start_met"])
 
     first_epoch = l1b_de["epoch"][0].item()
     last_epoch = l1b_de["epoch"][-1].item()
-    # Find the repoint interval that contains first_epoch
-    repoint_mask_first = (
-            (repoint_df["repoint_end_ttj2000ns"] <= first_epoch)
-            & (repoint_df["repoint_start_ttj2000ns"].shift(-1) >= first_epoch)
-    )
-    repoint_mask_last = (
-        (repoint_df["repoint_end_ttj2000ns"] <= last_epoch) &
-        (repoint_df["repoint_start_ttj2000ns"].shift(-1) > last_epoch)
-    )
-    #TODO: getting first idx is confusing, should only have 1
-    repoint_first_idx = repoint_mask_first.idxmax() if repoint_mask_first.any() else None
-    repoint_last_idx = repoint_mask_last.idxmax() if repoint_mask_last.any() else None
 
-    pointing_start = repoint_df["repoint_end_ttj2000ns"].iloc[
-        repoint_first_idx] if repoint_first_idx is not None else None
-    pointing_end = repoint_df["repoint_start_ttj2000ns"].iloc[
-        repoint_last_idx + 1] if repoint_last_idx is not None else None
+    pointing_start, pointing_end = pointing_times(repoint_df, first_epoch)
 
+    pointing_start_spin_idx = find_spin_idx(spin_df, pointing_start)
+    pointing_end_spin_idx = find_spin_idx(spin_df, pointing_end, start=False)
 
-    print(f"Repoint end time: {pointing_start}")
-    print(f"First epoch: {first_epoch}")
-
-    pointing_start_spin_mask = (
-        (spin_df["spin_start_ttj2000ns"] <= pointing_start) &
-        (spin_df["spin_start_ttj2000ns"].shift(-1) > pointing_start)
-    )
-    pointing_end_spin_mask = (
-        (spin_df["spin_start_ttj2000ns"] <= pointing_end - 1) &
-        (spin_df["spin_start_ttj2000ns"].shift(-1) >= pointing_end - 1)
-    )
-
-    pointing_start_spin_idx = pointing_start_spin_mask.idxmax() if pointing_start_spin_mask.any() else None
-    pointing_end_spin_idx = pointing_end_spin_mask.idxmax() if pointing_end_spin_mask.any() else None
-    start_spin_number = spin_df["spin_number"].iloc[pointing_start_spin_idx] if pointing_start_spin_idx is not None else None
-    end_spin_number = spin_df["spin_number"].iloc[pointing_end_spin_idx] if pointing_end_spin_idx is not None else None
+    start_spin_number = spin_df["spin_number"].iloc[
+        pointing_start_spin_idx] if pointing_start_spin_idx is not None else None
+    end_spin_number = spin_df["spin_number"].iloc[
+        pointing_end_spin_idx] if pointing_end_spin_idx is not None else None
 
     print(f"Start spin number: {start_spin_number}")
 
     return start_spin_number, end_spin_number
 
+def pointing_times(df, epoch):
+    mask_start = (df["repoint_end_ttj2000ns"] <= epoch) & (
+                df["repoint_start_ttj2000ns"].shift(-1) >= epoch)
+    mask_end = (df["repoint_end_ttj2000ns"] <= epoch) & (
+                df["repoint_start_ttj2000ns"].shift(-1) > epoch)
+
+    if all(mask_start == mask_end):
+        repoint_idx = mask_start.idxmax() if mask_start.any() else None
+        pointing_start = df["repoint_end_ttj2000ns"].iloc[
+            repoint_idx] if repoint_idx is not None else None
+        pointing_end = df["repoint_start_ttj2000ns"].iloc[
+            repoint_idx + 1] if repoint_idx is not None else None
+    return pointing_start, pointing_end
+
+def find_spin_idx(df, time, start=True):
+    if start:
+        mask = (df["spin_start_ttj2000ns"] <= time) & (
+                    df["spin_start_ttj2000ns"].shift(-1) > time)
+    else:
+        mask = (df["spin_start_ttj2000ns"] <= time - 1) & (
+                    df["spin_start_ttj2000ns"].shift(-1) >= time - 1)
+    return mask.idxmax() if mask.any() else None
 
 def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:
     """

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -9,7 +9,7 @@ import xarray as xr
 from scipy.stats import binned_statistic_dd
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.spice.repoint import get_pointing_start_time, get_repoint_data
+from imap_processing.spice.repoint import get_pointing_times
 from imap_processing.spice.spin import get_spin_number
 from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_met
 
@@ -59,21 +59,21 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         full_counts = create_pset_counts(l1b_goodtimes_only)
 
         # Set the pointing start and end times based on the first epoch
-        pointing_start_met = get_pointing_start_time(
+        pointing_start_met, pointing_end_met = get_pointing_times(
             ttj2000ns_to_met(l1b_goodtimes_only["epoch"][0].item())
         )
+
         pset["pointing_start_met"] = xr.DataArray(
             np.array([pointing_start_met]),
             dims="epoch",
             # attrs=attr_mgr.get_variable_attributes("pointing_start_met)"
         )
-
-        # set the pointing end met as the start of the next repointing
-        pset["pointing_end_met"] = get_pointing_end_time(
-            pset["pointing_start_met"].item()
+        pset["pointing_end_met"] = xr.DataArray(
+            np.array([pointing_end_met]),
+            dims="epoch",
+            # attrs=attr_mgr.get_variable_attributes("pointing_start_met)"
         )
 
-        # pset["pointing_end_met"] = xr.DataArray(
         # Set the epoch to the start of the pointing
         pset["epoch"] = xr.DataArray(
             met_to_ttj2000ns(pset["pointing_start_met"].values),
@@ -82,12 +82,12 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
 
         # Get the start and end spin numbers based on the pointing start and end MET
         pset["start_spin_number"] = xr.DataArray(
-            np.array([get_spin_number(pset["pointing_start_met"].item())]),
+            [get_spin_number(pset["pointing_start_met"].item())],
             dims="epoch",
             # attrs=attr_mgr.get_variable_attributes("start_spin_number"),
         )
         pset["end_spin_number"] = xr.DataArray(
-            np.array([get_spin_number(pset["pointing_end_met"].item())]),
+            [get_spin_number(pset["pointing_end_met"].item())],
             dims="epoch",
             # attrs=attr_mgr.get_variable_attributes("end_spin_number"),
         )
@@ -340,34 +340,6 @@ def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.Dat
     )
 
     return exposure_time
-
-
-def get_pointing_end_time(pointing_start_met: float) -> xr.DataArray:
-    """
-    Get the end of the current pointing in MET.
-
-    The pointing end MET time is set to the start of the next repointing.
-
-    Parameters
-    ----------
-    pointing_start_met : xr.DataArray
-        The start time of the pointing in MET.
-
-    Returns
-    -------
-    pointing_end_met : xr.DataArray
-        The pointing end MET time.
-    """
-    repoint_df = get_repoint_data()
-    pointing_idx = repoint_df.index[
-        repoint_df["repoint_end_met"] == pointing_start_met
-    ][0]
-    pointing_end_met = xr.DataArray(
-        np.array([repoint_df["repoint_start_met"].iloc[pointing_idx + 1]]),
-        dims="epoch",
-        # attrs=attr_mgr.get_variable_attributes("pointing_end_met")
-    )
-    return pointing_end_met
 
 
 def create_datasets(

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -2,6 +2,7 @@
 
 from dataclasses import Field
 from enum import Enum
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -58,7 +59,44 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         l1b_goodtimes_only = filter_goodtimes(l1b_de, anc_dependencies)
         pset = initialize_pset(l1b_goodtimes_only, attr_mgr, logical_source)
         full_counts = create_pset_counts(l1b_goodtimes_only)
-        start_spin_number, end_spin_number = get_spin_numbers(l1b_goodtimes_only)
+
+        # Set the pointing start and end times based on the first epoch
+        point_start_met, pointing_end_met = get_pointing_times(
+            l1b_goodtimes_only["epoch"][0].item()
+        )
+        pset["pointing_start_met"] = xr.DataArray(
+            np.array([point_start_met]),
+            dims=["epoch"],
+            # attrs=attr_mgr.get_variable_attributes("pointing_start_met"),
+        )
+        pset["pointing_end_met"] = xr.DataArray(
+            np.array([pointing_end_met]),
+            dims=["epoch"],
+            # attrs=attr_mgr.get_variable_attributes("pointing_end_met"),
+        )
+
+        # Set the epoch to the start of the pointing
+        pset["epoch"] = xr.DataArray(
+            met_to_ttj2000ns(pset["pointing_start_met"].values),
+            attrs=attr_mgr.get_variable_attributes("epoch"),
+        )
+
+        # Get the start and end spin numbers based on the pointing start and end MET
+        start_spin_number, end_spin_number = get_spin_numbers(
+            pset["pointing_start_met"].item(), pset["pointing_end_met"].item()
+        )
+        pset["start_spin_number"] = xr.DataArray(
+            np.array([start_spin_number]),
+            dims=["epoch"],
+            # attrs=attr_mgr.get_variable_attributes("start_spin_number"),
+        )
+        pset["end_spin_number"] = xr.DataArray(
+            np.array([end_spin_number]),
+            dims=["epoch"],
+            # attrs=attr_mgr.get_variable_attributes("end_spin_number"),
+        )
+
+        # Set the counts
         pset["triples_counts"] = create_pset_counts(
             l1b_goodtimes_only, FilterType.TRIPLES
         )
@@ -67,6 +105,8 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         )
         pset["h_counts"] = create_pset_counts(l1b_goodtimes_only, FilterType.HYDROGEN)
         pset["o_counts"] = create_pset_counts(l1b_goodtimes_only, FilterType.OXYGEN)
+
+        # Set the exposure time
         pset["exposure_time"] = calculate_exposure_times(
             full_counts, l1b_goodtimes_only
         )
@@ -77,6 +117,7 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
 
     pset = pset.assign_coords(
         {
+            "epoch": pset["epoch"],
             "energy": np.arange(1, 8),
             "longitude": np.arange(3600),
             "latitude": np.arange(40),
@@ -258,7 +299,59 @@ def create_pset_counts(
     return counts
 
 
-def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
+def get_pointing_times(epoch: int) -> tuple[Any | None, Any | None]:
+    """
+    Get the pointing start and end times for a given epoch.
+
+    The pointing start time is the end of the repointing period
+    and the pointing end time is the start of the next repointing period.
+
+    Parameters
+    ----------
+    epoch : int
+        The first epoch time in the L1B Direct Events (TTJ2000NS).
+
+    Returns
+    -------
+    tuple[int, int]
+        The pointing start and end times in TTJ2000NS.
+        If no pointing times are found, both values will be None.
+    """
+    # Get the repoint table
+    repoint_df = get_repoint_data()
+
+    # Convert repoint and spin MET to TTJ2000NS to compare with the epoch
+    repoint_df["repoint_end_ttj2000ns"] = met_to_ttj2000ns(
+        repoint_df["repoint_end_met"]
+    )
+    repoint_df["repoint_start_ttj2000ns"] = met_to_ttj2000ns(
+        repoint_df["repoint_start_met"]
+    )
+
+    repoint_mask = (repoint_df["repoint_end_ttj2000ns"] <= epoch) & (
+        repoint_df["repoint_start_ttj2000ns"].shift(-1) >= epoch
+    )
+
+    # Get the repoint index that contains the epoch
+    repoint_idx = repoint_mask.idxmax() if repoint_mask.any() else None
+    # use the index to get the pointing start and end times
+    pointing_start = (
+        repoint_df["repoint_end_met"].iloc[repoint_idx]
+        if repoint_idx is not None
+        else None
+    )
+    pointing_end = (
+        repoint_df["repoint_start_met"].iloc[repoint_idx + 1]
+        if repoint_idx is not None
+        else None
+    )
+
+    return pointing_start, pointing_end
+
+
+def get_spin_numbers(
+    pointing_start: int, pointing_end: int
+) -> tuple[Any | None, Any | None]:
     """
     Get the start and end spin numbers from the L1B Direct Event dataset.
 
@@ -267,102 +360,42 @@ def get_spin_numbers(l1b_de: xr.Dataset) -> tuple[int, int]:
 
     Parameters
     ----------
-    l1b_de : xarray.Dataset
-        L1B Direct Event dataset.
+    pointing_start : int
+        The pointing start time in MET.
+    pointing_end : int
+        The pointing end time in MET.
 
     Returns
     -------
     tuple[int, int]
         The start and end spin numbers.
     """
-    repoint_df = get_repoint_data()
+    # Get the spoin table
     spin_df = get_spin_data()
 
-    # Convert repoint and spin MET to TTJ2000NS
-    repoint_df["repoint_end_ttj2000ns"] = met_to_ttj2000ns(
-        repoint_df["repoint_end_met"]
+    # create a mask for the spin that contains the start of the pointing
+    mask_start = (spin_df["spin_start_met"] <= pointing_start) & (
+        spin_df["spin_start_met"].shift(-1) > pointing_start
     )
-    repoint_df["repoint_start_ttj2000ns"] = met_to_ttj2000ns(
-        repoint_df["repoint_start_met"]
+    # create a masks for the spin that contains the end of the pointing
+    mask_end = (spin_df["spin_start_met"] <= pointing_end) & (
+        spin_df["spin_start_met"].shift(-1) >= pointing_end
     )
-    spin_df["spin_start_ttj2000ns"] = met_to_ttj2000ns(spin_df["spin_start_met"])
+    # get the index for the spin that contains the start and end of the pointing
+    spin_start_idx = mask_start.idxmax() if mask_start.any() else None
+    spin_end_idx = mask_end.idxmax() if mask_end.any() else None
 
-    first_epoch = l1b_de["epoch"][0].item()
-    last_epoch = l1b_de["epoch"][-1].item()
-
-    pointing_start, pointing_end = pointing_times(repoint_df, first_epoch)
-
-    pointing_start_spin_idx = find_spin_idx(spin_df, pointing_start)
-    pointing_end_spin_idx = find_spin_idx(spin_df, pointing_end, start=False)
-
+    # get the spin numbers for the start and end of the pointing
     start_spin_number = (
-        spin_df["spin_number"].iloc[pointing_start_spin_idx]
-        if pointing_start_spin_idx is not None
+        spin_df["spin_number"].iloc[spin_start_idx]
+        if spin_start_idx is not None
         else None
     )
     end_spin_number = (
-        spin_df["spin_number"].iloc[pointing_end_spin_idx]
-        if pointing_end_spin_idx is not None
-        else None
+        spin_df["spin_number"].iloc[spin_end_idx] if spin_end_idx is not None else None
     )
-
-    print(f"Start spin number: {start_spin_number}")
 
     return start_spin_number, end_spin_number
-
-
-def pointing_times(df, epoch):
-    """
-    Get the pointing start and end times for a given epoch.
-    The pointing start time is the end of the repointing period
-    and the pointing end time is the start of the next repointing period.
-
-    Parameters
-    ----------
-    df : pandas.DataFrame
-        DataFrame containing the repointing data with columns:
-            - repoint_end_ttj2000ns
-            - repoint_start_ttj2000ns
-    epoch : int
-        The epoch time in TTJ2000NS to find the pointing start and end times for
-    Returns
-    -------
-    tuple[int, int]
-        The pointing start and end times in TTJ2000NS.
-        If no pointing times are found, both values will be None.
-    """
-    mask_start = (df["repoint_end_ttj2000ns"] <= epoch) & (
-        df["repoint_start_ttj2000ns"].shift(-1) >= epoch
-    )
-    mask_end = (df["repoint_end_ttj2000ns"] <= epoch) & (
-        df["repoint_start_ttj2000ns"].shift(-1) > epoch
-    )
-
-    if all(mask_start == mask_end):
-        repoint_idx = mask_start.idxmax() if mask_start.any() else None
-        pointing_start = (
-            df["repoint_end_ttj2000ns"].iloc[repoint_idx]
-            if repoint_idx is not None
-            else None
-        )
-        pointing_end = (
-            df["repoint_start_ttj2000ns"].iloc[repoint_idx + 1]
-            if repoint_idx is not None
-            else None
-        )
-    return pointing_start, pointing_end
-
-
-def find_spin_idx(df, time, start=True):
-    if start:
-        mask = (df["spin_start_ttj2000ns"] <= time) & (
-            df["spin_start_ttj2000ns"].shift(-1) > time
-        )
-    else:
-        mask = (df["spin_start_ttj2000ns"] <= time - 1) & (
-            df["spin_start_ttj2000ns"].shift(-1) >= time - 1
-        )
-    return mask.idxmax() if mask.any() else None
 
 
 def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -2,7 +2,6 @@
 
 from dataclasses import Field
 from enum import Enum
-from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -61,18 +60,8 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         full_counts = create_pset_counts(l1b_goodtimes_only)
 
         # Set the pointing start and end times based on the first epoch
-        point_start_met, pointing_end_met = get_pointing_times(
+        pset["pointing_start_met"], pset["pointing_end_met"] = get_pointing_times(
             l1b_goodtimes_only["epoch"][0].item()
-        )
-        pset["pointing_start_met"] = xr.DataArray(
-            np.array([point_start_met]),
-            dims=["epoch"],
-            # attrs=attr_mgr.get_variable_attributes("pointing_start_met"),
-        )
-        pset["pointing_end_met"] = xr.DataArray(
-            np.array([pointing_end_met]),
-            dims=["epoch"],
-            # attrs=attr_mgr.get_variable_attributes("pointing_end_met"),
         )
 
         # Set the epoch to the start of the pointing
@@ -82,18 +71,8 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         )
 
         # Get the start and end spin numbers based on the pointing start and end MET
-        start_spin_number, end_spin_number = get_spin_numbers(
+        pset["start_spin_number"], pset["end_spin_number"] = get_spin_numbers(
             pset["pointing_start_met"].item(), pset["pointing_end_met"].item()
-        )
-        pset["start_spin_number"] = xr.DataArray(
-            np.array([start_spin_number]),
-            dims=["epoch"],
-            # attrs=attr_mgr.get_variable_attributes("start_spin_number"),
-        )
-        pset["end_spin_number"] = xr.DataArray(
-            np.array([end_spin_number]),
-            dims=["epoch"],
-            # attrs=attr_mgr.get_variable_attributes("end_spin_number"),
         )
 
         # Set the counts
@@ -299,7 +278,7 @@ def create_pset_counts(
     return counts
 
 
-def get_pointing_times(epoch: int) -> tuple[Any | None, Any | None]:
+def get_pointing_times(epoch: int) -> tuple[xr.DataArray, xr.DataArray]:
     """
     Get the pointing start and end times for a given epoch.
 
@@ -313,7 +292,7 @@ def get_pointing_times(epoch: int) -> tuple[Any | None, Any | None]:
 
     Returns
     -------
-    tuple[int, int]
+    tuple[xarray.DataArray, xarray.DataArray]
         The pointing start and end times in TTJ2000NS.
         If no pointing times are found, both values will be None.
     """
@@ -346,12 +325,15 @@ def get_pointing_times(epoch: int) -> tuple[Any | None, Any | None]:
         else None
     )
 
-    return pointing_start, pointing_end
+    return (
+        xr.DataArray(np.array([pointing_start]), dims=["epoch"]),
+        xr.DataArray(np.array([pointing_end]), dims=["epoch"]),
+    )
 
 
 def get_spin_numbers(
     pointing_start: int, pointing_end: int
-) -> tuple[Any | None, Any | None]:
+) -> tuple[xr.DataArray, xr.DataArray]:
     """
     Get the start and end spin numbers from the L1B Direct Event dataset.
 
@@ -367,10 +349,10 @@ def get_spin_numbers(
 
     Returns
     -------
-    tuple[int, int]
+    tuple[xarray.DataArray, xarray.DataArray]
         The start and end spin numbers.
     """
-    # Get the spoin table
+    # Get the spin table
     spin_df = get_spin_data()
 
     # create a mask for the spin that contains the start of the pointing
@@ -395,7 +377,10 @@ def get_spin_numbers(
         spin_df["spin_number"].iloc[spin_end_idx] if spin_end_idx is not None else None
     )
 
-    return start_spin_number, end_spin_number
+    return (
+        xr.DataArray(np.array([start_spin_number]), dims=["epoch"]),
+        xr.DataArray(np.array([end_spin_number]), dims=["epoch"]),
+    )
 
 
 def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.DataArray:

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -195,19 +195,29 @@ def interpolate_repoint_data(
     return out_df
 
 
-def get_pointing_start_time(query_met_time: float) -> tuple[float, float]:
+def get_pointing_times(met_time: float) -> tuple[float, float]:
     """
     Get the start and end MET times for the pointing that contains the query MET time.
 
     Parameters
     ----------
-    query_met_time : float
-        The MET time to query for the pointing start time.
+    met_time : float
+        The MET time in a pointing.
 
     Returns
     -------
     pointing_start_time : float
         The MET time of the repoint maneuver that ends before the query MET time.
+    pointing_end_time : float
+        The MET time of the repoint maneuver that starts after the query MET time.
     """
-    repoint_df = interpolate_repoint_data(query_met_time)
-    return repoint_df["repoint_end_met"].item()
+    # Find the pointing start time by finding the repoint end time
+    repoint_df = interpolate_repoint_data(met_time)
+    pointing_start_met = repoint_df["repoint_end_met"].item()
+    # Find the pointing end time by finding the next repoint start time
+    repoint_df = get_repoint_data()
+    pointing_idx = repoint_df.index[
+        repoint_df["repoint_end_met"] == pointing_start_met
+    ][0]
+    pointing_end_met = repoint_df["repoint_start_met"].iloc[pointing_idx + 1].item()
+    return pointing_start_met, pointing_end_met

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -195,12 +195,9 @@ def interpolate_repoint_data(
     return out_df
 
 
-def get_pointing_times(query_met_time: float) -> tuple[float, float]:
+def get_pointing_start_time(query_met_time: float) -> tuple[float, float]:
     """
-    Get the pointing start time for a given MET time.
-
-    The pointing start time is defined as the MET time of the repoint maneuver
-    that starts before the given query MET time.
+    Get the start and end MET times for the pointing that contains the query MET time.
 
     Parameters
     ----------
@@ -211,8 +208,6 @@ def get_pointing_times(query_met_time: float) -> tuple[float, float]:
     -------
     pointing_start_time : float
         The MET time of the repoint maneuver that ends before the query MET time.
-    point_end_time : float
-        The MET time of the repoint maneuver that starts after the query MET time.
     """
     repoint_df = interpolate_repoint_data(query_met_time)
-    return repoint_df["repoint_end_met"], repoint_df["repoint_start_met"]
+    return repoint_df["repoint_end_met"].item()

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -193,3 +193,26 @@ def interpolate_repoint_data(
     out_df["repoint_in_progress"] = query_met_times < out_df["repoint_end_met"].values
 
     return out_df
+
+
+def get_pointing_times(query_met_time: float) -> tuple[float, float]:
+    """
+    Get the pointing start time for a given MET time.
+
+    The pointing start time is defined as the MET time of the repoint maneuver
+    that starts before the given query MET time.
+
+    Parameters
+    ----------
+    query_met_time : float
+        The MET time to query for the pointing start time.
+
+    Returns
+    -------
+    pointing_start_time : float
+        The MET time of the repoint maneuver that ends before the query MET time.
+    point_end_time : float
+        The MET time of the repoint maneuver that starts after the query MET time.
+    """
+    repoint_df = interpolate_repoint_data(query_met_time)
+    return repoint_df["repoint_end_met"], repoint_df["repoint_start_met"]

--- a/imap_processing/spice/spin.py
+++ b/imap_processing/spice/spin.py
@@ -212,6 +212,27 @@ def interpolate_spin_data(query_met_times: float | npt.NDArray) -> pd.DataFrame:
     return out_df
 
 
+def get_spin_number(query_met_time: float) -> int:
+    """
+    Get the spin number for the input query time.
+
+    The spin number is the index of the spin table row that contains the
+    spin data for the input query time.
+
+    Parameters
+    ----------
+    query_met_time : float
+        Query time in Mission Elapsed Time (MET).
+
+    Returns
+    -------
+    spin_number : int
+        Spin number for the input query time.
+    """
+    spin_df = interpolate_spin_data(query_met_time)
+    return spin_df["spin_number"].item()
+
+
 def get_spin_angle(
     spin_phases: float | npt.NDArray,
     degrees: bool = False,

--- a/imap_processing/spice/spin.py
+++ b/imap_processing/spice/spin.py
@@ -212,7 +212,7 @@ def interpolate_spin_data(query_met_times: float | npt.NDArray) -> pd.DataFrame:
     return out_df
 
 
-def get_spin_number(query_met_time: float) -> int:
+def get_spin_number(met_time: float) -> int:
     """
     Get the spin number for the input query time.
 
@@ -221,7 +221,7 @@ def get_spin_number(query_met_time: float) -> int:
 
     Parameters
     ----------
-    query_met_time : float
+    met_time : float
         Query time in Mission Elapsed Time (MET).
 
     Returns
@@ -229,7 +229,7 @@ def get_spin_number(query_met_time: float) -> int:
     spin_number : int
         Spin number for the input query time.
     """
-    spin_df = interpolate_spin_data(query_met_time)
+    spin_df = interpolate_spin_data(met_time)
     return spin_df["spin_number"].item()
 
 

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -397,7 +397,10 @@ def generate_repoint_data(
         Repoint dataframe with start and end repoint times provided and incrementing
         repoint_ids starting at 1.
     """
-    repoint_start_times = np.array(repoint_start_met)
+    if isinstance(repoint_start_met, float):
+        repoint_start_times = np.array(repoint_start_met)
+    elif isinstance(repoint_start_met, np.ndarray):
+        repoint_start_times = repoint_start_met
     if repoint_end_met is None:
         repoint_end_met = repoint_start_times + 15 * 60
     # Calculate UTC times without spice (accepting ~5 second inaccuracy)

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -401,8 +401,10 @@ def generate_repoint_data(
         repoint_start_times = np.array(repoint_start_met)
     elif isinstance(repoint_start_met, np.ndarray):
         repoint_start_times = repoint_start_met
+    repoint_start_times = np.atleast_1d(repoint_start_met)
     if repoint_end_met is None:
         repoint_end_met = repoint_start_times + 15 * 60
+
     # Calculate UTC times without spice (accepting ~5 second inaccuracy)
     repoint_start_dt64 = TTJ2000_EPOCH + (repoint_start_times * 1e9).astype(
         "timedelta64[ns]"

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -397,10 +397,6 @@ def generate_repoint_data(
         Repoint dataframe with start and end repoint times provided and incrementing
         repoint_ids starting at 1.
     """
-    if isinstance(repoint_start_met, float):
-        repoint_start_times = np.array(repoint_start_met)
-    elif isinstance(repoint_start_met, np.ndarray):
-        repoint_start_times = repoint_start_met
     repoint_start_times = np.atleast_1d(repoint_start_met)
     if repoint_end_met is None:
         repoint_end_met = repoint_start_times + 15 * 60

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -9,7 +9,6 @@ from imap_processing.lo.l1c.lo_l1c import (
     calculate_exposure_times,
     create_pset_counts,
     filter_goodtimes,
-    get_pointing_end_time,
     initialize_pset,
     lo_l1c,
 )
@@ -271,18 +270,3 @@ def test_calculate_exposure_times(l1b_de):
         expected_exposure_times,
         atol=1e-2,
     )
-
-
-def test_get_pointing_end_time(
-    l1b_de_spin,
-    anc_dependencies,
-    use_fake_repoint_data_for_time,
-    use_fake_spin_data_for_time,
-    repoint_met,
-):
-    use_fake_spin_data_for_time(511000000)
-    use_fake_repoint_data_for_time(np.arange(511000000, 511000000 + 86400 * 5, 86400))
-
-    pointing_end_time = get_pointing_end_time(511000900)
-
-    assert pointing_end_time.item() == 511000000 + 86400

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -268,7 +268,6 @@ def test_get_pointing_times(l1b_de_spin, repoint_met, use_fake_repoint_data_for_
 
 
 def test_get_spin_numbers(
-    l1b_de_spin,
     repoint_met,
     use_fake_spin_data_for_time,
 ):
@@ -279,7 +278,7 @@ def test_get_spin_numbers(
     expected_spin_numbers = (60, 5759)
 
     # Act
-    spin_numbers = get_spin_numbers(l1b_de_spin, repoint_met[0] + 900, repoint_met[1])
+    spin_numbers = get_spin_numbers(repoint_met[0] + 900, repoint_met[1])
 
     # Assert
     np.testing.assert_array_equal(spin_numbers, expected_spin_numbers)

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -258,7 +258,10 @@ def test_get_pointing_times(l1b_de_spin, repoint_met, use_fake_repoint_data_for_
     # Arrange
     use_fake_repoint_data_for_time(repoint_met)
 
-    expected_pointing_times = (repoint_met[0] + 900, repoint_met[1])
+    expected_pointing_times = (
+        np.array([repoint_met[0] + 900]),
+        np.array([repoint_met[1]]),
+    )
 
     # Act
     pointing_times = get_pointing_times(l1b_de_spin["epoch"].values[0])
@@ -275,7 +278,7 @@ def test_get_spin_numbers(
 
     use_fake_spin_data_for_time(repoint_met[0])
 
-    expected_spin_numbers = (60, 5759)
+    expected_spin_numbers = (np.array([60]), np.array([5759]))
 
     # Act
     spin_numbers = get_spin_numbers(repoint_met[0] + 900, repoint_met[1])

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -4,15 +4,15 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.spice.time import t
+from imap_processing.spice.time import met_to_ttj2000ns
 from imap_processing.lo.l1c.lo_l1c import (
     FilterType,
     calculate_exposure_times,
     create_pset_counts,
     filter_goodtimes,
+    get_spin_numbers,
     initialize_pset,
     lo_l1c,
-    get_spin_numbers
 )
 
 
@@ -49,6 +49,38 @@ def l1b_de():
     )
     return l1b_de
 
+@pytest.fixture
+def spin_met():
+    met = np.array([511000000, 511000001, 511000002, 511000003, 511000004])
+    return met
+@pytest.fixture
+def l1b_de_spin(spin_met):
+
+
+    l1b_de = xr.Dataset(
+        {
+            "pointing_bin_lon": ("epoch", [20, 0, 20, 2000, 3500]),
+            "pointing_bin_lat": ("epoch", [20, 20, 20, 20, 20]),
+            "esa_step": ("epoch", [1, 2, 1, 4, 5]),
+            "coincidence_type": (
+                "epoch",
+                [
+                    "111111",
+                    "111100",
+                    "111000",
+                    "110100",
+                    "110000",
+                ],
+            ),
+            "species": ("epoch", ["h", "o", "h", "h", "o"]),
+            "spin_cycle": ("epoch", [1, 2, 3, 4, 5]),
+            "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9]),
+        },
+        coords={
+            "epoch": met_to_ttj2000ns(spin_met),
+        },
+    )
+    return l1b_de
 
 @pytest.fixture
 def anc_dependencies():
@@ -210,21 +242,19 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
     # Assert
     np.testing.assert_array_equal(counts, doubles_counts)
 
-def test_get_spin_numbers(l1b_de, use_fake_repoint_data_for_time, use_fake_spin_data_for_time):
+
+def test_get_spin_numbers(
+    l1b_de_spin, spin_met,  use_fake_repoint_data_for_time, use_fake_spin_data_for_time
+):
     # Arrange
+
+    use_fake_spin_data_for_time(spin_met[0])
+    use_fake_repoint_data_for_time(spin_met)
+
     expected_spin_numbers = np.array([1, 2, 3, 4, 5])
-    repoint_start_times = np.array([7.9794907049e17, 7.9794907153e17, 7.9794907254e17, 7.9794907354e17, 7.9794907454e17])
-    use_fake_repoint_data_for_time(
-        np.array([7.9794907049e17, 7.9794907153e17, 7.9794907254e17, 7.9794907354e17, 7.9794907454e17]),
-        np.array([7.9794907050e17, 7.9794907154e17, 7.9794907255e17, 7.9794907355e17, 7.9794907455e17]),
-        np.array([1, 2, 3, 4, 5])
-    )
-    #use_fake_spin_data_for_time(
-    #    np.array([7.9794907049e17, 7.9794907153e17, 7.9794907254e17, 7.9794907354e17, 7.9794907454e17]),
-    #)
 
     # Act
-    spin_numbers = get_spin_numbers(l1b_de)
+    spin_numbers = get_spin_numbers(l1b_de_spin)
 
     # Assert
     np.testing.assert_array_equal(spin_numbers, expected_spin_numbers)

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.spice.time import t
 from imap_processing.lo.l1c.lo_l1c import (
     FilterType,
     calculate_exposure_times,
@@ -11,6 +12,7 @@ from imap_processing.lo.l1c.lo_l1c import (
     filter_goodtimes,
     initialize_pset,
     lo_l1c,
+    get_spin_numbers
 )
 
 
@@ -207,6 +209,25 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
 
     # Assert
     np.testing.assert_array_equal(counts, doubles_counts)
+
+def test_get_spin_numbers(l1b_de, use_fake_repoint_data_for_time, use_fake_spin_data_for_time):
+    # Arrange
+    expected_spin_numbers = np.array([1, 2, 3, 4, 5])
+    repoint_start_times = np.array([7.9794907049e17, 7.9794907153e17, 7.9794907254e17, 7.9794907354e17, 7.9794907454e17])
+    use_fake_repoint_data_for_time(
+        np.array([7.9794907049e17, 7.9794907153e17, 7.9794907254e17, 7.9794907354e17, 7.9794907454e17]),
+        np.array([7.9794907050e17, 7.9794907154e17, 7.9794907255e17, 7.9794907355e17, 7.9794907455e17]),
+        np.array([1, 2, 3, 4, 5])
+    )
+    #use_fake_spin_data_for_time(
+    #    np.array([7.9794907049e17, 7.9794907153e17, 7.9794907254e17, 7.9794907354e17, 7.9794907454e17]),
+    #)
+
+    # Act
+    spin_numbers = get_spin_numbers(l1b_de)
+
+    # Assert
+    np.testing.assert_array_equal(spin_numbers, expected_spin_numbers)
 
 
 def test_calculate_exposure_times(l1b_de):

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -4,7 +4,6 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.spice.time import met_to_ttj2000ns
 from imap_processing.lo.l1c.lo_l1c import (
     FilterType,
     calculate_exposure_times,
@@ -14,6 +13,7 @@ from imap_processing.lo.l1c.lo_l1c import (
     initialize_pset,
     lo_l1c,
 )
+from imap_processing.spice.time import met_to_ttj2000ns
 
 
 @pytest.fixture
@@ -49,14 +49,15 @@ def l1b_de():
     )
     return l1b_de
 
+
 @pytest.fixture
 def repoint_met():
     met = np.arange(511000000, 511000000 + 86400 * 5, 86400)
     return met
+
+
 @pytest.fixture
-def l1b_de_spin(repoint_met):
-
-
+def l1b_de_spin():
     l1b_de = xr.Dataset(
         {
             "pointing_bin_lon": ("epoch", [20, 0, 20, 2000, 3500]),
@@ -81,6 +82,7 @@ def l1b_de_spin(repoint_met):
         },
     )
     return l1b_de
+
 
 @pytest.fixture
 def anc_dependencies():
@@ -244,7 +246,10 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
 
 
 def test_get_spin_numbers(
-    l1b_de_spin, repoint_met,  use_fake_repoint_data_for_time, use_fake_spin_data_for_time
+    l1b_de_spin,
+    repoint_met,
+    use_fake_repoint_data_for_time,
+    use_fake_spin_data_for_time,
 ):
     # Arrange
 

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -9,8 +9,7 @@ from imap_processing.lo.l1c.lo_l1c import (
     calculate_exposure_times,
     create_pset_counts,
     filter_goodtimes,
-    get_pointing_times,
-    get_spin_numbers,
+    get_pointing_end_time,
     initialize_pset,
     lo_l1c,
 )
@@ -79,7 +78,7 @@ def l1b_de_spin():
             "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9]),
         },
         coords={
-            "epoch": met_to_ttj2000ns(np.arange(511000000, 511000000 + 200, 40) + 901),
+            "epoch": met_to_ttj2000ns(np.arange(511000000, 511000000 + 200, 40) + 902),
         },
     )
     return l1b_de
@@ -140,16 +139,16 @@ def doubles_counts(counts):
 
 
 def test_lo_l1c(
-    l1b_de,
+    l1b_de_spin,
     anc_dependencies,
     use_fake_repoint_data_for_time,
     use_fake_spin_data_for_time,
     repoint_met,
 ):
     # Arrange
-    data = {"imap_lo_l1b_de": l1b_de}
-    use_fake_spin_data_for_time(482300000)
-    use_fake_repoint_data_for_time(np.arange(482300000, 482300000 + 86400 * 5, 86400))
+    data = {"imap_lo_l1b_de": l1b_de_spin}
+    use_fake_spin_data_for_time(511000000)
+    use_fake_repoint_data_for_time(np.arange(511000000, 511000000 + 86400 * 5, 86400))
 
     expected_logical_source = "imap_lo_l1c_pset"
     # Act
@@ -254,39 +253,6 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
     np.testing.assert_array_equal(counts, doubles_counts)
 
 
-def test_get_pointing_times(l1b_de_spin, repoint_met, use_fake_repoint_data_for_time):
-    # Arrange
-    use_fake_repoint_data_for_time(repoint_met)
-
-    expected_pointing_times = (
-        np.array([repoint_met[0] + 900]),
-        np.array([repoint_met[1]]),
-    )
-
-    # Act
-    pointing_times = get_pointing_times(l1b_de_spin["epoch"].values[0])
-
-    # Assert
-    np.testing.assert_array_equal(pointing_times, expected_pointing_times)
-
-
-def test_get_spin_numbers(
-    repoint_met,
-    use_fake_spin_data_for_time,
-):
-    # Arrange
-
-    use_fake_spin_data_for_time(repoint_met[0])
-
-    expected_spin_numbers = (np.array([60]), np.array([5759]))
-
-    # Act
-    spin_numbers = get_spin_numbers(repoint_met[0] + 900, repoint_met[1])
-
-    # Assert
-    np.testing.assert_array_equal(spin_numbers, expected_spin_numbers)
-
-
 def test_calculate_exposure_times(l1b_de):
     # Arrange
     counts = create_pset_counts(l1b_de)
@@ -305,3 +271,18 @@ def test_calculate_exposure_times(l1b_de):
         expected_exposure_times,
         atol=1e-2,
     )
+
+
+def test_get_pointing_end_time(
+    l1b_de_spin,
+    anc_dependencies,
+    use_fake_repoint_data_for_time,
+    use_fake_spin_data_for_time,
+    repoint_met,
+):
+    use_fake_spin_data_for_time(511000000)
+    use_fake_repoint_data_for_time(np.arange(511000000, 511000000 + 86400 * 5, 86400))
+
+    pointing_end_time = get_pointing_end_time(511000900)
+
+    assert pointing_end_time.item() == 511000000 + 86400

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -50,11 +50,11 @@ def l1b_de():
     return l1b_de
 
 @pytest.fixture
-def spin_met():
-    met = np.array([511000000, 511000001, 511000002, 511000003, 511000004])
+def repoint_met():
+    met = np.arange(511000000, 511000000 + 86400 * 5, 86400)
     return met
 @pytest.fixture
-def l1b_de_spin(spin_met):
+def l1b_de_spin(repoint_met):
 
 
     l1b_de = xr.Dataset(
@@ -77,7 +77,7 @@ def l1b_de_spin(spin_met):
             "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9]),
         },
         coords={
-            "epoch": met_to_ttj2000ns(spin_met),
+            "epoch": met_to_ttj2000ns(np.arange(511000000, 511000000 + 200, 40) + 901),
         },
     )
     return l1b_de
@@ -244,14 +244,14 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
 
 
 def test_get_spin_numbers(
-    l1b_de_spin, spin_met,  use_fake_repoint_data_for_time, use_fake_spin_data_for_time
+    l1b_de_spin, repoint_met,  use_fake_repoint_data_for_time, use_fake_spin_data_for_time
 ):
     # Arrange
 
-    use_fake_spin_data_for_time(spin_met[0])
-    use_fake_repoint_data_for_time(spin_met)
+    use_fake_spin_data_for_time(repoint_met[0])
+    use_fake_repoint_data_for_time(repoint_met)
 
-    expected_spin_numbers = np.array([1, 2, 3, 4, 5])
+    expected_spin_numbers = (60, 5759)
 
     # Act
     spin_numbers = get_spin_numbers(l1b_de_spin)

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -9,6 +9,7 @@ from imap_processing.lo.l1c.lo_l1c import (
     calculate_exposure_times,
     create_pset_counts,
     filter_goodtimes,
+    get_pointing_times,
     get_spin_numbers,
     initialize_pset,
     lo_l1c,
@@ -138,9 +139,17 @@ def doubles_counts(counts):
     return doubles
 
 
-def test_lo_l1c(l1b_de, anc_dependencies):
+def test_lo_l1c(
+    l1b_de,
+    anc_dependencies,
+    use_fake_repoint_data_for_time,
+    use_fake_spin_data_for_time,
+    repoint_met,
+):
     # Arrange
     data = {"imap_lo_l1b_de": l1b_de}
+    use_fake_spin_data_for_time(482300000)
+    use_fake_repoint_data_for_time(np.arange(482300000, 482300000 + 86400 * 5, 86400))
 
     expected_logical_source = "imap_lo_l1c_pset"
     # Act
@@ -245,21 +254,32 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
     np.testing.assert_array_equal(counts, doubles_counts)
 
 
+def test_get_pointing_times(l1b_de_spin, repoint_met, use_fake_repoint_data_for_time):
+    # Arrange
+    use_fake_repoint_data_for_time(repoint_met)
+
+    expected_pointing_times = (repoint_met[0] + 900, repoint_met[1])
+
+    # Act
+    pointing_times = get_pointing_times(l1b_de_spin["epoch"].values[0])
+
+    # Assert
+    np.testing.assert_array_equal(pointing_times, expected_pointing_times)
+
+
 def test_get_spin_numbers(
     l1b_de_spin,
     repoint_met,
-    use_fake_repoint_data_for_time,
     use_fake_spin_data_for_time,
 ):
     # Arrange
 
     use_fake_spin_data_for_time(repoint_met[0])
-    use_fake_repoint_data_for_time(repoint_met)
 
     expected_spin_numbers = (60, 5759)
 
     # Act
-    spin_numbers = get_spin_numbers(l1b_de_spin)
+    spin_numbers = get_spin_numbers(l1b_de_spin, repoint_met[0] + 900, repoint_met[1])
 
     # Assert
     np.testing.assert_array_equal(spin_numbers, expected_spin_numbers)

--- a/imap_processing/tests/spice/test_repoint.py
+++ b/imap_processing/tests/spice/test_repoint.py
@@ -70,14 +70,15 @@ def test_interpolate_repoint_data(fake_repoint_data):
         np.testing.assert_array_equal(repoint_df[key].values, expected_array)
 
 
-def test_get_pointing_start_time(fake_repoint_data):
+def test_get_pointing_times(fake_repoint_data):
     """Test coverage for get_pointing_times function."""
-    query_times = 6
-    expected_start_times = 5.1
+    times = 6
+    expected_times = (5.1, 15.2)
 
-    pointing_start_time = repoint.get_pointing_start_time(query_times)
+    pointing_start_time, pointing_end_time = repoint.get_pointing_times(times)
 
-    assert pointing_start_time == expected_start_times
+    assert pointing_start_time == expected_times[0]
+    assert pointing_end_time == expected_times[1]
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/spice/test_repoint.py
+++ b/imap_processing/tests/spice/test_repoint.py
@@ -70,6 +70,16 @@ def test_interpolate_repoint_data(fake_repoint_data):
         np.testing.assert_array_equal(repoint_df[key].values, expected_array)
 
 
+def test_get_pointing_start_time(fake_repoint_data):
+    """Test coverage for get_pointing_times function."""
+    query_times = 6
+    expected_start_times = 5.1
+
+    pointing_start_time = repoint.get_pointing_start_time(query_times)
+
+    assert pointing_start_time == expected_start_times
+
+
 @pytest.mark.parametrize(
     "query_times, match_str",
     [

--- a/imap_processing/tests/spice/test_spin.py
+++ b/imap_processing/tests/spice/test_spin.py
@@ -97,6 +97,15 @@ def test_interpolate_spin_data(query_met_times, expected, fake_spin_data):
         )
 
 
+def test_get_spin_number(fake_spin_data):
+    """Test get_spin_number() with generated spin data."""
+    # Call the function
+    spin_number = spin.get_spin_number(query_met_time=15.1)
+
+    # Test the value
+    assert spin_number == 1
+
+
 @pytest.mark.parametrize(
     "query_met_times, expected",
     [

--- a/imap_processing/tests/spice/test_spin.py
+++ b/imap_processing/tests/spice/test_spin.py
@@ -97,13 +97,16 @@ def test_interpolate_spin_data(query_met_times, expected, fake_spin_data):
         )
 
 
-def test_get_spin_number(fake_spin_data):
+@pytest.mark.parametrize(
+    "met_time,spin_number_expected", [(0, 0), (14.9, 0), (15.1, 1), (32, 2)]
+)
+def test_get_spin_number(fake_spin_data, met_time, spin_number_expected):
     """Test get_spin_number() with generated spin data."""
     # Call the function
-    spin_number = spin.get_spin_number(query_met_time=15.1)
+    spin_number = spin.get_spin_number(met_time=met_time)
 
     # Test the value
-    assert spin_number == 1
+    assert spin_number == spin_number_expected
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 [tool.poetry]
 name = "imap-processing"
 # Gets updated dynamically by the poetry-dynamic-versioning plugin
-version = "0.0.0"
+version = "0.6.0.post483.dev0+03229ea"
 description = "IMAP Science Operations Center Processing"
 authors = ["IMAP SDC Developers <imap-sdc@lists.lasp.colorado.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 [tool.poetry]
 name = "imap-processing"
 # Gets updated dynamically by the poetry-dynamic-versioning plugin
-version = "0.6.0.post483.dev0+03229ea"
+version = "0.0.0"
 description = "IMAP Science Operations Center Processing"
 authors = ["IMAP SDC Developers <imap-sdc@lists.lasp.colorado.edu>"]
 readme = "README.md"


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds code to create the pointing start/end times fields and the spin numbers fields.

The pointing start field contains the time that the pointing starts and the pointing end field contains the time that the pointing ends.

The spin start number contains the spin number at the start of the pointing and the spin end number contains the spin number at the end of the pointing.

## Updated Files
- lo_l1c.py
   - added functions for the spin start/end fields and the pointing start/end fields
   - Set the epoch as the pointing start field

## Testing
Add unit tests for each function added and updated the test_lo_l1c unit test.

Closes #2027
Closes #1900