### PR TITLE
Fix bug in calculation of GLOWS spin-axis statistics

### DIFF
--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -851,7 +851,7 @@ class HistogramL1B:
             geometry.frame_transform(
                 time_range,
                 np.array([0, 0, 1]),
-                SpiceFrame.IMAP_DPS,
+                SpiceFrame.IMAP_SPACECRAFT,
                 SpiceFrame.ECLIPJ2000,
             )
         )
@@ -872,7 +872,7 @@ class HistogramL1B:
         )
         position = imap_state[:, :3]
         velocity = imap_state[:, 3:]
-        # averange and standard deviation over time (rows)
+        # average and standard deviation over time (rows)
         self.spacecraft_location_average = np.average(position, axis=0)
         self.spacecraft_location_std_dev = np.std(position, axis=0)
         self.spacecraft_velocity_average = np.average(velocity, axis=0)


### PR DESCRIPTION
GLOWS L1B processing should use the spacecraft z-axis for computing the spin-axis statistics instead of DPS z-axis

# Change Summary

## Overview
When reviewing GLOWS code in order to respond to a question about how the spin-axis statistics were calculated, I found this bug in which z-axis was being used. For the L1b code, GLOWS wants to use the spacecraft z-axis instead of the DPS z-axis. This will capture any nutation, precession, or coning in the statistics. The DPS z-axis is an averaged spin-axis and thus would have stddev of 0 over a pointing.

## Updated Files
- updated file 1
   - Use the IMAP_SPACECRAFT z-axis instead of the IMAP_DPS z-axis for the spin-axis
   - Fix typo in comment

Closes: #2173 
