### PR TITLE
Lo L1B DE - Direction Vector and Pointing Bin Fixes

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -15,7 +15,11 @@ from imap_processing.lo.l1b.tof_conversions import (
     TOF2_CONV,
     TOF3_CONV,
 )
-from imap_processing.spice.geometry import SpiceFrame, instrument_pointing
+from imap_processing.spice.geometry import (
+    SpiceFrame,
+    cartesian_to_latitudinal,
+    instrument_pointing,
+)
 from imap_processing.spice.repoint import get_pointing_times
 from imap_processing.spice.spin import get_spin_number
 from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_et
@@ -777,14 +781,16 @@ def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
     l1b_de : xarray.Dataset
         The L1B DE dataset with the pointing bins added.
     """
-    et = ttj2000ns_to_et(l1b_de["epoch"])
-
-    # get lon and lat in degrees
-    direction = instrument_pointing(et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_HAE)
-    # First column: latitudes
-    lats = direction[:, 1]
-    # Second column: longitudes
-    lons = direction[:, 0]
+    x = l1b_de["hae_x"]
+    y = l1b_de["hae_y"]
+    z = l1b_de["hae_z"]
+    # convert the pointing direction to latitudinal coordinates
+    direction = cartesian_to_latitudinal(np.column_stack((x, y, z)))
+    # first column: radius (Not needed)
+    # second column: longitude
+    lons = direction[:, 1]
+    # third column: latitude
+    lats = direction[:, 2]
 
     # Define bin edges
     # 3600 bins, 0.1° each

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -728,22 +728,31 @@ def set_pointing_direction(l1b_de: xr.Dataset) -> xr.Dataset:
     """
     # Get the pointing bin for each DE
     et = ttj2000ns_to_et(l1b_de["epoch"])
-
-    direction = instrument_pointing(et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_HAE)
+    # get the direction in HAE coordinates
+    direction = instrument_pointing(
+        et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_HAE, cartesian=True
+    )
     # TODO: Need to ask Lo what to do if a latitude is outside of the
     # +/-2 degree range. Is that possible?
-    l1b_de["direction_spin"] = xr.DataArray(
+    l1b_de["hae_x"] = xr.DataArray(
         direction[:, 0],
         dims=["epoch"],
         # TODO: Add direction_lon to YAML file
-        # attrs=attr_mgr.get_variable_attributes("direction_lon"),
+        # attrs=attr_mgr.get_variable_attributes("hae_x"),
     )
 
-    l1b_de["direction_off_angle"] = xr.DataArray(
+    l1b_de["hae_y"] = xr.DataArray(
         direction[:, 1],
         dims=["epoch"],
         # TODO: Add direction_lat to YAML file
-        # attrs=attr_mgr.get_variable_attributes("direction_lat"),
+        # attrs=attr_mgr.get_variable_attributes("hae_y"),
+    )
+
+    l1b_de["hae_z"] = xr.DataArray(
+        direction[:, 2],
+        dims=["epoch"],
+        # TODO: Add direction_lat to YAML file
+        # attrs=attr_mgr.get_variable_attributes("hae_z"),
     )
 
     return l1b_de
@@ -768,10 +777,14 @@ def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
     l1b_de : xarray.Dataset
         The L1B DE dataset with the pointing bins added.
     """
+    et = ttj2000ns_to_et(l1b_de["epoch"])
+
+    # get lon and lat in degrees
+    direction = instrument_pointing(et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_HAE)
     # First column: latitudes
-    lats = l1b_de["direction_off_angle"]
+    lats = direction[:, 1]
     # Second column: longitudes
-    lons = l1b_de["direction_spin"]
+    lons = direction[:, 0]
 
     # Define bin edges
     # 3600 bins, 0.1° each
@@ -784,18 +797,18 @@ def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
     lon_bins = np.digitize(lons, lon_bins) - 1
     lat_bins = np.digitize(lats, lat_bins) - 1
 
-    l1b_de["off_angle_bin"] = xr.DataArray(
+    l1b_de["spin_bin"] = xr.DataArray(
         lon_bins,
         dims=["epoch"],
         # TODO: Add pointing_bin_lon to YAML file
-        # attrs=attr_mgr.get_variable_attributes("pointing_bin_lon"),
+        # attrs=attr_mgr.get_variable_attributes("spin_bin"),
     )
 
-    l1b_de["spin_bin"] = xr.DataArray(
+    l1b_de["off_angle_bin"] = xr.DataArray(
         lat_bins,
         dims=["epoch"],
         # TODO: Add point_bin_lat to YAML file
-        # attrs=attr_mgr.get_variable_attributes("pointing_bin_lat"),
+        # attrs=attr_mgr.get_variable_attributes("spin_bin"),
     )
 
     return l1b_de

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -3,7 +3,6 @@
 import logging
 from dataclasses import Field
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import xarray as xr
@@ -68,11 +67,6 @@ def lo_l1b(sci_dependencies: dict, anc_dependencies: list) -> list[Path]:
         avg_spin_durations_per_cycle = get_avg_spin_durations_per_cycle(
             acq_start, acq_end
         )
-        # get spin angle (0 - 360 degrees) for each DE
-        spin_angle = get_spin_angle(l1a_de)
-        # calculate and set the spin bin based on the spin angle
-        # spin bins are 0 - 60 bins
-        l1b_de = set_spin_bin(l1b_de, spin_angle)
         # set the spin cycle for each direct event
         l1b_de = set_spin_cycle(pointing_start_met, l1a_de, l1b_de)
         # get spin start times for each event
@@ -273,54 +267,6 @@ def get_avg_spin_durations_per_cycle(
     # There are 28 spins per epoch (1 aggregated science cycle)
     avg_spin_durations_per_cycle = (acq_end - acq_start) / 28
     return avg_spin_durations_per_cycle
-
-
-def get_spin_angle(l1a_de: xr.Dataset) -> np.ndarray[np.float64] | Any:
-    """
-    Get the spin angle (0 - 360 degrees) for each DE.
-
-    Parameters
-    ----------
-    l1a_de : xarray.Dataset
-        The L1A DE dataset.
-
-    Returns
-    -------
-    spin_angle : np.ndarray
-        The spin angle for each DE.
-    """
-    de_times = l1a_de["de_time"].values
-    # DE Time is 12 bit DN. The max possible value is 4096
-    spin_angle = np.array(de_times / 4096 * 360, dtype=np.float64)
-    return spin_angle
-
-
-def set_spin_bin(l1b_de: xr.Dataset, spin_angle: np.ndarray) -> xr.Dataset:
-    """
-    Set the spin bin (0 - 60 bins) for each Direct Event where each bin is 6 degrees.
-
-    Parameters
-    ----------
-    l1b_de : xarray.Dataset
-        The L1B Direct Event dataset.
-    spin_angle : np.ndarray
-        The spin angle (0-360 degrees) for each Direct Event.
-
-    Returns
-    -------
-    l1b_de : xarray.Dataset
-        The L1B DE dataset with the spin bin added.
-    """
-    # Get the spin bin for each DE
-    # Spin bins are 0 - 60 where each bin is 6 degrees
-    spin_bin = (spin_angle // 6).astype(int)
-    l1b_de["spin_bin"] = xr.DataArray(
-        spin_bin,
-        dims=["epoch"],
-        # TODO: Add spin angle to YAML file
-        # attrs=attr_mgr.get_variable_attributes("spin_bin"),
-    )
-    return l1b_de
 
 
 def set_spin_cycle(
@@ -783,17 +729,17 @@ def set_pointing_direction(l1b_de: xr.Dataset) -> xr.Dataset:
     # Get the pointing bin for each DE
     et = ttj2000ns_to_et(l1b_de["epoch"])
 
-    direction = instrument_pointing(et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_DPS)
+    direction = instrument_pointing(et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_HAE)
     # TODO: Need to ask Lo what to do if a latitude is outside of the
     # +/-2 degree range. Is that possible?
-    l1b_de["direction_lon"] = xr.DataArray(
+    l1b_de["direction_spin"] = xr.DataArray(
         direction[:, 0],
         dims=["epoch"],
         # TODO: Add direction_lon to YAML file
         # attrs=attr_mgr.get_variable_attributes("direction_lon"),
     )
 
-    l1b_de["direction_lat"] = xr.DataArray(
+    l1b_de["direction_off_angle"] = xr.DataArray(
         direction[:, 1],
         dims=["epoch"],
         # TODO: Add direction_lat to YAML file
@@ -807,7 +753,7 @@ def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
     """
     Set the pointing bin for each direct event.
 
-    The pointing bins are defined as 3600 bins for longitude and 40 bins for latitude.
+    The pointing bins are defined as 3600 bins for spin and 40 bins for off angle.
     Each bin is 0.1 degrees. The bins are defined as follows:
     Longitude bins: -180 to 180 degrees
     Latitude bins: -2 to 2 degrees
@@ -823,9 +769,9 @@ def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
         The L1B DE dataset with the pointing bins added.
     """
     # First column: latitudes
-    lats = l1b_de["direction_lat"]
+    lats = l1b_de["direction_off_angle"]
     # Second column: longitudes
-    lons = l1b_de["direction_lon"]
+    lons = l1b_de["direction_spin"]
 
     # Define bin edges
     # 3600 bins, 0.1° each
@@ -838,14 +784,14 @@ def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
     lon_bins = np.digitize(lons, lon_bins) - 1
     lat_bins = np.digitize(lats, lat_bins) - 1
 
-    l1b_de["pointing_bin_lon"] = xr.DataArray(
+    l1b_de["off_angle_bin"] = xr.DataArray(
         lon_bins,
         dims=["epoch"],
         # TODO: Add pointing_bin_lon to YAML file
         # attrs=attr_mgr.get_variable_attributes("pointing_bin_lon"),
     )
 
-    l1b_de["pointing_bin_lat"] = xr.DataArray(
+    l1b_de["spin_bin"] = xr.DataArray(
         lat_bins,
         dims=["epoch"],
         # TODO: Add point_bin_lat to YAML file

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -80,10 +80,15 @@ def attr_mgr_l1a():
     return_value=(473389199, 473472001),
 )
 @patch("imap_processing.lo.l1b.lo_l1b.get_spin_number", return_value=0)
+@patch(
+    "imap_processing.lo.l1b.lo_l1b.cartesian_to_latitudinal",
+    return_value=np.zeros((2000, 3)),
+)
 def test_lo_l1b(
     mock_instrument_pointing,
     mocked_get_pointing_times,
     mock_spin_number,
+    mock_cartesian_to_latitudinal,
     anc_dependencies,
 ):
     # Arrange
@@ -599,13 +604,17 @@ def test_set_direction(imap_ena_sim_metakernel):
 
 
 @patch(
-    "imap_processing.lo.l1b.lo_l1b.instrument_pointing",
-    return_value=np.array([[-180, -2], [0, 0], [90, 1], [180, 2]]),
+    "imap_processing.lo.l1b.lo_l1b.cartesian_to_latitudinal",
+    return_value=np.array([[0, -180, -2], [0, 0, 0], [0, 90, 1], [0, 180, 2]]),
 )
 def test_pointing_bins(imap_ena_sim_metakernel):
     # Arrange
     l1b_de = xr.Dataset(
-        {},
+        {
+            "hae_x": ("epoch", [1, 1, 1, 1]),
+            "hae_y": ("epoch", [0, 0, 0, 0]),
+            "hae_z": ("epoch", [0, 0, 0, 0]),
+        },
         coords={
             "epoch": [
                 7.9794907049e17,

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -14,7 +14,6 @@ from imap_processing.lo.l1b.lo_l1b import (
     convert_tofs_to_eu,
     create_datasets,
     get_avg_spin_durations_per_cycle,
-    get_spin_angle,
     get_spin_start_times,
     identify_species,
     initialize_l1b_de,
@@ -27,7 +26,6 @@ from imap_processing.lo.l1b.lo_l1b import (
     set_event_met,
     set_pointing_bin,
     set_pointing_direction,
-    set_spin_bin,
     set_spin_cycle,
 )
 from imap_processing.spice.time import met_to_ttj2000ns
@@ -75,7 +73,7 @@ def attr_mgr_l1a():
 
 @patch(
     "imap_processing.lo.l1b.lo_l1b.instrument_pointing",
-    return_value=np.zeros((2000, 2)),
+    return_value=np.zeros((2000, 3)),
 )
 @patch(
     "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
@@ -267,41 +265,6 @@ def test_get_avg_spin_durations():
 
     # Assert
     np.testing.assert_array_equal(avg_spin_durations, expected_avg_spin_durations)
-
-
-def test_get_spin_angle():
-    # Arrange
-    de = xr.Dataset(
-        {
-            "de_count": ("epoch", [2, 3]),
-            "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000]),
-        },
-        coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4]},
-    )
-    spin_angle_expected = np.array([0, 87.89, 175.78, 263.67, 351.56])
-
-    # Act
-    spin_angle = get_spin_angle(de)
-
-    # Assert
-    np.testing.assert_allclose(
-        spin_angle,
-        spin_angle_expected,
-        atol=1e-2,
-    )
-
-
-def test_spin_bin():
-    # Arrange
-    l1b_de = xr.Dataset()
-    spin_angle = np.array([0, 50, 150, 250, 365])
-    expected_spin_bins = np.array([0, 8, 25, 41, 60])
-
-    # Act
-    l1b_de = set_spin_bin(l1b_de, spin_angle)
-
-    # Assert
-    np.testing.assert_array_equal(l1b_de["spin_bin"], expected_spin_bins)
 
 
 @patch("imap_processing.lo.l1b.lo_l1b.get_spin_number", return_value=0)
@@ -597,71 +560,68 @@ def test_set_bad_times():
     np.testing.assert_array_equal(l1b_de["badtimes"], expected_bad_times)
 
 
-@pytest.mark.external_kernel
+@patch(
+    "imap_processing.lo.l1b.lo_l1b.instrument_pointing",
+    return_value=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]),
+)
 def test_set_direction(imap_ena_sim_metakernel):
     # Arrange
     l1b_de = xr.Dataset(
         {},
         coords={
-            "epoch": [
-                7.9794907254e17,
-                # + 1 second. Should be 24deg diff from
-                # previous epoch
-                7.9794907254e17 + 1e9,
-                # + 7.5 seconds. Should be 180deg diff from
-                # first epoch
-                7.9794907254e17 + 7.5e9,
-                # + 15 seconds. Should be 360deg diff from
-                # previous epoch
-                7.9794907254e17 + 15e9,
-            ],
+            "epoch": [0, 1, 2, 3],
         },
     )
     # latitudes are -90 to 90
-    expected_direction_lat = np.array([0, 0, 0, 0])
-    # longitude are -180 to 180
-    expected_direction_lon = np.array([140.5, 164.5, -39.5, 140.5])
+    expected_hae_x = np.array([1, 4, 7, 10])
+    expected_hae_y = np.array([2, 5, 8, 11])
+    expected_hae_z = np.array([3, 6, 9, 12])
 
     # Act
     l1b_de = set_pointing_direction(l1b_de)
 
     # Assert
     np.testing.assert_allclose(
-        l1b_de["direction_lat"].values,
-        expected_direction_lat,
+        l1b_de["hae_x"].values,
+        expected_hae_x,
         atol=1e-1,
     )
     np.testing.assert_allclose(
-        l1b_de["direction_lon"].values,
-        expected_direction_lon,
+        l1b_de["hae_y"].values,
+        expected_hae_y,
+        atol=1e-1,
+    )
+    np.testing.assert_allclose(
+        l1b_de["hae_z"].values,
+        expected_hae_z,
         atol=1e-1,
     )
 
 
-def test_pointing_bins():
+@patch(
+    "imap_processing.lo.l1b.lo_l1b.instrument_pointing",
+    return_value=np.array([[-180, -2], [0, 0], [90, 1], [180, 2]]),
+)
+def test_pointing_bins(imap_ena_sim_metakernel):
     # Arrange
     l1b_de = xr.Dataset(
-        {
-            "direction_lat": ("epoch", [0, 0, 0, 0, 0]),
-            "direction_lon": ("epoch", [-180, 91.3, 116.3, 140.5, 180]),
-        },
+        {},
         coords={
             "epoch": [
                 7.9794907049e17,
                 7.9794907153e17,
                 7.9794907254e17,
                 7.9794907354e17,
-                7.9794907454e17,
             ],
         },
     )
 
-    expected_pointing_lats = np.array([20, 20, 20, 20, 20])
-    expected_pointing_lons = np.array([0, 2712, 2962, 3205, 3600])
+    expected_pointing_lats = np.array([0, 20, 30, 40])
+    expected_pointing_lons = np.array([0, 1800, 2700, 3600])
 
     # Act
     l1b_de = set_pointing_bin(l1b_de)
 
     # Assert
-    np.testing.assert_array_equal(l1b_de["pointing_bin_lat"], expected_pointing_lats)
-    np.testing.assert_array_equal(l1b_de["pointing_bin_lon"], expected_pointing_lons)
+    np.testing.assert_array_equal(l1b_de["off_angle_bin"], expected_pointing_lats)
+    np.testing.assert_array_equal(l1b_de["spin_bin"], expected_pointing_lons)


### PR DESCRIPTION
# Change Summary

## Overview
- Pointing bins
   - Updated pointing bins to be named off_angle_bin and spin_bin
   - Using HAE instead of DPS
- Direction Vector
   - using instrument_pointing function to get the cartesian coordinates and set variable
      - hae_x
      - hae_y
      - hae_z
- Removed spin_bin and spin_angle functions
   - spin_angle was used to get spin_bin (0-60 bins). Lo said these are no longer needed since we are using a 3600 bin spin_bin


A follow-on PR will be created to populate the badtimes variable using the bad-times ancillary file which will close out the L1B DE product.
