### PR TITLE
ULTRA L1C sensitivity calculation for helio and spacecraft psets

### DIFF
--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -112,7 +112,10 @@ EXTERNAL_TEST_DATA = [
     ("imap_ultra_l1b-90sensor-tofxemedium_20250101_v000.pgm", "ultra/data/l1/"),
     ("imap_ultra_l1b-90sensor-tofxesteep_20250101_v000.pgm", "ultra/data/l1/"),
     ("imap_ultra_l1b-tofxph_20250101_v000.pgm","ultra/data/l1/"),
-    ("imap_ultra_l1c-45sensor-nominal-for-lookup_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-sc-pointing-theta-n32-test_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-sc-pointing-phi-n32-test_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-sc-pointing-index-n32-test_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-sc-pointing-bsf-n32-test_20250101_v000.csv", "ultra/data/l1/"),
 
     # MAG
     ("mag-l1b-l1c-t013-magi-burst-in.csv",

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -535,8 +535,22 @@ def ancillary_files():
         "l1c-90sensor-efficiencies": path
         / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
         "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
-        "l1c-45sensor-nominal-for-lookup": path
-        / "imap_ultra_l1c-45sensor-nominal-for-lookup_20250101_v000.csv",
+        "l1c-90sensor-sc-pointing-theta-n32": path
+        / "imap_ultra_l1c-90sensor-sc-pointing-theta-n32-test_20250101_v000.csv",
+        "l1c-90sensor-sc-pointing-phi-n32": path
+        / "imap_ultra_l1c-90sensor-sc-pointing-phi-n32-test_20250101_v000.csv",
+        "l1c-90sensor-sc-pointing-index-n32": path
+        / "imap_ultra_l1c-90sensor-sc-pointing-index-n32-test_20250101_v000.csv",
+        "l1c-90sensor-sc-pointing-bsf-n32": path
+        / "imap_ultra_l1c-90sensor-sc-pointing-bsf-n32-test_20250101_v000.csv",
+        "l1c-45sensor-sc-pointing-theta-n32": path
+        / "imap_ultra_l1c-90sensor-sc-pointing-theta-n32-test_20250101_v000.csv",
+        "l1c-45sensor-sc-pointing-phi-n32": path
+        / "imap_ultra_l1c-90sensor-sc-pointing-phi-n32-test_20250101_v000.csv",
+        "l1c-45sensor-sc-pointing-index-n32": path
+        / "imap_ultra_l1c-90sensor-sc-pointing-index-n32-test_20250101_v000.csv",
+        "l1c-45sensor-sc-pointing-bsf-n32": path
+        / "imap_ultra_l1c-90sensor-sc-pointing-bsf-n32-test_20250101_v000.csv",
     }
 
 

--- a/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
@@ -1,0 +1,62 @@
+import healpy as hp
+import numpy as np
+import pytest
+
+from imap_processing.ultra.l1c.l1c_lookup_utils import (
+    get_spacecraft_pointing_lookup_tables,
+    mask_below_fwhm_scattering_threshold,
+)
+
+
+@pytest.mark.external_test_data
+def test_get_spacecraft_pointing_lookup_tables(ancillary_files):
+    """Test get_spacecraft_pointing_lookup_tables."""
+    instrument_id = 90
+    (
+        for_indices_by_spin_phase,
+        theta_vals,
+        phi_vals,
+        ra_and_dec,
+        boundary_scale_factors,
+    ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
+    npix = hp.nside2npix(32) - 1  # test files dont have headers
+    # Test shapes
+    # There should be 498 spin phase steps. In the real test files there will be 15000
+    cols = 498
+    assert for_indices_by_spin_phase.shape == (npix, cols)
+    assert theta_vals.shape == (npix, cols)
+    assert phi_vals.shape == (npix, cols)
+    assert ra_and_dec.shape == (npix, 2)
+
+    # Value tests
+    assert for_indices_by_spin_phase.dtype == bool
+    assert theta_vals.dtype == np.float64
+    assert phi_vals.dtype == np.float64
+    assert ra_and_dec.dtype == np.float64
+    assert boundary_scale_factors.dtype == np.float64
+
+
+@pytest.mark.external_test_data
+def test_get_mask_below_fwhm_scattering_threshold(ancillary_files):
+    """Tests function get_mask_below_fwhm_scattering_threshold."""
+    energy = 5  # At energy 5, the FWHM threshold is 10
+    theta_coeffs = np.array(
+        [
+            [np.nan, 10],  # This will result in a NaN value (False)
+            [5, -0.1],  # FWHM value below the threshold (True)
+            [4, -0.1],  # FWHM value below the threshold (True)
+        ]
+    )
+    phi_coeffs = np.array(
+        [
+            [3, -0.1],  # FWHM value below the threshold (True)
+            [5, -0.1],  # FWHM value below the threshold (True)
+            [15, -0.1],  # FWHM value above the threshold (False)
+        ]
+    )
+    # Only indices where both the theta and phi coefficients are below the FWHM
+    # threshold should be True.
+    expected_pixel_mask = np.array([False, True, False])
+    pixel_mask = mask_below_fwhm_scattering_threshold(theta_coeffs, phi_coeffs, energy)
+    np.testing.assert_array_equal(pixel_mask.shape, (3,))
+    np.testing.assert_array_equal(pixel_mask, expected_pixel_mask)

--- a/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
@@ -1,4 +1,4 @@
-import healpy as hp
+import astropy_healpix.healpy as hp
 import numpy as np
 import pytest
 

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -127,7 +127,11 @@ def test_get_geometric_function(ancillary_files):
         phi.shape, ImapDEOutliersUltraFlags.NONE.value, dtype=np.uint16
     )
     gf = get_geometric_factor(
-        ancillary_files, "l1b-sensor-gf-noblades", phi, theta, quality_flags
+        phi,
+        theta,
+        quality_flags,
+        ancillary_files,
+        "l1b-sensor-gf-noblades",
     )
 
     np.testing.assert_array_equal(

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -14,12 +14,10 @@ from imap_processing.ultra.l1b.lookup_utils import (
     get_energy_norm,
     get_geometric_factor,
     get_image_params,
-    get_nominal_for_by_spin_phase,
     get_norm,
     get_ph_corrected,
     get_scattering_coefficients,
     get_y_adjust,
-    mask_below_fwhm_scattering_threshold,
 )
 
 BASE_PATH = imap_module_directory / "ultra" / "lookup_tables"
@@ -180,10 +178,11 @@ def test_get_scattering_coefficients(ancillary_files):
     """Tests function get_scattering_data."""
 
     theta_coeffs, phi_coeffs = get_scattering_coefficients(
-        ancillary_files,
-        45,
         np.array([47, 43]),
         np.array([43, 42]),
+        lookup_tables=None,
+        ancillary_files=ancillary_files,
+        instrument_id=45,
     )
     # Test a theta coefficients
     np.testing.assert_array_equal(theta_coeffs[:, 0], np.array([np.nan, 35.23100]))
@@ -193,43 +192,3 @@ def test_get_scattering_coefficients(ancillary_files):
     np.testing.assert_array_equal(phi_coeffs[:, 0], np.array([np.nan, 168.3100]))
     # Test b phi coefficients
     np.testing.assert_array_equal(phi_coeffs[:, 1], np.array([np.nan, -1.0752]))
-
-
-@pytest.mark.external_test_data
-def test_get_nominal_for_by_spin_phase(ancillary_files):
-    """Tests function get_nominal_fov_by_spin_phase."""
-    for_inds, theta_and_phi, ra_and_dec = get_nominal_for_by_spin_phase(
-        ancillary_files, 45
-    )
-    np.testing.assert_array_equal(for_inds.shape, (3072, 15000))
-    np.testing.assert_array_equal(theta_and_phi.shape, (3072, 2))
-    np.testing.assert_array_equal(ra_and_dec.shape, (3072, 2))
-
-    # Assert fov_inds contains only 0s and 1s
-    assert np.all(np.isin(for_inds, [0, 1]))
-
-
-@pytest.mark.external_test_data
-def test_get_mask_below_fwhm_scattering_threshold(ancillary_files):
-    """Tests function get_mask_below_fwhm_scattering_threshold."""
-    energy = 5  # At energy 5, the FWHM threshold is 10
-    theta_coeffs = np.array(
-        [
-            [np.nan, 10],  # This will result in a NaN value (False)
-            [5, -0.1],  # FWHM value below the threshold (True)
-            [4, -0.1],  # FWHM value below the threshold (True)
-        ]
-    )
-    phi_coeffs = np.array(
-        [
-            [3, -0.1],  # FWHM value below the threshold (True)
-            [5, -0.1],  # FWHM value below the threshold (True)
-            [15, -0.1],  # FWHM value above the threshold (False)
-        ]
-    )
-    # Only indices where both the theta and phi coefficients are below the FWHM
-    # threshold should be True.
-    expected_pixel_mask = np.array([False, True, False])
-    pixel_mask = mask_below_fwhm_scattering_threshold(theta_coeffs, phi_coeffs, energy)
-    np.testing.assert_array_equal(pixel_mask.shape, (3,))
-    np.testing.assert_array_equal(pixel_mask, expected_pixel_mask)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-import healpy as hp
+import astropy_healpix.healpy as hp
 import numpy as np
 import pandas as pd
 import pytest

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -262,11 +262,13 @@ def test_calculate_helio_pset_with_cdf(
     mock_spacecraft_pointing_lookups,
     deadtime_datasets,
     use_fake_spin_data_for_time,
+    use_fake_repoint_data_for_time,
 ):
     """Tests ultra_l1c function with imported test data."""
 
     # Simulate a spin table from MET = 0 to MET = 141 * 15 seconds
     use_fake_spin_data_for_time(start_met=0, end_met=141 * 15)
+    use_fake_repoint_data_for_time(np.arange(4.32374e08, 4.99374e08 + 10, 10))
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
 
     # Select a single pointing number

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+import healpy as hp
 import numpy as np
 import pandas as pd
 import pytest
@@ -18,6 +21,43 @@ from imap_processing.ultra.l1c.ultra_l1c import ultra_l1c
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
+
+
+@pytest.fixture
+def mock_spacecraft_pointing_lookups():
+    """Test lookup tables fixture."""
+    pix = hp.nside2npix(128)
+    steps = 10  # Reduced for testing
+    for_indices_by_spin_phase = np.random.choice(
+        [True, False], size=(pix, steps), p=[0.1, 0.9]
+    )
+    theta_vals = np.random.uniform(-60, 60, size=(pix, steps))
+    phi_vals = np.random.uniform(-60, 60, size=(pix, steps))
+    ra_and_dec = np.random.uniform(-80, 80, size=(pix, 2))
+    boundary_scale_factors = np.ones((pix, steps))
+    with (
+        mock.patch(
+            "imap_processing.ultra.l1c.spacecraft_pset.get_spacecraft_pointing_lookup_tables"
+        ) as mock_lookup,
+        mock.patch(
+            "imap_processing.ultra.l1c.helio_pset.get_spacecraft_pointing_lookup_tables"
+        ) as mock_lookup_helio,
+    ):
+        mock_lookup.return_value = (
+            for_indices_by_spin_phase,
+            theta_vals,
+            phi_vals,
+            ra_and_dec,
+            boundary_scale_factors,
+        )
+        mock_lookup_helio.return_value = (
+            for_indices_by_spin_phase,
+            theta_vals,
+            phi_vals,
+            ra_and_dec,
+            boundary_scale_factors,
+        )
+        yield mock_lookup
 
 
 @pytest.fixture
@@ -144,6 +184,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     deadtime_datasets,
     imap_ena_sim_metakernel,
     use_fake_spin_data_for_time,
+    mock_spacecraft_pointing_lookups,
 ):
     """Tests ultra_l1c function with imported test data."""
     # Simulate a spin table from MET = 0 to MET = 141 * 15 seconds
@@ -214,9 +255,18 @@ def test_calculate_spacecraft_pset_with_cdf(
 
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
-def test_calculate_helio_pset_with_cdf(ancillary_files, imap_ena_sim_metakernel):
+def test_calculate_helio_pset_with_cdf(
+    random_spin_data,
+    ancillary_files,
+    imap_ena_sim_metakernel,
+    mock_spacecraft_pointing_lookups,
+    deadtime_datasets,
+    use_fake_spin_data_for_time,
+):
     """Tests ultra_l1c function with imported test data."""
 
+    # Simulate a spin table from MET = 0 to MET = 141 * 15 seconds
+    use_fake_spin_data_for_time(start_met=0, end_met=141 * 15)
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
 
     # Select a single pointing number
@@ -264,17 +314,8 @@ def test_calculate_helio_pset_with_cdf(ancillary_files, imap_ena_sim_metakernel)
         "imap_ultra_l1b_45sensor-de": dataset,
         "imap_ultra_l1b_45sensor-extendedspin": xr.Dataset(),  # placeholder
         "imap_ultra_l1b_45sensor-cullingmask": xr.Dataset(),  # placeholder
-    }
-
-    path = imap_module_directory / "tests" / "ultra" / "data" / "l1"
-    ancillary_files = {
-        "l1c-90sensor-dps-exposure": path
-        / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
-        "l1c-90sensor-efficiencies": path
-        / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv",
-        "l1c-90sensor-gf": path / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv",
-        "l1c-45sensor-nominal-for-lookup": path
-        / "imap_ultra_l1c-45sensor-nominal-for-lookup_20250101_v000.csv",
+        "imap_ultra_l1a_45sensor-rates": deadtime_datasets["rates"],
+        "imap_ultra_l1a_45sensor-params": deadtime_datasets["params"],
     }
 
     output_datasets = ultra_l1c(data_dict, ancillary_files, has_spice=True)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -19,16 +19,12 @@ from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     get_deadtime_ratios,
     get_deadtime_ratios_by_spin_phase,
     get_energy_delta_minus_plus,
-    get_helio_exposure_times,
-    get_helio_sensitivity,
+    get_helio_adjusted_data,
     get_sectored_rates,
     get_spacecraft_background_rates,
     get_spacecraft_count_rate_uncertainty,
     get_spacecraft_exposure_times,
     get_spacecraft_histogram,
-    get_spacecraft_sensitivity,
-    grid_sensitivity,
-    interpolate_sensitivity,
 )
 
 BASE_PATH = imap_module_directory / "ultra" / "lookup_tables"
@@ -240,21 +236,18 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
     """Tests apply_deadtime_correction function."""
     nside = 8
     pix = hp.nside2npix(nside)
-    mock_theta_and_phi = np.hstack(
-        [
-            np.full((pix, 1), -1.54120),  # theta (deg)
-            np.full((pix, 1), -18.12384),  # phi (deg)
-        ]
-    )
-    spin_phase_steps = np.zeros((pix, 15000)).astype(bool)  # Spin phase steps 1-15000,
+    steps = 500  # Reduced for testing
+    mock_theta = np.random.uniform(-60, 60, (pix, steps))
+    mock_phi = np.random.uniform(-60, 60, (pix, steps))
+    spin_phase_steps = np.zeros((pix, steps)).astype(bool)  # Spin phase steps 1-15000,
     # Simulate first 100 pixels are in the FOR for all spin phases
     inside_inds = 100
     spin_phase_steps[:inside_inds, :] = True
-    deadtime_ratios = np.ones(15000)
+    deadtime_ratios = np.ones(steps)
     exposure_pointing = pd.Series(np.ones(pix))
 
     pixels_below_threshold = calculate_pixels_within_scattering_threshold(
-        spin_phase_steps, mock_theta_and_phi, ancillary_files, 45
+        spin_phase_steps, mock_theta, mock_phi, ancillary_files, 45
     )
 
     exposure_pointing_adjusted = apply_deadtime_correction(
@@ -280,33 +273,31 @@ def test_get_spacecraft_exposure_times(
     constant_exposure = (
         TEST_PATH / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
     )
+    steps = 500  # reduced for testing
     rates = deadtime_datasets["rates"]
     params = deadtime_datasets["params"]
     shape = 786
     df_exposure = pd.read_csv(constant_exposure)[:shape]  # Subset for testing
 
     pix = len(df_exposure)
-    mock_theta_and_phi = np.hstack(
-        [
-            np.random.uniform(-60, 60, (pix, 1)),  # theta (deg)
-            np.random.uniform(-60, 60, (pix, 1)),  # phi (deg)
-        ]
-    )
-    spin_phase_steps = np.random.randint(0, 2, (pix, 15000)).astype(
+    mock_theta = np.random.uniform(-60, 60, (pix, steps))
+    mock_phi = np.random.uniform(-60, 60, (pix, steps))
+    spin_phase_steps = np.random.randint(0, 2, (pix, steps)).astype(
         bool
-    )  # Spin phase steps 1-15000, random 0 or 1
+    )  # Spin phase steps, random 0 or 1
 
     pixels_below_threshold = calculate_pixels_within_scattering_threshold(
-        spin_phase_steps, mock_theta_and_phi, ancillary_files, 45
+        spin_phase_steps, mock_theta, mock_phi, ancillary_files, 45
     )
-    exposure_pointing = get_spacecraft_exposure_times(
+    exposure_pointing, deadtimes = get_spacecraft_exposure_times(
         df_exposure, rates, params, pixels_below_threshold
     )
-    assert exposure_pointing.shape == (24, shape)
+    np.testing.assert_array_equal(exposure_pointing.shape, (24, shape))
+    np.testing.assert_array_equal(deadtimes.shape, (15000,))
 
 
 @pytest.mark.external_kernel
-def test_get_helio_exposure_times(imap_ena_sim_metakernel):
+def test_get_helio_exposure_time_and_sensitivity(imap_ena_sim_metakernel):
     """Tests get_helio_exposure_times function."""
 
     start_time = 829485054.185627
@@ -314,112 +305,27 @@ def test_get_helio_exposure_times(imap_ena_sim_metakernel):
 
     mid_time = np.average([start_time, end_time])
 
-    constant_exposure = (
-        TEST_PATH / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
-    )
-    df_exposure = pd.read_csv(constant_exposure)
-
-    helio_exposure = get_helio_exposure_times(mid_time, df_exposure)
-
     _, energy_midpoints, _ = build_energy_bins()
-
     nside = 128
     npix = hp.nside2npix(nside)
-    assert helio_exposure.shape == (len(energy_midpoints), npix)
+    shape = (len(energy_midpoints), npix)
+    exposure = np.ones(shape)
+    eff = np.ones(shape)
+    gf = np.ones(shape)
+    mock_ra = np.random.uniform(-80, 80, (npix))
+    mock_dec = np.random.uniform(-80, 80, (npix))
 
-    total_input = np.sum(df_exposure["Exposure Time"].values)
-    total_output = np.sum(helio_exposure[23, :])
-
-    assert np.allclose(total_input, total_output, atol=1e-6)
-
-
-@pytest.mark.external_test_data
-def test_get_spacecraft_sensitivity():
-    """Tests get_spacecraft_sensitivity function."""
-    # TODO: remove below here with lookup table aux api
-    efficiencies = TEST_PATH / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv"
-    geometric_function = TEST_PATH / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv"
-
-    df_efficiencies = pd.read_csv(efficiencies)
-    df_geometric_function = pd.read_csv(geometric_function)
-
-    sensitivity, energy_vals, right_ascension, declination = get_spacecraft_sensitivity(
-        df_efficiencies, df_geometric_function
+    helio_exposure, helio_eff, helio_gf = get_helio_adjusted_data(
+        mid_time, exposure, gf, eff, mock_ra, mock_dec
     )
 
-    assert sensitivity.shape == (df_efficiencies.shape[0], df_efficiencies.shape[1] - 2)
-    assert np.array_equal(energy_vals, np.arange(3.0, 80.5, 0.5))
-
-    df_efficiencies_test = pd.DataFrame(
-        {"3.0keV": [1.0, 2.0], "3.5keV": [3.0, 4.0], "4.0keV": [5.0, 6.0]}
-    )
-
-    df_geometric_function_test = pd.DataFrame({"Response": [0.1, 0.2]})
-
-    df_sensitivity_test = df_efficiencies_test.mul(
-        df_geometric_function_test["Response"], axis=0
-    )
-
-    expected_sensitivity = pd.DataFrame(
-        {"3.0keV": [0.1, 0.4], "3.5keV": [0.3, 0.8], "4.0keV": [0.5, 1.2]}
-    )
-
-    assert np.allclose(
-        df_sensitivity_test.to_numpy(), expected_sensitivity.to_numpy(), atol=1e-6
-    )
-
-    expected_result = sensitivity["3.0keV"].values
-    result = grid_sensitivity(df_efficiencies, df_geometric_function, 3.0)
-
-    assert np.allclose(result, expected_result, atol=1e-5)
-
-    # Check that out-of-bounds energy returns all FILL values
-    result = grid_sensitivity(df_efficiencies, df_geometric_function, 2.5)
-    assert np.all(result == -1.0e31)
-
-    result = interpolate_sensitivity(df_efficiencies, df_geometric_function)
-    assert result.shape == (24, 196608)
-
-
-@pytest.mark.external_test_data
-@pytest.mark.external_kernel
-def test_get_helio_sensitivity(monkeypatch, imap_ena_sim_metakernel):
-    """Test get_helio_sensitivity function."""
-
-    # Load test data
-    efficiencies = TEST_PATH / "imap_ultra_l1c-90sensor-efficiencies_20250101_v000.csv"
-    geometric_function = TEST_PATH / "imap_ultra_l1c-90sensor-gf_20250101_v000.csv"
-    df_efficiencies = pd.read_csv(efficiencies)
-    df_geometric_function = pd.read_csv(geometric_function)
-
-    # Patch spacecraft velocity to be zero
-    monkeypatch.setattr(ultra_l1c_pset_bins, "imap_state", mock_imap_state)
-
-    # Define time
-    start_time = 829485054.185627
-    end_time = 829567884.185627
-    mid_time = np.average([start_time, end_time])
-
-    # Build energy bins and spacecraft-frame sensitivity
-    _, energy_midpoints, _ = build_energy_bins()
-    sc_sensitivity = []
-    for energy in energy_midpoints:
-        s = grid_sensitivity(df_efficiencies, df_geometric_function, energy)
-        sc_sensitivity.append(s)
-    sc_sensitivity = np.stack(sc_sensitivity, axis=1).T  # shape: (n_energy_bins, npix)
-
-    # Compute helio-frame sensitivity
-    helio_sensitivity = get_helio_sensitivity(
-        mid_time,
-        df_efficiencies,
-        df_geometric_function,
-    )
-
-    # Flatten and compare
-    flat_sc = np.nansum(sc_sensitivity, axis=0)
-    flat_helio = np.nansum(helio_sensitivity, axis=0)
-
-    np.testing.assert_allclose(flat_sc, flat_helio, atol=1e-5)
+    for helio_array, array in zip(
+        [helio_exposure, helio_eff, helio_gf], [exposure, eff, gf], strict=False
+    ):
+        total_input = np.sum(array)
+        total_output = np.sum(total_input)
+        assert np.allclose(total_input, total_output, atol=1e-6)
+        assert helio_array.shape == shape
 
 
 def test_get_spacecraft_background_rates(

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -108,6 +108,7 @@ class UltraConstants:
         341.989454569026,
         1e5,
     ]
+    # TODO read these in from a lookup table
     # Culling FWHM Scattering values as a function of energy.
     # The tuple represents the energy range (min, max) in keV, and the value is the
     # FWHM scattering threshold in degrees.

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -338,18 +338,18 @@ def calculate_de(
         de_dict["tof_energy"], de_dict["phi"], de_dict["theta"], ancillary_files
     )
     de_dict["geometric_factor_blades"] = get_geometric_factor(
+        de_dict["phi"],
+        de_dict["theta"],
+        quality_flags,
         ancillary_files,
         "l1b-sensor-gf-blades",
-        de_dict["phi"],
-        de_dict["theta"],
-        quality_flags,
     )
     de_dict["geometric_factor_noblades"] = get_geometric_factor(
-        ancillary_files,
-        "l1b-sensor-gf-noblades",
         de_dict["phi"],
         de_dict["theta"],
         quality_flags,
+        ancillary_files,
+        "l1b-sensor-gf-noblades",
     )
     de_dict["quality_outliers"] = quality_flags
     flag_scattering(

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -1,7 +1,5 @@
 """Contains tools for lookup tables for l1b."""
 
-import logging
-
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -9,9 +7,6 @@ import xarray as xr
 from numpy.typing import NDArray
 
 from imap_processing.quality_flags import ImapDEOutliersUltraFlags
-from imap_processing.ultra.constants import UltraConstants
-
-logger = logging.getLogger(__name__)
 
 
 def get_y_adjust(dy_lut: np.ndarray, ancillary_files: dict) -> npt.NDArray:
@@ -291,33 +286,25 @@ def get_geometric_factor(
     return geometric_factor
 
 
-def get_scattering_coefficients(
-    ancillary_files: dict,
-    instrument_id: int,
-    theta: NDArray,
-    phi: NDArray,
-) -> tuple[NDArray, NDArray]:
+def load_scattering_lookup_tables(ancillary_files: dict, instrument_id: int) -> dict:
     """
-    Get a and g coefficients for theta and phi to compute scattering FWHM.
+    Load scattering coefficient lookup tables for the specified instrument.
 
     Parameters
     ----------
-    ancillary_files : dict[Path]
+    ancillary_files : dict
         Ancillary files.
     instrument_id : int
         Instrument ID, either 45 or 90.
-    theta : NDArray
-        Elevation angles in degrees.
-    phi : NDArray
-        Azimuth angles in degrees.
 
     Returns
     -------
-    tuple
-        Scattering a and g values corresponding to the given theta and phi values.
+    dict
+        Dictionary containing arrays for theta_grid, phi_grid, a_theta, g_theta,
+         a_phi, g_phi.
     """
     # TODO remove the line below when the 45 sensor scattering coefficients are
-    #   delivered.
+    #  delivered.
     instrument_id = 90
     descriptor = f"l1b-{instrument_id}sensor-scattering-calibration"
     theta_grid = pd.read_csv(
@@ -338,16 +325,66 @@ def get_scattering_coefficients(
     g_phi = pd.read_csv(
         ancillary_files[descriptor], header=None, skiprows=1217, nrows=241
     ).to_numpy(dtype=float)
+    return {
+        "theta_grid": theta_grid,
+        "phi_grid": phi_grid,
+        "a_theta": a_theta,
+        "g_theta": g_theta,
+        "a_phi": a_phi,
+        "g_phi": g_phi,
+    }
 
-    # Assume uniform grids: extract 1D arrays from first row/col
+
+def get_scattering_coefficients(
+    theta: NDArray,
+    phi: NDArray,
+    lookup_tables: dict | None = None,
+    ancillary_files: dict | None = None,
+    instrument_id: int | None = None,
+) -> tuple[NDArray, NDArray]:
+    """
+    Get a and g coefficients for theta and phi to compute scattering FWHM.
+
+    Parameters
+    ----------
+    theta : NDArray
+        Elevation angles in degrees.
+    phi : NDArray
+        Azimuth angles in degrees.
+    lookup_tables : dict, optional
+        Preloaded lookup tables. If not provided, will load using ancillary_files and
+         instrument_id.
+    ancillary_files : dict, optional
+        Ancillary files, required if lookup_tables is not provided.
+    instrument_id : int, optional
+        Instrument ID, required if lookup_tables is not provided.
+
+    Returns
+    -------
+    tuple
+        Scattering a and g values corresponding to the given theta and phi values.
+    """
+    if lookup_tables is None:
+        if ancillary_files is None or instrument_id is None:
+            raise ValueError(
+                "ancillary_files and instrument_id must be provided if lookup_tables "
+                "is not supplied."
+            )
+        lookup_tables = load_scattering_lookup_tables(ancillary_files, instrument_id)
+
+    theta_grid = lookup_tables["theta_grid"]
+    phi_grid = lookup_tables["phi_grid"]
+    a_theta = lookup_tables["a_theta"]
+    g_theta = lookup_tables["g_theta"]
+    a_phi = lookup_tables["a_phi"]
+    g_phi = lookup_tables["g_phi"]
+
     theta_vals = theta_grid[0, :]  # columns represent theta
     phi_vals = phi_grid[:, 0]  # rows represent phi
 
-    # Find nearest index in table for each input value
     phi_idx = np.abs(phi_vals[:, None] - phi).argmin(axis=0)
     theta_idx = np.abs(theta_vals[:, None] - theta).argmin(axis=0)
 
-    # Fetch a and g values at nearest (phi, theta) pairs
     a_theta_val = a_theta[phi_idx, theta_idx]
     g_theta_val = g_theta[phi_idx, theta_idx]
     a_phi_val = a_phi[phi_idx, theta_idx]
@@ -356,93 +393,6 @@ def get_scattering_coefficients(
     return np.column_stack([a_theta_val, g_theta_val]), np.column_stack(
         [a_phi_val, g_phi_val]
     )
-
-
-def mask_below_fwhm_scattering_threshold(
-    theta_coeffs: np.ndarray,
-    phi_coeffs: np.ndarray,
-    energy: int,
-) -> np.ndarray:
-    """
-    Determine indices of theta and phi values below the FWHM scattering threshold.
-
-    For each phi and theta, calculate the FWHM using the formula:
-    FWHM = A*E^g
-    If Phi FWHM or Theta FWHM > the scattering requirements from the table above,
-    mask the instrument frame pixel.
-
-    Parameters
-    ----------
-    theta_coeffs : NDArray
-        Coefficients for theta FWHM calculation (a and g) for each pixel.
-    phi_coeffs : NDArray
-        Coefficients for phi FWHM calculation (a and g) for each pixel.
-    energy : int
-        Energy in keV.
-
-    Returns
-    -------
-    numpy.ndarray
-        Boolean array indicating incides below the scattering threshold.
-    """
-    scattering_thresholds = UltraConstants.ULTRA_FWHM_SCATTERING_CULLING_THRESHOLDS
-    # Calculate FWHM for theta and phi
-    fwhm_theta = theta_coeffs[..., 0] * energy ** theta_coeffs[..., 1]
-    fwhm_phi = phi_coeffs[..., 0] * energy ** phi_coeffs[..., 1]
-
-    try:
-        # Get the scattering threshold based on the energy
-        threshold = next(
-            threshold
-            for energy_range, threshold in scattering_thresholds.items()
-            if energy_range[0] <= energy < energy_range[1]
-        )
-    except StopIteration:
-        logger.warning(
-            f"Energy {energy} keV is out of bounds for scattering thresholds. Using "
-            f"zero for as threshold."
-        )
-        threshold = 0
-    # Combine conditions for both theta and phi
-    return np.logical_and(fwhm_theta <= threshold, fwhm_phi <= threshold)
-
-
-def get_nominal_for_by_spin_phase(
-    ancillary_files: dict, instrument_id: int
-) -> tuple[NDArray, NDArray, NDArray]:
-    """
-    Get indices of pixels in the nominal FOR as a function of spin phase.
-
-    This function also returns the theta / phi values in the instrument frame and
-    right ascension / declination values in the IMAP frame.
-
-    Parameters
-    ----------
-    ancillary_files : dict[Path]
-        Ancillary files.
-    instrument_id : int
-        Instrument ID, either 45 or 90.
-
-    Returns
-    -------
-    tuple
-        Scattering a and g values corresponding to the given theta and phi values.
-    """
-    # TODO replace with actual lookup table when available.
-    descriptor = f"l1c-{instrument_id}sensor-nominal-for-lookup"
-    filename = ancillary_files[descriptor]
-
-    calibration_data = pd.read_csv(filename, header=None, skiprows=1).to_numpy(
-        dtype=float
-    )
-    ra_and_dec = calibration_data[:, :2]  # Shape (npix, 2)
-    theta_and_phi = np.random.randint(-60, 60, size=ra_and_dec.shape)  # Shape (npix, 2)
-    # This array indicates whether each pixel is in the nominal FOR at each spin phase
-    # step (15000 steps for a full rotation with 1 ms resolution).
-    for_indices_by_spin_phase = calibration_data[:, 2:].astype(
-        bool
-    )  # Shape (npix, 15000)
-    return for_indices_by_spin_phase, theta_and_phi, ra_and_dec
 
 
 def is_inside_fov(phi: np.ndarray, theta: np.ndarray) -> np.ndarray:

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -232,15 +232,12 @@ def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
     return lookup_table
 
 
-def get_geometric_factor(
+def load_geometric_factor_tables(
     ancillary_files: dict,
     filename: str,
-    phi: NDArray,
-    theta: NDArray,
-    quality_flag: NDArray,
-) -> tuple[NDArray, NDArray]:
+) -> dict:
     """
-    Lookup table for geometric factor using nearest neighbor.
+    Lookup tables for geometric factor.
 
     Parameters
     ----------
@@ -248,17 +245,11 @@ def get_geometric_factor(
         Ancillary files.
     filename : str
         Name of the file in ancillary_files to use.
-    phi : NDArray
-        Azimuth angles in degrees.
-    theta : NDArray
-        Elevation angles in degrees.
-    quality_flag : NDArray
-        Quality flag to set when geometric factor is zero.
 
     Returns
     -------
-    geometric_factor : NDArray
-        Geometric factor.
+    geometric_factor_tables : dict
+        Geometric factor lookup tables.
     """
     gf_table = pd.read_csv(
         ancillary_files[filename], header=None, skiprows=6, nrows=301
@@ -269,16 +260,64 @@ def get_geometric_factor(
     phi_table = pd.read_csv(
         ancillary_files[filename], header=None, skiprows=610, nrows=301
     ).to_numpy(dtype=float)
+
+    return {
+        "gf_table": gf_table,
+        "theta_table": theta_table,
+        "phi_table": phi_table,
+    }
+
+
+def get_geometric_factor(
+    phi: NDArray,
+    theta: NDArray,
+    quality_flag: NDArray,
+    ancillary_files: dict | None = None,
+    filename: str | None = None,
+    geometric_factor_tables: dict | None = None,
+) -> tuple[NDArray, NDArray]:
+    """
+    Lookup table for geometric factor using nearest neighbor.
+
+    Parameters
+    ----------
+    phi : NDArray
+        Azimuth angles in degrees.
+    theta : NDArray
+        Elevation angles in degrees.
+    quality_flag : NDArray
+        Quality flag to set when geometric factor is zero.
+    ancillary_files : dict[Path], optional
+        Ancillary files.
+    filename : str, optional
+        Name of the file in ancillary_files to use.
+    geometric_factor_tables : dict, optional
+        Preloaded geometric factor lookup tables. If not provided, will load.
+
+    Returns
+    -------
+    geometric_factor : NDArray
+        Geometric factor.
+    """
+    if geometric_factor_tables is None:
+        if ancillary_files is None or filename is None:
+            raise ValueError(
+                "ancillary_files and filename must be provided if "
+                "geometric_factor_tables is not supplied."
+            )
+        geometric_factor_tables = load_geometric_factor_tables(
+            ancillary_files, filename
+        )
     # Assume uniform grids: extract 1D arrays from first row/col
-    theta_vals = theta_table[0, :]  # columns represent theta
-    phi_vals = phi_table[:, 0]  # rows represent phi
+    theta_vals = geometric_factor_tables["theta_table"][0, :]  # columns represent theta
+    phi_vals = geometric_factor_tables["phi_table"][:, 0]  # rows represent phi
 
     # Find nearest index in table for each input value
     phi_idx = np.abs(phi_vals[:, None] - phi).argmin(axis=0)
     theta_idx = np.abs(theta_vals[:, None] - theta).argmin(axis=0)
 
     # Fetch geometric factor values at nearest (phi, theta) pairs
-    geometric_factor = gf_table[phi_idx, theta_idx]
+    geometric_factor = geometric_factor_tables["gf_table"][phi_idx, theta_idx]
 
     outside_fov = ~is_inside_fov(np.deg2rad(phi), np.deg2rad(theta))
     quality_flag[outside_fov] |= ImapDEOutliersUltraFlags.FOV.value

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -514,7 +514,11 @@ def flag_scattering(
         # Input the theta and phi values for the current energy range.
         # Returns a_theta_val, g_theta_val, a_phi_val, g_phi_val
         theta_coeffs, phi_coeffs = get_scattering_coefficients(
-            ancillary_files, int(sensor[-2:]), theta[event_mask], phi[event_mask]
+            theta[event_mask],
+            phi[event_mask],
+            lookup_tables=None,
+            ancillary_files=ancillary_files,
+            instrument_id=int(sensor[-2:]),
         )
         # FWHM_PHI = A_PHI * E^G_PHI
         # FWHM_THETA = A_THETA * E^G_THETA

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from imap_processing.spice.time import sct_to_et
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     calculate_pixels_within_scattering_threshold,
     get_spacecraft_pointing_lookup_tables,
@@ -105,8 +106,8 @@ def calculate_helio_pset(
     efficiencies, geometric_function = get_efficiencies_and_geometric_function(
         pixels_below_scattering, theta_vals, phi_vals, n_pix, ancillary_files
     )
-
-    mid_time = np.mean(de_dataset["event_times"].data)
+    # TODO fix midpoint time calculation
+    mid_time = sct_to_et(np.median(de_dataset["event_times"].data))
     exposure_time, efficiency, geometric_function = get_helio_adjusted_data(
         mid_time,
         exposure_time,

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -8,10 +8,8 @@ import xarray as xr
 
 from imap_processing.spice.time import sct_to_et
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
-    get_spacecraft_pointing_lookup_tables,
-)
-from imap_processing.ultra.l1c.spacecraft_pset import (
     calculate_pixels_within_scattering_threshold,
+    get_spacecraft_pointing_lookup_tables,
 )
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -6,7 +6,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from imap_processing.spice.time import sct_to_et
+from imap_processing.spice.repoint import get_pointing_times
+from imap_processing.spice.time import (
+    et_to_met,
+    met_to_ttj2000ns,
+    sct_to_et,
+    ttj2000ns_to_et,
+)
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     calculate_pixels_within_scattering_threshold,
     get_spacecraft_pointing_lookup_tables,
@@ -106,8 +112,12 @@ def calculate_helio_pset(
     efficiencies, geometric_function = get_efficiencies_and_geometric_function(
         pixels_below_scattering, theta_vals, phi_vals, n_pix, ancillary_files
     )
-    # TODO fix midpoint time calculation
-    mid_time = sct_to_et(np.median(de_dataset["event_times"].data))
+    # Get midpoint timestamp for pointing.
+    # TODO remove sct_to_et conversion
+    pointing_start, pointing_stop = get_pointing_times(
+        et_to_met(sct_to_et(de_dataset["event_times"].data[0]))
+    )
+    mid_time = ttj2000ns_to_et(met_to_ttj2000ns((pointing_start + pointing_stop) / 2))
     exposure_time, efficiency, geometric_function = get_helio_adjusted_data(
         mid_time,
         exposure_time,

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from imap_processing.spice.time import sct_to_et
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     calculate_pixels_within_scattering_threshold,
     get_spacecraft_pointing_lookup_tables,
@@ -107,7 +106,7 @@ def calculate_helio_pset(
         pixels_below_scattering, theta_vals, phi_vals, n_pix, ancillary_files
     )
 
-    mid_time = sct_to_et(np.median(de_dataset["event_times"].data))
+    mid_time = np.mean(de_dataset["event_times"].data)
     exposure_time, efficiency, geometric_function = get_helio_adjusted_data(
         mid_time,
         exposure_time,

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -1,25 +1,39 @@
 """Calculate Pointing Set Grids."""
 
+import logging
+
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 from imap_processing.spice.time import sct_to_et
+from imap_processing.ultra.l1c.l1c_lookup_utils import (
+    get_spacecraft_pointing_lookup_tables,
+)
+from imap_processing.ultra.l1c.spacecraft_pset import (
+    calculate_pixels_within_scattering_threshold,
+)
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
-    get_helio_exposure_times,
-    get_helio_sensitivity,
+    get_efficiencies_and_geometric_function,
+    get_helio_adjusted_data,
+    get_spacecraft_exposure_times,
     get_spacecraft_histogram,
 )
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
+
+logger = logging.getLogger(__name__)
 
 
 def calculate_helio_pset(
     de_dataset: xr.Dataset,
     extendedspin_dataset: xr.Dataset,
     cullingmask_dataset: xr.Dataset,
+    rates_dataset: xr.Dataset,
+    params_dataset: xr.Dataset,
     name: str,
     ancillary_files: dict,
+    instrument_id: int,
 ) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
@@ -32,10 +46,16 @@ def calculate_helio_pset(
         Dataset containing extendedspin data.
     cullingmask_dataset : xarray.Dataset
         Dataset containing cullingmask data.
+    rates_dataset : xarray.Dataset
+        Dataset containing image rates data.
+    params_dataset : xarray.Dataset
+        Dataset containing image parameters data.
     name : str
         Name of the dataset.
     ancillary_files : dict
         Ancillary files.
+    instrument_id : int
+        Instrument ID, either 45 or 90.
 
     Returns
     -------
@@ -60,22 +80,45 @@ def calculate_helio_pset(
 
     healpix = np.arange(n_pix)
 
-    efficiencies = ancillary_files["l1c-90sensor-efficiencies"]
-    geometric_function = ancillary_files["l1c-90sensor-gf"]
+    # Get lookup table for FOR indices by spin phase step
+    (
+        for_indices_by_spin_phase,
+        theta_vals,
+        phi_vals,
+        ra_and_dec,
+        boundary_scale_factors,
+    ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
+    # Check that the number of rows in the lookup table matches the number of pixels
+    if for_indices_by_spin_phase.shape[0] != n_pix:
+        logger.warning(
+            "The lookup table is expected to have the same number of rows as "
+            "the number of HEALPix pixels."
+        )
 
-    df_efficiencies = pd.read_csv(efficiencies)
-    df_geometric_function = pd.read_csv(geometric_function)
-    mid_time = sct_to_et(np.median(de_dataset["event_times"].data))
-    sensitivity = get_helio_sensitivity(
-        mid_time,
-        df_efficiencies,
-        df_geometric_function,
+    pixels_below_scattering = calculate_pixels_within_scattering_threshold(
+        for_indices_by_spin_phase, theta_vals, phi_vals, ancillary_files, instrument_id
     )
-
     # Calculate exposure
     constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
     df_exposure = pd.read_csv(constant_exposure)
-    exposure_pointing = get_helio_exposure_times(mid_time, df_exposure)
+    exposure_time, deadtime_ratios = get_spacecraft_exposure_times(
+        df_exposure, rates_dataset, params_dataset, pixels_below_scattering
+    )
+    # calculate efficiency and geometric function as a function of energy
+    efficiencies, geometric_function = get_efficiencies_and_geometric_function(
+        pixels_below_scattering, theta_vals, phi_vals, n_pix, ancillary_files
+    )
+
+    mid_time = sct_to_et(np.median(de_dataset["event_times"].data))
+    exposure_time, efficiency, geometric_function = get_helio_adjusted_data(
+        mid_time,
+        exposure_time,
+        geometric_function,
+        efficiencies,
+        ra_and_dec[:, 0],
+        ra_and_dec[:, 1],
+    )
+    sensitivity = efficiencies * geometric_function
 
     # For ISTP, epoch should be the center of the time bin.
     pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)
@@ -83,12 +126,15 @@ def calculate_helio_pset(
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
-    pset_dict["helio_exposure_factor"] = exposure_pointing[np.newaxis, ...]
+    pset_dict["helio_exposure_factor"] = exposure_time
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
         np.newaxis, ...
     ]
-    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
+    pset_dict["sensitivity"] = sensitivity
+    pset_dict["efficiency"] = efficiencies
+    pset_dict["geometric_function"] = geometric_function
+    pset_dict["dead_time_ratio"] = deadtime_ratios
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -92,7 +92,7 @@ def calculate_pixels_within_scattering_threshold(
 
     Returns
     -------
-    exposure_pointing_adjusted : list
+    pixels_below_scattering : list
         A Nested list of arrays indicating pixels within the scattering threshold.
         The outer list indicates spin phase steps, the middle list indicates energy
         bins, and the inner arrays contain indices indicating pixels that are below

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -1,0 +1,126 @@
+"""Contains tools for lookup tables for l1c."""
+
+import logging
+
+import numpy as np
+import pandas as pd
+from numpy._typing import NDArray
+
+from imap_processing.ultra.constants import UltraConstants
+
+logger = logging.getLogger(__name__)
+
+
+def mask_below_fwhm_scattering_threshold(
+    theta_coeffs: np.ndarray,
+    phi_coeffs: np.ndarray,
+    energy: int,
+) -> np.ndarray:
+    """
+    Determine indices of theta and phi values below the FWHM scattering threshold.
+
+    For each phi and theta, calculate the FWHM using the formula:
+    FWHM = A*E^g
+    If Phi FWHM or Theta FWHM > the scattering requirements from the table above,
+    mask the instrument frame pixel.
+
+    Parameters
+    ----------
+    theta_coeffs : NDArray
+        Coefficients for theta FWHM calculation (a and g) for each pixel.
+    phi_coeffs : NDArray
+        Coefficients for phi FWHM calculation (a and g) for each pixel.
+    energy : int
+        Energy in keV.
+
+    Returns
+    -------
+    numpy.ndarray
+        Boolean array indicating indices below the scattering threshold.
+    """
+    scattering_thresholds = UltraConstants.ULTRA_FWHM_SCATTERING_CULLING_THRESHOLDS
+    # Calculate FWHM for theta and phi
+    fwhm_theta = theta_coeffs[..., 0] * energy ** theta_coeffs[..., 1]
+    fwhm_phi = phi_coeffs[..., 0] * energy ** phi_coeffs[..., 1]
+
+    try:
+        # Get the scattering threshold based on the energy
+        threshold = next(
+            threshold
+            for energy_range, threshold in scattering_thresholds.items()
+            if energy_range[0] <= energy < energy_range[1]
+        )
+    except StopIteration:
+        logger.warning(
+            f"Energy {energy} keV is out of bounds for scattering thresholds. Using "
+            f"zero for as threshold."
+        )
+        threshold = 0
+    # Combine conditions for both theta and phi
+    return np.logical_and(fwhm_theta <= threshold, fwhm_phi <= threshold)
+
+
+def get_spacecraft_pointing_lookup_tables(
+    ancillary_files: dict, instrument_id: int
+) -> tuple[NDArray, NDArray, NDArray, NDArray, NDArray]:
+    """
+    Get indices of pixels in the nominal FOR as a function of spin phase.
+
+    This function also returns the theta / phi values in the instrument frame per spin
+    phase, right ascension / declination values in the SC frame, and boundary scale
+    factors for each pixel at each spin phase.
+
+    Parameters
+    ----------
+    ancillary_files : dict[Path]
+        Ancillary files.
+    instrument_id : int
+        Instrument ID, either 45 or 90.
+
+    Returns
+    -------
+    for_indices_by_spin_phase : NDArray
+        A 2D boolean array of shape (npix, n_spin_phase_steps).
+        True indicates pixels that are within the Field of Regard (FOR) at that
+        spin phase.
+    theta_vals : NDArray
+        A 2D array of theta values for each HEALPix pixel at each spin phase step.
+    phi_vals : NDArray
+         A 2D array of phi values for each HEALPix pixel at each spin phase step.
+    ra_and_dec : NDArray
+        A 2D array of right ascension and declination values for each HEALPix pixel.
+    boundary_scale_factors : NDArray
+        A 2D array of boundary scale factors for each HEALPix pixel at each spin phase
+        step.
+    """
+    theta_descriptor = f"l1c-{instrument_id}sensor-sc-pointing-theta-n32"
+    phi_descriptor = f"l1c-{instrument_id}sensor-sc-pointing-phi-n32"
+    index_descriptor = f"l1c-{instrument_id}sensor-sc-pointing-index-n32"
+    bsf_descriptor = f"l1c-{instrument_id}sensor-sc-pointing-bsf-n32"
+
+    theta_vals = pd.read_csv(
+        ancillary_files[theta_descriptor], header=None, skiprows=1
+    ).to_numpy(dtype=float)[:, 2:]
+    phi_vals = pd.read_csv(
+        ancillary_files[phi_descriptor], header=None, skiprows=1
+    ).to_numpy(dtype=float)[:, 2:]
+    index_grid = pd.read_csv(
+        ancillary_files[index_descriptor], header=None, skiprows=1
+    ).to_numpy(dtype=float)
+    boundary_scale_factors = pd.read_csv(
+        ancillary_files[bsf_descriptor], header=None, skiprows=1
+    ).to_numpy(dtype=float)[:, 2:]
+
+    ra_and_dec = index_grid[:, :2]  # Shape (npix, 2)
+    # This array indicates whether each pixel is in the nominal FOR at each spin phase
+    # step (15000 steps for a full rotation with 1 ms resolution).
+    for_indices_by_spin_phase = np.nan_to_num(index_grid[:, 2:], nan=0).astype(
+        bool
+    )  # Shape (npix, 15000)
+    return (
+        for_indices_by_spin_phase,
+        theta_vals,
+        phi_vals,
+        ra_and_dec,
+        boundary_scale_factors,
+    )

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -7,6 +7,11 @@ import pandas as pd
 from numpy._typing import NDArray
 
 from imap_processing.ultra.constants import UltraConstants
+from imap_processing.ultra.l1b.lookup_utils import (
+    get_scattering_coefficients,
+    load_scattering_lookup_tables,
+)
+from imap_processing.ultra.l1c.ultra_l1c_pset_bins import build_energy_bins
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +63,76 @@ def mask_below_fwhm_scattering_threshold(
         threshold = 0
     # Combine conditions for both theta and phi
     return np.logical_and(fwhm_theta <= threshold, fwhm_phi <= threshold)
+
+
+def calculate_pixels_within_scattering_threshold(
+    for_indices_by_spin_phase: np.ndarray,
+    theta_vals: np.ndarray,
+    phi_vals: np.ndarray,
+    ancillary_files: dict,
+    instrument_id: int,
+) -> list:
+    """
+    Calculate pixels within the FWHM scattering threshold for each spin phase step.
+
+    Parameters
+    ----------
+    for_indices_by_spin_phase : np.ndarray
+        A 2D boolean array where cols are spin phase steps are rows are HEALPix pixels.
+        True indicates pixels that are within the Field of Regard (FOR) at that
+        spin phase.
+    theta_vals : np.ndarray
+        A 2D array of theta values for each HEALPix pixel at each spin phase step.
+    phi_vals : np.ndarray
+         A 2D array of phi values for each HEALPix pixel at each spin phase step.
+    ancillary_files : dict
+        Dictionary containing ancillary files.
+    instrument_id : int,
+        Instrument ID, either 45 or 90.
+
+    Returns
+    -------
+    exposure_pointing_adjusted : list
+        A Nested list of arrays indicating pixels within the scattering threshold.
+        The outer list indicates spin phase steps, the middle list indicates energy
+        bins, and the inner arrays contain indices indicating pixels that are below
+        the FWHM scattering threshold.
+    """
+    # Load scattering coefficient lookup table
+    scattering_luts = load_scattering_lookup_tables(ancillary_files, instrument_id)
+    pixels_below_scattering = []
+    # Get energy bin geometric means
+    energy_bin_geometric_means = build_energy_bins()[2]
+    steps = for_indices_by_spin_phase.shape[1]
+    # The "for_indices_by_spin_phase" lookup table contains the boolean values of each
+    # pixel at each spin phase step, indicating whether the pixel is inside the FOR.
+    # It starts at Spin-phase = 0, and increments in fine steps (1 ms), spinning the
+    # spacecraft in the despun frame. At each iteration, query for the pixels in the
+    # FOR, and calculate whether the FWHM value is below the threshold at the energy.
+    for i in range(steps):
+        # Calculate spin phase for the current iteration
+        for_inds = for_indices_by_spin_phase[:, i]
+        pixels_below_scattering_for_energy = []
+
+        for energy_idx in range(len(energy_bin_geometric_means)):
+            # Get a mask for pixels below the FWHM scattering threshold
+            energy = int(energy_bin_geometric_means[energy_idx])
+            # Using the lookup table, get the indices of the pixels inside the FOR at
+            # the current spin phase step.
+            theta = theta_vals[for_inds, i]
+            phi = phi_vals[for_inds, i]
+            theta_coeffs, phi_coeffs = get_scattering_coefficients(
+                theta, phi, lookup_tables=scattering_luts
+            )
+            scattering_mask = mask_below_fwhm_scattering_threshold(
+                theta_coeffs, phi_coeffs, energy
+            )
+            pixels_below_scattering_for_energy.append(
+                np.where(for_inds)[0][scattering_mask]
+            )
+        pixels_below_scattering.append(pixels_below_scattering_for_energy)
+
+    return pixels_below_scattering
 
 
 def get_spacecraft_pointing_lookup_tables(

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -1,13 +1,18 @@
 """Calculate Pointing Set Grids."""
 
+import logging
+
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.ultra.l1b.lookup_utils import (
-    get_nominal_for_by_spin_phase,
     get_scattering_coefficients,
+    load_scattering_lookup_tables,
+)
+from imap_processing.ultra.l1c.l1c_lookup_utils import (
+    get_spacecraft_pointing_lookup_tables,
     mask_below_fwhm_scattering_threshold,
 )
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
@@ -19,10 +24,13 @@ from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
 )
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
+logger = logging.getLogger(__name__)
+
 
 def calculate_pixels_within_scattering_threshold(
     for_indices_by_spin_phase: np.ndarray,
-    theta_and_phi: np.ndarray,
+    theta_vals: np.ndarray,
+    phi_vals: np.ndarray,
     ancillary_files: dict,
     instrument_id: int,
 ) -> list:
@@ -35,9 +43,10 @@ def calculate_pixels_within_scattering_threshold(
         A 2D boolean array where cols are spin phase steps are rows are HEALPix pixels.
         True indicates pixels that are within the Field of Regard (FOR) at that
         spin phase.
-    theta_and_phi : np.ndarray
-        A 2D array where the first column is theta values and the second column is
-        phi values for each HEALPix pixel.
+    theta_vals : np.ndarray
+        A 2D array of theta values for each HEALPix pixel at each spin phase step.
+    phi_vals : np.ndarray
+         A 2D array of phi values for each HEALPix pixel at each spin phase step.
     ancillary_files : dict
         Dictionary containing ancillary files.
     instrument_id : int,
@@ -51,17 +60,12 @@ def calculate_pixels_within_scattering_threshold(
         bins, and the inner arrays contain indices indicating pixels that are below
         the FWHM scattering threshold.
     """
+    # Load scattering coefficient lookup table
+    scattering_luts = load_scattering_lookup_tables(ancillary_files, instrument_id)
     pixels_below_scattering = []
     # Get energy bin geometric means
     energy_bin_geometric_means = build_energy_bins()[2]
     steps = for_indices_by_spin_phase.shape[1]
-    # Using the lookup table, get the indices of the pixels inside the FOR at the
-    # current spin phase step.
-    theta = theta_and_phi[:, 0]
-    phi = theta_and_phi[:, 1]
-    theta_coeffs, phi_coeffs = get_scattering_coefficients(
-        ancillary_files, instrument_id, theta, phi
-    )
     # The "for_indices_by_spin_phase" lookup table contains the boolean values of each
     # pixel at each spin phase step, indicating whether the pixel is inside the FOR.
     # It starts at Spin-phase = 0, and increments in fine steps (1 ms), spinning the
@@ -71,11 +75,19 @@ def calculate_pixels_within_scattering_threshold(
         # Calculate spin phase for the current iteration
         for_inds = for_indices_by_spin_phase[:, i]
         pixels_below_scattering_for_energy = []
+
         for energy_idx in range(len(energy_bin_geometric_means)):
             # Get a mask for pixels below the FWHM scattering threshold
             energy = int(energy_bin_geometric_means[energy_idx])
+            # Using the lookup table, get the indices of the pixels inside the FOR at
+            # the current spin phase step.
+            theta = theta_vals[for_inds, i]
+            phi = phi_vals[for_inds, i]
+            theta_coeffs, phi_coeffs = get_scattering_coefficients(
+                theta, phi, lookup_tables=scattering_luts
+            )
             scattering_mask = mask_below_fwhm_scattering_threshold(
-                theta_coeffs[for_inds], phi_coeffs[for_inds], energy
+                theta_coeffs, phi_coeffs, energy
             )
             pixels_below_scattering_for_energy.append(
                 np.where(for_inds)[0][scattering_mask]
@@ -140,24 +152,34 @@ def calculate_spacecraft_pset(
     healpix = np.arange(n_pix)
 
     # Get lookup table for FOR indices by spin phase step
-    for_indices_by_spin_phase, theta_and_phi, ra_and_dec = (
-        get_nominal_for_by_spin_phase(ancillary_files, instrument_id)
-    )
+    (
+        for_indices_by_spin_phase,
+        theta_vals,
+        phi_vals,
+        ra_and_dec,
+        boundary_scale_factors,
+    ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
+    # Check that the number of rows in the lookup table matches the number of pixels
+    if for_indices_by_spin_phase.shape[0] != n_pix:
+        logger.warning(
+            "The lookup table is expected to have the same number of rows as "
+            "the number of HEALPix pixels."
+        )
+
     pixels_below_scattering = calculate_pixels_within_scattering_threshold(
-        for_indices_by_spin_phase, theta_and_phi, ancillary_files, instrument_id
+        for_indices_by_spin_phase, theta_vals, phi_vals, ancillary_files, instrument_id
     )
     # calculate efficiency and geometric function as a function of energy
     efficiencies, geometric_function = get_efficiencies_and_geometric_function(
-        pixels_below_scattering, theta_and_phi, ancillary_files
+        pixels_below_scattering, theta_vals, phi_vals, n_pix, ancillary_files
     )
-    # TODO handle sensitivity
-    # sensitivity = interpolate_sensitivity(efficiencies, geometric_function)
+    sensitivity = efficiencies * geometric_function
 
     # Calculate exposure
     constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
     df_exposure = pd.read_csv(constant_exposure)
 
-    exposure_pointing = get_spacecraft_exposure_times(
+    exposure_pointing, deadtime_ratios = get_spacecraft_exposure_times(
         df_exposure, rates_dataset, params_dataset, pixels_below_scattering
     )
 
@@ -177,12 +199,16 @@ def calculate_spacecraft_pset(
     pset_dict["longitude"] = longitude[np.newaxis, ...]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
     pset_dict["background_rates"] = background_rates[np.newaxis, ...]
-    pset_dict["exposure_factor"] = exposure_pointing[np.newaxis, ...]
+    pset_dict["exposure_factor"] = exposure_pointing
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
         np.newaxis, ...
     ]
-    # pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
+
+    pset_dict["sensitivity"] = sensitivity
+    pset_dict["efficiency"] = efficiencies
+    pset_dict["geometric_function"] = geometric_function
+    pset_dict["dead_time_ratio"] = deadtime_ratios
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -7,13 +7,9 @@ import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
-from imap_processing.ultra.l1b.lookup_utils import (
-    get_scattering_coefficients,
-    load_scattering_lookup_tables,
-)
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
+    calculate_pixels_within_scattering_threshold,
     get_spacecraft_pointing_lookup_tables,
-    mask_below_fwhm_scattering_threshold,
 )
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
@@ -25,76 +21,6 @@ from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 logger = logging.getLogger(__name__)
-
-
-def calculate_pixels_within_scattering_threshold(
-    for_indices_by_spin_phase: np.ndarray,
-    theta_vals: np.ndarray,
-    phi_vals: np.ndarray,
-    ancillary_files: dict,
-    instrument_id: int,
-) -> list:
-    """
-    Calculate pixels within the FWHM scattering threshold for each spin phase step.
-
-    Parameters
-    ----------
-    for_indices_by_spin_phase : np.ndarray
-        A 2D boolean array where cols are spin phase steps are rows are HEALPix pixels.
-        True indicates pixels that are within the Field of Regard (FOR) at that
-        spin phase.
-    theta_vals : np.ndarray
-        A 2D array of theta values for each HEALPix pixel at each spin phase step.
-    phi_vals : np.ndarray
-         A 2D array of phi values for each HEALPix pixel at each spin phase step.
-    ancillary_files : dict
-        Dictionary containing ancillary files.
-    instrument_id : int,
-        Instrument ID, either 45 or 90.
-
-    Returns
-    -------
-    exposure_pointing_adjusted : list
-        A Nested list of arrays indicating pixels within the scattering threshold.
-        The outer list indicates spin phase steps, the middle list indicates energy
-        bins, and the inner arrays contain indices indicating pixels that are below
-        the FWHM scattering threshold.
-    """
-    # Load scattering coefficient lookup table
-    scattering_luts = load_scattering_lookup_tables(ancillary_files, instrument_id)
-    pixels_below_scattering = []
-    # Get energy bin geometric means
-    energy_bin_geometric_means = build_energy_bins()[2]
-    steps = for_indices_by_spin_phase.shape[1]
-    # The "for_indices_by_spin_phase" lookup table contains the boolean values of each
-    # pixel at each spin phase step, indicating whether the pixel is inside the FOR.
-    # It starts at Spin-phase = 0, and increments in fine steps (1 ms), spinning the
-    # spacecraft in the despun frame. At each iteration, query for the pixels in the
-    # FOR, and calculate whether the FWHM value is below the threshold at the energy.
-    for i in range(steps):
-        # Calculate spin phase for the current iteration
-        for_inds = for_indices_by_spin_phase[:, i]
-        pixels_below_scattering_for_energy = []
-
-        for energy_idx in range(len(energy_bin_geometric_means)):
-            # Get a mask for pixels below the FWHM scattering threshold
-            energy = int(energy_bin_geometric_means[energy_idx])
-            # Using the lookup table, get the indices of the pixels inside the FOR at
-            # the current spin phase step.
-            theta = theta_vals[for_inds, i]
-            phi = phi_vals[for_inds, i]
-            theta_coeffs, phi_coeffs = get_scattering_coefficients(
-                theta, phi, lookup_tables=scattering_luts
-            )
-            scattering_mask = mask_below_fwhm_scattering_threshold(
-                theta_coeffs, phi_coeffs, energy
-            )
-            pixels_below_scattering_for_energy.append(
-                np.where(for_inds)[0][scattering_mask]
-            )
-        pixels_below_scattering.append(pixels_below_scattering_for_energy)
-
-    return pixels_below_scattering
 
 
 def calculate_spacecraft_pset(

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -50,8 +50,11 @@ def ultra_l1c(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-extendedspin"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-cullingmask"],
+                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
+                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-params"],
                 f"imap_ultra_l1c_{instrument_id}sensor-heliopset",
                 ancillary_files,
+                instrument_id,
             )
             output_datasets = [helio_pset]
         elif (

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -524,7 +524,7 @@ def get_efficiencies_and_geometric_function(
 
 
 def get_helio_adjusted_data(
-    time: np.ndarray,
+    time: float,
     exposure_time: np.ndarray,
     geometric_factor: np.ndarray,
     efficiency: np.ndarray,
@@ -540,7 +540,7 @@ def get_helio_adjusted_data(
 
     Parameters
     ----------
-    time : np.ndarray
+    time : float
         Median time of pointing in et.
     exposure_time : np.ndarray
         Spacecraft exposure. Shape = (energy, npix).

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -3,11 +3,9 @@
 import astropy_healpix.healpy as hp
 import numpy as np
 import pandas
-import pandas as pd
 import xarray as xr
 from numpy.typing import NDArray
 from scipy import interpolate
-from scipy.interpolate import interp1d
 
 from imap_processing.spice.geometry import (
     SpiceFrame,
@@ -400,7 +398,7 @@ def get_spacecraft_exposure_times(
     rates_dataset: xr.Dataset,
     params_dataset: xr.Dataset,
     pixels_below_scattering: list[list],
-) -> NDArray:
+) -> tuple[NDArray, NDArray]:
     """
     Compute exposure times for HEALPix pixels.
 
@@ -424,24 +422,27 @@ def get_spacecraft_exposure_times(
         Total exposure times of pixels in a
         Healpix tessellation of the sky
         in the pointing (dps) frame.
+    nominal_deadtime_ratios : np.ndarray
+        Deadtime ratios at each spin phase step (1ms res).
     """
     # TODO: use the universal spin table and
     #  universal pointing table here to determine actual number of spins
     sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
     nominal_deadtime_ratios = get_deadtime_ratios_by_spin_phase(sectored_rates)
-    # TODO save nominal_deadtime_ratios to the pset.
     exposure_pointing = (
         constant_exposure["Exposure Time"] * 5760
     )  # 5760 spins per pointing (for now)
     exposure_pointing_adjusted = apply_deadtime_correction(
         exposure_pointing, nominal_deadtime_ratios, pixels_below_scattering
     )
-    return exposure_pointing_adjusted
+    return exposure_pointing_adjusted, nominal_deadtime_ratios
 
 
 def get_efficiencies_and_geometric_function(
     pixels_below_scattering: list[list],
-    theta_and_phi: np.ndarray,
+    theta_vals: np.ndarray,
+    phi_vals: np.ndarray,
+    npix: int,
     ancillary_files: dict,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
@@ -456,9 +457,12 @@ def get_efficiencies_and_geometric_function(
         The outer list indicates spin phase steps, the middle list indicates energy
         bins, and the inner list contains pixel indices indicating pixels that are
         below the FWHM scattering threshold.
-    theta_and_phi : np.ndarray
-        Array of theta and phi values for each pixel. First column is theta,
-        second is phi.
+    theta_vals : np.ndarray
+        A 2D array of theta values for each HEALPix pixel at each spin phase step.
+    phi_vals : np.ndarray
+         A 2D array of phi values for each HEALPix pixel at each spin phase step.
+    npix : int
+        Number of HEALPix pixels.
     ancillary_files : dict
         Dictionary containing ancillary files.
 
@@ -474,67 +478,76 @@ def get_efficiencies_and_geometric_function(
     # Get energy bin geometric means
     energy_bin_geometric_means = build_energy_bins()[2]
     energy_bins = len(energy_bin_geometric_means)
-    # Number of pixels is the length of theta or phi
-    npix = theta_and_phi.shape[0]
     # Initialize summation arrays for geometric factors and efficiencies
     gf_summation = np.zeros((energy_bins, npix))
     eff_summation = np.zeros((energy_bins, npix))
     sample_count = np.zeros((energy_bins, npix))
-    # Compute gf and eff for these theta/phi pairs
-    gf_values = get_geometric_factor(
-        ancillary_files,
-        "l1b-sensor-gf-blades",
-        theta_and_phi[:, 0],  # Theta
-        theta_and_phi[:, 1],  # Phi
-        np.zeros(theta_and_phi.shape[0]).astype(np.uint16),
-    )
     # Loop through spin phases
-    for pixels_at_spin in pixels_below_scattering:
+    for i, pixels_at_spin in enumerate(pixels_below_scattering):
         # Loop through energy bins
+        # Compute gf and eff for these theta/phi pairs
+        theta_at_spin = theta_vals[:, i]
+        phi_at_spin = phi_vals[:, i]
+        gf_values = get_geometric_factor(
+            ancillary_files,
+            "l1b-sensor-gf-blades",
+            theta_at_spin,
+            phi_at_spin,
+            np.zeros(len(phi_at_spin)).astype(np.uint16),
+        )
         for energy_bin_idx in range(energy_bins):
             pixel_inds = pixels_at_spin[energy_bin_idx]
             if pixel_inds.size == 0:
                 continue
             energy = energy_bin_geometric_means[energy_bin_idx]
-            # Get theta and phi vals for pixels in the FOR at this spin phase
-            theta_vals = theta_and_phi[pixel_inds, 0]
-            phi_vals = theta_and_phi[pixel_inds, 1]
             eff_values = get_efficiency(
-                np.full(phi_vals.shape, energy),
-                phi_vals,
-                theta_vals,
+                np.full(phi_at_spin[pixel_inds].shape, energy),
+                phi_at_spin[pixel_inds],
+                theta_at_spin[pixel_inds],
                 ancillary_files,
                 interpolator=eff_interpolator,
             )
-
-            # Accumulate
+            # Accumulate gf and eff values
             gf_summation[energy_bin_idx, pixel_inds] += gf_values[pixel_inds]
             eff_summation[energy_bin_idx, pixel_inds] += eff_values
             sample_count[energy_bin_idx, pixel_inds] += 1
 
     # return averaged geometric factors and efficiencies across all spin phases
     # These are now energy dependent.
-    non_zero = sample_count > 0
-    gf_averaged = gf_summation[non_zero] / sample_count[non_zero]
-    eff_averaged = eff_summation[non_zero] / sample_count[non_zero]
+    gf_averaged = np.divide(gf_summation, sample_count, where=sample_count != 0)
+    eff_averaged = np.divide(eff_summation, sample_count, where=sample_count != 0)
     return gf_averaged, eff_averaged
 
 
-def get_helio_exposure_times(
+def get_helio_adjusted_data(
     time: np.ndarray,
-    df_exposure: pd.DataFrame,
+    exposure_time: np.ndarray,
+    geometric_factor: np.ndarray,
+    efficiency: np.ndarray,
+    ra: np.ndarray,
+    dec: np.ndarray,
     nside: int = 128,
     nested: bool = False,
-) -> NDArray:
+) -> tuple[NDArray, NDArray, NDArray]:
     """
-    Compute a 2D (Healpix index, energy) array of exposure in the helio frame.
+    Compute 2D (Healpix index, energy) arrays for in the helio frame.
+
+    Build CG corrected exposure, efficiency, and geometric factor arrays.
 
     Parameters
     ----------
     time : np.ndarray
         Median time of pointing in et.
-    df_exposure : pd.DataFrame
-        Spacecraft exposure in healpix coordinates.
+    exposure_time : np.ndarray
+        Spacecraft exposure. Shape = (energy, npix).
+    geometric_factor : np.ndarray
+        Geometric factor values. Shape = (energy, npix).
+    efficiency : np.ndarray
+        Efficiency values. Shape = (energy, npix).
+    ra : np.ndarray
+        Right ascension in the spacecraft frame (degrees).
+    dec : np.ndarray
+        Declination in the spacecraft frame (degrees).
     nside : int, optional
         The nside parameter of the Healpix tessellation (default is 128).
     nested : bool, optional
@@ -543,7 +556,11 @@ def get_helio_exposure_times(
     Returns
     -------
     helio_exposure : np.ndarray
-        A 2D array of shape (npix, n_energy_bins).
+        A 2D array of shape (n_energy_bins, npix).
+    helio_efficiency : np.ndarray
+        A 2D array of shape (n_energy_bins, npix).
+    helio_geometric_factors : np.ndarray
+        A 2D array of shape (n_energy_bins, npix).
 
     Notes
     -----
@@ -551,10 +568,6 @@ def get_helio_exposure_times(
     """
     # Get energy midpoints.
     _, energy_midpoints, _ = build_energy_bins()
-    # Extract (RA/Dec) and exposure from the spacecraft frame.
-    ra = df_exposure["Right Ascension (deg)"].values
-    dec = df_exposure["Declination (deg)"].values
-    exposure_flat = df_exposure["Exposure Time"].values
 
     # The Cartesian state vector representing the position and velocity of the
     # IMAP spacecraft.
@@ -565,12 +578,21 @@ def get_helio_exposure_times(
     # Convert (RA, Dec) angles into 3D unit vectors.
     # Each unit vector represents a direction in the sky where the spacecraft observed
     # and accumulated exposure time.
+    npix = hp.nside2npix(nside)
     unit_dirs = hp.ang2vec(ra, dec, lonlat=True).T  # Shape (N, 3)
-
+    shape = (len(energy_midpoints), int(npix))
+    if np.any(
+        [arr.shape != shape for arr in [exposure_time, geometric_factor, efficiency]]
+    ):
+        raise ValueError(
+            f"Input arrays must have the same shape {shape}, but got "
+            f"{exposure_time.shape}, {geometric_factor.shape}, {efficiency.shape}."
+        )
     # Initialize output array.
     # Each row corresponds to a HEALPix pixel, and each column to an energy bin.
-    npix = hp.nside2npix(nside)
     helio_exposure = np.zeros((len(energy_midpoints), npix))
+    helio_efficiency = np.zeros((len(energy_midpoints), npix))
+    helio_geometric_factors = np.zeros((len(energy_midpoints), npix))
 
     # Loop through energy bins and compute transformed exposure.
     for i, energy_midpoint in enumerate(energy_midpoints):
@@ -600,225 +622,19 @@ def get_helio_exposure_times(
         # Convert azimuth/elevation directions to HEALPix pixel indices.
         hpix_idx = hp.ang2pix(nside, az, el, nest=nested, lonlat=True)
 
-        # Accumulate exposure values into HEALPix pixels for this energy bin.
+        # Accumulate exposure, eff, and gf values into HEALPix pixels for this energy
+        # bin.
         helio_exposure[i, :] = np.bincount(
-            hpix_idx, weights=exposure_flat, minlength=npix
+            hpix_idx, weights=exposure_time[i, :], minlength=npix
+        )
+        helio_efficiency[i, :] = np.bincount(
+            hpix_idx, weights=efficiency[i, :], minlength=npix
+        )
+        helio_geometric_factors[i, :] = np.bincount(
+            hpix_idx, weights=geometric_factor[i, :], minlength=npix
         )
 
-    return helio_exposure
-
-
-def get_spacecraft_sensitivity(
-    efficiencies: pandas.DataFrame,
-    geometric_function: pandas.DataFrame,
-) -> tuple[pandas.DataFrame, NDArray, NDArray, NDArray]:
-    """
-    Compute sensitivity as efficiency * geometric factor.
-
-    Parameters
-    ----------
-    efficiencies : pandas.DataFrame
-        Efficiencies at different energy levels.
-    geometric_function : pandas.DataFrame
-        Geometric function.
-
-    Returns
-    -------
-    pointing_sensitivity : pandas.DataFrame
-        Sensitivity with dimensions (HEALPIX pixel_number, energy).
-    energy_vals : NDArray
-        Energy values of dataframe.
-    right_ascension : NDArray
-        Right ascension (longitude/azimuth) values of dataframe (0 - 360 degrees).
-    declination : NDArray
-        Declination (latitude/elevation) values of dataframe (-90 to 90 degrees).
-    """
-    # Exclude "Right Ascension (deg)" and "Declination (deg)" from the multiplication
-    energy_columns = [
-        col
-        for col in efficiencies.columns
-        if col not in ["Right Ascension (deg)", "Declination (deg)"]
-    ]
-    sensitivity = efficiencies[energy_columns].mul(
-        geometric_function["Response (cm2-sr)"].values, axis=0
-    )
-
-    right_ascension = efficiencies["Right Ascension (deg)"]
-    declination = efficiencies["Declination (deg)"]
-
-    energy_vals = np.array([float(col.replace("keV", "")) for col in energy_columns])
-
-    return sensitivity, energy_vals, right_ascension, declination
-
-
-def grid_sensitivity(
-    efficiencies: pandas.DataFrame,
-    geometric_function: pandas.DataFrame,
-    energy: float,
-) -> NDArray:
-    """
-    Grid the sensitivity.
-
-    Parameters
-    ----------
-    efficiencies : pandas.DataFrame
-        Efficiencies at different energy levels.
-    geometric_function : pandas.DataFrame
-        Geometric function.
-    energy : float
-        Energy to which we are interpolating.
-
-    Returns
-    -------
-    interpolated_sensitivity : np.ndarray
-        Sensitivity with dimensions (HEALPIX pixel_number, 1).
-    """
-    sensitivity, energy_vals, right_ascension, declination = get_spacecraft_sensitivity(
-        efficiencies, geometric_function
-    )
-
-    # Create interpolator over energy dimension for each pixel (axis=1)
-    interp_func = interp1d(
-        energy_vals,
-        sensitivity.values,
-        axis=1,
-        bounds_error=False,
-        fill_value=np.nan,
-    )
-
-    # Interpolate to energy
-    interpolated = interp_func(energy)
-    interpolated = np.where(np.isnan(interpolated), FILLVAL_FLOAT32, interpolated)
-
-    return interpolated
-
-
-def interpolate_sensitivity(
-    efficiencies: pd.DataFrame,
-    geometric_function: pd.DataFrame,
-    nside: int = 128,
-) -> NDArray:
-    """
-    Interpolate the sensitivity and bin it in HEALPix space.
-
-    Parameters
-    ----------
-    efficiencies : pandas.DataFrame
-        Efficiencies at different energy levels.
-    geometric_function : pandas.DataFrame
-        Geometric function.
-    nside : int, optional
-        Healpix nside resolution (default is 128).
-
-    Returns
-    -------
-    interpolated_sensitivity : np.ndarray
-        Array of shape (n_energy_bins, n_healpix_pixels).
-    """
-    _, _, energy_bin_geometric_means = build_energy_bins()
-    npix = hp.nside2npix(nside)
-
-    interpolated_sensitivity = np.full(
-        (len(energy_bin_geometric_means), npix), FILLVAL_FLOAT32
-    )
-
-    for i, energy in enumerate(energy_bin_geometric_means):
-        pixel_sensitivity = grid_sensitivity(
-            efficiencies, geometric_function, energy
-        ).flatten()
-        interpolated_sensitivity[i, :] = pixel_sensitivity
-
-    return interpolated_sensitivity
-
-
-def get_helio_sensitivity(
-    time: np.ndarray,
-    efficiencies: pandas.DataFrame,
-    geometric_function: pandas.DataFrame,
-    nside: int = 128,
-    nested: bool = False,
-) -> NDArray:
-    """
-    Compute a 2D (Healpix index, energy) array of sensitivity in the helio frame.
-
-    Parameters
-    ----------
-    time : np.ndarray
-        Median time of pointing in et.
-    efficiencies : pandas.DataFrame
-        Efficiencies at different energy levels.
-    geometric_function : pandas.DataFrame
-        Geometric function.
-    nside : int, optional
-        The nside parameter of the Healpix tessellation (default is 128).
-    nested : bool, optional
-        Whether the Healpix tessellation is nested (default is False).
-
-    Returns
-    -------
-    helio_sensitivity : np.ndarray
-        A 2D array of shape (npix, n_energy_bins).
-
-    Notes
-    -----
-    These calculations are performed once per pointing.
-    """
-    # Get energy midpoints.
-    _, energy_midpoints, _ = build_energy_bins()
-
-    # Get sensitivity on the spacecraft grid
-    _, _, ra, dec = get_spacecraft_sensitivity(efficiencies, geometric_function)
-
-    # The Cartesian state vector representing the position and velocity of the
-    # IMAP spacecraft.
-    state = imap_state(time, ref_frame=SpiceFrame.IMAP_DPS)
-
-    # Extract the velocity part of the state vector
-    spacecraft_velocity = state[3:6]
-    # Convert (RA, Dec) angles into 3D unit vectors.
-    # Each unit vector represents a direction in the sky where the spacecraft observed
-    # and accumulated sensitivity.
-    unit_dirs = hp.ang2vec(ra, dec, lonlat=True).T  # Shape (N, 3)
-
-    # Initialize output array.
-    # Each row corresponds to a HEALPix pixel, and each column to an energy bin.
-    npix = hp.nside2npix(nside)
-    helio_sensitivity = np.zeros((len(energy_midpoints), npix))
-
-    # Loop through energy bins and compute transformed sensitivity.
-    for i, energy in enumerate(energy_midpoints):
-        # Convert the midpoint energy to a velocity (km/s).
-        # Based on kinetic energy equation: E = 1/2 * m * v^2.
-        energy_velocity = (
-            np.sqrt(2 * energy * UltraConstants.KEV_J / UltraConstants.MASS_H) / 1e3
-        )
-
-        # Use Galilean Transform to transform the velocity wrt spacecraft
-        # to the velocity wrt heliosphere.
-        # energy_velocity * cartesian -> apply the magnitude of the velocity
-        # to every position on the grid in the despun grid.
-        helio_velocity = spacecraft_velocity.reshape(1, 3) + energy_velocity * unit_dirs
-
-        # Normalized vectors representing the direction of the heliocentric velocity.
-        helio_normalized = helio_velocity / np.linalg.norm(
-            helio_velocity, axis=1, keepdims=True
-        )
-
-        # Convert Cartesian heliocentric vectors into spherical coordinates.
-        # Result: azimuth (longitude) and elevation (latitude) in degrees.
-        helio_spherical = cartesian_to_spherical(helio_normalized)
-        az, el = helio_spherical[:, 1], helio_spherical[:, 2]
-
-        # Convert azimuth/elevation directions to HEALPix pixel indices.
-        hpix_idx = hp.ang2pix(nside, az, el, nest=nested, lonlat=True)
-        gridded_sensitivity = grid_sensitivity(efficiencies, geometric_function, energy)
-
-        # Accumulate sensitivity values into HEALPix pixels for this energy bin.
-        helio_sensitivity[i, :] = np.bincount(
-            hpix_idx, weights=gridded_sensitivity, minlength=npix
-        )
-
-    return helio_sensitivity
+    return helio_exposure, helio_efficiency, helio_geometric_factors
 
 
 def get_spacecraft_background_rates(

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -17,6 +17,7 @@ from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.lookup_utils import (
     get_geometric_factor,
     get_image_params,
+    load_geometric_factor_tables,
 )
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
     get_pulses_per_spin,
@@ -475,6 +476,10 @@ def get_efficiencies_and_geometric_function(
     """
     # Load callable efficiency interpolator function
     eff_interpolator = get_efficiency_interpolator(ancillary_files)
+    # load geometric factor lookup table
+    geometric_lookup_table = load_geometric_factor_tables(
+        ancillary_files, "l1b-sensor-gf-blades"
+    )
     # Get energy bin geometric means
     energy_bin_geometric_means = build_energy_bins()[2]
     energy_bins = len(energy_bin_geometric_means)
@@ -489,11 +494,10 @@ def get_efficiencies_and_geometric_function(
         theta_at_spin = theta_vals[:, i]
         phi_at_spin = phi_vals[:, i]
         gf_values = get_geometric_factor(
-            ancillary_files,
-            "l1b-sensor-gf-blades",
-            theta_at_spin,
-            phi_at_spin,
-            np.zeros(len(phi_at_spin)).astype(np.uint16),
+            phi=phi_at_spin,
+            theta=theta_at_spin,
+            quality_flag=np.zeros(len(phi_at_spin)).astype(np.uint16),
+            geometric_factor_tables=geometric_lookup_table,
         )
         for energy_bin_idx in range(energy_bins):
             pixel_inds = pixels_at_spin[energy_bin_idx]

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -571,7 +571,7 @@ def get_helio_adjusted_data(
     These calculations are performed once per pointing.
     """
     # Get energy midpoints.
-    _, energy_midpoints, _ = build_energy_bins()
+    _, _, energy_bin_geometric_means = build_energy_bins()
 
     # The Cartesian state vector representing the position and velocity of the
     # IMAP spacecraft.
@@ -584,7 +584,7 @@ def get_helio_adjusted_data(
     # and accumulated exposure time.
     npix = hp.nside2npix(nside)
     unit_dirs = hp.ang2vec(ra, dec, lonlat=True).T  # Shape (N, 3)
-    shape = (len(energy_midpoints), int(npix))
+    shape = (len(energy_bin_geometric_means), int(npix))
     if np.any(
         [arr.shape != shape for arr in [exposure_time, geometric_factor, efficiency]]
     ):
@@ -594,16 +594,16 @@ def get_helio_adjusted_data(
         )
     # Initialize output array.
     # Each row corresponds to a HEALPix pixel, and each column to an energy bin.
-    helio_exposure = np.zeros((len(energy_midpoints), npix))
-    helio_efficiency = np.zeros((len(energy_midpoints), npix))
-    helio_geometric_factors = np.zeros((len(energy_midpoints), npix))
+    helio_exposure = np.zeros(shape)
+    helio_efficiency = np.zeros(shape)
+    helio_geometric_factors = np.zeros(shape)
 
     # Loop through energy bins and compute transformed exposure.
-    for i, energy_midpoint in enumerate(energy_midpoints):
+    for i, energy_mean in enumerate(energy_bin_geometric_means):
         # Convert the midpoint energy to a velocity (km/s).
         # Based on kinetic energy equation: E = 1/2 * m * v^2.
         energy_velocity = (
-            np.sqrt(2 * energy_midpoint * UltraConstants.KEV_J / UltraConstants.MASS_H)
+            np.sqrt(2 * energy_mean * UltraConstants.KEV_J / UltraConstants.MASS_H)
             / 1e3
         )
 

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -135,14 +135,31 @@ def create_dataset(  # noqa: PLR0912
             )
         elif key in {
             "counts",
-            "exposure_factor",
             "background_rates",
-            "helio_exposure_factor",
-            "sensitivity",
         }:
             dataset[key] = xr.DataArray(
                 data,
                 dims=["epoch", "energy_bin_geometric_mean", "pixel_index"],
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            )
+        elif key in {
+            "exposure_factor",
+            "helio_exposure_factor",
+            "sensitivity",
+            "efficiency",
+            "geometric_function",
+        }:
+            dataset[key] = xr.DataArray(
+                data,
+                dims=["energy_bin_geometric_mean", "pixel_index"],
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            )
+        elif key in {
+            "dead_time_ratio",
+        }:
+            dataset[key] = xr.DataArray(
+                data,
+                dims=["spin_phase"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         else:


### PR DESCRIPTION
# Change Summary

## Overview
This PR updates the spacecraft pset and helio pset to calculate sensitivity, efficiency, and geometric factor arrays as function of energy. This is required because maps require pixels over a certain uncertainty to be culled. Scattering culling has to be calculated and that is a function of spin phase. At each energy bin, there are different scattering thresholds so this means we have to calculate exposure pointing,  sensitivity, efficiency, and geometric factors in regards to the energy bin now. 

Helio psets also need to adjust the values above for the energy differences between the spacecraft and heliocentric frame. Laura already had code to do this thankfully. 

## New Files
- imap_processing/ultra/l1c/l1c_lookup_utils.py
   - move l1c lookups from l1b lookup utils file. 

## Updated Files
- imap_processing/ultra/l1c/helio_pset.py
   - Update helio pset to calculate the eff, gf, exposure time, and sensitivity arrays as functions of energy. 
   - Adjust for heliocentric frame
- imap_processing/ultra/l1c/spacecraft_pset.py
   - fix scattering culling. There was a bug in the old way. I had made assumptions about what the lookup tables would look like. 

## Testing
Test lookup tables for l1c. 
