### PR TITLE
Ultra l1c - adding species filtering prior to pset calculations

### DIFF
--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -153,6 +153,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
         de_dict["quality_scattering"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
         de_dict["quality_outliers"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
+        de_dict["species"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
 
         name = "imap_ultra_l1b_45sensor-de"
         dataset = create_dataset(de_dict, name, "l1b")

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -231,6 +231,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     # Made up data for spin_number and energy_bin_geometric_mean
     de_dict["spin_number"] = np.full(len(sc_dps_velocity), 128)
     de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
+    de_dict["species"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
 
     name = "imap_ultra_l1b_45sensor-de"
     dataset = create_dataset(de_dict, name, "l1b")
@@ -312,6 +313,7 @@ def test_calculate_helio_pset_with_cdf(
     de_dict["energy_heliosphere"] = get_de_energy_kev(helio_dps_velocity, species_bin)
     de_dict["quality_scattering"] = np.zeros(len(helio_dps_velocity), dtype=np.uint16)
     de_dict["quality_outliers"] = np.zeros(len(helio_dps_velocity), dtype=np.uint16)
+    de_dict["species"] = np.ones(len(helio_dps_velocity), dtype=np.uint8)
 
     name = "imap_ultra_l1b_45sensor-de"
     dataset = create_dataset(de_dict, name, "l1b")

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -75,9 +75,10 @@ def calculate_helio_pset(
     species_dataset = de_dataset.isel(epoch=indices)
 
     rejected = get_de_rejection_mask(
-        de_dataset["quality_scattering"].values, de_dataset["quality_outliers"].values
+        species_dataset["quality_scattering"].values,
+        species_dataset["quality_outliers"].values,
     )
-    de_dataset = de_dataset.isel(epoch=~rejected)
+    de_dataset = species_dataset.isel(epoch=~rejected)
 
     v_mag_helio_spacecraft = np.linalg.norm(
         species_dataset["velocity_dps_helio"].values, axis=1

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -71,6 +71,7 @@ def calculate_helio_pset(
         Dataset containing the data.
     """
     pset_dict: dict[str, np.ndarray] = {}
+    # Select only the species we are interested in.
     indices = np.where(de_dataset["species"].values == species_id)[0]
     species_dataset = de_dataset.isel(epoch=indices)
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -39,6 +39,7 @@ def calculate_helio_pset(
     name: str,
     ancillary_files: dict,
     instrument_id: int,
+    species_id: int = 1,
 ) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
@@ -61,6 +62,8 @@ def calculate_helio_pset(
         Ancillary files.
     instrument_id : int
         Instrument ID, either 45 or 90.
+    species_id : int, optional
+        Species ID, default of 1 refers to Hydrogen.
 
     Returns
     -------
@@ -68,6 +71,8 @@ def calculate_helio_pset(
         Dataset containing the data.
     """
     pset_dict: dict[str, np.ndarray] = {}
+    indices = np.where(de_dataset["species"].values == species_id)[0]
+    species_dataset = de_dataset.isel(epoch=indices)
 
     rejected = get_de_rejection_mask(
         de_dataset["quality_scattering"].values, de_dataset["quality_outliers"].values
@@ -75,15 +80,16 @@ def calculate_helio_pset(
     de_dataset = de_dataset.isel(epoch=~rejected)
 
     v_mag_helio_spacecraft = np.linalg.norm(
-        de_dataset["velocity_dps_helio"].values, axis=1
+        species_dataset["velocity_dps_helio"].values, axis=1
     )
     vhat_dps_helio = (
-        de_dataset["velocity_dps_helio"].values / v_mag_helio_spacecraft[:, np.newaxis]
+        species_dataset["velocity_dps_helio"].values
+        / v_mag_helio_spacecraft[:, np.newaxis]
     )
     intervals, _, energy_bin_geometric_means = build_energy_bins()
     counts, latitude, longitude, n_pix = get_spacecraft_histogram(
         vhat_dps_helio,
-        de_dataset["energy_heliosphere"].values,
+        species_dataset["energy_heliosphere"].values,
         intervals,
         nside=128,
     )
@@ -121,7 +127,7 @@ def calculate_helio_pset(
     # Get midpoint timestamp for pointing.
     # TODO remove sct_to_et conversion
     pointing_start, pointing_stop = get_pointing_times(
-        et_to_met(sct_to_et(de_dataset["event_times"].data[0]))
+        et_to_met(sct_to_et(species_dataset["event_times"].data[0]))
     )
     mid_time = ttj2000ns_to_et(met_to_ttj2000ns((pointing_start + pointing_stop) / 2))
     exposure_time, efficiency, geometric_function = get_helio_adjusted_data(

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -62,7 +62,7 @@ def calculate_helio_pset(
         Ancillary files.
     instrument_id : int
         Instrument ID, either 45 or 90.
-    species_id : int, optional
+    species_id : int
         Species ID, default of 1 refers to Hydrogen.
 
     Returns

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -56,7 +56,7 @@ def calculate_spacecraft_pset(
         Ancillary files.
     instrument_id : int
         Instrument ID, either 45 or 90.
-    species_id : int, optional
+    species_id : int
         Species ID, default of 1 refers to Hydrogen.
 
     Returns

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -33,6 +33,7 @@ def calculate_spacecraft_pset(
     name: str,
     ancillary_files: dict,
     instrument_id: int,
+    species_id: int = 1,
 ) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
@@ -55,6 +56,8 @@ def calculate_spacecraft_pset(
         Ancillary files.
     instrument_id : int
         Instrument ID, either 45 or 90.
+    species_id : int, optional
+        Species ID, default of 1 refers to Hydrogen.
 
     Returns
     -------
@@ -63,22 +66,26 @@ def calculate_spacecraft_pset(
     """
     pset_dict: dict[str, np.ndarray] = {}
     sensor = parse_filename_like(name)["sensor"][0:2]
+    indices = np.where(de_dataset["species"].values == species_id)[0]
+    species_dataset = de_dataset.isel(epoch=indices)
 
     # Before we use the de_dataset to calculate the pointing set grid we need to filter.
     rejected = get_de_rejection_mask(
-        de_dataset["quality_scattering"].values, de_dataset["quality_outliers"].values
+        species_dataset["quality_scattering"].values, species_dataset["quality_outliers"].values
     )
-    de_dataset = de_dataset.isel(epoch=~rejected)
+    species_dataset = species_dataset.isel(epoch=~rejected)
 
-    v_mag_dps_spacecraft = np.linalg.norm(de_dataset["velocity_dps_sc"].values, axis=1)
+    v_mag_dps_spacecraft = np.linalg.norm(
+        species_dataset["velocity_dps_sc"].values, axis=1
+    )
     vhat_dps_spacecraft = (
-        de_dataset["velocity_dps_sc"].values / v_mag_dps_spacecraft[:, np.newaxis]
+        species_dataset["velocity_dps_sc"].values / v_mag_dps_spacecraft[:, np.newaxis]
     )
 
     intervals, _, energy_bin_geometric_means = build_energy_bins()
     counts, latitude, longitude, n_pix = get_spacecraft_histogram(
         vhat_dps_spacecraft,
-        de_dataset["energy_spacecraft"].values,
+        species_dataset["energy_spacecraft"].values,
         intervals,
         nside=128,
     )

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -66,12 +66,14 @@ def calculate_spacecraft_pset(
     """
     pset_dict: dict[str, np.ndarray] = {}
     sensor = parse_filename_like(name)["sensor"][0:2]
+    # Select only the species we are interested in.
     indices = np.where(de_dataset["species"].values == species_id)[0]
     species_dataset = de_dataset.isel(epoch=indices)
 
     # Before we use the de_dataset to calculate the pointing set grid we need to filter.
     rejected = get_de_rejection_mask(
-        species_dataset["quality_scattering"].values, species_dataset["quality_outliers"].values
+        species_dataset["quality_scattering"].values,
+        species_dataset["quality_outliers"].values,
     )
     species_dataset = species_dataset.isel(epoch=~rejected)
 


### PR DESCRIPTION
# Change Summary

## Overview
We need to use only hydrogen when creating the psets. This simply filters out the other species prior to creating the psets.

## Updated Files
- spacecraft_pset.py
   - Filter out the other species prior to creating the psets.
- helio_pset.py
   - Filter out the other species prior to creating the psets.
