### PR TITLE
Ultra l1c - Add background rates to the data product

### DIFF
--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -528,6 +528,11 @@ def ancillary_files():
         "l1b-tofxph": path / "imap_ultra_l1b-tofxph_20250101_v000.pgm",
         "l1b-90sensor-scattering-calibration": path
         / "imap_ultra_l1b-90sensor-scattering-calibration-data_20250101_v000.csv",
+        "l1c-90sensor-dps-exposure": path
+        / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
+        "l1c-90sensor-efficiencies": path
+        / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
+        "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
     }
 
 
@@ -548,6 +553,8 @@ def deadtime_datasets():
             "coin_bn": (["epoch"], np.random.randint(0, 5, epoch)),
             "stop_tn": (["epoch"], np.random.randint(0, 5, epoch)),
             "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
+            "shcoarse": (["epoch"], np.arange(epoch)),
+            "spin": (["epoch"], 127 + (np.arange(epoch) % (141 - 127))),
         }
     )
     # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -24,8 +24,16 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
-def test_calculate_spacecraft_pset(deadtime_datasets, imap_ena_sim_metakernel):
+def test_calculate_spacecraft_pset(
+    deadtime_datasets,
+    imap_ena_sim_metakernel,
+    use_fake_spin_data_for_time,
+    ancillary_files,
+):
     """Tests calculate_spacecraft_pset function."""
+    # Simulate a spin table from MET = 0 to MET = 141 * 15 seconds
+    use_fake_spin_data_for_time(start_met=0, end_met=141 * 15)
+
     # This is just setting up the data so that it is in the format of l1b_de_dataset.
     test_path = TEST_PATH / "ultra-90_raw_event_data_shortened.csv"
     df = pd.read_csv(test_path)
@@ -58,21 +66,13 @@ def test_calculate_spacecraft_pset(deadtime_datasets, imap_ena_sim_metakernel):
                 particle_velocity_dps_spacecraft,
             ),
             "energy_spacecraft": (["epoch"], energy_dps_spacecraft),
+            "spin_number": (["epoch"], df["Spin"].values),
         },
         coords={
             "epoch": ("epoch", epoch),
             "component": ("component", ["vx", "vy", "vz"]),
         },
     )
-
-    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
-    ancillary = {
-        "l1c-90sensor-dps-exposure": path
-        / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
-        "l1c-90sensor-efficiencies": path
-        / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
-        "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
-    }
 
     spacecraft_pset = calculate_spacecraft_pset(
         test_l1b_de_dataset,
@@ -81,7 +81,7 @@ def test_calculate_spacecraft_pset(deadtime_datasets, imap_ena_sim_metakernel):
         deadtime_datasets["rates"],
         deadtime_datasets["params"],
         "imap_ultra_l1c_45sensor-spacecraftpset",
-        ancillary,
+        ancillary_files,
     )
     assert "pixel_index" in spacecraft_pset.coords
     assert "epoch" in spacecraft_pset.coords
@@ -91,10 +91,14 @@ def test_calculate_spacecraft_pset(deadtime_datasets, imap_ena_sim_metakernel):
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
 def test_calculate_spacecraft_pset_with_cdf(
-    ancillary_files, deadtime_datasets, imap_ena_sim_metakernel
+    ancillary_files,
+    deadtime_datasets,
+    imap_ena_sim_metakernel,
+    use_fake_spin_data_for_time,
 ):
     """Tests calculate_spacecraft_pset function with imported test data."""
-
+    # Simulate a spin table from MET = 0 to MET = 141 * 15 seconds
+    use_fake_spin_data_for_time(start_met=0, end_met=141 * 15)
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
 
     # Loop over all unique pointing numbers
@@ -133,27 +137,21 @@ def test_calculate_spacecraft_pset_with_cdf(
 
         de_dict["velocity_dps_sc"] = sc_dps_velocity
         de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
+        # Made up data for spin_number and energy_bin_geometric_mean
+        de_dict["spin_number"] = np.full(len(sc_dps_velocity), 128)
+        de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
 
         name = "imap_ultra_l1b_45sensor-de"
         dataset = create_dataset(de_dict, name, "l1b")
 
-        path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
-        ancillary = {
-            "l1c-90sensor-dps-exposure": path
-            / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
-            "l1c-90sensor-efficiencies": path
-            / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
-            "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
-        }
-
         spacecraft_pset = calculate_spacecraft_pset(
             dataset,
-            xr.Dataset(),  # placeholder for extendedspin_dataset
-            xr.Dataset(),  # placeholder for cullingmask_dataset
+            dataset,  # placeholder for extendedspin_dataset
+            dataset,  # placeholder for cullingmask_dataset
             deadtime_datasets["rates"],
             deadtime_datasets["params"],
             "imap_ultra_l1c_45sensor-spacecraftpset",
-            ancillary,
+            ancillary_files,
         )
         # TODO: validate with output histogram data once we have it in healpix.
         assert (

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -131,10 +131,14 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
 def test_calculate_spacecraft_pset_with_cdf(
-    ancillary_files, deadtime_datasets, imap_ena_sim_metakernel
+    ancillary_files,
+    deadtime_datasets,
+    imap_ena_sim_metakernel,
+    use_fake_spin_data_for_time,
 ):
     """Tests ultra_l1c function with imported test data."""
-
+    # Simulate a spin table from MET = 0 to MET = 141 * 15 seconds
+    use_fake_spin_data_for_time(start_met=0, end_met=141 * 15)
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
 
     # Select a single pointing number
@@ -172,25 +176,19 @@ def test_calculate_spacecraft_pset_with_cdf(
 
     de_dict["velocity_dps_sc"] = sc_dps_velocity
     de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
+    # Made up data for spin_number and energy_bin_geometric_mean
+    de_dict["spin_number"] = np.full(len(sc_dps_velocity), 128)
+    de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
 
     name = "imap_ultra_l1b_45sensor-de"
     dataset = create_dataset(de_dict, name, "l1b")
 
     data_dict = {
         "imap_ultra_l1b_45sensor-de": dataset,
-        "imap_ultra_l1b_45sensor-extendedspin": xr.Dataset(),  # placeholder
-        "imap_ultra_l1b_45sensor-cullingmask": xr.Dataset(),  # placeholder
+        "imap_ultra_l1b_45sensor-extendedspin": dataset,  # placeholder
+        "imap_ultra_l1b_45sensor-cullingmask": dataset,  # placeholder
         "imap_ultra_l1a_45sensor-rates": deadtime_datasets["rates"],
         "imap_ultra_l1a_45sensor-params": deadtime_datasets["params"],
-    }
-
-    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
-    ancillary_files = {
-        "l1c-90sensor-dps-exposure": path
-        / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
-        "l1c-90sensor-efficiencies": path
-        / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
-        "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
     }
 
     output_datasets = ultra_l1c(data_dict, ancillary_files, has_spice=False)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -373,7 +373,6 @@ def test_get_helio_sensitivity(monkeypatch, imap_ena_sim_metakernel):
     np.testing.assert_allclose(flat_sc, flat_helio, atol=1e-5)
 
 
-@pytest.mark.external_kernel
 def test_get_spacecraft_background_rates(
     rates_l1_test_path, use_fake_spin_data_for_time, ancillary_files
 ):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -12,11 +12,9 @@ from imap_processing import imap_module_directory
 from imap_processing.ultra.l1c import ultra_l1c_pset_bins
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
-    calculate_background_rates,
     get_deadtime_interpolator,
     get_deadtime_ratios,
     get_energy_delta_minus_plus,
-    get_helio_background_rates,
     get_helio_exposure_times,
     get_helio_sensitivity,
     get_sectored_rates,
@@ -128,20 +126,6 @@ def test_get_spacecraft_histogram(test_data):
 def mock_imap_state(time, ref_frame):
     # Position (0, 0, 0), exaggerated velocity to force visible transformation
     return np.array([0, 0, 0, 0, 0, 0])
-
-
-def test_get_spacecraft_background_rates():
-    """Tests get_background_rates function."""
-    background_rates = get_spacecraft_background_rates(nside=128)
-    _, energy_midpoints, _ = build_energy_bins()
-    assert background_rates.shape == (len(energy_midpoints), hp.nside2npix(128))
-
-
-def test_get_helio_background_rates():
-    """Tests get_background_rates function."""
-    background_rates = get_helio_background_rates(nside=128)
-    _, energy_midpoints, _ = build_energy_bins()
-    assert background_rates.shape == (len(energy_midpoints), hp.nside2npix(128))
 
 
 def test_get_sectored_rates():
@@ -390,7 +374,7 @@ def test_get_helio_sensitivity(monkeypatch, imap_ena_sim_metakernel):
 
 
 @pytest.mark.external_kernel
-def test_calculate_background_rates(
+def test_get_spacecraft_background_rates(
     rates_l1_test_path, use_fake_spin_data_for_time, ancillary_files
 ):
     "Tests calculate_background_rates function."
@@ -423,7 +407,7 @@ def test_calculate_background_rates(
     energy_bin_edges, _, _ = build_energy_bins()
     cullingmask_spin_number = np.array([130, 131])
 
-    background_rates = calculate_background_rates(
+    background_rates = get_spacecraft_background_rates(
         rates, "ultra45", ancillary_files, energy_bin_edges, cullingmask_spin_number
     )
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -7,7 +7,6 @@ import xarray as xr
 from imap_processing.spice.time import sct_to_et
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
-    get_helio_background_rates,
     get_helio_exposure_times,
     get_helio_sensitivity,
     get_spacecraft_histogram,
@@ -61,9 +60,6 @@ def calculate_helio_pset(
 
     healpix = np.arange(n_pix)
 
-    # calculate background rates
-    background_rates = get_helio_background_rates()
-
     efficiencies = ancillary_files["l1c-90sensor-efficiencies"]
     geometric_function = ancillary_files["l1c-90sensor-gf"]
 
@@ -87,7 +83,6 @@ def calculate_helio_pset(
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
-    pset_dict["background_rates"] = background_rates[np.newaxis, ...]
     pset_dict["helio_exposure_factor"] = exposure_pointing[np.newaxis, ...]
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_spacecraft_background_rates,
@@ -49,6 +50,7 @@ def calculate_spacecraft_pset(
         Dataset containing the data.
     """
     pset_dict: dict[str, np.ndarray] = {}
+    sensor = parse_filename_like(name)["sensor"][0:2]
 
     v_mag_dps_spacecraft = np.linalg.norm(de_dataset["velocity_dps_sc"].values, axis=1)
     vhat_dps_spacecraft = (
@@ -64,9 +66,6 @@ def calculate_spacecraft_pset(
     )
     healpix = np.arange(n_pix)
 
-    # calculate background rates
-    background_rates = get_spacecraft_background_rates()
-
     efficiencies = ancillary_files["l1c-90sensor-efficiencies"]
     geometric_function = ancillary_files["l1c-90sensor-gf"]
 
@@ -79,6 +78,15 @@ def calculate_spacecraft_pset(
     df_exposure = pd.read_csv(constant_exposure)
     exposure_pointing = get_spacecraft_exposure_times(
         df_exposure, rates_dataset, params_dataset
+    )
+
+    # Calculate background rates
+    background_rates = get_spacecraft_background_rates(
+        rates_dataset,
+        sensor,
+        ancillary_files,
+        intervals,
+        cullingmask_dataset["spin_number"].values,
     )
 
     # For ISTP, epoch should be the center of the time bin.

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -181,60 +181,6 @@ def get_spacecraft_count_rate_uncertainty(hist: NDArray, exposure: NDArray) -> N
     return rate_uncertainty
 
 
-def get_spacecraft_background_rates(
-    nside: int = 128,
-) -> NDArray:
-    """
-    Calculate background rates.
-
-    Parameters
-    ----------
-    nside : int, optional
-        The nside parameter of the Healpix tessellation (default is 128).
-
-    Returns
-    -------
-    background_rates : np.ndarray
-        Array of background rates.
-
-    Notes
-    -----
-    This is a placeholder.
-    TODO: background rates to be provided by IT.
-    """
-    npix = hp.nside2npix(nside)
-    _, energy_midpoints, _ = build_energy_bins()
-    background = np.zeros((len(energy_midpoints), npix))
-    return background
-
-
-def get_helio_background_rates(
-    nside: int = 128,
-) -> NDArray:
-    """
-    Calculate background rates.
-
-    Parameters
-    ----------
-    nside : int, optional
-        The nside parameter of the Healpix tessellation (default is 128).
-
-    Returns
-    -------
-    background_rates : np.ndarray
-        Array of background rates.
-
-    Notes
-    -----
-    This is a placeholder.
-    TODO: background rates to be provided by IT.
-    """
-    npix = hp.nside2npix(nside)
-    _, energy_midpoints, _ = build_energy_bins()
-    background = np.zeros((len(energy_midpoints), npix))
-    return background
-
-
 def get_deadtime_ratios(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
     """
     Compute the dead time ratio at each sector.
@@ -721,7 +667,7 @@ def get_helio_sensitivity(
     return helio_sensitivity
 
 
-def calculate_background_rates(
+def get_spacecraft_background_rates(
     rates_dataset: xr.Dataset,
     sensor: str,
     ancillary_files: dict,


### PR DESCRIPTION
# Change Summary

## Overview
Add background rates to the data product

## Updated Files
- helio_pset.py
   - We do not need background rates in the helio frame based on conversations with George Clark. We also don't need to apply the background rate until the IT has had a chance to look at it.
- spacecraft_pset.py
   - Replace get_spacecraft_background_rates with new formula
- ultra_l1c_pset.py
   - Remove old formulas get_spacecraft_background_rates and get_helio_background_rates

## Testing
test_ultra_l1c_pset_bins.py
