### PR TITLE
ULTRA l2 map attributes 

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -220,7 +220,7 @@ geometric_function:
 
 efficiency:
   <<: *default_float32
-  CATDESC: Estimated event efficiency for particles path through the instrument calculated from multiple pointing sets.
+  CATDESC: Event efficiency calculated from multiple pointing sets.
   FIELDNAM: efficiency
   UNITS: " "
   DEPEND_0: epoch

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -229,7 +229,7 @@ efficiency:
   DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:Other
 
-positional_uncertainty_theta:
+positional_uncert_theta:
   <<: *default_float32
   CATDESC: Positional uncertainty in theta direction calculated from multiple pointing sets.
   FIELDNAM: positional_uncertainty_theta
@@ -240,7 +240,7 @@ positional_uncertainty_theta:
   DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:ArrivalDirection,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
-positional_uncertainty_phi:
+positional_uncert_phi:
   <<: *default_float32
   CATDESC: Positional uncertainty in phi direction calculated from multiple pointing sets.
   FIELDNAM: positional_uncertainty_phi
@@ -266,20 +266,8 @@ obs_date: &obs_date
 obs_date_range:
   <<: *default_int64
   datatype: int64
-  CATDESC: Range of the observation dates.
-  FIELDNAM: Observation date range
-  UNITS: ns
-  DEPEND_0: epoch
-  VAR_TYPE: data
-  LABLAXIS: epoch
-  DISPLAY_TYPE: image
-  TIME_SCALE: Terrestrial Time
-
-obs_date_for_std:
-  <<: *default_int64
-  datatype: int64
   CATDESC: Standard deviation of the observation date.
-  FIELDNAM: Observation date standard deviation
+  FIELDNAM: Observation date range
   UNITS: ns
   DEPEND_0: epoch
   VAR_TYPE: data

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -207,6 +207,50 @@ exposure_factor: &exposure_factor
   DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>TemporalDescription:Exposure,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
+geometric_function:
+  <<: *default_float32
+  CATDESC: The geometric function calculated from multiple pointing sets.
+  FIELDNAM: geometric_function
+  UNITS: cm^2 sr
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  LABLAXIS: Geometric Factor
+  DISPLAY_TYPE: no_plot
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:GeometricFactor,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+
+efficiency:
+  <<: *default_float32
+  CATDESC: Estimated event efficiency for particles path through the instrument calculated from multiple pointing sets.
+  FIELDNAM: efficiency
+  UNITS: " "
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  LABLAXIS: Efficiency
+  DISPLAY_TYPE: no_plot
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:Other
+
+positional_uncertainty_theta:
+  <<: *default_float32
+  CATDESC: Positional uncertainty in theta direction calculated from multiple pointing sets.
+  FIELDNAM: positional_uncertainty_theta
+  UNITS: degrees
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  LABLAXIS: Position Uncertainty Theta
+  DISPLAY_TYPE: no_plot
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:ArrivalDirection,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+
+positional_uncertainty_phi:
+  <<: *default_float32
+  CATDESC: Positional uncertainty in phi direction calculated from multiple pointing sets.
+  FIELDNAM: positional_uncertainty_phi
+  UNITS: degrees
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  LABLAXIS: Position Uncertainty Phi
+  DISPLAY_TYPE: no_plot
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:ArrivalDirection,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+
 obs_date: &obs_date
   <<: *default_int64
   datatype: int64
@@ -222,8 +266,20 @@ obs_date: &obs_date
 obs_date_range:
   <<: *default_int64
   datatype: int64
-  CATDESC: Standard deviation of the observation date.
+  CATDESC: Range of the observation dates.
   FIELDNAM: Observation date range
+  UNITS: ns
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  LABLAXIS: epoch
+  DISPLAY_TYPE: image
+  TIME_SCALE: Terrestrial Time
+
+obs_date_for_std:
+  <<: *default_int64
+  datatype: int64
+  CATDESC: Standard deviation of the observation date.
+  FIELDNAM: Observation date standard deviation
   UNITS: ns
   DEPEND_0: epoch
   VAR_TYPE: data

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -84,13 +84,13 @@ geometric_function:
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
 
-positional_uncertainty_theta:
+positional_uncert_theta:
   DEPEND_1: energy
   DEPEND_2: pixel_index
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
 
-positional_uncertainty_phi:
+positional_uncert_phi:
   DEPEND_1: energy
   DEPEND_2: pixel_index
   LABL_PTR_1: energy_label
@@ -127,13 +127,6 @@ obs_date_range:
   DEPEND_2: pixel_index
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
-
-obs_date_for_std:
-  DEPEND_1: energy
-  DEPEND_2: pixel_index
-  LABL_PTR_1: energy_label
-  LABL_PTR_2: pixel_index_label
-
 
 solid_angle:
   DEPEND_1: pixel_index

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -72,6 +72,29 @@ sensitivity:
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
 
+efficiency:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
+
+geometric_function:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
+
+positional_uncertainty_theta:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
+
+positional_uncertainty_phi:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
 # These data variables will have an extra (energy) dimension
 # only if the energy dimension is present in the L1C data.
 # The default is energy-independent.
@@ -98,6 +121,19 @@ obs_date:
   DEPEND_2: pixel_index
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
+
+obs_date_range:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
+
+obs_date_for_std:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
+
 
 solid_angle:
   DEPEND_1: pixel_index

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -134,6 +134,38 @@ exposure_factor:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
+efficiency:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+geometric_function:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+positional_uncertainty_theta:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+positional_uncertainty_phi:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
 obs_date:
   DEPEND_1: energy
   DEPEND_2: longitude
@@ -143,6 +175,14 @@ obs_date:
   LABL_PTR_3: latitude_label
 
 obs_date_range:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+obs_date_for_std:
   DEPEND_1: energy
   DEPEND_2: longitude
   DEPEND_3: latitude

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -150,7 +150,7 @@ geometric_function:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
-positional_uncertainty_theta:
+positional_uncert_theta:
   DEPEND_1: energy
   DEPEND_2: longitude
   DEPEND_3: latitude
@@ -158,7 +158,7 @@ positional_uncertainty_theta:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
-positional_uncertainty_phi:
+positional_uncert_phi:
   DEPEND_1: energy
   DEPEND_2: longitude
   DEPEND_3: latitude

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -182,14 +182,6 @@ obs_date_range:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
-obs_date_for_std:
-  DEPEND_1: energy
-  DEPEND_2: longitude
-  DEPEND_3: latitude
-  LABL_PTR_1: energy_label
-  LABL_PTR_2: longitude_label
-  LABL_PTR_3: latitude_label
-
 solid_angle:
   DEPEND_1: longitude
   DEPEND_2: latitude

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -63,6 +63,12 @@ class TestUltraL2:
                     )
                 )
             ]
+            # Add extra ultra specific variables to each pset
+            for pset in self.ultra_psets:
+                pset["efficiency"] = xr.ones_like(pset["exposure_factor"])
+                pset["geometric_function"] = xr.ones_like(pset["exposure_factor"])
+                pset["scatter_theta"] = xr.ones_like(pset["exposure_factor"])
+                pset["scatter_phi"] = xr.ones_like(pset["exposure_factor"])
 
         self.psets_total_counts = np.sum(
             [pset["counts"].values.sum() for pset in self.ultra_psets]
@@ -348,6 +354,11 @@ class TestUltraL2:
                 "values_to_pull_project": [
                     "exposure_factor",
                     "sensitivity",
+                    "efficiency",
+                    "sensitivity",
+                    "geometric_function",
+                    "scatter_theta",
+                    "scatter_phi",
                 ],
                 "nside": 16,
                 "nested": True,
@@ -392,6 +403,10 @@ class TestUltraL2:
             ),
         )
         assert map_dataset["solid_angle"].attrs["UNITS"] == "sr"
+
+        # Check that the positional uncertainty variables were renamed
+        assert "positional_uncert_theta" in map_dataset
+        assert "positional_uncert_phi" in map_dataset
 
     @pytest.mark.usefixtures("_setup_spice_kernels_list")
     def test_ultra_l2_rectangular(self, mock_data_dict, furnish_kernels):

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -155,6 +155,8 @@ class TestUltraL2:
             "scatter_theta",
             "scatter_phi",
             "obs_date",
+            "obs_date_range",
+            "obs_date_for_std",
         ]
         for var in expected_vars:
             assert var in hp_skymap.data_1d.data_vars

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -155,7 +155,6 @@ class TestUltraL2:
             "scatter_theta",
             "scatter_phi",
             "obs_date",
-            "obs_date_range",
         ]
         for var in expected_vars:
             assert var in hp_skymap.data_1d.data_vars

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -156,7 +156,6 @@ class TestUltraL2:
             "scatter_phi",
             "obs_date",
             "obs_date_range",
-            "obs_date_for_std",
         ]
         for var in expected_vars:
             assert var in hp_skymap.data_1d.data_vars

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -267,8 +267,10 @@ def generate_ultra_healpix_skymap(
     )
 
     all_pset_epochs = []
+    solid_angles = []
     for ultra_l1c_pset in ultra_l1c_psets:
         pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
+        solid_angles.append(pointing_set.solid_angle)
         all_pset_epochs.append(pointing_set.epoch)
         logger.info(
             f"Projecting a PointingSet with {pointing_set.num_points} pixels "
@@ -404,7 +406,7 @@ def generate_ultra_healpix_skymap(
     skymap.data_1d = skymap.data_1d.drop_vars(
         VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION,
     )
-
+    print(solid_angles, "HERE")
     return skymap, np.array(all_pset_epochs)
 
 
@@ -650,6 +652,8 @@ def ultra_l2(
             )
         )
 
-    # Adjust the dtype of obs_date to be int64
+    # Adjust the dtype of obs dates to be int64
     map_dataset["obs_date"] = map_dataset["obs_date"].astype(np.int64)
+    map_dataset["obs_date_range"] = map_dataset["obs_date_range"].astype(np.int64)
+    map_dataset["obs_date_for_std"] = map_dataset["obs_date_for_std"].astype(np.int64)
     return [map_dataset]

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -85,6 +85,7 @@ VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION = [
     "num_pointing_set_pixel_members",
     "corrected_count_rate",
     "obs_date_squared_for_std",
+    "obs_date_for_std",
 ]
 
 # These variables may or may not be energy dependent, depending on the
@@ -587,10 +588,8 @@ def ultra_l2(  # noqa: PLR0912
 
     # Rename positional uncertainty variables if present
     if "scatter_theta" in map_dataset and "scatter_phi" in map_dataset:
-        map_dataset = map_dataset.rename(
-            {"scatter_theta": "positional_uncertainty_theta"}
-        )
-        map_dataset = map_dataset.rename({"scatter_phi": "positional_uncertainty_phi"})
+        map_dataset = map_dataset.rename({"scatter_theta": "positional_uncert_theta"})
+        map_dataset = map_dataset.rename({"scatter_phi": "positional_uncert_phi"})
 
     # Add the defined attributes to the map's global attrs
     map_dataset.attrs.update(map_attrs)
@@ -660,5 +659,5 @@ def ultra_l2(  # noqa: PLR0912
     # Adjust the dtype of obs dates to be int64
     map_dataset["obs_date"] = map_dataset["obs_date"].astype(np.int64)
     map_dataset["obs_date_range"] = map_dataset["obs_date_range"].astype(np.int64)
-    map_dataset["obs_date_for_std"] = map_dataset["obs_date_for_std"].astype(np.int64)
+
     return [map_dataset]

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -267,10 +267,8 @@ def generate_ultra_healpix_skymap(
     )
 
     all_pset_epochs = []
-    solid_angles = []
     for ultra_l1c_pset in ultra_l1c_psets:
         pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
-        solid_angles.append(pointing_set.solid_angle)
         all_pset_epochs.append(pointing_set.epoch)
         logger.info(
             f"Projecting a PointingSet with {pointing_set.num_points} pixels "
@@ -406,11 +404,10 @@ def generate_ultra_healpix_skymap(
     skymap.data_1d = skymap.data_1d.drop_vars(
         VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION,
     )
-    print(solid_angles, "HERE")
     return skymap, np.array(all_pset_epochs)
 
 
-def ultra_l2(
+def ultra_l2(  # noqa: PLR0912
     data_dict: dict[str, xr.Dataset | str | Path],
     output_map_structure: (
         ena_maps.RectangularSkyMap | ena_maps.HealpixSkyMap
@@ -513,6 +510,7 @@ def ultra_l2(
         map_dataset = healpix_skymap.to_dataset()
         # Add attributes related to the map
         map_attrs = {
+            "HEALPix_solid_angle": str(healpix_skymap.solid_angle),
             "HEALPix_nside": str(output_map_structure.nside),
             "HEALPix_nest": str(output_map_structure.nested),
         }
@@ -586,6 +584,13 @@ def ultra_l2(
     # Energy at L1C is named "energy_bin_geometric_mean", but at L2 it is standardized
     # to "energy" for all instruments.
     map_dataset = map_dataset.rename({"energy_bin_geometric_mean": "energy"})
+
+    # Rename positional uncertainty variables if present
+    if "scatter_theta" in map_dataset and "scatter_phi" in map_dataset:
+        map_dataset = map_dataset.rename(
+            {"scatter_theta": "positional_uncertainty_theta"}
+        )
+        map_dataset = map_dataset.rename({"scatter_phi": "positional_uncertainty_phi"})
 
     # Add the defined attributes to the map's global attrs
     map_dataset.attrs.update(map_attrs)

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -84,8 +84,8 @@ VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION = [
     "pointing_set_exposure_times_solid_angle",
     "num_pointing_set_pixel_members",
     "corrected_count_rate",
-    "obs_date_squared_for_std",
     "obs_date_for_std",
+    "obs_date_squared_for_std",
 ]
 
 # These variables may or may not be energy dependent, depending on the
@@ -215,7 +215,7 @@ def generate_ultra_healpix_skymap(
     output_map_structure.values_to_push_project.extend(
         [
             "num_pointing_set_pixel_members",
-            "obs_date_range",
+            "obs_date_for_std",
             "obs_date_squared_for_std",
         ]
     )
@@ -298,11 +298,11 @@ def generate_ultra_healpix_skymap(
             fill_value=pointing_set.epoch,
             dtype=np.int64,
         )
-        pointing_set.data["obs_date_range"] = pointing_set.data["obs_date"].astype(
+        pointing_set.data["obs_date_for_std"] = pointing_set.data["obs_date"].astype(
             np.float64
         )
         pointing_set.data["obs_date_squared_for_std"] = (
-            pointing_set.data["obs_date_range"] ** 2
+            pointing_set.data["obs_date_for_std"] ** 2
         )
 
         # Add solid_angle * exposure of pointing set as data_var
@@ -392,7 +392,7 @@ def generate_ultra_healpix_skymap(
                 )
                 - (
                     (
-                        skymap.data_1d["obs_date_range"]
+                        skymap.data_1d["obs_date_for_std"]
                         / (skymap.data_1d["num_pointing_set_pixel_members"])
                     )
                     ** 2

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -75,6 +75,10 @@ VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE = [
     "sensitivity",
     "background_rates",
     "obs_date",
+    "geometric_function",
+    "efficiency",
+    "scatter_theta",
+    "scatter_phi",
 ]
 
 # These variables are dropped after they are used to
@@ -311,15 +315,17 @@ def generate_ultra_healpix_skymap(
             pointing_set.data["exposure_factor"] * pointing_set.solid_angle
         )
 
+        # Get variables that should be weighted by exposure and solid angle
+        existing_vars_to_weight = []
+        for var in VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE:
+            if var in pointing_set.data:
+                existing_vars_to_weight.append(var)
+
         # Initial processing for weighted quantities at PSET level
         # Weight the values by exposure and solid angle
         # Ensure only valid pointing set pixels contribute to the weighted mean.
-        pointing_set.data[
-            VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE
-        ] = (
-            pointing_set.data[
-                VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE
-            ]
+        pointing_set.data[existing_vars_to_weight] = (
+            pointing_set.data[existing_vars_to_weight]
             * pointing_set.data["pointing_set_exposure_times_solid_angle"]
         ).where(good_pixel_mask)
 
@@ -340,9 +346,9 @@ def generate_ultra_healpix_skymap(
         )
 
     # Subsequent processing for weighted quantities at SkyMap level
-    skymap.data_1d[VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE] /= (
-        skymap.data_1d["pointing_set_exposure_times_solid_angle"]
-    )
+    skymap.data_1d[existing_vars_to_weight] /= skymap.data_1d[
+        "pointing_set_exposure_times_solid_angle"
+    ]
 
     # Background rates must be scaled by the ratio of the solid angles of the
     # map pixel / pointing set pixel

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -88,7 +88,6 @@ VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION = [
     "pointing_set_exposure_times_solid_angle",
     "num_pointing_set_pixel_members",
     "corrected_count_rate",
-    "obs_date_for_std",
     "obs_date_squared_for_std",
 ]
 
@@ -219,7 +218,7 @@ def generate_ultra_healpix_skymap(
     output_map_structure.values_to_push_project.extend(
         [
             "num_pointing_set_pixel_members",
-            "obs_date_for_std",
+            "obs_date_range",
             "obs_date_squared_for_std",
         ]
     )
@@ -302,11 +301,11 @@ def generate_ultra_healpix_skymap(
             fill_value=pointing_set.epoch,
             dtype=np.int64,
         )
-        pointing_set.data["obs_date_for_std"] = pointing_set.data["obs_date"].astype(
+        pointing_set.data["obs_date_range"] = pointing_set.data["obs_date"].astype(
             np.float64
         )
         pointing_set.data["obs_date_squared_for_std"] = (
-            pointing_set.data["obs_date_for_std"] ** 2
+            pointing_set.data["obs_date_range"] ** 2
         )
 
         # Add solid_angle * exposure of pointing set as data_var
@@ -398,7 +397,7 @@ def generate_ultra_healpix_skymap(
                 )
                 - (
                     (
-                        skymap.data_1d["obs_date_for_std"]
+                        skymap.data_1d["obs_date_range"]
                         / (skymap.data_1d["num_pointing_set_pixel_members"])
                     )
                     ** 2


### PR DESCRIPTION
# Change Summary

closes #2078

## Overview
Update ena map attributes to include efficiency, geometric function, and positional uncertainty. 

## Updated Files
- imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
   - Add shared attribute values
- imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
   - Add healpix attrs
- imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
   - Add rectangular attrs
- imap_processing/tests/ultra/unit/test_ultra_l2.py
  - Keep obs date range and std ( IT request) 
- imap_processing/ultra/l2/ultra_l2.py
- rename any scatter theta or scatter phi vars to positional uncertainty 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
