### PR TITLE
ULTRA L1c remove constant exposure time

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -14,8 +14,8 @@ from imap_processing.ultra.l1c.spacecraft_pset import (
     calculate_fwhm_spun_scattering,
 )
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
-    apply_deadtime_correction,
     build_energy_bins,
+    calculate_exposure_time,
     get_deadtime_ratios,
     get_deadtime_ratios_by_spin_phase,
     get_energy_delta_minus_plus,
@@ -244,7 +244,6 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
     inside_inds = 100
     spin_phase_steps[:inside_inds, :] = True
     deadtime_ratios = np.ones(steps)
-    exposure_pointing = pd.Series(np.ones(pix))
 
     pixels_below_threshold, fwhm_theta, fwhm_phi, thresholds = (
         calculate_fwhm_spun_scattering(
@@ -252,8 +251,8 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
         )
     )
     boundary_sf = np.ones((pix, steps))
-    exposure_pointing_adjusted = apply_deadtime_correction(
-        exposure_pointing, deadtime_ratios, pixels_below_threshold, boundary_sf
+    exposure_pointing_adjusted = calculate_exposure_time(
+        deadtime_ratios, pixels_below_threshold, boundary_sf, pix
     )
     # The adjusted exposure should now be a function of pixels and energy (24)
     np.testing.assert_array_equal(exposure_pointing_adjusted.shape, (24, pix))
@@ -262,9 +261,9 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
     # Should have pixels that are below the FWHM scattering threshold and therefore,
     # have the exposure adjusted.
     last_energy_bin_vals = np.where(build_energy_bins()[2] >= 30)[0]
-    assert np.all(exposure_pointing_adjusted[last_energy_bin_vals, :inside_inds] > 1.0)
+    assert np.all(exposure_pointing_adjusted[last_energy_bin_vals, :inside_inds] > 0)
     # Assert that pixels outside the FOR remain at 1.0
-    assert np.all(exposure_pointing_adjusted[:, inside_inds:] == 1.0)
+    assert np.all(exposure_pointing_adjusted[:, inside_inds:] == 0)
 
 
 @pytest.mark.external_test_data
@@ -272,16 +271,11 @@ def test_get_spacecraft_exposure_times(
     deadtime_datasets, random_spin_data, imap_ena_sim_metakernel, ancillary_files
 ):
     """Test get_spacecraft_exposure_times function."""
-    constant_exposure = (
-        TEST_PATH / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv"
-    )
     steps = 500  # reduced for testing
     rates = deadtime_datasets["rates"]
     params = deadtime_datasets["params"]
-    shape = 786
-    df_exposure = pd.read_csv(constant_exposure)[:shape]  # Subset for testing
 
-    pix = len(df_exposure)
+    pix = 786
     mock_theta = np.random.uniform(-60, 60, (pix, steps))
     mock_phi = np.random.uniform(-60, 60, (pix, steps))
     spin_phase_steps = np.random.randint(0, 2, (pix, steps)).astype(
@@ -295,9 +289,9 @@ def test_get_spacecraft_exposure_times(
     )
     boundary_sf = np.ones((pix, steps))
     exposure_pointing, deadtimes = get_spacecraft_exposure_times(
-        df_exposure, rates, params, pixels_below_threshold, boundary_sf
+        rates, params, pixels_below_threshold, boundary_sf, pix
     )
-    np.testing.assert_array_equal(exposure_pointing.shape, (24, shape))
+    np.testing.assert_array_equal(exposure_pointing.shape, (24, pix))
     np.testing.assert_array_equal(deadtimes.shape, (15000,))
 
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -256,13 +256,13 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
     )
     # The adjusted exposure should now be a function of pixels and energy (24)
     np.testing.assert_array_equal(exposure_pointing_adjusted.shape, (24, pix))
-    # Check that the pixels inside the FOR have adjusted exposure > 1.0
+    # Check that the pixels inside the FOR have adjusted exposure > 0.
     # Subset the energy dimension to check values in the last energy bin. These
     # Should have pixels that are below the FWHM scattering threshold and therefore,
     # have the exposure adjusted.
     last_energy_bin_vals = np.where(build_energy_bins()[2] >= 30)[0]
     assert np.all(exposure_pointing_adjusted[last_energy_bin_vals, :inside_inds] > 0)
-    # Assert that pixels outside the FOR remain at 1.0
+    # Assert that pixels outside the FOR remain at 0.
     assert np.all(exposure_pointing_adjusted[:, inside_inds:] == 0)
 
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -98,13 +98,15 @@ def calculate_helio_pset(
     ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
 
     logger.info("calculating spun FWHM scattering values.")
-    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = calculate_fwhm_spun_scattering(
+    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = (
+        calculate_fwhm_spun_scattering(
             for_indices_by_spin_phase,
             theta_vals,
             phi_vals,
             ancillary_files,
             instrument_id,
         )
+    )
 
     nside = hp.npix2nside(for_indices_by_spin_phase.shape[0])
     counts, latitude, longitude, n_pix = get_spacecraft_histogram(

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -2,8 +2,8 @@
 
 import logging
 
+import astropy_healpix.healpy as hp
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 from imap_processing.quality_flags import ImapPSETUltraFlags
@@ -73,9 +73,6 @@ def calculate_helio_pset(
     # Select only the species we are interested in.
     indices = np.where(de_dataset["species"].values == species_id)[0]
     species_dataset = de_dataset.isel(epoch=indices)
-    helio_pset_quality_flags = np.full(
-        de_dataset["epoch"].shape, ImapPSETUltraFlags.NONE.value, dtype=np.uint16
-    )
 
     rejected = get_de_rejection_mask(
         species_dataset["quality_scattering"].values,
@@ -91,15 +88,6 @@ def calculate_helio_pset(
         / v_mag_helio_spacecraft[:, np.newaxis]
     )
     intervals, _, energy_bin_geometric_means = build_energy_bins()
-    counts, latitude, longitude, n_pix = get_spacecraft_histogram(
-        vhat_dps_helio,
-        species_dataset["energy_heliosphere"].values,
-        intervals,
-        nside=128,
-    )
-
-    healpix = np.arange(n_pix)
-
     # Get lookup table for FOR indices by spin phase step
     (
         for_indices_by_spin_phase,
@@ -108,32 +96,35 @@ def calculate_helio_pset(
         ra_and_dec,
         boundary_scale_factors,
     ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
-    # Check that the number of rows in the lookup table matches the number of pixels
-    if for_indices_by_spin_phase.shape[0] != n_pix:
-        logger.warning(
-            "The spacecraft pointing lookup table is expected to have the same number "
-            "of rows as the number of HEALPix pixels."
-        )
+
     logger.info("calculating spun FWHM scattering values.")
-    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = (
-        calculate_fwhm_spun_scattering(
+    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = calculate_fwhm_spun_scattering(
             for_indices_by_spin_phase,
             theta_vals,
             phi_vals,
             ancillary_files,
             instrument_id,
         )
+
+    nside = hp.npix2nside(for_indices_by_spin_phase.shape[0])
+    counts, latitude, longitude, n_pix = get_spacecraft_histogram(
+        vhat_dps_helio,
+        species_dataset["energy_heliosphere"].values,
+        intervals,
+        nside=nside,
     )
+    helio_pset_quality_flags = np.full(
+        n_pix, ImapPSETUltraFlags.NONE.value, dtype=np.uint16
+    )
+    healpix = np.arange(n_pix)
+
     logger.info("Calculating spacecraft exposure times with deadtime correction.")
-    # Calculate exposure
-    constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
-    df_exposure = pd.read_csv(constant_exposure)
     exposure_time, deadtime_ratios = get_spacecraft_exposure_times(
-        df_exposure,
         rates_dataset,
         params_dataset,
         pixels_below_scattering,
         boundary_scale_factors,
+        n_pix=n_pix,
     )
     logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
@@ -159,12 +150,9 @@ def calculate_helio_pset(
         efficiencies,
         ra_and_dec[:, 0],
         ra_and_dec[:, 1],
+        nside=nside,
     )
     sensitivity = efficiencies * geometric_function
-
-    helio_pset_quality_flags = np.full(
-        n_pix, ImapPSETUltraFlags.NONE.value, dtype=np.uint16
-    )
 
     start: float = np.min(de_dataset["event_times"].values)
     end: float = np.max(de_dataset["event_times"].values)
@@ -177,6 +165,7 @@ def calculate_helio_pset(
         time_bins,
         6378.1,  # Earth radius
         helio_pset_quality_flags,
+        nside=nside,
     )
 
     # For ISTP, epoch should be the center of the time bin.

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -2,8 +2,8 @@
 
 import logging
 
+import astropy_healpix.healpy as hp
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
@@ -85,13 +85,6 @@ def calculate_spacecraft_pset(
     )
 
     intervals, _, energy_bin_geometric_means = build_energy_bins()
-    counts, latitude, longitude, n_pix = get_spacecraft_histogram(
-        vhat_dps_spacecraft,
-        species_dataset["energy_spacecraft"].values,
-        intervals,
-        nside=128,
-    )
-    healpix = np.arange(n_pix)
 
     # Get lookup table for FOR indices by spin phase step
     (
@@ -101,22 +94,25 @@ def calculate_spacecraft_pset(
         ra_and_dec,
         boundary_scale_factors,
     ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
-    # Check that the number of rows in the lookup table matches the number of pixels
-    if for_indices_by_spin_phase.shape[0] != n_pix:
-        logger.warning(
-            "The lookup table is expected to have the same number of rows as "
-            "the number of HEALPix pixels."
-        )
+
     logger.info("calculating spun FWHM scattering values.")
-    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = (
-        calculate_fwhm_spun_scattering(
+    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = calculate_fwhm_spun_scattering(
             for_indices_by_spin_phase,
             theta_vals,
             phi_vals,
             ancillary_files,
             instrument_id,
         )
+    # Determine nside from the lookup table
+    nside = hp.npix2nside(len(for_indices_by_spin_phase))
+    counts, latitude, longitude, n_pix = get_spacecraft_histogram(
+        vhat_dps_spacecraft,
+        species_dataset["energy_spacecraft"].values,
+        intervals,
+        nside=nside,
     )
+    healpix = np.arange(n_pix)
+
     logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
     efficiencies, geometric_function = get_efficiencies_and_geometric_function(
@@ -129,16 +125,14 @@ def calculate_spacecraft_pset(
     )
     sensitivity = efficiencies * geometric_function
 
-    # Calculate exposure
-    constant_exposure = ancillary_files["l1c-90sensor-dps-exposure"]
-    df_exposure = pd.read_csv(constant_exposure)
+    # Calculate exposure times
     logger.info("Calculating spacecraft exposure times with deadtime correction.")
     exposure_pointing, deadtime_ratios = get_spacecraft_exposure_times(
-        df_exposure,
         rates_dataset,
         params_dataset,
         pixels_below_scattering,
         boundary_scale_factors,
+        n_pix=n_pix,
     )
     logger.info("Calculating background rates.")
     # Calculate background rates
@@ -148,6 +142,7 @@ def calculate_spacecraft_pset(
         ancillary_files,
         intervals,
         goodtimes_dataset["spin_number"].values,
+        nside=nside,
     )
     spacecraft_pset_quality_flags = np.full(
         n_pix, ImapPSETUltraFlags.NONE.value, dtype=np.uint16
@@ -164,6 +159,7 @@ def calculate_spacecraft_pset(
         time_bins,
         6378.1,  # Earth radius
         spacecraft_pset_quality_flags,
+        nside=nside,
     )
 
     # For ISTP, epoch should be the center of the time bin.

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -96,13 +96,15 @@ def calculate_spacecraft_pset(
     ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
 
     logger.info("calculating spun FWHM scattering values.")
-    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = calculate_fwhm_spun_scattering(
+    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = (
+        calculate_fwhm_spun_scattering(
             for_indices_by_spin_phase,
             theta_vals,
             phi_vals,
             ancillary_files,
             instrument_id,
         )
+    )
     # Determine nside from the lookup table
     nside = hp.npix2nside(len(for_indices_by_spin_phase))
     counts, latitude, longitude, n_pix = get_spacecraft_histogram(

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -2,7 +2,6 @@
 
 import astropy_healpix.healpy as hp
 import numpy as np
-import pandas
 import xarray as xr
 from numpy.typing import NDArray
 from scipy import interpolate
@@ -340,19 +339,17 @@ def get_deadtime_ratios_by_spin_phase(
     return interpolator(nominal_spin_phases_1ms_res)
 
 
-def apply_deadtime_correction(
-    exposure_pointing: pandas.DataFrame,
+def calculate_exposure_time(
     deadtime_ratios: np.ndarray,
     pixels_below_scattering: list,
     boundary_scale_factors: NDArray,
+    n_pix: int,
 ) -> np.ndarray:
     """
     Adjust the exposure time at each pixel to account for dead time.
 
     Parameters
     ----------
-    exposure_pointing : pandas.DataFrame
-        Exposure data.
     deadtime_ratios : PchipInterpolator
         Interpolating function for dead time ratios.
     pixels_below_scattering : list
@@ -362,6 +359,8 @@ def apply_deadtime_correction(
         the FWHM scattering threshold.
     boundary_scale_factors : np.ndarray
         Boundary scale factors for each pixel at each spin phase.
+    n_pix : int
+        Number of HEALPix pixels.
 
     Returns
     -------
@@ -370,12 +369,8 @@ def apply_deadtime_correction(
     """
     # Get energy bin geometric means
     energy_bin_geometric_means = build_energy_bins()[2]
-    # Exposure time should now be of shape (npix, energy)
-    exposure_pointing = np.repeat(
-        exposure_pointing.to_numpy()[np.newaxis, :],
-        len(energy_bin_geometric_means),
-        axis=0,
-    )
+    # Exposure time should now be of shape (energy, npix)
+    exposure_pointing = np.zeros((len(energy_bin_geometric_means), n_pix))
     # nominal spin phase step.
     nominal_ms_step = 15 / len(pixels_below_scattering)  # time step
     # Query the dead-time ratio and apply the nominal exposure time to pixels in the FOR
@@ -400,19 +395,17 @@ def apply_deadtime_correction(
 
 
 def get_spacecraft_exposure_times(
-    constant_exposure: pandas.DataFrame,
     rates_dataset: xr.Dataset,
     params_dataset: xr.Dataset,
     pixels_below_scattering: list[list],
     boundary_scale_factors: NDArray,
+    n_pix: int,
 ) -> tuple[NDArray, NDArray]:
     """
     Compute exposure times for HEALPix pixels.
 
     Parameters
     ----------
-    constant_exposure : pandas.DataFrame
-        Exposure data.
     rates_dataset : xarray.Dataset
         Dataset containing image rates data.
     params_dataset : xarray.Dataset
@@ -424,6 +417,8 @@ def get_spacecraft_exposure_times(
         below the FWHM scattering threshold.
     boundary_scale_factors : np.ndarray
         Boundary scale factors for each pixel at each spin phase.
+    n_pix : int
+        Number of HEALPix pixels.
 
     Returns
     -------
@@ -438,14 +433,8 @@ def get_spacecraft_exposure_times(
     #  universal pointing table here to determine actual number of spins
     sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
     nominal_deadtime_ratios = get_deadtime_ratios_by_spin_phase(sectored_rates)
-    exposure_pointing = (
-        constant_exposure["Exposure Time"] * 5760
-    )  # 5760 spins per pointing (for now)
-    exposure_pointing_adjusted = apply_deadtime_correction(
-        exposure_pointing,
-        nominal_deadtime_ratios,
-        pixels_below_scattering,
-        boundary_scale_factors,
+    exposure_pointing_adjusted = calculate_exposure_time(
+        nominal_deadtime_ratios, pixels_below_scattering, boundary_scale_factors, n_pix
     )
     return exposure_pointing_adjusted, nominal_deadtime_ratios
 


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

## New Dependencies
Standardize healpix pixels. Remove constant exposure. I had though we were adding a constant exposure but we are instead building the spun version on the fly. This PR removes the outdated reading in of the constant exposure. 

## Updated Files
- imap_processing/ultra/l1c/helio_pset.py
   - remove constant exposure 
   - Standardize nside and healpix pixel. They will be determined by the lookup table loaded.
- imap_processing/ultra/l1c/spacecraft_pset.py
   - remove constant exposure 
   - Standardize nside and healpix pixel. They will be determined by the lookup table loaded.

## Testing
Fix tests
