### PR TITLE
2053 spin   update instrument spin phase definition

### DIFF
--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -137,7 +137,9 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
     Get the spin phase offset from the spacecraft to the instrument.
 
     For now, the offset is a fixed lookup based on `Table 1: Nominal Instrument
-    to S/C CS Transformations` in document `7516-0011_drw.pdf`. These fixed
+    to S/C CS Transformations` in document `7516-0011_drw.pdf`. That Table
+    defines the angle from the spacecraft y-axis. We add 90 and take the modulous
+    with 360 in order to get the angle from the spacecraft x-axis. These fixed
     values will need to be updated based on calibration data or retrieved using
     SPICE and the latest IMAP frame kernel.
 
@@ -153,18 +155,18 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
     """
     # TODO: Implement retrieval from SPICE?
     offset_lookup = {
-        SpiceFrame.IMAP_LO_BASE: 330 / 360,
-        SpiceFrame.IMAP_HI_45: 255 / 360,
-        SpiceFrame.IMAP_HI_90: 285 / 360,
-        SpiceFrame.IMAP_ULTRA_45: 33 / 360,
-        SpiceFrame.IMAP_ULTRA_90: 210 / 360,
-        SpiceFrame.IMAP_SWAPI: 168 / 360,
-        SpiceFrame.IMAP_IDEX: 90 / 360,
-        SpiceFrame.IMAP_CODICE: 136 / 360,
-        SpiceFrame.IMAP_HIT: 30 / 360,
-        SpiceFrame.IMAP_SWE: 153 / 360,
-        SpiceFrame.IMAP_GLOWS: 127 / 360,
-        SpiceFrame.IMAP_MAG: 0 / 360,
+        SpiceFrame.IMAP_LO_BASE: 60 / 360,  # (330 + 90) % 360 = 60
+        SpiceFrame.IMAP_HI_45: 345 / 360,  # 255 + 90 = 345
+        SpiceFrame.IMAP_HI_90: 15 / 360,  # (285 + 90) % 360 = 15
+        SpiceFrame.IMAP_ULTRA_45: 123 / 360,  # 33 + 90 = 123
+        SpiceFrame.IMAP_ULTRA_90: 300 / 360,  # 210 + 90 = 300
+        SpiceFrame.IMAP_SWAPI: 258 / 360,  # 168 + 90 = 258
+        SpiceFrame.IMAP_IDEX: 180 / 360,  # 90 + 90 = 180
+        SpiceFrame.IMAP_CODICE: 226 / 360,  # 136 + 90 = 226
+        SpiceFrame.IMAP_HIT: 120 / 360,  # 30 + 90 = 120
+        SpiceFrame.IMAP_SWE: 243 / 360,  # 153 + 90 = 243
+        SpiceFrame.IMAP_GLOWS: 217 / 360,  # 127 + 90 = 217
+        SpiceFrame.IMAP_MAG: 90 / 360,  # 0 + 90 = 90
     }
     return offset_lookup[instrument]
 

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -190,8 +190,7 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
     to S/C CS Transformations` in document `7516-0011_drw.pdf`. That Table
     defines the angle from the spacecraft y-axis. We add 90 and take the modulous
     with 360 in order to get the angle from the spacecraft x-axis. These fixed
-    values will need to be updated based on calibration data or retrieved using
-    SPICE and the latest IMAP frame kernel.
+    values will need to be updated based on calibration data.
 
     Parameters
     ----------
@@ -203,7 +202,21 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
     spacecraft_to_instrument_spin_phase_offset : float
         The spin phase offset from the spacecraft to the instrument.
     """
-    return (get_instrument_mounting_az_el(instrument)[0] / 360) % 1
+    phase_offset_lookup = {
+        SpiceFrame.IMAP_LO_BASE: 60 / 360,  # (330 + 90) % 360 = 60
+        SpiceFrame.IMAP_HI_45: 345 / 360,  # 255 + 90 = 345
+        SpiceFrame.IMAP_HI_90: 15 / 360,  # (285 + 90) % 360 = 15
+        SpiceFrame.IMAP_ULTRA_45: 123 / 360,  # 33 + 90 = 123
+        SpiceFrame.IMAP_ULTRA_90: 300 / 360,  # 210 + 90 = 300
+        SpiceFrame.IMAP_SWAPI: 258 / 360,  # 168 + 90 = 258
+        SpiceFrame.IMAP_IDEX: 180 / 360,  # 90 + 90 = 180
+        SpiceFrame.IMAP_CODICE: 226 / 360,  # 136 + 90 = 226
+        SpiceFrame.IMAP_HIT: 120 / 360,  # 30 + 90 = 120
+        SpiceFrame.IMAP_SWE: 243 / 360,  # 153 + 90 = 243
+        SpiceFrame.IMAP_GLOWS: 217 / 360,  # 127 + 90 = 217
+        SpiceFrame.IMAP_MAG: 90 / 360,  # 0 + 90 = 90
+    }
+    return phase_offset_lookup[instrument]
 
 
 def frame_transform(

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -132,6 +132,56 @@ def imap_state(
     return np.asarray(state)
 
 
+def get_instrument_mounting_az_el(instrument: SpiceFrame) -> np.ndarray:
+    """
+    Calculate the azimuth and elevation angle of instrument mounting.
+
+    Azimuth and elevation to instrument mounting in the spacecraft frame.
+    Azimuth is measured in degrees from the spacecraft x-axis. Elevation is measured
+    in degrees from the spacecraft x-y plane.
+
+    Parameters
+    ----------
+    instrument : SpiceFrame
+        Instrument to get the azimuth and elevation angles for.
+
+    Returns
+    -------
+    instrument_mounting_az_el : np.ndarray
+        2-element array containing azimuth and elevation of the instrument
+        mounting in the spacecraft frame. Azimuth is measured in degrees from
+        the spacecraft x-axis. Elevation is measured in degrees from the
+        spacecraft x-y plane.
+    """
+    # Each instrument can have a unique basis vector in the instrument
+    # frame that is used to compute the s/c to instrument mounting.
+    # Most of these vectors are the same as the instrument boresight vector.
+    mounting_normal_vector = {
+        SpiceFrame.IMAP_LO_BASE: np.array([0, -1, 0]),
+        SpiceFrame.IMAP_HI_45: np.array([0, 1, 0]),
+        SpiceFrame.IMAP_HI_90: np.array([0, 1, 0]),
+        SpiceFrame.IMAP_ULTRA_45: np.array([0, 0, 1]),
+        SpiceFrame.IMAP_ULTRA_90: np.array([0, 0, 1]),
+        SpiceFrame.IMAP_MAG: np.array([-1, 0, 0]),
+        SpiceFrame.IMAP_SWE: np.array([-1, 0, 0]),
+        SpiceFrame.IMAP_SWAPI: np.array([0, 0, -1]),
+        SpiceFrame.IMAP_CODICE: np.array([-1, 0, 0]),
+        SpiceFrame.IMAP_HIT: np.array([0, 1, 0]),
+        SpiceFrame.IMAP_IDEX: np.array([0, 1, 0]),
+        SpiceFrame.IMAP_GLOWS: np.array([0, 0, -1]),
+    }
+
+    # Get the instrument mounting normal vector expressed in the spacecraft frame
+    # The reference frames are fixed, so the et argument can be fixed at 0
+    instrument_normal_sc = frame_transform(
+        0, mounting_normal_vector[instrument], instrument, SpiceFrame.IMAP_SPACECRAFT
+    )
+    # Convert the cartesian coordinate to azimuth/elevation angles in degrees
+    return np.rad2deg(
+        spiceypy.recazl(instrument_normal_sc, azccw=True, elplsz=True)[1:]
+    )
+
+
 def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> float:
     """
     Get the spin phase offset from the spacecraft to the instrument.
@@ -153,22 +203,7 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
     spacecraft_to_instrument_spin_phase_offset : float
         The spin phase offset from the spacecraft to the instrument.
     """
-    # TODO: Implement retrieval from SPICE?
-    offset_lookup = {
-        SpiceFrame.IMAP_LO_BASE: 60 / 360,  # (330 + 90) % 360 = 60
-        SpiceFrame.IMAP_HI_45: 345 / 360,  # 255 + 90 = 345
-        SpiceFrame.IMAP_HI_90: 15 / 360,  # (285 + 90) % 360 = 15
-        SpiceFrame.IMAP_ULTRA_45: 123 / 360,  # 33 + 90 = 123
-        SpiceFrame.IMAP_ULTRA_90: 300 / 360,  # 210 + 90 = 300
-        SpiceFrame.IMAP_SWAPI: 258 / 360,  # 168 + 90 = 258
-        SpiceFrame.IMAP_IDEX: 180 / 360,  # 90 + 90 = 180
-        SpiceFrame.IMAP_CODICE: 226 / 360,  # 136 + 90 = 226
-        SpiceFrame.IMAP_HIT: 120 / 360,  # 30 + 90 = 120
-        SpiceFrame.IMAP_SWE: 243 / 360,  # 153 + 90 = 243
-        SpiceFrame.IMAP_GLOWS: 217 / 360,  # 127 + 90 = 217
-        SpiceFrame.IMAP_MAG: 90 / 360,  # 0 + 90 = 90
-    }
-    return offset_lookup[instrument]
+    return (get_instrument_mounting_az_el(instrument)[0] / 360) % 1
 
 
 def frame_transform(

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -69,9 +69,16 @@ def test_hi_annotate_direct_events(
 
 
 @pytest.mark.external_test_data
+@mock.patch(
+    "imap_processing.spice.spin.get_spacecraft_to_instrument_spin_phase_offset",
+    return_value=0,
+)
 @mock.patch("imap_processing.hi.hi_l1b.instrument_pointing")
 def test_annotate_direct_events_with_hk(
-    mock_instrument_pointing, hi_l1_test_data_path, use_fake_spin_data_for_time
+    mock_instrument_pointing,
+    mock_inst_phase_offset,
+    hi_l1_test_data_path,
+    use_fake_spin_data_for_time,
 ):
     """Test imap_processing.hi_l1b.annotate_direct_events() with a
     coincident de and hk dataset but mocked spice."""

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -49,24 +49,24 @@ def test_imap_state_ecliptic(imap_ena_sim_metakernel):
 @pytest.mark.parametrize(
     "instrument, expected_offset",
     [
-        (SpiceFrame.IMAP_LO_BASE, 330 / 360),
-        (SpiceFrame.IMAP_HI_45, 255 / 360),
-        (SpiceFrame.IMAP_HI_90, 285 / 360),
-        (SpiceFrame.IMAP_ULTRA_45, 33 / 360),
-        (SpiceFrame.IMAP_ULTRA_90, 210 / 360),
-        (SpiceFrame.IMAP_SWAPI, 168 / 360),
-        (SpiceFrame.IMAP_IDEX, 90 / 360),
-        (SpiceFrame.IMAP_CODICE, 136 / 360),
-        (SpiceFrame.IMAP_HIT, 30 / 360),
-        (SpiceFrame.IMAP_SWE, 153 / 360),
-        (SpiceFrame.IMAP_GLOWS, 127 / 360),
-        (SpiceFrame.IMAP_MAG, 0 / 360),
+        (SpiceFrame.IMAP_LO_BASE, ((330 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_HI_45, ((255 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_HI_90, ((285 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_ULTRA_45, ((33 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_ULTRA_90, ((210 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_SWAPI, ((168 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_IDEX, ((90 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_CODICE, ((136 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_HIT, ((30 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_SWE, ((153 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_GLOWS, ((127 / 360) + 0.25) % 1),
+        (SpiceFrame.IMAP_MAG, ((0 / 360) + 0.25) % 1),
     ],
 )
 def test_get_spacecraft_to_instrument_spin_phase_offset(instrument, expected_offset):
     """Test coverage for get_spacecraft_to_instrument_spin_phase_offset()"""
     result = get_spacecraft_to_instrument_spin_phase_offset(instrument)
-    assert result == expected_offset
+    np.testing.assert_almost_equal(result, expected_offset)
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -77,32 +77,39 @@ def test_get_instrument_mounting_az_el(
 
 
 @pytest.mark.parametrize(
-    "instrument, expected_offset",
+    "instrument",
     [
         # Expected spin-phase offsets based on 7516-0011_drw.pdf
-        (SpiceFrame.IMAP_LO_BASE, 60 / 360),  # (330 + 90) % 360 = 60
-        # Note HI_45 and HI_90 appear to be swapped in imap_wkcp.tf so the
-        # expected values are swapped here.
-        (SpiceFrame.IMAP_HI_45, 15 / 360),  # 255 + 90 = 345
-        (SpiceFrame.IMAP_HI_90, 345 / 360),  # (285 + 90) % 360 = 15
-        (SpiceFrame.IMAP_ULTRA_45, 123 / 360),  # 33 + 90 = 123
-        (SpiceFrame.IMAP_ULTRA_90, 300 / 360),  # 210 + 90 = 300
-        (SpiceFrame.IMAP_SWAPI, 258 / 360),  # 168 + 90 = 258
-        (SpiceFrame.IMAP_IDEX, 180 / 360),  # 90 + 90 = 180
-        (SpiceFrame.IMAP_CODICE, 226 / 360),  # 136 + 90 = 226
-        (SpiceFrame.IMAP_HIT, 120 / 360),  # 30 + 90 = 120
-        (SpiceFrame.IMAP_SWE, 243 / 360),  # 153 + 90 = 243
-        (SpiceFrame.IMAP_GLOWS, 217 / 360),  # 127 + 90 = 217
-        (SpiceFrame.IMAP_MAG, 90 / 360),  # 0 + 90 = 90
+        SpiceFrame.IMAP_LO_BASE,
+        SpiceFrame.IMAP_HI_45,
+        SpiceFrame.IMAP_HI_90,
+        SpiceFrame.IMAP_ULTRA_45,
+        SpiceFrame.IMAP_ULTRA_90,
+        SpiceFrame.IMAP_SWAPI,
+        SpiceFrame.IMAP_IDEX,
+        SpiceFrame.IMAP_CODICE,
+        SpiceFrame.IMAP_HIT,
+        SpiceFrame.IMAP_SWE,
+        SpiceFrame.IMAP_GLOWS,
+        SpiceFrame.IMAP_MAG,
     ],
 )
 def test_get_spacecraft_to_instrument_spin_phase_offset(
-    furnish_kernels, spice_test_data_path, instrument, expected_offset
+    furnish_kernels, spice_test_data_path, instrument
 ):
     """Test coverage for get_spacecraft_to_instrument_spin_phase_offset()"""
+    # Test that the offset is close to SPICE derived mounting azimuth
     with furnish_kernels([spice_test_data_path / "imap_wkcp.tf"]):
+        # TODO: Remove this switch when we get a new imap_frames kernel
+        #    Hi 45 and Hi 90 are swapped in the imap_wkcp.tf kernel
+        if instrument == SpiceFrame.IMAP_HI_45:
+            expected = get_instrument_mounting_az_el(SpiceFrame.IMAP_HI_90)[0] / 360
+        elif instrument == SpiceFrame.IMAP_HI_90:
+            expected = get_instrument_mounting_az_el(SpiceFrame.IMAP_HI_45)[0] / 360
+        else:
+            expected = get_instrument_mounting_az_el(instrument)[0] / 360
         result = get_spacecraft_to_instrument_spin_phase_offset(instrument)
-        np.testing.assert_almost_equal(result, expected_offset, decimal=5)
+        np.testing.assert_almost_equal(result, expected, decimal=5)
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -14,6 +14,7 @@ from imap_processing.spice.geometry import (
     cartesian_to_spherical,
     frame_transform,
     frame_transform_az_el,
+    get_instrument_mounting_az_el,
     get_rotation_matrix,
     get_spacecraft_to_instrument_spin_phase_offset,
     imap_state,
@@ -47,26 +48,61 @@ def test_imap_state_ecliptic(imap_ena_sim_metakernel):
 
 
 @pytest.mark.parametrize(
-    "instrument, expected_offset",
+    "instrument, expected_az_el",
     [
-        (SpiceFrame.IMAP_LO_BASE, ((330 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_HI_45, ((255 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_HI_90, ((285 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_ULTRA_45, ((33 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_ULTRA_90, ((210 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_SWAPI, ((168 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_IDEX, ((90 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_CODICE, ((136 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_HIT, ((30 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_SWE, ((153 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_GLOWS, ((127 / 360) + 0.25) % 1),
-        (SpiceFrame.IMAP_MAG, ((0 / 360) + 0.25) % 1),
+        # Expected spin-phase offsets based on 7516-0011_drw.pdf
+        (SpiceFrame.IMAP_LO_BASE, (60, 0)),  # (330 + 90) % 360 = 60
+        # Note HI_45 and HI_90 appear to be swapped in imap_wkcp.tf so the
+        # expected values are swapped here.
+        (SpiceFrame.IMAP_HI_45, (15, 0)),  # 255 + 90 = 345
+        (SpiceFrame.IMAP_HI_90, (345, -45)),  # (285 + 90) % 360 = 15
+        (SpiceFrame.IMAP_ULTRA_45, (123, -45)),  # 33 + 90 = 123
+        (SpiceFrame.IMAP_ULTRA_90, (300, 0)),  # 210 + 90 = 300
+        (SpiceFrame.IMAP_SWAPI, (258, 0)),  # 168 + 90 = 258
+        (SpiceFrame.IMAP_IDEX, (180, -45)),  # 90 + 90 = 180
+        (SpiceFrame.IMAP_CODICE, (226, 0)),  # 136 + 90 = 226
+        (SpiceFrame.IMAP_HIT, (120, 0)),  # 30 + 90 = 120
+        (SpiceFrame.IMAP_SWE, (243, 0)),  # 153 + 90 = 243
+        (SpiceFrame.IMAP_GLOWS, (217, 15)),  # 127 + 90 = 217
+        (SpiceFrame.IMAP_MAG, (90, 0)),  # 0 + 90 = 90
     ],
 )
-def test_get_spacecraft_to_instrument_spin_phase_offset(instrument, expected_offset):
+def test_get_instrument_mounting_az_el(
+    furnish_kernels, spice_test_data_path, instrument, expected_az_el
+):
+    """Test coverage for get_instrument_mounting_az_el()"""
+    with furnish_kernels([spice_test_data_path / "imap_wkcp.tf"]):
+        result = get_instrument_mounting_az_el(instrument)
+        np.testing.assert_allclose(result, expected_az_el, atol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "instrument, expected_offset",
+    [
+        # Expected spin-phase offsets based on 7516-0011_drw.pdf
+        (SpiceFrame.IMAP_LO_BASE, 60 / 360),  # (330 + 90) % 360 = 60
+        # Note HI_45 and HI_90 appear to be swapped in imap_wkcp.tf so the
+        # expected values are swapped here.
+        (SpiceFrame.IMAP_HI_45, 15 / 360),  # 255 + 90 = 345
+        (SpiceFrame.IMAP_HI_90, 345 / 360),  # (285 + 90) % 360 = 15
+        (SpiceFrame.IMAP_ULTRA_45, 123 / 360),  # 33 + 90 = 123
+        (SpiceFrame.IMAP_ULTRA_90, 300 / 360),  # 210 + 90 = 300
+        (SpiceFrame.IMAP_SWAPI, 258 / 360),  # 168 + 90 = 258
+        (SpiceFrame.IMAP_IDEX, 180 / 360),  # 90 + 90 = 180
+        (SpiceFrame.IMAP_CODICE, 226 / 360),  # 136 + 90 = 226
+        (SpiceFrame.IMAP_HIT, 120 / 360),  # 30 + 90 = 120
+        (SpiceFrame.IMAP_SWE, 243 / 360),  # 153 + 90 = 243
+        (SpiceFrame.IMAP_GLOWS, 217 / 360),  # 127 + 90 = 217
+        (SpiceFrame.IMAP_MAG, 90 / 360),  # 0 + 90 = 90
+    ],
+)
+def test_get_spacecraft_to_instrument_spin_phase_offset(
+    furnish_kernels, spice_test_data_path, instrument, expected_offset
+):
     """Test coverage for get_spacecraft_to_instrument_spin_phase_offset()"""
-    result = get_spacecraft_to_instrument_spin_phase_offset(instrument)
-    np.testing.assert_almost_equal(result, expected_offset)
+    with furnish_kernels([spice_test_data_path / "imap_wkcp.tf"]):
+        result = get_spacecraft_to_instrument_spin_phase_offset(instrument)
+        np.testing.assert_almost_equal(result, expected_offset, decimal=5)
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/spice/test_spin.py
+++ b/imap_processing/tests/spice/test_spin.py
@@ -279,11 +279,14 @@ def test_get_spin_table_merge(tmp_path, use_test_spin_data_csv):
         SpiceFrame.IMAP_MAG,
     ],
 )
-def test_get_instrument_spin_phase(instrument, fake_spin_data):
+def test_get_instrument_spin_phase(
+    instrument, fake_spin_data, furnish_kernels, spice_test_data_path
+):
     """Test coverage for get_instrument_spin_phase()"""
     met_times = np.array([7.5, 30, 61, 75, 106, 121, 136])
     expected_nan_mask = np.array([False, False, True, False, True, True, False])
-    inst_phase = spin.get_instrument_spin_phase(met_times, instrument)
+    with furnish_kernels([spice_test_data_path / "imap_wkcp.tf"]):
+        inst_phase = spin.get_instrument_spin_phase(met_times, instrument)
     assert inst_phase.shape == met_times.shape
     np.testing.assert_array_equal(np.isnan(inst_phase), expected_nan_mask)
     assert np.logical_and(

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -256,8 +256,13 @@ def test_put_data_into_angle_bins():
 
 
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+@patch(
+    "imap_processing.spice.spin.get_spacecraft_to_instrument_spin_phase_offset",
+    return_value=153 / 360,
+)
 @pytest.mark.usefixtures("use_fake_spin_data_for_time")
 def test_swe_l2_15sec(
+    mock_phase_offset,
     mock_get_file_paths,
     use_fake_spin_data_for_time,
     l2_sector_validation_df,
@@ -360,8 +365,13 @@ def test_swe_l2_15sec(
 
 
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+@patch(
+    "imap_processing.spice.spin.get_spacecraft_to_instrument_spin_phase_offset",
+    return_value=153 / 360,
+)
 @pytest.mark.usefixtures("use_fake_spin_data_for_time")
 def test_swe_l2_14_6sec(
+    mock_phase_offset,
     mock_get_file_paths,
     use_fake_spin_data_for_time,
     l2_binned_flux_14sec_validation_df,


### PR DESCRIPTION
# Change Summary

## Overview
Updates the instrument spin phase 0 to be consistent with IT desires. That is where spin-phase 0 is when the instrument boresight is closest to the ecliptic north pole.

## Updated Files
- imap_processing/spice/geometry.py
   - Add 90 degrees and take the modulus with 360 to all instrument spin phase offsets
- imap_processing/tests/spice/test_geometry.py
   - Update expected values by calculating a slightly different way than above.
- imap_processing/tests/swe/test_swe_l2.py
   - Mock the SWE offset back to the previous value since validation of spin-phase was broken by above changes.

Closes: #2053 #1023 
