### PR TITLE
2209 bug   hi l1a de fails when no events are in data

### DIFF
--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -252,6 +252,7 @@ hi_de_ccsds_index:
 # LABL_PTR_i expects VAR_TYPE of metadata with char data type
 hi_hist_angle_label:
   CATDESC: Angle bin centers for histogram data.
+  DEPEND_1: angle
   FIELDNAM: ANGLE
   FORMAT: A5
   VAR_TYPE: metadata

--- a/imap_processing/hi/hi_l1a.py
+++ b/imap_processing/hi/hi_l1a.py
@@ -264,25 +264,40 @@ def create_de_dataset(de_data_dict: dict[str, npt.ArrayLike]) -> xr.Dataset:
         attrs=epoch_attrs,
     )
 
-    event_met_attrs = attr_mgr.get_variable_attributes(
-        "hi_de_event_met", check_schema=False
-    )
-    # For L1A DE, event_met is its own dimension, so we remove the DEPEND_0 attribute
-    _ = event_met_attrs.pop("DEPEND_0")
-
     # Compute the meta-event MET in seconds
     meta_event_met = (
         np.array(de_data_dict["esa_step_seconds"]).astype(np.float64)
         + np.array(de_data_dict["esa_step_milliseconds"]) * MILLISECOND_TO_S
     )
-    # Compute the MET of each event in seconds
-    # event MET = meta_event_met + de_clock
-    # See Hi Algorithm Document section 2.2.5
-    event_met_array = np.array(
-        meta_event_met[de_data_dict["ccsds_index"]]
-        + np.array(de_data_dict["de_tag"]) * DE_CLOCK_TICK_S,
-        dtype=event_met_attrs.pop("dtype"),
+
+    event_met_attrs = attr_mgr.get_variable_attributes(
+        "hi_de_event_met", check_schema=False
     )
+    # For L1A DE, event_met is its own dimension, so we remove the DEPEND_0 attribute
+    _ = event_met_attrs.pop("DEPEND_0")
+    event_met_dtype = event_met_attrs.pop("dtype")
+
+    # If there are no events, add a single event with fill values
+    if len(de_data_dict["de_tag"]) == 0:
+        logger.warning(
+            "No direct events found in SCIDE packets. "
+            "Creating a false DE entry with fill values."
+        )
+        for key in ["de_tag", "trigger_id", "tof_1", "tof_2", "tof_3", "ccsds_index"]:
+            attrs = attr_mgr.get_variable_attributes(f"hi_de_{key}", check_schema=False)
+            de_data_dict[key] = [attrs["FILLVAL"]]
+        event_met_array = np.array([event_met_attrs["FILLVAL"]], dtype=event_met_dtype)
+    else:
+        # Compute the MET of each event in seconds
+        # event MET = meta_event_met + de_clock
+        # See Hi Algorithm Document section 2.2.5
+        event_met_array = np.array(
+            meta_event_met[de_data_dict["ccsds_index"]]
+            + np.array(de_data_dict["de_tag"]) * DE_CLOCK_TICK_S,
+            dtype=event_met_dtype,
+        )
+
+    # Create the event_met coordinate
     event_met = xr.DataArray(
         event_met_array,
         name="event_met",
@@ -290,10 +305,12 @@ def create_de_dataset(de_data_dict: dict[str, npt.ArrayLike]) -> xr.Dataset:
         attrs=event_met_attrs,
     )
 
+    # Create a dataset with only coordinates
     dataset = xr.Dataset(
         coords={"epoch": epoch, "event_met": event_met},
     )
 
+    # Add variable to the dataset
     for var_name, data in de_data_dict.items():
         attrs = attr_mgr.get_variable_attributes(
             f"hi_de_{var_name}", check_schema=False
@@ -557,7 +574,7 @@ def finish_memdmp_dataset(input_ds: xr.Dataset) -> xr.Dataset:
         # offset index with a stride of the number of bytes in the dump
         # data divided by 4 (32-bit values).
         new_vars[new_var] = xr.DataArray(
-            data=full_uint32_data[offset::index_stride],
+            data=full_uint32_data[offset::index_stride].astype(np.uint32),
             dims=["epoch"],
         )
 

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -158,7 +158,7 @@ def annotate_direct_events(
     return [l1b_de_dataset]
 
 
-def any_good_direct_events(dataset: xr.Dataset) -> np.bool_:
+def any_good_direct_events(dataset: xr.Dataset) -> bool:
     """
     Test dataset to see if there are any good direct events.
 
@@ -173,10 +173,10 @@ def any_good_direct_events(dataset: xr.Dataset) -> np.bool_:
 
     Returns
     -------
-    any_good_events : numpy.bool_
+    any_good_events : bool
         True if there is at least one good direct event. False otherwise.
     """
-    return np.any(dataset["trigger_id"] != dataset["trigger_id"].attrs["FILLVAL"])
+    return bool(np.any(dataset["trigger_id"] != dataset["trigger_id"].attrs["FILLVAL"]))
 
 
 def compute_coincidence_type_and_tofs(

--- a/imap_processing/hi/hi_l1b.py
+++ b/imap_processing/hi/hi_l1b.py
@@ -158,6 +158,27 @@ def annotate_direct_events(
     return [l1b_de_dataset]
 
 
+def any_good_direct_events(dataset: xr.Dataset) -> np.bool_:
+    """
+    Test dataset to see if there are any good direct events.
+
+    Datasets can have no good direct events when there were no DEs in a pointing.
+    In this case, due to restrictions with cdflib, we have to write a single
+    bad DE in the CDF.
+
+    Parameters
+    ----------
+    dataset : xarray.Dataset
+        Run the check on this dataset.
+
+    Returns
+    -------
+    any_good_events : numpy.bool_
+        True if there is at least one good direct event. False otherwise.
+    """
+    return np.any(dataset["trigger_id"] != dataset["trigger_id"].attrs["FILLVAL"])
+
+
 def compute_coincidence_type_and_tofs(
     dataset: xr.Dataset,
 ) -> dict[str, xr.DataArray]:
@@ -190,6 +211,9 @@ def compute_coincidence_type_and_tofs(
         len(dataset.event_met),
         att_manager_lookup_str="hi_de_{0}",
     )
+    # Check for no valid direct events.
+    if not any_good_direct_events(dataset):
+        return new_vars
 
     # compute masks needed for coincidence type and ToF calculations
     a_first = dataset.trigger_id.values == TriggerId.A
@@ -301,6 +325,9 @@ def de_nominal_bin_and_spin_phase(dataset: xr.Dataset) -> dict[str, xr.DataArray
         len(dataset.event_met),
         att_manager_lookup_str="hi_de_{0}",
     )
+    # Check for no valid direct events.
+    if not any_good_direct_events(dataset):
+        return new_vars
 
     # nominal_bin is the index number of the 90 4-degree bins that each DE would
     # be binned into in the histogram packet. The Hi histogram data is binned by
@@ -345,6 +372,10 @@ def compute_hae_coordinates(dataset: xr.Dataset) -> dict[str, xr.DataArray]:
         len(dataset.event_met),
         att_manager_lookup_str="hi_de_{0}",
     )
+    # Check for no valid direct events.
+    if not any_good_direct_events(dataset):
+        return new_vars
+
     # Per Section 2.2.5 of Algorithm Document, add 1/2 of tick duration
     # to MET before computing pointing.
     sclk_ticks = met_to_sclkticks(dataset.event_met.values + HALF_CLOCK_TICK_S)
@@ -387,6 +418,9 @@ def de_esa_energy_step(
         len(l1b_de_ds.epoch),
         att_manager_lookup_str="hi_de_{0}",
     )
+    # Check for no valid direct events.
+    if not any_good_direct_events(l1b_de_ds):
+        return new_vars
 
     # Get the LUT object using the HK data and esa-energies ancillary csv
     esa_energies_lut = pd.read_csv(esa_energies_anc, comment="#")

--- a/imap_processing/hi/hi_l1c.py
+++ b/imap_processing/hi/hi_l1c.py
@@ -327,14 +327,18 @@ def pset_counts(
         fill_value=0,
     )
 
-    # Convert list of DEs to pandas dataframe for ease indexing/filtering
-    de_df = l1b_de_dataset.drop_dims("epoch").to_pandas()
+    # Drop events with FILLVAL for trigger_id. This should only occur for a
+    # pointing with no events that gets a single fill event
+    de_ds = l1b_de_dataset.drop_dims("epoch")
 
+    # Remove DEs with invalid trigger_id. This should only occur for a
+    # pointing with no events that gets a single fill event
+    good_mask = de_ds["trigger_id"].data != de_ds["trigger_id"].attrs["FILLVAL"]
     # Remove DEs not in Goodtimes/angles
-    good_mask = good_time_and_phase_mask(
+    good_mask &= good_time_and_phase_mask(
         l1b_de_dataset.event_met.values, l1b_de_dataset.spin_phase.values
     )
-    de_df = de_df[good_mask]
+    de_ds = de_ds.isel(event_met=good_mask)
 
     # The calibration product configuration potentially has different coincidence
     # types for each ESA and different TOF windows for each calibration product,
@@ -346,17 +350,17 @@ def pset_counts(
         # esa_energy_step is recorded for each packet rather than for each DE,
         # so we use ccsds_index to get the esa_energy_step for each DE
         esa_mask = (
-            l1b_de_dataset["esa_energy_step"].data[de_df["ccsds_index"].to_numpy()]
+            l1b_de_dataset["esa_energy_step"].data[de_ds["ccsds_index"].data]
             == esa_energy
         )
         # Now loop over the calibration products for the current ESA energy
         for config_row in esa_df.itertuples():
             # Remove DEs that are not at the current ESA energy and in the list
             # of coincidence types for the current calibration product
-            type_mask = de_df["coincidence_type"].isin(
+            type_mask = de_ds["coincidence_type"].isin(
                 config_row.coincidence_type_values
             )
-            filtered_de_df = de_df[(esa_mask & type_mask)]
+            filtered_de_ds = de_ds.isel(event_met=(esa_mask & type_mask))
 
             # Use the TOF window mask to remove DEs with TOFs outside the allowed range
             tof_fill_vals = {
@@ -366,17 +370,17 @@ def pset_counts(
                 for detector_pair in CalibrationProductConfig.tof_detector_pairs
             }
             tof_in_window_mask = get_tof_window_mask(
-                filtered_de_df, config_row, tof_fill_vals
+                filtered_de_ds, config_row, tof_fill_vals
             )
-            filtered_de_df = filtered_de_df[tof_in_window_mask]
+            filtered_de_ds = filtered_de_ds.isel(event_met=tof_in_window_mask)
 
             # Bin remaining DEs into spin-bins
             i_esa = np.flatnonzero(pset_coords["esa_energy_step"].data == esa_energy)[0]
             # spin_phase is in the range [0, 1). Multiplying by N_SPIN_BINS and
             # truncating to an integer gives the correct bin index
-            spin_bin_indices = (
-                filtered_de_df["spin_phase"].to_numpy() * N_SPIN_BINS
-            ).astype(int)
+            spin_bin_indices = (filtered_de_ds["spin_phase"].data * N_SPIN_BINS).astype(
+                int
+            )
             # When iterating over rows of a dataframe, the names of the multi-index
             # are not preserved. Below, `config_row.Index[0]` gets the
             # calibration_prod value from the namedtuple representing the
@@ -390,15 +394,15 @@ def pset_counts(
 
 
 def get_tof_window_mask(
-    de_df: pd.DataFrame, prod_config_row: NamedTuple, fill_vals: dict
+    de_ds: xr.Dataset, prod_config_row: NamedTuple, fill_vals: dict
 ) -> NDArray[bool]:
     """
     Generate a mask indicating which DEs to keep based on TOF windows.
 
     Parameters
     ----------
-    de_df : pandas.DataFrame
-        The Direct Event dataframe for the DEs to filter based on the TOF
+    de_ds : xarray.Dataset
+        The Direct Event Dataset for the DEs to filter based on the TOF
         windows.
     prod_config_row : NamedTuple
         A single row of the prod config dataframe represented as a named tuple.
@@ -415,11 +419,13 @@ def get_tof_window_mask(
         The mask is intended to directly filter the DE dataframe.
     """
     detector_pairs = CalibrationProductConfig.tof_detector_pairs
-    tof_in_window_mask = np.empty((len(detector_pairs), len(de_df)), dtype=bool)
+    tof_in_window_mask = np.empty(
+        (len(detector_pairs), len(de_ds["event_met"])), dtype=bool
+    )
     for i_pair, detector_pair in enumerate(detector_pairs):
         low_limit = getattr(prod_config_row, f"tof_{detector_pair}_low")
         high_limit = getattr(prod_config_row, f"tof_{detector_pair}_high")
-        tof_array = de_df[f"tof_{detector_pair}"].to_numpy()
+        tof_array = de_ds[f"tof_{detector_pair}"].data
         # The TOF in window mask contains True wherever the TOF is within
         # the configuration low/high bounds OR the FILLVAL is present. The
         # FILLVAL indicates that the detector pair was not hit. DEs with

--- a/imap_processing/tests/hi/test_hi_l1b.py
+++ b/imap_processing/tests/hi/test_hi_l1b.py
@@ -10,6 +10,7 @@ import xarray as xr
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.hi.hi_l1b import (
     annotate_direct_events,
+    any_good_direct_events,
     compute_coincidence_type_and_tofs,
     compute_hae_coordinates,
     de_esa_energy_step,
@@ -66,6 +67,22 @@ def test_hi_annotate_direct_events(
     assert len(l1b_datasets) == 1
     assert l1b_datasets[0].attrs["Logical_source"] == "imap_hi_l1b_45sensor-de"
     assert len(l1b_datasets[0].data_vars) == 15
+
+
+@pytest.mark.parametrize(
+    "trigger_id_data, fillval, expected_result",
+    [([0], 0, False), ([15, 15], 15, False), ([1], 0, True), ([1, 2, 3], 65536, True)],
+)
+def test_any_good_direct_events(trigger_id_data, fillval, expected_result):
+    """Test coverage for any_good_direct_events()"""
+    ds = xr.Dataset(
+        data_vars={
+            "trigger_id": xr.DataArray(
+                trigger_id_data, name="trigger_id", attrs={"FILLVAL": fillval}
+            )
+        }
+    )
+    assert any_good_direct_events(ds) == expected_result
 
 
 @pytest.mark.external_test_data
@@ -171,7 +188,10 @@ def synthetic_trigger_id_and_tof_data():
     return synthetic_l1a_ds, expected_histogram
 
 
-def test_compute_coincidence_type_and_time_deltas(synthetic_trigger_id_and_tof_data):
+@mock.patch("imap_processing.hi.hi_l1b.any_good_direct_events", return_value=True)
+def test_compute_coincidence_type_and_time_deltas(
+    mock_any_good_de, synthetic_trigger_id_and_tof_data
+):
     """Test coverage for
     `imap_processing.hi.hi_l1b.compute_coincidence_type_and_time_deltas`."""
     new_vars = compute_coincidence_type_and_tofs(synthetic_trigger_id_and_tof_data[0])
@@ -218,11 +238,15 @@ def test_compute_coincidence_type_and_time_deltas(synthetic_trigger_id_and_tof_d
     )
 
 
+@mock.patch("imap_processing.hi.hi_l1b.any_good_direct_events", return_value=True)
 @mock.patch("imap_processing.hi.hi_l1b.parse_sensor_number", return_value=90)
 @mock.patch("imap_processing.hi.hi_l1b.get_instrument_spin_phase")
 @mock.patch("imap_processing.hi.hi_l1b.get_spacecraft_spin_phase")
 def test_de_nominal_bin_and_spin_phase(
-    spacecraft_phase_moc, instrument_phase_mock, parse_sensor_number_mock
+    spacecraft_phase_moc,
+    instrument_phase_mock,
+    parse_sensor_number_mock,
+    any_good_de_mock,
 ):
     """Test coverage for de_nominal_bin_and_spin_phase."""
     # set the spacecraft_phase_mock to return an array of values between 0 and 1
@@ -266,8 +290,11 @@ def test_de_nominal_bin_and_spin_phase(
 
 
 @pytest.mark.parametrize("sensor_number", [45, 90])
+@mock.patch("imap_processing.hi.hi_l1b.any_good_direct_events", return_value=True)
 @mock.patch("imap_processing.hi.hi_l1b.instrument_pointing")
-def test_compute_hae_coordinates(mock_instrument_pointing, sensor_number):
+def test_compute_hae_coordinates(
+    mock_instrument_pointing, mock_any_good_de, sensor_number
+):
     """Test coverage for compute_hae_coordinates function."""
 
     # Mock out the instrument_pointing function to avoid needing kernels
@@ -302,9 +329,10 @@ def test_compute_hae_coordinates(mock_instrument_pointing, sensor_number):
     np.testing.assert_allclose(new_vars["hae_longitude"].values, sensor_number)
 
 
+@mock.patch("imap_processing.hi.hi_l1b.any_good_direct_events", return_value=True)
 @mock.patch("imap_processing.hi.hi_l1b.pd.read_csv")
 @mock.patch("imap_processing.hi.hi_l1b.get_esa_to_esa_energy_step_lut")
-def test_de_esa_energy_step(mock_get_esa_lut, mock_read_csv):
+def test_de_esa_energy_step(mock_get_esa_lut, mock_read_csv, mock_any_good_de):
     """Test coverage for de_esa_energy_step function."""
     mock_esa_lut = mock.MagicMock(spec=EsaEnergyStepLookupTable())
     mock_esa_lut.query.side_effect = lambda a, b: np.arange(len(a))[::-1] % 9

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -159,7 +159,7 @@ def test_pset_counts_empty_l1b(hi_l1_test_data_path, hi_test_cal_prod_config_pat
         HIAPID.H90_SCI_DE.sensor,
     )
     counts_var = hi_l1c.pset_counts(empty_pset.coords, cal_config_df, l1b_dataset)
-    assert "counts" in counts_var
+    assert counts_var["counts"].data.sum() == 0
 
 
 def test_get_tof_window_mask():

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -141,6 +141,27 @@ def test_pset_counts(hi_l1_test_data_path, hi_test_cal_prod_config_path):
     assert "counts" in counts_var
 
 
+@pytest.mark.external_test_data
+def test_pset_counts_empty_l1b(hi_l1_test_data_path, hi_test_cal_prod_config_path):
+    """Test coverage for pset_counts function when the input L1b contains no counts."""
+    l1b_de_path = hi_l1_test_data_path / "imap_hi_l1b_45sensor-de_20250415_v999.cdf"
+    l1b_dataset = load_cdf(l1b_de_path)
+    # remove all but one event and set its trigger_id to zero
+    l1b_dataset = l1b_dataset.isel(event_met=[0])
+    l1b_dataset["trigger_id"].data[0] = 0
+    cal_config_df = imap_processing.hi.utils.CalibrationProductConfig.from_csv(
+        hi_test_cal_prod_config_path
+    )
+    empty_pset = hi_l1c.empty_pset_dataset(
+        100,
+        l1b_dataset.esa_energy_step.data,
+        cal_config_df.cal_prod_config.number_of_products,
+        HIAPID.H90_SCI_DE.sensor,
+    )
+    counts_var = hi_l1c.pset_counts(empty_pset.coords, cal_config_df, l1b_dataset)
+    assert "counts" in counts_var
+
+
 def test_get_tof_window_mask():
     """Test coverage for get_tof_window_mask function."""
     # Create a synthetic dataframe with required columns containing data
@@ -166,20 +187,37 @@ def test_get_tof_window_mask():
         ],
     )
     prod_config_row = Row((1, 0), 0, 1, -1, 2, 1, 5, 4, 6)
-    synth_df = pd.DataFrame(
-        {
-            "tof_ab": np.array(
-                [0, 2, 1, 0, -1, -5, -11], dtype=np.int32
-            ),  # T, F, T, T, F, F, FILL
-            "tof_ac1": np.array(
-                [-1, 2, -2, 0, 3, 0, -12], dtype=np.int32
-            ),  # T, T, F, T, F, T, FILL
-            "tof_bc1": np.array(
-                [1, 5, 3, 0, 6, 2, -13], dtype=np.int32
-            ),  # T, T, T, F, F, T, FILL
-            "tof_c1c2": np.array(
-                [4, 6, 5, 3, 7, -9, -14], dtype=np.int32
-            ),  # T, T, T, F, F, F, FILL
+    synth_df = xr.Dataset(
+        coords={
+            "event_met": xr.DataArray(
+                np.arange(7), name="event_met", dims=["event_met"]
+            )
+        },
+        data_vars={
+            "tof_ab": xr.DataArray(
+                np.array(
+                    [0, 2, 1, 0, -1, -5, -11], dtype=np.int32
+                ),  # T, F, T, T, F, F, FILL
+                dims=["event_met"],
+            ),
+            "tof_ac1": xr.DataArray(
+                np.array(
+                    [-1, 2, -2, 0, 3, 0, -12], dtype=np.int32
+                ),  # T, T, F, T, F, T, FILL
+                dims=["event_met"],
+            ),
+            "tof_bc1": xr.DataArray(
+                np.array(
+                    [1, 5, 3, 0, 6, 2, -13], dtype=np.int32
+                ),  # T, T, T, F, F, T, FILL
+                dims=["event_met"],
+            ),
+            "tof_c1c2": xr.DataArray(
+                np.array(
+                    [4, 6, 5, 3, 7, -9, -14], dtype=np.int32
+                ),  # T, T, T, F, F, F, FILL
+                dims=["event_met"],
+            ),
         },
     )
     expected_mask = np.array([True, False, False, False, False, False, True])

--- a/imap_processing/tests/hi/test_l1a.py
+++ b/imap_processing/tests/hi/test_l1a.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from cdflib.xarray import xarray_to_cdf
 
 from imap_processing.cdf.utils import write_cdf
 from imap_processing.hi.hi_l1a import (
@@ -35,6 +36,34 @@ def test_sci_de_decom(hi_l0_test_data_path):
     cdf_filename = "imap_hi_l1a_90sensor-de_20241105_v999.cdf"
     cdf_filepath = write_cdf(processed_data[0])
     assert cdf_filepath.name == cdf_filename
+
+
+def test_create_de_dataset_no_events(tmp_path):
+    """Test that a DE dataset with no events correctly generates a CDF."""
+    # Generate a fake de_data_dict with no events
+    keys_with_data = [
+        "ccsds_met",
+        "src_seq_ctr",
+        "pkt_len",
+        "last_spin_num",
+        "spin_invalids",
+        "esa_step",
+        "esa_step_seconds",
+        "esa_step_milliseconds",
+    ]
+    de_data_dict = {k: np.arange(10) for k in keys_with_data}
+    empty_keys = ["de_tag", "trigger_id", "tof_1", "tof_2", "tof_3", "ccsds_index"]
+    for k in empty_keys:
+        de_data_dict[k] = []
+
+    ds = create_de_dataset(de_data_dict)
+    for k in empty_keys:
+        assert len(ds[k].data) == 1
+
+    # Just need to make sure that a cdf file gets written with compression on
+    out_path = tmp_path / "de.cdf"
+    xarray_to_cdf(ds, str(out_path), compression=6)
+    assert out_path.exists()
 
 
 def test_diag_fee_decom(hi_l0_test_data_path):


### PR DESCRIPTION
# Change Summary

## Overview
I had been dragging my feed on handling empty DE datasets because I think the ultimate solution would be to fix cdflib's handling of empty variables. Alas, I had to fix the issue in Hi code by writing one event to the L1A and L1B files with all DE related variables containing fill values. Then in L1B and L1C I added code to handle these Fill events.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/cdf/config/imap_hi_variable_attrs.yaml
   - Fix one warning about a missing depend variable
- imap_processing/hi/hi_l1a.py
   - If there are no events, create one artificial event with fill values that match the CDF FILLVAL
   - Fix one issue with MEMDMP parsing. cdflib doesn't like the ">u4" dtype, so convert to uint32.
- imap_processing/hi/hi_l1b.py
   - Add function that will check for any valid DEs in a dataset.
   - For all DE derived variables, return the filled dataarrays if there are no good DEs
- imap_processing/hi/hi_l1c.py
   - Filter out DEs with invalid trigger_id when binning counts
   - Keep object as xr.Dataset rather than converting to pd.Dataframe
- imap_processing/tests/hi/test_hi_l1b.py
   - Test new any_good_direct_events funciton
   - Add test for input dataset with single Filled DE
   - Add mocks for any_good_direct_event function where needed
- imap_processing/tests/hi/test_hi_l1c.py
   - Test input of "emtpy" l1b DE dataset
   - Update test to pass in xr.Dataset rather than pd.DataFrame
- imap_processing/tests/hi/test_l1a.py
   - Add test for handling no direct events

Closes: #2209