### PR TITLE
Remove uses of spiceypy.kclear() and spiceypy.furnsh() from tests

### DIFF
--- a/imap_processing/tests/spice/test_pointing_frame.py
+++ b/imap_processing/tests/spice/test_pointing_frame.py
@@ -22,7 +22,7 @@ from imap_processing.spice.time import TICK_DURATION
 
 
 @pytest.fixture
-def pointing_frame_kernels(furnish_kernels, spice_test_data_path):
+def furnish_pointing_frame_kernels(furnish_kernels, spice_test_data_path):
     """List SPICE kernels."""
     required_kernels = [
         "naif0012.tls",
@@ -36,7 +36,7 @@ def pointing_frame_kernels(furnish_kernels, spice_test_data_path):
 
 
 @pytest.fixture
-def et_times(pointing_frame_kernels):
+def et_times(furnish_pointing_frame_kernels):
     """Tests get_et_times function."""
     ck_kernel, _, _, _ = spiceypy.kdata(0, "ck")
     ck_cover = spiceypy.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
@@ -88,12 +88,12 @@ def test_write_pointing_frame_ck(
     segment_end_offset,
     quaternion,
     segment_id,
-    pointing_frame_kernels,
+    furnish_pointing_frame_kernels,
     tmp_path,
 ):
     """Test coverage for write_pointing_frame_ck"""
     ck_cover = spiceypy.ckcov(
-        pointing_frame_kernels[-1],
+        furnish_pointing_frame_kernels[-1],
         SpiceFrame.IMAP_SPACECRAFT,
         True,
         "INTERVAL",
@@ -146,7 +146,7 @@ def test_write_pointing_frame_ck(
     assert parent_file in lines[5]
 
 
-def test_average_quaternions(et_times, pointing_frame_kernels):
+def test_average_quaternions(et_times, furnish_pointing_frame_kernels):
     """Tests average_quaternions function."""
     q_avg = _average_quaternions(et_times)
 
@@ -155,7 +155,7 @@ def test_average_quaternions(et_times, pointing_frame_kernels):
     np.testing.assert_allclose(q_avg, q_avg_expected, atol=1e-4)
 
 
-def test_create_rotation_matrix(et_times, pointing_frame_kernels):
+def test_create_rotation_matrix(et_times, furnish_pointing_frame_kernels):
     """Tests create_rotation_matrix function."""
     q_avg = _average_quaternions(et_times)
     rotation_matrix = _create_rotation_matrix(q_avg)
@@ -186,7 +186,7 @@ def get_ck_met_coverage(ck_path: str):
 
 def test_calculate_pointing_attitude_segments(
     spice_test_data_path,
-    pointing_frame_kernels,
+    furnish_pointing_frame_kernels,
     tmp_path,
     et_times,
     use_fake_repoint_data_for_time,
@@ -200,7 +200,7 @@ def test_calculate_pointing_attitude_segments(
     #   2. Starts one second before the CK ends, ends 10 seconds after the CK ends
     # Result is the pointing starts 1-second after the CK start and ends 1-second
     # before the CK end
-    ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
+    ck_met_start, ck_met_end = get_ck_met_coverage(furnish_pointing_frame_kernels[-1])
     use_fake_repoint_data_for_time(
         np.array([ck_met_start - 10, ck_met_end - 1]),
         np.array([ck_met_start + 1, ck_met_end + 10]),
@@ -232,7 +232,7 @@ def test_calculate_pointing_attitude_segments(
 
 
 def test_multiple_pointings(
-    pointing_frame_kernels,
+    furnish_pointing_frame_kernels,
     spice_test_data_path,
     use_fake_repoint_data_for_time,
 ):
@@ -243,7 +243,7 @@ def test_multiple_pointings(
     #   2. Starts one hour after CK start, ends 1 second after it starts
     #   3. Starts one second before the CK ends, ends 10 seconds after the CK ends
     # Result is 2 pointings
-    ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
+    ck_met_start, ck_met_end = get_ck_met_coverage(furnish_pointing_frame_kernels[-1])
     repoint_start_met = np.array(
         [ck_met_start - 10, ck_met_start + 60 * 60, ck_met_end - 1]
     )

--- a/imap_processing/tests/spice/test_pointing_frame.py
+++ b/imap_processing/tests/spice/test_pointing_frame.py
@@ -22,7 +22,7 @@ from imap_processing.spice.time import TICK_DURATION
 
 
 @pytest.fixture
-def pointing_frame_kernels(spice_test_data_path):
+def pointing_frame_kernels(furnish_kernels, spice_test_data_path):
     """List SPICE kernels."""
     required_kernels = [
         "naif0012.tls",
@@ -31,29 +31,28 @@ def pointing_frame_kernels(spice_test_data_path):
         "imap_science_100.tf",
         "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
     ]
-    kernels = [str(spice_test_data_path / kernel) for kernel in required_kernels]
-    return kernels
+    with furnish_kernels(required_kernels):
+        yield [str(spice_test_data_path / k) for k in required_kernels]
 
 
 @pytest.fixture
-def et_times(furnish_kernels, pointing_frame_kernels):
+def et_times(pointing_frame_kernels):
     """Tests get_et_times function."""
-    with furnish_kernels(pointing_frame_kernels):
-        ck_kernel, _, _, _ = spiceypy.kdata(0, "ck")
-        ck_cover = spiceypy.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
-        et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
+    ck_kernel, _, _, _ = spiceypy.kdata(0, "ck")
+    ck_cover = spiceypy.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
+    et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
 
-        # 1 spin/15 seconds; 10 quaternions / spin.
-        num_samples = (et_end - et_start) / 15 * 10
-        # There were rounding errors when using spiceypy.pxform so np.ceil and np.floor
-        # were used to ensure the start and end times were within the ck range.
-        et_times = np.linspace(
-            np.ceil(et_start * 1e6) / 1e6,
-            np.floor(et_end * 1e6) / 1e6,
-            int(num_samples),
-        )
+    # 1 spin/15 seconds; 10 quaternions / spin.
+    num_samples = (et_end - et_start) / 15 * 10
+    # There were rounding errors when using spiceypy.pxform so np.ceil and np.floor
+    # were used to ensure the start and end times were within the ck range.
+    et_times = np.linspace(
+        np.ceil(et_start * 1e6) / 1e6,
+        np.floor(et_end * 1e6) / 1e6,
+        int(num_samples),
+    )
 
-        return et_times
+    return et_times
 
 
 @mock.patch(
@@ -89,94 +88,90 @@ def test_write_pointing_frame_ck(
     segment_end_offset,
     quaternion,
     segment_id,
-    furnish_kernels,
     pointing_frame_kernels,
     tmp_path,
 ):
     """Test coverage for write_pointing_frame_ck"""
-    with furnish_kernels(pointing_frame_kernels):
-        ck_cover = spiceypy.ckcov(
-            pointing_frame_kernels[-1],
-            SpiceFrame.IMAP_SPACECRAFT,
-            True,
-            "INTERVAL",
-            0,
-            "TDB",
-        )
-        et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
-        # Single segment file
-        segment_data = np.array(
-            [
-                (
-                    spiceypy.sce2c(IMAP_SC_ID, et_start + segment_start_offset[i_seg]),
-                    spiceypy.sce2c(IMAP_SC_ID, et_start + segment_end_offset[i_seg]),
-                    quaternion[i_seg],
-                    segment_id[i_seg],
-                )
-                for i_seg in range(len(segment_id))
-            ],
-            dtype=POINTING_SEGMENT_DTYPE,
-        )
-        pointing_ck = tmp_path / "pointing_ck.bc"
-        parent_file = "foo_att.ck"
-        write_pointing_frame_ck(pointing_ck, segment_data, parent_file)
+    ck_cover = spiceypy.ckcov(
+        pointing_frame_kernels[-1],
+        SpiceFrame.IMAP_SPACECRAFT,
+        True,
+        "INTERVAL",
+        0,
+        "TDB",
+    )
+    et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
+    # Single segment file
+    segment_data = np.array(
+        [
+            (
+                spiceypy.sce2c(IMAP_SC_ID, et_start + segment_start_offset[i_seg]),
+                spiceypy.sce2c(IMAP_SC_ID, et_start + segment_end_offset[i_seg]),
+                quaternion[i_seg],
+                segment_id[i_seg],
+            )
+            for i_seg in range(len(segment_id))
+        ],
+        dtype=POINTING_SEGMENT_DTYPE,
+    )
+    pointing_ck = tmp_path / "pointing_ck.bc"
+    parent_file = "foo_att.ck"
+    write_pointing_frame_ck(pointing_ck, segment_data, parent_file)
 
-        assert pointing_ck.exists()
-        # Using spiceypy.furnsh here is OK because it is inside of the furnish_kernels
-        # context manager which will clear this kernel upon exit
-        spiceypy.furnsh(str(pointing_ck.resolve()))
-        # Verify the correct # of segments
-        p_cover = spiceypy.ckcov(
-            str(pointing_ck), SpiceFrame.IMAP_DPS, True, "INTERVAL", 0, "TDB"
-        )
-        assert spiceypy.wncard(p_cover) == len(segment_data)
+    assert pointing_ck.exists()
+    # Using spiceypy.furnsh here is OK because it is inside of the furnish_kernels
+    # context manager which will clear this kernel upon exit
+    spiceypy.furnsh(str(pointing_ck.resolve()))
+    # Verify the correct # of segments
+    p_cover = spiceypy.ckcov(
+        str(pointing_ck), SpiceFrame.IMAP_DPS, True, "INTERVAL", 0, "TDB"
+    )
+    assert spiceypy.wncard(p_cover) == len(segment_data)
 
-        for i_seg in range(len(segment_id)):
-            # Verify that the rotation matrix is as expected
-            for et_to_test in np.linspace(
-                et_start + segment_start_offset[i_seg],
-                et_start + segment_end_offset[i_seg],
-                4,
-            ):
-                rotation_matrix = spiceypy.pxform("ECLIPJ2000", "IMAP_DPS", et_to_test)
-                np.testing.assert_allclose(
-                    rotation_matrix, spiceypy.q2m(segment_data[i_seg]["quaternion"])
-                )
-        fh = spiceypy.cklpf(str(pointing_ck))
-        n_lines, lines, all_lines_returned = spiceypy.dafec(fh, 8, 120)
-        assert all_lines_returned
-        assert n_lines == 7
-        assert parent_file in lines[5]
+    for i_seg in range(len(segment_id)):
+        # Verify that the rotation matrix is as expected
+        for et_to_test in np.linspace(
+            et_start + segment_start_offset[i_seg],
+            et_start + segment_end_offset[i_seg],
+            4,
+        ):
+            rotation_matrix = spiceypy.pxform("ECLIPJ2000", "IMAP_DPS", et_to_test)
+            np.testing.assert_allclose(
+                rotation_matrix, spiceypy.q2m(segment_data[i_seg]["quaternion"])
+            )
+    fh = spiceypy.cklpf(str(pointing_ck))
+    n_lines, lines, all_lines_returned = spiceypy.dafec(fh, 8, 120)
+    assert all_lines_returned
+    assert n_lines == 7
+    assert parent_file in lines[5]
 
 
-def test_average_quaternions(et_times, furnish_kernels, pointing_frame_kernels):
+def test_average_quaternions(et_times, pointing_frame_kernels):
     """Tests average_quaternions function."""
-    with furnish_kernels(pointing_frame_kernels):
-        q_avg = _average_quaternions(et_times)
+    q_avg = _average_quaternions(et_times)
 
-        # Generated from MATLAB code results
-        q_avg_expected = np.array([-0.6611, 0.4981, -0.5019, -0.2509])
-        np.testing.assert_allclose(q_avg, q_avg_expected, atol=1e-4)
+    # Generated from MATLAB code results
+    q_avg_expected = np.array([-0.6611, 0.4981, -0.5019, -0.2509])
+    np.testing.assert_allclose(q_avg, q_avg_expected, atol=1e-4)
 
 
-def test_create_rotation_matrix(et_times, furnish_kernels, pointing_frame_kernels):
+def test_create_rotation_matrix(et_times, pointing_frame_kernels):
     """Tests create_rotation_matrix function."""
-    with furnish_kernels(pointing_frame_kernels):
-        q_avg = _average_quaternions(et_times)
-        rotation_matrix = _create_rotation_matrix(q_avg)
-        z_avg = spiceypy.q2m(list(q_avg))[:, 2]
+    q_avg = _average_quaternions(et_times)
+    rotation_matrix = _create_rotation_matrix(q_avg)
+    z_avg = spiceypy.q2m(list(q_avg))[:, 2]
 
-        rotation_matrix_expected = np.array(
-            [
-                [0.0000, 0.0000, 1.0000],
-                [0.9104, -0.4136, 0.0000],
-                [0.4136, 0.9104, 0.0000],
-            ]
-        )
-        z_avg_expected = np.array([0.4136, 0.9104, 0.0000])
+    rotation_matrix_expected = np.array(
+        [
+            [0.0000, 0.0000, 1.0000],
+            [0.9104, -0.4136, 0.0000],
+            [0.4136, 0.9104, 0.0000],
+        ]
+    )
+    z_avg_expected = np.array([0.4136, 0.9104, 0.0000])
 
-        np.testing.assert_allclose(z_avg, z_avg_expected, atol=1e-4)
-        np.testing.assert_allclose(rotation_matrix, rotation_matrix_expected, atol=1e-4)
+    np.testing.assert_allclose(z_avg, z_avg_expected, atol=1e-4)
+    np.testing.assert_allclose(rotation_matrix, rotation_matrix_expected, atol=1e-4)
 
 
 def get_ck_met_coverage(ck_path: str):
@@ -197,79 +192,76 @@ def test_calculate_pointing_attitude_segments(
     use_fake_repoint_data_for_time,
 ):
     """Tests create_pointing_frame function."""
-    with spiceypy.KernelPool(pointing_frame_kernels):
-        # Set up the fake repoint data to coincide with the test CK
+    # Set up the fake repoint data to coincide with the test CK
 
-        # Define 2 repoints:
-        #   1. Starts 10 seconds before the input CK start, ends one second
-        #      after the CK start
-        #   2. Starts one second before the CK ends, ends 10 seconds after the CK ends
-        # Result is the pointing starts 1-second after the CK start and ends 1-second
-        # before the CK end
-        ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
-        use_fake_repoint_data_for_time(
-            np.array([ck_met_start - 10, ck_met_end - 1]),
-            np.array([ck_met_start + 1, ck_met_end + 10]),
-        )
+    # Define 2 repoints:
+    #   1. Starts 10 seconds before the input CK start, ends one second
+    #      after the CK start
+    #   2. Starts one second before the CK ends, ends 10 seconds after the CK ends
+    # Result is the pointing starts 1-second after the CK start and ends 1-second
+    # before the CK end
+    ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
+    use_fake_repoint_data_for_time(
+        np.array([ck_met_start - 10, ck_met_end - 1]),
+        np.array([ck_met_start + 1, ck_met_end + 10]),
+    )
 
-        segment_data = calculate_pointing_attitude_segments(
-            spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
-        )
+    segment_data = calculate_pointing_attitude_segments(
+        spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
+    )
 
-        # Nick Dutton's MATLAB code result
-        rotation_matrix_expected = np.array(
-            [
-                [0.0000, 0.0000, 1.0000],
-                [0.9104, -0.4136, 0.0000],
-                [0.4136, 0.9104, 0.0000],
-            ]
-        )
-        np.testing.assert_almost_equal(
-            spiceypy.q2m(segment_data["quaternion"][0]),
-            rotation_matrix_expected,
-            decimal=4,
-        )
+    # Nick Dutton's MATLAB code result
+    rotation_matrix_expected = np.array(
+        [
+            [0.0000, 0.0000, 1.0000],
+            [0.9104, -0.4136, 0.0000],
+            [0.4136, 0.9104, 0.0000],
+        ]
+    )
+    np.testing.assert_almost_equal(
+        spiceypy.q2m(segment_data["quaternion"][0]),
+        rotation_matrix_expected,
+        decimal=4,
+    )
 
-        # Tests error handling when incorrect kernel is loaded.
-        with pytest.raises(
-            ValueError, match="Error: Expected CK kernel .*badname_kernel.bc"
-        ):  # Replace match string with expected error message
-            calculate_pointing_attitude_segments(tmp_path / "badname_kernel.bc")
+    # Tests error handling when incorrect kernel is loaded.
+    with pytest.raises(
+        ValueError, match="Error: Expected CK kernel .*badname_kernel.bc"
+    ):  # Replace match string with expected error message
+        calculate_pointing_attitude_segments(tmp_path / "badname_kernel.bc")
 
 
 def test_multiple_pointings(
-    furnish_kernels,
     pointing_frame_kernels,
     spice_test_data_path,
     use_fake_repoint_data_for_time,
 ):
     """Tests create_pointing_frame function with multiple pointing kernels."""
-    with furnish_kernels(pointing_frame_kernels):
-        # Define 3 repoints:
-        #   1. Starts 10 second before the input CK start, ends one second
-        #      after the CK start
-        #   2. Starts one hour after CK start, ends 1 second after it starts
-        #   3. Starts one second before the CK ends, ends 10 seconds after the CK ends
-        # Result is 2 pointings
-        ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
-        repoint_start_met = np.array(
-            [ck_met_start - 10, ck_met_start + 60 * 60, ck_met_end - 1]
-        )
-        repoint_end_met = np.array(
-            [ck_met_start + 1, ck_met_start + 60 * 60 + 1, ck_met_end + 10]
-        )
-        use_fake_repoint_data_for_time(repoint_start_met, repoint_end_met)
+    # Define 3 repoints:
+    #   1. Starts 10 second before the input CK start, ends one second
+    #      after the CK start
+    #   2. Starts one hour after CK start, ends 1 second after it starts
+    #   3. Starts one second before the CK ends, ends 10 seconds after the CK ends
+    # Result is 2 pointings
+    ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
+    repoint_start_met = np.array(
+        [ck_met_start - 10, ck_met_start + 60 * 60, ck_met_end - 1]
+    )
+    repoint_end_met = np.array(
+        [ck_met_start + 1, ck_met_start + 60 * 60 + 1, ck_met_end + 10]
+    )
+    use_fake_repoint_data_for_time(repoint_start_met, repoint_end_met)
 
-        segment_data = calculate_pointing_attitude_segments(
-            spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
-        )
+    segment_data = calculate_pointing_attitude_segments(
+        spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
+    )
 
-        # Pointings are between repoints, so we expect one less than repoints
-        assert len(segment_data["start_sclk_ticks"]) == len(repoint_start_met) - 1
+    # Pointings are between repoints, so we expect one less than repoints
+    assert len(segment_data["start_sclk_ticks"]) == len(repoint_start_met) - 1
 
-        np.testing.assert_allclose(
-            segment_data["start_sclk_ticks"], repoint_end_met[:-1] / TICK_DURATION
-        )
-        np.testing.assert_allclose(
-            segment_data["end_sclk_ticks"], repoint_start_met[1:] / TICK_DURATION
-        )
+    np.testing.assert_allclose(
+        segment_data["start_sclk_ticks"], repoint_end_met[:-1] / TICK_DURATION
+    )
+    np.testing.assert_allclose(
+        segment_data["end_sclk_ticks"], repoint_start_met[1:] / TICK_DURATION
+    )

--- a/imap_processing/tests/spice/test_pointing_frame.py
+++ b/imap_processing/tests/spice/test_pointing_frame.py
@@ -36,23 +36,24 @@ def pointing_frame_kernels(spice_test_data_path):
 
 
 @pytest.fixture
-def et_times(pointing_frame_kernels):
+def et_times(furnish_kernels, pointing_frame_kernels):
     """Tests get_et_times function."""
-    spiceypy.furnsh(pointing_frame_kernels)
+    with furnish_kernels(pointing_frame_kernels):
+        ck_kernel, _, _, _ = spiceypy.kdata(0, "ck")
+        ck_cover = spiceypy.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
+        et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
 
-    ck_kernel, _, _, _ = spiceypy.kdata(0, "ck")
-    ck_cover = spiceypy.ckcov(ck_kernel, -43000, True, "INTERVAL", 0, "TDB")
-    et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
+        # 1 spin/15 seconds; 10 quaternions / spin.
+        num_samples = (et_end - et_start) / 15 * 10
+        # There were rounding errors when using spiceypy.pxform so np.ceil and np.floor
+        # were used to ensure the start and end times were within the ck range.
+        et_times = np.linspace(
+            np.ceil(et_start * 1e6) / 1e6,
+            np.floor(et_end * 1e6) / 1e6,
+            int(num_samples),
+        )
 
-    # 1 spin/15 seconds; 10 quaternions / spin.
-    num_samples = (et_end - et_start) / 15 * 10
-    # There were rounding errors when using spiceypy.pxform so np.ceil and np.floor
-    # were used to ensure the start and end times were within the ck range.
-    et_times = np.linspace(
-        np.ceil(et_start * 1e6) / 1e6, np.floor(et_end * 1e6) / 1e6, int(num_samples)
-    )
-
-    return et_times
+        return et_times
 
 
 @mock.patch(
@@ -88,87 +89,94 @@ def test_write_pointing_frame_ck(
     segment_end_offset,
     quaternion,
     segment_id,
+    furnish_kernels,
     pointing_frame_kernels,
     tmp_path,
 ):
     """Test coverage for write_pointing_frame_ck"""
-    spiceypy.furnsh(pointing_frame_kernels)
-    ck_cover = spiceypy.ckcov(
-        pointing_frame_kernels[-1],
-        SpiceFrame.IMAP_SPACECRAFT,
-        True,
-        "INTERVAL",
-        0,
-        "TDB",
-    )
-    et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
-    # Single segment file
-    segment_data = np.array(
-        [
-            (
-                spiceypy.sce2c(IMAP_SC_ID, et_start + segment_start_offset[i_seg]),
-                spiceypy.sce2c(IMAP_SC_ID, et_start + segment_end_offset[i_seg]),
-                quaternion[i_seg],
-                segment_id[i_seg],
-            )
-            for i_seg in range(len(segment_id))
-        ],
-        dtype=POINTING_SEGMENT_DTYPE,
-    )
-    pointing_ck = tmp_path / "pointing_ck.bc"
-    parent_file = "foo_att.ck"
-    write_pointing_frame_ck(pointing_ck, segment_data, parent_file)
+    with furnish_kernels(pointing_frame_kernels):
+        ck_cover = spiceypy.ckcov(
+            pointing_frame_kernels[-1],
+            SpiceFrame.IMAP_SPACECRAFT,
+            True,
+            "INTERVAL",
+            0,
+            "TDB",
+        )
+        et_start, et_end = spiceypy.wnfetd(ck_cover, 0)
+        # Single segment file
+        segment_data = np.array(
+            [
+                (
+                    spiceypy.sce2c(IMAP_SC_ID, et_start + segment_start_offset[i_seg]),
+                    spiceypy.sce2c(IMAP_SC_ID, et_start + segment_end_offset[i_seg]),
+                    quaternion[i_seg],
+                    segment_id[i_seg],
+                )
+                for i_seg in range(len(segment_id))
+            ],
+            dtype=POINTING_SEGMENT_DTYPE,
+        )
+        pointing_ck = tmp_path / "pointing_ck.bc"
+        parent_file = "foo_att.ck"
+        write_pointing_frame_ck(pointing_ck, segment_data, parent_file)
 
-    assert pointing_ck.exists()
-    spiceypy.furnsh(str(pointing_ck.resolve()))
-    # Verify the correct # of segments
-    p_cover = spiceypy.ckcov(
-        str(pointing_ck), SpiceFrame.IMAP_DPS, True, "INTERVAL", 0, "TDB"
-    )
-    assert spiceypy.wncard(p_cover) == len(segment_data)
+        assert pointing_ck.exists()
+        # Using spiceypy.furnsh here is OK because it is inside of the furnish_kernels
+        # context manager which will clear this kernel upon exit
+        spiceypy.furnsh(str(pointing_ck.resolve()))
+        # Verify the correct # of segments
+        p_cover = spiceypy.ckcov(
+            str(pointing_ck), SpiceFrame.IMAP_DPS, True, "INTERVAL", 0, "TDB"
+        )
+        assert spiceypy.wncard(p_cover) == len(segment_data)
 
-    for i_seg in range(len(segment_id)):
-        # Verify that the rotation matrix is as expected
-        for et_to_test in np.linspace(
-            et_start + segment_start_offset[i_seg],
-            et_start + segment_end_offset[i_seg],
-            4,
-        ):
-            rotation_matrix = spiceypy.pxform("ECLIPJ2000", "IMAP_DPS", et_to_test)
-            np.testing.assert_allclose(
-                rotation_matrix, spiceypy.q2m(segment_data[i_seg]["quaternion"])
-            )
-    fh = spiceypy.cklpf(str(pointing_ck))
-    n_lines, lines, all_lines_returned = spiceypy.dafec(fh, 8, 120)
-    assert all_lines_returned
-    assert n_lines == 7
-    assert parent_file in lines[5]
+        for i_seg in range(len(segment_id)):
+            # Verify that the rotation matrix is as expected
+            for et_to_test in np.linspace(
+                et_start + segment_start_offset[i_seg],
+                et_start + segment_end_offset[i_seg],
+                4,
+            ):
+                rotation_matrix = spiceypy.pxform("ECLIPJ2000", "IMAP_DPS", et_to_test)
+                np.testing.assert_allclose(
+                    rotation_matrix, spiceypy.q2m(segment_data[i_seg]["quaternion"])
+                )
+        fh = spiceypy.cklpf(str(pointing_ck))
+        n_lines, lines, all_lines_returned = spiceypy.dafec(fh, 8, 120)
+        assert all_lines_returned
+        assert n_lines == 7
+        assert parent_file in lines[5]
 
 
-def test_average_quaternions(et_times, pointing_frame_kernels):
+def test_average_quaternions(et_times, furnish_kernels, pointing_frame_kernels):
     """Tests average_quaternions function."""
-    spiceypy.furnsh(pointing_frame_kernels)
-    q_avg = _average_quaternions(et_times)
+    with furnish_kernels(pointing_frame_kernels):
+        q_avg = _average_quaternions(et_times)
 
-    # Generated from MATLAB code results
-    q_avg_expected = np.array([-0.6611, 0.4981, -0.5019, -0.2509])
-    np.testing.assert_allclose(q_avg, q_avg_expected, atol=1e-4)
+        # Generated from MATLAB code results
+        q_avg_expected = np.array([-0.6611, 0.4981, -0.5019, -0.2509])
+        np.testing.assert_allclose(q_avg, q_avg_expected, atol=1e-4)
 
 
-def test_create_rotation_matrix(et_times, pointing_frame_kernels):
+def test_create_rotation_matrix(et_times, furnish_kernels, pointing_frame_kernels):
     """Tests create_rotation_matrix function."""
-    spiceypy.furnsh(pointing_frame_kernels)
-    q_avg = _average_quaternions(et_times)
-    rotation_matrix = _create_rotation_matrix(q_avg)
-    z_avg = spiceypy.q2m(list(q_avg))[:, 2]
+    with furnish_kernels(pointing_frame_kernels):
+        q_avg = _average_quaternions(et_times)
+        rotation_matrix = _create_rotation_matrix(q_avg)
+        z_avg = spiceypy.q2m(list(q_avg))[:, 2]
 
-    rotation_matrix_expected = np.array(
-        [[0.0000, 0.0000, 1.0000], [0.9104, -0.4136, 0.0000], [0.4136, 0.9104, 0.0000]]
-    )
-    z_avg_expected = np.array([0.4136, 0.9104, 0.0000])
+        rotation_matrix_expected = np.array(
+            [
+                [0.0000, 0.0000, 1.0000],
+                [0.9104, -0.4136, 0.0000],
+                [0.4136, 0.9104, 0.0000],
+            ]
+        )
+        z_avg_expected = np.array([0.4136, 0.9104, 0.0000])
 
-    np.testing.assert_allclose(z_avg, z_avg_expected, atol=1e-4)
-    np.testing.assert_allclose(rotation_matrix, rotation_matrix_expected, atol=1e-4)
+        np.testing.assert_allclose(z_avg, z_avg_expected, atol=1e-4)
+        np.testing.assert_allclose(rotation_matrix, rotation_matrix_expected, atol=1e-4)
 
 
 def get_ck_met_coverage(ck_path: str):
@@ -189,74 +197,79 @@ def test_calculate_pointing_attitude_segments(
     use_fake_repoint_data_for_time,
 ):
     """Tests create_pointing_frame function."""
-    spiceypy.kclear()
-    spiceypy.furnsh(pointing_frame_kernels)
+    with spiceypy.KernelPool(pointing_frame_kernels):
+        # Set up the fake repoint data to coincide with the test CK
 
-    # Set up the fake repoint data to coincide with the test CK
+        # Define 2 repoints:
+        #   1. Starts 10 seconds before the input CK start, ends one second
+        #      after the CK start
+        #   2. Starts one second before the CK ends, ends 10 seconds after the CK ends
+        # Result is the pointing starts 1-second after the CK start and ends 1-second
+        # before the CK end
+        ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
+        use_fake_repoint_data_for_time(
+            np.array([ck_met_start - 10, ck_met_end - 1]),
+            np.array([ck_met_start + 1, ck_met_end + 10]),
+        )
 
-    # Define 2 repoints:
-    #   1. Starts 10 seconds before the input CK start, ends one second
-    #      after the CK start
-    #   2. Starts one second before the CK ends, ends 10 seconds after the CK ends
-    # Result is the pointing starts 1-second after the CK start and ends 1-second
-    # before the CK end
-    ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
-    use_fake_repoint_data_for_time(
-        np.array([ck_met_start - 10, ck_met_end - 1]),
-        np.array([ck_met_start + 1, ck_met_end + 10]),
-    )
+        segment_data = calculate_pointing_attitude_segments(
+            spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
+        )
 
-    segment_data = calculate_pointing_attitude_segments(
-        spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
-    )
+        # Nick Dutton's MATLAB code result
+        rotation_matrix_expected = np.array(
+            [
+                [0.0000, 0.0000, 1.0000],
+                [0.9104, -0.4136, 0.0000],
+                [0.4136, 0.9104, 0.0000],
+            ]
+        )
+        np.testing.assert_almost_equal(
+            spiceypy.q2m(segment_data["quaternion"][0]),
+            rotation_matrix_expected,
+            decimal=4,
+        )
 
-    # Nick Dutton's MATLAB code result
-    rotation_matrix_expected = np.array(
-        [[0.0000, 0.0000, 1.0000], [0.9104, -0.4136, 0.0000], [0.4136, 0.9104, 0.0000]]
-    )
-    np.testing.assert_almost_equal(
-        spiceypy.q2m(segment_data["quaternion"][0]), rotation_matrix_expected, decimal=4
-    )
-
-    # Tests error handling when incorrect kernel is loaded.
-    spiceypy.furnsh(pointing_frame_kernels)
-    with pytest.raises(
-        ValueError, match="Error: Expected CK kernel .*badname_kernel.bc"
-    ):  # Replace match string with expected error message
-        calculate_pointing_attitude_segments(tmp_path / "badname_kernel.bc")
+        # Tests error handling when incorrect kernel is loaded.
+        with pytest.raises(
+            ValueError, match="Error: Expected CK kernel .*badname_kernel.bc"
+        ):  # Replace match string with expected error message
+            calculate_pointing_attitude_segments(tmp_path / "badname_kernel.bc")
 
 
 def test_multiple_pointings(
-    pointing_frame_kernels, spice_test_data_path, use_fake_repoint_data_for_time
+    furnish_kernels,
+    pointing_frame_kernels,
+    spice_test_data_path,
+    use_fake_repoint_data_for_time,
 ):
     """Tests create_pointing_frame function with multiple pointing kernels."""
-    spiceypy.furnsh(pointing_frame_kernels)
+    with furnish_kernels(pointing_frame_kernels):
+        # Define 3 repoints:
+        #   1. Starts 10 second before the input CK start, ends one second
+        #      after the CK start
+        #   2. Starts one hour after CK start, ends 1 second after it starts
+        #   3. Starts one second before the CK ends, ends 10 seconds after the CK ends
+        # Result is 2 pointings
+        ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
+        repoint_start_met = np.array(
+            [ck_met_start - 10, ck_met_start + 60 * 60, ck_met_end - 1]
+        )
+        repoint_end_met = np.array(
+            [ck_met_start + 1, ck_met_start + 60 * 60 + 1, ck_met_end + 10]
+        )
+        use_fake_repoint_data_for_time(repoint_start_met, repoint_end_met)
 
-    # Define 3 repoints:
-    #   1. Starts 10 second before the input CK start, ends one second
-    #      after the CK start
-    #   2. Starts one hour after CK start, ends 1 second after it starts
-    #   3. Starts one second before the CK ends, ends 10 seconds after the CK ends
-    # Result is 2 pointings
-    ck_met_start, ck_met_end = get_ck_met_coverage(pointing_frame_kernels[-1])
-    repoint_start_met = np.array(
-        [ck_met_start - 10, ck_met_start + 60 * 60, ck_met_end - 1]
-    )
-    repoint_end_met = np.array(
-        [ck_met_start + 1, ck_met_start + 60 * 60 + 1, ck_met_end + 10]
-    )
-    use_fake_repoint_data_for_time(repoint_start_met, repoint_end_met)
+        segment_data = calculate_pointing_attitude_segments(
+            spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
+        )
 
-    segment_data = calculate_pointing_attitude_segments(
-        spice_test_data_path / "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
-    )
+        # Pointings are between repoints, so we expect one less than repoints
+        assert len(segment_data["start_sclk_ticks"]) == len(repoint_start_met) - 1
 
-    # Pointings are between repoints, so we expect one less than repoints
-    assert len(segment_data["start_sclk_ticks"]) == len(repoint_start_met) - 1
-
-    np.testing.assert_allclose(
-        segment_data["start_sclk_ticks"], repoint_end_met[:-1] / TICK_DURATION
-    )
-    np.testing.assert_allclose(
-        segment_data["end_sclk_ticks"], repoint_start_met[1:] / TICK_DURATION
-    )
+        np.testing.assert_allclose(
+            segment_data["start_sclk_ticks"], repoint_end_met[:-1] / TICK_DURATION
+        )
+        np.testing.assert_allclose(
+            segment_data["end_sclk_ticks"], repoint_start_met[1:] / TICK_DURATION
+        )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
@@ -11,7 +11,7 @@ from imap_processing.ultra.l1b.ultra_l1b_annotated import (
 
 
 @pytest.fixture
-def kernels(spice_test_data_path):
+def furnish_kernels(spice_test_data_path, furnish_kernels):
     """List SPICE kernels."""
     required_kernels = [
         "imap_science_100.tf",
@@ -23,60 +23,58 @@ def kernels(spice_test_data_path):
         "de440s.bsp",
         "imap_spk_demo.bsp",
     ]
-    kernels = [str(spice_test_data_path / kernel) for kernel in required_kernels]
-
-    return kernels
+    with furnish_kernels(required_kernels):
+        yield [str(spice_test_data_path / kernel) for kernel in required_kernels]
 
 
 @pytest.mark.external_kernel
-def test_get_particle_velocity(spice_test_data_path, furnish_kernels, kernels):
+def test_get_particle_velocity(spice_test_data_path, furnish_kernels):
     """Tests get_particle_velocity function."""
-    with furnish_kernels(kernels):
-        pointing_cover = spiceypy.ckcov(
-            str(spice_test_data_path / "sim_1yr_imap_pointing_frame.bc"),
-            SpiceFrame.IMAP_DPS.value,
-            True,
-            "SEGMENT",
-            0,
-            "TDB",
-        )
-        # Get start and end time of first interval
-        start, _ = spiceypy.wnfetd(pointing_cover, 0)
+    pointing_cover = spiceypy.ckcov(
+        str(spice_test_data_path / "sim_1yr_imap_pointing_frame.bc"),
+        SpiceFrame.IMAP_DPS.value,
+        True,
+        "SEGMENT",
+        0,
+        "TDB",
+    )
+    # Get start and end time of first interval
+    start, _ = spiceypy.wnfetd(pointing_cover, 0)
 
-        times = np.array([start])
-        instrument_velocity = np.array([[41.18609, -471.24467, -832.8784]])
+    times = np.array([start])
+    instrument_velocity = np.array([[41.18609, -471.24467, -832.8784]])
 
-        sc_velocity_45, sc_dps_velocity_45, helio_velocity_45 = (
-            get_annotated_particle_velocity(
-                times,
-                instrument_velocity,
-                SpiceFrame.IMAP_ULTRA_45,
-                SpiceFrame.IMAP_DPS,
-                SpiceFrame.IMAP_SPACECRAFT,
-            )
+    sc_velocity_45, sc_dps_velocity_45, helio_velocity_45 = (
+        get_annotated_particle_velocity(
+            times,
+            instrument_velocity,
+            SpiceFrame.IMAP_ULTRA_45,
+            SpiceFrame.IMAP_DPS,
+            SpiceFrame.IMAP_SPACECRAFT,
         )
-        sc_velocity_90, sc_dps_velocity_90, helio_velocity_90 = (
-            get_annotated_particle_velocity(
-                times,
-                instrument_velocity,
-                SpiceFrame.IMAP_ULTRA_90,
-                SpiceFrame.IMAP_DPS,
-                SpiceFrame.IMAP_SPACECRAFT,
-            )
+    )
+    sc_velocity_90, sc_dps_velocity_90, helio_velocity_90 = (
+        get_annotated_particle_velocity(
+            times,
+            instrument_velocity,
+            SpiceFrame.IMAP_ULTRA_90,
+            SpiceFrame.IMAP_DPS,
+            SpiceFrame.IMAP_SPACECRAFT,
         )
+    )
 
-        # Compute the magnitude of the velocity vectors in both frames
-        magnitude_sc_45 = np.linalg.norm(sc_velocity_45)
-        magnitude_sc_90 = np.linalg.norm(sc_velocity_90)
-        magnitude_dps_45 = np.linalg.norm(sc_dps_velocity_45)
-        magnitude_dps_90 = np.linalg.norm(sc_dps_velocity_90)
-        state, lt = spiceypy.spkezr("IMAP", times, "IMAP_DPS", "NONE", "SUN")
+    # Compute the magnitude of the velocity vectors in both frames
+    magnitude_sc_45 = np.linalg.norm(sc_velocity_45)
+    magnitude_sc_90 = np.linalg.norm(sc_velocity_90)
+    magnitude_dps_45 = np.linalg.norm(sc_dps_velocity_45)
+    magnitude_dps_90 = np.linalg.norm(sc_dps_velocity_90)
+    state, lt = spiceypy.spkezr("IMAP", times, "IMAP_DPS", "NONE", "SUN")
 
-        assert np.allclose(magnitude_sc_45, magnitude_sc_90, atol=1e-6)
-        assert np.allclose(magnitude_dps_45, magnitude_dps_90, atol=1e-6)
-        assert np.array_equal(
-            (helio_velocity_45 - state[0][3:6]).flatten(), sc_dps_velocity_45
-        )
-        assert np.array_equal(
-            (helio_velocity_90 - state[0][3:6]).flatten(), sc_dps_velocity_90
-        )
+    assert np.allclose(magnitude_sc_45, magnitude_sc_90, atol=1e-6)
+    assert np.allclose(magnitude_dps_45, magnitude_dps_90, atol=1e-6)
+    assert np.array_equal(
+        (helio_velocity_45 - state[0][3:6]).flatten(), sc_dps_velocity_45
+    )
+    assert np.array_equal(
+        (helio_velocity_90 - state[0][3:6]).flatten(), sc_dps_velocity_90
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
@@ -29,55 +29,54 @@ def kernels(spice_test_data_path):
 
 
 @pytest.mark.external_kernel
-def test_get_particle_velocity(spice_test_data_path, kernels):
+def test_get_particle_velocity(spice_test_data_path, furnish_kernels, kernels):
     """Tests get_particle_velocity function."""
-    spiceypy.furnsh(kernels)
-
-    pointing_cover = spiceypy.ckcov(
-        str(spice_test_data_path / "sim_1yr_imap_pointing_frame.bc"),
-        SpiceFrame.IMAP_DPS.value,
-        True,
-        "SEGMENT",
-        0,
-        "TDB",
-    )
-    # Get start and end time of first interval
-    start, _ = spiceypy.wnfetd(pointing_cover, 0)
-
-    times = np.array([start])
-    instrument_velocity = np.array([[41.18609, -471.24467, -832.8784]])
-
-    sc_velocity_45, sc_dps_velocity_45, helio_velocity_45 = (
-        get_annotated_particle_velocity(
-            times,
-            instrument_velocity,
-            SpiceFrame.IMAP_ULTRA_45,
-            SpiceFrame.IMAP_DPS,
-            SpiceFrame.IMAP_SPACECRAFT,
+    with furnish_kernels(kernels):
+        pointing_cover = spiceypy.ckcov(
+            str(spice_test_data_path / "sim_1yr_imap_pointing_frame.bc"),
+            SpiceFrame.IMAP_DPS.value,
+            True,
+            "SEGMENT",
+            0,
+            "TDB",
         )
-    )
-    sc_velocity_90, sc_dps_velocity_90, helio_velocity_90 = (
-        get_annotated_particle_velocity(
-            times,
-            instrument_velocity,
-            SpiceFrame.IMAP_ULTRA_90,
-            SpiceFrame.IMAP_DPS,
-            SpiceFrame.IMAP_SPACECRAFT,
+        # Get start and end time of first interval
+        start, _ = spiceypy.wnfetd(pointing_cover, 0)
+
+        times = np.array([start])
+        instrument_velocity = np.array([[41.18609, -471.24467, -832.8784]])
+
+        sc_velocity_45, sc_dps_velocity_45, helio_velocity_45 = (
+            get_annotated_particle_velocity(
+                times,
+                instrument_velocity,
+                SpiceFrame.IMAP_ULTRA_45,
+                SpiceFrame.IMAP_DPS,
+                SpiceFrame.IMAP_SPACECRAFT,
+            )
         )
-    )
+        sc_velocity_90, sc_dps_velocity_90, helio_velocity_90 = (
+            get_annotated_particle_velocity(
+                times,
+                instrument_velocity,
+                SpiceFrame.IMAP_ULTRA_90,
+                SpiceFrame.IMAP_DPS,
+                SpiceFrame.IMAP_SPACECRAFT,
+            )
+        )
 
-    # Compute the magnitude of the velocity vectors in both frames
-    magnitude_sc_45 = np.linalg.norm(sc_velocity_45)
-    magnitude_sc_90 = np.linalg.norm(sc_velocity_90)
-    magnitude_dps_45 = np.linalg.norm(sc_dps_velocity_45)
-    magnitude_dps_90 = np.linalg.norm(sc_dps_velocity_90)
-    state, lt = spiceypy.spkezr("IMAP", times, "IMAP_DPS", "NONE", "SUN")
+        # Compute the magnitude of the velocity vectors in both frames
+        magnitude_sc_45 = np.linalg.norm(sc_velocity_45)
+        magnitude_sc_90 = np.linalg.norm(sc_velocity_90)
+        magnitude_dps_45 = np.linalg.norm(sc_dps_velocity_45)
+        magnitude_dps_90 = np.linalg.norm(sc_dps_velocity_90)
+        state, lt = spiceypy.spkezr("IMAP", times, "IMAP_DPS", "NONE", "SUN")
 
-    assert np.allclose(magnitude_sc_45, magnitude_sc_90, atol=1e-6)
-    assert np.allclose(magnitude_dps_45, magnitude_dps_90, atol=1e-6)
-    assert np.array_equal(
-        (helio_velocity_45 - state[0][3:6]).flatten(), sc_dps_velocity_45
-    )
-    assert np.array_equal(
-        (helio_velocity_90 - state[0][3:6]).flatten(), sc_dps_velocity_90
-    )
+        assert np.allclose(magnitude_sc_45, magnitude_sc_90, atol=1e-6)
+        assert np.allclose(magnitude_dps_45, magnitude_dps_90, atol=1e-6)
+        assert np.array_equal(
+            (helio_velocity_45 - state[0][3:6]).flatten(), sc_dps_velocity_45
+        )
+        assert np.array_equal(
+            (helio_velocity_90 - state[0][3:6]).flatten(), sc_dps_velocity_90
+        )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_culling.py
@@ -33,8 +33,6 @@ def test_compute_culling_mask(furnish_kernels, spice_test_data_path):
     step_seconds = 1800  # 30 minutes
     et_steps = np.arange(et_start, et_end, step_seconds)
 
-    spiceypy.kclear()
-
     with furnish_kernels(kernels):
         mask, _ = compute_culling_mask(et_steps, keepout_radius_km)
 


### PR DESCRIPTION
# Change Summary

## Overview
I believe that the unpredictable test failures that were/are occurring on the Ubuntu 3.10 job are caused by the direct use of `spiceypy.kclear()` in tests. I removed those and also cleaned up a bunch of direct usages of `spiceypy.furnsh()`. In order to prevent tests from having SPICE related side effects, we should only be using the `furnish_kenrels` fixture. If a test requires no kernels be furnished, one can pass `furnish_kernels` an empty list.

## Updated Files
- imap_processing/tests/spice/test_pointing_frame.py
   - The biggest offender... remove `spiceypy.kclear`
   - Use `furnish_kernels` rather than `spiceypy.furnsh`
- imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
   - Use `furnish_kernels` rather than `spiceypy.furnsh`
- imap_processing/tests/ultra/unit/test_ultra_l1c_culling.py
   - remove `spiceypy.kclear`

Closes: #2095 
