### PR TITLE
ULTRA L1c and L2 testing and validation work

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -76,7 +76,7 @@ geometric_function:
   CATDESC: The effective sensitive area as a function of theta and phi in instrument frame (energy independent).
   FIELDNAM: geometric_function
   LABLAXIS: Geometric Factor
-  UNITS: " "
+  UNITS: cm^2
   VALIDMIN: 0.0
 
 efficiency:

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -177,3 +177,23 @@ energy_bin_delta:
   FIELDNAM: energy_bin_delta
   LABLAXIS: energy bin delta
   UNITS: keV
+
+energy_delta_minus:
+  <<: *default_float32
+  VAR_TYPE: support_data
+  CATDESC: Difference between the energy bin center and lower edge.
+  LABLAXIS: energy
+  UNITS: KeV
+  FIELDNAM: energy_bin_delta_minus
+  DISPLAY_TYPE: no_plot
+  DEPEND_1: energy_bin_geometric_mean
+
+energy_delta_plus:
+  <<: *default_float32
+  VAR_TYPE: support_data
+  CATDESC: Difference between the energy bin center and upper edge.
+  LABLAXIS: energy
+  UNITS: KeV
+  FIELDNAM: energy_bin_delta_plus
+  DISPLAY_TYPE: no_plot
+  DEPEND_1: energy_bin_geometric_mean

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1474,14 +1474,12 @@ class Ultra(ProcessInstrument):
             for path in anc_paths:
                 ancillary_files[path.stem.split("_")[2]] = path
             spice_paths = dependencies.get_file_paths(data_type="spice")
-
-            if any("/spk/" in path.as_posix() for path in spice_paths):
-                has_ephemeris_kernel = True
+            # Only the helio pset needs IMAP frames
+            if any("imap_frames" in path.as_posix() for path in spice_paths):
+                imap_frames = True
             else:
-                has_ephemeris_kernel = False
-            datasets = ultra_l1c.ultra_l1c(
-                combined, ancillary_files, has_ephemeris_kernel
-            )
+                imap_frames = False
+            datasets = ultra_l1c.ultra_l1c(combined, ancillary_files, imap_frames)
         elif self.data_level == "l2":
             all_pset_filepaths = dependencies.get_file_paths(
                 source="ultra", descriptor="pset"

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1462,7 +1462,10 @@ class Ultra(ProcessInstrument):
             }
             science_files = dependencies.get_file_paths(source="ultra", data_type="l1b")
             l1b_dict = {
-                dataset.attrs["Logical_source"]: dataset
+                # TODO remove
+                dataset.attrs["Logical_source"].replace(
+                    "cullingmask", "goodtimes"
+                ): dataset
                 for dataset in [load_cdf(sci_file) for sci_file in science_files]
             }
             combined = {**l1a_dict, **l1b_dict}
@@ -1471,11 +1474,14 @@ class Ultra(ProcessInstrument):
             for path in anc_paths:
                 ancillary_files[path.stem.split("_")[2]] = path
             spice_paths = dependencies.get_file_paths(data_type="spice")
-            if spice_paths:
-                has_spice = True
+
+            if any("/spk/" in path.as_posix() for path in spice_paths):
+                has_ephermis_kernel = True
             else:
-                has_spice = False
-            datasets = ultra_l1c.ultra_l1c(combined, ancillary_files, has_spice)
+                has_ephermis_kernel = False
+            datasets = ultra_l1c.ultra_l1c(
+                combined, ancillary_files, has_ephermis_kernel
+            )
         elif self.data_level == "l2":
             all_pset_filepaths = dependencies.get_file_paths(
                 source="ultra", descriptor="pset"

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1476,11 +1476,11 @@ class Ultra(ProcessInstrument):
             spice_paths = dependencies.get_file_paths(data_type="spice")
 
             if any("/spk/" in path.as_posix() for path in spice_paths):
-                has_ephermis_kernel = True
+                has_ephemeris_kernel = True
             else:
-                has_ephermis_kernel = False
+                has_ephemeris_kernel = False
             datasets = ultra_l1c.ultra_l1c(
-                combined, ancillary_files, has_ephermis_kernel
+                combined, ancillary_files, has_ephemeris_kernel
             )
         elif self.data_level == "l2":
             all_pset_filepaths = dependencies.get_file_paths(

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -529,7 +529,7 @@ def ancillary_files():
         "l1b-90sensor-tofxesteep": path
         / "imap_ultra_l1b-90sensor-tofxesteep_20250101_v000.pgm",
         "l1b-tofxph": path / "imap_ultra_l1b-tofxph_20250101_v000.pgm",
-        "l1b-90sensor-scattering-calibration": path
+        "l1b-90sensor-scattering-calibration-data": path
         / "imap_ultra_l1b-90sensor-scattering-calibration-data_20250101_v000.csv",
         "l1c-90sensor-dps-exposure": path
         / "imap_ultra_l1c-90sensor-dps-exposure_20250101_v000.csv",
@@ -594,10 +594,16 @@ def deadtime_datasets():
 @pytest.fixture
 def random_spin_data():
     """Fixture for random spin data."""
-    with mock.patch(
-        "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_spacecraft_spin_phase"
-    ) as mock_spin_phases:
+    with (
+        mock.patch(
+            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_spacecraft_spin_phase"
+        ) as mock_spin_phases,
+        mock.patch(
+            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met"
+        ) as mock_met,
+    ):
         mock_spin_phases.side_effect = lambda time: np.random.random(time.shape)
+        mock_met.side_effect = lambda time: time
         yield
 
 

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -1,5 +1,7 @@
 """Tests Spacecraft PSET for ULTRA L1c."""
 
+from unittest import mock
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -85,16 +87,25 @@ def test_calculate_spacecraft_pset(
             "component": ("component", ["vx", "vy", "vz"]),
         },
     )
-
-    spacecraft_pset = calculate_spacecraft_pset(
-        test_l1b_de_dataset,
-        test_l1b_de_dataset,  # placeholder for goodtimes_dataset
-        deadtime_datasets["rates"],
-        deadtime_datasets["params"],
-        "imap_ultra_l1c_45sensor-spacecraftpset",
-        ancillary_files,
-        45,
-    )
+    with (
+        mock.patch(
+            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times",
+            return_value=(482374890.0, 482374000.0),
+        ),
+        mock.patch(
+            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
+            side_effect=lambda x: x,
+        ),
+    ):
+        spacecraft_pset = calculate_spacecraft_pset(
+            test_l1b_de_dataset,
+            test_l1b_de_dataset,  # placeholder for goodtimes_dataset
+            deadtime_datasets["rates"],
+            deadtime_datasets["params"],
+            "imap_ultra_l1c_45sensor-spacecraftpset",
+            ancillary_files,
+            45,
+        )
     assert "pixel_index" in spacecraft_pset.coords
     assert "epoch" in spacecraft_pset.coords
     assert "energy_bin_geometric_mean" in spacecraft_pset.coords
@@ -163,16 +174,25 @@ def test_calculate_spacecraft_pset_with_cdf(
 
         name = "imap_ultra_l1b_45sensor-de"
         dataset = create_dataset(de_dict, name, "l1b")
-
-        spacecraft_pset = calculate_spacecraft_pset(
-            dataset,
-            dataset,  # placeholder for goodtimes_dataset
-            deadtime_datasets["rates"],
-            deadtime_datasets["params"],
-            "imap_ultra_l1c_45sensor-spacecraftpset",
-            ancillary_files,
-            45,
-        )
+        with (
+            mock.patch(
+                "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times",
+                return_value=(482374890.0, 482374000.0),
+            ),
+            mock.patch(
+                "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
+                side_effect=lambda x: x,
+            ),
+        ):
+            spacecraft_pset = calculate_spacecraft_pset(
+                dataset,
+                dataset,  # placeholder for goodtimes_dataset
+                deadtime_datasets["rates"],
+                deadtime_datasets["params"],
+                "imap_ultra_l1c_45sensor-spacecraftpset",
+                ancillary_files,
+                45,
+            )
         # TODO: validate with output histogram data once we have it in healpix.
         assert (
             spacecraft_pset.attrs["Logical_source"]

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -114,7 +114,7 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
     with pytest.raises(
         ValueError, match="Data dictionary does not contain the expected keys."
     ):
-        ultra_l1c(mock_data_l1b_dict, ancillary_files, has_ephemeris_kernel=False)
+        ultra_l1c(mock_data_l1b_dict, ancillary_files, imap_frames=False)
 
 
 @pytest.mark.external_test_data
@@ -195,9 +195,7 @@ def test_calculate_spacecraft_pset_with_cdf(
             side_effect=lambda x: x,
         ),
     ):
-        output_datasets = ultra_l1c(
-            data_dict, ancillary_files, has_ephemeris_kernel=False
-        )
+        output_datasets = ultra_l1c(data_dict, ancillary_files, imap_frames=False)
     output_datasets[0].attrs["Data_version"] = "999"
     output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
     test_data_path = write_cdf(output_datasets[0], istp=True)
@@ -290,9 +288,7 @@ def test_calculate_helio_pset_with_cdf(
             side_effect=lambda x: x,
         ),
     ):
-        output_datasets = ultra_l1c(
-            data_dict, ancillary_files, has_ephemeris_kernel=True
-        )
+        output_datasets = ultra_l1c(data_dict, ancillary_files, imap_frames=True)
     output_datasets[0].attrs["Data_version"] = "999"
     output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
     test_data_path = write_cdf(output_datasets[0], istp=True)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -8,7 +8,9 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import write_cdf
 from imap_processing.spice.geometry import SpiceFrame
-from imap_processing.spice.time import et_to_met
+from imap_processing.spice.time import (
+    et_to_met,
+)
 from imap_processing.ultra.l1b.ultra_l1b_annotated import (
     get_annotated_particle_velocity,
 )
@@ -112,7 +114,7 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
     with pytest.raises(
         ValueError, match="Data dictionary does not contain the expected keys."
     ):
-        ultra_l1c(mock_data_l1b_dict, ancillary_files, has_spice=False)
+        ultra_l1c(mock_data_l1b_dict, ancillary_files, has_ephermis_kernel=False)
 
 
 @pytest.mark.external_test_data
@@ -183,8 +185,19 @@ def test_calculate_spacecraft_pset_with_cdf(
         "imap_ultra_l1a_45sensor-rates": deadtime_datasets["rates"],
         "imap_ultra_l1a_45sensor-params": deadtime_datasets["params"],
     }
-
-    output_datasets = ultra_l1c(data_dict, ancillary_files, has_spice=False)
+    with (
+        mock.patch(
+            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times",
+            return_value=(482374890.0, 482374000.0),
+        ),
+        mock.patch(
+            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
+            side_effect=lambda x: x,
+        ),
+    ):
+        output_datasets = ultra_l1c(
+            data_dict, ancillary_files, has_ephermis_kernel=False
+        )
     output_datasets[0].attrs["Data_version"] = "999"
     output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
     test_data_path = write_cdf(output_datasets[0], istp=True)
@@ -266,11 +279,20 @@ def test_calculate_helio_pset_with_cdf(
         "imap_ultra_l1a_45sensor-rates": deadtime_datasets["rates"],
         "imap_ultra_l1a_45sensor-params": deadtime_datasets["params"],
     }
-    with mock.patch(
-        "imap_processing.ultra.l1c.helio_pset.get_pointing_times",
-        return_value=(482374890.0, 482374000.0),
+
+    with (
+        mock.patch(
+            "imap_processing.ultra.l1c.helio_pset.get_pointing_times",
+            return_value=(482374890.0, 482374000.0),
+        ),
+        mock.patch(
+            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
+            side_effect=lambda x: x,
+        ),
     ):
-        output_datasets = ultra_l1c(data_dict, ancillary_files, has_spice=True)
+        output_datasets = ultra_l1c(
+            data_dict, ancillary_files, has_ephermis_kernel=True
+        )
     output_datasets[0].attrs["Data_version"] = "999"
     output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
     test_data_path = write_cdf(output_datasets[0], istp=True)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -114,7 +114,7 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
     with pytest.raises(
         ValueError, match="Data dictionary does not contain the expected keys."
     ):
-        ultra_l1c(mock_data_l1b_dict, ancillary_files, has_ephermis_kernel=False)
+        ultra_l1c(mock_data_l1b_dict, ancillary_files, has_ephemeris_kernel=False)
 
 
 @pytest.mark.external_test_data
@@ -196,7 +196,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         ),
     ):
         output_datasets = ultra_l1c(
-            data_dict, ancillary_files, has_ephermis_kernel=False
+            data_dict, ancillary_files, has_ephemeris_kernel=False
         )
     output_datasets[0].attrs["Data_version"] = "999"
     output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"
@@ -291,7 +291,7 @@ def test_calculate_helio_pset_with_cdf(
         ),
     ):
         output_datasets = ultra_l1c(
-            data_dict, ancillary_files, has_ephermis_kernel=True
+            data_dict, ancillary_files, has_ephemeris_kernel=True
         )
     output_datasets[0].attrs["Data_version"] = "999"
     output_datasets[0].attrs["Repointing"] = f"repoint{pointing + 1:05d}"

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -151,7 +151,9 @@ def test_get_sectored_rates():
     sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
     np.testing.assert_array_equal(
         sectored_rates["test_data"].data,
-        np.hstack([np.arange(10, 20), np.arange(30, 40), np.arange(50, 60)]),
+        np.arange(
+            10, 20
+        ),  # Make sure duplicate epochs with the same mode are filtered out
     )
     # Test with one mode shift in the middle of the dataset.
     modes = np.array([1, 3, 1])
@@ -226,7 +228,7 @@ def test_get_deadtime_interpolator(random_spin_data):
         # Assert value error is raised for NaN values
         with pytest.raises(
             ValueError,
-            match="Dead time ratios contain NaN values, cannot create interpolator.",
+            match="All dead time radios are NaN, cannot interpolate",
         ):
             get_deadtime_ratios_by_spin_phase(sectored_rates_ds)
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -228,7 +228,7 @@ def test_get_deadtime_interpolator(random_spin_data):
         # Assert value error is raised for NaN values
         with pytest.raises(
             ValueError,
-            match="All dead time radios are NaN, cannot interpolate",
+            match="All dead time ratios are NaN, cannot interpolate",
         ):
             get_deadtime_ratios_by_spin_phase(sectored_rates_ds)
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -97,22 +97,11 @@ class TestUltraL2:
         pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
-        pset["efficiency"] = (
-            ["energy", "pixel_index"],
-            np.ones_like(pset["exposure_factor"].values),
-        )
-        pset["geometric_function"] = (
-            ["energy", "pixel_index"],
-            np.ones_like(pset["exposure_factor"].values),
-        )
-        pset["scatter_theta"] = (
-            ["energy", "pixel_index"],
-            np.ones_like(pset["exposure_factor"].values),
-        )
-        pset["scatter_phi"] = (
-            ["energy", "pixel_index"],
-            np.ones_like(pset["exposure_factor"].values),
-        )
+        pset["efficiency"] = xr.ones_like(pset["exposure_factor"])
+        pset["geometric_function"] = xr.ones_like(pset["exposure_factor"])
+        pset["scatter_theta"] = xr.ones_like(pset["exposure_factor"])
+        pset["scatter_phi"] = xr.ones_like(pset["exposure_factor"])
+
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
         if epoch_dim_for_energy_delta:
             # add an extra dim to the start

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -52,6 +52,7 @@ class TestUltraL2:
                     peak_exposure=1000,
                     timestr=manual_timestrs[i],
                     head=("90"),
+                    energy_dependent_exposure=True,
                 )
                 for i, mid_latitude in enumerate(
                     np.arange(
@@ -89,13 +90,29 @@ class TestUltraL2:
     ):
         # Avoid modifying the original pset
         pset = self.ultra_pset.copy(deep=True)
-
         # Set the values in the single input PSET for easy calculation
         # of the expected ena_intensity and ena_intensity statistical uncertainty
         pset["counts"].values = np.full_like(pset["counts"].values, 10)
-        pset["exposure_factor"].values = np.ones_like(pset["exposure_factor"].values)
+        pset["exposure_factor"].values = np.ones_like(pset["exposure_factor"])
         pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
+        pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
+        pset["efficiency"] = (
+            ["energy", "pixel_index"],
+            np.ones_like(pset["exposure_factor"].values),
+        )
+        pset["geometric_function"] = (
+            ["energy", "pixel_index"],
+            np.ones_like(pset["exposure_factor"].values),
+        )
+        pset["scatter_theta"] = (
+            ["energy", "pixel_index"],
+            np.ones_like(pset["exposure_factor"].values),
+        )
+        pset["scatter_phi"] = (
+            ["energy", "pixel_index"],
+            np.ones_like(pset["exposure_factor"].values),
+        )
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
         if epoch_dim_for_energy_delta:
             # add an extra dim to the start
@@ -119,6 +136,10 @@ class TestUltraL2:
                         "values_to_pull_project": [
                             "exposure_factor",
                             "sensitivity",
+                            "geometric_function",
+                            "efficiency",
+                            "scatter_theta",
+                            "scatter_phi",
                             "background_rates",
                         ],
                         "nside": 32,

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -156,6 +156,11 @@ class TestUltraL2:
             "ena_intensity",
             "ena_intensity_stat_unc",
             "exposure_factor",
+            "sensitivity",
+            "geometric_function",
+            "efficiency",
+            "scatter_theta",
+            "scatter_phi",
             "obs_date",
         ]
         for var in expected_vars:
@@ -246,10 +251,7 @@ class TestUltraL2:
         assert hp_skymap.data_1d["counts"].dims == counts_dims
         assert hp_skymap.data_1d["ena_intensity"].dims == counts_dims
         assert hp_skymap.data_1d["ena_intensity_stat_unc"].dims == counts_dims
-        assert hp_skymap.data_1d["exposure_factor"].dims == (
-            CoordNames.TIME.value,
-            CoordNames.GENERIC_PIXEL.value,
-        )
+        assert hp_skymap.data_1d["exposure_factor"].dims == counts_dims
 
     @pytest.mark.usefixtures("_setup_spice_kernels_list")
     def test_ultra_l2_output_unbinned_healpix(self, mock_data_dict, furnish_kernels):
@@ -375,11 +377,7 @@ class TestUltraL2:
             rect_map_dataset["ena_intensity_stat_unc"].dims
             == expected_ena_intensity_dims
         )
-        assert rect_map_dataset["exposure_factor"].dims == (
-            CoordNames.TIME.value,
-            CoordNames.AZIMUTH_L2.value,
-            CoordNames.ELEVATION_L2.value,
-        )
+        assert rect_map_dataset["exposure_factor"].dims == expected_ena_intensity_dims
 
         # Check that '_label' coordinates were added for all coordinates except 'epoch'
         for coord_var in expected_ena_intensity_dims[1:]:

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -345,7 +345,7 @@ def load_scattering_lookup_tables(ancillary_files: dict, instrument_id: int) -> 
     # TODO remove the line below when the 45 sensor scattering coefficients are
     #  delivered.
     instrument_id = 90
-    descriptor = f"l1b-{instrument_id}sensor-scattering-calibration"
+    descriptor = f"l1b-{instrument_id}sensor-scattering-calibration-data"
     theta_grid = pd.read_csv(
         ancillary_files[descriptor], header=None, skiprows=7, nrows=241
     ).to_numpy(dtype=float)

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -22,6 +22,7 @@ from imap_processing.ultra.l1c.ultra_l1c_culling import compute_culling_mask
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_efficiencies_and_geometric_function,
+    get_energy_delta_minus_plus,
     get_helio_adjusted_data,
     get_spacecraft_exposure_times,
     get_spacecraft_histogram,
@@ -190,6 +191,11 @@ def calculate_helio_pset(
     pset_dict["scatter_theta"] = scattering_theta
     pset_dict["scatter_phi"] = scattering_phi
     pset_dict["scatter_threshold"] = scattering_thresholds
+
+    # Add the energy delta plus/minus to the dataset
+    energy_delta_minus, energy_delta_plus = get_energy_delta_minus_plus()
+    pset_dict["energy_delta_minus"] = energy_delta_minus
+    pset_dict["energy_delta_plus"] = energy_delta_plus
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -138,15 +138,14 @@ def calculate_helio_pset(
         ancillary_files,
     )
     # Get midpoint timestamp for pointing.
-    # TODO remove sct_to_et conversion when l1b is updated
     pointing_start, pointing_stop = get_pointing_times(
         et_to_met(species_dataset["event_times"].data[0])
     )
-    mid_time = met_to_ttj2000ns((pointing_start + pointing_stop) / 2)
+    mid_time = ttj2000ns_to_et(met_to_ttj2000ns((pointing_start + pointing_stop) / 2))
 
     logger.info("Adjusting data for helio frame.")
     exposure_time, efficiency, geometric_function = get_helio_adjusted_data(
-        ttj2000ns_to_et(mid_time),
+        mid_time,
         exposure_time,
         geometric_function,
         efficiencies,
@@ -169,9 +168,9 @@ def calculate_helio_pset(
         helio_pset_quality_flags,
         nside=nside,
     )
-
-    # For ISTP, epoch should be the center of the time bin.
-    pset_dict["epoch"] = np.atleast_1d(mid_time).astype(np.int64)
+    pointing_start = met_to_ttj2000ns(pointing_start)
+    # Epoch should be the center of the pointing
+    pset_dict["epoch"] = np.atleast_1d(pointing_start).astype(np.int64)
     pset_dict["counts"] = counts[np.newaxis, ...]
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -170,7 +170,7 @@ def calculate_helio_pset(
         nside=nside,
     )
     pointing_start = met_to_ttj2000ns(pointing_start)
-    # Epoch should be the center of the pointing
+    # Epoch should be the start of the pointing
     pset_dict["epoch"] = np.atleast_1d(pointing_start).astype(np.int64)
     pset_dict["counts"] = counts[np.newaxis, ...]
     pset_dict["latitude"] = latitude[np.newaxis, ...]

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -11,7 +11,6 @@ from imap_processing.spice.repoint import get_pointing_times
 from imap_processing.spice.time import (
     et_to_met,
     met_to_ttj2000ns,
-    sct_to_et,
     ttj2000ns_to_et,
 )
 from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
@@ -139,14 +138,15 @@ def calculate_helio_pset(
         ancillary_files,
     )
     # Get midpoint timestamp for pointing.
-    # TODO remove sct_to_et conversion
+    # TODO remove sct_to_et conversion when l1b is updated
     pointing_start, pointing_stop = get_pointing_times(
-        et_to_met(sct_to_et(species_dataset["event_times"].data[0]))
+        et_to_met(species_dataset["event_times"].data[0])
     )
-    mid_time = ttj2000ns_to_et(met_to_ttj2000ns((pointing_start + pointing_stop) / 2))
+    mid_time = met_to_ttj2000ns((pointing_start + pointing_stop) / 2)
+
     logger.info("Adjusting data for helio frame.")
     exposure_time, efficiency, geometric_function = get_helio_adjusted_data(
-        mid_time,
+        ttj2000ns_to_et(mid_time),
         exposure_time,
         geometric_function,
         efficiencies,
@@ -171,7 +171,7 @@ def calculate_helio_pset(
     )
 
     # For ISTP, epoch should be the center of the time bin.
-    pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)
+    pset_dict["epoch"] = np.atleast_1d(mid_time).astype(np.int64)
     pset_dict["counts"] = counts[np.newaxis, ...]
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -172,9 +172,9 @@ def calculate_spacecraft_pset(
     pointing_start, pointing_stop = get_pointing_times(
         float(et_to_met(species_dataset["event_times"].data[0]))
     )
-    mid_time = met_to_ttj2000ns((pointing_start + pointing_stop) / 2)
-    # For ISTP, epoch should be the center of the time bin.
-    pset_dict["epoch"] = np.atleast_1d(mid_time).astype(np.int64)
+    pointing_start = met_to_ttj2000ns(pointing_start)
+    # Epoch should be the center of the pointing
+    pset_dict["epoch"] = np.atleast_1d(pointing_start).astype(np.int64)
     pset_dict["counts"] = counts[np.newaxis, ...]
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -8,6 +8,11 @@ import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.quality_flags import ImapPSETUltraFlags
+from imap_processing.spice.repoint import get_pointing_times
+from imap_processing.spice.time import (
+    et_to_met,
+    met_to_ttj2000ns,
+)
 from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     calculate_fwhm_spun_scattering,
@@ -163,9 +168,13 @@ def calculate_spacecraft_pset(
         spacecraft_pset_quality_flags,
         nside=nside,
     )
-
+    # Get midpoint timestamp for pointing.
+    pointing_start, pointing_stop = get_pointing_times(
+        float(et_to_met(species_dataset["event_times"].data[0]))
+    )
+    mid_time = met_to_ttj2000ns((pointing_start + pointing_stop) / 2)
     # For ISTP, epoch should be the center of the time bin.
-    pset_dict["epoch"] = de_dataset.epoch.data[:1].astype(np.int64)
+    pset_dict["epoch"] = np.atleast_1d(mid_time).astype(np.int64)
     pset_dict["counts"] = counts[np.newaxis, ...]
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -174,7 +174,7 @@ def calculate_spacecraft_pset(
         float(et_to_met(species_dataset["event_times"].data[0]))
     )
     pointing_start = met_to_ttj2000ns(pointing_start)
-    # Epoch should be the center of the pointing
+    # Epoch should be the start of the pointing
     pset_dict["epoch"] = np.atleast_1d(pointing_start).astype(np.int64)
     pset_dict["counts"] = counts[np.newaxis, ...]
     pset_dict["latitude"] = latitude[np.newaxis, ...]

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -169,7 +169,7 @@ def calculate_spacecraft_pset(
         spacecraft_pset_quality_flags,
         nside=nside,
     )
-    # Get midpoint timestamp for pointing.
+    # Get pointing start and stop times and convert to ttj2000ns
     pointing_start, pointing_stop = get_pointing_times(
         float(et_to_met(species_dataset["event_times"].data[0]))
     )

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -22,6 +22,7 @@ from imap_processing.ultra.l1c.ultra_l1c_culling import compute_culling_mask
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
     build_energy_bins,
     get_efficiencies_and_geometric_function,
+    get_energy_delta_minus_plus,
     get_spacecraft_background_rates,
     get_spacecraft_exposure_times,
     get_spacecraft_histogram,
@@ -196,6 +197,11 @@ def calculate_spacecraft_pset(
     pset_dict["scatter_theta"] = scattering_theta
     pset_dict["scatter_phi"] = scattering_phi
     pset_dict["scatter_threshold"] = scattering_thresholds
+
+    # Add the energy delta plus/minus to the dataset
+    energy_delta_minus, energy_delta_plus = get_energy_delta_minus_plus()
+    pset_dict["energy_delta_minus"] = energy_delta_minus
+    pset_dict["energy_delta_plus"] = energy_delta_plus
 
     dataset = create_dataset(pset_dict, name, "l1c")
 

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -7,7 +7,7 @@ from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
 
 
 def ultra_l1c(
-    data_dict: dict, ancillary_files: dict, has_spice: bool
+    data_dict: dict, ancillary_files: dict, has_ephermis_kernel: bool
 ) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A and L1B data into L1C CDF files at output_filepath.
@@ -18,8 +18,8 @@ def ultra_l1c(
         The data itself and its dependent data.
     ancillary_files : dict
         Ancillary files.
-    has_spice : bool
-        Whether to use SPICE data.
+    has_ephermis_kernel : bool
+        Whether to use ephemeris kernels.
 
     Returns
     -------
@@ -35,7 +35,7 @@ def ultra_l1c(
             and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
-            and has_spice
+            and has_ephermis_kernel
         ):
             helio_pset = calculate_helio_pset(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -7,7 +7,7 @@ from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
 
 
 def ultra_l1c(
-    data_dict: dict, ancillary_files: dict, has_ephemeris_kernel: bool
+    data_dict: dict, ancillary_files: dict, imap_frames: bool
 ) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A and L1B data into L1C CDF files at output_filepath.
@@ -18,8 +18,8 @@ def ultra_l1c(
         The data itself and its dependent data.
     ancillary_files : dict
         Ancillary files.
-    has_ephemeris_kernel : bool
-        Whether to use ephemeris kernels.
+    imap_frames : bool
+        Whether to use IMAP frames.
 
     Returns
     -------
@@ -35,7 +35,7 @@ def ultra_l1c(
             and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
-            and has_ephemeris_kernel
+            and imap_frames
         ):
             helio_pset = calculate_helio_pset(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -7,7 +7,7 @@ from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
 
 
 def ultra_l1c(
-    data_dict: dict, ancillary_files: dict, has_ephermis_kernel: bool
+    data_dict: dict, ancillary_files: dict, has_ephemeris_kernel: bool
 ) -> list[xr.Dataset]:
     """
     Will process ULTRA L1A and L1B data into L1C CDF files at output_filepath.
@@ -18,7 +18,7 @@ def ultra_l1c(
         The data itself and its dependent data.
     ancillary_files : dict
         Ancillary files.
-    has_ephermis_kernel : bool
+    has_ephemeris_kernel : bool
         Whether to use ephemeris kernels.
 
     Returns
@@ -35,7 +35,7 @@ def ultra_l1c(
             and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
-            and has_ephermis_kernel
+            and has_ephemeris_kernel
         ):
             helio_pset = calculate_helio_pset(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -255,9 +255,8 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
 
     # This means that data was collected as a function of spin allowing for fine grained
     # rate analysis.
-    params = params_ds.copy()
     # Only get unique combinations of epoch and imageratescadence
-    params = params.groupby(["epoch", "imageratescadence"]).first()
+    params = params_ds.groupby(["epoch", "imageratescadence"]).first()
 
     sector_mode_start_inds = np.where(params["imageratescadence"] == 3)[0]
     # get the sector mode start and stop indices
@@ -331,7 +330,7 @@ def get_deadtime_ratios_by_spin_phase(
     deadtime_medians = deadtime_by_spin_phase.groupby("spin_phase").median(skipna=True)
     if np.any(np.isnan(deadtime_medians["deadtime_ratio"].values)):
         if not np.any(np.isfinite(deadtime_medians["deadtime_ratio"].values)):
-            raise ValueError("All dead time radios are NaN, cannot interpolate.")
+            raise ValueError("All dead time ratios are NaN, cannot interpolate.")
         logger.warning(
             "Dead time ratios contain NaN values, filtering data to only include "
             "finite values."

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -259,6 +259,8 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
     params = params_ds.groupby(["epoch", "imageratescadence"]).first()
 
     sector_mode_start_inds = np.where(params["imageratescadence"] == 3)[0]
+    if len(sector_mode_start_inds) == 0:
+        raise ValueError("No sector mode data found in the parameters dataset.")
     # get the sector mode start and stop indices
     sector_mode_stop_inds = sector_mode_start_inds + 1
     # get the sector mode start and stop times

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -1,5 +1,7 @@
 """Module to create pointing sets."""
 
+import logging
+
 import astropy_healpix.healpy as hp
 import numpy as np
 import xarray as xr
@@ -12,6 +14,7 @@ from imap_processing.spice.geometry import (
     imap_state,
 )
 from imap_processing.spice.spin import get_spacecraft_spin_phase, get_spin_angle
+from imap_processing.spice.time import ttj2000ns_to_met
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.lookup_utils import (
     get_geometric_factor,
@@ -29,6 +32,8 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
 
 # TODO: add species binning.
 FILLVAL_FLOAT32 = -1.0e31
+
+logger = logging.getLogger(__name__)
 
 
 def build_energy_bins() -> tuple[list[tuple[float, float]], np.ndarray, np.ndarray]:
@@ -221,7 +226,6 @@ def get_deadtime_ratios(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
         - sectored_rates_ds.stop_tn
         - sectored_rates_ds.stop_bn
     )
-
     corrected_valid_events = b * np.exp(1e-7 * 8 * coin_stop_nd)
 
     # Compute dead time ratio
@@ -251,21 +255,23 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
 
     # This means that data was collected as a function of spin allowing for fine grained
     # rate analysis.
-    sector_mode_start_inds = np.where(params_ds["imageratescadence"] == 3)[0]
+    params = params_ds.copy()
+    # Only get unique combinations of epoch and imageratescadence
+    params = params.groupby(["epoch", "imageratescadence"]).first()
+
+    sector_mode_start_inds = np.where(params["imageratescadence"] == 3)[0]
     # get the sector mode start and stop indices
     sector_mode_stop_inds = sector_mode_start_inds + 1
     # get the sector mode start and stop times
-    mode_3_start = params_ds["epoch"].values[sector_mode_start_inds]
-
+    mode_3_start = params["epoch"].values[sector_mode_start_inds]
     # if the last mode is a sector mode, we can assume that the sector data goes through
     # the end of the dataset, so we append np.inf to the end of the last time range.
-    if sector_mode_stop_inds[-1] == len(params_ds["epoch"]):
+    if sector_mode_stop_inds[-1] == len(params["epoch"]):
         mode_3_end = np.append(
-            params_ds["epoch"].values[sector_mode_stop_inds[:-1]], np.inf
+            params["epoch"].values[sector_mode_stop_inds[:-1]], np.inf
         )
     else:
-        mode_3_end = params_ds["epoch"].values[sector_mode_stop_inds]
-
+        mode_3_end = params["epoch"].values[sector_mode_stop_inds]
     # Build a list of conditions for each sector mode time range
     conditions = [
         (rates_ds["epoch"] >= start) & (rates_ds["epoch"] < end)
@@ -294,10 +300,9 @@ def get_deadtime_ratios_by_spin_phase(
     """
     deadtime_ratios = get_deadtime_ratios(sectored_rates)
     # Get the spin phase at the start of each sector rate measurement
+    met_times = ttj2000ns_to_met(sectored_rates.epoch.data)
     spin_phases = np.asarray(
-        get_spin_angle(
-            get_spacecraft_spin_phase(np.array(sectored_rates.epoch.data)), degrees=True
-        )
+        get_spin_angle(get_spacecraft_spin_phase(met_times), degrees=True)
     )
     # Assume the sectored rate data is evenly spaced in time, and find the middle spin
     # phase value for each sector.
@@ -324,11 +329,16 @@ def get_deadtime_ratios_by_spin_phase(
     deadtime_by_spin_phase = deadtime_by_spin_phase.sortby("spin_phase")
     # Group by spin phase and calculate the median dead time ratio for each phase
     deadtime_medians = deadtime_by_spin_phase.groupby("spin_phase").median(skipna=True)
-
     if np.any(np.isnan(deadtime_medians["deadtime_ratio"].values)):
-        raise ValueError(
-            "Dead time ratios contain NaN values, cannot create interpolator."
+        if not np.any(np.isfinite(deadtime_medians["deadtime_ratio"].values)):
+            raise ValueError("All dead time radios are NaN, cannot interpolate.")
+        logger.warning(
+            "Dead time ratios contain NaN values, filtering data to only include "
+            "finite values."
         )
+    deadtime_medians = deadtime_medians.where(
+        np.isfinite(deadtime_medians["deadtime_ratio"]), drop=True
+    )
     interpolator = interpolate.PchipInterpolator(
         deadtime_medians["spin_phase"].values, deadtime_medians["deadtime_ratio"].values
     )

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -55,6 +55,10 @@ REQUIRED_L1C_VARIABLES_PUSH = [
 REQUIRED_L1C_VARIABLES_PULL = [
     "exposure_factor",
     "sensitivity",
+    "geometric_function",
+    "efficiency",
+    "scatter_theta",
+    "scatter_phi",
     "background_rates",
     "obs_date",
 ]

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -95,11 +95,6 @@ VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION = [
 INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES = [
     "obs_date",
     "exposure_factor",
-    "sensitivity",
-    "geometric_function",
-    "efficiency",
-    "scatter_theta",
-    "scatter_phi",
     "obs_date_range",
 ]
 

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -10,6 +10,7 @@ import xarray as xr
 from numpy.typing import NDArray
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.cdf.utils import load_cdf
 from imap_processing.ena_maps import ena_maps
 from imap_processing.ena_maps.utils.coordinates import CoordNames
 from imap_processing.ena_maps.utils.naming import (
@@ -253,8 +254,13 @@ def generate_ultra_healpix_skymap(
     # Add expected but not required variables to the pull projection list
     # Log a warning if they are missing from any PSET but continue processing.
     expected_present_vars = []
+    first_pset = (
+        load_cdf(ultra_l1c_psets[0])
+        if isinstance(ultra_l1c_psets[0], (str, Path))
+        else ultra_l1c_psets[0]
+    )
     for var in EXPECTED_L1C_VARIABLES_PULL:
-        if var not in ultra_l1c_psets[0].variables:
+        if var not in first_pset.variables:
             logger.warning(
                 f"Expected variable {var} not found in the first L1C PSET. "
                 "This variable will not be projected to the map."

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -55,14 +55,18 @@ REQUIRED_L1C_VARIABLES_PUSH = [
 REQUIRED_L1C_VARIABLES_PULL = [
     "exposure_factor",
     "sensitivity",
+    "background_rates",
+    "obs_date",
+]
+# These variables are expected but not strictly required. In certain test scenarios,
+# they may be missing, in which case we will raise a warning and continue.
+# All psets must be consistent and either have these variables or not.
+EXPECTED_L1C_VARIABLES_PULL = [
     "geometric_function",
     "efficiency",
     "scatter_theta",
     "scatter_phi",
-    "background_rates",
-    "obs_date",
 ]
-
 # These variables are projected to the map as the mean of pointing set pixels value,
 # weighted by that pointing set pixel's exposure and solid angle
 VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE = [
@@ -90,6 +94,12 @@ VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION = [
 INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES = [
     "obs_date",
     "exposure_factor",
+    "exposure_factor",
+    "sensitivity",
+    "geometric_function",
+    "efficiency",
+    "scatter_theta",
+    "scatter_phi",
     "obs_date_range",
 ]
 
@@ -239,6 +249,22 @@ def generate_ultra_healpix_skymap(
             f"PUSH Variables: {output_map_structure.values_to_push_project} \n"
             f"PULL Variables: {output_map_structure.values_to_pull_project}"
         )
+    # TODO remove this in the future once all test data includes these variables
+    # Add expected but not required variables to the pull projection list
+    # Log a warning if they are missing from any PSET but continue processing.
+    expected_present_vars = []
+    for var in EXPECTED_L1C_VARIABLES_PULL:
+        if var not in ultra_l1c_psets[0].variables:
+            logger.warning(
+                f"Expected variable {var} not found in the first L1C PSET. "
+                "This variable will not be projected to the map."
+            )
+        else:
+            expected_present_vars.append(var)
+
+    output_map_structure.values_to_pull_project = list(
+        set(output_map_structure.values_to_pull_project + expected_present_vars)
+    )
 
     all_pset_epochs = []
     for ultra_l1c_pset in ultra_l1c_psets:

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -95,7 +95,6 @@ VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION = [
 INCONSISTENTLY_ENERGY_DEPENDENT_VARIABLES = [
     "obs_date",
     "exposure_factor",
-    "exposure_factor",
     "sensitivity",
     "geometric_function",
     "efficiency",

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -110,7 +110,12 @@ def create_dataset(  # noqa: PLR0912
                 dims=["epoch", "component"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-        elif key in ["ena_rates_threshold", "scatter_threshold"]:
+        elif key in [
+            "ena_rates_threshold",
+            "scatter_threshold",
+            "energy_delta_minus",
+            "energy_delta_plus",
+        ]:
             dataset[key] = xr.DataArray(
                 data,
                 dims=["energy_bin_geometric_mean"],


### PR DESCRIPTION
# Change Summary

closes #2077

## Overview
Validation and testing updates for l1c and l2. I ran some fake data through l1c using the command below and fixed any bugs. 
I also added updates from these power points: 
[l2_validation.pptx](https://github.com/user-attachments/files/22127250/l2_validation.pptx)
[l1c_validation.pptx](https://github.com/user-attachments/files/22127252/l1c_validation.pptx)



`imap_cli --instrument ultra --data-level l1c --descriptor 90sensor-spacecraftpset --start-date 20260926 --version v001 --dependency '[{"type": "science","files": ["imap_ultra_l1b_90sensor-goodtimes_20260926_v002.cdf"]},{"type": "science","files": ["imap_ultra_l1b_90sensor-de_20260926_v001.cdf"]},{"type": "science","files": ["imap_ultra_l1a_90sensor-rates_20260926_v006.cdf"]},{"type": "science","files": ["imap_ultra_l1a_90sensor-params_20260926_v006.cdf"]},{"type": "ancillary","files": ["imap_ultra_l1c-90sensor-sc-pointing-bsf_20250101_v000.csv"]},{"type": "ancillary","files": ["imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v000.csv"]},{"type": "ancillary","files": ["imap_ultra_l1c-90sensor-sc-pointing-phi_20250101_v000.csv"]},{"type": "ancillary","files": ["imap_ultra_l1c-90sensor-sc-pointing-index_20250101_v000.csv"]},{"type": "ancillary","files": ["imap_ultra_l1b-90sensor-scattering-calibration-data_20250101_v000.csv"]},{"type": "ancillary","files": ["imap_ultra_l1b-scattering-thresholds-per-energy_20250101_v000.csv"]},{"type": "ancillary","files": ["imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"]},{"type": "ancillary","files": ["imap_ultra_l1b-90sensor-imgparams-lookup_20250101_v001.csv"]},{"type": "ancillary","files": ["imap_ultra_l1b-sensor-gf-blades_20250101_v000.csv"]},{"type": "repoint","files": ["imap_2026_269_05.repoint.csv"]},{"type": "spin","files": ["imap_2026_268_2026_269_01.spin.csv"]},{"type": "spice", "files": ["naif0012.tls", "imap_sclk_0000.tsc"]}]'`


## Updated Files
-imap_processing/cli.py
   - Spacecraft pset and helio pset both have SPICE dependencies. Only helio has ephemeris data. 
- imap_processing/ultra/l1c/helio_pset.py, imap_processing/ultra/l1c/helio_pset.py
   - Update epoch to be the beginning of the pointing. 
   - Add energy delta minus and plus as requested from the IT team 
- imap_processing/ultra/l2/ultra_l2.py
   - add energy dependent deps. Allow for maps to run with or without new variables. NOTE *** In the future we should probably remove this handling 

## Testing
Fixed tests to mock pointing data. 
