### PR TITLE
CoDICE fix external data configuration

### DIFF
--- a/imap_processing/tests/codice/conftest.py
+++ b/imap_processing/tests/codice/conftest.py
@@ -1,30 +1,32 @@
 from imap_processing import imap_module_directory
 
 TEST_DATA_PATH = imap_module_directory / "tests" / "codice" / "data"
-TEST_L0_FILE = TEST_DATA_PATH / "imap_codice_l0_raw_20241110_v001.pkts"
+TEST_DATA_L0_PATH = TEST_DATA_PATH / "l0_data"
+TEST_L0_FILE = TEST_DATA_L0_PATH / "imap_codice_l0_raw_20241110_v001.pkts"
 
+TEST_DATA_L1A_PATH = TEST_DATA_PATH / "l1a_data"
 TEST_L1A_FILES = [
-    TEST_DATA_PATH / "imap_codice_l1a_hi-counters-aggregated_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_hi-counters-singles_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_hi-ialirt_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_hi-omni_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_hi-priority_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_hi-sectored_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_hskp_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-counters-aggregated_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-counters-singles_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-ialirt_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-nsw-angular_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-nsw-priority_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-nsw-species_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-sw-angular_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-sw-priority_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-sw-species_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_hi-counters-aggregated_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_hi-counters-singles_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_hi-ialirt_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_hi-omni_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_hi-priority_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_hi-sectored_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_hskp_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-counters-aggregated_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-counters-singles_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-ialirt_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-nsw-angular_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-nsw-priority_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-nsw-species_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-sw-angular_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-sw-priority_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-sw-species_20241110_v001.cdf",
 ]
 
 TEST_L2_FILES = [
-    TEST_DATA_PATH / "imap_codice_l1a_hi-direct-events_20241110_v001.cdf",
-    TEST_DATA_PATH / "imap_codice_l1a_lo-direct-events_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_hi-direct-events_20241110_v001.cdf",
+    TEST_DATA_L1A_PATH / "imap_codice_l1a_lo-direct-events_20241110_v001.cdf",
 ]
 
 # ruff: noqa

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -11,6 +11,7 @@ EXTERNAL_TEST_DATA = [
 
     # CoDICE
     # L0 data
+    ("imap_codice_l0_raw_20241110_v001.pkts", "codice/data/l0_data/"),
     ("imap_codice_lo-sw-species_20250814_v001.pkts", "codice/data/l0_data/"),
     ("imap_codice_lo-nsw-species_20250814_v001.pkts", "codice/data/l0_data/"),
     ("imap_codice_lo-sw-angular_20250814_v001.pkts", "codice/data/l0_data/"),


### PR DESCRIPTION

# Change Summary
Fix recent changes to CoDICE external data configuration.

- Add imap_codice_l0_raw_20241110_v001.pkts back in to codice external data
- Update codice conftest paths to match recent changes in downloaded data locations


Closes: #2199 
