### PR TITLE
Ultra - adding species bin

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -260,6 +260,18 @@ imap_ultra_l1c_90sensor-spacecraftpset:
     Logical_source: imap_ultra_l1c_90sensor-spacecraftpset
     Logical_source_description: IMAP-Ultra Instrument Level-1C Spacecraft Pointing Set Grid.
 
+imap_ultra_l1c_45sensor-spacecraftpset-nonproton:
+    <<: *instrument_base
+    Data_type: L1C_45Sensor-PSET>Level-1C Pointing Set Grid for Ultra45
+    Logical_source: imap_ultra_l1c_45sensor-spacecraftpset-nonproton
+    Logical_source_description: IMAP-Ultra Instrument Level-1C Spacecraft Pointing Set Grid for Non-Proton Species.
+
+imap_ultra_l1c_90sensor-spacecraftpset-nonproton:
+    <<: *instrument_base
+    Data_type: L1C_90Sensor-PSET>Level-1C Pointing Set Grid for Ultra90
+    Logical_source: imap_ultra_l1c_90sensor-spacecraftpset-nonproton
+    Logical_source_description: IMAP-Ultra Instrument Level-1C Spacecraft Pointing Set Grid for Non-Proton Species.
+
 imap_ultra_l1c_45sensor-heliopset:
     <<: *instrument_base
     Data_type: L1C_45Sensor-PSET>Level-1C Pointing Set Grid for Ultra45

--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -239,7 +239,7 @@ energy_heliosphere:
 species:
   <<: *default_uint8
   DISPLAY_TYPE: no_plot
-  CATDESC: Label species type.
+  CATDESC: Label species type. Non-proton (heavy ion) = 0, proton = 1, misc = 3
   FIELDNAM: Label species type.
   LABLAXIS: species
   UNITS: " "

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -11,6 +11,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.spice.geometry import SpiceFrame
 from imap_processing.spice.time import met_to_sclkticks, sct_to_et
+from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_annotated import (
     get_annotated_particle_velocity,
 )
@@ -66,6 +67,7 @@ def test_calculate_spacecraft_pset(
     test_l1b_de_dataset = xr.Dataset(
         {
             "species": (["epoch"], species),
+            "e_bin": (["epoch"], np.ones(len(species), dtype=np.uint8)),
             "velocity_dps_sc": (
                 ["epoch", "component"],
                 particle_velocity_dps_spacecraft,
@@ -105,6 +107,7 @@ def test_calculate_spacecraft_pset(
             "imap_ultra_l1c_45sensor-spacecraftpset",
             ancillary_files,
             45,
+            UltraConstants.TOFXPH_SPECIES_GROUPS["proton"],
         )
     assert "pixel_index" in spacecraft_pset.coords
     assert "epoch" in spacecraft_pset.coords
@@ -167,7 +170,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
         de_dict["quality_scattering"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
         de_dict["quality_outliers"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
-        de_dict["species"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
+        de_dict["e_bin"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
         de_dict["event_times"] = 817561854.185627 + (
             df_subset["tdb"].values - df_subset["tdb"].values[0]
         )
@@ -192,6 +195,7 @@ def test_calculate_spacecraft_pset_with_cdf(
                 "imap_ultra_l1c_45sensor-spacecraftpset",
                 ancillary_files,
                 45,
+                UltraConstants.TOFXPH_SPECIES_GROUPS["proton"],
             )
         # TODO: validate with output histogram data once we have it in healpix.
         assert (

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -8,6 +8,7 @@ from imap_processing import imap_module_directory
 from imap_processing.quality_flags import ImapDEOutliersUltraFlags
 from imap_processing.spice.spin import get_spin_data
 from imap_processing.spice.time import sct_to_et
+from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.lookup_utils import get_angular_profiles
 from imap_processing.ultra.l1b.ultra_l1b_extended import (
     CoinType,
@@ -341,11 +342,7 @@ def test_get_de_energy_kev(test_fixture):
     df_ph = df_filt[np.isin(df_filt["StopType"], [StopType.PH.value])]
     df_ph = df_ph[df_ph["energy_revised"].astype("str") != "FILL"]
 
-    species_bin_ph = determine_species(
-        df_ph["TOF"].astype("float").to_numpy(),
-        df_ph["r"].astype("float").to_numpy(),
-        "PH",
-    )
+    species_bin_ph = np.ones_like(df_ph["Energy"].values, dtype=np.uint8)
     test_xf, test_yf, test_xb, test_yb, test_d, test_tof = (
         df_ph[col].astype("float").values
         for col in ["Xf", "Yf", "Xb", "Yb", "d", "TOF"]
@@ -457,28 +454,47 @@ def test_get_ctof(test_fixture):
 
 
 @pytest.mark.external_test_data
-def test_determine_species(test_fixture):
+def test_determine_species():
     """Tests determine_species function."""
-    df_filt, _, _, _ = test_fixture
-    df_ph = df_filt[np.isin(df_filt["StopType"], [StopType.PH.value])]
-    df_ssd = df_filt[np.isin(df_filt["StopType"], [StopType.SSD.value])]
 
-    species_bin_ph = determine_species(
-        df_ph["TOF"].astype("float").to_numpy(),
-        df_ph["r"].astype("float").to_numpy(),
+    species_bin_ph_proton = determine_species(
+        np.array(UltraConstants.TOFXPH_SPECIES_GROUPS["proton"], dtype=np.uint8),
         "PH",
     )
-    species_bin_ssd = determine_species(
-        df_ssd["TOF"].astype("float").to_numpy(),
-        df_ssd["r"].astype("float").to_numpy(),
+    species_bin_ph_non_proton = determine_species(
+        np.array(UltraConstants.TOFXPH_SPECIES_GROUPS["non_proton"], dtype=np.uint8),
+        "PH",
+    )
+
+    species_bin_ssd_proton = determine_species(
+        np.array(UltraConstants.TOFXE_SPECIES_GROUPS["proton"], dtype=np.uint8),
+        "SSD",
+    )
+
+    species_bin_ssd_non_proton = determine_species(
+        np.array(UltraConstants.TOFXE_SPECIES_GROUPS["non_proton"], dtype=np.uint8),
         "SSD",
     )
 
     np.testing.assert_array_equal(
-        species_bin_ph, np.full(len(df_ph), 1, dtype=np.uint8)
+        species_bin_ph_proton,
+        np.full(len(UltraConstants.TOFXPH_SPECIES_GROUPS["proton"]), 1, dtype=np.uint8),
     )
     np.testing.assert_array_equal(
-        species_bin_ssd, np.full(len(df_ssd), 1, dtype=np.uint8)
+        species_bin_ssd_proton,
+        np.full(len(UltraConstants.TOFXE_SPECIES_GROUPS["proton"]), 1, dtype=np.uint8),
+    )
+    np.testing.assert_array_equal(
+        species_bin_ph_non_proton,
+        np.full(
+            len(UltraConstants.TOFXPH_SPECIES_GROUPS["non_proton"]), 0, dtype=np.uint8
+        ),
+    )
+    np.testing.assert_array_equal(
+        species_bin_ssd_non_proton,
+        np.full(
+            len(UltraConstants.TOFXE_SPECIES_GROUPS["non_proton"]), 0, dtype=np.uint8
+        ),
     )
 
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -173,6 +173,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     de_dict["spin_number"] = np.full(len(sc_dps_velocity), 128)
     de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
     de_dict["species"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
+    de_dict["e_bin"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
     de_dict["event_times"] = df_subset["tdb"].values
 
     name = "imap_ultra_l1b_45sensor-de"
@@ -235,6 +236,7 @@ def test_calculate_helio_pset_with_cdf(
     de_dict["epoch"] = df_subset["epoch"].values
     # Fake SCLK in seconds that matches SPICE.
     de_dict["event_times"] = np.full(len(df_subset), 2.41187e13)
+    de_dict["e_bin"] = np.ones(len(df_subset), dtype=np.uint8)
     species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
 
     # PosYSlit is True for left (start_type = 1)

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -127,6 +127,10 @@ class UltraConstants:
     TOFDIFFTPMIN_EVENTFILTER = 226
     TOFDIFFTPMAX_EVENTFILTER = 266
 
+    TOFXE_SPECIES_GROUPS: ClassVar[dict[str, list[int]]] = {
+        "proton": [3],
+        "non_proton": [20, 28, 36],
+    }
     TOFXPH_SPECIES_GROUPS: ClassVar[dict[str, list[int]]] = {
         "proton": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
         "non_proton": [20, 21, 22, 23, 24, 25, 26],

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -126,3 +126,8 @@ class UltraConstants:
     ETOFMIN_EVENTFILTER = -400
     TOFDIFFTPMIN_EVENTFILTER = 226
     TOFDIFFTPMAX_EVENTFILTER = 266
+
+    TOFXPH_SPECIES_GROUPS: ClassVar[dict[str, list[int]]] = {
+        "proton": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+        "non_proton": [20, 21, 22, 23, 24, 25, 26],
+    }

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -197,7 +197,6 @@ def calculate_de(
         (xb[ph_indices], yb[ph_indices]),
         d[ph_indices],
     )
-    species_bin[ph_indices] = determine_species(tof[ph_indices], r[ph_indices], "PH")
     etof[ph_indices], xc[ph_indices] = get_coincidence_positions(
         de_dataset.isel(epoch=ph_indices),
         t2[ph_indices],
@@ -230,6 +229,7 @@ def calculate_de(
         coinphvalid,
         ancillary_files,
     )
+    species_bin[ph_indices] = determine_species(e_bin[ph_indices], "PH")
     ctof[ph_indices], magnitude_v[ph_indices] = get_ctof(
         tof[ph_indices], r[ph_indices], "PH"
     )
@@ -263,9 +263,7 @@ def calculate_de(
         f"ultra{sensor}",
         ancillary_files,
     )
-    species_bin[ssd_indices] = determine_species(
-        tof[ssd_indices], r[ssd_indices], "SSD"
-    )
+    species_bin[ssd_indices] = determine_species(e_bin[ssd_indices], "SSD")
     ctof[ssd_indices], magnitude_v[ssd_indices] = get_ctof(
         tof[ssd_indices], r[ssd_indices], "SSD"
     )

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -839,25 +839,16 @@ def get_ctof(
     return ctof, magnitude_v
 
 
-def determine_species(tof: np.ndarray, path_length: np.ndarray, type: str) -> NDArray:
+def determine_species(e_bin: np.ndarray, type: str) -> NDArray:
     """
     Determine the species for pulse-height events.
 
-    Species is determined from the particle velocity.
-    For velocity, the particle TOF is normalized with respect
-    to a fixed distance dmin between the front and back detectors.
-    The normalized TOF is termed the corrected TOF (ctof).
-    Particle species are determined from ctof using thresholds.
-
-    Further description is available on pages 42-44 of
-    IMAP-Ultra Flight Software Specification document.
+    Species is determined using the computed e_bin.
 
     Parameters
     ----------
-    tof : np.ndarray
-        Time of flight of the SSD event (tenths of a nanosecond).
-    path_length : np.ndarray
-        Path length (r) (hundredths of a millimeter).
+    e_bin : np.ndarray
+        Computed e_bin.
     type : str
         Type of data (PH or SSD).
 
@@ -866,11 +857,17 @@ def determine_species(tof: np.ndarray, path_length: np.ndarray, type: str) -> ND
     species_bin : np.array
         Species bin.
     """
-    # Event TOF normalization to Z axis
-    ctof, _ = get_ctof(tof, path_length, type)
-    # Assign Species 1 ("H") to bins
-    # TODO: this is a placeholder for future species assignments.
-    species_bin = np.full(len(ctof), 1, dtype=np.uint8)
+    if type == "PH":
+        species_groups = UltraConstants.TOFXPH_SPECIES_GROUPS
+    if type == "SSD":
+        species_groups = UltraConstants.TOFXE_SPECIES_GROUPS
+
+    non_proton_bins = species_groups["non_proton"]
+    proton_bins = species_groups["proton"]
+
+    species_bin = np.full(e_bin.shape, fill_value=2, dtype=int)
+    species_bin[np.isin(e_bin, non_proton_bins)] = 0
+    species_bin[np.isin(e_bin, proton_bins)] = 1
 
     return species_bin
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -40,7 +40,7 @@ def calculate_helio_pset(
     name: str,
     ancillary_files: dict,
     instrument_id: int,
-    species_id: int = 1,
+    species_id: list,
 ) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
@@ -61,8 +61,8 @@ def calculate_helio_pset(
         Ancillary files.
     instrument_id : int
         Instrument ID, either 45 or 90.
-    species_id : int
-        Species ID, default of 1 refers to Hydrogen.
+    species_id : List
+        Species ID.
 
     Returns
     -------
@@ -71,7 +71,7 @@ def calculate_helio_pset(
     """
     pset_dict: dict[str, np.ndarray] = {}
     # Select only the species we are interested in.
-    indices = np.where(de_dataset["species"].values == species_id)[0]
+    indices = np.where(np.isin(de_dataset["e_bin"].values, species_id))[0]
     species_dataset = de_dataset.isel(epoch=indices)
 
     rejected = get_de_rejection_mask(

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -41,7 +41,7 @@ def calculate_helio_pset(
     ancillary_files: dict,
     instrument_id: int,
     species_id: list,
-) -> xr.Dataset:
+) -> xr.Dataset | None:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
 
@@ -78,7 +78,7 @@ def calculate_helio_pset(
         species_dataset["quality_scattering"].values,
         species_dataset["quality_outliers"].values,
     )
-    de_dataset = species_dataset.isel(epoch=~rejected)
+    species_dataset = species_dataset.isel(epoch=~rejected)
 
     v_mag_helio_spacecraft = np.linalg.norm(
         species_dataset["velocity_dps_helio"].values, axis=1
@@ -156,8 +156,8 @@ def calculate_helio_pset(
     )
     sensitivity = efficiencies * geometric_function
 
-    start: float = np.min(de_dataset["event_times"].values)
-    end: float = np.max(de_dataset["event_times"].values)
+    start: float = np.min(species_dataset["event_times"].values)
+    end: float = np.max(species_dataset["event_times"].values)
 
     # Time bins in 30 minute intervals
     time_bins = np.arange(start, end + 1800, 1800)

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -72,7 +72,7 @@ def calculate_spacecraft_pset(
     pset_dict: dict[str, np.ndarray] = {}
 
     sensor = parse_filename_like(name)["sensor"][0:2]
-    indices = np.where(np.isin(de_dataset["species"].values, species_id))[0]
+    indices = np.where(np.isin(de_dataset["e_bin"].values, species_id))[0]
     species_dataset = de_dataset.isel(epoch=indices)
 
     # Before we use the de_dataset to calculate the pointing set grid we need to filter.

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -75,6 +75,10 @@ def calculate_spacecraft_pset(
     indices = np.where(np.isin(de_dataset["e_bin"].values, species_id))[0]
     species_dataset = de_dataset.isel(epoch=indices)
 
+    # If there are no species return None.
+    if indices.size == 0:
+        return None
+
     # Before we use the de_dataset to calculate the pointing set grid we need to filter.
     rejected = get_de_rejection_mask(
         species_dataset["quality_scattering"].values,
@@ -155,8 +159,8 @@ def calculate_spacecraft_pset(
         n_pix, ImapPSETUltraFlags.NONE.value, dtype=np.uint16
     )
 
-    start: float = np.min(de_dataset["event_times"].values)
-    end: float = np.max(de_dataset["event_times"].values)
+    start: float = np.min(species_dataset["event_times"].values)
+    end: float = np.max(species_dataset["event_times"].values)
 
     # Time bins in 30 minute intervals
     time_bins = np.arange(start, end + 1800, 1800)

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -40,7 +40,7 @@ def calculate_spacecraft_pset(
     name: str,
     ancillary_files: dict,
     instrument_id: int,
-    species_id: int = 1,
+    species_id: list,
 ) -> xr.Dataset:
     """
     Create dictionary with defined datatype for Pointing Set Grid Data.
@@ -61,8 +61,8 @@ def calculate_spacecraft_pset(
         Ancillary files.
     instrument_id : int
         Instrument ID, either 45 or 90.
-    species_id : int
-        Species ID, default of 1 refers to Hydrogen.
+    species_id : List
+        Species ID.
 
     Returns
     -------
@@ -72,8 +72,7 @@ def calculate_spacecraft_pset(
     pset_dict: dict[str, np.ndarray] = {}
 
     sensor = parse_filename_like(name)["sensor"][0:2]
-    # Select only the species we are interested in.
-    indices = np.where(de_dataset["species"].values == species_id)[0]
+    indices = np.where(np.isin(de_dataset["species"].values, species_id))[0]
     species_dataset = de_dataset.isel(epoch=indices)
 
     # Before we use the de_dataset to calculate the pointing set grid we need to filter.

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -46,6 +46,7 @@ def ultra_l1c(
                 f"imap_ultra_l1c_{instrument_id}sensor-heliopset",
                 ancillary_files,
                 instrument_id,
+                UltraConstants.TOFXPH_SPECIES_GROUPS["proton"],
             )
             output_datasets = [helio_pset]
         elif (

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -65,6 +65,7 @@ def ultra_l1c(
                 instrument_id,
                 UltraConstants.TOFXPH_SPECIES_GROUPS["proton"],
             )
+            output_datasets = [spacecraft_pset]
             spacecraft_pset_non_proton = calculate_spacecraft_pset(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-goodtimes"],
@@ -75,7 +76,8 @@ def ultra_l1c(
                 instrument_id,
                 UltraConstants.TOFXPH_SPECIES_GROUPS["non_proton"],
             )
-            output_datasets = [spacecraft_pset, spacecraft_pset_non_proton]
+            if spacecraft_pset_non_proton is not None:
+                output_datasets.append(spacecraft_pset_non_proton)
     if not output_datasets:
         raise ValueError("Data dictionary does not contain the expected keys.")
 

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -2,6 +2,7 @@
 
 import xarray as xr
 
+from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1c.helio_pset import calculate_helio_pset
 from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
 
@@ -61,8 +62,19 @@ def ultra_l1c(
                 f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset",
                 ancillary_files,
                 instrument_id,
+                UltraConstants.TOFXPH_SPECIES_GROUPS["proton"],
             )
-            output_datasets = [spacecraft_pset]
+            spacecraft_pset_non_proton = calculate_spacecraft_pset(
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
+                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-goodtimes"],
+                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
+                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-params"],
+                f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset-nonproton",
+                ancillary_files,
+                instrument_id,
+                UltraConstants.TOFXPH_SPECIES_GROUPS["non_proton"],
+            )
+            output_datasets = [spacecraft_pset, spacecraft_pset_non_proton]
     if not output_datasets:
         raise ValueError("Data dictionary does not contain the expected keys.")
 


### PR DESCRIPTION
# Change Summary

## Overview
Adding a non-proton data product for Ultra based on defined species

## Updated Files
- imap_ultra_global_cdf_attrs.yaml
   - Added two data products
- imap_ultra_l1b_variable_attrs.yaml
   - Label species types updated description
- constants.py
   - Define species groups
- de.py
   - Update inputs to determine_species.py
- ultra_l1b_extended.py
   - Assign species to based on bin number
- spacecraft_pset.py
   - Filter based on bin number
- helio_pset.py
   - Filter based on bin number
- ultra_l1c.py
   - Create non-proton data products

## Testing
test_ultra_l1b_extended.py
test_spacecraft_pset.py
test_ultra_l1c.py
