### PR TITLE
Ultra l1c convert fqhm to uncert

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -106,14 +106,14 @@ helio_exposure_factor:
 
 scatter_theta:
   <<: *energy_dependent
-  CATDESC: Scattering theta values for a pointing.
+  CATDESC: Scattering theta values for a pointing (reported in gaussian uncertainty).
   FIELDNAM: scatter_theta
   LABLAXIS: scatter theta
   UNITS: degrees
 
 scatter_phi:
   <<: *energy_dependent
-  CATDESC: Scattering phi values for a pointing.
+  CATDESC: Scattering phi values for a pointing (reported in gaussian uncertainty).
   FIELDNAM: scatter_phi
   LABLAXIS: scatter phi
   UNITS: degrees

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -106,14 +106,14 @@ helio_exposure_factor:
 
 scatter_theta:
   <<: *energy_dependent
-  CATDESC: Scattering theta values for a pointing (reported in gaussian uncertainty).
+  CATDESC: Scattering theta values for a pointing (reported as gaussian uncertainty).
   FIELDNAM: scatter_theta
   LABLAXIS: scatter theta
   UNITS: degrees
 
 scatter_phi:
   <<: *energy_dependent
-  CATDESC: Scattering phi values for a pointing (reported in gaussian uncertainty).
+  CATDESC: Scattering phi values for a pointing (reported as gaussian uncertainty).
   FIELDNAM: scatter_phi
   LABLAXIS: scatter phi
   UNITS: degrees

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -197,8 +197,11 @@ def calculate_spacecraft_pset(
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))
 
-    pset_dict["scatter_theta"] = scattering_theta
-    pset_dict["scatter_phi"] = scattering_phi
+    # Convert FWHM to gaussian uncertainty by dividing by 2.355
+    # See algorithm documentation (section 3.5.7, third bullet point) for more details
+    pset_dict["scatter_theta"] = scattering_theta / 2.355
+    pset_dict["scatter_phi"] = scattering_phi / 2.355
+
     pset_dict["scatter_threshold"] = scattering_thresholds
 
     # Add the energy delta plus/minus to the dataset


### PR DESCRIPTION
# Change Summary

## Overview
Convert scattering values to uncertainty. 

## Updated Files
-imap_processing/ultra/l1c/spacecraft_pset.py
   - report scattering values as gaussian uncertainty arrays 