### PR TITLE
Ultra l1b - address validation feedback and add valid events cullling

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -364,8 +364,7 @@ spin_start_time:
   LABLAXIS: spin start time
   # TODO: come back to format
   UNITS: s
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
+  DEPEND_0: spin_number
 
 spin_period:
   <<: *default
@@ -373,8 +372,7 @@ spin_period:
   FIELDNAM: spin_period
   LABLAXIS: spin_period
   UNITS: s
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
+  DEPEND_0: spin_number
 
 spin_rate:
   <<: *default
@@ -382,8 +380,7 @@ spin_rate:
   FIELDNAM: spin_rate
   LABLAXIS: spin_rate
   UNITS: rpm
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
+  DEPEND_0: spin_number
 
 rate_start_pulses:
   <<: *default
@@ -440,8 +437,7 @@ start_pulses_per_spin:
   CATDESC: Total start pulses per spin.
   FIELDNAM: start_pulses_per_spin
   LABLAXIS: start pulses per spin
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
+  DEPEND_0: spin_number
   UNITS: " "
 
 stop_pulses_per_spin:
@@ -449,8 +445,7 @@ stop_pulses_per_spin:
   CATDESC: Total start pulses per spin.
   FIELDNAM: stop_pulses_per_spin
   LABLAXIS: stop pulses per spin
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
+  DEPEND_0: spin_number
   UNITS: " "
 
 coin_pulses_per_spin:
@@ -458,8 +453,7 @@ coin_pulses_per_spin:
   CATDESC: Total coincidence pulses per spin.
   FIELDNAM: coin_pulses_per_spin
   LABLAXIS: coin_pulses_per_spin
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
+  DEPEND_0: spin_number
   UNITS: " "
 
 rejected_events_per_spin:
@@ -467,8 +461,7 @@ rejected_events_per_spin:
   CATDESC: Rejected events per spin.
   FIELDNAM: rejected_events_per_spin
   LABLAXIS: rejected events per spin
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
+  DEPEND_0: spin_number
   UNITS: " "
 
 ena_rates_threshold:
@@ -485,8 +478,7 @@ quality_ena_rates:
   CATDESC: Spin filter derived from Ultra ena rates. Bitwise flagging used to filter the spin.
   FIELDNAM: quality_ena_rates
   LABLAXIS: quality_ena_rates
-  DEPEND_0: energy_bin_geometric_mean
-  DEPEND_1: spin_number
+  DEPEND_0: spin_number
   UNITS: " "
 
 quality_attitude:
@@ -496,9 +488,8 @@ quality_attitude:
   LABLAXIS: quality attitude
   # TODO: come back to format
   UNITS: " "
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
-  DEPEND_2: energy_bin_geometric_mean
+  DEPEND_0: spin_number
+  DEPEND_1: energy_bin_geometric_mean
 
 quality_instruments:
   <<: *default_uint16
@@ -507,9 +498,8 @@ quality_instruments:
   LABLAXIS: quality instruments
   # TODO: come back to format
   UNITS: " "
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
-  DEPEND_2: energy_bin_geometric_mean
+  DEPEND_0: spin_number
+  DEPEND_1: energy_bin_geometric_mean
 
 quality_hk:
   <<: *default_uint16
@@ -518,9 +508,8 @@ quality_hk:
   LABLAXIS: quality hk
   # TODO: come back to format
   UNITS: " "
-  DEPEND_0: epoch
-  DEPEND_1: spin_number
-  DEPEND_2: energy_bin_geometric_mean
+  DEPEND_0: spin_number
+  DEPEND_1: energy_bin_geometric_mean
 
 quality_outliers:
   <<: *default_uint16

--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -72,6 +72,22 @@ default_float64_attrs: &default_float64
   VALIDMAX: 1.7976931348623157e+308
   dtype: float64
 
+computed_ebin:
+  <<: *default_uint8
+  CATDESC: Computed event bin index
+  FIELDNAM: Bin
+  LABLAXIS: bin
+  UNITS: " "
+  DEPEND_0: epoch
+
+ebin:
+  <<: *default_uint8
+  CATDESC: Event bin index
+  FIELDNAM: Bin
+  LABLAXIS: bin
+  UNITS: " "
+  DEPEND_0: epoch
+
 x_front:
   <<: *default_float32
   CATDESC: x front position

--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -75,16 +75,16 @@ default_float64_attrs: &default_float64
 computed_ebin:
   <<: *default_uint8
   CATDESC: Computed event bin index
-  FIELDNAM: Bin
-  LABLAXIS: bin
+  FIELDNAM: Computed ebin
+  LABLAXIS: computed_ebin
   UNITS: " "
   DEPEND_0: epoch
 
 ebin:
   <<: *default_uint8
   CATDESC: Event bin index
-  FIELDNAM: Bin
-  LABLAXIS: bin
+  FIELDNAM: Ebin
+  LABLAXIS: ebin
   UNITS: " "
   DEPEND_0: epoch
 

--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -431,9 +431,8 @@ ena_rates:
   CATDESC: Rates calculated from de packet.
   FIELDNAM: ena_rates
   LABLAXIS: ena rates
-  DEPEND_0: epoch
+  DEPEND_0: energy_bin_geometric_mean
   DEPEND_1: spin_number
-  DEPEND_2: energy_bin_geometric_mean
   UNITS: " "
 
 start_pulses_per_spin:
@@ -477,9 +476,8 @@ ena_rates_threshold:
   CATDESC: Rates threshold used for flagging data.
   FIELDNAM: ena_rates_threshold
   LABLAXIS: ena_rates_threshold
-  DEPEND_0: epoch
+  DEPEND_0: energy_bin_geometric_mean
   DEPEND_1: spin_number
-  DEPEND_2: energy_bin_geometric_mean
   UNITS: " "
 
 quality_ena_rates:
@@ -487,9 +485,8 @@ quality_ena_rates:
   CATDESC: Spin filter derived from Ultra ena rates. Bitwise flagging used to filter the spin.
   FIELDNAM: quality_ena_rates
   LABLAXIS: quality_ena_rates
-  DEPEND_0: epoch
+  DEPEND_0: energy_bin_geometric_mean
   DEPEND_1: spin_number
-  DEPEND_2: energy_bin_geometric_mean
   UNITS: " "
 
 quality_attitude:

--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -43,6 +43,8 @@ class ImapDEOutliersUltraFlags(FlagNameMixin):
     NONE = CommonFlags.NONE
     FOV = 2**0  # bit 0
     PHCORR = 2**1  # bit 1
+    SSD = 2**2  # bit 2 # SSD event
+    PH = 2**3  # bit 3 # PH event
 
 
 class ImapHkUltraFlags(FlagNameMixin):

--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -43,8 +43,7 @@ class ImapDEOutliersUltraFlags(FlagNameMixin):
     NONE = CommonFlags.NONE
     FOV = 2**0  # bit 0
     PHCORR = 2**1  # bit 1
-    SSD = 2**2  # bit 2 # SSD event
-    PH = 2**3  # bit 3 # PH event
+    COINPH = 2**2  # bit 4 # Event validity
 
 
 class ImapHkUltraFlags(FlagNameMixin):

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -529,7 +529,7 @@ def ancillary_files():
         "l1b-90sensor-tofxesteep": path
         / "imap_ultra_l1b-90sensor-tofxesteep_20250101_v000.pgm",
         "l1b-tofxph": path / "imap_ultra_l1b-tofxph_20250101_v000.pgm",
-        "l1b-90sensor-scattering-calibration": path
+        "l1b-90sensor-scattering-calibration-data": path
         / "imap_ultra_l1b-90sensor-scattering-calibration-data_20250101_v000.csv",
         "l1c-90sensor-dps-exposure": path
         / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -202,6 +202,7 @@ def test_cdf_extendedspin(use_fake_spin_data_for_time, faux_aux_dataset, rates_d
     """Tests that CDF file is created and contains same attributes as xarray."""
     l1b_extendedspin_dataset[0].attrs["Data_version"] = "999"
     l1b_extendedspin_dataset[0].attrs["Repointing"] = "repoint99999"
+    l1b_extendedspin_dataset[0].attrs["Start_date"] = "20240207"
     test_data_path = write_cdf(l1b_extendedspin_dataset[0])
     assert test_data_path.exists()
     assert (
@@ -238,6 +239,7 @@ def test_cdf_goodtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_data
     )
     goodtimes_dataset[0].attrs["Data_version"] = "999"
     goodtimes_dataset[0].attrs["Repointing"] = "repoint99999"
+    goodtimes_dataset[0].attrs["Start_date"] = "20240207"
     test_data_path = write_cdf(goodtimes_dataset[0])
     assert test_data_path.exists()
     assert (
@@ -283,6 +285,7 @@ def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_datas
     )
     l1b_badtimes_dataset[0].attrs["Data_version"] = "999"
     l1b_badtimes_dataset[0].attrs["Repointing"] = "repoint99999"
+    l1b_badtimes_dataset[0].attrs["Start_date"] = "20240207"
     test_data_path = write_cdf(l1b_badtimes_dataset[0])
     assert test_data_path.exists()
     assert (

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -202,7 +202,7 @@ def test_cdf_extendedspin(use_fake_spin_data_for_time, faux_aux_dataset, rates_d
     """Tests that CDF file is created and contains same attributes as xarray."""
     l1b_extendedspin_dataset[0].attrs["Data_version"] = "999"
     l1b_extendedspin_dataset[0].attrs["Repointing"] = "repoint99999"
-    test_data_path = write_cdf(l1b_extendedspin_dataset[0], istp=True)
+    test_data_path = write_cdf(l1b_extendedspin_dataset[0])
     assert test_data_path.exists()
     assert (
         test_data_path.name
@@ -238,7 +238,7 @@ def test_cdf_goodtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_data
     )
     goodtimes_dataset[0].attrs["Data_version"] = "999"
     goodtimes_dataset[0].attrs["Repointing"] = "repoint99999"
-    test_data_path = write_cdf(goodtimes_dataset[0], istp=True)
+    test_data_path = write_cdf(goodtimes_dataset[0])
     assert test_data_path.exists()
     assert (
         test_data_path.name
@@ -283,7 +283,7 @@ def test_cdf_badtimes(use_fake_spin_data_for_time, faux_aux_dataset, rates_datas
     )
     l1b_badtimes_dataset[0].attrs["Data_version"] = "999"
     l1b_badtimes_dataset[0].attrs["Repointing"] = "repoint99999"
-    test_data_path = write_cdf(l1b_badtimes_dataset[0], istp=True)
+    test_data_path = write_cdf(l1b_badtimes_dataset[0])
     assert test_data_path.exists()
     assert (
         test_data_path.name

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -286,37 +286,37 @@ def test_get_de_velocity(test_fixture):
     )
     np.testing.assert_allclose(
         vhat[test_tof > 0][:, 0],
-        df_ph["vhatX"].astype("float").values[test_tof > 0],
-        atol=1e-01,
-        rtol=0,
-    )
-    np.testing.assert_allclose(
-        vhat[test_tof > 0][:, 1],
-        df_ph["vhatY"].astype("float").values[test_tof > 0],
-        atol=1e-01,
-        rtol=0,
-    )
-    np.testing.assert_allclose(
-        vhat[test_tof > 0][:, 2],
-        df_ph["vhatZ"].astype("float").values[test_tof > 0],
-        atol=1e-01,
-        rtol=0,
-    )
-    np.testing.assert_allclose(
-        r[test_tof > 0][:, 0],
         -df_ph["vhatX"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
     np.testing.assert_allclose(
-        r[test_tof > 0][:, 1],
+        vhat[test_tof > 0][:, 1],
         -df_ph["vhatY"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
     np.testing.assert_allclose(
-        r[test_tof > 0][:, 2],
+        vhat[test_tof > 0][:, 2],
         -df_ph["vhatZ"].astype("float").values[test_tof > 0],
+        atol=1e-01,
+        rtol=0,
+    )
+    np.testing.assert_allclose(
+        r[test_tof > 0][:, 0],
+        df_ph["vhatX"].astype("float").values[test_tof > 0],
+        atol=1e-01,
+        rtol=0,
+    )
+    np.testing.assert_allclose(
+        r[test_tof > 0][:, 1],
+        df_ph["vhatY"].astype("float").values[test_tof > 0],
+        atol=1e-01,
+        rtol=0,
+    )
+    np.testing.assert_allclose(
+        r[test_tof > 0][:, 2],
+        df_ph["vhatZ"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -10,12 +10,12 @@ from imap_processing.spice.spin import get_spin_data
 from imap_processing.spice.time import sct_to_et
 from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles
 from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles, get_norm
+from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles
 from imap_processing.ultra.l1b.ultra_l1b_extended import (
     CoinType,
     StartType,
     StopType,
     calculate_etof_xc,
-    create_valid_event_filter,
     determine_ebin_pulse_height,
     determine_ebin_ssd,
     determine_species,
@@ -727,28 +727,9 @@ def test_is_back_tof_valid(test_fixture, ancillary_files):
 
 
 @pytest.mark.external_test_data
-def test_is_coin_ph_valid(test_fixture, ancillary_files):
+def test_create_valid_event_filter(test_fixture, ancillary_files):
     """Tests is_coin_ph_valid function."""
     df_filt, _, _, de_dataset = test_fixture
-    df_ph = df_filt[np.isin(df_filt["StopType"], [StopType.PH.value])]
-
-    valid = is_coin_ph_valid(
-        df_ph["eTOF"].astype(float).values,
-        df_ph["Xc"].astype(float).values,
-        df_ph["Xb"].astype(float).values,
-        "ultra45",
-        ancillary_files,
-    )
-    coin_ph_valid_bool = df_ph["CoinPHValid"].astype(int).astype(bool).values
-    valid = np.asarray(valid, dtype=bool)
-
-    np.testing.assert_equal(coin_ph_valid_bool, valid)
-
-
-@pytest.mark.external_test_data
-def test_create_valid_event_filter(test_fixture, ancillary_files):
-    """Tests create_valid_event_filter function."""
-    df_filt, _, _, _ = test_fixture
     df_ph = df_filt[np.isin(df_filt["StopType"], [StopType.PH.value])]
 
     # Test data
@@ -760,8 +741,23 @@ def test_create_valid_event_filter(test_fixture, ancillary_files):
     stop_south_tdc = df_ph["StopSouthTDC"].astype(int).values
     stop_east_tdc = df_ph["StopEastTDC"].astype(int).values
     stop_west_tdc = df_ph["StopWestTDC"].astype(int).values
+    quality_flags = np.full(
+        len(ctof), ImapDEOutliersUltraFlags.NONE.value, dtype=np.uint16
+    )
 
-    combined_mask = create_valid_event_filter(ctof, etof, xc, xb, stop_north_tdc,
-                                              stop_south_tdc, stop_east_tdc,
-                                              stop_west_tdc, "ultra45", ancillary_files)
-    print('hi')
+    combined_mask = is_coin_ph_valid(
+        etof,
+        xc,
+        xb,
+        stop_north_tdc,
+        stop_south_tdc,
+        stop_east_tdc,
+        stop_west_tdc,
+        "ultra45",
+        ancillary_files,
+        quality_flags,
+    )
+
+    assert len(etof) == np.count_nonzero(combined_mask) + np.count_nonzero(
+        quality_flags
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -9,11 +9,13 @@ from imap_processing.quality_flags import ImapDEOutliersUltraFlags
 from imap_processing.spice.spin import get_spin_data
 from imap_processing.spice.time import sct_to_et
 from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles
+from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles, get_norm
 from imap_processing.ultra.l1b.ultra_l1b_extended import (
     CoinType,
     StartType,
     StopType,
     calculate_etof_xc,
+    create_valid_event_filter,
     determine_ebin_pulse_height,
     determine_ebin_ssd,
     determine_species,
@@ -741,3 +743,25 @@ def test_is_coin_ph_valid(test_fixture, ancillary_files):
     valid = np.asarray(valid, dtype=bool)
 
     np.testing.assert_equal(coin_ph_valid_bool, valid)
+
+
+@pytest.mark.external_test_data
+def test_create_valid_event_filter(test_fixture, ancillary_files):
+    """Tests create_valid_event_filter function."""
+    df_filt, _, _, _ = test_fixture
+    df_ph = df_filt[np.isin(df_filt["StopType"], [StopType.PH.value])]
+
+    # Test data
+    ctof = df_ph["cTOF"].astype(float).values
+    etof = df_ph["eTOF"].astype(float).values
+    xc = df_ph["Xc"].astype(float).values
+    xb = df_ph["Xb"].astype(float).values
+    stop_north_tdc = df_ph["StopNorthTDC"].astype(int).values
+    stop_south_tdc = df_ph["StopSouthTDC"].astype(int).values
+    stop_east_tdc = df_ph["StopEastTDC"].astype(int).values
+    stop_west_tdc = df_ph["StopWestTDC"].astype(int).values
+
+    combined_mask = create_valid_event_filter(ctof, etof, xc, xb, stop_north_tdc,
+                                              stop_south_tdc, stop_east_tdc,
+                                              stop_west_tdc, "ultra45", ancillary_files)
+    print('hi')

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -725,7 +725,7 @@ def test_is_back_tof_valid(test_fixture, ancillary_files):
 
 
 @pytest.mark.external_test_data
-def test_create_valid_event_filter(test_fixture, ancillary_files):
+def test_is_coin_ph_valid(test_fixture, ancillary_files):
     """Tests is_coin_ph_valid function."""
     df_filt, _, _, de_dataset = test_fixture
     df_ph = df_filt[np.isin(df_filt["StopType"], [StopType.PH.value])]

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -9,8 +9,6 @@ from imap_processing.quality_flags import ImapDEOutliersUltraFlags
 from imap_processing.spice.spin import get_spin_data
 from imap_processing.spice.time import sct_to_et
 from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles
-from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles, get_norm
-from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles
 from imap_processing.ultra.l1b.ultra_l1b_extended import (
     CoinType,
     StartType,

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -187,6 +187,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     output_datasets = ultra_l1c(data_dict, ancillary_files, has_spice=False)
     output_datasets[0].attrs["Data_version"] = "999"
     output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
+    output_datasets[0].attrs["Start_date"] = "20250415"
     test_data_path = write_cdf(output_datasets[0], istp=True)
 
     assert test_data_path.exists()

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -114,3 +114,15 @@ class UltraConstants:
         341.989454569026,
         1e5,
     ]
+
+    # Valid event filter constants
+    # Note these appear similar to image params constants
+    # but they should be used only for the valid event filter.
+    ETOFOFF1_EVENTFILTER = 100
+    ETOFOFF2_EVENTFILTER = -50
+    ETOFSLOPE1_EVENTFILTER = 6667
+    ETOFSLOPE2_EVENTFILTER = 7500
+    ETOFMAX_EVENTFILTER = 90
+    ETOFMIN_EVENTFILTER = -400
+    TOFDIFFTPMIN_EVENTFILTER = 226
+    TOFDIFFTPMAX_EVENTFILTER = 266

--- a/imap_processing/ultra/l1b/badtimes.py
+++ b/imap_processing/ultra/l1b/badtimes.py
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset, extract_data_dict
 
 FILLVAL_UINT16 = 65535
+FILLVAL_FLOAT32 = -1.0e31
 FILLVAL_FLOAT64 = -1.0e31
 FILLVAL_UINT32 = 4294967295
 
@@ -33,11 +34,9 @@ def calculate_badtimes(
     badtimes_dataset : xarray.Dataset
         Dataset containing the extendedspin data that has been culled.
     """
+    n_bins = extendedspin_dataset.dims["energy_bin_geometric_mean"]
     culled_spins = np.setdiff1d(
         extendedspin_dataset["spin_number"].values, goodtimes_spins
-    )
-    extendedspin_dataset = extendedspin_dataset.assign_coords(
-        epoch=("spin_number", extendedspin_dataset["epoch"].values)
     )
     filtered_dataset = extendedspin_dataset.sel(spin_number=culled_spins)
 
@@ -48,9 +47,6 @@ def calculate_badtimes(
     if badtimes_dataset["spin_number"].size == 0:
         badtimes_dataset = badtimes_dataset.drop_dims("spin_number")
         badtimes_dataset = badtimes_dataset.expand_dims(spin_number=[FILLVAL_UINT32])
-        badtimes_dataset = badtimes_dataset.assign_coords(
-            epoch=("spin_number", [extendedspin_dataset["epoch"].values[0]])
-        )
         badtimes_dataset["spin_start_time"] = xr.DataArray(
             np.array([FILLVAL_FLOAT64], dtype="float64"), dims=["spin_number"]
         )
@@ -60,16 +56,44 @@ def calculate_badtimes(
         badtimes_dataset["spin_rate"] = xr.DataArray(
             np.array([FILLVAL_FLOAT64], dtype="float64"), dims=["spin_number"]
         )
+        badtimes_dataset["start_pulses_per_spin"] = xr.DataArray(
+            np.array([FILLVAL_FLOAT32], dtype="float32"),
+            dims=["spin_number"],
+        )
+        badtimes_dataset["stop_pulses_per_spin"] = xr.DataArray(
+            np.array([FILLVAL_FLOAT32], dtype="float32"),
+            dims=["spin_number"],
+        )
+        badtimes_dataset["coin_pulses_per_spin"] = xr.DataArray(
+            np.array([FILLVAL_FLOAT32], dtype="float32"),
+            dims=["spin_number"],
+        )
+        badtimes_dataset["rejected_events_per_spin"] = xr.DataArray(
+            np.array([FILLVAL_UINT32], dtype="uint32"),
+            dims=["spin_number"],
+        )
         badtimes_dataset["quality_attitude"] = xr.DataArray(
             np.array([FILLVAL_UINT16], dtype="uint16"), dims=["spin_number"]
         )
+        badtimes_dataset["quality_hk"] = xr.DataArray(
+            np.array([FILLVAL_UINT16], dtype="uint16"),
+            dims=["spin_number"],
+        )
+        badtimes_dataset["quality_instruments"] = xr.DataArray(
+            np.array([FILLVAL_UINT16], dtype="uint16"),
+            dims=["spin_number"],
+        )
         badtimes_dataset["quality_ena_rates"] = (
             ("energy_bin_geometric_mean", "spin_number"),
-            np.full((3, 1), FILLVAL_UINT16, dtype="uint16"),
+            np.full((n_bins, 1), FILLVAL_UINT16, dtype="uint16"),
         )
         badtimes_dataset["ena_rates"] = (
             ("energy_bin_geometric_mean", "spin_number"),
-            np.full((3, 1), FILLVAL_FLOAT64, dtype="float64"),
+            np.full((n_bins, 1), FILLVAL_FLOAT64, dtype="float64"),
+        )
+        badtimes_dataset["ena_rates_threshold"] = (
+            ("energy_bin_geometric_mean", "spin_number"),
+            np.full((n_bins, 1), FILLVAL_FLOAT32, dtype="float32"),
         )
 
     return badtimes_dataset

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -42,6 +42,7 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 FILLVAL_UINT8 = 255
+FILLVAL_UINT32 = 4294967295
 FILLVAL_FLOAT32 = -1.0e31
 
 
@@ -127,6 +128,7 @@ def calculate_de(
     magnitude_v = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
     energy = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
     e_bin = np.full(len(de_dataset["epoch"]), FILLVAL_UINT8, dtype=np.uint8)
+    e_bin_l1a = np.full(len(de_dataset["epoch"]), FILLVAL_UINT8, dtype=np.uint8)
     species_bin = np.full(len(de_dataset["epoch"]), FILLVAL_UINT8, dtype=np.uint8)
     t2 = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
     event_times = np.full(len(de_dataset["epoch"]), FILLVAL_FLOAT32, dtype=np.float32)
@@ -143,6 +145,10 @@ def calculate_de(
     quality_flags = np.full(
         de_dataset["epoch"].shape, ImapDEOutliersUltraFlags.NONE.value, dtype=np.uint16
     )
+    # Track PH or SSD
+    quality_flags[ph_indices] |= ImapDEOutliersUltraFlags.PH.value
+    quality_flags[ssd_indices] |= ImapDEOutliersUltraFlags.SSD.value
+
     scattering_quality_flags = np.full(
         de_dataset["epoch"].shape,
         ImapDEScatteringUltraFlags.NONE.value,
@@ -264,6 +270,8 @@ def calculate_de(
         tof[ssd_indices], r[ssd_indices], "SSD"
     )
 
+
+
     # Combine ph_yb and ssd_yb along with their indices
     de_dict["x_front"] = xf.astype(np.float32)
     de_dict["event_times"] = event_times
@@ -289,7 +297,6 @@ def calculate_de(
             de_dict["tof_start_stop"][valid_indices],
         )
     )
-    de_dict["direct_event_velocity"] = velocities.astype(np.float32)
     de_dict["direct_event_unit_velocity"] = v_hat.astype(np.float32)
     de_dict["direct_event_unit_position"] = r_hat.astype(np.float32)
 
@@ -298,7 +305,10 @@ def calculate_de(
     )
     de_dict["tof_energy"] = tof_energy
     de_dict["energy"] = energy
-    de_dict["ebin"] = e_bin
+    de_dict["computed_ebin"] = e_bin
+    valid_ebin = de_dataset["bin"].values != FILLVAL_UINT32
+    e_bin_l1a[valid_ebin] = de_dataset["bin"].values[valid_ebin]
+    de_dict["ebin"] = e_bin_l1a
     de_dict["species"] = species_bin
 
     # Annotated Events.
@@ -313,7 +323,7 @@ def calculate_de(
             helio_velocity[valid_events],
         ) = get_annotated_particle_velocity(
             event_times[valid_events],
-            de_dict["direct_event_velocity"][valid_events],
+            velocities.astype(np.float32)[valid_events],
             ultra_frame,
             SpiceFrame.IMAP_DPS,
             SpiceFrame.IMAP_SPACECRAFT,

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -83,7 +83,6 @@ def calculate_de(
         "event_type",
         "de_event_met",
         "phase_angle",
-        "spin",
     ]
     dataset_keys = [
         "coin_type",
@@ -91,7 +90,6 @@ def calculate_de(
         "stop_type",
         "shcoarse",
         "phase_angle",
-        "spin",
     ]
 
     de_dict.update(

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -145,9 +145,6 @@ def calculate_de(
     quality_flags = np.full(
         de_dataset["epoch"].shape, ImapDEOutliersUltraFlags.NONE.value, dtype=np.uint16
     )
-    # Track PH or SSD
-    quality_flags[ph_indices] |= ImapDEOutliersUltraFlags.PH.value
-    quality_flags[ssd_indices] |= ImapDEOutliersUltraFlags.SSD.value
 
     scattering_quality_flags = np.full(
         de_dataset["epoch"].shape,
@@ -219,8 +216,13 @@ def calculate_de(
         etof[ph_indices],
         xc[ph_indices],
         xb[ph_indices],
+        de_dataset["stop_north_tdc"][ph_indices].values,
+        de_dataset["stop_south_tdc"][ph_indices].values,
+        de_dataset["stop_east_tdc"][ph_indices].values,
+        de_dataset["stop_west_tdc"][ph_indices].values,
         f"ultra{sensor}",
         ancillary_files,
+        quality_flags[ph_indices],
     )
     e_bin[ph_indices] = determine_ebin_pulse_height(
         energy[ph_indices],
@@ -269,8 +271,6 @@ def calculate_de(
     ctof[ssd_indices], magnitude_v[ssd_indices] = get_ctof(
         tof[ssd_indices], r[ssd_indices], "SSD"
     )
-
-
 
     # Combine ph_yb and ssd_yb along with their indices
     de_dict["x_front"] = xf.astype(np.float32)

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -60,12 +60,6 @@ def calculate_extendedspin(
     hk_qf = flag_hk(de_dataset["spin"].values)
     inst_qf = flag_imap_instruments(de_dataset["spin"].values)
 
-    # Get the first epoch for each spin.
-    mask = xr.DataArray(np.isin(de_dataset["spin"], spin), dims="epoch")
-    filtered_dataset = de_dataset.where(mask, drop=True)
-    _, first_indices = np.unique(filtered_dataset["spin"].values, return_index=True)
-    first_epochs = filtered_dataset["epoch"].values[first_indices]
-
     # Get the number of pulses per spin.
     pulses = get_pulses_per_spin(rates_dataset)
 
@@ -77,7 +71,6 @@ def calculate_extendedspin(
         de_dataset["quality_outliers"].values,
     )
     # These will be the coordinates.
-    extendedspin_dict["epoch"] = first_epochs
     extendedspin_dict["spin_number"] = spin
     extendedspin_dict["energy_bin_geometric_mean"] = energy_bin_geometric_mean
 

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import xarray as xr
+from numpy.typing import NDArray
 
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
     count_rejected_events_per_spin,
@@ -15,6 +16,7 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 FILLVAL_UINT16 = 65535
+FILLVAL_FLOAT32 = -1.0e31
 
 
 def calculate_extendedspin(
@@ -84,9 +86,26 @@ def calculate_extendedspin(
     extendedspin_dict["spin_start_time"] = spin_starttime
     extendedspin_dict["spin_period"] = spin_period
     extendedspin_dict["spin_rate"] = spin_rates
-    extendedspin_dict["start_pulses_per_spin"] = pulses.start_per_spin
-    extendedspin_dict["stop_pulses_per_spin"] = pulses.stop_per_spin
-    extendedspin_dict["coin_pulses_per_spin"] = pulses.coin_per_spin
+
+    # Get index of pulses.unique_spins corresponding to each spin.
+    idx: NDArray[np.intp] = np.searchsorted(pulses.unique_spins, spin)
+
+    # Validate that the spin values match
+    valid = (idx < pulses.unique_spins.size) & (pulses.unique_spins[idx] == spin)
+
+    start_per_spin = np.full(len(spin), FILLVAL_FLOAT32, dtype=np.float32)
+    stop_per_spin = np.full(len(spin), FILLVAL_FLOAT32, dtype=np.float32)
+    coin_per_spin = np.full(len(spin), FILLVAL_FLOAT32, dtype=np.float32)
+
+    # Fill only the valid ones
+    start_per_spin[valid] = pulses.start_per_spin[idx[valid]]
+    stop_per_spin[valid] = pulses.stop_per_spin[idx[valid]]
+    coin_per_spin[valid] = pulses.coin_per_spin[idx[valid]]
+
+    # account for rates spins which are not in the direct event spins
+    extendedspin_dict["start_pulses_per_spin"] = start_per_spin
+    extendedspin_dict["stop_pulses_per_spin"] = stop_per_spin
+    extendedspin_dict["coin_pulses_per_spin"] = coin_per_spin
     extendedspin_dict["rejected_events_per_spin"] = rejected_counts
     extendedspin_dict["quality_attitude"] = attitude_qf
     extendedspin_dict["quality_ena_rates"] = rates_qf

--- a/imap_processing/ultra/l1b/goodtimes.py
+++ b/imap_processing/ultra/l1b/goodtimes.py
@@ -7,6 +7,7 @@ from imap_processing.ultra.l1b.quality_flag_filters import SPIN_QUALITY_FLAG_FIL
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset, extract_data_dict
 
 FILLVAL_UINT16 = 65535
+FILLVAL_FLOAT32 = -1.0e31
 FILLVAL_FLOAT64 = -1.0e31
 FILLVAL_UINT32 = 4294967295
 
@@ -27,6 +28,7 @@ def calculate_goodtimes(extendedspin_dataset: xr.Dataset, name: str) -> xr.Datas
     goodtimes_dataset : xarray.Dataset
         Dataset containing the extendedspin data that remains after culling.
     """
+    n_bins = extendedspin_dataset.dims["energy_bin_geometric_mean"]
     # If the spin rate was too high or low then the spin should be thrown out.
     # If the rates at any energy level are too high then throw out the entire spin.
     good_mask = (
@@ -47,9 +49,6 @@ def calculate_goodtimes(extendedspin_dataset: xr.Dataset, name: str) -> xr.Datas
             == 0
         ).all(dim="energy_bin_geometric_mean")
     )
-    extendedspin_dataset = extendedspin_dataset.assign_coords(
-        epoch=("spin_number", extendedspin_dataset["epoch"].values)
-    )
     filtered_dataset = extendedspin_dataset.sel(
         spin_number=extendedspin_dataset["spin_number"][good_mask]
     )
@@ -61,9 +60,6 @@ def calculate_goodtimes(extendedspin_dataset: xr.Dataset, name: str) -> xr.Datas
     if goodtimes_dataset["spin_number"].size == 0:
         goodtimes_dataset = goodtimes_dataset.drop_dims("spin_number")
         goodtimes_dataset = goodtimes_dataset.expand_dims(spin_number=[FILLVAL_UINT32])
-        goodtimes_dataset = goodtimes_dataset.assign_coords(
-            epoch=("spin_number", [extendedspin_dataset["epoch"].values[0]])
-        )
         goodtimes_dataset["spin_start_time"] = xr.DataArray(
             np.array([FILLVAL_FLOAT64], dtype="float64"), dims=["spin_number"]
         )
@@ -73,16 +69,44 @@ def calculate_goodtimes(extendedspin_dataset: xr.Dataset, name: str) -> xr.Datas
         goodtimes_dataset["spin_rate"] = xr.DataArray(
             np.array([FILLVAL_FLOAT64], dtype="float64"), dims=["spin_number"]
         )
+        goodtimes_dataset["start_pulses_per_spin"] = xr.DataArray(
+            np.array([FILLVAL_FLOAT32], dtype="float32"),
+            dims=["spin_number"],
+        )
+        goodtimes_dataset["stop_pulses_per_spin"] = xr.DataArray(
+            np.array([FILLVAL_FLOAT32], dtype="float32"),
+            dims=["spin_number"],
+        )
+        goodtimes_dataset["coin_pulses_per_spin"] = xr.DataArray(
+            np.array([FILLVAL_FLOAT32], dtype="float32"),
+            dims=["spin_number"],
+        )
+        goodtimes_dataset["rejected_events_per_spin"] = xr.DataArray(
+            np.array([FILLVAL_UINT32], dtype="uint32"),
+            dims=["spin_number"],
+        )
         goodtimes_dataset["quality_attitude"] = xr.DataArray(
             np.array([FILLVAL_UINT16], dtype="uint16"), dims=["spin_number"]
         )
+        goodtimes_dataset["quality_hk"] = xr.DataArray(
+            np.array([FILLVAL_UINT16], dtype="uint16"),
+            dims=["spin_number"],
+        )
+        goodtimes_dataset["quality_instruments"] = xr.DataArray(
+            np.array([FILLVAL_UINT16], dtype="uint16"),
+            dims=["spin_number"],
+        )
         goodtimes_dataset["quality_ena_rates"] = (
             ("energy_bin_geometric_mean", "spin_number"),
-            np.full((3, 1), FILLVAL_UINT16, dtype="uint16"),
+            np.full((n_bins, 1), FILLVAL_UINT16, dtype="uint16"),
         )
         goodtimes_dataset["ena_rates"] = (
             ("energy_bin_geometric_mean", "spin_number"),
-            np.full((3, 1), FILLVAL_FLOAT64, dtype="float64"),
+            np.full((n_bins, 1), FILLVAL_FLOAT64, dtype="float64"),
+        )
+        goodtimes_dataset["ena_rates_threshold"] = (
+            ("energy_bin_geometric_mean", "spin_number"),
+            np.full((n_bins, 1), FILLVAL_FLOAT32, dtype="float32"),
         )
 
     return goodtimes_dataset

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -345,7 +345,7 @@ def load_scattering_lookup_tables(ancillary_files: dict, instrument_id: int) -> 
     # TODO remove the line below when the 45 sensor scattering coefficients are
     #  delivered.
     instrument_id = 90
-    descriptor = f"l1b-{instrument_id}sensor-scattering-calibration"
+    descriptor = f"l1b-{instrument_id}sensor-scattering-calibration-data"
     theta_grid = pd.read_csv(
         ancillary_files[descriptor], header=None, skiprows=7, nrows=241
     ).to_numpy(dtype=float)

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -345,7 +345,7 @@ def load_scattering_lookup_tables(ancillary_files: dict, instrument_id: int) -> 
     # TODO remove the line below when the 45 sensor scattering coefficients are
     #  delivered.
     instrument_id = 90
-    descriptor = f"l1b-{instrument_id}sensor-scattering-calibration-data"
+    descriptor = f"l1b-{instrument_id}sensor-scattering-calibration"
     theta_grid = pd.read_csv(
         ancillary_files[descriptor], header=None, skiprows=7, nrows=241
     ).to_numpy(dtype=float)

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -31,6 +31,7 @@ SPIN_DURATION = 15  # Default spin duration in seconds.
 RateResult = namedtuple(
     "RateResult",
     [
+        "unique_spins",
         "start_per_spin",
         "stop_per_spin",
         "coin_per_spin",
@@ -424,6 +425,8 @@ def get_pulses_per_spin(rates: xr.Dataset) -> RateResult:
 
     Returns
     -------
+    unique_spins : NDArray
+        Unique spin numbers.
     start_per_spin : NDArray
         Total start pulses per spin.
     stop_per_spin : NDArray
@@ -474,6 +477,7 @@ def get_pulses_per_spin(rates: xr.Dataset) -> RateResult:
     coin_per_spin = np.bincount(spin_idx, weights=coin_pulses)
 
     return RateResult(
+        unique_spins=unique_spins,
         start_per_spin=start_per_spin,
         stop_per_spin=stop_per_spin,
         coin_per_spin=coin_per_spin,

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -12,6 +12,7 @@ from numpy import ndarray
 from numpy.typing import NDArray
 from scipy.interpolate import LinearNDInterpolator, RegularGridInterpolator
 
+from imap_processing.quality_flags import ImapDEOutliersUltraFlags
 from imap_processing.spice.spin import get_spin_data
 from imap_processing.spice.time import sct_to_et
 from imap_processing.ultra.constants import UltraConstants
@@ -1376,69 +1377,19 @@ def is_coin_ph_valid(
     etof: NDArray,
     xc: NDArray,
     xb: NDArray,
+    stop_north_tdc: NDArray,
+    stop_south_tdc: NDArray,
+    stop_east_tdc: NDArray,
+    stop_west_tdc: NDArray,
     sensor: str,
     ancillary_files: dict,
+    quality_flags: NDArray,
 ) -> NDArray:
     """
-    Determine whether Coincidence-PH data are valid.
-
-    This is based on thresholds defined in the IMAP-Ultra Flight Software Specification
-    (see page 36).
+    Determine event validity.
 
     Parameters
     ----------
-    etof : NDArray
-        Electron TOF (tenths of a nanosecond).
-    xc : NDArray
-        Coincidence X position (hundredths of a mm).
-    xb : NDArray
-        Back X position (hundredths of a mm).
-    sensor : str
-        Sensor name: "ultra45" or "ultra90".
-    ancillary_files : dict
-        Ancillary files for lookup.
-
-    Returns
-    -------
-    valid_mask : NDArray
-        Boolean array indicating Coin-PH validity.
-
-    Notes
-    -----
-    Logic derived from page 36 of the IMAP-Ultra Flight Software Specification document.
-    """
-    etof_min = get_image_params("eTOFMin", sensor, ancillary_files)
-    etof_max = get_image_params("eTOFMax", sensor, ancillary_files)
-
-    etof_valid = (etof >= etof_min) & (etof <= etof_max)
-
-    diff_x = xc - xb
-    etof_offset1 = get_image_params("eTOFOff1", sensor, ancillary_files)
-    etof_offset2 = get_image_params("eTOFOff2", sensor, ancillary_files)
-    etof_slope1 = get_image_params("eTOFSlope1", sensor, ancillary_files)
-    etof_slope2 = get_image_params("eTOFSlope2", sensor, ancillary_files)
-
-    t1 = (etof - etof_offset1) * etof_slope1 / 1024
-    t2 = (etof - etof_offset2) * etof_slope2 / 1024
-
-    condition_1 = (diff_x >= t1) & (diff_x <= t2)
-    condition_2 = (diff_x >= -t2) & (diff_x <= -t1)
-
-    spatial_valid = condition_1 | condition_2
-
-    return etof_valid & spatial_valid
-
-
-def create_valid_event_filter(ctof: NDArray, etof: NDArray,
-                              xc: NDArray, xb: NDArray, stop_north_tdc: NDArray, stop_south_tdc: NDArray,
-                              stop_east_tdc: NDArray, stop_west_tdc: NDArray, sensor: str, ancillary_files: dict) -> NDArray:#, quality_flags: NDArray):
-    """
-    Determine whether back TOF is valid based on stop type.
-
-    Parameters
-    ----------
-    ctof : NDArray
-        Corrected TOF (tenths of a ns).
     etof : NDArray
         Time for the electrons to travel back to the coincidence
         anode (tenths of a nanosecond).
@@ -1447,17 +1398,19 @@ def create_valid_event_filter(ctof: NDArray, etof: NDArray,
     xb : NDArray
         Back positions in x direction (hundredths of a millimeter).
     stop_north_tdc : NDArray
-        Stop North Time to Digital Converter
+        Stop North Time to Digital Converter.
     stop_south_tdc : NDArray
-        Stop South Time to Digital Converter
+        Stop South Time to Digital Converter.
     stop_east_tdc : NDArray
-        Stop East Time to Digital Converter
+        Stop East Time to Digital Converter.
     stop_west_tdc : NDArray
-        Stop West Time to Digital Converter
+        Stop West Time to Digital Converter.
     sensor : str
         Sensor name: "ultra45" or "ultra90".
     ancillary_files : dict
         Ancillary files for lookup.
+    quality_flags : NDArray
+        Quality flag to set when there is an outlier.
 
     Returns
     -------
@@ -1468,33 +1421,34 @@ def create_valid_event_filter(ctof: NDArray, etof: NDArray,
     -----
     From page 36 of the IMAP-Ultra Flight Software Specification document.
     """
-
     # Make certain etof is within range for tenths of a nanosecond.
-    etof_valid = (etof >= UltraConstants.ETOFMIN_EVENTFILTER) & (etof <= UltraConstants.ETOFMAX_EVENTFILTER)
+    etof_valid = (etof >= UltraConstants.ETOFMIN_EVENTFILTER) & (
+        etof <= UltraConstants.ETOFMAX_EVENTFILTER
+    )
 
     # Hundredths of a mm.
     diff_x = xc - xb
 
-    t1 = (etof - UltraConstants.ETOFOFF1_EVENTFILTER) * UltraConstants.ETOFSLOPE1_EVENTFILTER / 1024
-    t2 = (etof - UltraConstants.ETOFOFF2_EVENTFILTER) * UltraConstants.ETOFSLOPE2_EVENTFILTER / 1024
+    t1 = (
+        (etof - UltraConstants.ETOFOFF1_EVENTFILTER)
+        * UltraConstants.ETOFSLOPE1_EVENTFILTER
+        / 1024
+    )
+    t2 = (
+        (etof - UltraConstants.ETOFOFF2_EVENTFILTER)
+        * UltraConstants.ETOFSLOPE2_EVENTFILTER
+        / 1024
+    )
 
     condition_1 = (diff_x >= t1) & (diff_x <= t2)
     condition_2 = (diff_x >= -t2) & (diff_x <= -t1)
 
     spatial_valid = condition_1 | condition_2
 
-    sp_n_norm = get_norm(
-        stop_north_tdc, "SpN", sensor, ancillary_files
-    )
-    sp_s_norm = get_norm(
-        stop_south_tdc, "SpS", sensor, ancillary_files
-    )
-    sp_e_norm = get_norm(
-        stop_east_tdc, "SpE", sensor, ancillary_files
-    )
-    sp_w_norm = get_norm(
-        stop_west_tdc, "SpW", sensor, ancillary_files
-    )
+    sp_n_norm = get_norm(stop_north_tdc, "SpN", sensor, ancillary_files)
+    sp_s_norm = get_norm(stop_south_tdc, "SpS", sensor, ancillary_files)
+    sp_e_norm = get_norm(stop_east_tdc, "SpE", sensor, ancillary_files)
+    sp_w_norm = get_norm(stop_west_tdc, "SpW", sensor, ancillary_files)
 
     tofx = sp_n_norm + sp_s_norm
     tofy = sp_e_norm + sp_w_norm
@@ -1502,13 +1456,12 @@ def create_valid_event_filter(ctof: NDArray, etof: NDArray,
     # Units in tenths of a nanosecond
     delta_tof = tofy - tofx
 
-    delta_tof_mask = (
-            (delta_tof >= UltraConstants.TOFDIFFTPMIN_EVENTFILTER) &
-            (delta_tof <= UltraConstants.TOFDIFFTPMAX_EVENTFILTER)
+    delta_tof_mask = (delta_tof >= UltraConstants.TOFDIFFTPMIN_EVENTFILTER) & (
+        delta_tof <= UltraConstants.TOFDIFFTPMAX_EVENTFILTER
     )
-     # TODO: Ask Ultra team where 5 and 55 come from.
-    ctof_mask = (ctof >= 5) & (ctof <= 55)
 
-    combined_mask = etof_valid & spatial_valid & delta_tof_mask & ctof_mask
+    combined_mask = etof_valid & spatial_valid & delta_tof_mask
 
-    return combined_mask, diff_x, etof
+    quality_flags[~combined_mask] |= ImapDEOutliersUltraFlags.COINPH.value
+
+    return combined_mask

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -553,7 +553,7 @@ def get_de_velocity(
     v_hat = velocities / np.linalg.norm(velocities, axis=1)[:, None]
     r_hat = -v_hat
 
-    return velocities, v_hat, r_hat
+    return velocities, -v_hat, -r_hat
 
 
 def get_ssd_tof(
@@ -1427,3 +1427,88 @@ def is_coin_ph_valid(
     spatial_valid = condition_1 | condition_2
 
     return etof_valid & spatial_valid
+
+
+def create_valid_event_filter(ctof: NDArray, etof: NDArray,
+                              xc: NDArray, xb: NDArray, stop_north_tdc: NDArray, stop_south_tdc: NDArray,
+                              stop_east_tdc: NDArray, stop_west_tdc: NDArray, sensor: str, ancillary_files: dict) -> NDArray:#, quality_flags: NDArray):
+    """
+    Determine whether back TOF is valid based on stop type.
+
+    Parameters
+    ----------
+    ctof : NDArray
+        Corrected TOF (tenths of a ns).
+    etof : NDArray
+        Time for the electrons to travel back to the coincidence
+        anode (tenths of a nanosecond).
+    xc : NDArray
+        X coincidence position (hundredths of a millimeter).
+    xb : NDArray
+        Back positions in x direction (hundredths of a millimeter).
+    stop_north_tdc : NDArray
+        Stop North Time to Digital Converter
+    stop_south_tdc : NDArray
+        Stop South Time to Digital Converter
+    stop_east_tdc : NDArray
+        Stop East Time to Digital Converter
+    stop_west_tdc : NDArray
+        Stop West Time to Digital Converter
+    sensor : str
+        Sensor name: "ultra45" or "ultra90".
+    ancillary_files : dict
+        Ancillary files for lookup.
+
+    Returns
+    -------
+    combined_mask : NDArray
+        Boolean array indicating whether back TOF is valid.
+
+    Notes
+    -----
+    From page 36 of the IMAP-Ultra Flight Software Specification document.
+    """
+
+    # Make certain etof is within range for tenths of a nanosecond.
+    etof_valid = (etof >= UltraConstants.ETOFMIN_EVENTFILTER) & (etof <= UltraConstants.ETOFMAX_EVENTFILTER)
+
+    # Hundredths of a mm.
+    diff_x = xc - xb
+
+    t1 = (etof - UltraConstants.ETOFOFF1_EVENTFILTER) * UltraConstants.ETOFSLOPE1_EVENTFILTER / 1024
+    t2 = (etof - UltraConstants.ETOFOFF2_EVENTFILTER) * UltraConstants.ETOFSLOPE2_EVENTFILTER / 1024
+
+    condition_1 = (diff_x >= t1) & (diff_x <= t2)
+    condition_2 = (diff_x >= -t2) & (diff_x <= -t1)
+
+    spatial_valid = condition_1 | condition_2
+
+    sp_n_norm = get_norm(
+        stop_north_tdc, "SpN", sensor, ancillary_files
+    )
+    sp_s_norm = get_norm(
+        stop_south_tdc, "SpS", sensor, ancillary_files
+    )
+    sp_e_norm = get_norm(
+        stop_east_tdc, "SpE", sensor, ancillary_files
+    )
+    sp_w_norm = get_norm(
+        stop_west_tdc, "SpW", sensor, ancillary_files
+    )
+
+    tofx = sp_n_norm + sp_s_norm
+    tofy = sp_e_norm + sp_w_norm
+
+    # Units in tenths of a nanosecond
+    delta_tof = tofy - tofx
+
+    delta_tof_mask = (
+            (delta_tof >= UltraConstants.TOFDIFFTPMIN_EVENTFILTER) &
+            (delta_tof <= UltraConstants.TOFDIFFTPMAX_EVENTFILTER)
+    )
+     # TODO: Ask Ultra team where 5 and 55 come from.
+    ctof_mask = (ctof >= 5) & (ctof <= 55)
+
+    combined_mask = etof_valid & spatial_valid & delta_tof_mask & ctof_mask
+
+    return combined_mask, diff_x, etof

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -1,6 +1,5 @@
 """Create dataset."""
 
-import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
@@ -40,7 +39,6 @@ def create_dataset(  # noqa: PLR0912
                 "energy_bin_geometric_mean",
                 data_dict["energy_bin_geometric_mean"],
             ),
-            "epoch": ("spin_number", np.asarray(data_dict["epoch"])),
         }
         default_dimension = "spin_number"
     # L1c pset data products


### PR DESCRIPTION
# Change Summary

## Overview
The Ultra team added this on to cull out valid events based on parameters.

[FSW_VE_Criterion_SDC_v2.pptx](https://github.com/user-attachments/files/22033752/FSW_VE_Criterion_SDC_v2.pptx)

[l1b_de_validation.pptx](https://github.com/user-attachments/files/22033775/l1b_de_validation.pptx)

I'm seeing the same shape after I cull out a different dataset:
<img width="736" height="623" alt="Screenshot 2025-08-28 at 3 44 31 PM" src="https://github.com/user-attachments/assets/b0d53415-087c-4e6c-ac70-9d938f7de650" />

## Updated Files
- imap_ultra_l1b_variable_attrs.yaml
   - Added attributes computed_ebin and ebin

- quality_flags.py
   - Added event validity flag

- constants.py
   - Added filters for the event

- de.py
   - Removed direct_event_velocity as requested by IT
   - Added computed_ebin and ebin
   - Updated input to is_coin_ph_valid

- ultra_l1b_extended.py
   - Updated is_coin_ph_valid based on new criteria

- badtimes.py, goodtimes.py, extendedspin.py, imap_ultra_l1b_variable_attrs.yaml
 - Removed epoch as a coordinate and dimension

- extendedspin.py
 - The direct events packet and rates packet have slightly different spins. I chose to rely on the events packet and use fill values for the rates packet properties that did not have corresponding spins.

- lookup_utils.py
 - When I went to run this test the name of the descriptor included "-data" so I made the change for the lut.

## Testing
test_ultra_l1b_extended.py