### PR TITLE
Codice - add L2 attributes to yaml

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -1,3 +1,5 @@
+# TODO: Add DEPEND_1 to energy delta variables (energy_h_minus, energy_h_plus, etc.)
+
 # <=== Useful Variables ===>
 int_fillval: &int_fillval -9223372036854775808
 uint8_fillval: &uint8_fillval 255

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -414,8 +414,8 @@ lo-nsw-species-spin_sector_index_label:
   VAR_TYPE: metadata
 
 lo-sw-species-spin_sector_index_label:
-  CATDESC: Spin Sector Index for Lo-SW Species
-  FIELDNAM: Spin Sector Index for Lo-SW Species
+  CATDESC: Spin Sector Index for Lo SW-Species
+  FIELDNAM: Spin Sector Index for Lo SW-Species
   FORMAT: A1
   VAR_TYPE: metadata
 

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -53,6 +53,7 @@ default_lo_species_attrs: &default_lo_species
 
 default_lo_angular_attrs: &default_lo_angular
   <<: *default
+  VAR_TYPE: data
   DEPEND_1: energy_table
   DEPEND_2: elevation_angle
   DEPEND_3: spin_angle
@@ -63,7 +64,20 @@ default_lo_angular_attrs: &default_lo_angular
   UNITS: particles / cm2 s sr keV/q
   VALIDMAX: 10000000000.0
   VALIDMIN: 1.000000013351432e-10
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+default_lo_ialirt_attrs: &default_lo_ialirt
+  <<: *default
   VAR_TYPE: data
+  DISPLAY_TYPE: time_series
+  FILLVAL: 1.0e+31
+  FORMAT: '%lf'
+  LABLAXIS: ratio
+  SCALETYP: linear
+  UNITS: ratio
+  VALIDMAX: 1.0e+31
+  VALIDMIN: 0.0
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 # <=== Coordinates ===>
 event_num:
@@ -1233,3 +1247,34 @@ lo-nsw-species-o:
 lo-nsw-angular-heplusplus:
   CATDESC: Counts - NSW - He++
   FIELDNAM: Non-Sunward Facing Counts - NSW - He++
+
+# lo-ialirt Attributes
+c_over_o_abundance_ratio:
+  <<: *default_lo_ialirt
+  CATDESC: Elemental Abundance Ratio - C/O
+  FIELDNAM: C/O
+
+c_plus_6_over_c_plus_5_ratio:
+  <<: *default_lo_ialirt
+  CATDESC: Charge State Ratio - C+6/C+5
+  FIELDNAM: C+6/C+5
+
+fe_low_over_fe_high_ratio:
+  <<: *default_lo_ialirt
+  CATDESC: Charge State Ratio - Fe(low)/Fe(high)
+  FIELDNAM: Fe(low)/Fe(high)
+
+fe_over_o_abundance_ratio:
+  <<: *default_lo_ialirt
+  CATDESC: Elemental Abundance Ratio - Fe/O
+  FIELDNAM: Fe/O
+
+mg_over_o_abundance_ratio:
+  <<: *default_lo_ialirt
+  CATDESC: Elemental Abundance Ratio - Mg/O
+  FIELDNAM: Mg/O
+
+o_plus_7_over_o_plus_6_ratio:
+  <<: *default_lo_ialirt
+  CATDESC: Charge State Ratio - O+7/O+6
+  FIELDNAM: O+7/O+6

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -15,7 +15,7 @@ max_uint24: &max_uint24 8388607
 max_uint32: &max_uint32 4294967295
 max_epoch: &max_epoch 3155630469184000000
 
-# TODO: Complete SPASE. Used HIT as reference for intensity attributes
+# TODO: Complete SPASE. 'Other' used temporarily.
 # TODO: Update FORMAT to use fortran format
 # TODO: Review units with CoDICE
 # TODO: Review LABLAXIS with CoDICE. (Diff. Intensity vs Diff. # Flux)

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -16,6 +16,21 @@ default_attrs: &default
     VALIDMAX: *max_int
     VAR_TYPE: data
 
+default_lo_sw_species_attrs: &default_lo_sw_species
+  <<: *default
+  VAR_TYPE: data
+  DEPEND_1: energy_table
+  DEPEND_2: spin_sector_index
+  DISPLAY_TYPE: time_series
+  FILLVAL: .nan
+  FORMAT: '%f'
+  LABLAXIS: Diff. Intensity
+  SCALETYP: log
+  UNITS: particles / cm2 s sr keV/q
+  VALIDMAX: 10000000000.0
+  VALIDMIN: 1.000000013351432e-10
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
 # <=== Coordinates ===>
 event_num:
     CATDESC: Event Number
@@ -1026,3 +1041,101 @@ P7_TOF:
     FILLVAL: 65535
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
+
+
+# <=== lo-sw-species Attributes ===>
+
+cnoplus:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - CNO+ (PUI)
+  FIELDNAM: Counts - SW - CNO+ (PUI)
+
+cplus4:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - C+4
+  FIELDNAM: Counts - SW - C+4
+
+cplus5:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - C+5
+  FIELDNAM: Counts - SW - C+5
+
+cplus6:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - C+6
+  FIELDNAM: Counts - SW - C+6
+
+data_quality:
+  DEPEND_0: epoch
+  DISPLAY_TYPE: time_series
+  FILLVAL: 255
+  FORMAT: '%d'
+  LABLAXIS: Data Quality
+  SCALETYP: linear
+  UNITS: ' '
+  VALIDMAX: 1
+  VALIDMIN: 0
+  VAR_TYPE: data
+  CATDESC: Indicates whether data quality is suspect (1).
+  FIELDNAM: Data Quality
+
+fe_hiq:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - Fe highQ
+  FIELDNAM: Counts - SW - Fe highQ
+
+fe_loq:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - Fe lowQ
+  FIELDNAM: Counts - SW - Fe lowQ
+
+heplus:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - He+ (PUI)
+  FIELDNAM: Counts - SW - He+ (PUI)
+
+heplusplus:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - He++
+  FIELDNAM: Counts - SW - He++
+
+hplus:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - H+
+  FIELDNAM: Counts - SW - H+
+
+mg:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - Mg
+  FIELDNAM: Counts - SW - Mg
+
+ne:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - Ne
+  FIELDNAM: Counts - SW - Ne
+
+oplus5:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - O+5
+  FIELDNAM: Counts - SW - O+5
+
+oplus6:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - O+6
+  FIELDNAM: Counts - SW - O+6
+
+oplus7:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - O+7
+  FIELDNAM: Counts - SW - O+7
+
+oplus8:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - O+8
+  FIELDNAM: Counts - SW - O+8
+
+si:
+  <<: *default_lo_sw_species
+  CATDESC: Counts - SW - Si
+  FIELDNAM: Counts - SW - Si
+

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -19,7 +19,7 @@ max_epoch: &max_epoch 3155630469184000000
 # TODO: Update FORMAT to use fortran format
 # TODO: Review units with CoDICE
 # TODO: Review LABLAXIS with CoDICE. (Diff. Intensity vs Diff. # Flux)
-# TODO: Review FILLVAL with CoDICE. (lo-ialirt has 1.0e+31, but should it be negative?)
+# TODO: Review FILLVAL with CoDICE.
 # TODO: Review VALIDMIN with CoDICE (VALIDMIN: 0.05000000074505806 ??)
 # TODO: Update direct events attributes - products have new structure
 
@@ -52,7 +52,7 @@ direct_events_attrs: &direct_events_default
 lo_ialirt_attrs: &lo_ialirt_default
   <<: *default
   DISPLAY_TYPE: time_series
-  FILLVAL: 1.0e+31
+  FILLVAL: *real_fillval
   FORMAT: '%lf'
   LABLAXIS: ratio
   UNITS: ratio
@@ -184,6 +184,7 @@ epoch_delta_minus:
   VALIDMIN: *min_int
   VALIDMAX: *max_int
   VAR_TYPE: support_data
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
 
 epoch_delta_plus:
   CATDESC: Time from acquisition center to acquisition end
@@ -196,6 +197,7 @@ epoch_delta_plus:
   VALIDMIN: *min_int
   VALIDMAX: *max_int
   VAR_TYPE: support_data
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
 
 elevation_angle:
   CATDESC: Elevation Angle
@@ -216,7 +218,7 @@ energy_table:
   CATDESC: Energy Table
   FIELDNAM: Energy Table
   FORMAT: '%f'
-  LABLAXIS: keV/e
+  LABLAXIS: Energy per charge
   SCALETYP: log
   UNITS: keV/e
   VALIDMAX: 82.0

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -17,11 +17,8 @@ max_epoch: &max_epoch 3155630469184000000
 
 # TODO: Complete SPASE. 'Other' used temporarily.
 # TODO: Update FORMAT to use fortran format
-# TODO: Review units with CoDICE
-# TODO: Review LABLAXIS with CoDICE. (Diff. Intensity vs Diff. # Flux)
-# TODO: Review FILLVAL with CoDICE.
 # TODO: Review VALIDMIN with CoDICE (VALIDMIN: 0.05000000074505806 ??)
-# TODO: Update direct events attributes - products have new structure
+# TODO: Update direct events attributes - products have new var names
 
 
 # <=== Defaults ===>
@@ -33,19 +30,16 @@ default_attrs: &default
   FILLVAL: *int_fillval
   FORMAT: I12
   SCALETYP: linear
-  UNITS: dN
+  UNITS: ' '
   VALIDMIN: *min_int
   VALIDMAX: *max_int
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 direct_events_attrs: &direct_events_default
   <<: *default
-  CATDESC: Fill in at creation
   DISPLAY_TYPE: time_series
-  FIELDNAM: Fill in at creation
   FILLVAL: *uint8_fillval
   FORMAT: I5
-  UNITS: unitless
   VALIDMIN: 0
   VALIDMAX: 10000
 
@@ -55,7 +49,7 @@ lo_ialirt_attrs: &lo_ialirt_default
   FILLVAL: *real_fillval
   FORMAT: '%lf'
   LABLAXIS: ratio
-  UNITS: ratio
+  UNITS: ' '
   VALIDMAX: 1.0e+31
   VALIDMIN: 0.0
 
@@ -65,7 +59,7 @@ lo_species_attrs: &lo_species_default
   DEPEND_2: spin_sector_index
   LABL_PTR_1: energy_table_label
   LABL_PTR_2: spin_sector_index_label
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FORMAT: '%f'
   SCALETYP: log
   UNITS: particles / cm2 s sr keV/q
@@ -82,7 +76,7 @@ lo_angular_attrs: &lo_angular_default
   LABL_PTR_1: energy_table_label
   LABL_PTR_2: elevation_angle_label
   LABL_PTR_3: spin_angle_label
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FORMAT: '%f'
   SCALETYP: log
   UNITS: particles / cm2 s sr keV/q
@@ -93,7 +87,7 @@ lo_angular_attrs: &lo_angular_default
 
 hi_omni_attrs: &hi_omni_default
   <<: *default
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FORMAT: '%f'
   LABLAXIS: Diff. Intensity
   SCALETYP: linear
@@ -105,7 +99,7 @@ hi_omni_attrs: &hi_omni_default
 
 hi_sectored_attrs: &hi_sectored_attrs_default
   <<: *default
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   DEPEND_2: elevation_angle
   DEPEND_3: spin_sector_index
   LABL_PTR_2: elevation_angle_label
@@ -148,12 +142,14 @@ spin_angles_attrs: &spin_angles_default
 
 spin_sector_index_attrs: &spin_sector_index_default
   VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
   CATDESC: Spin Sector Index
   FIELDNAM: Spin Sector Index
   FORMAT: '%d'
   LABLAXIS: Spin Sector Index
   SCALETYP: linear
   UNITS: ' '
+  FILLVAL: *uint8_fillval
   VALIDMAX: 1
   VALIDMIN: 0
   DICT_KEY: SPASE>Support>SupportQuantity:Other
@@ -429,6 +425,7 @@ lo-sw-species-spin_sector_index_label:
 # The following are set in multiple data products
 data_quality:
   <<: *default
+  VAR_TYPE: data
   CATDESC: Indicates whether data quality is suspect (1).
   DISPLAY_TYPE: time_series
   FIELDNAM: Data Quality
@@ -439,7 +436,7 @@ data_quality:
   UNITS: ' '
   VALIDMAX: 1
   VALIDMIN: 0
-  VAR_TYPE: data
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 # The following are data product-specific
 # Direct Events Attributes
@@ -1600,7 +1597,7 @@ hi-ialirt-h:
   LABL_PTR_1: energy_h_label
   LABL_PTR_2: ssd_index_label
   LABL_PTR_3: spin_sector_index_label
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FILLVAL: 4294967294
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 16777216

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -408,8 +408,8 @@ hi-ialirt-spin_sector_index_label:
   VAR_TYPE: metadata
 
 lo-nsw-species-spin_sector_index_label:
-  CATDESC: Spin Sector Index for Lo-NSW Species
-  FIELDNAM: Spin Sector Index for Lo-NSW Species
+  CATDESC: Spin Sector Index for Lo NSW-Species
+  FIELDNAM: Spin Sector Index for Lo NSW-Species
   FORMAT: A1
   VAR_TYPE: metadata
 

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -79,6 +79,15 @@ default_lo_ialirt_attrs: &default_lo_ialirt
   VALIDMIN: 0.0
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
+default_hi_ialirt_attrs: &default_hi_ialirt
+  VAR_TYPE: support_data
+  FORMAT: '%f'
+  SCALETYP: log
+  UNITS: MeV/nuc
+  VALIDMAX: 200.0
+  VALIDMIN: 0.05000000074505806
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
 # <=== Coordinates ===>
 event_num:
     CATDESC: Event Number
@@ -1278,3 +1287,45 @@ o_plus_7_over_o_plus_6_ratio:
   <<: *default_lo_ialirt
   CATDESC: Charge State Ratio - O+7/O+6
   FIELDNAM: O+7/O+6
+
+# hi-ialirt Attributes
+energy_h_minus:
+  <<: *default_hi_ialirt
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+  LABLAXIS: MeV/nuc
+
+energy_h_plus:
+  <<: *default_hi_ialirt
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+  LABLAXIS: MeV/nuc
+
+h:
+  <<: *default_hi_ialirt
+  CATDESC: h (x2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_h
+  DEPEND_2: ssd_index
+  DEPEND_3: spin_sector_index
+  DISPLAY_TYPE: time_series
+  FIELDNAM: h
+  FILLVAL: 4294967294
+  LABLAXIS: Diff. Intensity
+  SCALETYP: linear
+  UNITS: '# / cm2 s sr MeV/nuc'
+  VALIDMAX: 16777216
+  VALIDMIN: 0
+  VAR_TYPE: data
+
+spin_angles:
+  <<: *default_hi_ialirt
+  CATDESC: Spin Angle
+  DEPEND_1: spin_sector_index
+  DEPEND_2: elevation_angle
+  FIELDNAM: Spin Angle
+  LABLAXIS: Spin Angle
+  SCALETYP: linear
+  UNITS: degrees
+  VALIDMAX: 360.0
+  VALIDMIN: 0.0

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -1398,149 +1398,149 @@ P7_TOF:
 # lo-sw-species Attributes
 lo-sw-species-cnoplus:
   <<: *lo_species_default
-  CATDESC: Counts - SW - CNO+ (PUI)
+  CATDESC: Counts - Sunward - CNO+ Pick Up Ions (PUI)
   FIELDNAM: Counts - SW - CNO+ (PUI)
 
 lo-sw-species-cplus4:
   <<: *lo_species_default
-  CATDESC: Counts - SW - C+4
+  CATDESC: Counts - Sunward - C+4
   FIELDNAM: Counts - SW - C+4
 
 lo-sw-species-cplus5:
   <<: *lo_species_default
-  CATDESC: Counts - SW - C+5
+  CATDESC: Counts - Sunward - C+5
   FIELDNAM: Counts - SW - C+5
 
 lo-sw-species-cplus6:
   <<: *lo_species_default
-  CATDESC: Counts - SW - C+6
+  CATDESC: Counts - Sunward - C+6
   FIELDNAM: Counts - SW - C+6
 
 lo-sw-species-fe_hiq:
   <<: *lo_species_default
-  CATDESC: Counts - SW - Fe highQ
+  CATDESC: Counts - Sunward - Fe highQ
   FIELDNAM: Counts - SW - Fe highQ
 
 lo-sw-species-fe_loq:
   <<: *lo_species_default
-  CATDESC: Counts - SW - Fe lowQ
+  CATDESC: Counts - Sunward - Fe lowQ
   FIELDNAM: Counts - SW - Fe lowQ
 
 lo-sw-species-heplus:
   <<: *lo_species_default
-  CATDESC: Counts - SW - He+ (PUI)
+  CATDESC: Counts - Sunward - He+ (PUI)
   FIELDNAM: Counts - SW - He+ (PUI)
 
 lo-sw-species-heplusplus:
   <<: *lo_species_default
-  CATDESC: Counts - SW - He++
+  CATDESC: Counts - Sunward - He++
   FIELDNAM: Counts - SW - He++
 
 lo-sw-species-hplus:
   <<: *lo_species_default
-  CATDESC: Counts - SW - H+
+  CATDESC: Counts - Sunward - H+
   FIELDNAM: Counts - SW - H+
 
 lo-sw-species-mg:
   <<: *lo_species_default
-  CATDESC: Counts - SW - Mg
+  CATDESC: Counts - Sunward - Mg
   FIELDNAM: Counts - SW - Mg
 
 lo-sw-species-ne:
   <<: *lo_species_default
-  CATDESC: Counts - SW - Ne
+  CATDESC: Counts - Sunward - Ne
   FIELDNAM: Counts - SW - Ne
 
 lo-sw-species-oplus5:
   <<: *lo_species_default
-  CATDESC: Counts - SW - O+5
+  CATDESC: Counts - Sunward - O+5
   FIELDNAM: Counts - SW - O+5
 
 lo-sw-species-oplus6:
   <<: *lo_species_default
-  CATDESC: Counts - SW - O+6
+  CATDESC: Counts - Sunward - O+6
   FIELDNAM: Counts - SW - O+6
 
 lo-sw-species-oplus7:
   <<: *lo_species_default
-  CATDESC: Counts - SW - O+7
+  CATDESC: Counts - Sunward - O+7
   FIELDNAM: Counts - SW - O+7
 
 lo-sw-species-oplus8:
   <<: *lo_species_default
-  CATDESC: Counts - SW - O+8
+  CATDESC: Counts - Sunward - O+8
   FIELDNAM: Counts - SW - O+8
 
 lo-sw-species-si:
   <<: *lo_species_default
-  CATDESC: Counts - SW - Si
+  CATDESC: Counts - Sunward - Si
   FIELDNAM: Counts - SW - Si
 
 # lo-sw-angular Attributes
 lo-sw-angular-fe_loq:
   <<: *lo_angular_default
-  CATDESC: Counts - SW - Fe lowQ
+  CATDESC: Counts - Sunward - Fe lowQ
   FIELDNAM: Sunward Facing Counts - SW - Fe lowQ
 
 lo-sw-angular-heplusplus:
   <<: *lo_angular_default
-  CATDESC: Counts - SW - He++
+  CATDESC: Counts - Sunward - He++
   FIELDNAM: Sunward Facing Counts - SW - He++
 
 lo-sw-angular-hplus:
   <<: *lo_angular_default
-  CATDESC: Counts - SW - H+
+  CATDESC: Counts - Sunward - H+
   FIELDNAM: Sunward Facing Counts - SW - H+
 
 lo-sw-angular-oplus6:
   <<: *lo_angular_default
-  CATDESC: Counts - SW - O+6
+  CATDESC: Counts - Sunward - O+6
   FIELDNAM: Sunward Facing Counts - SW - O+6
 
 # lo-nsw-species Attributes
 lo-nsw-species-c:
   <<: *lo_species_default
-  CATDESC: Counts - NSW - C
+  CATDESC: Counts - Non-Sunward - C
   FIELDNAM: Counts - NSW - C
 
 lo-nsw-species-cnoplus:
   <<: *lo_species_default
-  CATDESC: Counts - NSW - CNO+
+  CATDESC: Counts - Non-Sunward - CNO+
   FIELDNAM: Counts - NSW - CNO+
 
 lo-nsw-species-fe:
   <<: *lo_species_default
-  CATDESC: Counts - NSW - Fe
+  CATDESC: Counts - Non-Sunward - Fe
   FIELDNAM: Counts - NSW - Fe
 
 lo-nsw-species-heplus:
   <<: *lo_species_default
-  CATDESC: Counts - NSW - He+
+  CATDESC: Counts - Non-Sunward - He+
   FIELDNAM: Counts - NSW - He+
 
 lo-nsw-species-heplusplus:
   <<: *lo_species_default
-  CATDESC: Counts - NSW - He++
+  CATDESC: Counts - Non-Sunward - He++
   FIELDNAM: Counts - NSW - He++
 
 lo-nsw-species-hplus:
   <<: *lo_species_default
-  CATDESC: Counts - NSW - H+
+  CATDESC: Counts - Non-Sunward - H+
   FIELDNAM: Counts - NSW - H+
 
 lo-nsw-species-ne_si_mg:
   <<: *lo_species_default
-  CATDESC: Counts - NSW - Ne_Si_Mg
+  CATDESC: Counts - Non-Sunward - Ne_Si_Mg
   FIELDNAM: Counts - NSW - Ne_Si_Mg
 
 lo-nsw-species-o:
   <<: *lo_species_default
-  CATDESC: Counts - NSW - O
+  CATDESC: Counts - Non-Sunward - O
   FIELDNAM: Counts - NSW - O
 
 # lo-nsw-angular Attributes
 lo-nsw-angular-heplusplus:
-  CATDESC: Counts - NSW - He++
+  CATDESC: Counts - Non-Sunward - He++
   FIELDNAM: Non-Sunward Facing Counts - NSW - He++
 
 # lo-ialirt Attributes

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -27,6 +27,7 @@ max_epoch: &max_epoch 3155630469184000000
 #   (hi-ialirt-spin_sector_index, lo-nsw-spin_sector_index). The difference is in the VALIDMAX value. the two lo ones
 #   are an exact match.
 #  -lo ialirt only has epoch as coordinate. Should there be more?
+#  -is the validmin for energy variables correct? VALIDMIN: 0.05000000074505806
 
 
 # <=== Defaults ===>
@@ -293,12 +294,133 @@ lo-sw-species-spin_sector_index:
 
 
 # <=== Labels ===>
+#TODO: double check FORMAT for labels
 event_num_label:
   CATDESC: Event Number
-  DEPEND_1: event_num
   FIELDNAM: Event Number
   FORMAT: A5
   VAR_TYPE: metadata
+
+epoch_delta_minus_label:
+  CATDESC: Time from acquisition start to acquisition center
+  FIELDNAM: Epoch delta minus
+  FORMAT: A18
+  VAR_TYPE: metadata
+
+epoch_delta_plus_label:
+  CATDESC: Time from acquisition center to acquisition end
+  FIELDNAM: Epoch delta plus
+  FORMAT: A18
+  VAR_TYPE: metadata
+
+elevation_angle_label:
+  CATDESC: Elevation Angle
+  FIELDNAM: Elevation Angle
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+spin_angle_label:
+  CATDESC: Spin Angle
+  FIELDNAM: Spin Angle
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_table_label:
+  CATDESC: Energy Table
+  FIELDNAM: Energy Table
+  FORMAT: A4
+  VAR_TYPE: metadata
+
+energy_cno_label:
+  CATDESC: Energy CNO
+  FIELDNAM: Energy CNO
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_fe_label:
+  CATDESC: Energy Fe
+  FIELDNAM: Energy Fe
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_h_label:
+  CATDESC: Energy H
+  FIELDNAM: Energy H
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_he3he4_label:
+  CATDESC: Energy He3He4
+  FIELDNAM: Energy He3He4
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_c_label:
+  CATDESC: Energy C
+  FIELDNAM: Energy C
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_he3_label:
+  CATDESC: Energy He3
+  FIELDNAM: Energy He3
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_he4_label:
+  CATDESC: Energy He4
+  FIELDNAM: Energy He4
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_junk_label:
+  CATDESC: Energy Junk
+  FIELDNAM: Energy Junk
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_ne_mg_si_label:
+  CATDESC: Energy NeMgSi
+  FIELDNAM: Energy NeMgSi
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_o_label:
+  CATDESC: Energy O
+  FIELDNAM: Energy O
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+energy_uh_label:
+  CATDESC: Energy UH
+  FIELDNAM: Energy UH
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+hi-sectored-spin_sector_index_label:
+  CATDESC: Spin Sector Index for Hi-Sectored
+  FIELDNAM: Spin Sector Index for Hi-Sectored
+  FORMAT: A2
+  VAR_TYPE: metadata
+
+hi-ialirt-spin_sector_index_label:
+  CATDESC: Spin Sector Index for Hi-Ialirt
+  FIELDNAM: Spin Sector Index for Hi-Ialirt
+  FORMAT: A1
+  VAR_TYPE: metadata
+
+lo-nsw-species-spin_sector_index_label:
+  CATDESC: Spin Sector Index for Lo-NSW Species
+  FIELDNAM: Spin Sector Index for Lo-NSW Species
+  FORMAT: A1
+  VAR_TYPE: metadata
+
+lo-sw-species-spin_sector_index_label:
+  CATDESC: Spin Sector Index for Lo-SW Species
+  FIELDNAM: Spin Sector Index for Lo-SW Species
+  FORMAT: A1
+  VAR_TYPE: metadata
+
 
 # <=== Dataset Variable Attributes ===>
 

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -28,6 +28,7 @@ max_epoch: &max_epoch 3155630469184000000
 #   are an exact match.
 #  -lo ialirt only has epoch as coordinate. Should there be more?
 #  -is the validmin for energy variables correct? VALIDMIN: 0.05000000074505806
+#  - what is the difference between spin_angle and spin_sector_index coordinates?
 
 
 # <=== Defaults ===>
@@ -59,9 +60,10 @@ lo_species_attrs: &lo_species_default
   <<: *default
   DEPEND_1: energy_table
   DEPEND_2: spin_sector_index
+  LABL_PTR_1: energy_table_label
+  LABL_PTR_2: spin_sector_index_label
   DISPLAY_TYPE: time_series
   FORMAT: '%f'
-  LABLAXIS: Diff. Intensity
   SCALETYP: log
   UNITS: particles / cm2 s sr keV/q
   VALIDMAX: 10000000000.0
@@ -73,9 +75,11 @@ lo_angular_attrs: &lo_angular_default
   DEPEND_1: energy_table
   DEPEND_2: elevation_angle
   DEPEND_3: spin_angle
+  LABL_PTR_1: energy_table_label
+  LABL_PTR_2: elevation_angle_label
+  LABL_PTR_3: spin_angle_label
   DISPLAY_TYPE: time_series
   FORMAT: '%f'
-  LABLAXIS: 'Diff. # Flux'
   SCALETYP: log
   UNITS: particles / cm2 s sr keV/q
   VALIDMAX: 10000000000.0
@@ -110,9 +114,10 @@ hi_sectored_attrs: &hi_sectored_attrs_default
   DISPLAY_TYPE: time_series
   DEPEND_2: elevation_angle
   DEPEND_3: spin_sector_index
+  LABL_PTR_2: elevation_angle_label
+  LABL_PTR_3: spin_sector_index_label
   FILLVAL: *uint32_fillval
   FORMAT: '%f'
-  LABLAXIS: 'Diff. # Flux'
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 16777216
   VALIDMIN: 0
@@ -122,7 +127,7 @@ energy_attrs: &energy_default
   VAR_TYPE: support_data
   CATDESC: Geometric Mean of the Energy
   FIELDNAM: Energy Table
-  LABLAXIS: MeV/nuc
+  LABLAXIS: Energy
   SCALETYP: log
   UNITS: MeV/nuc
   FORMAT: '%f'
@@ -138,7 +143,6 @@ spin_angles_attrs: &spin_angles_default
   VAR_TYPE: support_data
   CATDESC: Spin Angle
   FIELDNAM: Spin Angle
-  LABLAXIS: Spin Angle
   SCALETYP: linear
   UNITS: degrees
   FILLVAL: *int_fillval
@@ -211,6 +215,7 @@ elevation_angle:
 
 spin_angle:
   <<: *spin_angles_default
+  LABLAXIS: Spin Angle
 
 energy_table:
   CATDESC: Energy Table
@@ -1580,11 +1585,13 @@ hi-ialirt-energy_h_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_h
 
 hi-ialirt-energy_h_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_h
 
 hi-ialirt-h:
   <<: *default
@@ -1593,6 +1600,9 @@ hi-ialirt-h:
   DEPEND_1: energy_h
   DEPEND_2: ssd_index
   DEPEND_3: spin_sector_index
+  LABL_PTR_1: energy_h_label
+  LABL_PTR_2: ssd_index_label
+  LABL_PTR_3: spin_sector_index_label
   DISPLAY_TYPE: time_series
   FILLVAL: 4294967294
   LABLAXIS: Diff. Intensity
@@ -1604,160 +1614,190 @@ hi-ialirt-spin_angles:
   <<: *spin_angles_default
   DEPEND_1: spin_sector_index
   DEPEND_2: elevation_angle
+  LABL_PTR_1: spin_sector_index_label
+  LABL_PTR_2: elevation_angle_label
 
 # hi-omni Attributes
 hi-omni-energy_c_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_c
 
 hi-omni-energy_c_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_c
 
 hi-omni-energy_fe_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_fe
 
 hi-omni-energy_fe_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_fe
 
 hi-omni-energy_h_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_h
 
 hi-omni-energy_h_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_h
 
 hi-omni-energy_he3_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_he3
 
 hi-omni-energy_he3_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_he3
 
 hi-omni-energy_he4_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_he4
 
 hi-omni-energy_he4_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_he4
 
 hi-omni-energy_junk_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_junk
 
 hi-omni-energy_junk_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_junk
 
 hi-omni-energy_ne_mg_si_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_ne_mg_si
 
 hi-omni-energy_ne_mg_si_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_ne_mg_si
 
 hi-omni-energy_o_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_o
 
 hi-omni-energy_o_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_o
 
 hi-omni-energy_uh_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_uh
 
 hi-omni-energy_uh_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_uh
 
 hi-omni-c:
   <<: *hi_omni_default
   CATDESC: c (Root 2 spacing)
+  FIELDNAM: c
   DEPEND_0: epoch
   DEPEND_1: energy_c
-  FIELDNAM: c
+  LABLAXIS: energy_c_label
 
 hi-omni-fe:
   <<: *hi_omni_default
   CATDESC: fe (Root 2 spacing)
+  FIELDNAM: fe
   DEPEND_0: epoch
   DEPEND_1: energy_fe
-  FIELDNAM: fe
+  LABLAXIS: energy_fe_label
 
 hi-omni-h:
   <<: *hi_omni_default
   CATDESC: h (Root 2 spacing)
+  FIELDNAM: h
   DEPEND_0: epoch
   DEPEND_1: energy_h
-  FIELDNAM: h
+  LABLAXIS: energy_h_label
 
 hi-omni-he3:
   <<: *hi_omni_default
   CATDESC: he3 (Root 2 spacing)
+  FIELDNAM: he3
   DEPEND_0: epoch
   DEPEND_1: energy_he3
-  FIELDNAM: he3
+  LABLAXIS: energy_he3_label
+
 
 hi-omni-he4:
   <<: *hi_omni_default
   CATDESC: he4 (Root 2 spacing)
+  FIELDNAM: he4
   DEPEND_0: epoch
   DEPEND_1: energy_he4
-  FIELDNAM: he4
+  LABLAXIS: energy_he4_label
 
 hi-omni-junk:
   <<: *hi_omni_default
   CATDESC: junk (Root 2 spacing)
+  FIELDNAM: junk
   DEPEND_0: epoch
   DEPEND_1: energy_junk
-  FIELDNAM: junk
+  LABLAXIS: energy_junk_label
 
 hi-omni-ne_mg_si:
   <<: *hi_omni_default
   CATDESC: ne-mg-si (Root 2 spacing)
+  FIELDNAM: ne-mg-si
   DEPEND_0: epoch
   DEPEND_1: energy_ne_mg_si
-  FIELDNAM: ne-mg-si
+  LABLAXIS: energy_ne_mg_si_label
 
 hi-omni-o:
   <<: *hi_omni_default
   CATDESC: o (Root 2 spacing)
+  FIELDNAM: o
   DEPEND_0: epoch
   DEPEND_1: energy_o
-  FIELDNAM: o
+  LABLAXIS: energy_o_label
 
 hi-omni-uh:
   <<: *hi_omni_default
   CATDESC: uh (Root 2 spacing)
+  FIELDNAM: uh
   DEPEND_0: epoch
   DEPEND_1: energy_uh
-  FIELDNAM: uh
+  LABLAXIS: energy_uh_label
 
 # hi-sectored Attributes
 hi-sectored-cno:
@@ -1765,67 +1805,81 @@ hi-sectored-cno:
   CATDESC: cno (x2 spacing)
   FIELDNAM: cno
   DEPEND_1: energy_cno
+  LABL_PTR_1: energy_cno_label
 
 hi-sectored-fe:
   <<: *hi_sectored_attrs_default
   CATDESC: fe (x2 spacing)
   FIELDNAM: fe
   DEPEND_1: energy_fe
+  LABL_PTR_1: energy_fe_label
 
 hi-sectored-h:
   <<: *hi_sectored_attrs_default
   CATDESC: h (x2 spacing)
   FIELDNAM: h
   DEPEND_1: energy_h
+  LABL_PTR_1: energy_h_label
 
 hi-sectored-he3he4:
   <<: *hi_sectored_attrs_default
   CATDESC: he3he4 (x2 spacing)
   FIELDNAM: he3he4
   DEPEND_1: energy_he3he4
+  LABL_PTR_1: energy_he3he4_label
 
 hi-sectored-energy_cno_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_cno
 
 hi-sectored-energy_cno_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_cno
 
 hi-sectored-energy_fe_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_fe
 
 hi-sectored-energy_fe_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_fe
 
 hi-sectored-energy_h_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_h
 
 hi-sectored-energy_h_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_h
 
 hi-sectored-energy_he3he4_minus:
   <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
+  DEPEND_1: energy_he3he4
 
 hi-sectored-energy_he3he4_plus:
   <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
+  DEPEND_1: energy_he3he4
 
 hi-sectored-spin_angles:
   <<: *spin_angles_default
   DEPEND_1: spin_sector_index
   DEPEND_2: elevation_angle
+  LABL_PTR_1: spin_sector_index_label
+  LABL_PTR_2: elevation_angle_label
 

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -51,7 +51,7 @@ default_lo_species_attrs: &default_lo_species
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 
-default_lo_sw_angular_attrs: &default_lo_sw_angular
+default_lo_angular_attrs: &default_lo_angular
   <<: *default
   DEPEND_1: energy_table
   DEPEND_2: elevation_angle
@@ -59,20 +59,6 @@ default_lo_sw_angular_attrs: &default_lo_sw_angular
   DISPLAY_TYPE: time_series
   FORMAT: '%f'
   LABLAXIS: 'Diff. # Flux'
-  SCALETYP: log
-  UNITS: particles / cm2 s sr keV/q
-  VALIDMAX: 10000000000.0
-  VALIDMIN: 1.000000013351432e-10
-  VAR_TYPE: data
-
-default_lo_nsw_species_attrs: &default_lo_nsw_species_attrs
-  DEPEND_0: epoch
-  DEPEND_1: energy_table
-  DEPEND_2: spin_sector_index
-  DISPLAY_TYPE: time_series
-  FILLVAL: .nan
-  FORMAT: '%f'
-  LABLAXIS: Diff. Intensity
   SCALETYP: log
   UNITS: particles / cm2 s sr keV/q
   VALIDMAX: 10000000000.0
@@ -1183,62 +1169,67 @@ lo-sw-species-si:
 
 # lo-sw-angular Attributes
 lo-sw-angular-fe_loq:
-  <<: *default_lo_sw_angular
+  <<: *default_lo_angular
   CATDESC: Counts - SW - Fe lowQ
   FIELDNAM: Sunward Facing Counts - SW - Fe lowQ
 
 lo-sw-angular-heplusplus:
-  <<: *default_lo_sw_angular
+  <<: *default_lo_angular
   CATDESC: Counts - SW - He++
   FIELDNAM: Sunward Facing Counts - SW - He++
 
 lo-sw-angular-hplus:
-  <<: *default_lo_sw_angular
+  <<: *default_lo_angular
   CATDESC: Counts - SW - H+
   FIELDNAM: Sunward Facing Counts - SW - H+
 
 lo-sw-angular-oplus6:
-  <<: *default_lo_sw_angular
+  <<: *default_lo_angular
   CATDESC: Counts - SW - O+6
   FIELDNAM: Sunward Facing Counts - SW - O+6
 
 # lo-nsw-species Attributes
 lo-nsw-species-c:
-  <<: *default_lo_nsw_species_attrs
+  <<: *default_lo_species
   CATDESC: Counts - NSW - C
   FIELDNAM: Counts - NSW - C
 
 lo-nsw-species-cnoplus:
-  <<: *default_lo_nsw_species_attrs
+  <<: *default_lo_species
   CATDESC: Counts - NSW - CNO+
   FIELDNAM: Counts - NSW - CNO+
 
 lo-nsw-species-fe:
-  <<: *default_lo_nsw_species_attrs
+  <<: *default_lo_species
   CATDESC: Counts - NSW - Fe
   FIELDNAM: Counts - NSW - Fe
 
 lo-nsw-species-heplus:
-  <<: *default_lo_nsw_species_attrs
+  <<: *default_lo_species
   CATDESC: Counts - NSW - He+
   FIELDNAM: Counts - NSW - He+
 
 lo-nsw-species-heplusplus:
-  <<: *default_lo_nsw_species_attrs
+  <<: *default_lo_species
   CATDESC: Counts - NSW - He++
   FIELDNAM: Counts - NSW - He++
 
 lo-nsw-species-hplus:
-  <<: *default_lo_nsw_species_attrs
+  <<: *default_lo_species
   CATDESC: Counts - NSW - H+
   FIELDNAM: Counts - NSW - H+
 
 lo-nsw-species-ne_si_mg:
-  <<: *default_lo_nsw_species_attrs
+  <<: *default_lo_species
   CATDESC: Counts - NSW - Ne_Si_Mg
   FIELDNAM: Counts - NSW - Ne_Si_Mg
 
 lo-nsw-species-o:
-  <<: *default_lo_nsw_species_attrs
+  <<: *default_lo_species
   CATDESC: Counts - NSW - O
   FIELDNAM: Counts - NSW - O
+
+# lo-nsw-angular Attributes
+lo-nsw-angular-heplusplus:
+  CATDESC: Counts - NSW - He++
+  FIELDNAM: Non-Sunward Facing Counts - NSW - He++

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -15,20 +15,12 @@ max_uint24: &max_uint24 8388607
 max_uint32: &max_uint32 4294967295
 max_epoch: &max_epoch 3155630469184000000
 
-# TODO:
-#  -update fillval, validmin and validmax for floats (look at l1a yaml)
-#  -add DICT_KEY where applicable
-#  -Update format to use Fortran values
-#  -Add LABLAXIS or LABL_PTR_1 where applicable
-#  -Replace hash with num, counts, or rates? '# / cm2 s sr MeV/nuc'
-#  -LABLAXIS: Diff. Intensity vs 'Diff. # Flux'  Both are used. Are these the same?
-#  -should fillval for lo-ialirt be negative instead of positive? See ISTP guidelines
-#  -what to do with duplicate spin_sector_index variables? Added product prefix for now
-#   (hi-ialirt-spin_sector_index, lo-nsw-spin_sector_index). The difference is in the VALIDMAX value. the two lo ones
-#   are an exact match.
-#  -lo ialirt only has epoch as coordinate. Should there be more?
-#  -is the validmin for energy variables correct? VALIDMIN: 0.05000000074505806
-#  - what is the difference between spin_angle and spin_sector_index coordinates?
+# TODO: Complete SPASE. Used HIT as reference for intensity attributes
+# TODO: Update FORMAT to use fortran format
+# TODO: Review units with CoDICE
+# TODO: Review LABLAXIS with CoDICE. Diff. Intensity vs Diff. # Flux
+# TODO: Review FILLVAL with CoDICE. lo-ialirt has 1.0e+31, but should it be negative?
+# TODO: Review VALIDMIN with CoDICE (i.e. VALIDMIN: 0.05000000074505806 ??)
 
 
 # <=== Defaults ===>
@@ -43,6 +35,7 @@ default_attrs: &default
   UNITS: dN
   VALIDMIN: *min_int
   VALIDMAX: *max_int
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 direct_events_attrs: &direct_events_default
   <<: *default
@@ -54,7 +47,16 @@ direct_events_attrs: &direct_events_default
   UNITS: unitless
   VALIDMIN: 0
   VALIDMAX: 10000
-  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+lo_ialirt_attrs: &lo_ialirt_default
+  <<: *default
+  DISPLAY_TYPE: time_series
+  FILLVAL: 1.0e+31
+  FORMAT: '%lf'
+  LABLAXIS: ratio
+  UNITS: ratio
+  VALIDMAX: 1.0e+31
+  VALIDMIN: 0.0
 
 lo_species_attrs: &lo_species_default
   <<: *default
@@ -84,18 +86,7 @@ lo_angular_attrs: &lo_angular_default
   UNITS: particles / cm2 s sr keV/q
   VALIDMAX: 10000000000.0
   VALIDMIN: 1.000000013351432e-10
-  DICT_KEY: SPASE>Support>SupportQuantity:Other
-
-lo_ialirt_attrs: &lo_ialirt_default
-  <<: *default
-  DISPLAY_TYPE: time_series
-  FILLVAL: 1.0e+31
-  FORMAT: '%lf'
-  LABLAXIS: ratio
-  UNITS: ratio
-  VALIDMAX: 1.0e+31
-  VALIDMIN: 0.0
-  DICT_KEY: SPASE>Support>SupportQuantity:Other
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 hi_omni_attrs: &hi_omni_default
   <<: *default
@@ -107,7 +98,7 @@ hi_omni_attrs: &hi_omni_default
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 16777216.0
   VALIDMIN: 0
-  DICT_KEY: SPASE>Support>SupportQuantity:Other
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 hi_sectored_attrs: &hi_sectored_attrs_default
   <<: *default
@@ -121,7 +112,7 @@ hi_sectored_attrs: &hi_sectored_attrs_default
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 16777216
   VALIDMIN: 0
-  DICT_KEY: SPASE>Support>SupportQuantity:Other
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 energy_attrs: &energy_default
   VAR_TYPE: support_data
@@ -1730,7 +1721,6 @@ hi-omni-c:
   <<: *hi_omni_default
   CATDESC: c (Root 2 spacing)
   FIELDNAM: c
-  DEPEND_0: epoch
   DEPEND_1: energy_c
   LABLAXIS: energy_c_label
 
@@ -1738,7 +1728,6 @@ hi-omni-fe:
   <<: *hi_omni_default
   CATDESC: fe (Root 2 spacing)
   FIELDNAM: fe
-  DEPEND_0: epoch
   DEPEND_1: energy_fe
   LABLAXIS: energy_fe_label
 
@@ -1746,7 +1735,6 @@ hi-omni-h:
   <<: *hi_omni_default
   CATDESC: h (Root 2 spacing)
   FIELDNAM: h
-  DEPEND_0: epoch
   DEPEND_1: energy_h
   LABLAXIS: energy_h_label
 
@@ -1754,7 +1742,6 @@ hi-omni-he3:
   <<: *hi_omni_default
   CATDESC: he3 (Root 2 spacing)
   FIELDNAM: he3
-  DEPEND_0: epoch
   DEPEND_1: energy_he3
   LABLAXIS: energy_he3_label
 
@@ -1763,7 +1750,6 @@ hi-omni-he4:
   <<: *hi_omni_default
   CATDESC: he4 (Root 2 spacing)
   FIELDNAM: he4
-  DEPEND_0: epoch
   DEPEND_1: energy_he4
   LABLAXIS: energy_he4_label
 
@@ -1771,7 +1757,6 @@ hi-omni-junk:
   <<: *hi_omni_default
   CATDESC: junk (Root 2 spacing)
   FIELDNAM: junk
-  DEPEND_0: epoch
   DEPEND_1: energy_junk
   LABLAXIS: energy_junk_label
 
@@ -1779,7 +1764,6 @@ hi-omni-ne_mg_si:
   <<: *hi_omni_default
   CATDESC: ne-mg-si (Root 2 spacing)
   FIELDNAM: ne-mg-si
-  DEPEND_0: epoch
   DEPEND_1: energy_ne_mg_si
   LABLAXIS: energy_ne_mg_si_label
 
@@ -1787,7 +1771,6 @@ hi-omni-o:
   <<: *hi_omni_default
   CATDESC: o (Root 2 spacing)
   FIELDNAM: o
-  DEPEND_0: epoch
   DEPEND_1: energy_o
   LABLAXIS: energy_o_label
 
@@ -1795,7 +1778,6 @@ hi-omni-uh:
   <<: *hi_omni_default
   CATDESC: uh (Root 2 spacing)
   FIELDNAM: uh
-  DEPEND_0: epoch
   DEPEND_1: energy_uh
   LABLAXIS: energy_uh_label
 

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -23,8 +23,10 @@ max_epoch: &max_epoch 3155630469184000000
 #  -Replace hash with num, counts, or rates? '# / cm2 s sr MeV/nuc'
 #  -LABLAXIS: Diff. Intensity vs 'Diff. # Flux'  Both are used. Are these the same?
 #  -should fillval for lo-ialirt be negative instead of positive? See ISTP guidelines
-#  -what to do with duplicate spin_sector_index variables? Renamed the hi-ialirt one to hi-ialirt-spin_sector_index
-#   for now. The difference is in the VALIDMAX value, which is 4 for hi-ialirt-spin_sector_index and 12 for the others.
+#  -what to do with duplicate spin_sector_index variables? Added product prefix for now
+#   (hi-ialirt-spin_sector_index, lo-nsw-spin_sector_index). The difference is in the VALIDMAX value. the two lo ones
+#   are an exact match.
+#  -lo ialirt only has epoch as coordinate. Should there be more?
 
 
 # <=== Defaults ===>
@@ -132,57 +134,68 @@ energy_delta_attrs: &energy_delta_default
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Uncertainty
 
 spin_angles_attrs: &spin_angles_default
-  <<: *default
   VAR_TYPE: support_data
   CATDESC: Spin Angle
-  DEPEND_1: spin_sector_index
-  DEPEND_2: elevation_angle
   FIELDNAM: Spin Angle
   LABLAXIS: Spin Angle
   SCALETYP: linear
   UNITS: degrees
+  FILLVAL: *int_fillval
   VALIDMAX: 360.0
   VALIDMIN: 0.0
   FORMAT: '%f'
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:ArrivalDirection,Qualifer:DirectionAngle.AzimuthAngle
 
+spin_sector_index_attrs: &spin_sector_index_default
+  VAR_TYPE: support_data
+  CATDESC: Spin Sector Index
+  FIELDNAM: Spin Sector Index
+  FORMAT: '%d'
+  LABLAXIS: ' '
+  SCALETYP: linear
+  UNITS: ' '
+  VALIDMAX: 1
+  VALIDMIN: 0
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+
 # <=== Coordinates ===>
 event_num:
-    CATDESC: Event Number
-    FIELDNAM: Event Number
-    FILLVAL: *uint16_fillval
-    FORMAT: I5
-    LABLAXIS: Event Number
-    SCALETYP: linear
-    UNITS: " "
-    VALIDMIN: 0
-    VALIDMAX: 10000
-    VAR_TYPE: support_data
-    DICT_KEY: SPASE>Support>SupportQuantity:Other
+  CATDESC: Event Number
+  FIELDNAM: Event Number
+  FILLVAL: *uint16_fillval
+  FORMAT: I5
+  LABLAXIS: Event Number
+  SCALETYP: linear
+  UNITS: " "
+  VALIDMIN: 0
+  VALIDMAX: 10000
+  VAR_TYPE: support_data
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 epoch_delta_minus:
-    CATDESC: Time from acquisition start to acquisition center
-    FIELDNAM: epoch_delta_minus
-    FILLVAL: *int_fillval
-    FORMAT: I18
-    LABLAXIS: epoch_delta_minus
-    SCALETYP: linear
-    UNITS: ns
-    VALIDMIN: *min_int
-    VALIDMAX: *max_int
-    VAR_TYPE: support_data
+  CATDESC: Time from acquisition start to acquisition center
+  FIELDNAM: epoch_delta_minus
+  FILLVAL: *int_fillval
+  FORMAT: I18
+  LABLAXIS: epoch_delta_minus
+  SCALETYP: linear
+  UNITS: ns
+  VALIDMIN: *min_int
+  VALIDMAX: *max_int
+  VAR_TYPE: support_data
 
 epoch_delta_plus:
-    CATDESC: Time from acquisition center to acquisition end
-    FIELDNAM: epoch_delta_plus
-    FILLVAL: *int_fillval
-    FORMAT: I18
-    LABLAXIS: epoch_delta_plus
-    SCALETYP: linear
-    UNITS: ns
-    VALIDMIN: *min_int
-    VALIDMAX: *max_int
-    VAR_TYPE: support_data
+  CATDESC: Time from acquisition center to acquisition end
+  FIELDNAM: epoch_delta_plus
+  FILLVAL: *int_fillval
+  FORMAT: I18
+  LABLAXIS: epoch_delta_plus
+  SCALETYP: linear
+  UNITS: ns
+  VALIDMIN: *min_int
+  VALIDMAX: *max_int
+  VAR_TYPE: support_data
 
 elevation_angle:
   CATDESC: Elevation Angle
@@ -193,6 +206,20 @@ elevation_angle:
   UNITS: degrees
   VALIDMAX: 180.0
   VALIDMIN: 0.0
+  VAR_TYPE: support_data
+
+spin_angle:
+  <<: *spin_angles_default
+
+energy_table:
+  CATDESC: Energy Table
+  FIELDNAM: Energy Table
+  FORMAT: '%f'
+  LABLAXIS: keV/e
+  SCALETYP: log
+  UNITS: keV/e
+  VALIDMAX: 82.0
+  VALIDMIN: 0.5
   VAR_TYPE: support_data
 
 energy_cno:
@@ -250,27 +277,19 @@ energy_uh:
   DELTA_MINUS_VAR: energy_uh_minus
   DELTA_PLUS_VAR: energy_uh_plus
 
-spin_sector_index:
-  CATDESC: Spin Sector Index
-  FIELDNAM: Spin Sector Index
-  FORMAT: '%d'
-  LABLAXIS: ' '
-  SCALETYP: linear
-  UNITS: ' '
+hi-sectored-spin_sector_index:
+  <<: *spin_sector_index_default
   VALIDMAX: 12
-  VALIDMIN: 0
-  VAR_TYPE: support_data
 
 hi-ialirt-spin_sector_index:
-  CATDESC: Spin Sector Index
-  FIELDNAM: Spin Sector Index
-  FORMAT: '%d'
-  LABLAXIS: ' '
-  SCALETYP: linear
-  UNITS: ' '
+  <<: *spin_sector_index_default
   VALIDMAX: 4
-  VALIDMIN: 0
-  VAR_TYPE: support_data
+
+lo-nsw-species-spin_sector_index:
+  <<: *spin_sector_index_default
+
+lo-sw-species-spin_sector_index:
+  <<: *spin_sector_index_default
 
 
 # <=== Labels ===>
@@ -1461,6 +1480,8 @@ hi-ialirt-h:
 
 hi-ialirt-spin_angles:
   <<: *spin_angles_default
+  DEPEND_1: spin_sector_index
+  DEPEND_2: elevation_angle
 
 # hi-omni Attributes
 hi-omni-energy_c_minus:
@@ -1683,4 +1704,6 @@ hi-sectored-energy_he3he4_plus:
 
 hi-sectored-spin_angles:
   <<: *spin_angles_default
+  DEPEND_1: spin_sector_index
+  DEPEND_2: elevation_angle
 

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -18,9 +18,10 @@ max_epoch: &max_epoch 3155630469184000000
 # TODO: Complete SPASE. Used HIT as reference for intensity attributes
 # TODO: Update FORMAT to use fortran format
 # TODO: Review units with CoDICE
-# TODO: Review LABLAXIS with CoDICE. Diff. Intensity vs Diff. # Flux
-# TODO: Review FILLVAL with CoDICE. lo-ialirt has 1.0e+31, but should it be negative?
-# TODO: Review VALIDMIN with CoDICE (i.e. VALIDMIN: 0.05000000074505806 ??)
+# TODO: Review LABLAXIS with CoDICE. (Diff. Intensity vs Diff. # Flux)
+# TODO: Review FILLVAL with CoDICE. (lo-ialirt has 1.0e+31, but should it be negative?)
+# TODO: Review VALIDMIN with CoDICE (VALIDMIN: 0.05000000074505806 ??)
+# TODO: Update direct events attributes - products have new structure
 
 
 # <=== Defaults ===>
@@ -147,7 +148,7 @@ spin_sector_index_attrs: &spin_sector_index_default
   CATDESC: Spin Sector Index
   FIELDNAM: Spin Sector Index
   FORMAT: '%d'
-  LABLAXIS: ' '
+  LABLAXIS: Spin Sector Index
   SCALETYP: linear
   UNITS: ' '
   VALIDMAX: 1
@@ -163,7 +164,7 @@ event_num:
   FORMAT: I5
   LABLAXIS: Event Number
   SCALETYP: linear
-  UNITS: " "
+  UNITS: ' '
   VALIDMIN: 0
   VALIDMAX: 10000
   VAR_TYPE: support_data
@@ -171,10 +172,10 @@ event_num:
 
 epoch_delta_minus:
   CATDESC: Time from acquisition start to acquisition center
-  FIELDNAM: epoch_delta_minus
+  FIELDNAM: epoch delta minus
   FILLVAL: *int_fillval
   FORMAT: I18
-  LABLAXIS: epoch_delta_minus
+  LABLAXIS: Epoch Delta Minus
   SCALETYP: linear
   UNITS: ns
   VALIDMIN: *min_int
@@ -183,10 +184,10 @@ epoch_delta_minus:
 
 epoch_delta_plus:
   CATDESC: Time from acquisition center to acquisition end
-  FIELDNAM: epoch_delta_plus
+  FIELDNAM: epoch delta plus
   FILLVAL: *int_fillval
   FORMAT: I18
-  LABLAXIS: epoch_delta_plus
+  LABLAXIS: Epoch Delta Plus
   SCALETYP: linear
   UNITS: ns
   VALIDMIN: *min_int
@@ -1587,7 +1588,7 @@ hi-ialirt-energy_h_plus:
 hi-ialirt-h:
   <<: *default
   CATDESC: h (x2 spacing)
-  FIELDNAM: h
+  FIELDNAM: h Diff. Intensity
   DEPEND_1: energy_h
   DEPEND_2: ssd_index
   DEPEND_3: spin_sector_index
@@ -1596,7 +1597,6 @@ hi-ialirt-h:
   LABL_PTR_3: spin_sector_index_label
   DISPLAY_TYPE: time_series
   FILLVAL: 4294967294
-  LABLAXIS: Diff. Intensity
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 16777216
   VALIDMIN: 0
@@ -1722,28 +1722,28 @@ hi-omni-c:
   CATDESC: c (Root 2 spacing)
   FIELDNAM: c
   DEPEND_1: energy_c
-  LABLAXIS: energy_c_label
+  LABL_PTR_1: energy_c_label
 
 hi-omni-fe:
   <<: *hi_omni_default
   CATDESC: fe (Root 2 spacing)
   FIELDNAM: fe
   DEPEND_1: energy_fe
-  LABLAXIS: energy_fe_label
+  LABL_PTR_1: energy_fe_label
 
 hi-omni-h:
   <<: *hi_omni_default
   CATDESC: h (Root 2 spacing)
   FIELDNAM: h
   DEPEND_1: energy_h
-  LABLAXIS: energy_h_label
+  LABL_PTR_1: energy_h_label
 
 hi-omni-he3:
   <<: *hi_omni_default
   CATDESC: he3 (Root 2 spacing)
   FIELDNAM: he3
   DEPEND_1: energy_he3
-  LABLAXIS: energy_he3_label
+  LABL_PTR_1: energy_he3_label
 
 
 hi-omni-he4:
@@ -1751,35 +1751,35 @@ hi-omni-he4:
   CATDESC: he4 (Root 2 spacing)
   FIELDNAM: he4
   DEPEND_1: energy_he4
-  LABLAXIS: energy_he4_label
+  LABL_PTR_1: energy_he4_label
 
 hi-omni-junk:
   <<: *hi_omni_default
   CATDESC: junk (Root 2 spacing)
   FIELDNAM: junk
   DEPEND_1: energy_junk
-  LABLAXIS: energy_junk_label
+  LABL_PTR_1: energy_junk_label
 
 hi-omni-ne_mg_si:
   <<: *hi_omni_default
   CATDESC: ne-mg-si (Root 2 spacing)
   FIELDNAM: ne-mg-si
   DEPEND_1: energy_ne_mg_si
-  LABLAXIS: energy_ne_mg_si_label
+  LABL_PTR_1: energy_ne_mg_si_label
 
 hi-omni-o:
   <<: *hi_omni_default
   CATDESC: o (Root 2 spacing)
   FIELDNAM: o
   DEPEND_1: energy_o
-  LABLAXIS: energy_o_label
+  LABL_PTR_1: energy_o_label
 
 hi-omni-uh:
   <<: *hi_omni_default
   CATDESC: uh (Root 2 spacing)
   FIELDNAM: uh
   DEPEND_1: energy_uh
-  LABLAXIS: energy_uh_label
+  LABL_PTR_1: energy_uh_label
 
 # hi-sectored Attributes
 hi-sectored-cno:

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -18,15 +18,13 @@ max_epoch: &max_epoch 3155630469184000000
 # TODO:
 #  -update fillval, validmin and validmax for floats (look at l1a yaml)
 #  -add DICT_KEY where applicable
-#  -Update default_attrs where needed (i.e. format)
 #  -Update format to use Fortran values
-#  -Add coordinate attributes
 #  -Add LABLAXIS or LABL_PTR_1 where applicable
-#  -Add energy defaults
-#  -Add energy delta defaults
-#  -Should energy delta vars have DEPEND_1: energy_XX to point to energy it's a delta of?
 #  -Replace hash with num, counts, or rates? '# / cm2 s sr MeV/nuc'
 #  -LABLAXIS: Diff. Intensity vs 'Diff. # Flux'  Both are used. Are these the same?
+#  -should fillval for lo-ialirt be negative instead of positive? See ISTP guidelines
+#  -what to do with duplicate spin_sector_index variables? Renamed the hi-ialirt one to hi-ialirt-spin_sector_index
+#   for now. The difference is in the VALIDMAX value, which is 4 for hi-ialirt-spin_sector_index and 12 for the others.
 
 
 # <=== Defaults ===>
@@ -47,7 +45,7 @@ direct_events_attrs: &direct_events_default
   CATDESC: Fill in at creation
   DISPLAY_TYPE: time_series
   FIELDNAM: Fill in at creation
-  FILLVAL: uint8_fillval
+  FILLVAL: *uint8_fillval
   FORMAT: I5
   UNITS: unitless
   VALIDMIN: 0
@@ -95,7 +93,7 @@ lo_ialirt_attrs: &lo_ialirt_default
 hi_omni_attrs: &hi_omni_default
   <<: *default
   DISPLAY_TYPE: time_series
-  FILLVAL: uint32_fillval
+  FILLVAL: *uint32_fillval
   FORMAT: '%f'
   LABLAXIS: Diff. Intensity
   SCALETYP: linear
@@ -109,7 +107,7 @@ hi_sectored_attrs: &hi_sectored_attrs_default
   DISPLAY_TYPE: time_series
   DEPEND_2: elevation_angle
   DEPEND_3: spin_sector_index
-  FILLVAL: uint32_fillval
+  FILLVAL: *uint32_fillval
   FORMAT: '%f'
   LABLAXIS: 'Diff. # Flux'
   UNITS: '# / cm2 s sr MeV/nuc'
@@ -119,7 +117,8 @@ hi_sectored_attrs: &hi_sectored_attrs_default
 
 energy_attrs: &energy_default
   VAR_TYPE: support_data
-  CATDESC: Energy Table
+  CATDESC: Geometric Mean of the Energy
+  FIELDNAM: Energy Table
   LABLAXIS: MeV/nuc
   SCALETYP: log
   UNITS: MeV/nuc
@@ -151,7 +150,7 @@ spin_angles_attrs: &spin_angles_default
 event_num:
     CATDESC: Event Number
     FIELDNAM: Event Number
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     FORMAT: I5
     LABLAXIS: Event Number
     SCALETYP: linear
@@ -185,30 +184,119 @@ epoch_delta_plus:
     VALIDMAX: *max_int
     VAR_TYPE: support_data
 
+elevation_angle:
+  CATDESC: Elevation Angle
+  FIELDNAM: Elevation Angle
+  FORMAT: '%f'
+  LABLAXIS: Elevation Angle
+  SCALETYP: linear
+  UNITS: degrees
+  VALIDMAX: 180.0
+  VALIDMIN: 0.0
+  VAR_TYPE: support_data
+
+energy_cno:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_cno_minus
+  DELTA_PLUS_VAR: energy_cno_plus
+
+energy_fe:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_fe_minus
+  DELTA_PLUS_VAR: energy_fe_plus
+
+energy_h:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_h_minus
+  DELTA_PLUS_VAR: energy_h_plus
+
+energy_he3he4:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_he3he4_minus
+  DELTA_PLUS_VAR: energy_he3he4_plus
+
+energy_c:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_c_minus
+  DELTA_PLUS_VAR: energy_c_plus
+
+energy_he3:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_he3_minus
+  DELTA_PLUS_VAR: energy_he3_plus
+
+energy_he4:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_he4_minus
+  DELTA_PLUS_VAR: energy_he4_plus
+
+energy_junk:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_junk_minus
+  DELTA_PLUS_VAR: energy_junk_plus
+
+energy_ne_mg_si:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_ne_mg_si_minus
+  DELTA_PLUS_VAR: energy_ne_mg_si_plus
+
+energy_o:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_o_minus
+  DELTA_PLUS_VAR: energy_o_plus
+
+energy_uh:
+  <<: *energy_default
+  DELTA_MINUS_VAR: energy_uh_minus
+  DELTA_PLUS_VAR: energy_uh_plus
+
+spin_sector_index:
+  CATDESC: Spin Sector Index
+  FIELDNAM: Spin Sector Index
+  FORMAT: '%d'
+  LABLAXIS: ' '
+  SCALETYP: linear
+  UNITS: ' '
+  VALIDMAX: 12
+  VALIDMIN: 0
+  VAR_TYPE: support_data
+
+hi-ialirt-spin_sector_index:
+  CATDESC: Spin Sector Index
+  FIELDNAM: Spin Sector Index
+  FORMAT: '%d'
+  LABLAXIS: ' '
+  SCALETYP: linear
+  UNITS: ' '
+  VALIDMAX: 4
+  VALIDMIN: 0
+  VAR_TYPE: support_data
+
+
 # <=== Labels ===>
 event_num_label:
-    CATDESC: Event Number
-    DEPEND_1: event_num
-    FIELDNAM: Event Number
-    FORMAT: A5
-    VAR_TYPE: metadata
+  CATDESC: Event Number
+  DEPEND_1: event_num
+  FIELDNAM: Event Number
+  FORMAT: A5
+  VAR_TYPE: metadata
 
 # <=== Dataset Variable Attributes ===>
 
 # The following are set in multiple data products
 data_quality:
-    <<: *default
-    CATDESC: Indicates whether data quality is suspect (1).
-    DISPLAY_TYPE: time_series
-    FIELDNAM: Data Quality
-    FILLVAL: 255
-    FORMAT: '%d'
-    LABLAXIS: Data Quality
-    SCALETYP: linear
-    UNITS: ' '
-    VALIDMAX: 1
-    VALIDMIN: 0
-    VAR_TYPE: data
+  <<: *default
+  CATDESC: Indicates whether data quality is suspect (1).
+  DISPLAY_TYPE: time_series
+  FIELDNAM: Data Quality
+  FILLVAL: *uint8_fillval
+  FORMAT: '%d'
+  LABLAXIS: Data Quality
+  SCALETYP: linear
+  UNITS: ' '
+  VALIDMAX: 1
+  VALIDMIN: 0
+  VAR_TYPE: data
 
 # The following are data product-specific
 # Direct Events Attributes
@@ -227,7 +315,7 @@ P0_APDEnergy:
     CATDESC: Priority 0 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 0 APD Energy
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 512
 
@@ -275,7 +363,7 @@ P0_NumEvents:
     <<: *direct_events_default
     CATDESC: Priority 0 Number of Events
     FIELDNAM: Priority 0 Number of Events
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABLAXIS: " "
 
 P0_PHAType:
@@ -331,7 +419,7 @@ P0_TOF:
     CATDESC: Priority 0 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Time of Flight
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
 
@@ -356,7 +444,7 @@ P1_APDEnergy:
     CATDESC: Priority 1 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 1 APD Energy
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 512
 
@@ -404,7 +492,7 @@ P1_NumEvents:
     <<: *direct_events_default
     CATDESC: Priority 1 Number of Events
     FIELDNAM: Priority 1 Number of Events
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABLAXIS: " "
 
 P1_PHAType:
@@ -460,7 +548,7 @@ P1_TOF:
     CATDESC: Priority 1 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Time of Flight
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
 
@@ -485,7 +573,7 @@ P2_APDEnergy:
     CATDESC: Priority 2 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 2 APD Energy
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 512
 
@@ -533,7 +621,7 @@ P2_NumEvents:
     <<: *direct_events_default
     CATDESC: Priority 2 Number of Events
     FIELDNAM: Priority 2 Number of Events
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABLAXIS: " "
 
 P2_PHAType:
@@ -589,7 +677,7 @@ P2_TOF:
     CATDESC: Priority 2 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Time of Flight
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
 
@@ -614,7 +702,7 @@ P3_APDEnergy:
     CATDESC: Priority 3 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 3 APD Energy
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 512
 
@@ -662,7 +750,7 @@ P3_NumEvents:
     <<: *direct_events_default
     CATDESC: Priority 3 Number of Events
     FIELDNAM: Priority 3 Number of Events
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABLAXIS: " "
 
 P3_PHAType:
@@ -718,7 +806,7 @@ P3_TOF:
     CATDESC: Priority 3 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Time of Flight
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
 
@@ -743,7 +831,7 @@ P4_APDEnergy:
     CATDESC: Priority 4 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 4 APD Energy
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 512
 
@@ -791,7 +879,7 @@ P4_NumEvents:
     <<: *direct_events_default
     CATDESC: Priority 4 Number of Events
     FIELDNAM: Priority 4 Number of Events
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABLAXIS: " "
 
 P4_PHAType:
@@ -847,7 +935,7 @@ P4_TOF:
     CATDESC: Priority 4 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Time of Flight
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
 
@@ -872,7 +960,7 @@ P5_APDEnergy:
     CATDESC: Priority 5 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 5 APD Energy
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 512
 
@@ -920,7 +1008,7 @@ P5_NumEvents:
     <<: *direct_events_default
     CATDESC: Priority 5 Number of Events
     FIELDNAM: Priority 5 Number of Events
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABLAXIS: " "
 
 P5_PHAType:
@@ -976,7 +1064,7 @@ P5_TOF:
     CATDESC: Priority 5 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Time of Flight
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
 
@@ -1001,7 +1089,7 @@ P6_APDEnergy:
     CATDESC: Priority 6 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 6 APD Energy
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 512
 
@@ -1041,7 +1129,7 @@ P6_NumEvents:
     <<: *direct_events_default
     CATDESC: Priority 6 Number of Events
     FIELDNAM: Priority 6 Number of Events
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABLAXIS: " "
 
 P6_PHAType:
@@ -1073,7 +1161,7 @@ P6_TOF:
     CATDESC: Priority 6 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 6 Time of Flight
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
 
@@ -1090,7 +1178,7 @@ P7_APDEnergy:
     CATDESC: Priority 7 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 7 APD Energy
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 512
 
@@ -1130,7 +1218,7 @@ P7_NumEvents:
     <<: *direct_events_default
     CATDESC: Priority 7 Number of Events
     FIELDNAM: Priority 7 Number of Events
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABLAXIS: " "
 
 P7_PHAType:
@@ -1162,7 +1250,7 @@ P7_TOF:
     CATDESC: Priority 7 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 7 Time of Flight
-    FILLVAL: 65535
+    FILLVAL: *uint16_fillval
     LABL_PTR_1: event_num_label
     VALIDMAX: 1024
 

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -1,7 +1,19 @@
 # <=== Useful Variables ===>
 int_fillval: &int_fillval -9223372036854775808
+uint8_fillval: &uint8_fillval 255
+uint16_fillval: &uint16_fillval 65535
+uint32_fillval: &uint32_fillval 4294967295
+real_fillval: &real_fillval -1.0e+31
+
 min_int: &min_int -9223372036854775808
+min_epoch: &min_epoch -315575942816000000
+
 max_int: &max_int 9223372036854775807
+max_uint8: &max_uint8 255
+max_uint16: &max_uint16 65535
+max_uint24: &max_uint24 8388607
+max_uint32: &max_uint32 4294967295
+max_epoch: &max_epoch 3155630469184000000
 
 # TODO:
 #  -update fillval, validmin and validmax for floats (look at l1a yaml)
@@ -13,36 +25,37 @@ max_int: &max_int 9223372036854775807
 #  -Add energy defaults
 #  -Add energy delta defaults
 #  -Should energy delta vars have DEPEND_1: energy_XX to point to energy it's a delta of?
+#  -Replace hash with num, counts, or rates? '# / cm2 s sr MeV/nuc'
+#  -LABLAXIS: Diff. Intensity vs 'Diff. # Flux'  Both are used. Are these the same?
 
 
 # <=== Defaults ===>
 default_attrs: &default
-    DEPEND_0: epoch
-    DISPLAY_TYPE: no_plot
-    FIELDNAM: " "
-    FILLVAL: *int_fillval
-    FORMAT: I12
-    SCALETYP: linear
-    UNITS: dN
-    VALIDMIN: *min_int
-    VALIDMAX: *max_int
-    VAR_TYPE: data
-
-direct_events_attrs: &direct_events
-    <<: *default
-    CATDESC: Fill in at creation
-    DISPLAY_TYPE: time_series
-    FIELDNAM: Fill in at creation
-    FILLVAL: 255
-    FORMAT: I5
-    UNITS: unitless
-    VALIDMIN: 0
-    VALIDMAX: 10000
-    DICT_KEY: SPASE>Support>SupportQuantity:Other
-
-default_lo_species_attrs: &default_lo_species
-  <<: *default
   VAR_TYPE: data
+  DEPEND_0: epoch
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: " "
+  FILLVAL: *int_fillval
+  FORMAT: I12
+  SCALETYP: linear
+  UNITS: dN
+  VALIDMIN: *min_int
+  VALIDMAX: *max_int
+
+direct_events_attrs: &direct_events_default
+  <<: *default
+  CATDESC: Fill in at creation
+  DISPLAY_TYPE: time_series
+  FIELDNAM: Fill in at creation
+  FILLVAL: uint8_fillval
+  FORMAT: I5
+  UNITS: unitless
+  VALIDMIN: 0
+  VALIDMAX: 10000
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+lo_species_attrs: &lo_species_default
+  <<: *default
   DEPEND_1: energy_table
   DEPEND_2: spin_sector_index
   DISPLAY_TYPE: time_series
@@ -54,10 +67,8 @@ default_lo_species_attrs: &default_lo_species
   VALIDMIN: 1.000000013351432e-10
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
-
-default_lo_angular_attrs: &default_lo_angular
+lo_angular_attrs: &lo_angular_default
   <<: *default
-  VAR_TYPE: data
   DEPEND_1: energy_table
   DEPEND_2: elevation_angle
   DEPEND_3: spin_angle
@@ -70,34 +81,21 @@ default_lo_angular_attrs: &default_lo_angular
   VALIDMIN: 1.000000013351432e-10
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
-default_lo_ialirt_attrs: &default_lo_ialirt
+lo_ialirt_attrs: &lo_ialirt_default
   <<: *default
-  VAR_TYPE: data
   DISPLAY_TYPE: time_series
   FILLVAL: 1.0e+31
   FORMAT: '%lf'
   LABLAXIS: ratio
-  SCALETYP: linear
   UNITS: ratio
   VALIDMAX: 1.0e+31
   VALIDMIN: 0.0
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
-default_hi_ialirt_attrs: &default_hi_ialirt
+hi_omni_attrs: &hi_omni_default
   <<: *default
-  VAR_TYPE: support_data
-  FORMAT: '%f'
-  SCALETYP: log
-  UNITS: MeV/nuc
-  VALIDMAX: 200.0
-  VALIDMIN: 0.05000000074505806
-  DICT_KEY: SPASE>Support>SupportQuantity:Other
-
-default_hi_omni_attrs: &default_hi_omni
-  <<: *default
-  VAR_TYPE: data
   DISPLAY_TYPE: time_series
-  FILLVAL: 4294967294
+  FILLVAL: uint32_fillval
   FORMAT: '%f'
   LABLAXIS: Diff. Intensity
   SCALETYP: linear
@@ -106,20 +104,48 @@ default_hi_omni_attrs: &default_hi_omni
   VALIDMIN: 0
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
-default_omni_energy_attrs: &default_omni_energy
-  <<: *default_hi_omni
+hi_sectored_attrs: &hi_sectored_attrs_default
+  <<: *default
+  DISPLAY_TYPE: time_series
+  DEPEND_2: elevation_angle
+  DEPEND_3: spin_sector_index
+  FILLVAL: uint32_fillval
+  FORMAT: '%f'
+  LABLAXIS: 'Diff. # Flux'
+  UNITS: '# / cm2 s sr MeV/nuc'
+  VALIDMAX: 16777216
+  VALIDMIN: 0
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+energy_attrs: &energy_default
+  VAR_TYPE: support_data
   CATDESC: Energy Table
   LABLAXIS: MeV/nuc
   SCALETYP: log
   UNITS: MeV/nuc
+  FORMAT: '%f'
   VALIDMAX: 200.0
   VALIDMIN: 0.05000000074505806
-  VAR_TYPE: support_data
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Characteristic
 
-default_omni_energy_delta_attrs: &default_omni_energy_delta
-  <<: *default_omni_energy
+energy_delta_attrs: &energy_delta_default
+  <<: *energy_default
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Uncertainty
+
+spin_angles_attrs: &spin_angles_default
+  <<: *default
+  VAR_TYPE: support_data
+  CATDESC: Spin Angle
+  DEPEND_1: spin_sector_index
+  DEPEND_2: elevation_angle
+  FIELDNAM: Spin Angle
+  LABLAXIS: Spin Angle
+  SCALETYP: linear
+  UNITS: degrees
+  VALIDMAX: 360.0
+  VALIDMIN: 0.0
+  FORMAT: '%f'
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:ArrivalDirection,Qualifer:DirectionAngle.AzimuthAngle
 
 # <=== Coordinates ===>
 event_num:
@@ -168,8 +194,8 @@ event_num_label:
     VAR_TYPE: metadata
 
 # <=== Dataset Variable Attributes ===>
-# The following are set in multiple data products
 
+# The following are set in multiple data products
 data_quality:
     <<: *default
     CATDESC: Indicates whether data quality is suspect (1).
@@ -189,7 +215,7 @@ data_quality:
 
 # TODO: update var names to be lowercase and underscores.
 P0_APD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 APD ID
     DEPEND_1: event_num
     FIELDNAM: Priority 0 APD ID
@@ -197,7 +223,7 @@ P0_APD_ID:
     VALIDMAX: 32
 
 P0_APDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 0 APD Energy
@@ -206,7 +232,7 @@ P0_APDEnergy:
     VALIDMAX: 512
 
 P0_APDGain:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 APD Gain
     DEPEND_1: event_num
     FIELDNAM: Priority 0 APD Gain
@@ -214,7 +240,7 @@ P0_APDGain:
     VALIDMAX: 1
 
 P0_DataQuality:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Data Quality
     FIELDNAM: Priority 0 Data Quality
     LABLAXIS: " "
@@ -222,7 +248,7 @@ P0_DataQuality:
     DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 P0_EnergyStep:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Energy Step
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Energy Step
@@ -230,7 +256,7 @@ P0_EnergyStep:
     VALIDMAX: 128
 
 P0_ERGE:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Energy Range
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Energy Range
@@ -238,7 +264,7 @@ P0_ERGE:
     VALIDMAX: 4
 
 P0_MultiFlag:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Multi Flag
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Multi Flag
@@ -246,14 +272,14 @@ P0_MultiFlag:
     VALIDMAX: 1
 
 P0_NumEvents:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Number of Events
     FIELDNAM: Priority 0 Number of Events
     FILLVAL: 65535
     LABLAXIS: " "
 
 P0_PHAType:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 PHA Type
     DEPEND_1: event_num
     FIELDNAM: Priority 0 PHA Type
@@ -261,7 +287,7 @@ P0_PHAType:
     VALIDMAX: 4
 
 P0_Position:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Position
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Position
@@ -269,7 +295,7 @@ P0_Position:
     VALIDMAX: 32
 
 P0_SpinAngle:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Spin Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Spin Angle
@@ -277,7 +303,7 @@ P0_SpinAngle:
     VALIDMAX: 128
 
 P0_SpinNumber:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Spin Number
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Spin Number
@@ -285,7 +311,7 @@ P0_SpinNumber:
     VALIDMAX: 32
 
 P0_SSD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 SSD ID or Azimuth Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 0 SSD ID or Azimuth Angle
@@ -293,7 +319,7 @@ P0_SSD_ID:
     VALIDMAX: 32
 
 P0_SSDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 0 APD Energy
@@ -301,7 +327,7 @@ P0_SSDEnergy:
     VALIDMAX: 2048
 
 P0_TOF:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Time of Flight
@@ -310,7 +336,7 @@ P0_TOF:
     VALIDMAX: 1024
 
 P0_Type:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 0 Type
     DEPEND_1: event_num
     FIELDNAM: Priority 0 Type
@@ -318,7 +344,7 @@ P0_Type:
     VALIDMAX: 3
 
 P1_APD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 APD ID
     DEPEND_1: event_num
     FIELDNAM: Priority 1 APD ID
@@ -326,7 +352,7 @@ P1_APD_ID:
     VALIDMAX: 32
 
 P1_APDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 1 APD Energy
@@ -335,7 +361,7 @@ P1_APDEnergy:
     VALIDMAX: 512
 
 P1_APDGain:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 APD Gain
     DEPEND_1: event_num
     FIELDNAM: Priority 1 APD Gain
@@ -343,7 +369,7 @@ P1_APDGain:
     VALIDMAX: 1
 
 P1_DataQuality:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Data Quality
     FIELDNAM: Priority 1 Data Quality
     LABLAXIS: " "
@@ -351,7 +377,7 @@ P1_DataQuality:
     DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 P1_EnergyStep:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Energy Step
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Energy Step
@@ -359,7 +385,7 @@ P1_EnergyStep:
     VALIDMAX: 128
 
 P1_ERGE:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Energy Range
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Energy Range
@@ -367,7 +393,7 @@ P1_ERGE:
     VALIDMAX: 4
 
 P1_MultiFlag:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Multi Flag
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Multi Flag
@@ -375,14 +401,14 @@ P1_MultiFlag:
     VALIDMAX: 1
 
 P1_NumEvents:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Number of Events
     FIELDNAM: Priority 1 Number of Events
     FILLVAL: 65535
     LABLAXIS: " "
 
 P1_PHAType:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 PHA Type
     DEPEND_1: event_num
     FIELDNAM: Priority 1 PHA Type
@@ -390,7 +416,7 @@ P1_PHAType:
     VALIDMAX: 4
 
 P1_Position:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Position
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Position
@@ -398,7 +424,7 @@ P1_Position:
     VALIDMAX: 32
 
 P1_SpinAngle:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Spin Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Spin Angle
@@ -406,7 +432,7 @@ P1_SpinAngle:
     VALIDMAX: 128
 
 P1_SpinNumber:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Spin Number
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Spin Number
@@ -414,7 +440,7 @@ P1_SpinNumber:
     VALIDMAX: 32
 
 P1_SSD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 SSD ID or Azimuth Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 1 SSD ID or Azimuth Angle
@@ -422,7 +448,7 @@ P1_SSD_ID:
     VALIDMAX: 32
 
 P1_SSDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 1 APD Energy
@@ -430,7 +456,7 @@ P1_SSDEnergy:
     VALIDMAX: 2048
 
 P1_TOF:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Time of Flight
@@ -439,7 +465,7 @@ P1_TOF:
     VALIDMAX: 1024
 
 P1_Type:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 1 Type
     DEPEND_1: event_num
     FIELDNAM: Priority 1 Type
@@ -447,7 +473,7 @@ P1_Type:
     VALIDMAX: 3
 
 P2_APD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 APD ID
     DEPEND_1: event_num
     FIELDNAM: Priority 2 APD ID
@@ -455,7 +481,7 @@ P2_APD_ID:
     VALIDMAX: 32
 
 P2_APDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 2 APD Energy
@@ -464,7 +490,7 @@ P2_APDEnergy:
     VALIDMAX: 512
 
 P2_APDGain:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 APD Gain
     DEPEND_1: event_num
     FIELDNAM: Priority 2 APD Gain
@@ -472,7 +498,7 @@ P2_APDGain:
     VALIDMAX: 1
 
 P2_DataQuality:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Data Quality
     FIELDNAM: Priority 2 Data Quality
     LABLAXIS: " "
@@ -480,7 +506,7 @@ P2_DataQuality:
     DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 P2_EnergyStep:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Energy Step
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Energy Step
@@ -488,7 +514,7 @@ P2_EnergyStep:
     VALIDMAX: 128
 
 P2_ERGE:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Energy Range
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Energy Range
@@ -496,7 +522,7 @@ P2_ERGE:
     VALIDMAX: 4
 
 P2_MultiFlag:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Multi Flag
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Multi Flag
@@ -504,14 +530,14 @@ P2_MultiFlag:
     VALIDMAX: 1
 
 P2_NumEvents:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Number of Events
     FIELDNAM: Priority 2 Number of Events
     FILLVAL: 65535
     LABLAXIS: " "
 
 P2_PHAType:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 PHA Type
     DEPEND_1: event_num
     FIELDNAM: Priority 2 PHA Type
@@ -519,7 +545,7 @@ P2_PHAType:
     VALIDMAX: 4
 
 P2_Position:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Position
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Position
@@ -527,7 +553,7 @@ P2_Position:
     VALIDMAX: 32
 
 P2_SpinAngle:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Spin Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Spin Angle
@@ -535,7 +561,7 @@ P2_SpinAngle:
     VALIDMAX: 128
 
 P2_SpinNumber:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Spin Number
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Spin Number
@@ -543,7 +569,7 @@ P2_SpinNumber:
     VALIDMAX: 32
 
 P2_SSD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 SSD ID or Azimuth Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 2 SSD ID or Azimuth Angle
@@ -551,7 +577,7 @@ P2_SSD_ID:
     VALIDMAX: 32
 
 P2_SSDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 2 APD Energy
@@ -559,7 +585,7 @@ P2_SSDEnergy:
     VALIDMAX: 2048
 
 P2_TOF:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Time of Flight
@@ -568,7 +594,7 @@ P2_TOF:
     VALIDMAX: 1024
 
 P2_Type:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 2 Type
     DEPEND_1: event_num
     FIELDNAM: Priority 2 Type
@@ -576,7 +602,7 @@ P2_Type:
     VALIDMAX: 3
 
 P3_APD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 APD ID
     DEPEND_1: event_num
     FIELDNAM: Priority 3 APD ID
@@ -584,7 +610,7 @@ P3_APD_ID:
     VALIDMAX: 32
 
 P3_APDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 3 APD Energy
@@ -593,7 +619,7 @@ P3_APDEnergy:
     VALIDMAX: 512
 
 P3_APDGain:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 APD Gain
     DEPEND_1: event_num
     FIELDNAM: Priority 3 APD Gain
@@ -601,7 +627,7 @@ P3_APDGain:
     VALIDMAX: 1
 
 P3_DataQuality:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Data Quality
     FIELDNAM: Priority 3 Data Quality
     LABLAXIS: " "
@@ -609,7 +635,7 @@ P3_DataQuality:
     DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 P3_EnergyStep:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Energy Step
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Energy Step
@@ -617,7 +643,7 @@ P3_EnergyStep:
     VALIDMAX: 128
 
 P3_ERGE:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Energy Range
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Energy Range
@@ -625,7 +651,7 @@ P3_ERGE:
     VALIDMAX: 4
 
 P3_MultiFlag:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Multi Flag
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Multi Flag
@@ -633,14 +659,14 @@ P3_MultiFlag:
     VALIDMAX: 1
 
 P3_NumEvents:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Number of Events
     FIELDNAM: Priority 3 Number of Events
     FILLVAL: 65535
     LABLAXIS: " "
 
 P3_PHAType:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 PHA Type
     DEPEND_1: event_num
     FIELDNAM: Priority 3 PHA Type
@@ -648,7 +674,7 @@ P3_PHAType:
     VALIDMAX: 4
 
 P3_Position:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Position
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Position
@@ -656,7 +682,7 @@ P3_Position:
     VALIDMAX: 32
 
 P3_SpinAngle:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Spin Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Spin Angle
@@ -664,7 +690,7 @@ P3_SpinAngle:
     VALIDMAX: 128
 
 P3_SpinNumber:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Spin Number
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Spin Number
@@ -672,7 +698,7 @@ P3_SpinNumber:
     VALIDMAX: 32
 
 P3_SSD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 SSD ID or Azimuth Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 3 SSD ID or Azimuth Angle
@@ -680,7 +706,7 @@ P3_SSD_ID:
     VALIDMAX: 32
 
 P3_SSDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 3 APD Energy
@@ -688,7 +714,7 @@ P3_SSDEnergy:
     VALIDMAX: 2048
 
 P3_TOF:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Time of Flight
@@ -697,7 +723,7 @@ P3_TOF:
     VALIDMAX: 1024
 
 P3_Type:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 3 Type
     DEPEND_1: event_num
     FIELDNAM: Priority 3 Type
@@ -705,7 +731,7 @@ P3_Type:
     VALIDMAX: 3
 
 P4_APD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 APD ID
     DEPEND_1: event_num
     FIELDNAM: Priority 4 APD ID
@@ -713,7 +739,7 @@ P4_APD_ID:
     VALIDMAX: 32
 
 P4_APDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 4 APD Energy
@@ -722,7 +748,7 @@ P4_APDEnergy:
     VALIDMAX: 512
 
 P4_APDGain:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 APD Gain
     DEPEND_1: event_num
     FIELDNAM: Priority 4 APD Gain
@@ -730,7 +756,7 @@ P4_APDGain:
     VALIDMAX: 1
 
 P4_DataQuality:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Data Quality
     FIELDNAM: Priority 4 Data Quality
     LABLAXIS: " "
@@ -738,7 +764,7 @@ P4_DataQuality:
     DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 P4_EnergyStep:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Energy Step
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Energy Step
@@ -746,7 +772,7 @@ P4_EnergyStep:
     VALIDMAX: 128
 
 P4_ERGE:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Energy Range
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Energy Range
@@ -754,7 +780,7 @@ P4_ERGE:
     VALIDMAX: 4
 
 P4_MultiFlag:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Multi Flag
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Multi Flag
@@ -762,14 +788,14 @@ P4_MultiFlag:
     VALIDMAX: 1
 
 P4_NumEvents:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Number of Events
     FIELDNAM: Priority 4 Number of Events
     FILLVAL: 65535
     LABLAXIS: " "
 
 P4_PHAType:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 PHA Type
     DEPEND_1: event_num
     FIELDNAM: Priority 4 PHA Type
@@ -777,7 +803,7 @@ P4_PHAType:
     VALIDMAX: 4
 
 P4_Position:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Position
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Position
@@ -785,7 +811,7 @@ P4_Position:
     VALIDMAX: 32
 
 P4_SpinAngle:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Spin Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Spin Angle
@@ -793,7 +819,7 @@ P4_SpinAngle:
     VALIDMAX: 128
 
 P4_SpinNumber:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Spin Number
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Spin Number
@@ -801,7 +827,7 @@ P4_SpinNumber:
     VALIDMAX: 32
 
 P4_SSD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 SSD ID or Azimuth Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 4 SSD ID or Azimuth Angle
@@ -809,7 +835,7 @@ P4_SSD_ID:
     VALIDMAX: 32
 
 P4_SSDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 4 APD Energy
@@ -817,7 +843,7 @@ P4_SSDEnergy:
     VALIDMAX: 2048
 
 P4_TOF:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Time of Flight
@@ -826,7 +852,7 @@ P4_TOF:
     VALIDMAX: 1024
 
 P4_Type:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 4 Type
     DEPEND_1: event_num
     FIELDNAM: Priority 4 Type
@@ -834,7 +860,7 @@ P4_Type:
     VALIDMAX: 3
 
 P5_APD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 APD ID
     DEPEND_1: event_num
     FIELDNAM: Priority 5 APD ID
@@ -842,7 +868,7 @@ P5_APD_ID:
     VALIDMAX: 32
 
 P5_APDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 5 APD Energy
@@ -851,7 +877,7 @@ P5_APDEnergy:
     VALIDMAX: 512
 
 P5_APDGain:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 APD Gain
     DEPEND_1: event_num
     FIELDNAM: Priority 5 APD Gain
@@ -859,7 +885,7 @@ P5_APDGain:
     VALIDMAX: 1
 
 P5_DataQuality:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Data Quality
     FIELDNAM: Priority 5 Data Quality
     LABLAXIS: " "
@@ -867,7 +893,7 @@ P5_DataQuality:
     DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 P5_EnergyStep:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Energy Step
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Energy Step
@@ -875,7 +901,7 @@ P5_EnergyStep:
     VALIDMAX: 128
 
 P5_ERGE:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Energy Range
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Energy Range
@@ -883,7 +909,7 @@ P5_ERGE:
     VALIDMAX: 4
 
 P5_MultiFlag:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Multi Flag
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Multi Flag
@@ -891,14 +917,14 @@ P5_MultiFlag:
     VALIDMAX: 1
 
 P5_NumEvents:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Number of Events
     FIELDNAM: Priority 5 Number of Events
     FILLVAL: 65535
     LABLAXIS: " "
 
 P5_PHAType:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 PHA Type
     DEPEND_1: event_num
     FIELDNAM: Priority 5 PHA Type
@@ -906,7 +932,7 @@ P5_PHAType:
     VALIDMAX: 4
 
 P5_Position:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Position
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Position
@@ -914,7 +940,7 @@ P5_Position:
     VALIDMAX: 32
 
 P5_SpinAngle:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Spin Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Spin Angle
@@ -922,7 +948,7 @@ P5_SpinAngle:
     VALIDMAX: 128
 
 P5_SpinNumber:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Spin Number
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Spin Number
@@ -930,7 +956,7 @@ P5_SpinNumber:
     VALIDMAX: 32
 
 P5_SSD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 SSD ID or Azimuth Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 5 SSD ID or Azimuth Angle
@@ -938,7 +964,7 @@ P5_SSD_ID:
     VALIDMAX: 32
 
 P5_SSDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 5 APD Energy
@@ -946,7 +972,7 @@ P5_SSDEnergy:
     VALIDMAX: 2048
 
 P5_TOF:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Time of Flight
@@ -955,7 +981,7 @@ P5_TOF:
     VALIDMAX: 1024
 
 P5_Type:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 5 Type
     DEPEND_1: event_num
     FIELDNAM: Priority 5 Type
@@ -963,7 +989,7 @@ P5_Type:
     VALIDMAX: 3
 
 P6_APD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 APD ID
     DEPEND_1: event_num
     FIELDNAM: Priority 6 APD ID
@@ -971,7 +997,7 @@ P6_APD_ID:
     VALIDMAX: 32
 
 P6_APDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 6 APD Energy
@@ -980,7 +1006,7 @@ P6_APDEnergy:
     VALIDMAX: 512
 
 P6_APDGain:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 APD Gain
     DEPEND_1: event_num
     FIELDNAM: Priority 6 APD Gain
@@ -988,7 +1014,7 @@ P6_APDGain:
     VALIDMAX: 1
 
 P6_DataQuality:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 Data Quality
     FIELDNAM: Priority 6 Data Quality
     LABLAXIS: " "
@@ -996,7 +1022,7 @@ P6_DataQuality:
     DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 P6_EnergyStep:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 Energy Step
     DEPEND_1: event_num
     FIELDNAM: Priority 6 Energy Step
@@ -1004,7 +1030,7 @@ P6_EnergyStep:
     VALIDMAX: 128
 
 P6_MultiFlag:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 Multi Flag
     DEPEND_1: event_num
     FIELDNAM: Priority 6 Multi Flag
@@ -1012,14 +1038,14 @@ P6_MultiFlag:
     VALIDMAX: 1
 
 P6_NumEvents:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 Number of Events
     FIELDNAM: Priority 6 Number of Events
     FILLVAL: 65535
     LABLAXIS: " "
 
 P6_PHAType:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 PHA Type
     DEPEND_1: event_num
     FIELDNAM: Priority 6 PHA Type
@@ -1027,7 +1053,7 @@ P6_PHAType:
     VALIDMAX: 4
 
 P6_Position:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 Position
     DEPEND_1: event_num
     FIELDNAM: Priority 6 Position
@@ -1035,7 +1061,7 @@ P6_Position:
     VALIDMAX: 32
 
 P6_SpinAngle:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 Spin Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 6 Spin Angle
@@ -1043,7 +1069,7 @@ P6_SpinAngle:
     VALIDMAX: 128
 
 P6_TOF:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 6 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 6 Time of Flight
@@ -1052,7 +1078,7 @@ P6_TOF:
     VALIDMAX: 1024
 
 P7_APD_ID:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 APD ID
     DEPEND_1: event_num
     FIELDNAM: Priority 7 APD ID
@@ -1060,7 +1086,7 @@ P7_APD_ID:
     VALIDMAX: 32
 
 P7_APDEnergy:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 APD Energy
     DEPEND_1: event_num
     FIELDNAM: Priority 7 APD Energy
@@ -1069,7 +1095,7 @@ P7_APDEnergy:
     VALIDMAX: 512
 
 P7_APDGain:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 APD Gain
     DEPEND_1: event_num
     FIELDNAM: Priority 7 APD Gain
@@ -1077,7 +1103,7 @@ P7_APDGain:
     VALIDMAX: 1
 
 P7_DataQuality:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 Data Quality
     FIELDNAM: Priority 7 Data Quality
     LABLAXIS: " "
@@ -1085,7 +1111,7 @@ P7_DataQuality:
     DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
 
 P7_EnergyStep:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 Energy Step
     DEPEND_1: event_num
     FIELDNAM: Priority 7 Energy Step
@@ -1093,7 +1119,7 @@ P7_EnergyStep:
     VALIDMAX: 128
 
 P7_MultiFlag:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 Multi Flag
     DEPEND_1: event_num
     FIELDNAM: Priority 7 Multi Flag
@@ -1101,14 +1127,14 @@ P7_MultiFlag:
     VALIDMAX: 1
 
 P7_NumEvents:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 Number of Events
     FIELDNAM: Priority 7 Number of Events
     FILLVAL: 65535
     LABLAXIS: " "
 
 P7_PHAType:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 PHA Type
     DEPEND_1: event_num
     FIELDNAM: Priority 7 PHA Type
@@ -1116,7 +1142,7 @@ P7_PHAType:
     VALIDMAX: 4
 
 P7_Position:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 Position
     DEPEND_1: event_num
     FIELDNAM: Priority 7 Position
@@ -1124,7 +1150,7 @@ P7_Position:
     VALIDMAX: 32
 
 P7_SpinAngle:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 Spin Angle
     DEPEND_1: event_num
     FIELDNAM: Priority 7 Spin Angle
@@ -1132,7 +1158,7 @@ P7_SpinAngle:
     VALIDMAX: 128
 
 P7_TOF:
-    <<: *direct_events
+    <<: *direct_events_default
     CATDESC: Priority 7 Time of Flight
     DEPEND_1: event_num
     FIELDNAM: Priority 7 Time of Flight
@@ -1142,146 +1168,145 @@ P7_TOF:
 
 
 # lo-sw-species Attributes
-
 lo-sw-species-cnoplus:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - CNO+ (PUI)
   FIELDNAM: Counts - SW - CNO+ (PUI)
 
 lo-sw-species-cplus4:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - C+4
   FIELDNAM: Counts - SW - C+4
 
 lo-sw-species-cplus5:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - C+5
   FIELDNAM: Counts - SW - C+5
 
 lo-sw-species-cplus6:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - C+6
   FIELDNAM: Counts - SW - C+6
 
 lo-sw-species-fe_hiq:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - Fe highQ
   FIELDNAM: Counts - SW - Fe highQ
 
 lo-sw-species-fe_loq:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - Fe lowQ
   FIELDNAM: Counts - SW - Fe lowQ
 
 lo-sw-species-heplus:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - He+ (PUI)
   FIELDNAM: Counts - SW - He+ (PUI)
 
 lo-sw-species-heplusplus:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - He++
   FIELDNAM: Counts - SW - He++
 
 lo-sw-species-hplus:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - H+
   FIELDNAM: Counts - SW - H+
 
 lo-sw-species-mg:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - Mg
   FIELDNAM: Counts - SW - Mg
 
 lo-sw-species-ne:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - Ne
   FIELDNAM: Counts - SW - Ne
 
 lo-sw-species-oplus5:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - O+5
   FIELDNAM: Counts - SW - O+5
 
 lo-sw-species-oplus6:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - O+6
   FIELDNAM: Counts - SW - O+6
 
 lo-sw-species-oplus7:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - O+7
   FIELDNAM: Counts - SW - O+7
 
 lo-sw-species-oplus8:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - O+8
   FIELDNAM: Counts - SW - O+8
 
 lo-sw-species-si:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - SW - Si
   FIELDNAM: Counts - SW - Si
 
 # lo-sw-angular Attributes
 lo-sw-angular-fe_loq:
-  <<: *default_lo_angular
+  <<: *lo_angular_default
   CATDESC: Counts - SW - Fe lowQ
   FIELDNAM: Sunward Facing Counts - SW - Fe lowQ
 
 lo-sw-angular-heplusplus:
-  <<: *default_lo_angular
+  <<: *lo_angular_default
   CATDESC: Counts - SW - He++
   FIELDNAM: Sunward Facing Counts - SW - He++
 
 lo-sw-angular-hplus:
-  <<: *default_lo_angular
+  <<: *lo_angular_default
   CATDESC: Counts - SW - H+
   FIELDNAM: Sunward Facing Counts - SW - H+
 
 lo-sw-angular-oplus6:
-  <<: *default_lo_angular
+  <<: *lo_angular_default
   CATDESC: Counts - SW - O+6
   FIELDNAM: Sunward Facing Counts - SW - O+6
 
 # lo-nsw-species Attributes
 lo-nsw-species-c:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - NSW - C
   FIELDNAM: Counts - NSW - C
 
 lo-nsw-species-cnoplus:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - NSW - CNO+
   FIELDNAM: Counts - NSW - CNO+
 
 lo-nsw-species-fe:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - NSW - Fe
   FIELDNAM: Counts - NSW - Fe
 
 lo-nsw-species-heplus:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - NSW - He+
   FIELDNAM: Counts - NSW - He+
 
 lo-nsw-species-heplusplus:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - NSW - He++
   FIELDNAM: Counts - NSW - He++
 
 lo-nsw-species-hplus:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - NSW - H+
   FIELDNAM: Counts - NSW - H+
 
 lo-nsw-species-ne_si_mg:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - NSW - Ne_Si_Mg
   FIELDNAM: Counts - NSW - Ne_Si_Mg
 
 lo-nsw-species-o:
-  <<: *default_lo_species
+  <<: *lo_species_default
   CATDESC: Counts - NSW - O
   FIELDNAM: Counts - NSW - O
 
@@ -1292,209 +1317,282 @@ lo-nsw-angular-heplusplus:
 
 # lo-ialirt Attributes
 lo-ialirt-c_over_o_abundance_ratio:
-  <<: *default_lo_ialirt
+  <<: *lo_ialirt_default
   CATDESC: Elemental Abundance Ratio - C/O
   FIELDNAM: C/O
 
 lo-ialirt-c_plus_6_over_c_plus_5_ratio:
-  <<: *default_lo_ialirt
+  <<: *lo_ialirt_default
   CATDESC: Charge State Ratio - C+6/C+5
   FIELDNAM: C+6/C+5
 
 lo-ialirt-fe_low_over_fe_high_ratio:
-  <<: *default_lo_ialirt
+  <<: *lo_ialirt_default
   CATDESC: Charge State Ratio - Fe(low)/Fe(high)
   FIELDNAM: Fe(low)/Fe(high)
 
 lo-ialirt-fe_over_o_abundance_ratio:
-  <<: *default_lo_ialirt
+  <<: *lo_ialirt_default
   CATDESC: Elemental Abundance Ratio - Fe/O
   FIELDNAM: Fe/O
 
 lo-ialirt-mg_over_o_abundance_ratio:
-  <<: *default_lo_ialirt
+  <<: *lo_ialirt_default
   CATDESC: Elemental Abundance Ratio - Mg/O
   FIELDNAM: Mg/O
 
 lo-ialirt-o_plus_7_over_o_plus_6_ratio:
-  <<: *default_lo_ialirt
+  <<: *lo_ialirt_default
   CATDESC: Charge State Ratio - O+7/O+6
   FIELDNAM: O+7/O+6
 
 # hi-ialirt Attributes
 hi-ialirt-energy_h_minus:
-  <<: *default_hi_ialirt
+  <<: *energy_delta_default
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
-  LABLAXIS: MeV/nuc
 
 hi-ialirt-energy_h_plus:
-  <<: *default_hi_ialirt
+  <<: *energy_delta_default
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
-  LABLAXIS: MeV/nuc
 
 hi-ialirt-h:
-  <<: *default_hi_ialirt
+  <<: *default
   CATDESC: h (x2 spacing)
-  DEPEND_0: epoch
+  FIELDNAM: h
   DEPEND_1: energy_h
   DEPEND_2: ssd_index
   DEPEND_3: spin_sector_index
   DISPLAY_TYPE: time_series
-  FIELDNAM: h
   FILLVAL: 4294967294
   LABLAXIS: Diff. Intensity
-  SCALETYP: linear
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 16777216
   VALIDMIN: 0
-  VAR_TYPE: data
 
 hi-ialirt-spin_angles:
-  <<: *default_hi_ialirt
-  CATDESC: Spin Angle
-  DEPEND_1: spin_sector_index
-  DEPEND_2: elevation_angle
-  FIELDNAM: Spin Angle
-  LABLAXIS: Spin Angle
-  SCALETYP: linear
-  UNITS: degrees
-  VALIDMAX: 360.0
-  VALIDMIN: 0.0
+  <<: *spin_angles_default
 
 # hi-omni Attributes
+hi-omni-energy_c_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_c_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_fe_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_fe_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_h_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_h_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_he3_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_he3_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_he4_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_he4_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_junk_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_junk_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_ne_mg_si_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_ne_mg_si_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_o_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_o_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_uh_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_uh_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
 hi-omni-c:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: c (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_c
   FIELDNAM: c
 
-hi-omni-energy_c_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_c_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
-hi-omni-energy_fe_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_fe_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
-hi-omni-energy_h_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_h_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
-hi-omni-energy_he3_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_he3_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
-hi-omni-energy_he4_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_he4_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
-hi-omni-energy_junk_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_junk_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
-hi-omni-energy_ne_mg_si_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_ne_mg_si_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
-hi-omni-energy_o_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_o_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
-hi-omni-energy_uh_minus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta minus
-
-hi-omni-energy_uh_plus:
-  <<: *default_omni_energy_delta
-  FIELDNAM: energy delta plus
-
 hi-omni-fe:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: fe (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_fe
   FIELDNAM: fe
 
 hi-omni-h:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: h (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_h
   FIELDNAM: h
 
 hi-omni-he3:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: he3 (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_he3
   FIELDNAM: he3
 
 hi-omni-he4:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: he4 (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_he4
   FIELDNAM: he4
 
 hi-omni-junk:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: junk (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_junk
   FIELDNAM: junk
 
 hi-omni-ne_mg_si:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: ne-mg-si (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_ne_mg_si
   FIELDNAM: ne-mg-si
 
 hi-omni-o:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: o (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_o
   FIELDNAM: o
 
 hi-omni-uh:
-  <<: *default_hi_omni
+  <<: *hi_omni_default
   CATDESC: uh (Root 2 spacing)
   DEPEND_0: epoch
   DEPEND_1: energy_uh
   FIELDNAM: uh
+
+# hi-sectored Attributes
+hi-sectored-cno:
+  <<: *hi_sectored_attrs_default
+  CATDESC: cno (x2 spacing)
+  FIELDNAM: cno
+  DEPEND_1: energy_cno
+
+hi-sectored-fe:
+  <<: *hi_sectored_attrs_default
+  CATDESC: fe (x2 spacing)
+  FIELDNAM: fe
+  DEPEND_1: energy_fe
+
+hi-sectored-h:
+  <<: *hi_sectored_attrs_default
+  CATDESC: h (x2 spacing)
+  FIELDNAM: h
+  DEPEND_1: energy_h
+
+hi-sectored-he3he4:
+  <<: *hi_sectored_attrs_default
+  CATDESC: he3he4 (x2 spacing)
+  FIELDNAM: he3he4
+  DEPEND_1: energy_he3he4
+
+hi-sectored-energy_cno_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-sectored-energy_cno_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-sectored-energy_fe_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-sectored-energy_fe_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-sectored-energy_h_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-sectored-energy_h_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-sectored-energy_he3he4_minus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Minus value
+  FIELDNAM: energy delta minus
+
+hi-sectored-energy_he3he4_plus:
+  <<: *energy_delta_default
+  CATDESC: Energy Table Plus value
+  FIELDNAM: energy delta plus
+
+hi-sectored-spin_angles:
+  <<: *spin_angles_default
+

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -69,9 +69,10 @@ lo_species_attrs: &lo_species_default
   FORMAT: '%f'
   SCALETYP: log
   UNITS: particles / cm2 s sr keV/q
+  FILLVAL: *real_fillval
   VALIDMAX: 10000000000.0
   VALIDMIN: 1.000000013351432e-10
-  DICT_KEY: SPASE>Support>SupportQuantity:Other
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 lo_angular_attrs: &lo_angular_default
   <<: *default
@@ -85,6 +86,7 @@ lo_angular_attrs: &lo_angular_default
   FORMAT: '%f'
   SCALETYP: log
   UNITS: particles / cm2 s sr keV/q
+  FILLVAL: *real_fillval
   VALIDMAX: 10000000000.0
   VALIDMIN: 1.000000013351432e-10
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
@@ -92,13 +94,13 @@ lo_angular_attrs: &lo_angular_default
 hi_omni_attrs: &hi_omni_default
   <<: *default
   DISPLAY_TYPE: time_series
-  FILLVAL: *uint32_fillval
   FORMAT: '%f'
   LABLAXIS: Diff. Intensity
   SCALETYP: linear
   UNITS: '# / cm2 s sr MeV/nuc'
+  FILLVAL: *real_fillval
   VALIDMAX: 16777216.0
-  VALIDMIN: 0
+  VALIDMIN: 0.0
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 hi_sectored_attrs: &hi_sectored_attrs_default
@@ -117,12 +119,13 @@ hi_sectored_attrs: &hi_sectored_attrs_default
 
 energy_attrs: &energy_default
   VAR_TYPE: support_data
-  CATDESC: Geometric Mean of the Energy
+  CATDESC: Geometric mean energy per nucleon
   FIELDNAM: Energy Table
   LABLAXIS: Energy
   SCALETYP: log
   UNITS: MeV/nuc
   FORMAT: '%f'
+  FILLVAL: *real_fillval
   VALIDMAX: 200.0
   VALIDMIN: 0.05000000074505806
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Characteristic
@@ -137,7 +140,7 @@ spin_angles_attrs: &spin_angles_default
   FIELDNAM: Spin Angle
   SCALETYP: linear
   UNITS: degrees
-  FILLVAL: *int_fillval
+  FILLVAL: *real_fillval
   VALIDMAX: 360.0
   VALIDMIN: 0.0
   FORMAT: '%f'

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -6,9 +6,13 @@ max_int: &max_int 9223372036854775807
 # TODO:
 #  -update fillval, validmin and validmax for floats (look at l1a yaml)
 #  -add DICT_KEY where applicable
-#  -Update default_attrs as needed (i.e. format)
+#  -Update default_attrs where needed (i.e. format)
 #  -Update format to use Fortran values
 #  -Add coordinate attributes
+#  -Add LABLAXIS or LABL_PTR_1 where applicable
+#  -Add energy defaults
+#  -Add energy delta defaults
+#  -Should energy delta vars have DEPEND_1: energy_XX to point to energy it's a delta of?
 
 
 # <=== Defaults ===>
@@ -80,6 +84,7 @@ default_lo_ialirt_attrs: &default_lo_ialirt
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 default_hi_ialirt_attrs: &default_hi_ialirt
+  <<: *default
   VAR_TYPE: support_data
   FORMAT: '%f'
   SCALETYP: log
@@ -87,6 +92,34 @@ default_hi_ialirt_attrs: &default_hi_ialirt
   VALIDMAX: 200.0
   VALIDMIN: 0.05000000074505806
   DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+default_hi_omni_attrs: &default_hi_omni
+  <<: *default
+  VAR_TYPE: data
+  DISPLAY_TYPE: time_series
+  FILLVAL: 4294967294
+  FORMAT: '%f'
+  LABLAXIS: Diff. Intensity
+  SCALETYP: linear
+  UNITS: '# / cm2 s sr MeV/nuc'
+  VALIDMAX: 16777216.0
+  VALIDMIN: 0
+  DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+default_omni_energy_attrs: &default_omni_energy
+  <<: *default_hi_omni
+  CATDESC: Energy Table
+  LABLAXIS: MeV/nuc
+  SCALETYP: log
+  UNITS: MeV/nuc
+  VALIDMAX: 200.0
+  VALIDMIN: 0.05000000074505806
+  VAR_TYPE: support_data
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Characteristic
+
+default_omni_energy_delta_attrs: &default_omni_energy_delta
+  <<: *default_omni_energy
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Uncertainty
 
 # <=== Coordinates ===>
 event_num:
@@ -1258,50 +1291,50 @@ lo-nsw-angular-heplusplus:
   FIELDNAM: Non-Sunward Facing Counts - NSW - He++
 
 # lo-ialirt Attributes
-c_over_o_abundance_ratio:
+lo-ialirt-c_over_o_abundance_ratio:
   <<: *default_lo_ialirt
   CATDESC: Elemental Abundance Ratio - C/O
   FIELDNAM: C/O
 
-c_plus_6_over_c_plus_5_ratio:
+lo-ialirt-c_plus_6_over_c_plus_5_ratio:
   <<: *default_lo_ialirt
   CATDESC: Charge State Ratio - C+6/C+5
   FIELDNAM: C+6/C+5
 
-fe_low_over_fe_high_ratio:
+lo-ialirt-fe_low_over_fe_high_ratio:
   <<: *default_lo_ialirt
   CATDESC: Charge State Ratio - Fe(low)/Fe(high)
   FIELDNAM: Fe(low)/Fe(high)
 
-fe_over_o_abundance_ratio:
+lo-ialirt-fe_over_o_abundance_ratio:
   <<: *default_lo_ialirt
   CATDESC: Elemental Abundance Ratio - Fe/O
   FIELDNAM: Fe/O
 
-mg_over_o_abundance_ratio:
+lo-ialirt-mg_over_o_abundance_ratio:
   <<: *default_lo_ialirt
   CATDESC: Elemental Abundance Ratio - Mg/O
   FIELDNAM: Mg/O
 
-o_plus_7_over_o_plus_6_ratio:
+lo-ialirt-o_plus_7_over_o_plus_6_ratio:
   <<: *default_lo_ialirt
   CATDESC: Charge State Ratio - O+7/O+6
   FIELDNAM: O+7/O+6
 
 # hi-ialirt Attributes
-energy_h_minus:
+hi-ialirt-energy_h_minus:
   <<: *default_hi_ialirt
   CATDESC: Energy Table Minus value
   FIELDNAM: energy delta minus
   LABLAXIS: MeV/nuc
 
-energy_h_plus:
+hi-ialirt-energy_h_plus:
   <<: *default_hi_ialirt
   CATDESC: Energy Table Plus value
   FIELDNAM: energy delta plus
   LABLAXIS: MeV/nuc
 
-h:
+hi-ialirt-h:
   <<: *default_hi_ialirt
   CATDESC: h (x2 spacing)
   DEPEND_0: epoch
@@ -1318,7 +1351,7 @@ h:
   VALIDMIN: 0
   VAR_TYPE: data
 
-spin_angles:
+hi-ialirt-spin_angles:
   <<: *default_hi_ialirt
   CATDESC: Spin Angle
   DEPEND_1: spin_sector_index
@@ -1329,3 +1362,139 @@ spin_angles:
   UNITS: degrees
   VALIDMAX: 360.0
   VALIDMIN: 0.0
+
+# hi-omni Attributes
+hi-omni-c:
+  <<: *default_hi_omni
+  CATDESC: c (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_c
+  FIELDNAM: c
+
+hi-omni-energy_c_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_c_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_fe_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_fe_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_h_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_h_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_he3_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_he3_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_he4_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_he4_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_junk_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_junk_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_ne_mg_si_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_ne_mg_si_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_o_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_o_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-energy_uh_minus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta minus
+
+hi-omni-energy_uh_plus:
+  <<: *default_omni_energy_delta
+  FIELDNAM: energy delta plus
+
+hi-omni-fe:
+  <<: *default_hi_omni
+  CATDESC: fe (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_fe
+  FIELDNAM: fe
+
+hi-omni-h:
+  <<: *default_hi_omni
+  CATDESC: h (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_h
+  FIELDNAM: h
+
+hi-omni-he3:
+  <<: *default_hi_omni
+  CATDESC: he3 (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_he3
+  FIELDNAM: he3
+
+hi-omni-he4:
+  <<: *default_hi_omni
+  CATDESC: he4 (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_he4
+  FIELDNAM: he4
+
+hi-omni-junk:
+  <<: *default_hi_omni
+  CATDESC: junk (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_junk
+  FIELDNAM: junk
+
+hi-omni-ne_mg_si:
+  <<: *default_hi_omni
+  CATDESC: ne-mg-si (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_ne_mg_si
+  FIELDNAM: ne-mg-si
+
+hi-omni-o:
+  <<: *default_hi_omni
+  CATDESC: o (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_o
+  FIELDNAM: o
+
+hi-omni-uh:
+  <<: *default_hi_omni
+  CATDESC: uh (Root 2 spacing)
+  DEPEND_0: epoch
+  DEPEND_1: energy_uh
+  FIELDNAM: uh

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -36,7 +36,7 @@ direct_events_attrs: &direct_events
     VALIDMAX: 10000
     DICT_KEY: SPASE>Support>SupportQuantity:Other
 
-default_lo_sw_species_attrs: &default_lo_sw_species
+default_lo_species_attrs: &default_lo_species
   <<: *default
   VAR_TYPE: data
   DEPEND_1: energy_table
@@ -50,6 +50,7 @@ default_lo_sw_species_attrs: &default_lo_sw_species
   VALIDMIN: 1.000000013351432e-10
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
+
 default_lo_sw_angular_attrs: &default_lo_sw_angular
   <<: *default
   DEPEND_1: energy_table
@@ -58,6 +59,20 @@ default_lo_sw_angular_attrs: &default_lo_sw_angular
   DISPLAY_TYPE: time_series
   FORMAT: '%f'
   LABLAXIS: 'Diff. # Flux'
+  SCALETYP: log
+  UNITS: particles / cm2 s sr keV/q
+  VALIDMAX: 10000000000.0
+  VALIDMIN: 1.000000013351432e-10
+  VAR_TYPE: data
+
+default_lo_nsw_species_attrs: &default_lo_nsw_species_attrs
+  DEPEND_0: epoch
+  DEPEND_1: energy_table
+  DEPEND_2: spin_sector_index
+  DISPLAY_TYPE: time_series
+  FILLVAL: .nan
+  FORMAT: '%f'
+  LABLAXIS: Diff. Intensity
   SCALETYP: log
   UNITS: particles / cm2 s sr keV/q
   VALIDMAX: 10000000000.0
@@ -1087,82 +1102,82 @@ P7_TOF:
 # lo-sw-species Attributes
 
 lo-sw-species-cnoplus:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - CNO+ (PUI)
   FIELDNAM: Counts - SW - CNO+ (PUI)
 
 lo-sw-species-cplus4:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - C+4
   FIELDNAM: Counts - SW - C+4
 
 lo-sw-species-cplus5:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - C+5
   FIELDNAM: Counts - SW - C+5
 
 lo-sw-species-cplus6:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - C+6
   FIELDNAM: Counts - SW - C+6
 
 lo-sw-species-fe_hiq:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - Fe highQ
   FIELDNAM: Counts - SW - Fe highQ
 
 lo-sw-species-fe_loq:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - Fe lowQ
   FIELDNAM: Counts - SW - Fe lowQ
 
 lo-sw-species-heplus:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - He+ (PUI)
   FIELDNAM: Counts - SW - He+ (PUI)
 
 lo-sw-species-heplusplus:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - He++
   FIELDNAM: Counts - SW - He++
 
 lo-sw-species-hplus:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - H+
   FIELDNAM: Counts - SW - H+
 
 lo-sw-species-mg:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - Mg
   FIELDNAM: Counts - SW - Mg
 
 lo-sw-species-ne:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - Ne
   FIELDNAM: Counts - SW - Ne
 
 lo-sw-species-oplus5:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - O+5
   FIELDNAM: Counts - SW - O+5
 
 lo-sw-species-oplus6:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - O+6
   FIELDNAM: Counts - SW - O+6
 
 lo-sw-species-oplus7:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - O+7
   FIELDNAM: Counts - SW - O+7
 
 lo-sw-species-oplus8:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - O+8
   FIELDNAM: Counts - SW - O+8
 
 lo-sw-species-si:
-  <<: *default_lo_sw_species
+  <<: *default_lo_species
   CATDESC: Counts - SW - Si
   FIELDNAM: Counts - SW - Si
 
@@ -1186,3 +1201,44 @@ lo-sw-angular-oplus6:
   <<: *default_lo_sw_angular
   CATDESC: Counts - SW - O+6
   FIELDNAM: Sunward Facing Counts - SW - O+6
+
+# lo-nsw-species Attributes
+lo-nsw-species-c:
+  <<: *default_lo_nsw_species_attrs
+  CATDESC: Counts - NSW - C
+  FIELDNAM: Counts - NSW - C
+
+lo-nsw-species-cnoplus:
+  <<: *default_lo_nsw_species_attrs
+  CATDESC: Counts - NSW - CNO+
+  FIELDNAM: Counts - NSW - CNO+
+
+lo-nsw-species-fe:
+  <<: *default_lo_nsw_species_attrs
+  CATDESC: Counts - NSW - Fe
+  FIELDNAM: Counts - NSW - Fe
+
+lo-nsw-species-heplus:
+  <<: *default_lo_nsw_species_attrs
+  CATDESC: Counts - NSW - He+
+  FIELDNAM: Counts - NSW - He+
+
+lo-nsw-species-heplusplus:
+  <<: *default_lo_nsw_species_attrs
+  CATDESC: Counts - NSW - He++
+  FIELDNAM: Counts - NSW - He++
+
+lo-nsw-species-hplus:
+  <<: *default_lo_nsw_species_attrs
+  CATDESC: Counts - NSW - H+
+  FIELDNAM: Counts - NSW - H+
+
+lo-nsw-species-ne_si_mg:
+  <<: *default_lo_nsw_species_attrs
+  CATDESC: Counts - NSW - Ne_Si_Mg
+  FIELDNAM: Counts - NSW - Ne_Si_Mg
+
+lo-nsw-species-o:
+  <<: *default_lo_nsw_species_attrs
+  CATDESC: Counts - NSW - O
+  FIELDNAM: Counts - NSW - O

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -3,6 +3,14 @@ int_fillval: &int_fillval -9223372036854775808
 min_int: &min_int -9223372036854775808
 max_int: &max_int 9223372036854775807
 
+# TODO:
+#  -update fillval, validmin and validmax for floats (look at l1a yaml)
+#  -add DICT_KEY where applicable
+#  -Update default_attrs as needed (i.e. format)
+#  -Update format to use Fortran values
+#  -Add coordinate attributes
+
+
 # <=== Defaults ===>
 default_attrs: &default
     DEPEND_0: epoch
@@ -16,13 +24,24 @@ default_attrs: &default
     VALIDMAX: *max_int
     VAR_TYPE: data
 
+direct_events_attrs: &direct_events
+    <<: *default
+    CATDESC: Fill in at creation
+    DISPLAY_TYPE: time_series
+    FIELDNAM: Fill in at creation
+    FILLVAL: 255
+    FORMAT: I5
+    UNITS: unitless
+    VALIDMIN: 0
+    VALIDMAX: 10000
+    DICT_KEY: SPASE>Support>SupportQuantity:Other
+
 default_lo_sw_species_attrs: &default_lo_sw_species
   <<: *default
   VAR_TYPE: data
   DEPEND_1: energy_table
   DEPEND_2: spin_sector_index
   DISPLAY_TYPE: time_series
-  FILLVAL: .nan
   FORMAT: '%f'
   LABLAXIS: Diff. Intensity
   SCALETYP: log
@@ -30,6 +49,20 @@ default_lo_sw_species_attrs: &default_lo_sw_species
   VALIDMAX: 10000000000.0
   VALIDMIN: 1.000000013351432e-10
   DICT_KEY: SPASE>Support>SupportQuantity:Other
+
+default_lo_sw_angular_attrs: &default_lo_sw_angular
+  <<: *default
+  DEPEND_1: energy_table
+  DEPEND_2: elevation_angle
+  DEPEND_3: spin_angle
+  DISPLAY_TYPE: time_series
+  FORMAT: '%f'
+  LABLAXIS: 'Diff. # Flux'
+  SCALETYP: log
+  UNITS: particles / cm2 s sr keV/q
+  VALIDMAX: 10000000000.0
+  VALIDMIN: 1.000000013351432e-10
+  VAR_TYPE: data
 
 # <=== Coordinates ===>
 event_num:
@@ -77,19 +110,27 @@ event_num_label:
     FORMAT: A5
     VAR_TYPE: metadata
 
-# <=== Direct Events Attributes ===>
-direct_events_attrs: &direct_events
-    <<: *default
-    CATDESC: Fill in at creation
-    DISPLAY_TYPE: time_series
-    FIELDNAM: Fill in at creation
-    FILLVAL: 255
-    FORMAT: I5
-    UNITS: unitless
-    VALIDMIN: 0
-    VALIDMAX: 10000
-    DICT_KEY: SPASE>Support>SupportQuantity:Other
+# <=== Dataset Variable Attributes ===>
+# The following are set in multiple data products
 
+data_quality:
+    <<: *default
+    CATDESC: Indicates whether data quality is suspect (1).
+    DISPLAY_TYPE: time_series
+    FIELDNAM: Data Quality
+    FILLVAL: 255
+    FORMAT: '%d'
+    LABLAXIS: Data Quality
+    SCALETYP: linear
+    UNITS: ' '
+    VALIDMAX: 1
+    VALIDMIN: 0
+    VAR_TYPE: data
+
+# The following are data product-specific
+# Direct Events Attributes
+
+# TODO: update var names to be lowercase and underscores.
 P0_APD_ID:
     <<: *direct_events
     CATDESC: Priority 0 APD ID
@@ -1043,99 +1084,105 @@ P7_TOF:
     VALIDMAX: 1024
 
 
-# <=== lo-sw-species Attributes ===>
+# lo-sw-species Attributes
 
-cnoplus:
+lo-sw-species-cnoplus:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - CNO+ (PUI)
   FIELDNAM: Counts - SW - CNO+ (PUI)
 
-cplus4:
+lo-sw-species-cplus4:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - C+4
   FIELDNAM: Counts - SW - C+4
 
-cplus5:
+lo-sw-species-cplus5:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - C+5
   FIELDNAM: Counts - SW - C+5
 
-cplus6:
+lo-sw-species-cplus6:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - C+6
   FIELDNAM: Counts - SW - C+6
 
-data_quality:
-  DEPEND_0: epoch
-  DISPLAY_TYPE: time_series
-  FILLVAL: 255
-  FORMAT: '%d'
-  LABLAXIS: Data Quality
-  SCALETYP: linear
-  UNITS: ' '
-  VALIDMAX: 1
-  VALIDMIN: 0
-  VAR_TYPE: data
-  CATDESC: Indicates whether data quality is suspect (1).
-  FIELDNAM: Data Quality
-
-fe_hiq:
+lo-sw-species-fe_hiq:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - Fe highQ
   FIELDNAM: Counts - SW - Fe highQ
 
-fe_loq:
+lo-sw-species-fe_loq:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - Fe lowQ
   FIELDNAM: Counts - SW - Fe lowQ
 
-heplus:
+lo-sw-species-heplus:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - He+ (PUI)
   FIELDNAM: Counts - SW - He+ (PUI)
 
-heplusplus:
+lo-sw-species-heplusplus:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - He++
   FIELDNAM: Counts - SW - He++
 
-hplus:
+lo-sw-species-hplus:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - H+
   FIELDNAM: Counts - SW - H+
 
-mg:
+lo-sw-species-mg:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - Mg
   FIELDNAM: Counts - SW - Mg
 
-ne:
+lo-sw-species-ne:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - Ne
   FIELDNAM: Counts - SW - Ne
 
-oplus5:
+lo-sw-species-oplus5:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - O+5
   FIELDNAM: Counts - SW - O+5
 
-oplus6:
+lo-sw-species-oplus6:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - O+6
   FIELDNAM: Counts - SW - O+6
 
-oplus7:
+lo-sw-species-oplus7:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - O+7
   FIELDNAM: Counts - SW - O+7
 
-oplus8:
+lo-sw-species-oplus8:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - O+8
   FIELDNAM: Counts - SW - O+8
 
-si:
+lo-sw-species-si:
   <<: *default_lo_sw_species
   CATDESC: Counts - SW - Si
   FIELDNAM: Counts - SW - Si
 
+# lo-sw-angular Attributes
+lo-sw-angular-fe_loq:
+  <<: *default_lo_sw_angular
+  CATDESC: Counts - SW - Fe lowQ
+  FIELDNAM: Sunward Facing Counts - SW - Fe lowQ
+
+lo-sw-angular-heplusplus:
+  <<: *default_lo_sw_angular
+  CATDESC: Counts - SW - He++
+  FIELDNAM: Sunward Facing Counts - SW - He++
+
+lo-sw-angular-hplus:
+  <<: *default_lo_sw_angular
+  CATDESC: Counts - SW - H+
+  FIELDNAM: Sunward Facing Counts - SW - H+
+
+lo-sw-angular-oplus6:
+  <<: *default_lo_sw_angular
+  CATDESC: Counts - SW - O+6
+  FIELDNAM: Sunward Facing Counts - SW - O+6

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -402,8 +402,8 @@ hi-sectored-spin_sector_index_label:
   VAR_TYPE: metadata
 
 hi-ialirt-spin_sector_index_label:
-  CATDESC: Spin Sector Index for Hi-Ialirt
-  FIELDNAM: Spin Sector Index for Hi-Ialirt
+  CATDESC: Spin Sector Index for Hi I-ALiRT
+  FIELDNAM: Spin Sector Index for Hi I-ALiRT
   FORMAT: A1
   VAR_TYPE: metadata
 

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -59,10 +59,25 @@ def process_codice_l2(file_path: Path) -> xr.Dataset:
     l2_dataset.attrs = cdf_attrs.get_global_attributes(dataset_name)
 
     # Set the variable attributes
-    for variable_name in l2_dataset:
-        l2_dataset[variable_name].attrs = cdf_attrs.get_variable_attributes(
-            variable_name, check_schema=False
-        )
+    for variable_name in l2_dataset.data_vars.keys():
+        try:
+            l2_dataset[variable_name].attrs = cdf_attrs.get_variable_attributes(
+                variable_name, check_schema=False
+            )
+        except KeyError:
+            # Some variables may have a product descriptor prefix in the
+            # cdf attributes key if they are common to multiple products.
+            descriptor = dataset_name.split("imap_codice_l2_")[-1]
+            cdf_attrs_key = f"{descriptor}-{variable_name}"
+            try:
+                l2_dataset[variable_name].attrs = cdf_attrs.get_variable_attributes(
+                    f"{cdf_attrs_key}", check_schema=False
+                )
+            except KeyError:
+                logger.error(
+                    f"Field '{variable_name}' and '{cdf_attrs_key}' not found in "
+                    f"attribute manager."
+                )
 
     if dataset_name in [
         "imap_codice_l2_hi-counters-singles",

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -52,32 +52,7 @@ def process_codice_l2(file_path: Path) -> xr.Dataset:
 
     # Get the L2 CDF attributes
     cdf_attrs = ImapCdfAttributes()
-    cdf_attrs.add_instrument_global_attrs("codice")
-    cdf_attrs.add_instrument_variable_attrs("codice", "l2")
-
-    # Update the global attributes
-    l2_dataset.attrs = cdf_attrs.get_global_attributes(dataset_name)
-
-    # Set the variable attributes
-    for variable_name in l2_dataset.data_vars.keys():
-        try:
-            l2_dataset[variable_name].attrs = cdf_attrs.get_variable_attributes(
-                variable_name, check_schema=False
-            )
-        except KeyError:
-            # Some variables may have a product descriptor prefix in the
-            # cdf attributes key if they are common to multiple products.
-            descriptor = dataset_name.split("imap_codice_l2_")[-1]
-            cdf_attrs_key = f"{descriptor}-{variable_name}"
-            try:
-                l2_dataset[variable_name].attrs = cdf_attrs.get_variable_attributes(
-                    f"{cdf_attrs_key}", check_schema=False
-                )
-            except KeyError:
-                logger.error(
-                    f"Field '{variable_name}' and '{cdf_attrs_key}' not found in "
-                    f"attribute manager."
-                )
+    l2_dataset = add_dataset_attributes(l2_dataset, dataset_name, cdf_attrs)
 
     if dataset_name in [
         "imap_codice_l2_hi-counters-singles",
@@ -149,4 +124,53 @@ def process_codice_l2(file_path: Path) -> xr.Dataset:
 
     logger.info(f"\nFinal data product:\n{l2_dataset}\n")
 
+    return l2_dataset
+
+
+def add_dataset_attributes(
+    l2_dataset: xr.Dataset, dataset_name: str, cdf_attrs: ImapCdfAttributes
+) -> xr.Dataset:
+    """
+    Add the global and variable attributes to the dataset.
+
+    Parameters
+    ----------
+    l2_dataset : xarray.Dataset
+        The dataset to update.
+    dataset_name : str
+        The name of the dataset.
+    cdf_attrs : ImapCdfAttributes
+        The attribute manager for CDF attributes.
+
+    Returns
+    -------
+    xarray.Dataset
+        The updated dataset.
+    """
+    cdf_attrs.add_instrument_global_attrs("codice")
+    cdf_attrs.add_instrument_variable_attrs("codice", "l2")
+
+    # Update the global attributes
+    l2_dataset.attrs = cdf_attrs.get_global_attributes(dataset_name)
+
+    # Set the variable attributes
+    for variable_name in l2_dataset.data_vars.keys():
+        try:
+            l2_dataset[variable_name].attrs = cdf_attrs.get_variable_attributes(
+                variable_name, check_schema=False
+            )
+        except KeyError:
+            # Some variables may have a product descriptor prefix in the
+            # cdf attributes key if they are common to multiple products.
+            descriptor = dataset_name.split("imap_codice_l2_")[-1]
+            cdf_attrs_key = f"{descriptor}-{variable_name}"
+            try:
+                l2_dataset[variable_name].attrs = cdf_attrs.get_variable_attributes(
+                    f"{cdf_attrs_key}", check_schema=False
+                )
+            except KeyError:
+                logger.error(
+                    f"Field '{variable_name}' and '{cdf_attrs_key}' not found in "
+                    f"attribute manager."
+                )
     return l2_dataset

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -1,9 +1,12 @@
 """Tests the L2 processing of CoDICE L1 data"""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 import xarray as xr
 
-from imap_processing.codice.codice_l2 import process_codice_l2
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.codice.codice_l2 import add_dataset_attributes, process_codice_l2
 
 from .conftest import TEST_L2_FILES
 
@@ -28,6 +31,20 @@ def test_l2_data(request) -> xr.Dataset:
     return dataset
 
 
+@pytest.fixture
+def mock_cdf_attrs():
+    # Create a mock ImapCdfAttributes object
+    cdf_attrs = MagicMock(spec=ImapCdfAttributes)
+    cdf_attrs.get_global_attributes.return_value = {
+        "global_attr_key": "global_attr_value"
+    }
+    cdf_attrs.get_variable_attributes.side_effect = lambda var, check_schema: {
+        "var1": {"attr1": "value1"},
+        "test-product-var2": {"attr2": "value2"},
+    }[var]
+    return cdf_attrs
+
+
 @pytest.mark.parametrize(
     "test_l2_data, expected_logical_source",
     list(zip(TEST_L2_FILES, EXPECTED_LOGICAL_SOURCES, strict=False)),
@@ -48,3 +65,42 @@ def test_l2_logical_sources(test_l2_data: xr.Dataset, expected_logical_source: s
     dataset = test_l2_data
 
     assert dataset.attrs["Logical_source"] == expected_logical_source
+
+
+def test_add_dataset_attributes(mock_cdf_attrs):
+    dataset_name = "imap_codice_l2_test-product"
+
+    # Create a sample xarray.Dataset
+    sample_dataset = xr.Dataset(
+        {
+            "var1": (["dim1"], [1, 2, 3]),
+            "var2": (["dim1"], [4, 5, 6]),
+            "var3": (["dim1"], [7, 8, 9]),
+        }
+    )
+
+    # Patch the logger to capture error messages
+    with patch("imap_processing.codice.codice_l2.logger") as mock_logger:
+        # Call the function
+        updated_dataset = add_dataset_attributes(
+            sample_dataset, dataset_name, mock_cdf_attrs
+        )
+
+        # Assert global attributes are updated
+        assert updated_dataset.attrs == {"global_attr_key": "global_attr_value"}
+
+        # Assert variable attributes are updated
+
+        # var1 should get attributes directly
+        assert updated_dataset["var1"].attrs == {"attr1": "value1"}
+
+        # var2 should get attributes with product descriptor prefix (test-product)
+        assert updated_dataset["var2"].attrs == {"attr2": "value2"}
+
+        # var3 should log an error since it doesn't have corresponding attributes
+        assert updated_dataset["var3"].attrs == {}
+
+        # Check logger error call for missing attributes
+        mock_logger.error.assert_called_with(
+            "Field 'var3' and 'test-product-var3' not found in attribute manager."
+        )


### PR DESCRIPTION
This PR adds attributes for L2 products to a yaml file. Metadata was pulled from CDF validation files produced by CoDICE. Some work is needed to refine these attributes, which will be handled in a future PR, since it will require some iteration with CoDICE. TODOs have been added to the yaml file outlining specific areas that will need to be re-visited.

 Closes #2054 
