### PR TITLE
MAG L1C Metadata update

### DIFF
--- a/imap_processing/cdf/config/imap_mag_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l1c_variable_attrs.yaml
@@ -4,7 +4,7 @@ default_attrs: &default
   # Assumed values for all variable attrs unless overwritten
   DEPEND_0: epoch
   DISPLAY_TYPE: time_series
-  FILLVAL: -1e31
+  FILLVAL: -1.0e+31
   FORMAT: I12
   VALIDMIN: -9223372036854775808
   VALIDMAX: 9223372036854775807

--- a/imap_processing/cdf/config/imap_mag_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l1c_variable_attrs.yaml
@@ -4,7 +4,7 @@ default_attrs: &default
   # Assumed values for all variable attrs unless overwritten
   DEPEND_0: epoch
   DISPLAY_TYPE: time_series
-  FILLVAL: -9223372036854775808
+  FILLVAL: -1e31
   FORMAT: I12
   VALIDMIN: -9223372036854775808
   VALIDMAX: 9223372036854775807
@@ -104,6 +104,29 @@ compression_flags_attrs:
   VALIDMIN: 0
   LABL_PTR_1: compression_label
   DISPLAY_TYPE: no_plot
+
+generated_flag_attrs:
+  <<: *default
+  CATDESC: Data has been downsampled and interpolated from higher frequency measurements
+  FIELDNAM: Generated Flag
+  LABLAXIS: Generated Flag
+  FILLVAL: 255
+  FORMAT: I1
+  UNITS: ' '
+  VALIDMAX: 1
+  VALIDMIN: 0
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+vector_magnitude_attrs:
+  <<: *support_default
+  CATDESC: Magnitude of the magnetic field vector
+  FIELDNAM: Magnetic Field Magnitude
+  LABLAXIS: "|B|"
+  FORMAT: F12.5
+  UNITS: nT
+  VALIDMIN: 0
+  VALIDMAX: 9223372036854775807
+  DICT_KEY: SPASE>Field>FieldQuantity:Magnetic,Qualifier:Scalar
 
 compression:
     <<: *support_default

--- a/imap_processing/cdf/config/imap_mag_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l1c_variable_attrs.yaml
@@ -106,7 +106,7 @@ compression_flags_attrs:
   DISPLAY_TYPE: no_plot
 
 generated_flag_attrs:
-  <<: *default
+  <<: *support_default
   CATDESC: Flag indicating data has been downsampled and interpolated from higher frequency measurements
   FIELDNAM: Generated Flag
   LABLAXIS: Generated Flag

--- a/imap_processing/cdf/config/imap_mag_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l1c_variable_attrs.yaml
@@ -107,7 +107,7 @@ compression_flags_attrs:
 
 generated_flag_attrs:
   <<: *default
-  CATDESC: Data has been downsampled and interpolated from higher frequency measurements
+  CATDESC: Flag indicating data has been downsampled and interpolated from higher frequency measurements
   FIELDNAM: Generated Flag
   LABLAXIS: Generated Flag
   FILLVAL: 255

--- a/imap_processing/mag/l1c/mag_l1c.py
+++ b/imap_processing/mag/l1c/mag_l1c.py
@@ -161,7 +161,9 @@ def mag_l1c(
         output_core_dims=[[]],
         vectorize=True,
     )
-    output_dataset['vector_magnitude'].attrs = attribute_manager.get_variable_attributes("vector_magnitude_attrs")
+    output_dataset[
+        "vector_magnitude"
+    ].attrs = attribute_manager.get_variable_attributes("vector_magnitude_attrs")
 
     output_dataset["compression_flags"] = xr.DataArray(
         completed_timeline[:, 6:8],

--- a/imap_processing/mag/l1c/mag_l1c.py
+++ b/imap_processing/mag/l1c/mag_l1c.py
@@ -161,8 +161,7 @@ def mag_l1c(
         output_core_dims=[[]],
         vectorize=True,
     )
-    # output_dataset['vector_magnitude'].attrs =
-    # attribute_manager.get_variable_attributes("vector_magnitude_attrs")
+    output_dataset['vector_magnitude'].attrs = attribute_manager.get_variable_attributes("vector_magnitude_attrs")
 
     output_dataset["compression_flags"] = xr.DataArray(
         completed_timeline[:, 6:8],
@@ -175,7 +174,7 @@ def mag_l1c(
         completed_timeline[:, 5],
         name="generated_flag",
         dims=["epoch"],
-        # attrs=attribute_manager.get_variable_attributes("generated_flag_attrs"),
+        attrs=attribute_manager.get_variable_attributes("generated_flag_attrs"),
     )
 
     return output_dataset


### PR DESCRIPTION
# Change Summary

## Overview

Add missing L1C metadata for MAG, and add those attributes to the output CDF 

## New Dependencies
N/A

## New Files
N/A

## Deleted Files
N/A

## Updated Files
/workspaces/imap_processing/imap_processing/mag/l1b
- imap_mag_l1c_variable_attrs.yaml
   - Add `generated_flag_attrs` to add ISTP required attributes for `generated_flag` variable
   - Add `vector_magnitude_attrs` to add ISTP required attributes for `vector_magnitude` variable
   - Changed the default FILLVAL to -1e31 for MAG variables, which are mostly CDF_DOUBLEs
- mag_l1c.py
   - Restore code to pull necessary variable attributes for CDF output

## Testing

