### PR TITLE
ULTRA l1c validation - write out scattering variables

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -96,6 +96,27 @@ helio_exposure_factor:
   # TODO: come back to format
   UNITS: seconds
 
+scatter_theta:
+  <<: *energy_dependent
+  CATDESC: Scattering theta values for a pointing.
+  FIELDNAM: scatter_theta
+  LABLAXIS: scatter theta
+  UNITS: degrees
+
+scatter_phi:
+  <<: *energy_dependent
+  CATDESC: Scattering phi values for a pointing.
+  FIELDNAM: scatter_phi
+  LABLAXIS: scatter phi
+  UNITS: degrees
+
+scatter_threshold:
+  <<: *energy_dependent
+  CATDESC: Scattering threshold values for each energy bin for a pointing.
+  FIELDNAM: scatter_threshold
+  LABLAXIS: scatter threshold
+  UNITS: degrees
+
 counts:
   <<: *default
   CATDESC: Counts for a spin.

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -604,15 +604,15 @@ def random_spin_data():
 @pytest.fixture
 def mock_spacecraft_pointing_lookups():
     """Test lookup tables fixture."""
-    pix = hp.nside2npix(8)  # reduced for testing
-    steps = 5  # Reduced for testing
+    pix = hp.nside2npix(128)  # reduced for testing
+    steps = 2  # Reduced for testing
     for_indices_by_spin_phase = np.random.choice(
         [True, False], size=(pix, steps), p=[0.1, 0.9]
     )
     theta_vals = np.random.uniform(-60, 60, size=(pix, steps))
     phi_vals = np.random.uniform(-60, 60, size=(pix, steps))
     # Ra and Dec pixel shape needs to be the default healpix pixel count
-    ra_and_dec = np.random.uniform(-80, 80, size=(hp.nside2npix(128), 2))
+    ra_and_dec = np.random.uniform(-80, 80, size=(pix, 2))
     boundary_scale_factors = np.ones((pix, steps))
     with (
         mock.patch(

--- a/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
@@ -59,7 +59,7 @@ def test_get_mask_below_fwhm_scattering_threshold(ancillary_files):
     # Only indices where both the theta and phi coefficients are below the FWHM
     # threshold should be True.
     expected_pixel_mask = np.array([[False], [True], [False]])
-    pixel_mask = mask_below_fwhm_scattering_threshold(
+    pixel_mask, scat_theta, scat_phi = mask_below_fwhm_scattering_threshold(
         theta_coeffs, phi_coeffs, energy[np.newaxis, :], thresholds
     )
     np.testing.assert_array_equal(pixel_mask.shape, (3, 1))
@@ -87,7 +87,7 @@ def test_get_mask_below_fwhm_scattering_threshold_zero(ancillary_files):
     )
     # Since energy is zero, all should be False although some pixels are below threshold
     expected_pixel_mask = np.array([[False], [False], [False]])
-    pixel_mask = mask_below_fwhm_scattering_threshold(
+    pixel_mask, scat_theta, scat_phi = mask_below_fwhm_scattering_threshold(
         theta_coeffs, phi_coeffs, energy, thresholds
     )
     np.testing.assert_array_equal(pixel_mask.shape, (3, 1))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -11,7 +11,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.ultra.l1c import ultra_l1c_pset_bins
 from imap_processing.ultra.l1c.spacecraft_pset import (
-    calculate_pixels_within_scattering_threshold,
+    calculate_fwhm_spun_scattering,
 )
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     apply_deadtime_correction,
@@ -246,8 +246,10 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
     deadtime_ratios = np.ones(steps)
     exposure_pointing = pd.Series(np.ones(pix))
 
-    pixels_below_threshold = calculate_pixels_within_scattering_threshold(
-        spin_phase_steps, mock_theta, mock_phi, ancillary_files, 45
+    pixels_below_threshold, fwhm_theta, fwhm_phi, thresholds = (
+        calculate_fwhm_spun_scattering(
+            spin_phase_steps, mock_theta, mock_phi, ancillary_files, 45
+        )
     )
     boundary_sf = np.ones((pix, steps))
     exposure_pointing_adjusted = apply_deadtime_correction(
@@ -286,8 +288,10 @@ def test_get_spacecraft_exposure_times(
         bool
     )  # Spin phase steps, random 0 or 1
 
-    pixels_below_threshold = calculate_pixels_within_scattering_threshold(
-        spin_phase_steps, mock_theta, mock_phi, ancillary_files, 45
+    pixels_below_threshold, fwhm_theta, fwhm_phi, thresholds = (
+        calculate_fwhm_spun_scattering(
+            spin_phase_steps, mock_theta, mock_phi, ancillary_files, 45
+        )
     )
     boundary_sf = np.ones((pix, steps))
     exposure_pointing, deadtimes = get_spacecraft_exposure_times(

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -15,7 +15,7 @@ from imap_processing.spice.time import (
 )
 from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
-    calculate_pixels_within_scattering_threshold,
+    calculate_fwhm_spun_scattering,
     get_spacecraft_pointing_lookup_tables,
 )
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
@@ -109,13 +109,20 @@ def calculate_helio_pset(
     # Check that the number of rows in the lookup table matches the number of pixels
     if for_indices_by_spin_phase.shape[0] != n_pix:
         logger.warning(
-            "The lookup table is expected to have the same number of rows as "
-            "the number of HEALPix pixels."
+            "The spacecraft pointing lookup table is expected to have the same number "
+            "of rows as the number of HEALPix pixels."
         )
-
-    pixels_below_scattering = calculate_pixels_within_scattering_threshold(
-        for_indices_by_spin_phase, theta_vals, phi_vals, ancillary_files, instrument_id
+    logger.info("calculating spun FWHM scattering values.")
+    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = (
+        calculate_fwhm_spun_scattering(
+            for_indices_by_spin_phase,
+            theta_vals,
+            phi_vals,
+            ancillary_files,
+            instrument_id,
+        )
     )
+    logger.info("Calculating spacecraft exposure times with deadtime correction.")
     # Calculate exposure
     constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
     df_exposure = pd.read_csv(constant_exposure)
@@ -126,6 +133,7 @@ def calculate_helio_pset(
         pixels_below_scattering,
         boundary_scale_factors,
     )
+    logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
     efficiencies, geometric_function = get_efficiencies_and_geometric_function(
         pixels_below_scattering,
@@ -141,6 +149,7 @@ def calculate_helio_pset(
         et_to_met(sct_to_et(species_dataset["event_times"].data[0]))
     )
     mid_time = ttj2000ns_to_et(met_to_ttj2000ns((pointing_start + pointing_stop) / 2))
+    logger.info("Adjusting data for helio frame.")
     exposure_time, efficiency, geometric_function = get_helio_adjusted_data(
         mid_time,
         exposure_time,
@@ -167,6 +176,10 @@ def calculate_helio_pset(
     pset_dict["geometric_function"] = geometric_function
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))
+
+    pset_dict["scatter_theta"] = scattering_theta
+    pset_dict["scatter_phi"] = scattering_phi
+    pset_dict["scatter_threshold"] = scattering_thresholds
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -21,7 +21,7 @@ def mask_below_fwhm_scattering_threshold(
     phi_coeffs: np.ndarray,
     energy: np.ndarray,
     scattering_thresholds: np.ndarray,
-) -> np.ndarray:
+) -> tuple[NDArray, NDArray, NDArray]:
     """
     Determine indices of theta and phi values below the FWHM scattering threshold.
 
@@ -43,8 +43,12 @@ def mask_below_fwhm_scattering_threshold(
 
     Returns
     -------
-    numpy.ndarray
+    scattering_mask : numpy.ndarray
         Boolean array indicating indices below the scattering threshold.
+    fwhm_theta : numpy.ndarray
+        Calculated FWHM values for theta.
+    fwhm_phi : numpy.ndarray
+        Calculated FWHM values for phi.
     """
     # Calculate FWHM for all pixels and all energies
     fwhm_theta = theta_coeffs[..., 0:1] * (
@@ -58,18 +62,21 @@ def mask_below_fwhm_scattering_threshold(
 
     # Combine conditions for both theta and phi.
     # shape = (npix, energy.shape[1])
-    return np.logical_and(fwhm_theta <= thresholds, fwhm_phi <= thresholds)
+    scattering_mask = np.logical_and(fwhm_theta <= thresholds, fwhm_phi <= thresholds)
+    return scattering_mask, fwhm_theta, fwhm_phi
 
 
-def calculate_pixels_within_scattering_threshold(
+def calculate_fwhm_spun_scattering(
     for_indices_by_spin_phase: np.ndarray,
     theta_vals: np.ndarray,
     phi_vals: np.ndarray,
     ancillary_files: dict,
     instrument_id: int,
-) -> list:
+) -> tuple[list, NDArray, NDArray, NDArray]:
     """
-    Calculate pixels within the FWHM scattering threshold for each spin phase step.
+    Calculate FWHM scattering values for each pixel, energy bin, and spin phase step.
+
+    This function also calculates a mask for pixels that are below the FWHM threshold.
 
     Parameters
     ----------
@@ -93,6 +100,14 @@ def calculate_pixels_within_scattering_threshold(
         The outer list indicates spin phase steps, the middle list indicates energy
         bins, and the inner arrays contain indices indicating pixels that are below
         the FWHM scattering threshold.
+    scattering_fwhm_theta : NDArray
+        Calculated FWHM scatting values for theta at each energy bin and averaged
+        over spin phase.
+    scattering_fwhm_phi : NDArray
+        Calculated FWHM scatting values for theta at each energy bin and averaged
+        over spin phase.
+    scattering_thresholds_for_energy_mean : NDArray
+        Scattering thresholds corresponding to each energy bin.
     """
     # Load scattering coefficient lookup table
     scattering_luts = load_scattering_lookup_tables(ancillary_files, instrument_id)
@@ -103,6 +118,13 @@ def calculate_pixels_within_scattering_threshold(
     scattering_thresholds_for_energy_mean = get_scattering_thresholds_for_energy(
         energy_bin_geometric_means, ancillary_files
     )
+    # Initialize arrays to accumulate FWHM values for averaging
+    fwhm_theta_sum = np.zeros(
+        (len(energy_bin_geometric_means), for_indices_by_spin_phase.shape[0])
+    )
+    fwhm_phi_sum = np.zeros_like(fwhm_theta_sum)
+    sample_count = np.zeros_like(fwhm_theta_sum)
+
     steps = for_indices_by_spin_phase.shape[1]
     energies = energy_bin_geometric_means[np.newaxis, :]
     # The "for_indices_by_spin_phase" lookup table contains the boolean values of each
@@ -132,7 +154,7 @@ def calculate_pixels_within_scattering_threshold(
             theta, phi, lookup_tables=scattering_luts
         )
         # Get a mask for pixels below the FWHM scattering threshold
-        scattering_mask = mask_below_fwhm_scattering_threshold(
+        scattering_mask, fwhm_theta, fwhm_phi = mask_below_fwhm_scattering_threshold(
             theta_coeffs,
             phi_coeffs,
             energies,
@@ -147,8 +169,19 @@ def calculate_pixels_within_scattering_threshold(
             pixels_below_scattering_for_energy.append(for_pixel_indices[valid_pixels])
 
         pixels_below_scattering.append(pixels_below_scattering_for_energy)
+        # Accumulate FWHM values for averaging
+        fwhm_theta_sum[:, for_inds] += fwhm_theta.T
+        fwhm_phi_sum[:, for_inds] += fwhm_phi.T
+        sample_count[:, for_inds] += 1
 
-    return pixels_below_scattering
+    fwhm_phi_avg = np.divide(fwhm_theta_sum, sample_count, where=sample_count != 0)
+    fwhm_theta_avg = np.divide(fwhm_theta_sum, sample_count, where=sample_count != 0)
+    return (
+        pixels_below_scattering,
+        fwhm_theta_avg,
+        fwhm_phi_avg,
+        scattering_thresholds_for_energy_mean,
+    )
 
 
 def get_spacecraft_pointing_lookup_tables(

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -9,7 +9,7 @@ import xarray as xr
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
-    calculate_pixels_within_scattering_threshold,
+    calculate_fwhm_spun_scattering,
     get_spacecraft_pointing_lookup_tables,
 )
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
@@ -107,10 +107,17 @@ def calculate_spacecraft_pset(
             "The lookup table is expected to have the same number of rows as "
             "the number of HEALPix pixels."
         )
-
-    pixels_below_scattering = calculate_pixels_within_scattering_threshold(
-        for_indices_by_spin_phase, theta_vals, phi_vals, ancillary_files, instrument_id
+    logger.info("calculating spun FWHM scattering values.")
+    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = (
+        calculate_fwhm_spun_scattering(
+            for_indices_by_spin_phase,
+            theta_vals,
+            phi_vals,
+            ancillary_files,
+            instrument_id,
+        )
     )
+    logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
     efficiencies, geometric_function = get_efficiencies_and_geometric_function(
         pixels_below_scattering,
@@ -125,7 +132,7 @@ def calculate_spacecraft_pset(
     # Calculate exposure
     constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
     df_exposure = pd.read_csv(constant_exposure)
-
+    logger.info("Calculating spacecraft exposure times with deadtime correction.")
     exposure_pointing, deadtime_ratios = get_spacecraft_exposure_times(
         df_exposure,
         rates_dataset,
@@ -133,7 +140,7 @@ def calculate_spacecraft_pset(
         pixels_below_scattering,
         boundary_scale_factors,
     )
-
+    logger.info("Calculating background rates.")
     # Calculate background rates
     background_rates = get_spacecraft_background_rates(
         rates_dataset,
@@ -161,6 +168,10 @@ def calculate_spacecraft_pset(
     pset_dict["geometric_function"] = geometric_function
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))
+
+    pset_dict["scatter_theta"] = scattering_theta
+    pset_dict["scatter_phi"] = scattering_phi
+    pset_dict["scatter_threshold"] = scattering_thresholds
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -110,7 +110,7 @@ def create_dataset(  # noqa: PLR0912
                 dims=["epoch", "component"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-        elif key == "ena_rates_threshold":
+        elif key in ["ena_rates_threshold", "scatter_threshold"]:
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean"],
@@ -155,6 +155,8 @@ def create_dataset(  # noqa: PLR0912
             "sensitivity",
             "efficiency",
             "geometric_function",
+            "scatter_theta",
+            "scatter_phi",
         }:
             dataset[key] = xr.DataArray(
                 data,


### PR DESCRIPTION
# Change Summary

## Overview
The ULTRA IT team requests that the scattering values for theta and phi and the scattering thresholds for each energy bin are stored in the l1c helio and spacecraft pset. 

## Updated Files
- imap_processing/ultra/l1c/helio_pset.py
   - Write out scatter theta, phi, and thresholds
-  imap_processing/ultra/l1c/spacecraft_pset.py
     - Write out scatter theta, phi, and thresholds
-imap_processing/ultra/l1c/l1c_lookup_utils.py
     - Return averaged theta and phi scattering values over all the spin phases. 

## Testing
Update test data to have the same number of pixels. 
