### PR TITLE
IDEX l2a calibration curve implementation 

### DIFF
--- a/imap_processing/cdf/config/imap_idex_l2a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2a_variable_attrs.yaml
@@ -28,7 +28,7 @@ impact_charge_base: &impact_charge_base
   DICT_KEY: SPASE>Particle>ParticleType:Dust>ParticleQuantity:Current>Qualifier:Derived # TODO quantity should be charge but there is no SPASE charge
 
 mass_estimate_base: &mass_estimate_base
-  UNITS: amu
+  UNITS: Kg
   VALIDMIN: 0.0
   VALIDMAX: *int_maxval
   VAR_TYPE: data
@@ -127,7 +127,7 @@ target_fit_parameter_index:
 mass_index:
   CATDESC: Mass index values from 1 to 500
   FIELDNAM: Mass Index
-  UNITS: amu
+  UNITS: Kg
   FORMAT: I4
   VAR_TYPE: support_data
   SCALETYP: linear
@@ -157,7 +157,7 @@ tof_snr:
 tof_peak_kappa:
   CATDESC: TOF High spectrum with x-axis converted from time to mass.
   FIELDNAM: Mass Scale
-  UNITS: amu
+  UNITS: Kg
   VALIDMIN: 0.0
   VALIDMAX: 1.0
   VAR_TYPE: data
@@ -219,7 +219,7 @@ tof_peak_reduced_chi_squared:
 mass_scale:
   CATDESC: TOF High spectrum with x-axis converted from time to mass.
   FIELDNAM: Mass Scale
-  UNITS: amu
+  UNITS: Kg
   VALIDMIN: 0.0
   VALIDMAX: *int_maxval
   FILLVAL: *double_fillval

--- a/imap_processing/cdf/config/imap_idex_l2a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2a_variable_attrs.yaml
@@ -38,6 +38,17 @@ mass_estimate_base: &mass_estimate_base
   FILLVAL: *double_fillval
   DICT_KEY: SPASE>Particle>ParticleType:Dust>ParticleQuantity:Mass>Qualifier:Derived
 
+velocity_estimate_base: &velocity_estimate_base
+  UNITS: km/s
+  VALIDMIN: 0.0
+  VALIDMAX: *int_maxval
+  VAR_TYPE: data
+  DEPEND_0: epoch
+  DISPLAY_TYPE: time_series
+  FORMAT: F20.4
+  FILLVAL: *double_fillval
+  DICT_KEY: SPASE>Particle>ParticleType:Dust>ParticleQuantity:Velocity>Qualifier:Derived
+
 chi_square_base: &chi_square_base
   UNITS: " "
   VALIDMIN: 0.0
@@ -239,6 +250,12 @@ target_low_dust_mass_estimate:
   CATDESC: Estimated dust mass from Target Low signal based on impact charge.
   FIELDNAM: Estimated Dust Mass (Target Low)
 
+target_low_velocity_estimate:
+  <<: *velocity_estimate_base
+  LABLAXIS: Target Low Velocity Estimate
+  CATDESC: Estimated particle velocity from Target Low signal based on impact charge.
+  FIELDNAM: Estimated Velocity (Target Low)
+
 target_low_chi_squared:
   <<: *chi_square_base
   LABLAXIS: Target Low Chi Square
@@ -275,6 +292,12 @@ target_high_dust_mass_estimate:
   CATDESC: Estimated dust mass from Target High signal based on impact charge.
   FIELDNAM: Estimated Dust Mass (Target High)
 
+target_high_velocity_estimate:
+  <<: *velocity_estimate_base
+  LABLAXIS: Target High Velocity Estimate
+  CATDESC: Estimated particle velocity from Target High signal based on impact charge.
+  FIELDNAM: Estimated Velocity (Target High)
+
 target_high_chi_squared:
   <<: *chi_square_base
   LABLAXIS: Target High Chi Square
@@ -310,6 +333,12 @@ ion_grid_dust_mass_estimate:
   LABLAXIS: Ion Grid Dust Mass Estimate
   CATDESC: Estimated dust mass from Ion Grid signal based on impact charge.
   FIELDNAM: Estimated Dust Mass (Ion Grid)
+
+ion_grid_velocity_estimate:
+  <<: *velocity_estimate_base
+  LABLAXIS: Ion Grid Velocity Estimate
+  CATDESC: Estimated particle velocity from Ion Grid signal based on impact charge.
+  FIELDNAM: Estimated Velocity (Ion Grid)
 
 ion_grid_chi_squared:
   <<: *chi_square_base

--- a/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
@@ -32,12 +32,12 @@ mass:
   CATDESC: Log-spaced mass
   FIELDNAM: Mass (kg)
   UNITS: kg
-  FORMAT: I4
+  FORMAT: E10.4
   VAR_TYPE: support_data
   SCALETYP: log
   LABLAXIS: Mass (kg)
-  VALIDMIN: 0
-  VALIDMAX: 10
+  VALIDMIN: 0.0
+  VALIDMAX: 1.00e-14
   FILLVAL: *double_fillval
   LABL_PTR_1: mass_labels
   DICT_KEY: SPASE>Support>SupportQuantity:Other
@@ -51,8 +51,8 @@ spin_phase:
     SCALETYP: linear
     FILLVAL: *int_fillval
     FORMAT: I4
-    VALIDMIN: 0
-    VALIDMAX: 3
+    VALIDMIN: 0.0
+    VALIDMAX: 360
     LABL_PTR_1: spin_phase_labels
     UNITS: deg
     DICT_KEY: SPASE>SupportQuantity:SpinPhase,Qualifier:Array
@@ -64,9 +64,9 @@ impact_charge:
     VAR_TYPE: support_data
     SCALETYP: log
     FILLVAL: *int_fillval
-    FORMAT: I4
-    VALIDMIN: 0
-    VALIDMAX: 10
+    FORMAT: E10.3
+    VALIDMIN: 0.0
+    VALIDMAX: 1.00e04
     LABL_PTR_1: spin_phase_labels
     UNITS: fC
     DICT_KEY: SPASE>Support>SupportQuantity:Other

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -956,14 +956,18 @@ class Idex(ProcessInstrument):
             dependency = load_cdf(science_files[0])
             datasets = [idex_l1b(dependency)]
         elif self.data_level == "l2a":
-            if len(dependency_list) != 1:
+            if len(dependency_list) != 3:
                 raise ValueError(
                     f"Unexpected dependencies found for IDEX L2A:"
-                    f"{dependency_list}. Expected only one dependency."
+                    f"{dependency_list}. Expected three dependencies."
                 )
             science_files = dependencies.get_file_paths(source="idex")
             dependency = load_cdf(science_files[0])
-            datasets = [idex_l2a(dependency)]
+            anc_paths = dependencies.get_file_paths(data_type="ancillary")
+            ancillary_files = {}
+            for path in anc_paths:
+                ancillary_files[path.stem.split("_")[2]] = path
+            datasets = [idex_l2a(dependency, ancillary_files)]
         elif self.data_level == "l2b":
             if len(dependency_list) < 3 or len(dependency_list) > 4:
                 raise ValueError(

--- a/imap_processing/idex/idex_l2a.py
+++ b/imap_processing/idex/idex_l2a.py
@@ -361,7 +361,7 @@ def log_smooth_powerlaw(log_v: float, log_a: float, params: np.ndarray) -> float
         Velocity.
     log_a : float
         Scale factor.
-    params : np.array
+    params : np.ndarray
         Calibration parameters for the power law.
 
     Returns

--- a/imap_processing/idex/idex_l2a.py
+++ b/imap_processing/idex/idex_l2a.py
@@ -342,7 +342,12 @@ def calculate_velocity_and_mass(
         )
         v_est = 10**root.root
     except Exception:
-        v_est = 0.0
+        logger.error(
+            "Unable to calculate velocity and mass estimate. "
+            "The root finding failed for power law function. "
+            "Returning nans for the estimate."
+        )
+        return np.nan, np.nan
 
     log_a_y: float = np.log10(yield_params[0])
     yield_val = 10 ** log_smooth_powerlaw(np.log10(v_est), log_a_y, yield_params[1:])

--- a/imap_processing/idex/idex_l2a.py
+++ b/imap_processing/idex/idex_l2a.py
@@ -24,7 +24,7 @@ import pandas as pd
 import xarray as xr
 from numpy.typing import NDArray
 from scipy.integrate import quad
-from scipy.optimize import curve_fit
+from scipy.optimize import curve_fit, root_scalar
 from scipy.signal import butter, detrend, filtfilt, find_peaks
 from scipy.stats import exponnorm
 
@@ -52,7 +52,33 @@ class BaselineNoiseTime(IntEnum):
     STOP = -5
 
 
-def idex_l2a(l1b_dataset: xr.Dataset) -> xr.Dataset:
+def load_calibration_files(ancillary_files: dict) -> tuple[NDArray, NDArray]:
+    """
+    Load calibration files for IDEX L2A processing.
+
+    Parameters
+    ----------
+    ancillary_files : dict
+        Dictionary containing paths to calibration files.
+
+    Returns
+    -------
+    numpy.ndarray
+        Calibration parameters for the rise time function.
+    numpy.ndarray
+        Calibration parameters for the charge yield function.
+    """
+    # Load calibration coefficients from ancillary files
+    t_rise_params = pd.read_csv(
+        ancillary_files["l2a-calibration-curve-yield-params"], skiprows=1, header=None
+    ).values.flatten()[:8]
+    yield_params = pd.read_csv(
+        ancillary_files["l2a-calibration-curve-t-rise"], skiprows=1, header=None
+    ).values.flatten()[:8]
+    return t_rise_params, yield_params
+
+
+def idex_l2a(l1b_dataset: xr.Dataset, ancillary_files: dict) -> xr.Dataset:
     """
     Will process IDEX l1b data to create l2a data products.
 
@@ -68,6 +94,9 @@ def idex_l2a(l1b_dataset: xr.Dataset) -> xr.Dataset:
     ----------
     l1b_dataset : xarray.Dataset
         IDEX L1a dataset to process.
+    ancillary_files : dict
+        Ancillary files containing calibration coefficients needed to estimate
+        velocity and mass of the dust particles.
 
     Returns
     -------
@@ -79,6 +108,7 @@ def idex_l2a(l1b_dataset: xr.Dataset) -> xr.Dataset:
     logger.info(
         f"Running IDEX L2A processing on dataset: {l1b_dataset.attrs['Logical_source']}"
     )
+    t_rise_params, yield_params = load_calibration_files(ancillary_files)
 
     tof_high = l1b_dataset["TOF_High"]
     hs_time = l1b_dataset["time_high_sample_rate"]
@@ -176,11 +206,24 @@ def idex_l2a(l1b_dataset: xr.Dataset) -> xr.Dataset:
             output_dtypes=[np.float64] * 6,
             keep_attrs=True,
         )
+        # Calculate mass and velocity estimates
+        velocity_mass_results = xr.apply_ufunc(
+            calculate_velocity_and_mass,
+            fit_results[1],  # signal amplitude
+            fit_results[0].data[:, 3],  # fit params
+            output_core_dims=[[], []],
+            vectorize=True,
+            output_dtypes=[np.float64, np.float64],
+            keep_attrs=True,
+            kwargs={"t_rise_params": t_rise_params, "yield_params": yield_params},
+        )
+
         waveform_name = waveform.lower()
         output_vars = {
             f"{waveform_name}_fit_parameters": fit_results[0],
             f"{waveform_name}_impact_charge": fit_results[1],
-            f"{waveform_name}_dust_mass_estimate": fit_results[1],
+            f"{waveform_name}_velocity_estimate": velocity_mass_results[0],
+            f"{waveform_name}_dust_mass_estimate": velocity_mass_results[1],
             # Same as impact_charge for now
             f"{waveform_name}_chi_squared": fit_results[2],
             f"{waveform_name}_reduced_chi_squared": fit_results[3],
@@ -259,6 +302,84 @@ def idex_l2a(l1b_dataset: xr.Dataset) -> xr.Dataset:
     logger.info("IDEX L2A science data processing completed.")
     l2a_dataset.attrs.update(idex_attrs.get_global_attributes("imap_idex_l2a_sci"))
     return l2a_dataset
+
+
+def calculate_velocity_and_mass(
+    sig_amp: float, t_rise: float, t_rise_params: np.ndarray, yield_params: np.ndarray
+) -> tuple[float, float]:
+    """
+    Calculate velocity and mass estimates.
+
+    The fitted target signals are used to generate IDEX’s specific charge yield as a
+    function of the impact speed. The calibration curve is fitted with a
+    segmented power law distribution. The charge yield curve enables the mass of
+    the dust particle to be estimated from the total charge it generates on the target.
+
+    Parameters
+    ----------
+    sig_amp : float
+        Signal amplitude.
+    t_rise : float
+        T_rise fit parameter from the target fit.
+    t_rise_params : np.ndarray
+        Calibration parameters for rise time.
+    yield_params : np.ndarray
+        Calibration parameters for yield.
+
+    Returns
+    -------
+    v_est : float
+        Estimated velocity.
+    mass_est : float
+        Estimated mass.
+    """
+    log_a_t: float = np.log10(t_rise_params[0])
+    try:
+        root = root_scalar(
+            lambda lv: log_smooth_powerlaw(lv, log_a_t, t_rise_params[1:])
+            - np.log10(t_rise),
+            bracket=[-1, 2],
+        )
+        v_est = 10**root.root
+    except Exception:
+        v_est = 0.0
+
+    log_a_y: float = np.log10(yield_params[0])
+    yield_val = 10 ** log_smooth_powerlaw(np.log10(v_est), log_a_y, yield_params[1:])
+    mass_est = sig_amp / yield_val
+
+    return v_est, mass_est
+
+
+def log_smooth_powerlaw(log_v: float, log_a: float, params: np.ndarray) -> float:
+    """
+    Define a smoothly transitioning power law to fit the calibration curve to.
+
+    Parameters
+    ----------
+    log_v : float
+        Velocity.
+    log_a : float
+        Scale factor.
+    params : np.array
+        Calibration parameters for the power law.
+
+    Returns
+    -------
+    float
+        The value of the power law at the given velocity.
+    """
+    # Unpack the rest of the calibration parameters
+    # a1, a2, and a3 are the power law exponents for the low, medium, and high-velocity
+    # segments.
+    # vb and vc are the characteristic speeds where the slope transition happens, and k
+    # setting the sharpness of the transitions.
+    a1, a2, a3, vb, vc, k, m = params
+    v = 10**log_v
+    base = log_a + a1 * log_v
+    transition1 = (1 + (v / vb) ** m) ** ((a2 - a1) / m)
+    transition2 = (1 + (v / vc) ** m) ** ((a3 - a2) / m)
+    return base + np.log10(transition1 * transition2)
 
 
 def time_to_mass(

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -62,10 +62,12 @@ EXTERNAL_TEST_DATA = [
     # IDEX
     ("idex_l1a_validation_file.h5", "idex/test_data/"),
     ("idex_l1b_validation_file.h5", "idex/test_data/"),
-    ("IMAP-Ultra45_r1_L1_V0_shortened.csv", "ultra/data/l1/"),
+    ("imap_idex_l2a-calibration-curve-yield-params_20250101_v001.csv", "idex/test_data/"),
+    ("imap_idex_l2a-calibration-curve-t-rise_20250101_v001.csv", "idex/test_data/"),
 
     # Ultra
     ("FM90_Startup_20230711T081655.CCSDS", "ultra/data/l0/"),
+    ("IMAP-Ultra45_r1_L1_V0_shortened.csv", "ultra/data/l1/"),
     ("FM45_UltraFM45Extra_TV_Tests_2024-01-22T0930_20240122T093008.CCSDS", "ultra/data/l0/"),
     ("ultra45_raw_sc_rawnrgevnt_19840122_00.csv", "ultra/data/l0/"),
     ("ultra45_raw_sc_enaphxtofhnrgimg_FM45_UltraFM45Extra_TV_Tests_2024-01-22T0930_20240122T093008.csv",

--- a/imap_processing/tests/idex/conftest.py
+++ b/imap_processing/tests/idex/conftest.py
@@ -192,3 +192,15 @@ def load_hdf_file(path: str) -> xr.Dataset:
     example_dataset = xr.concat(datasets, dim="event")
 
     return example_dataset
+
+
+@pytest.fixture
+def ancillary_files():
+    """Fixture to return ancillary files."""
+    path = imap_module_directory / "tests" / "idex" / "test_data"
+    return {
+        "l2a-calibration-curve-yield-params": path
+        / "imap_idex_l2a-calibration-curve-yield-params_20250101_v001.csv",
+        "l2a-calibration-curve-t-rise": path
+        / "imap_idex_l2a-calibration-curve-t-rise_20250101_v001.csv",
+    }

--- a/imap_processing/tests/idex/test_idex_l2a.py
+++ b/imap_processing/tests/idex/test_idex_l2a.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 from scipy.stats import exponnorm
@@ -16,6 +17,7 @@ from imap_processing.idex.idex_l2a import (
     butter_lowpass_filter,
     calculate_kappa,
     calculate_snr,
+    calculate_velocity_and_mass,
     chi_square,
     estimate_dust_mass,
     fit_impact,
@@ -28,7 +30,9 @@ from imap_processing.idex.idex_utils import get_idex_attrs
 
 
 @pytest.fixture
-def l2a_dataset(l1b_dataset: xr.Dataset, decom_test_data_sci) -> xr.Dataset:
+def l2a_dataset(
+    l1b_dataset: xr.Dataset, decom_test_data_sci, ancillary_files, _download_test_data
+) -> xr.Dataset:
     """Return a ``xarray`` dataset containing test data.
     Returns
     -------
@@ -45,7 +49,7 @@ def l2a_dataset(l1b_dataset: xr.Dataset, decom_test_data_sci) -> xr.Dataset:
         "imap_processing.idex.idex_l1b.get_spice_data",
         return_value={"spin_phase": spin_phase_angles},
     ):
-        dataset = idex_l2a(idex_l1b(decom_test_data_sci))
+        dataset = idex_l2a(idex_l1b(decom_test_data_sci), ancillary_files)
     return dataset
 
 
@@ -62,6 +66,7 @@ def mock_microphonics_noise(time: np.ndarray) -> np.ndarray:
     return combined_sig
 
 
+@pytest.mark.external_test_data
 def test_l2a_logical_source_and_cdf(l2a_dataset: xr.Dataset):
     """Tests that the ``idex_l2a`` function generates datasets
     with the expected logical source.
@@ -86,18 +91,21 @@ def test_l2a_logical_source_and_cdf(l2a_dataset: xr.Dataset):
         "target_low_fit_parameters",
         "target_low_impact_charge",
         "target_low_dust_mass_estimate",
+        "target_low_velocity_estimate",
         "target_low_chi_squared",
         "target_low_reduced_chi_squared",
         "target_low_fit_results",
         "target_high_fit_parameters",
         "target_high_impact_charge",
         "target_high_dust_mass_estimate",
+        "target_high_velocity_estimate",
         "target_high_chi_squared",
         "target_high_reduced_chi_squared",
         "target_high_fit_results",
         "ion_grid_fit_parameters",
         "ion_grid_impact_charge",
         "ion_grid_dust_mass_estimate",
+        "ion_grid_velocity_estimate",
         "ion_grid_chi_squared",
         "ion_grid_reduced_chi_squared",
         "ion_grid_fit_results",
@@ -265,6 +273,20 @@ def test_analyze_peaks_warning(caplog):
     np.testing.assert_array_equal(redchi, np.zeros(redchi.shape))
     np.testing.assert_array_equal(fit_params, np.zeros(fit_params.shape))
     np.testing.assert_array_equal(area_under_curve, np.zeros(area_under_curve.shape))
+
+
+def test_velocity_and_mass_estimate(ancillary_files):
+    """Tests that the velocity and mass estimate function."""
+    # Load calibration coefficients from ancillary files
+    t_rise_params = pd.read_csv(
+        ancillary_files["l2a-calibration-curve-yield-params"], skiprows=1, header=None
+    ).values.flatten()[:8]
+    yield_params = pd.read_csv(
+        ancillary_files["l2a-calibration-curve-t-rise"], skiprows=1, header=None
+    ).values.flatten()[:8]
+    estimates = calculate_velocity_and_mass(0, 0, t_rise_params, yield_params)
+    assert len(estimates) == 2
+    assert not np.any(np.isnan(estimates))
 
 
 def test_analyze_peaks_perfect_fits():

--- a/imap_processing/tests/idex/test_idex_l2a.py
+++ b/imap_processing/tests/idex/test_idex_l2a.py
@@ -285,7 +285,7 @@ def test_velocity_and_mass_estimate(ancillary_files):
     yield_params = pd.read_csv(
         ancillary_files["l2a-calibration-curve-t-rise"], skiprows=1, header=None
     ).values.flatten()[:8]
-    estimates = calculate_velocity_and_mass(0, 0, t_rise_params, yield_params)
+    estimates = calculate_velocity_and_mass(10, 2, t_rise_params, yield_params)
     assert len(estimates) == 2
     assert not np.any(np.isnan(estimates))
 

--- a/imap_processing/tests/idex/test_idex_l2a.py
+++ b/imap_processing/tests/idex/test_idex_l2a.py
@@ -275,6 +275,7 @@ def test_analyze_peaks_warning(caplog):
     np.testing.assert_array_equal(area_under_curve, np.zeros(area_under_curve.shape))
 
 
+@pytest.mark.external_test_data
 def test_velocity_and_mass_estimate(ancillary_files):
     """Tests that the velocity and mass estimate function."""
     # Load calibration coefficients from ancillary files


### PR DESCRIPTION
# Change Summary

## Overview
This was added as a change request:

"Calibration curve implementation: IDEX has obtained more calibration data over the last 2 months that we want to incorporate in our mass estimates. This is a 6th-order polynomial (p(x) = a6*x^6 + a5*x^5 + a4*x^4 + a3*x^3 + a2*x^2 + a1*x + a0) that will be used to estimate the mass from the impact charge and velocity."

Ethan has been working on this code for a while and supplied me with the power law functions and estimation code which I have used almost verbatim ( aside from organization and variable naming). 

## Updated Files
- imap_processing/cdf/config/imap_idex_l2a_variable_attrs.yaml
   - Add new attributes for the velocity estimates
- imap_processing/idex/idex_l2a.py
   - Calibration curve implementation

## Testing
Add a minimal test. I didnt test this that much due to time constraints. Please let me know if this needs more testing and I will be happy to add some. 
