### PR TITLE
MNT: Update Lo L1c pointing set dimensions and attribute naming

### DIFF
--- a/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
@@ -78,17 +78,6 @@ spin_default_attrs: &spin_default
   DEPEND_1: spin
   LABL_PTR_1: spin_label
 
-
-# Re-used Coordinate
-epoch:
-  <<: *default_int64
-  CATDESC: Epoch Time
-  DEPEND_0: epoch
-  FIELDNAM: Epoch time
-  Units: 'ns'
-  VAR_TYPE: support_data
-  LABLAXIS: Epoch
-
 esa_step_label:
    CATDESC: ESA Steps
    FIELDNAM: ESA Steps

--- a/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
@@ -113,6 +113,10 @@ hae_longitude:
   FORMAT: I12
   UNITS: degrees
   LABLAXIS: Bin longitudes
+  DEPEND_1: spin_angle
+  DEPEND_2: off_angle
+  LABL_PTR_1: spin_angle_label
+  LABL_PTR_2: off_angle_label
 
 hae_latitude:
   <<: *default
@@ -123,6 +127,10 @@ hae_latitude:
   FORMAT: I12
   UNITS: degrees
   LABLAXIS: Bin latitudes
+  DEPEND_1: spin_angle
+  DEPEND_2: off_angle
+  LABL_PTR_1: spin_angle_label
+  LABL_PTR_2: off_angle_label
 
 exposure_time:
   <<: *default

--- a/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
@@ -56,7 +56,7 @@ off_angle:
   UNITS: "degrees"
   FORMAT: I4
   VAR_TYPE: support_data
-  LABLAXIS: off axis angle
+  LABLAXIS: off angle
 
 pointing_start_met:
   <<: *default
@@ -64,7 +64,7 @@ pointing_start_met:
   FIELDNAM: Pointing start time
   FORMAT: I12
   UNITS: s
-  LABLAXIS: pointing start time
+  LABLAXIS: pointing start
 
 pointing_end_met:
   <<: *default
@@ -72,21 +72,21 @@ pointing_end_met:
   FIELDNAM: Pointing end time
   FORMAT: I12
   UNITS: s
-  LABLAXIS: pointing end time
+  LABLAXIS: pointing end
 
 start_spin_number:
   <<: *default
   CATDESC: The spin number at the start of the pointing
   FIELDNAM: Spin number at start of pointing
   FORMAT: I12
-  LABLAXIS: First spin number of pointing
+  LABLAXIS: Start spin
 
 end_spin_number:
   <<: *default
   CATDESC: The spin number at the start of the pointing
   FIELDNAM: Spin number at the end of the pointing
   FORMAT: I12
-  LABLAXIS: Last spin number of pointing
+  LABLAXIS: End spin
 
 pivot_angle:
   <<: *default
@@ -99,11 +99,11 @@ pivot_angle:
 
 esa_mode:
   <<: *default
-  DEPEND_0: esa_energy_step
+  DEPEND_1: esa_energy_step
   CATDESC: Science Mode for Pointing
   FIELDNAM: Science Mode
   FORMAT: I12
-  LABLAXIS: science mode
+  LABLAXIS: esa mode
 
 hae_longitude:
   <<: *default
@@ -112,7 +112,7 @@ hae_longitude:
   FIELDNAM: Bin longitudes
   FORMAT: I12
   UNITS: degrees
-  LABLAXIS: Bin longitudes
+  LABLAXIS: longitude
   DEPEND_1: spin_angle
   DEPEND_2: off_angle
   LABL_PTR_1: spin_angle_label
@@ -126,7 +126,7 @@ hae_latitude:
   FIELDNAM: Bin latitudes
   FORMAT: I12
   UNITS: degrees
-  LABLAXIS: Bin latitudes
+  LABLAXIS: latitude
   DEPEND_1: spin_angle
   DEPEND_2: off_angle
   LABL_PTR_1: spin_angle_label
@@ -164,7 +164,7 @@ doubles_counts:
   DEPEND_3: off_angle
   FIELDNAM: Double coincidence counts
   FORMAT: I12
-  LABLAXIS: double coincidence counts
+  LABLAXIS: doubles
   LABL_PTR_1: esa_energy_step_label
   LABL_PTR_2: spin_angle_label
   LABL_PTR_3: off_angle_label
@@ -192,6 +192,8 @@ h_background_rates:
   LABL_PTR_2: spin_angle_label
   LABL_PTR_3: off_angle_label
   FORMAT: I12
+  DELTA_PLUS_VAR: h_background_rates_stat_uncert
+  DELTA_MINUS_VAR: h_background_rates_stat_uncert
 
 h_background_rates_stat_uncert:
   <<: *default
@@ -240,6 +242,8 @@ o_background_rates:
   LABL_PTR_2: spin_angle_label
   LABL_PTR_3: off_angle_label
   FORMAT: I12
+  DELTA_PLUS_VAR: o_background_rates_stat_uncert
+  DELTA_MINUS_VAR: o_background_rates_stat_uncert
 
 o_background_rates_stat_uncert:
   <<: *default

--- a/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
@@ -7,7 +7,7 @@ default_attrs: &default
   DEPEND_0: epoch
   VALIDMAX: 9223372036854775807
   VAR_TYPE: data
-  UNITS: ' '
+  UNITS: " "
 
 # Non-epoch Coordinates
 esa_energy_step_label:
@@ -21,7 +21,7 @@ esa_energy_step:
   VALIDMAX: 7
   CATDESC: Energy Step
   FIELDNAM: Energy Step
-  UNITS: ' '
+  UNITS: " "
   FORMAT: I1
   VAR_TYPE: support_data
   LABLAXIS: ESA
@@ -34,13 +34,13 @@ spin_angle_label:
 
 spin_angle:
   VALIDMIN: 0
-  VALIDMAX: 3599
-  CATDESC: Spin angle bins
-  FIELDNAM: Spin angle bins
-  UNITS: ' '
+  VALIDMAX: 360
+  CATDESC: Spin angle in despun pointing frame
+  FIELDNAM: Spin angle
+  UNITS: "degrees"
   FORMAT: I4
   VAR_TYPE: support_data
-  LABLAXIS: spin angle bins
+  LABLAXIS: spin angle
 
 off_angle_label:
   CATDESC: Off axis angles
@@ -49,14 +49,14 @@ off_angle_label:
   VAR_TYPE: metadata
 
 off_angle:
-  VALIDMIN: 0
-  VALIDMAX: 39
-  CATDESC: Off axis angle bins
-  FIELDNAM: Off axis angle bins
-  UNITS: ' '
+  VALIDMIN: -2
+  VALIDMAX: 2
+  CATDESC: Off axis angle in despun pointing frame
+  FIELDNAM: Off axis angle
+  UNITS: "degrees"
   FORMAT: I4
   VAR_TYPE: support_data
-  LABLAXIS: off axis angle bins
+  LABLAXIS: off axis angle
 
 pointing_start_met:
   <<: *default

--- a/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
@@ -35,7 +35,7 @@ spin_angle_label:
 spin_angle:
   VALIDMIN: 0
   VALIDMAX: 360
-  CATDESC: Spin angle in despun pointing frame
+  CATDESC: Spin angle bin center in despun pointing frame
   FIELDNAM: Spin angle
   UNITS: "degrees"
   FORMAT: I4
@@ -51,7 +51,7 @@ off_angle_label:
 off_angle:
   VALIDMIN: -2
   VALIDMAX: 2
-  CATDESC: Off axis angle in despun pointing frame
+  CATDESC: Off axis angle bin center in despun pointing frame
   FIELDNAM: Off axis angle
   UNITS: "degrees"
   FORMAT: I4

--- a/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
@@ -10,45 +10,55 @@ default_attrs: &default
   UNITS: ' '
 
 # Non-epoch Coordinates
-esa_step_label:
+esa_energy_step_label:
   CATDESC: ESA Steps
   FIELDNAM: ESA Steps
   FORMAT: A1
   VAR_TYPE: metadata
 
-esa_step:
+esa_energy_step:
   VALIDMIN: 1
   VALIDMAX: 7
-  FILLVAL: -9223372036854775808
   CATDESC: Energy Step
-  DEPEND_1: esa_step
   FIELDNAM: Energy Step
   UNITS: ' '
   FORMAT: I1
   VAR_TYPE: support_data
   LABLAXIS: ESA
-  LABL_PTR_1: esa_step_label
 
-pointing_bins_label:
-  CATDESC: Pointing bins
-  FIELDNAM: Pointing bins
+spin_angle_label:
+  CATDESC: Spin angles
+  FIELDNAM: Spin angles
   FORMAT: A4
   VAR_TYPE: metadata
 
-pointing_bins:
+spin_angle:
   VALIDMIN: 0
   VALIDMAX: 3599
-  FILLVAL: -9223372036854775808
-  CATDESC: Pointing bins
-  DEPEND_1: pointing_bins
-  FIELDNAM: Pointing Bins
+  CATDESC: Spin angle bins
+  FIELDNAM: Spin angle bins
   UNITS: ' '
   FORMAT: I4
   VAR_TYPE: support_data
-  LABLAXIS: pointing bins
-  LABL_PTR_1: pointing_bins_label
+  LABLAXIS: spin angle bins
 
-pointing_start:
+off_angle_label:
+  CATDESC: Off axis angles
+  FIELDNAM: Off axis angles
+  FORMAT: A4
+  VAR_TYPE: metadata
+
+off_angle:
+  VALIDMIN: 0
+  VALIDMAX: 39
+  CATDESC: Off axis angle bins
+  FIELDNAM: Off axis angle bins
+  UNITS: ' '
+  FORMAT: I4
+  VAR_TYPE: support_data
+  LABLAXIS: off axis angle bins
+
+pointing_start_met:
   <<: *default
   CATDESC: MET of start of pointing
   FIELDNAM: Pointing start time
@@ -56,7 +66,7 @@ pointing_start:
   UNITS: s
   LABLAXIS: pointing start time
 
-pointing_end:
+pointing_end_met:
   <<: *default
   CATDESC: MET of end of pointing
   FIELDNAM: Pointing end time
@@ -64,12 +74,19 @@ pointing_end:
   UNITS: s
   LABLAXIS: pointing end time
 
-mode:
+start_spin_number:
   <<: *default
-  CATDESC: Science Mode for Pointing
-  FIELDNAM: Science Mode
+  CATDESC: The spin number at the start of the pointing
+  FIELDNAM: Spin number at start of pointing
   FORMAT: I12
-  LABLAXIS: science mode
+  LABLAXIS: First spin number of pointing
+
+end_spin_number:
+  <<: *default
+  CATDESC: The spin number at the start of the pointing
+  FIELDNAM: Spin number at the end of the pointing
+  FORMAT: I12
+  LABLAXIS: Last spin number of pointing
 
 pivot_angle:
   <<: *default
@@ -80,100 +97,162 @@ pivot_angle:
   UNITS: degrees
   LABLAXIS: pivot angle
 
-triples_counts:
+esa_mode:
   <<: *default
-  CATDESC: Counts for triple coincidence events
-  DEPEND_1: pointing_bins
-  DEPEND_2: esa_step
-  FIELDNAM: triples coincidence counts
+  DEPEND_0: esa_energy_step
+  CATDESC: Science Mode for Pointing
+  FIELDNAM: Science Mode
   FORMAT: I12
-  LABLAXIS: triples coincidence counts
-  LABL_PTR_1: pointing_bins_label
-  LABL_PTR_2: esa_step_label
+  LABLAXIS: science mode
 
-triples_rates:
+hae_longitude:
   <<: *default
-  CATDESC: Count rates for triple coincidence events
-  DEPEND_1: pointing_bins
-  DEPEND_2: esa_step
-  FILLVAL: -1.0000000E+31
-  FIELDNAM: triple coincidence count rates
-  LABLAXIS: triple coincidence count rates
-  LABL_PTR_1: pointing_bins_label
-  LABL_PTR_2: esa_step_label
-
-doubles_counts:
-  <<: *default
-  CATDESC: "Counts for double coincidence events"
-  DEPEND_1: pointing_bins
-  DEPEND_2: esa_step
-  FIELDNAM: Double coincidence counts
+  VALIDMAX: 360
+  CATDESC: Bin longitudes in HAE coordinates
+  FIELDNAM: Bin longitudes
   FORMAT: I12
-  LABLAXIS: double coincidence counts
-  LABL_PTR_1: pointing_bins_label
-  LABL_PTR_2: esa_step_label
+  UNITS: degrees
+  LABLAXIS: Bin longitudes
 
-doubles_rates:
+hae_latitude:
   <<: *default
-  CATDESC: Count rates for double coincidence events
-  DEPEND_1: pointing_bins
-  DEPEND_2: esa_step
-  FILLVAL: -1.0000000E+31
-  FIELDNAM: double coincidence count rates
-  LABLAXIS: double coincidence count rates
-  LABL_PTR_1: pointing_bins_label
-  LABL_PTR_2: esa_step_label
-
-hydrogen_counts:
-  <<: *default
-  CATDESC: Counts for Hydrogen events
-  DEPEND_1: pointing_bins
-  DEPEND_2: esa_step
-  FIELDNAM: Hydrogen counts
+  VALIDMIN: -90
+  VALIDMAX: 90
+  CATDESC: Bin latitudes in HAE coordinates
+  FIELDNAM: Bin latitudes
   FORMAT: I12
-  LABLAXIS: H counts
-  LABL_PTR_1: pointing_bins_label
-  LABL_PTR_2: esa_step_label
-
-hydrogen_rates:
-  <<: *default
-  CATDESC: Count rates for Hydrogen events
-  DEPEND_1: pointing_bins
-  DEPEND_2: esa_step
-  FILLVAL: -1.0000000E+31
-  FIELDNAM: Hydrogen count rates
-  LABLAXIS: H coincidence count rates
-  LABL_PTR_1: pointing_bins_label
-  LABL_PTR_2: esa_step_label
-
-oxygen_counts:
-  <<: *default
-  CATDESC: Count rates for Oxygen events
-  DEPEND_1: pointing_bins
-  DEPEND_2: esa_step
-  FORMAT: I12
-  FIELDNAM: Oxygen count rates
-  LABLAXIS: O count rates
-  LABL_PTR_1: pointing_bins_label
-  LABL_PTR_2: esa_step_label
-
-oxygen_rates:
-  <<: *default
-  CATDESC : Count rates for Oxygen events
-  DEPEND_1 : pointing_bins
-  DEPEND_2 : esa_step
-  FILLVAL: -1.0000000E+31
-  FIELDNAM : Oxygen count rates
-  LABLAXIS : O count rates
-  LABL_PTR_1: pointing_bins_label
-  LABL_PTR_2: esa_step_label
+  UNITS: degrees
+  LABLAXIS: Bin latitudes
 
 exposure_time:
   <<: *default
   CATDESC: Exposure times by ESA step
-  DEPEND_1: esa_step
-  FILLVAL: -1.0000000E+31
   FIELDNAM: Exposure Times
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
   UNITS: "s"
-  LABLAXIS: exposure times
-  LABL_PTR_1: esa_step_label
+
+triples_counts:
+  <<: *default
+  CATDESC: Counts for triple coincidence events
+  FIELDNAM: triples coincidence counts
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+  FORMAT: I12
+
+doubles_counts:
+  <<: *default
+  CATDESC: Counts for double coincidence events
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  FIELDNAM: Double coincidence counts
+  FORMAT: I12
+  LABLAXIS: double coincidence counts
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+
+h_counts:
+  <<: *default
+  CATDESC: Counts for Hydrogen events
+  FIELDNAM: Hydrogen counts
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+  FORMAT: I12
+
+h_background_rates:
+  <<: *default
+  CATDESC: Background Hydrogen rates
+  FIELDNAM: Background Hydrogen rates
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+  FORMAT: I12
+
+h_background_rates_stat_uncert:
+  <<: *default
+  CATDESC: Background Hydrogen rates statistical uncertainty
+  FIELDNAM: Background Hydrogen rates stat uncertainty
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+  FORMAT: I12
+
+h_background_rates_sys_err:
+  <<: *default
+  CATDESC: Background Hydrogen rates systematic error
+  FIELDNAM: Background Hydrogen rates systematic error
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+  FORMAT: I12
+
+o_counts:
+  <<: *default
+  CATDESC: Count rates for Oxygen events
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  FORMAT: I12
+  FIELDNAM: Oxygen count rates
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+
+o_background_rates:
+  <<: *default
+  CATDESC: Background Oxygen rates
+  FIELDNAM: Background Oxygen rates
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+  FORMAT: I12
+
+o_background_rates_stat_uncert:
+  <<: *default
+  CATDESC: Background Oxygen rates statistical uncertainty
+  FIELDNAM: Background Oxygen rates stat uncertainty
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+  FORMAT: I12
+
+o_background_rates_sys_err:
+  <<: *default
+  CATDESC: Background Oxygen rates systematic error
+  FIELDNAM: Background Oxygen rates systematic error
+  DEPEND_1: esa_energy_step
+  DEPEND_2: spin_angle
+  DEPEND_3: off_angle
+  LABL_PTR_1: esa_energy_step_label
+  LABL_PTR_2: spin_angle_label
+  LABL_PTR_3: off_angle_label
+  FORMAT: I12

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -652,15 +652,10 @@ class LoPointingSet(PointingSet):
 
     def __init__(self, dataset: xr.Dataset):
         super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.IMAP_DPS)
-        # TODO: Use spatial_utils.az_el_grid instead of
-        #  manually creating the lon/lat values
-        inferred_spacing_deg = 360 / dataset.longitude.size
-        longitude_bin_centers = np.arange(
-            0 + inferred_spacing_deg / 2, 360, inferred_spacing_deg
-        )
-        latitude_bin_centers = np.arange(
-            -2 + inferred_spacing_deg / 2, 2, inferred_spacing_deg
-        )
+        # 0.1 degree bin spacing in both spin angle (longitude) and off angle (latitude)
+        bin_spacing_deg = 0.1
+        longitude_bin_centers = np.arange(0 + bin_spacing_deg / 2, 360, bin_spacing_deg)
+        latitude_bin_centers = np.arange(-2 + bin_spacing_deg / 2, 2, bin_spacing_deg)
 
         # Could be wrong about the order here
         longitude_grid, latitude_grid = np.meshgrid(
@@ -673,7 +668,7 @@ class LoPointingSet(PointingSet):
         latitude = latitude_grid.ravel()
 
         self.az_el_points = np.column_stack((longitude, latitude))
-        self.spatial_coords = ("longitude", "latitude")
+        self.spatial_coords = ("spin_angle", "off_angle")
 
 
 # Define the Map classes

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -651,23 +651,15 @@ class LoPointingSet(PointingSet):
     """
 
     def __init__(self, dataset: xr.Dataset):
-        super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.IMAP_DPS)
-        # 0.1 degree bin spacing in both spin angle (longitude) and off angle (latitude)
-        bin_spacing_deg = 0.1
-        longitude_bin_centers = np.arange(0 + bin_spacing_deg / 2, 360, bin_spacing_deg)
-        latitude_bin_centers = np.arange(-2 + bin_spacing_deg / 2, 2, bin_spacing_deg)
+        super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.IMAP_HAE)
 
-        # Could be wrong about the order here
-        longitude_grid, latitude_grid = np.meshgrid(
-            longitude_bin_centers,
-            latitude_bin_centers,
-            indexing="ij",
+        # The HAE centers are stored in the pset as (1, 3600, 40) arrays
+        self.az_el_points = np.column_stack(
+            (
+                np.squeeze(self.data["hae_longitude"]).values.ravel(),
+                np.squeeze(self.data["hae_latitude"]).values.ravel(),
+            )
         )
-
-        longitude = longitude_grid.ravel()
-        latitude = latitude_grid.ravel()
-
-        self.az_el_points = np.column_stack((longitude, latitude))
         self.spatial_coords = ("spin_angle", "off_angle")
 
 

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -78,12 +78,12 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         pset["pointing_start_met"] = xr.DataArray(
             np.array([pointing_start_met]),
             dims="epoch",
-            # attrs=attr_mgr.get_variable_attributes("pointing_start_met)"
+            attrs=attr_mgr.get_variable_attributes("pointing_start_met"),
         )
         pset["pointing_end_met"] = xr.DataArray(
             np.array([pointing_end_met]),
             dims="epoch",
-            # attrs=attr_mgr.get_variable_attributes("pointing_start_met)"
+            attrs=attr_mgr.get_variable_attributes("pointing_end_met"),
         )
 
         # Set the epoch to the start of the pointing
@@ -96,12 +96,12 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         pset["start_spin_number"] = xr.DataArray(
             [get_spin_number(pset["pointing_start_met"].item())],
             dims="epoch",
-            # attrs=attr_mgr.get_variable_attributes("start_spin_number"),
+            attrs=attr_mgr.get_variable_attributes("start_spin_number"),
         )
         pset["end_spin_number"] = xr.DataArray(
             [get_spin_number(pset["pointing_end_met"].item())],
             dims="epoch",
-            # attrs=attr_mgr.get_variable_attributes("end_spin_number"),
+            attrs=attr_mgr.get_variable_attributes("end_spin_number"),
         )
 
         # Set the counts

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -111,8 +111,8 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
     pset = pset.assign_coords(
         {
             "esa_energy_step": np.arange(1, 8),
-            "spin_angle": np.arange(3600),
-            "off_angle": np.arange(40),
+            "spin_angle": np.arange(3600) / 3600 + 0.05,
+            "off_angle": np.arange(40) / 40 - 1.95,
         }
     )
 
@@ -386,7 +386,7 @@ def create_datasets(
         )
 
         spin_angle = xr.DataArray(
-            data=np.arange(3600),
+            data=np.arange(3600) / 3600 + 0.05,
             name="spin_angle",
             dims=["spin_angle"],
             attrs=attr_mgr.get_variable_attributes("spin_angle"),
@@ -399,13 +399,13 @@ def create_datasets(
         )
 
         off_angle = xr.DataArray(
-            data=np.arange(40),
+            data=np.arange(40) / 40 - 1.95,
             name="off_angle",
             dims=["off_angle"],
             attrs=attr_mgr.get_variable_attributes("off_angle"),
         )
         off_angle_label = xr.DataArray(
-            spin_angle.values.astype(str),
+            off_angle.values.astype(str),
             name="off_angle_label",
             dims=["off_angle_label"],
             attrs=attr_mgr.get_variable_attributes("off_angle_label"),

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -13,6 +13,18 @@ from imap_processing.spice.repoint import get_pointing_times
 from imap_processing.spice.spin import get_spin_number
 from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_met
 
+N_ESA_ENERGY_STEPS = 7
+N_SPIN_ANGLE_BINS = 3600
+N_OFF_ANGLE_BINS = 40
+# 1 time, 7 energy steps, 3600 spin angle bins, and 40 off angle bins
+PSET_SHAPE = (1, N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS)
+PSET_DIMS = ["epoch", "esa_energy_step", "spin_angle", "off_angle"]
+ESA_ENERGY_STEPS = np.arange(N_ESA_ENERGY_STEPS) + 1  # 1 to 7 inclusive
+SPIN_ANGLE_BIN_EDGES = np.linspace(0, 360, N_SPIN_ANGLE_BINS + 1)
+SPIN_ANGLE_BIN_CENTERS = (SPIN_ANGLE_BIN_EDGES[:-1] + SPIN_ANGLE_BIN_EDGES[1:]) / 2
+OFF_ANGLE_BIN_EDGES = np.linspace(-2, 2, N_OFF_ANGLE_BINS + 1)
+OFF_ANGLE_BIN_CENTERS = (OFF_ANGLE_BIN_EDGES[:-1] + OFF_ANGLE_BIN_EDGES[1:]) / 2
+
 
 class FilterType(str, Enum):
     """
@@ -110,9 +122,9 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
 
     pset = pset.assign_coords(
         {
-            "esa_energy_step": np.arange(1, 8),
-            "spin_angle": np.arange(3600) / 3600 + 0.05,
-            "off_angle": np.arange(40) / 40 - 1.95,
+            "esa_energy_step": ESA_ENERGY_STEPS,
+            "spin_angle": SPIN_ANGLE_BIN_CENTERS,
+            "off_angle": OFF_ANGLE_BIN_CENTERS,
         }
     )
 
@@ -285,7 +297,7 @@ def create_pset_counts(
 
     counts = xr.DataArray(
         data=hist.astype(np.int16),
-        dims=["epoch", "esa_energy_step", "spin_angle", "off_angle"],
+        dims=PSET_DIMS,
     )
 
     return counts
@@ -311,11 +323,6 @@ def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.Dat
     exposure_time : xarray.DataArray
         The exposure times for the L1B Direct Event dataset.
     """
-    # Create bin edges
-    lon_edges = np.arange(3601)
-    lat_edges = np.arange(41)
-    energy_edges = np.arange(8)
-
     data = np.column_stack(
         (l1b_de["esa_step"], l1b_de["pointing_bin_lon"], l1b_de["pointing_bin_lat"])
     )
@@ -325,14 +332,19 @@ def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.Dat
         # exposure time equation from Lo Alg Document 10.1.1.4
         4 * l1b_de["avg_spin_durations"].to_numpy() / 3600,
         statistic="mean",
-        bins=[energy_edges, lon_edges, lat_edges],
+        # NOTE: The l1b pointing_bin_lon is bin number, not actual angle
+        bins=[
+            np.arange(N_ESA_ENERGY_STEPS + 1),
+            np.arange(N_SPIN_ANGLE_BINS + 1),
+            np.arange(N_OFF_ANGLE_BINS + 1),
+        ],
     )
 
     stat = result.statistic[np.newaxis, :, :, :]
 
     exposure_time = xr.DataArray(
         data=stat.astype(np.float16),
-        dims=["epoch", "esa_energy_step", "spin_angle", "off_angle"],
+        dims=PSET_DIMS,
     )
 
     return exposure_time
@@ -373,7 +385,7 @@ def create_datasets(
 
     if logical_source == "imap_lo_l1c_pset":
         esa_energy_step = xr.DataArray(
-            data=[1, 2, 3, 4, 5, 6, 7],
+            data=ESA_ENERGY_STEPS,
             name="esa_energy_step",
             dims=["esa_energy_step"],
             attrs=attr_mgr.get_variable_attributes("esa_energy_step"),
@@ -386,7 +398,7 @@ def create_datasets(
         )
 
         spin_angle = xr.DataArray(
-            data=np.arange(3600) / 3600 + 0.05,
+            data=SPIN_ANGLE_BIN_CENTERS,
             name="spin_angle",
             dims=["spin_angle"],
             attrs=attr_mgr.get_variable_attributes("spin_angle"),
@@ -399,7 +411,7 @@ def create_datasets(
         )
 
         off_angle = xr.DataArray(
-            data=np.arange(40) / 40 - 1.95,
+            data=OFF_ANGLE_BIN_CENTERS,
             name="off_angle",
             dims=["off_angle"],
             attrs=attr_mgr.get_variable_attributes("off_angle"),
@@ -460,13 +472,13 @@ def create_datasets(
 
         elif "rates" in field:
             dataset[field] = xr.DataArray(
-                data=np.ones((1, 7, 3600, 40), dtype=np.float16),
+                data=np.ones(PSET_SHAPE, dtype=np.float16),
                 dims=dims,
                 attrs=attr_mgr.get_variable_attributes(field),
             )
         else:
             dataset[field] = xr.DataArray(
-                data=np.ones((1, 7, 3600, 40), dtype=np.int16),
+                data=np.ones(PSET_SHAPE, dtype=np.int16),
                 dims=dims,
                 attrs=attr_mgr.get_variable_attributes(field),
             )

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -107,16 +107,12 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
             full_counts, l1b_goodtimes_only
         )
     pset.attrs = attr_mgr.get_global_attributes(logical_source)
-    # TODO: Temp fix before adding attribute variables.
-    #  CDF won't open if DEPEND_0 is not deleted currently.
-    del pset["epoch"].attrs["DEPEND_0"]
 
     pset = pset.assign_coords(
         {
-            "epoch": pset["epoch"],
-            "energy": np.arange(1, 8),
-            "longitude": np.arange(3600),
-            "latitude": np.arange(40),
+            "esa_energy_step": np.arange(1, 8),
+            "spin_angle": np.arange(3600),
+            "off_angle": np.arange(40),
         }
     )
 
@@ -289,7 +285,7 @@ def create_pset_counts(
 
     counts = xr.DataArray(
         data=hist.astype(np.int16),
-        dims=["epoch", "energy", "longitude", "latitude"],
+        dims=["epoch", "esa_energy_step", "spin_angle", "off_angle"],
     )
 
     return counts
@@ -336,7 +332,7 @@ def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.Dat
 
     exposure_time = xr.DataArray(
         data=stat.astype(np.float16),
-        dims=["epoch", "energy", "longitude", "latitude"],
+        dims=["epoch", "esa_energy_step", "spin_angle", "off_angle"],
     )
 
     return exposure_time
@@ -368,8 +364,6 @@ def create_datasets(
     #  can be used direction
     epoch_converted_time = [1]
 
-    # Create a data array for the epoch time
-    # TODO: might need to update the attrs to use new YAML file
     epoch_time = xr.DataArray(
         data=epoch_converted_time,
         name="epoch",
@@ -378,38 +372,54 @@ def create_datasets(
     )
 
     if logical_source == "imap_lo_l1c_pset":
-        esa_step = xr.DataArray(
+        esa_energy_step = xr.DataArray(
             data=[1, 2, 3, 4, 5, 6, 7],
-            name="esa_step",
-            dims=["esa_step"],
-            attrs=attr_mgr.get_variable_attributes("esa_step"),
+            name="esa_energy_step",
+            dims=["esa_energy_step"],
+            attrs=attr_mgr.get_variable_attributes("esa_energy_step"),
         )
-        pointing_bins = xr.DataArray(
-            data=np.arange(3600),
-            name="pointing_bins",
-            dims=["pointing_bins"],
-            attrs=attr_mgr.get_variable_attributes("pointing_bins"),
-        )
-
-        esa_step_label = xr.DataArray(
-            esa_step.values.astype(str),
+        esa_energy_step_label = xr.DataArray(
+            esa_energy_step.values.astype(str),
             name="esa_step_label",
             dims=["esa_step_label"],
             attrs=attr_mgr.get_variable_attributes("esa_step_label"),
         )
-        pointing_bins_label = xr.DataArray(
-            pointing_bins.values.astype(str),
-            name="pointing_bins_label",
-            dims=["pointing_bins_label"],
-            attrs=attr_mgr.get_variable_attributes("pointing_bins_label"),
+
+        spin_angle = xr.DataArray(
+            data=np.arange(3600),
+            name="spin_angle",
+            dims=["spin_angle"],
+            attrs=attr_mgr.get_variable_attributes("spin_angle"),
         )
+        spin_angle_label = xr.DataArray(
+            spin_angle.values.astype(str),
+            name="spin_angle_label",
+            dims=["spin_angle_label"],
+            attrs=attr_mgr.get_variable_attributes("spin_angle_label"),
+        )
+
+        off_angle = xr.DataArray(
+            data=np.arange(40),
+            name="off_angle",
+            dims=["off_angle"],
+            attrs=attr_mgr.get_variable_attributes("off_angle"),
+        )
+        off_angle_label = xr.DataArray(
+            spin_angle.values.astype(str),
+            name="off_angle_label",
+            dims=["off_angle_label"],
+            attrs=attr_mgr.get_variable_attributes("off_angle_label"),
+        )
+
         dataset = xr.Dataset(
             coords={
                 "epoch": epoch_time,
-                "pointing_bins": pointing_bins,
-                "pointing_bins_label": pointing_bins_label,
-                "esa_step": esa_step,
-                "esa_step_label": esa_step_label,
+                "esa_energy_step": esa_energy_step,
+                "esa_energy_step_label": esa_energy_step_label,
+                "spin_angle": spin_angle,
+                "spin_angle_label": spin_angle_label,
+                "off_angle": off_angle,
+                "off_angle_label": off_angle_label,
             },
             attrs=attr_mgr.get_global_attributes(logical_source),
         )
@@ -429,30 +439,34 @@ def create_datasets(
 
         # Create a data array for the current field and add it to the dataset
         # TODO: TEMPORARY. need to update to use l1b data once that's available.
-        if field in ["pointing_start", "pointing_end", "mode", "pivot_angle"]:
+        if field in [
+            "pointing_start_met",
+            "pointing_end_met",
+            "esa_mode",
+            "pivot_angle",
+        ]:
             dataset[field] = xr.DataArray(
                 data=[1],
                 dims=dims,
                 attrs=attr_mgr.get_variable_attributes(field),
             )
         # TODO: This is temporary.
-        #  The data type will be set in the data class when that's created
         elif field == "exposure_time":
             dataset[field] = xr.DataArray(
-                data=np.ones((1, 7), dtype=np.float16),
+                data=np.ones((1, 7, 3600, 40), dtype=np.float16),
                 dims=dims,
                 attrs=attr_mgr.get_variable_attributes(field),
             )
 
-        elif "rate" in field:
+        elif "rates" in field:
             dataset[field] = xr.DataArray(
-                data=np.ones((1, 3600, 7), dtype=np.float16),
+                data=np.ones((1, 7, 3600, 40), dtype=np.float16),
                 dims=dims,
                 attrs=attr_mgr.get_variable_attributes(field),
             )
         else:
             dataset[field] = xr.DataArray(
-                data=np.ones((1, 3600, 7), dtype=np.int16),
+                data=np.ones((1, 7, 3600, 40), dtype=np.int16),
                 dims=dims,
                 attrs=attr_mgr.get_variable_attributes(field),
             )

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -195,19 +195,19 @@ class TestHiPointingSet:
 
 @pytest.fixture
 def lo_pset_ds():
-    h_counts = np.zeros((1, 3600, 40, 7))
+    h_counts = np.zeros((1, 7, 3600, 40))
     h_counts[:, :, 0:10, :] = 1
 
-    exposure_time = np.full((1, 3600, 40, 7), 0.5)
+    exposure_time = np.full((1, 7, 3600, 40), 0.5)
     dataset = xr.Dataset()
     dataset["h_counts"] = xr.DataArray(
         h_counts,
-        dims=("epoch", "longitude", "latitude", "energy"),
+        dims=("epoch", "esa_energy_step", "spin_angle", "off_angle"),
         name="h_counts",
     )
     dataset["exposure_time"] = xr.DataArray(
         exposure_time,
-        dims=("epoch", "longitude", "latitude", "energy"),
+        dims=("epoch", "esa_energy_step", "spin_angle", "off_angle"),
         name="exposure_time",
     )
     dataset.coords["epoch"] = xr.DataArray(
@@ -215,20 +215,20 @@ def lo_pset_ds():
         dims=["epoch"],
         name="epoch",
     )
-    dataset.coords["longitude"] = xr.DataArray(
+    dataset.coords["spin_angle"] = xr.DataArray(
         [i for i in range(3600)],
-        dims=["longitude"],
-        name="longitude",
+        dims=["spin_angle"],
+        name="spin_angle",
     )
-    dataset.coords["latitude"] = xr.DataArray(
+    dataset.coords["off_angle"] = xr.DataArray(
         [i for i in range(40)],
-        dims=["latitude"],
-        name="latitude",
+        dims=["off_angle"],
+        name="off_angle",
     )
-    dataset.coords["energy"] = xr.DataArray(
+    dataset.coords["esa_energy_step"] = xr.DataArray(
         [i for i in range(1, 8)],
-        dims=["energy"],
-        name="energy",
+        dims=["esa_energy_step"],
+        name="esa_energy_step",
     )
 
     attr_mgr = ImapCdfAttributes()

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -199,6 +199,14 @@ def lo_pset_ds():
     h_counts[:, :, 0:10, :] = 1
 
     exposure_time = np.full((1, 7, 3600, 40), 0.5)
+    lons = np.linspace(0, 359.9, 3600)
+    lats = np.linspace(-2, 2, 40)
+    lons, lats = np.meshgrid(lons, lats, indexing="ij")
+    hae_longitude = np.empty((1, 3600, 40))
+    hae_latitude = np.empty((1, 3600, 40))
+    hae_longitude[0, :, :] = lons
+    hae_latitude[0, :, :] = lats
+
     dataset = xr.Dataset()
     dataset["h_counts"] = xr.DataArray(
         h_counts,
@@ -210,6 +218,17 @@ def lo_pset_ds():
         dims=("epoch", "esa_energy_step", "spin_angle", "off_angle"),
         name="exposure_time",
     )
+    dataset["hae_longitude"] = xr.DataArray(
+        hae_longitude,
+        dims=("epoch", "spin_angle", "off_angle"),
+        name="exposure_time",
+    )
+    dataset["hae_latitude"] = xr.DataArray(
+        hae_latitude,
+        dims=("epoch", "spin_angle", "off_angle"),
+        name="exposure_time",
+    )
+
     dataset.coords["epoch"] = xr.DataArray(
         [8.1794907049e17],
         dims=["epoch"],
@@ -252,7 +271,7 @@ class TestLoPointingSet:
         """Test coverage for __init__ method."""
         lo_pset = ena_maps.LoPointingSet(lo_pset_ds)
         assert isinstance(lo_pset, ena_maps.LoPointingSet)
-        assert lo_pset.spice_reference_frame == geometry.SpiceFrame.IMAP_DPS
+        assert lo_pset.spice_reference_frame == geometry.SpiceFrame.IMAP_HAE
         assert lo_pset.num_points == 144000
         np.testing.assert_array_equal(lo_pset.az_el_points.shape, (144000, 2))
 

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -5,6 +5,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.lo.l1c.lo_l1c import (
+    PSET_SHAPE,
     FilterType,
     calculate_exposure_times,
     create_pset_counts,
@@ -102,7 +103,7 @@ def attr_mgr():
 @pytest.fixture
 def counts():
     """Fixture for initial counts."""
-    return np.zeros((1, 7, 3600, 40))
+    return np.zeros(PSET_SHAPE)
 
 
 @pytest.fixture

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -256,7 +256,7 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
 def test_calculate_exposure_times(l1b_de):
     # Arrange
     counts = create_pset_counts(l1b_de)
-    expected_exposure_times = np.full((1, 7, 3600, 40), np.nan)
+    expected_exposure_times = np.full(PSET_SHAPE, np.nan)
     # Average of the exposure times for each bin
     expected_exposure_times[0, 1, 20, 20] = 4 * np.mean([15.2, 14.9]) / 3600
     expected_exposure_times[0, 4, 2000, 20] = 4 * 15 / 3600

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -23,17 +23,20 @@ def pset():
 
     dataset = xr.Dataset(
         {
-            "h_counts": (("epoch", "energy", "longitude", "latitude"), h_counts),
+            "h_counts": (
+                ("epoch", "esa_energy_step", "spin_angle", "off_angle"),
+                h_counts,
+            ),
             "exposure_time": (
-                ("epoch", "energy", "longitude", "latitude"),
+                ("epoch", "esa_energy_step", "spin_angle", "off_angle"),
                 exposure_time,
             ),
         },
         coords={
             "epoch": [8.1794907049e17],
-            "energy": [i for i in range(1, 8)],
-            "longitude": [i for i in range(3600)],
-            "latitude": [i for i in range(40)],
+            "esa_energy_step": [i for i in range(1, 8)],
+            "spin_angle": [i for i in range(3600)],
+            "off_angle": [i for i in range(40)],
         },
     )
     return dataset

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -21,6 +21,14 @@ def pset():
 
     exposure_time = np.full((1, 7, 3600, 40), 0.5)
 
+    lons = np.linspace(0, 359.9, 3600)
+    lats = np.linspace(-2, 2, 40)
+    lons, lats = np.meshgrid(lons, lats, indexing="ij")
+    hae_longitude = np.empty((1, 3600, 40))
+    hae_latitude = np.empty((1, 3600, 40))
+    hae_longitude[0, :, :] = lons
+    hae_latitude[0, :, :] = lats
+
     dataset = xr.Dataset(
         {
             "h_counts": (
@@ -31,6 +39,8 @@ def pset():
                 ("epoch", "esa_energy_step", "spin_angle", "off_angle"),
                 exposure_time,
             ),
+            "hae_longitude": (("epoch", "spin_angle", "off_angle"), hae_longitude),
+            "hae_latitude": (("epoch", "spin_angle", "off_angle"), hae_latitude),
         },
         coords={
             "epoch": [8.1794907049e17],

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -4,6 +4,15 @@ import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.ena_maps.ena_maps import HealpixSkyMap, RectangularSkyMap
+from imap_processing.lo.l1c.lo_l1c import (
+    ESA_ENERGY_STEPS,
+    N_OFF_ANGLE_BINS,
+    N_SPIN_ANGLE_BINS,
+    OFF_ANGLE_BIN_CENTERS,
+    PSET_DIMS,
+    PSET_SHAPE,
+    SPIN_ANGLE_BIN_CENTERS,
+)
 from imap_processing.lo.l2.lo_l2 import (
     add_attributes,
     calculate_fluxes,
@@ -16,27 +25,27 @@ from imap_processing.spice import geometry
 
 @pytest.fixture
 def pset():
-    h_counts = np.zeros((1, 7, 3600, 40))
+    h_counts = np.zeros(PSET_SHAPE)
     h_counts[:, :, :, 0:10] = 1
 
-    exposure_time = np.full((1, 7, 3600, 40), 0.5)
+    exposure_time = np.full(PSET_SHAPE, 0.5)
 
-    lons = np.linspace(0, 359.9, 3600)
-    lats = np.linspace(-2, 2, 40)
-    lons, lats = np.meshgrid(lons, lats, indexing="ij")
-    hae_longitude = np.empty((1, 3600, 40))
-    hae_latitude = np.empty((1, 3600, 40))
+    lons, lats = np.meshgrid(
+        SPIN_ANGLE_BIN_CENTERS, OFF_ANGLE_BIN_CENTERS, indexing="ij"
+    )
+    hae_longitude = np.empty((1, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS))
+    hae_latitude = np.empty((1, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS))
     hae_longitude[0, :, :] = lons
     hae_latitude[0, :, :] = lats
 
     dataset = xr.Dataset(
         {
             "h_counts": (
-                ("epoch", "esa_energy_step", "spin_angle", "off_angle"),
+                PSET_DIMS,
                 h_counts,
             ),
             "exposure_time": (
-                ("epoch", "esa_energy_step", "spin_angle", "off_angle"),
+                PSET_DIMS,
                 exposure_time,
             ),
             "hae_longitude": (("epoch", "spin_angle", "off_angle"), hae_longitude),
@@ -44,9 +53,9 @@ def pset():
         },
         coords={
             "epoch": [8.1794907049e17],
-            "esa_energy_step": [i for i in range(1, 8)],
-            "spin_angle": [i for i in range(3600)],
-            "off_angle": [i for i in range(40)],
+            "esa_energy_step": ESA_ENERGY_STEPS,
+            "spin_angle": SPIN_ANGLE_BIN_CENTERS,
+            "off_angle": OFF_ANGLE_BIN_CENTERS,
         },
     )
     return dataset
@@ -72,7 +81,7 @@ def map():
             "epoch": [8.1794907049e17],
             "longitude": [i for i in range(60)],
             "latitude": [i for i in range(30)],
-            "energy": [i for i in range(1, 8)],
+            "energy": ESA_ENERGY_STEPS,
         },
     )
     return dataset


### PR DESCRIPTION
Based upon the pset variables named here: https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/281316700/Remaining+PSET+Work

Updates all of the dimensions to be (epoch, esa_energy_step, spin_angle, off_angle). One question I still have is whether we want to fill in the actual spin_angle values instead of an integer bin number. This is what I would want, but I am unclear what the standard is for other instruments and the files provided had integer bin numbers (even though the variables don't have the `_bin` suffix). Thoughts on which approach to use?