### PR TITLE
Ultra - L1b DE culling

### DIFF
--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -116,6 +116,8 @@ EXTERNAL_TEST_DATA = [
     ("imap_ultra_l1c-90sensor-sc-pointing-phi-n32-test_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-90sensor-sc-pointing-index-n32-test_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-90sensor-sc-pointing-bsf-n32-test_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf","ultra/data/l1/"),
+    ("imap_ultra_l1c-45sensor-nominal-for-lookup_20250101_v000.csv", "ultra/data/l1/"),
 
     # MAG
     ("mag-l1b-l1c-t013-magi-burst-in.csv",

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -68,6 +68,14 @@ def test_calculate_spacecraft_pset(
             ),
             "energy_spacecraft": (["epoch"], energy_dps_spacecraft),
             "spin_number": (["epoch"], df["Spin"].values),
+            "quality_scattering": (
+                ["epoch"],
+                np.zeros(len(df["Spin"].values), dtype=np.uint16),
+            ),
+            "quality_outliers": (
+                ["epoch"],
+                np.zeros(len(df["Spin"].values), dtype=np.uint16),
+            ),
         },
         coords={
             "epoch": ("epoch", epoch),
@@ -143,6 +151,8 @@ def test_calculate_spacecraft_pset_with_cdf(
         # Made up data for spin_number and energy_bin_geometric_mean
         de_dict["spin_number"] = np.full(len(sc_dps_velocity), 128)
         de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
+        de_dict["quality_scattering"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
+        de_dict["quality_outliers"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
 
         name = "imap_ultra_l1b_45sensor-de"
         dataset = create_dataset(de_dict, name, "l1b")

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -154,7 +154,9 @@ def test_ultra_l1b_extendedspin(
 ):
     """Tests that L1b data is created."""
     use_fake_spin_data_for_time(0, 141 * 15)
-    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset_path = (
+        TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf"
+    )
     l1b_de_dataset = load_cdf(l1b_de_dataset_path)
 
     data_dict = {
@@ -180,7 +182,9 @@ def test_ultra_l1b_extendedspin(
 @pytest.mark.external_test_data
 def test_cdf_extendedspin(use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset):
     use_fake_spin_data_for_time(0, 141 * 15)
-    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset_path = (
+        TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf"
+    )
     l1b_de_dataset = load_cdf(l1b_de_dataset_path)
 
     data_dict = {
@@ -210,7 +214,9 @@ def test_cdf_extendedspin(use_fake_spin_data_for_time, faux_aux_dataset, rates_d
 def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
     use_fake_spin_data_for_time(0, 141 * 15)
-    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset_path = (
+        TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf"
+    )
     l1b_de_dataset = load_cdf(l1b_de_dataset_path)
 
     data_dict = {
@@ -244,7 +250,9 @@ def test_cdf_cullingmask(use_fake_spin_data_for_time, faux_aux_dataset, rates_da
 def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_dataset):
     """Tests that CDF file is created and contains same attributes as xarray."""
     use_fake_spin_data_for_time(0, 141 * 15)
-    l1b_de_dataset_path = TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207_v999.cdf"
+    l1b_de_dataset_path = (
+        TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999"
+    )
     l1b_de_dataset = load_cdf(l1b_de_dataset_path)
 
     data_dict = {

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -21,6 +21,7 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_imap_instruments,
     flag_rates,
     flag_scattering,
+    get_de_rejection_mask,
     get_energy_histogram,
     get_n_sigma,
     get_pulses_per_spin,
@@ -265,6 +266,18 @@ def test_flag_scattering(ancillary_files):
     assert np.all(quality_flags == np.array([1, 1, 2, 2, 2, 2, 2, 2, 2]))
 
 
+def test_get_de_rejection_mask():
+    """Tests get_de_rejection_mask function."""
+    quality_scattering = np.array([0, 1, 0, 1, 1, 0, 0, 1, 0])
+    quality_outliers = np.array([0, 0, 1, 0, 1, 0, 1, 0, 0])
+
+    counted = get_de_rejection_mask(quality_scattering, quality_outliers)
+
+    np.testing.assert_array_equal(
+        counted, np.array([False, True, True, True, True, False, True, True, False])
+    )
+
+
 def test_count_rejected_events_per_spin():
     """Tests count_rejected_events_per_spin function."""
 
@@ -276,4 +289,4 @@ def test_count_rejected_events_per_spin():
         spins, quality_scattering, quality_outliers
     )
 
-    np.testing.array_equal(counted.scattering, np.array([2, 2, 2]))
+    np.testing.assert_array_equal(counted, np.array([2, 2, 2]))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -15,6 +15,7 @@ from imap_processing.quality_flags import (
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
     compare_aux_univ_spin_table,
+    count_rejected_events_per_spin,
     flag_attitude,
     flag_hk,
     flag_imap_instruments,
@@ -262,3 +263,17 @@ def test_flag_scattering(ancillary_files):
     )
     flag_scattering(tof_energy, theta, phi, ancillary_files, "ultra45", quality_flags)
     assert np.all(quality_flags == np.array([1, 1, 2, 2, 2, 2, 2, 2, 2]))
+
+
+def test_count_rejected_events_per_spin():
+    """Tests count_rejected_events_per_spin function."""
+
+    spins = np.array([0, 0, 0, 1, 1, 2, 2, 2, 2])
+    quality_scattering = np.array([0, 1, 0, 1, 1, 0, 0, 1, 0])
+    quality_outliers = np.array([0, 0, 1, 0, 1, 0, 1, 0, 0])
+
+    counted = count_rejected_events_per_spin(
+        spins, quality_scattering, quality_outliers
+    )
+
+    np.testing.array_equal(counted.scattering, np.array([2, 2, 2]))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -214,6 +214,8 @@ def test_calculate_spacecraft_pset_with_cdf(
         tof_tenths_ns,
     )
     de_dict["direct_event_velocity"] = v.astype(np.float32)
+    de_dict["quality_scattering"] = np.zeros(len(v), dtype=np.uint16)
+    de_dict["quality_outliers"] = np.zeros(len(v), dtype=np.uint16)
 
     ultra_frame = SpiceFrame.IMAP_ULTRA_45
     _, sc_dps_velocity, _ = get_annotated_particle_velocity(
@@ -308,6 +310,8 @@ def test_calculate_helio_pset_with_cdf(
 
     de_dict["velocity_dps_helio"] = helio_dps_velocity
     de_dict["energy_heliosphere"] = get_de_energy_kev(helio_dps_velocity, species_bin)
+    de_dict["quality_scattering"] = np.zeros(len(helio_dps_velocity), dtype=np.uint16)
+    de_dict["quality_outliers"] = np.zeros(len(helio_dps_velocity), dtype=np.uint16)
 
     name = "imap_ultra_l1b_45sensor-de"
     dataset = create_dataset(de_dict, name, "l1b")

--- a/imap_processing/ultra/l1b/cullingmask.py
+++ b/imap_processing/ultra/l1b/cullingmask.py
@@ -3,7 +3,7 @@
 import numpy as np
 import xarray as xr
 
-from imap_processing.ultra.l1b.quality_flag_filters import QUALITY_FLAG_FILTERS
+from imap_processing.ultra.l1b.quality_flag_filters import SPIN_QUALITY_FLAG_FILTERS
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset, extract_data_dict
 
 FILLVAL_UINT16 = 65535
@@ -32,14 +32,17 @@ def calculate_cullingmask(extendedspin_dataset: xr.Dataset, name: str) -> xr.Dat
     good_mask = (
         (
             extendedspin_dataset["quality_attitude"]
-            & sum(flag.value for flag in QUALITY_FLAG_FILTERS["quality_attitude"])
+            & sum(flag.value for flag in SPIN_QUALITY_FLAG_FILTERS["quality_attitude"])
         )
         == 0
     ) & (
         (
             (
                 extendedspin_dataset["quality_ena_rates"]
-                & sum(flag.value for flag in QUALITY_FLAG_FILTERS["quality_ena_rates"])
+                & sum(
+                    flag.value
+                    for flag in SPIN_QUALITY_FLAG_FILTERS["quality_ena_rates"]
+                )
             )
             == 0
         ).all(dim="energy_bin_geometric_mean")

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -4,6 +4,7 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
+    count_rejected_events_per_spin,
     flag_attitude,
     flag_hk,
     flag_imap_instruments,
@@ -66,6 +67,13 @@ def calculate_extendedspin(
     # Get the number of pulses per spin.
     pulses = get_pulses_per_spin(rates_dataset)
 
+    # Track rejected events in each spin based on
+    # quality flags in de l1b data.
+    rejected_counts = count_rejected_events_per_spin(
+        de_dataset["spin"].values,
+        de_dataset["quality_scattering"].values,
+        de_dataset["quality_outliers"].values,
+    )
     # These will be the coordinates.
     extendedspin_dict["epoch"] = first_epochs
     extendedspin_dict["spin_number"] = spin
@@ -79,12 +87,7 @@ def calculate_extendedspin(
     extendedspin_dict["start_pulses_per_spin"] = pulses.start_per_spin
     extendedspin_dict["stop_pulses_per_spin"] = pulses.stop_per_spin
     extendedspin_dict["coin_pulses_per_spin"] = pulses.coin_per_spin
-    # TODO: this will be used to track rejected events in each
-    #  spin based on quality flags in de l1b data.
-    extendedspin_dict["rejected_events_per_spin"] = np.full_like(
-        spin, FILLVAL_UINT16, dtype=np.uint16
-    )
-
+    extendedspin_dict["rejected_events_per_spin"] = rejected_counts
     extendedspin_dict["quality_attitude"] = attitude_qf
     extendedspin_dict["quality_ena_rates"] = rates_qf
     extendedspin_dict["quality_hk"] = hk_qf

--- a/imap_processing/ultra/l1b/quality_flag_filters.py
+++ b/imap_processing/ultra/l1b/quality_flag_filters.py
@@ -2,13 +2,22 @@
 
 from imap_processing.quality_flags import (
     FlagNameMixin,
+    ImapDEOutliersUltraFlags,
+    ImapDEScatteringUltraFlags,
     ImapRatesUltraFlags,
 )
 
-QUALITY_FLAG_FILTERS: dict[str, list[FlagNameMixin]] = {
+SPIN_QUALITY_FLAG_FILTERS: dict[str, list[FlagNameMixin]] = {
     "quality_attitude": [],
     "quality_ena_rates": [
         ImapRatesUltraFlags.FIRSTSPIN,
         ImapRatesUltraFlags.LASTSPIN,
+    ],
+}
+
+DE_QUALITY_FLAG_FILTERS: dict[str, list[FlagNameMixin]] = {
+    "quality_outliers": [ImapDEOutliersUltraFlags.FOV],
+    "quality_scattering": [
+        ImapDEScatteringUltraFlags.ABOVE_THRESHOLD,
     ],
 }

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -20,6 +20,7 @@ from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.lookup_utils import (
     get_scattering_coefficients,
 )
+from imap_processing.ultra.l1b.quality_flag_filters import DE_QUALITY_FLAG_FILTERS
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -537,3 +538,47 @@ def flag_scattering(
         quality_flags[np.where(event_mask)[0][either_exceeds]] |= (
             ImapDEScatteringUltraFlags.ABOVE_THRESHOLD.value
         )
+
+
+def count_rejected_events_per_spin(
+    spins: NDArray, quality_scattering: NDArray, quality_outliers: NDArray
+) -> NDArray:
+    """
+    Count rejected events per spin based on DE_QUALITY_FLAG_FILTERS.
+
+    Parameters
+    ----------
+    spins : NDArray
+        Spins in which each direct event is within.
+    quality_scattering : NDArray
+        Quality scattering flags.
+    quality_outliers : NDArray
+        Quality outliers flags.
+
+    Returns
+    -------
+    rejected_counts : NDArray
+        Rejected counts per spin.
+    """
+    # Bitmasks from the DE_QUALITY_FLAG_FILTERS
+    scattering_mask = sum(
+        flag.value for flag in DE_QUALITY_FLAG_FILTERS["quality_scattering"]
+    )
+    outliers_mask = sum(
+        flag.value for flag in DE_QUALITY_FLAG_FILTERS["quality_outliers"]
+    )
+
+    # Boolean mask where event is rejected due to relevant flags
+    rejected = ((quality_scattering & scattering_mask) != 0) | (
+        (quality_outliers & outliers_mask) != 0
+    )
+
+    # Unique spin numbers
+    unique_spins = np.unique(spins)
+
+    # Count rejected events per spin
+    rejected_counts = {
+        spin: int(np.count_nonzero(rejected[spins == spin])) for spin in unique_spins
+    }
+
+    return rejected_counts

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -540,6 +540,40 @@ def flag_scattering(
         )
 
 
+def get_de_rejection_mask(
+    quality_scattering: NDArray, quality_outliers: NDArray
+) -> NDArray:
+    """
+    Create boolean mask where event is rejected due to relevant flags.
+
+    Parameters
+    ----------
+    quality_scattering : NDArray
+        Quality scattering flags.
+    quality_outliers : NDArray
+        Quality outliers flags.
+
+    Returns
+    -------
+    rejected : NDArray
+        Rejected events where True = rejected.
+    """
+    # Bitmasks from the DE_QUALITY_FLAG_FILTERS
+    scattering_mask = sum(
+        flag.value for flag in DE_QUALITY_FLAG_FILTERS["quality_scattering"]
+    )
+    outliers_mask = sum(
+        flag.value for flag in DE_QUALITY_FLAG_FILTERS["quality_outliers"]
+    )
+
+    # Boolean mask where event is rejected due to relevant flags
+    rejected = ((quality_scattering & scattering_mask) != 0) | (
+        (quality_outliers & outliers_mask) != 0
+    )
+
+    return rejected
+
+
 def count_rejected_events_per_spin(
     spins: NDArray, quality_scattering: NDArray, quality_outliers: NDArray
 ) -> NDArray:
@@ -560,25 +594,15 @@ def count_rejected_events_per_spin(
     rejected_counts : NDArray
         Rejected counts per spin.
     """
-    # Bitmasks from the DE_QUALITY_FLAG_FILTERS
-    scattering_mask = sum(
-        flag.value for flag in DE_QUALITY_FLAG_FILTERS["quality_scattering"]
-    )
-    outliers_mask = sum(
-        flag.value for flag in DE_QUALITY_FLAG_FILTERS["quality_outliers"]
-    )
-
     # Boolean mask where event is rejected due to relevant flags
-    rejected = ((quality_scattering & scattering_mask) != 0) | (
-        (quality_outliers & outliers_mask) != 0
-    )
+    rejected = get_de_rejection_mask(quality_scattering, quality_outliers)
 
     # Unique spin numbers
     unique_spins = np.unique(spins)
 
     # Count rejected events per spin
-    rejected_counts = {
-        spin: int(np.count_nonzero(rejected[spins == spin])) for spin in unique_spins
-    }
+    rejected_counts = np.array(
+        [np.count_nonzero(rejected[spins == spin]) for spin in unique_spins], dtype=int
+    )
 
     return rejected_counts

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 FILLVAL_UINT8 = 255
 FILLVAL_FLOAT32 = -1.0e31
+FILLVAL_FLOAT64 = -1.0e31
 
 
 class StartType(Enum):
@@ -633,13 +634,17 @@ def get_de_energy_kev(v: np.ndarray, species: np.ndarray) -> NDArray:
     # Compute the sum of squares.
     v2 = np.sum(vv**2, axis=1)
 
-    index_hydrogen = np.where(species == 1)
-    energy = np.full_like(v2, np.nan)
+    # Only compute where species == 1 and v is valid
+    index_hydrogen = species == 1
+    valid_velocity = np.isfinite(v2)
+    valid_mask = index_hydrogen & valid_velocity
+
+    energy = np.full_like(v2, FILLVAL_FLOAT32)
 
     # TODO: we will calculate the energies of the different species here.
     # 1/2 mv^2 in Joules, convert to keV
-    energy[index_hydrogen] = (
-        0.5 * UltraConstants.MASS_H * v2[index_hydrogen] * UltraConstants.J_KEV
+    energy[valid_mask] = (
+        0.5 * UltraConstants.MASS_H * v2[valid_mask] * UltraConstants.J_KEV
     )
 
     return energy
@@ -1042,8 +1047,11 @@ def interpolate_fwhm(
     )
 
     # Note: will return nan for those out-of-bounds inputs.
-    phi_interp = interp_phi((energy, phi_inst))
-    theta_interp = interp_theta((energy, theta_inst))
+    phi_vals = interp_phi((energy, phi_inst))
+    theta_vals = interp_theta((energy, theta_inst))
+
+    phi_interp = np.where(np.isnan(phi_vals), FILLVAL_FLOAT32, phi_vals)
+    theta_interp = np.where(np.isnan(theta_vals), FILLVAL_FLOAT32, theta_vals)
 
     return phi_interp, theta_interp
 
@@ -1081,8 +1089,8 @@ def get_fwhm(
     theta_interp : NDArray
         Interpolated theta FWHM values.
     """
-    phi_interp = np.full_like(phi_inst, np.nan, dtype=np.float64)
-    theta_interp = np.full_like(theta_inst, np.nan, dtype=np.float64)
+    phi_interp = np.full_like(phi_inst, FILLVAL_FLOAT64, dtype=np.float64)
+    theta_interp = np.full_like(theta_inst, FILLVAL_FLOAT64, dtype=np.float64)
     lt_table = get_angular_profiles("left", sensor, ancillary_files)
     rt_table = get_angular_profiles("right", sensor, ancillary_files)
 
@@ -1131,7 +1139,7 @@ def get_efficiency_interpolator(ancillary_files: dict) -> RegularGridInterpolato
         (theta_vals, phi_vals, energy_vals),
         efficiency_grid,
         bounds_error=False,
-        fill_value=np.nan,
+        fill_value=FILLVAL_FLOAT32,
     )
 
     return interpolator

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -17,6 +17,8 @@ from imap_processing.ultra.l1c.l1c_lookup_utils import (
     calculate_pixels_within_scattering_threshold,
     get_spacecraft_pointing_lookup_tables,
 )
+from imap_processing.spice.time import sct_to_et
+from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_efficiencies_and_geometric_function,
@@ -67,6 +69,11 @@ def calculate_helio_pset(
         Dataset containing the data.
     """
     pset_dict: dict[str, np.ndarray] = {}
+
+    rejected = get_de_rejection_mask(
+        de_dataset["quality_scattering"].values, de_dataset["quality_outliers"].values
+    )
+    de_dataset = de_dataset.isel(epoch=~rejected)
 
     v_mag_helio_spacecraft = np.linalg.norm(
         de_dataset["velocity_dps_helio"].values, axis=1

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -13,12 +13,11 @@ from imap_processing.spice.time import (
     sct_to_et,
     ttj2000ns_to_et,
 )
+from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     calculate_pixels_within_scattering_threshold,
     get_spacecraft_pointing_lookup_tables,
 )
-from imap_processing.spice.time import sct_to_et
-from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_efficiencies_and_geometric_function,

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -7,11 +7,11 @@ import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
+from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     calculate_pixels_within_scattering_threshold,
     get_spacecraft_pointing_lookup_tables,
-from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
-
+)
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_efficiencies_and_geometric_function,

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -10,7 +10,8 @@ from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     calculate_pixels_within_scattering_threshold,
     get_spacecraft_pointing_lookup_tables,
-)
+from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
+
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_efficiencies_and_geometric_function,
@@ -62,6 +63,12 @@ def calculate_spacecraft_pset(
     """
     pset_dict: dict[str, np.ndarray] = {}
     sensor = parse_filename_like(name)["sensor"][0:2]
+
+    # Before we use the de_dataset to calculate the pointing set grid we need to filter.
+    rejected = get_de_rejection_mask(
+        de_dataset["quality_scattering"].values, de_dataset["quality_outliers"].values
+    )
+    de_dataset = de_dataset.isel(epoch=~rejected)
 
     v_mag_dps_spacecraft = np.linalg.norm(de_dataset["velocity_dps_sc"].values, axis=1)
     vhat_dps_spacecraft = (


### PR DESCRIPTION
# Change Summary

## Overview
This code 
1. addresses the possibilities of nans in the code
2. adds a way to keep track of filtered direct events per spin
3. culls direct events

(sorry for the incorrect branch name)

## Updated Files
- ultra_l1b_culling.py 
   - Creates a boolean mask where event is rejected due to relevant flags and counts the culled events per spin
- helio_pset.py
   - Culls direct events
- spacecraft_pset.py
   - Culls direct events
- extendedspin.py
   -  Now calls on new function from ultra_l1b_culling.py
- quality_flag_filters.py
   -  Rename filters
- cullingmask.py
   -  Rename filters
- lookup_utils.py
   -   addressed potential for nans
- ultra_l1b_extended.py
   -  addressed potential for nans

## Testing
test_ultra_l1b_culling.py
