### PR TITLE
IDEX handle missing science acquisition events 

### DIFF
--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -141,9 +141,9 @@ def idex_l2b(
         daily_on_percentage,
     )
     # Create l2b Dataset
-    charge_bins = CHARGE_BIN_EDGES[1:]
-    mass_bins = CHARGE_BIN_EDGES[1:]
-    spin_phase_bins = SPIN_PHASE_BIN_EDGES[1:]
+    charge_bin_means = np.sqrt(CHARGE_BIN_EDGES[:-1] * CHARGE_BIN_EDGES[1:])
+    mass_bin_means = np.sqrt(MASS_BIN_EDGES[:-1] * MASS_BIN_EDGES[1:])
+    spin_phase_means = (SPIN_PHASE_BIN_EDGES[:-1] + SPIN_PHASE_BIN_EDGES[1:]) / 2
 
     # Define xarrays that are shared between l2b and l2c
     epoch = xr.DataArray(
@@ -162,7 +162,7 @@ def idex_l2b(
         ),
         "charge_labels": xr.DataArray(
             name="impact_charge_labels",
-            data=charge_bins.astype(str),
+            data=charge_bin_means.astype(str),
             dims="impact_charge",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "charge_labels", check_schema=False
@@ -170,7 +170,7 @@ def idex_l2b(
         ),
         "mass_labels": xr.DataArray(
             name="mass_labels",
-            data=mass_bins.astype(str),
+            data=mass_bin_means.astype(str),
             dims="mass",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "mass_labels", check_schema=False
@@ -178,7 +178,7 @@ def idex_l2b(
         ),
         "impact_charge": xr.DataArray(
             name="impact_charge",
-            data=charge_bins,
+            data=charge_bin_means,
             dims="impact_charge",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "impact_charge", check_schema=False
@@ -186,7 +186,7 @@ def idex_l2b(
         ),
         "mass": xr.DataArray(
             name="mass",
-            data=mass_bins,
+            data=mass_bin_means,
             dims="mass",
             attrs=idex_l2b_attrs.get_variable_attributes("mass", check_schema=False),
         ),
@@ -194,7 +194,7 @@ def idex_l2b(
     l2b_vars = common_vars | {
         "spin_phase": xr.DataArray(
             name="spin_phase",
-            data=spin_phase_bins,
+            data=spin_phase_means,
             dims="spin_phase",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "spin_phase", check_schema=False
@@ -202,7 +202,7 @@ def idex_l2b(
         ),
         "spin_phase_labels": xr.DataArray(
             name="spin_phase_labels",
-            data=spin_phase_bins.astype(str),
+            data=spin_phase_means.astype(str),
             dims="spin_phase",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "spin_phase_labels", check_schema=False

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -141,9 +141,6 @@ def idex_l2b(
         daily_on_percentage,
     )
     # Create l2b Dataset
-    charge_bins = np.arange(len(CHARGE_BIN_EDGES) - 1)
-    mass_bins = np.arange(len(CHARGE_BIN_EDGES) - 1)
-    spin_phase_bins = np.arange(len(SPIN_PHASE_BIN_EDGES) - 1)
 
     # Define xarrays that are shared between l2b and l2c
     epoch = xr.DataArray(
@@ -162,7 +159,7 @@ def idex_l2b(
         ),
         "charge_labels": xr.DataArray(
             name="impact_charge_labels",
-            data=charge_bins.astype(str),
+            data=CHARGE_BIN_EDGES.astype(str),
             dims="impact_charge",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "charge_labels", check_schema=False
@@ -170,7 +167,7 @@ def idex_l2b(
         ),
         "mass_labels": xr.DataArray(
             name="mass_labels",
-            data=mass_bins.astype(str),
+            data=MASS_BIN_EDGES.astype(str),
             dims="mass",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "mass_labels", check_schema=False
@@ -178,7 +175,7 @@ def idex_l2b(
         ),
         "impact_charge": xr.DataArray(
             name="impact_charge",
-            data=charge_bins,
+            data=CHARGE_BIN_EDGES,
             dims="impact_charge",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "impact_charge", check_schema=False
@@ -186,7 +183,7 @@ def idex_l2b(
         ),
         "mass": xr.DataArray(
             name="mass",
-            data=mass_bins,
+            data=MASS_BIN_EDGES,
             dims="mass",
             attrs=idex_l2b_attrs.get_variable_attributes("mass", check_schema=False),
         ),
@@ -194,7 +191,7 @@ def idex_l2b(
     l2b_vars = common_vars | {
         "spin_phase": xr.DataArray(
             name="spin_phase",
-            data=spin_phase_bins,
+            data=SPIN_PHASE_BIN_EDGES,
             dims="spin_phase",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "spin_phase", check_schema=False
@@ -202,7 +199,7 @@ def idex_l2b(
         ),
         "spin_phase_labels": xr.DataArray(
             name="spin_phase_labels",
-            data=spin_phase_bins.astype(str),
+            data=SPIN_PHASE_BIN_EDGES.astype(str),
             dims="spin_phase",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "spin_phase_labels", check_schema=False

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -109,7 +109,6 @@ def idex_l2b(
         "processed at the same time as L2B datasets because L2C needs no additional "
         "dependencies."
     )
-    l2b_rate_vars, l2c_rate_vars = None, None
     # create the attribute manager for this data level
     idex_l2b_attrs = get_idex_attrs("l2b")
     idex_l2c_attrs = get_idex_attrs("l2c")
@@ -127,71 +126,25 @@ def idex_l2b(
     ) = compute_counts_by_charge_and_mass(l2a_dataset, epoch_doy_unique)
     # Get science acquisition percentage for each day
     daily_on_percentage = get_science_acquisition_on_percentage(evt_dataset)
-    if daily_on_percentage is None:
+    if daily_on_percentage == {}:
         logger.warning(
-            "No science acquisition uptime percentages found. Unable to compute rates"
+            "No science acquisition uptime percentages found. Rates will all be set"
+            " to -1"
         )
-    else:
-        (
-            rate_by_charge,
-            rate_by_mass,
-            rate_by_charge_map,
-            rate_by_mass_map,
-            rate_quality_flags,
-        ) = compute_rates_by_charge_and_mass(
-            counts_by_charge,
-            counts_by_mass,
-            counts_by_charge_map,
-            counts_by_mass_map,
-            epoch_doy_unique,
-            daily_on_percentage,
-        )
-        l2b_rate_vars = {
-            "rate_calculation_quality_flags": xr.DataArray(
-                name="rate_calculation_quality_flags",
-                data=rate_quality_flags,
-                dims="epoch",
-                attrs=idex_l2b_attrs.get_variable_attributes(
-                    "rate_calculation_quality_flags"
-                ),
-            ),
-            "rate_by_charge": xr.DataArray(
-                name="rate_by_charge",
-                data=rate_by_charge,
-                dims=("epoch", "impact_charge", "spin_phase"),
-                attrs=idex_l2b_attrs.get_variable_attributes("rate_by_charge"),
-            ),
-            "rate_by_mass": xr.DataArray(
-                name="rate_by_mass",
-                data=rate_by_mass,
-                dims=("epoch", "mass", "spin_phase"),
-                attrs=idex_l2b_attrs.get_variable_attributes("rate_by_mass"),
-            ),
-        }
-        l2c_rate_vars = {
-            "rate_by_charge_map": xr.DataArray(
-                name="rate_by_charge_map",
-                data=rate_by_charge_map,
-                dims=(
-                    "epoch",
-                    "impact_charge",
-                    "rectangular_lon_pixel",
-                    "rectangular_lat_pixel",
-                ),
-                attrs=idex_l2c_attrs.get_variable_attributes("rate_by_charge_map"),
-            ),
-            "rate_by_mass_map": xr.DataArray(
-                name="rate_by_mass_map",
-                data=rate_by_mass_map,
-                dims=(
-                    "epoch",
-                    "mass",
-                    "rectangular_lon_pixel",
-                    "rectangular_lat_pixel",
-                ),
-                attrs=idex_l2c_attrs.get_variable_attributes("rate_by_mass_map"),
-            ),
-        }
+    (
+        rate_by_charge,
+        rate_by_mass,
+        rate_by_charge_map,
+        rate_by_mass_map,
+        rate_quality_flags,
+    ) = compute_rates_by_charge_and_mass(
+        counts_by_charge,
+        counts_by_mass,
+        counts_by_charge_map,
+        counts_by_mass_map,
+        epoch_doy_unique,
+        daily_on_percentage,
+    )
     # Create l2b Dataset
     charge_bins = np.arange(len(CHARGE_BIN_EDGES) - 1)
     mass_bins = np.arange(len(CHARGE_BIN_EDGES) - 1)
@@ -260,6 +213,14 @@ def idex_l2b(
                 "spin_phase_labels", check_schema=False
             ),
         ),
+        "rate_calculation_quality_flags": xr.DataArray(
+            name="rate_calculation_quality_flags",
+            data=rate_quality_flags,
+            dims="epoch",
+            attrs=idex_l2b_attrs.get_variable_attributes(
+                "rate_calculation_quality_flags"
+            ),
+        ),
         "counts_by_charge": xr.DataArray(
             name="counts_by_charge",
             data=counts_by_charge.astype(np.int64),
@@ -271,6 +232,18 @@ def idex_l2b(
             data=counts_by_mass.astype(np.int64),
             dims=("epoch", "mass", "spin_phase"),
             attrs=idex_l2b_attrs.get_variable_attributes("counts_by_mass"),
+        ),
+        "rate_by_charge": xr.DataArray(
+            name="rate_by_charge",
+            data=rate_by_charge,
+            dims=("epoch", "impact_charge", "spin_phase"),
+            attrs=idex_l2b_attrs.get_variable_attributes("rate_by_charge"),
+        ),
+        "rate_by_mass": xr.DataArray(
+            name="rate_by_mass",
+            data=rate_by_mass,
+            dims=("epoch", "mass", "spin_phase"),
+            attrs=idex_l2b_attrs.get_variable_attributes("rate_by_mass"),
         ),
     }
     l2c_vars = common_vars | {
@@ -328,12 +301,29 @@ def idex_l2b(
             ),
             attrs=idex_l2c_attrs.get_variable_attributes("counts_by_mass_map"),
         ),
+        "rate_by_charge_map": xr.DataArray(
+            name="rate_by_charge_map",
+            data=rate_by_charge_map,
+            dims=(
+                "epoch",
+                "impact_charge",
+                "rectangular_lon_pixel",
+                "rectangular_lat_pixel",
+            ),
+            attrs=idex_l2c_attrs.get_variable_attributes("rate_by_charge_map"),
+        ),
+        "rate_by_mass_map": xr.DataArray(
+            name="rate_by_mass_map",
+            data=rate_by_mass_map,
+            dims=(
+                "epoch",
+                "mass",
+                "rectangular_lon_pixel",
+                "rectangular_lat_pixel",
+            ),
+            attrs=idex_l2c_attrs.get_variable_attributes("rate_by_mass_map"),
+        ),
     }
-    # Add rate variables if they were computed
-    if l2c_rate_vars:
-        l2c_vars = l2c_vars | l2c_rate_vars
-    if l2b_rate_vars:
-        l2b_vars = l2b_vars | l2b_rate_vars
 
     l2b_dataset = xr.Dataset(
         coords={"epoch": epoch},
@@ -644,7 +634,7 @@ def get_science_acquisition_timestamps(
     )
 
 
-def get_science_acquisition_on_percentage(evt_dataset: xr.Dataset) -> dict | None:
+def get_science_acquisition_on_percentage(evt_dataset: xr.Dataset) -> dict:
     """
     Calculate the percentage of time science acquisition was occurring for each day.
 
@@ -657,7 +647,7 @@ def get_science_acquisition_on_percentage(evt_dataset: xr.Dataset) -> dict | Non
     -------
     dict
         Percentages of time the instrument was in science acquisition mode for each day
-         of year. Returns None if no science acquisition events are found.
+         of year.
     """
     # Get science acquisition start and stop times
     evt_logs, evt_time, evt_values = get_science_acquisition_timestamps(evt_dataset)
@@ -666,7 +656,7 @@ def get_science_acquisition_on_percentage(evt_dataset: xr.Dataset) -> dict | Non
             "No science acquisition events found in event dataset. Returning empty "
             "uptime percentages."
         )
-        return None
+        return {}
     # Track total and 'on' durations per day
     daily_totals: collections.defaultdict = defaultdict(timedelta)
     daily_on: collections.defaultdict = defaultdict(timedelta)

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -126,11 +126,6 @@ def idex_l2b(
     ) = compute_counts_by_charge_and_mass(l2a_dataset, epoch_doy_unique)
     # Get science acquisition percentage for each day
     daily_on_percentage = get_science_acquisition_on_percentage(evt_dataset)
-    if daily_on_percentage == {}:
-        logger.warning(
-            "No science acquisition uptime percentages found. Rates will all be set"
-            " to -1"
-        )
     (
         rate_by_charge,
         rate_by_mass,
@@ -654,7 +649,7 @@ def get_science_acquisition_on_percentage(evt_dataset: xr.Dataset) -> dict:
     if len(evt_time) == 0:
         logger.warning(
             "No science acquisition events found in event dataset. Returning empty "
-            "uptime percentages."
+            "uptime percentages. All rate variables will be set to -1."
         )
         return {}
     # Track total and 'on' durations per day

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -141,6 +141,9 @@ def idex_l2b(
         daily_on_percentage,
     )
     # Create l2b Dataset
+    charge_bins = CHARGE_BIN_EDGES[1:]
+    mass_bins = CHARGE_BIN_EDGES[1:]
+    spin_phase_bins = SPIN_PHASE_BIN_EDGES[1:]
 
     # Define xarrays that are shared between l2b and l2c
     epoch = xr.DataArray(
@@ -159,7 +162,7 @@ def idex_l2b(
         ),
         "charge_labels": xr.DataArray(
             name="impact_charge_labels",
-            data=CHARGE_BIN_EDGES.astype(str),
+            data=charge_bins.astype(str),
             dims="impact_charge",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "charge_labels", check_schema=False
@@ -167,7 +170,7 @@ def idex_l2b(
         ),
         "mass_labels": xr.DataArray(
             name="mass_labels",
-            data=MASS_BIN_EDGES.astype(str),
+            data=mass_bins.astype(str),
             dims="mass",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "mass_labels", check_schema=False
@@ -175,7 +178,7 @@ def idex_l2b(
         ),
         "impact_charge": xr.DataArray(
             name="impact_charge",
-            data=CHARGE_BIN_EDGES,
+            data=charge_bins,
             dims="impact_charge",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "impact_charge", check_schema=False
@@ -183,7 +186,7 @@ def idex_l2b(
         ),
         "mass": xr.DataArray(
             name="mass",
-            data=MASS_BIN_EDGES,
+            data=mass_bins,
             dims="mass",
             attrs=idex_l2b_attrs.get_variable_attributes("mass", check_schema=False),
         ),
@@ -191,7 +194,7 @@ def idex_l2b(
     l2b_vars = common_vars | {
         "spin_phase": xr.DataArray(
             name="spin_phase",
-            data=SPIN_PHASE_BIN_EDGES,
+            data=spin_phase_bins,
             dims="spin_phase",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "spin_phase", check_schema=False
@@ -199,7 +202,7 @@ def idex_l2b(
         ),
         "spin_phase_labels": xr.DataArray(
             name="spin_phase_labels",
-            data=SPIN_PHASE_BIN_EDGES.astype(str),
+            data=spin_phase_bins.astype(str),
             dims="spin_phase",
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "spin_phase_labels", check_schema=False

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -109,7 +109,7 @@ def idex_l2b(
         "processed at the same time as L2B datasets because L2C needs no additional "
         "dependencies."
     )
-
+    l2b_rate_vars, l2c_rate_vars = None, None
     # create the attribute manager for this data level
     idex_l2b_attrs = get_idex_attrs("l2b")
     idex_l2c_attrs = get_idex_attrs("l2c")
@@ -127,20 +127,71 @@ def idex_l2b(
     ) = compute_counts_by_charge_and_mass(l2a_dataset, epoch_doy_unique)
     # Get science acquisition percentage for each day
     daily_on_percentage = get_science_acquisition_on_percentage(evt_dataset)
-    (
-        rate_by_charge,
-        rate_by_mass,
-        rate_by_charge_map,
-        rate_by_mass_map,
-        rate_quality_flags,
-    ) = compute_rates_by_charge_and_mass(
-        counts_by_charge,
-        counts_by_mass,
-        counts_by_charge_map,
-        counts_by_mass_map,
-        epoch_doy_unique,
-        daily_on_percentage,
-    )
+    if daily_on_percentage is None:
+        logger.warning(
+            "No science acquisition uptime percentages found. Unable to compute rates"
+        )
+    else:
+        (
+            rate_by_charge,
+            rate_by_mass,
+            rate_by_charge_map,
+            rate_by_mass_map,
+            rate_quality_flags,
+        ) = compute_rates_by_charge_and_mass(
+            counts_by_charge,
+            counts_by_mass,
+            counts_by_charge_map,
+            counts_by_mass_map,
+            epoch_doy_unique,
+            daily_on_percentage,
+        )
+        l2b_rate_vars = {
+            "rate_calculation_quality_flags": xr.DataArray(
+                name="rate_calculation_quality_flags",
+                data=rate_quality_flags,
+                dims="epoch",
+                attrs=idex_l2b_attrs.get_variable_attributes(
+                    "rate_calculation_quality_flags"
+                ),
+            ),
+            "rate_by_charge": xr.DataArray(
+                name="rate_by_charge",
+                data=rate_by_charge,
+                dims=("epoch", "impact_charge", "spin_phase"),
+                attrs=idex_l2b_attrs.get_variable_attributes("rate_by_charge"),
+            ),
+            "rate_by_mass": xr.DataArray(
+                name="rate_by_mass",
+                data=rate_by_mass,
+                dims=("epoch", "mass", "spin_phase"),
+                attrs=idex_l2b_attrs.get_variable_attributes("rate_by_mass"),
+            ),
+        }
+        l2c_rate_vars = {
+            "rate_by_charge_map": xr.DataArray(
+                name="rate_by_charge_map",
+                data=rate_by_charge_map,
+                dims=(
+                    "epoch",
+                    "impact_charge",
+                    "rectangular_lon_pixel",
+                    "rectangular_lat_pixel",
+                ),
+                attrs=idex_l2c_attrs.get_variable_attributes("rate_by_charge_map"),
+            ),
+            "rate_by_mass_map": xr.DataArray(
+                name="rate_by_mass_map",
+                data=rate_by_mass_map,
+                dims=(
+                    "epoch",
+                    "mass",
+                    "rectangular_lon_pixel",
+                    "rectangular_lat_pixel",
+                ),
+                attrs=idex_l2c_attrs.get_variable_attributes("rate_by_mass_map"),
+            ),
+        }
     # Create l2b Dataset
     charge_bins = np.arange(len(CHARGE_BIN_EDGES) - 1)
     mass_bins = np.arange(len(CHARGE_BIN_EDGES) - 1)
@@ -209,14 +260,6 @@ def idex_l2b(
                 "spin_phase_labels", check_schema=False
             ),
         ),
-        "rate_calculation_quality_flags": xr.DataArray(
-            name="rate_calculation_quality_flags",
-            data=rate_quality_flags,
-            dims="epoch",
-            attrs=idex_l2b_attrs.get_variable_attributes(
-                "rate_calculation_quality_flags"
-            ),
-        ),
         "counts_by_charge": xr.DataArray(
             name="counts_by_charge",
             data=counts_by_charge.astype(np.int64),
@@ -228,18 +271,6 @@ def idex_l2b(
             data=counts_by_mass.astype(np.int64),
             dims=("epoch", "mass", "spin_phase"),
             attrs=idex_l2b_attrs.get_variable_attributes("counts_by_mass"),
-        ),
-        "rate_by_charge": xr.DataArray(
-            name="rate_by_charge",
-            data=rate_by_charge,
-            dims=("epoch", "impact_charge", "spin_phase"),
-            attrs=idex_l2b_attrs.get_variable_attributes("rate_by_charge"),
-        ),
-        "rate_by_mass": xr.DataArray(
-            name="rate_by_mass",
-            data=rate_by_mass,
-            dims=("epoch", "mass", "spin_phase"),
-            attrs=idex_l2b_attrs.get_variable_attributes("rate_by_mass"),
         ),
     }
     l2c_vars = common_vars | {
@@ -297,29 +328,13 @@ def idex_l2b(
             ),
             attrs=idex_l2c_attrs.get_variable_attributes("counts_by_mass_map"),
         ),
-        "rate_by_charge_map": xr.DataArray(
-            name="rate_by_charge_map",
-            data=rate_by_charge_map,
-            dims=(
-                "epoch",
-                "impact_charge",
-                "rectangular_lon_pixel",
-                "rectangular_lat_pixel",
-            ),
-            attrs=idex_l2c_attrs.get_variable_attributes("rate_by_charge_map"),
-        ),
-        "rate_by_mass_map": xr.DataArray(
-            name="rate_by_mass_map",
-            data=rate_by_mass_map,
-            dims=(
-                "epoch",
-                "mass",
-                "rectangular_lon_pixel",
-                "rectangular_lat_pixel",
-            ),
-            attrs=idex_l2c_attrs.get_variable_attributes("rate_by_mass_map"),
-        ),
     }
+    # Add rate variables if they were computed
+    if l2c_rate_vars:
+        l2c_vars = l2c_vars | l2c_rate_vars
+    if l2b_rate_vars:
+        l2b_vars = l2b_vars | l2b_rate_vars
+
     l2b_dataset = xr.Dataset(
         coords={"epoch": epoch},
         data_vars=l2b_vars,
@@ -629,7 +644,7 @@ def get_science_acquisition_timestamps(
     )
 
 
-def get_science_acquisition_on_percentage(evt_dataset: xr.Dataset) -> dict:
+def get_science_acquisition_on_percentage(evt_dataset: xr.Dataset) -> dict | None:
     """
     Calculate the percentage of time science acquisition was occurring for each day.
 
@@ -642,10 +657,16 @@ def get_science_acquisition_on_percentage(evt_dataset: xr.Dataset) -> dict:
     -------
     dict
         Percentages of time the instrument was in science acquisition mode for each day
-         of year.
+         of year. Returns None if no science acquisition events are found.
     """
     # Get science acquisition start and stop times
     evt_logs, evt_time, evt_values = get_science_acquisition_timestamps(evt_dataset)
+    if len(evt_time) == 0:
+        logger.warning(
+            "No science acquisition events found in event dataset. Returning empty "
+            "uptime percentages."
+        )
+        return None
     # Track total and 'on' durations per day
     daily_totals: collections.defaultdict = defaultdict(timedelta)
     daily_on: collections.defaultdict = defaultdict(timedelta)

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -1,5 +1,7 @@
 """Tests the L2b processing for IDEX data"""
 
+from unittest import mock
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -215,6 +217,17 @@ def test_get_science_acquisition_on_percentage(decom_test_data_evt: list[xr.Data
     # The uptime should be less than 1% for both
     assert on_percentages[8] < 1
     assert on_percentages[9] < 1  # The uptime should be less than 1%
+
+
+def test_get_science_acquisition_on_percentage_no_acquisition(caplog):
+    """Test the function returns an empty dict when there is no science acquisition."""
+    with mock.patch(
+        "imap_processing.idex.idex_l2b.get_science_acquisition_timestamps",
+        return_value=([], [], []),
+    ):
+        on_percentages = get_science_acquisition_on_percentage(xr.Dataset())
+    assert not on_percentages
+    assert "No science acquisition events found" in caplog.text
 
 
 def test_compute_counts_by_charge_and_mass():

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -466,3 +466,45 @@ def test_compute_rates_by_charge_and_mass_missing_acquisition_time(caplog):
     # Assert that quality flags are 0 for the missing acquisition time
     assert quality_flags[0] == 1
     assert quality_flags[1] == 0
+
+
+def test_compute_rates_no_acquisition_data(caplog):
+    """Test that the function produces -1 rates when hk data isn't available."""
+    caplog.at_level("WARNING")
+    # Mock example inputs
+    counts_by_charge = np.ones(
+        (2, len(CHARGE_BIN_EDGES), len(SPIN_PHASE_BIN_EDGES) - 1)
+    )
+    counts_by_mass = counts_by_charge
+    counts_by_charge_map = np.ones(
+        (
+            2,
+            len(CHARGE_BIN_EDGES),
+            len(SKY_GRID.az_bin_edges) - 1,
+            len(SKY_GRID.el_bin_edges) - 1,
+        )
+    )
+    counts_by_mass_map = counts_by_charge_map
+    # Mock DOY values for the epochs
+    epoch_doy = np.array([1, 2])
+    # Mock daily idex uptime percentages. Purposefully leave out day 2 to simulate
+    # missing acquisition times
+    daily_on_percentage = {}
+    # Compute the rates by charge and mass and assert there is a warning in the logs.
+    rate_by_charge, rate_by_mass, rate_mass_map, rate_charge_map, quality_flags = (
+        compute_rates_by_charge_and_mass(
+            counts_by_charge,
+            counts_by_mass,
+            counts_by_charge_map,
+            counts_by_mass_map,
+            epoch_doy,
+            daily_on_percentage,
+        )
+    )
+
+    # All rates by charge and mass should be -1.0
+    np.testing.assert_array_equal(rate_by_charge, np.full(rate_by_charge.shape, -1.0))
+    np.testing.assert_array_equal(rate_by_mass, np.full(rate_by_mass.shape, -1.0))
+
+    # Assert that quality flags are all 0 for missing acquisition times
+    np.testing.assert_array_equal(quality_flags, np.full(quality_flags.shape, 0))


### PR DESCRIPTION
# Change Summary

## Overview
If there are no science acquisition events found, rate variables can not be computed. In this case only return the datasets with the counts variables. 


## Updated Files
- imap_processing/idex/idex_l2b.py
   - Log warning if there are missing events 
   - return only counts if rates can not be computed
