### PR TITLE
ULTRA L1c attr updates

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -163,7 +163,7 @@ ena_rate:
   DISPLAY_TYPE: image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
-background_rates:
+bg_rate:
   <<: *default_float32
   CATDESC: Estimated background count rate.
   FIELDNAM: Background Rate

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -187,9 +187,9 @@ ena_count:
 
 sensitivity:
   <<: *default_float32
-  CATDESC: Calibration/sensitivity factor calculated from multiple pointing sets.
-  FIELDNAM: sensitivity
-  UNITS: cm^-3
+  CATDESC: Averaged instrument sensitive area.
+  FIELDNAM: Sensitivity
+  UNITS: cm^2
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: sensitivity
@@ -209,8 +209,8 @@ exposure_factor: &exposure_factor
 
 geometric_function:
   <<: *default_float32
-  CATDESC: The geometric function calculated from multiple pointing sets.
-  FIELDNAM: geometric_function
+  CATDESC: Averaged aperture area as seen by the backstop.
+  FIELDNAM: Geometric Function
   UNITS: cm^2 sr
   DEPEND_0: epoch
   VAR_TYPE: data
@@ -220,8 +220,8 @@ geometric_function:
 
 efficiency:
   <<: *default_float32
-  CATDESC: Event efficiency calculated from multiple pointing sets.
-  FIELDNAM: efficiency
+  CATDESC: Efficiency of the instrument in converting ENAs to valid events.
+  FIELDNAM: Efficiency
   UNITS: " "
   DEPEND_0: epoch
   VAR_TYPE: data
@@ -231,8 +231,8 @@ efficiency:
 
 positional_uncert_theta:
   <<: *default_float32
-  CATDESC: Positional uncertainty in theta direction calculated from multiple pointing sets.
-  FIELDNAM: positional_uncertainty_theta
+  CATDESC: Averaged position uncertainty along the theta dimension of the instrument.
+  FIELDNAM: Positional Uncertainty Theta
   UNITS: degrees
   DEPEND_0: epoch
   VAR_TYPE: data
@@ -242,8 +242,8 @@ positional_uncert_theta:
 
 positional_uncert_phi:
   <<: *default_float32
-  CATDESC: Positional uncertainty in phi direction calculated from multiple pointing sets.
-  FIELDNAM: positional_uncertainty_phi
+  CATDESC: Averaged position uncertainty along the phi dimension of the instrument.
+  FIELDNAM: Positional Uncertainty Phi
   UNITS: degrees
   DEPEND_0: epoch
   VAR_TYPE: data

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -163,7 +163,7 @@ ena_rate:
   DISPLAY_TYPE: image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
-bg_rate:
+background_rates:
   <<: *default_float32
   CATDESC: Estimated background count rate.
   FIELDNAM: Background Rate

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -212,9 +212,8 @@ geometric_function:
   CATDESC: Averaged aperture area as seen by the backstop.
   FIELDNAM: Geometric Function
   UNITS: cm^2 sr
-  DEPEND_0: epoch
-  VAR_TYPE: data
-  LABLAXIS: Geometric Factor
+  VAR_TYPE: support_data
+  LABLAXIS: Geometric Function
   DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:GeometricFactor,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
@@ -234,8 +233,7 @@ positional_uncert_theta:
   CATDESC: Averaged position uncertainty along the theta dimension of the instrument.
   FIELDNAM: Positional Uncertainty Theta
   UNITS: degrees
-  DEPEND_0: epoch
-  VAR_TYPE: data
+  VAR_TYPE: support_data
   LABLAXIS: Position Uncertainty Theta
   DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:ArrivalDirection,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
@@ -245,8 +243,7 @@ positional_uncert_phi:
   CATDESC: Averaged position uncertainty along the phi dimension of the instrument.
   FIELDNAM: Positional Uncertainty Phi
   UNITS: degrees
-  DEPEND_0: epoch
-  VAR_TYPE: data
+  VAR_TYPE: support_data
   LABLAXIS: Position Uncertainty Phi
   DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:ArrivalDirection,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -147,10 +147,10 @@ quality_flags:
   DEPEND_2: energy_bin_geometric_mean
   UNITS: " "
 
-bg_rate:
+background_rates:
   <<: *default_float32
   CATDESC: Background rates. Background dominated by accidentals caused by a combination of UV light and misregistered low energy ENA events.
-  FIELDNAM: bg_rate
+  FIELDNAM: background_rates
   LABLAXIS: background rates
   # TODO: come back to format
   UNITS: counts/second

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -27,7 +27,6 @@ default_uint16_attrs: &default_uint16
 
 energy_dependent_attrs: &energy_dependent
   <<: *default_float32
-  DEPEND_0: epoch
   DEPEND_1: energy_bin_geometric_mean
   DEPEND_2: pixel_index
 
@@ -91,6 +90,7 @@ efficiency:
 
 exposure_factor:
   <<: *energy_dependent
+  DEPEND_0: epoch
   CATDESC: Exposure time with the deadtime correction applied for a pointing.
   FIELDNAM: exposure_factor
   LABLAXIS: exposure factor

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -27,6 +27,7 @@ default_uint16_attrs: &default_uint16
 
 energy_dependent_attrs: &energy_dependent
   <<: *default_float32
+  DEPEND_0: epoch
   DEPEND_1: energy_bin_geometric_mean
   DEPEND_2: pixel_index
 
@@ -65,15 +66,15 @@ dead_time_ratio:
 
 sensitivity:
   <<: *energy_dependent
-  CATDESC: Calibration/sensitivity factor.
+  CATDESC: Averaged instrument sensitive area.
   FIELDNAM: sensitivity
   LABLAXIS: sensitivity
   # TODO: come back to format
-  UNITS: counts/second
+  UNITS: cm^2
 
 geometric_function:
   <<: *energy_dependent
-  CATDESC: The effective sensitive area as a function of theta and phi in instrument frame (energy independent).
+  CATDESC: Averaged aperture area as seen by the backstop.
   FIELDNAM: geometric_function
   LABLAXIS: Geometric Factor
   UNITS: cm^2
@@ -81,7 +82,7 @@ geometric_function:
 
 efficiency:
   <<: *energy_dependent
-  CATDESC: Estimated event efficiency for particles path through the instrument.
+  CATDESC: Efficiency of the instrument in converting ENAs to valid events.
   FIELDNAM: efficiency
   LABLAXIS: Efficiency
   UNITS: " "
@@ -146,10 +147,10 @@ quality_flags:
   DEPEND_2: energy_bin_geometric_mean
   UNITS: " "
 
-background_rates:
+bg_rate:
   <<: *default_float32
   CATDESC: Background rates. Background dominated by accidentals caused by a combination of UV light and misregistered low energy ENA events.
-  FIELDNAM: background_rates
+  FIELDNAM: bg_rate
   LABLAXIS: background rates
   # TODO: come back to format
   UNITS: counts/second

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -68,6 +68,7 @@ sensitivity:
   CATDESC: Averaged instrument sensitive area.
   FIELDNAM: sensitivity
   LABLAXIS: sensitivity
+  DEPEND_0: epoch
   # TODO: come back to format
   UNITS: cm^2
 
@@ -85,6 +86,7 @@ efficiency:
   FIELDNAM: efficiency
   LABLAXIS: Efficiency
   UNITS: " "
+  DEPEND_0: epoch
   VALIDMIN: 0.0
   VALIDMAX: 1.0
 
@@ -102,6 +104,7 @@ helio_exposure_factor:
   CATDESC: Exposure time with the deadtime correction applied for a pointing.
   FIELDNAM: exposure_factor
   LABLAXIS: exposure factor
+  DEPEND_0: epoch
   # TODO: come back to format
   UNITS: seconds
 

--- a/imap_processing/tests/ultra/mock_data.py
+++ b/imap_processing/tests/ultra/mock_data.py
@@ -318,6 +318,7 @@ def mock_l1c_pset_product_healpix(
     # add an epoch dimension
     counts = np.expand_dims(counts, axis=0)
     sensitivity = np.ones_like(counts)
+    geometric_function = sensitivity[0]  # pointing independent
 
     # Determine the epoch, which is TT time in nanoseconds since J2000 epoch
     tdb_et = str_to_et(timestr)
@@ -357,6 +358,13 @@ def mock_l1c_pset_product_healpix(
                     CoordNames.HEALPIX_INDEX.value,
                 ],
                 sensitivity,
+            ),
+            "geometric_function": (
+                [
+                    CoordNames.ENERGY_ULTRA_L1C.value,
+                    CoordNames.HEALPIX_INDEX.value,
+                ],
+                geometric_function,
             ),
             CoordNames.AZIMUTH_L1C.value: (
                 [CoordNames.HEALPIX_INDEX.value],

--- a/imap_processing/tests/ultra/mock_data.py
+++ b/imap_processing/tests/ultra/mock_data.py
@@ -338,7 +338,7 @@ def mock_l1c_pset_product_healpix(
                 ],
                 counts,
             ),
-            "background_rates": (
+            "bg_rate": (
                 [
                     CoordNames.TIME.value,
                     CoordNames.ENERGY_ULTRA_L1C.value,

--- a/imap_processing/tests/ultra/mock_data.py
+++ b/imap_processing/tests/ultra/mock_data.py
@@ -338,7 +338,7 @@ def mock_l1c_pset_product_healpix(
                 ],
                 counts,
             ),
-            "bg_rate": (
+            "background_rates": (
                 [
                     CoordNames.TIME.value,
                     CoordNames.ENERGY_ULTRA_L1C.value,

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -8,6 +8,7 @@ import xarray as xr
 from astropy_healpix.healpy import nside2pixarea
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.cdf.utils import write_cdf
 from imap_processing.ena_maps import ena_maps
 from imap_processing.ena_maps.utils.coordinates import CoordNames
 from imap_processing.quality_flags import ImapPSETUltraFlags
@@ -30,7 +31,10 @@ class TestUltraL2:
     def _mock_single_pset(self, _setup_spice_kernels_list, furnish_kernels):
         with furnish_kernels(self.required_kernel_names):
             self.ultra_pset = mock_l1c_pset_product_healpix(
-                nside=128, stripe_center_lat=0, timestr="2025-05-15T12:00:00"
+                nside=128,
+                stripe_center_lat=0,
+                timestr="2025-05-15T12:00:00",
+                energy_dependent_exposure=True,
             )
 
     @pytest.fixture
@@ -65,10 +69,9 @@ class TestUltraL2:
             ]
             # Add extra ultra specific variables to each pset
             for pset in self.ultra_psets:
-                pset["efficiency"] = xr.ones_like(pset["exposure_factor"])
-                pset["geometric_function"] = xr.ones_like(pset["exposure_factor"])
-                pset["scatter_theta"] = xr.ones_like(pset["exposure_factor"])
-                pset["scatter_phi"] = xr.ones_like(pset["exposure_factor"])
+                pset["efficiency"] = xr.ones_like(pset["sensitivity"])
+                pset["scatter_theta"] = xr.ones_like(pset["geometric_function"])
+                pset["scatter_phi"] = xr.ones_like(pset["geometric_function"])
 
         self.psets_total_counts = np.sum(
             [pset["counts"].values.sum() for pset in self.ultra_psets]
@@ -103,11 +106,13 @@ class TestUltraL2:
         pset["exposure_factor"].values = np.ones_like(pset["exposure_factor"])
         pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
+        pset["geometric_function"].values = np.ones_like(
+            pset["geometric_function"].values
+        )
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
-        pset["efficiency"] = xr.ones_like(pset["exposure_factor"])
-        pset["geometric_function"] = xr.ones_like(pset["exposure_factor"])
-        pset["scatter_theta"] = xr.ones_like(pset["exposure_factor"])
-        pset["scatter_phi"] = xr.ones_like(pset["exposure_factor"])
+        pset["efficiency"] = xr.ones_like(pset["sensitivity"])
+        pset["scatter_theta"] = xr.ones_like(pset["geometric_function"])
+        pset["scatter_phi"] = xr.ones_like(pset["geometric_function"])
 
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
         if epoch_dim_for_energy_delta:
@@ -319,13 +324,18 @@ class TestUltraL2:
             hp_skymap.data_1d["counts"].sum(),
             self.psets_total_counts,
         )
-
+        # The pointing independent variables should have been pulled once
+        np.testing.assert_allclose(
+            hp_skymap.data_1d["geometric_function"],
+            np.ones_like(hp_skymap.data_1d["geometric_function"]),
+        )
         # The map should contain the following variables,
         # because we did not drop any variables
         expected_vars = (
             ultra_l2.REQUIRED_L1C_VARIABLES_PUSH
             + ultra_l2.REQUIRED_L1C_VARIABLES_PULL
             + ultra_l2.VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION
+            + ultra_l2.EXPECTED_L1C_POINTING_INDEPENDENT_VARIABLES_PULL
             + ["ena_intensity", "ena_intensity_stat_unc"]
         )
         for var in expected_vars:
@@ -337,10 +347,21 @@ class TestUltraL2:
             CoordNames.ENERGY_ULTRA_L1C.value,
             CoordNames.GENERIC_PIXEL.value,
         )
+        pointing_independent_dims = (
+            CoordNames.ENERGY_ULTRA_L1C.value,
+            CoordNames.GENERIC_PIXEL.value,
+        )
         assert hp_skymap.data_1d["counts"].dims == counts_dims
         assert hp_skymap.data_1d["ena_intensity"].dims == counts_dims
         assert hp_skymap.data_1d["ena_intensity_stat_unc"].dims == counts_dims
         assert hp_skymap.data_1d["exposure_factor"].dims == counts_dims
+        assert hp_skymap.data_1d["sensitivity"].dims == counts_dims
+        assert hp_skymap.data_1d["background_rates"].dims == counts_dims
+        assert hp_skymap.data_1d["efficiency"].dims == counts_dims
+
+        assert hp_skymap.data_1d["geometric_function"].dims == pointing_independent_dims
+        assert hp_skymap.data_1d["scatter_theta"].dims == pointing_independent_dims
+        assert hp_skymap.data_1d["scatter_phi"].dims == pointing_independent_dims
 
     @pytest.mark.usefixtures("_setup_spice_kernels_list")
     def test_ultra_l2_output_unbinned_healpix(self, mock_data_dict, furnish_kernels):
@@ -658,3 +679,5 @@ class TestUltraL2:
         )
         assert output_map.attrs["Spice_reference_frame"] == "IMAP_HAE"
         assert output_map.attrs["HEALPix_nside"] == "32"
+
+        write_cdf(output_map)

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -101,7 +101,7 @@ class TestUltraL2:
         # of the expected ena_intensity and ena_intensity statistical uncertainty
         pset["counts"].values = np.full_like(pset["counts"].values, 10)
         pset["exposure_factor"].values = np.ones_like(pset["exposure_factor"])
-        pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
+        pset["bg_rate"].values = np.ones_like(pset["bg_rate"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
         pset["efficiency"] = xr.ones_like(pset["exposure_factor"])
@@ -136,7 +136,7 @@ class TestUltraL2:
                             "efficiency",
                             "scatter_theta",
                             "scatter_phi",
-                            "background_rates",
+                            "bg_rate",
                         ],
                         "nside": 32,
                         "nested": False,
@@ -150,7 +150,7 @@ class TestUltraL2:
         # Check that required variables are present, and dropped variables are not
         expected_vars = [
             "counts",
-            "background_rates",
+            "bg_rate",
             "ena_intensity",
             "obs_date_range",
             "ena_intensity_stat_unc",
@@ -217,7 +217,7 @@ class TestUltraL2:
         # of the expected ena_intensity and ena_intensity statistical uncertainty
         pset["counts"].values = np.full_like(pset["counts"].values, 10)
         pset["exposure_factor"].values = np.ones_like(pset["exposure_factor"].values)
-        pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
+        pset["bg_rate"].values = np.ones_like(pset["bg_rate"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
 
@@ -245,7 +245,7 @@ class TestUltraL2:
                         "values_to_pull_project": [
                             "exposure_factor",
                             "sensitivity",
-                            "background_rates",
+                            "bg_rate",
                         ],
                         "nside": 32,
                         "nested": False,
@@ -259,7 +259,7 @@ class TestUltraL2:
         # Check that required variables are present, and dropped variables are not
         expected_vars = [
             "counts",
-            "background_rates",
+            "bg_rate",
             "ena_intensity",
             "obs_date_range",
             "ena_intensity_stat_unc",
@@ -302,7 +302,7 @@ class TestUltraL2:
                             "values_to_pull_project": [
                                 "exposure_factor",
                                 "sensitivity",
-                                "background_rates",
+                                "bg_rate",
                             ],
                             "spacing_deg": 2.0,
                         }

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -101,7 +101,7 @@ class TestUltraL2:
         # of the expected ena_intensity and ena_intensity statistical uncertainty
         pset["counts"].values = np.full_like(pset["counts"].values, 10)
         pset["exposure_factor"].values = np.ones_like(pset["exposure_factor"])
-        pset["bg_rate"].values = np.ones_like(pset["bg_rate"].values)
+        pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
         pset["efficiency"] = xr.ones_like(pset["exposure_factor"])
@@ -136,7 +136,7 @@ class TestUltraL2:
                             "efficiency",
                             "scatter_theta",
                             "scatter_phi",
-                            "bg_rate",
+                            "background_rates",
                         ],
                         "nside": 32,
                         "nested": False,
@@ -150,7 +150,7 @@ class TestUltraL2:
         # Check that required variables are present, and dropped variables are not
         expected_vars = [
             "counts",
-            "bg_rate",
+            "background_rates",
             "ena_intensity",
             "obs_date_range",
             "ena_intensity_stat_unc",
@@ -217,7 +217,7 @@ class TestUltraL2:
         # of the expected ena_intensity and ena_intensity statistical uncertainty
         pset["counts"].values = np.full_like(pset["counts"].values, 10)
         pset["exposure_factor"].values = np.ones_like(pset["exposure_factor"].values)
-        pset["bg_rate"].values = np.ones_like(pset["bg_rate"].values)
+        pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
 
@@ -245,7 +245,7 @@ class TestUltraL2:
                         "values_to_pull_project": [
                             "exposure_factor",
                             "sensitivity",
-                            "bg_rate",
+                            "background_rates",
                         ],
                         "nside": 32,
                         "nested": False,
@@ -259,7 +259,7 @@ class TestUltraL2:
         # Check that required variables are present, and dropped variables are not
         expected_vars = [
             "counts",
-            "bg_rate",
+            "background_rates",
             "ena_intensity",
             "obs_date_range",
             "ena_intensity_stat_unc",
@@ -302,7 +302,7 @@ class TestUltraL2:
                             "values_to_pull_project": [
                                 "exposure_factor",
                                 "sensitivity",
-                                "bg_rate",
+                                "background_rates",
                             ],
                             "spacing_deg": 2.0,
                         }

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -181,15 +181,15 @@ def calculate_helio_pset(
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
         np.newaxis, ...
     ]
-    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
-    pset_dict["efficiency"] = efficiencies[np.newaxis, ...]
-    pset_dict["geometric_function"] = geometric_function[np.newaxis, ...]
+    pset_dict["sensitivity"] = sensitivity
+    pset_dict["efficiency"] = efficiencies
+    pset_dict["geometric_function"] = geometric_function
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))
     pset_dict["quality_flags"] = helio_pset_quality_flags[np.newaxis, ...]
 
-    pset_dict["scatter_theta"] = scattering_theta[np.newaxis, ...]
-    pset_dict["scatter_phi"] = scattering_phi[np.newaxis, ...]
+    pset_dict["scatter_theta"] = scattering_theta
+    pset_dict["scatter_phi"] = scattering_phi
     pset_dict["scatter_threshold"] = scattering_thresholds
 
     # Add the energy delta plus/minus to the dataset

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -181,8 +181,8 @@ def calculate_helio_pset(
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
         np.newaxis, ...
     ]
-    pset_dict["sensitivity"] = sensitivity
-    pset_dict["efficiency"] = efficiencies
+    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
+    pset_dict["efficiency"] = efficiencies[np.newaxis, ...]
     pset_dict["geometric_function"] = geometric_function
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -176,20 +176,20 @@ def calculate_helio_pset(
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
-    pset_dict["helio_exposure_factor"] = exposure_time
+    pset_dict["helio_exposure_factor"] = exposure_time[np.newaxis, ...]
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
         np.newaxis, ...
     ]
-    pset_dict["sensitivity"] = sensitivity
-    pset_dict["efficiency"] = efficiencies
-    pset_dict["geometric_function"] = geometric_function
+    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
+    pset_dict["efficiency"] = efficiencies[np.newaxis, ...]
+    pset_dict["geometric_function"] = geometric_function[np.newaxis, ...]
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))
     pset_dict["quality_flags"] = helio_pset_quality_flags[np.newaxis, ...]
 
-    pset_dict["scatter_theta"] = scattering_theta
-    pset_dict["scatter_phi"] = scattering_phi
+    pset_dict["scatter_theta"] = scattering_theta[np.newaxis, ...]
+    pset_dict["scatter_phi"] = scattering_phi[np.newaxis, ...]
     pset_dict["scatter_threshold"] = scattering_thresholds
 
     # Add the energy delta plus/minus to the dataset

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -183,24 +183,24 @@ def calculate_spacecraft_pset(
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
-    pset_dict["background_rates"] = background_rates[np.newaxis, ...]
-    pset_dict["exposure_factor"] = exposure_pointing
+    pset_dict["bg_rate"] = background_rates[np.newaxis, ...]
+    pset_dict["exposure_factor"] = exposure_pointing[np.newaxis, ...]
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
         np.newaxis, ...
     ]
     pset_dict["quality_flags"] = spacecraft_pset_quality_flags[np.newaxis, ...]
 
-    pset_dict["sensitivity"] = sensitivity
-    pset_dict["efficiency"] = efficiencies
-    pset_dict["geometric_function"] = geometric_function
+    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
+    pset_dict["efficiency"] = efficiencies[np.newaxis, ...]
+    pset_dict["geometric_function"] = geometric_function[np.newaxis, ...]
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))
 
     # Convert FWHM to gaussian uncertainty by dividing by 2.355
     # See algorithm documentation (section 3.5.7, third bullet point) for more details
-    pset_dict["scatter_theta"] = scattering_theta / 2.355
-    pset_dict["scatter_phi"] = scattering_phi / 2.355
+    pset_dict["scatter_theta"] = scattering_theta[np.newaxis, ...] / 2.355
+    pset_dict["scatter_phi"] = scattering_phi[np.newaxis, ...] / 2.355
 
     pset_dict["scatter_threshold"] = scattering_thresholds
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -191,8 +191,8 @@ def calculate_spacecraft_pset(
     ]
     pset_dict["quality_flags"] = spacecraft_pset_quality_flags[np.newaxis, ...]
 
-    pset_dict["sensitivity"] = sensitivity
-    pset_dict["efficiency"] = efficiencies
+    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
+    pset_dict["efficiency"] = efficiencies[np.newaxis, ...]
     pset_dict["geometric_function"] = geometric_function
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -183,7 +183,7 @@ def calculate_spacecraft_pset(
     pset_dict["latitude"] = latitude[np.newaxis, ...]
     pset_dict["longitude"] = longitude[np.newaxis, ...]
     pset_dict["energy_bin_geometric_mean"] = energy_bin_geometric_means
-    pset_dict["bg_rate"] = background_rates[np.newaxis, ...]
+    pset_dict["background_rates"] = background_rates[np.newaxis, ...]
     pset_dict["exposure_factor"] = exposure_pointing[np.newaxis, ...]
     pset_dict["pixel_index"] = healpix
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -191,16 +191,16 @@ def calculate_spacecraft_pset(
     ]
     pset_dict["quality_flags"] = spacecraft_pset_quality_flags[np.newaxis, ...]
 
-    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
-    pset_dict["efficiency"] = efficiencies[np.newaxis, ...]
-    pset_dict["geometric_function"] = geometric_function[np.newaxis, ...]
+    pset_dict["sensitivity"] = sensitivity
+    pset_dict["efficiency"] = efficiencies
+    pset_dict["geometric_function"] = geometric_function
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))
 
     # Convert FWHM to gaussian uncertainty by dividing by 2.355
     # See algorithm documentation (section 3.5.7, third bullet point) for more details
-    pset_dict["scatter_theta"] = scattering_theta[np.newaxis, ...] / 2.355
-    pset_dict["scatter_phi"] = scattering_phi[np.newaxis, ...] / 2.355
+    pset_dict["scatter_theta"] = scattering_theta / 2.355
+    pset_dict["scatter_phi"] = scattering_phi / 2.355
 
     pset_dict["scatter_threshold"] = scattering_thresholds
 

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -64,8 +64,10 @@ REQUIRED_L1C_VARIABLES_PULL = [
 # they may be missing, in which case we will raise a warning and continue.
 # All psets must be consistent and either have these variables or not.
 EXPECTED_L1C_VARIABLES_PULL = [
-    "geometric_function",
     "efficiency",
+]
+EXPECTED_L1C_POINTING_INDEPENDENT_VARIABLES_PULL = [
+    "geometric_function",
     "scatter_theta",
     "scatter_phi",
 ]
@@ -75,10 +77,7 @@ VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE = [
     "sensitivity",
     "background_rates",
     "obs_date",
-    "geometric_function",
     "efficiency",
-    "scatter_theta",
-    "scatter_phi",
 ]
 
 # These variables are dropped after they are used to
@@ -148,7 +147,7 @@ def get_variable_attributes_optional_energy_dependence(
     return metadata
 
 
-def generate_ultra_healpix_skymap(
+def generate_ultra_healpix_skymap(  # noqa: PLR0912
     ultra_l1c_psets: list[str | xr.Dataset],
     output_map_structure: (
         ena_maps.RectangularSkyMap | ena_maps.HealpixSkyMap
@@ -252,6 +251,7 @@ def generate_ultra_healpix_skymap(
     # Add expected but not required variables to the pull projection list
     # Log a warning if they are missing from any PSET but continue processing.
     expected_present_vars = []
+    expected_present_vars_pointing_ind = []
     first_pset = (
         load_cdf(ultra_l1c_psets[0])
         if isinstance(ultra_l1c_psets[0], (str, Path))
@@ -266,12 +266,21 @@ def generate_ultra_healpix_skymap(
         else:
             expected_present_vars.append(var)
 
+    for var in EXPECTED_L1C_POINTING_INDEPENDENT_VARIABLES_PULL:
+        if var not in first_pset.variables:
+            logger.warning(
+                f"Expected variable {var} not found in the first L1C PSET. "
+                "This variable will not be projected to the map."
+            )
+        else:
+            expected_present_vars_pointing_ind.append(var)
+
     output_map_structure.values_to_pull_project = list(
         set(output_map_structure.values_to_pull_project + expected_present_vars)
     )
 
     all_pset_epochs = []
-    for ultra_l1c_pset in ultra_l1c_psets:
+    for i, ultra_l1c_pset in enumerate(ultra_l1c_psets):
         pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
         all_pset_epochs.append(pointing_set.epoch)
         logger.info(
@@ -343,7 +352,15 @@ def generate_ultra_healpix_skymap(
             index_match_method=ena_maps.IndexMatchMethod.PULL,
             pset_valid_mask=good_pixel_mask,
         )
-
+        if i == 0:
+            # Pull pointing independent variables if they exist in the PSETs
+            # Use first pset
+            skymap.project_pset_values_to_map(
+                pointing_set=pointing_set,
+                value_keys=expected_present_vars_pointing_ind,
+                index_match_method=ena_maps.IndexMatchMethod.PULL,
+                pset_valid_mask=good_pixel_mask,
+            )
     # Subsequent processing for weighted quantities at SkyMap level
     skymap.data_1d[existing_vars_to_weight] /= skymap.data_1d[
         "pointing_set_exposure_times_solid_angle"
@@ -635,7 +652,6 @@ def ultra_l2(  # noqa: PLR0912
         energy_delta_plus,
         dims=(CoordNames.ENERGY_L2.value,),
     )
-
     # Add variable specific attributes to the map's data_vars and coords
     for variable in map_dataset.data_vars:
         # Skip the subdivision depth variables, as these will only be
@@ -643,14 +659,25 @@ def ultra_l2(  # noqa: PLR0912
         if "subdivision_depth" in variable:
             continue
 
+        # Support variables do not have epoch as the first dimension
+        # skip schema check for support variables or choords
+        skip_schema_check = not (
+            "epoch" not in map_dataset[variable].dims  # Support data
+            or variable
+            in [
+                "longitude",
+                "latitude",
+                "longitude_delta",
+                "latitude_delta",
+            ]  # Coordinate vars
+        )
         # The longitude and latitude variables will be present only in Healpix tiled
         # map, and, as support_data, should not have schema validation
         map_dataset[variable].attrs.update(
             get_variable_attributes_optional_energy_dependence(
                 cdf_attrs=cdf_attrs,
                 variable_array=map_dataset[variable],
-                check_schema=variable
-                not in ["longitude", "latitude", "longitude_delta", "latitude_delta"],
+                check_schema=skip_schema_check,
             )
         )
     for coord_variable in map_dataset.coords:

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -35,7 +35,7 @@ DEFAULT_ULTRA_L2_MAP_STRUCTURE: ena_maps.RectangularSkyMap | ena_maps.HealpixSky
             "values_to_pull_project": [
                 "exposure_factor",
                 "sensitivity",
-                "background_rates",
+                "bg_rate",
             ],
             "nside": 32,
             "nested": False,
@@ -57,7 +57,7 @@ REQUIRED_L1C_VARIABLES_PUSH = [
 REQUIRED_L1C_VARIABLES_PULL = [
     "exposure_factor",
     "sensitivity",
-    "background_rates",
+    "bg_rate",
     "obs_date",
 ]
 # These variables are expected but not strictly required. In certain test scenarios,
@@ -73,7 +73,7 @@ EXPECTED_L1C_VARIABLES_PULL = [
 # weighted by that pointing set pixel's exposure and solid angle
 VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE = [
     "sensitivity",
-    "background_rates",
+    "bg_rate",
     "obs_date",
     "geometric_function",
     "efficiency",
@@ -351,7 +351,7 @@ def generate_ultra_healpix_skymap(
 
     # Background rates must be scaled by the ratio of the solid angles of the
     # map pixel / pointing set pixel
-    skymap.data_1d["background_rates"] *= skymap.solid_angle / pointing_set.solid_angle
+    skymap.data_1d["bg_rate"] *= skymap.solid_angle / pointing_set.solid_angle
 
     # Get the energy bin widths from a PointingSet (they will all be the same)
     delta_energy = pointing_set.data["energy_bin_delta"]
@@ -368,7 +368,7 @@ def generate_ultra_healpix_skymap(
         # Get corrected count rate with background subtraction applied
         skymap.data_1d["corrected_count_rate"] = (
             skymap.data_1d["counts"].astype(float) / skymap.data_1d["exposure_factor"]
-        ) - skymap.data_1d["background_rates"]
+        ) - skymap.data_1d["bg_rate"]
 
         # Calculate ena_intensity = corrected_counts / (
         # sensitivity * solid_angle * delta_energy)

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -35,7 +35,7 @@ DEFAULT_ULTRA_L2_MAP_STRUCTURE: ena_maps.RectangularSkyMap | ena_maps.HealpixSky
             "values_to_pull_project": [
                 "exposure_factor",
                 "sensitivity",
-                "bg_rate",
+                "background_rates",
             ],
             "nside": 32,
             "nested": False,
@@ -57,7 +57,7 @@ REQUIRED_L1C_VARIABLES_PUSH = [
 REQUIRED_L1C_VARIABLES_PULL = [
     "exposure_factor",
     "sensitivity",
-    "bg_rate",
+    "background_rates",
     "obs_date",
 ]
 # These variables are expected but not strictly required. In certain test scenarios,
@@ -73,7 +73,7 @@ EXPECTED_L1C_VARIABLES_PULL = [
 # weighted by that pointing set pixel's exposure and solid angle
 VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE = [
     "sensitivity",
-    "bg_rate",
+    "background_rates",
     "obs_date",
     "geometric_function",
     "efficiency",
@@ -351,7 +351,7 @@ def generate_ultra_healpix_skymap(
 
     # Background rates must be scaled by the ratio of the solid angles of the
     # map pixel / pointing set pixel
-    skymap.data_1d["bg_rate"] *= skymap.solid_angle / pointing_set.solid_angle
+    skymap.data_1d["background_rates"] *= skymap.solid_angle / pointing_set.solid_angle
 
     # Get the energy bin widths from a PointingSet (they will all be the same)
     delta_energy = pointing_set.data["energy_bin_delta"]
@@ -368,7 +368,7 @@ def generate_ultra_healpix_skymap(
         # Get corrected count rate with background subtraction applied
         skymap.data_1d["corrected_count_rate"] = (
             skymap.data_1d["counts"].astype(float) / skymap.data_1d["exposure_factor"]
-        ) - skymap.data_1d["bg_rate"]
+        ) - skymap.data_1d["background_rates"]
 
         # Calculate ena_intensity = corrected_counts / (
         # sensitivity * solid_angle * delta_energy)

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -148,6 +148,13 @@ def create_dataset(  # noqa: PLR0912
             "background_rates",
             "exposure_factor",
             "helio_exposure_factor",
+        }:
+            dataset[key] = xr.DataArray(
+                data,
+                dims=["epoch", "energy_bin_geometric_mean", "pixel_index"],
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            )
+        elif key in {
             "sensitivity",
             "efficiency",
             "geometric_function",
@@ -156,7 +163,7 @@ def create_dataset(  # noqa: PLR0912
         }:
             dataset[key] = xr.DataArray(
                 data,
-                dims=["epoch", "energy_bin_geometric_mean", "pixel_index"],
+                dims=["energy_bin_geometric_mean", "pixel_index"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in {

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -145,7 +145,7 @@ def create_dataset(  # noqa: PLR0912
             )
         elif key in {
             "counts",
-            "bg_rate",
+            "background_rates",
             "exposure_factor",
             "helio_exposure_factor",
             "sensitivity",

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -145,14 +145,7 @@ def create_dataset(  # noqa: PLR0912
             )
         elif key in {
             "counts",
-            "background_rates",
-        }:
-            dataset[key] = xr.DataArray(
-                data,
-                dims=["epoch", "energy_bin_geometric_mean", "pixel_index"],
-                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
-            )
-        elif key in {
+            "bg_rate",
             "exposure_factor",
             "helio_exposure_factor",
             "sensitivity",
@@ -163,7 +156,7 @@ def create_dataset(  # noqa: PLR0912
         }:
             dataset[key] = xr.DataArray(
                 data,
-                dims=["energy_bin_geometric_mean", "pixel_index"],
+                dims=["epoch", "energy_bin_geometric_mean", "pixel_index"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in {

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -148,6 +148,8 @@ def create_dataset(  # noqa: PLR0912
             "background_rates",
             "exposure_factor",
             "helio_exposure_factor",
+            "sensitivity",
+            "efficiency",
         }:
             dataset[key] = xr.DataArray(
                 data,
@@ -155,8 +157,6 @@ def create_dataset(  # noqa: PLR0912
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         elif key in {
-            "sensitivity",
-            "efficiency",
             "geometric_function",
             "scatter_theta",
             "scatter_phi",


### PR DESCRIPTION
# Change Summary

## Overview
Change CATDESCs to reflect ULTRA IT CATDESCs. Add epoch as dim to new variables (I 

## Updated Files
- imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
   - new catdescs
- imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
   - new catdescs
- imap_processing/ultra/l1c/helio_pset.py ,  imap_processing/ultra/l1c/spacecraft_pset.py
   - add epoch as first dim. This is necessary for ultra l2 maps


