### PR TITLE
2138 hi l2   combine calibration products

### DIFF
--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -302,34 +302,36 @@ def combine_calibration_products(
     ena_flux = map_ds["ena_intensity"]
     sys_err = map_ds["ena_intensity_sys_err"]
 
-    # Calculate improved uncertainty estimates using geometric factor ratios
-    # to reduce bias from Poisson uncertainty estimation
+    # Calculate improved statistical variance estimates using geometric factor
+    # ratios to reduce bias from Poisson uncertainty estimation
     improved_stat_variance = _calculate_improved_stat_variance(
         map_ds, geometric_factors, esa_energies
     )
 
-    # Calculate total uncertainty (quadrature sum of statistical and systematic)
+    # Calculate total variance
+    # Note that sys_err contains uncertainty, so it must be squared to get
+    # the systematic variance needed in this equation.
     total_variance = improved_stat_variance + sys_err**2
 
     # Perform inverse-variance weighted averaging
     # Handle divide by zero and invalid values
     with np.errstate(divide="ignore", invalid="ignore"):
-        flux_weights = 1.0 / total_variance
-
-        # Calculate weights for statistical uncertainty combination using only
-        # statistical uncertainty
+        # Calculate weights for statistical variance combination using only
+        # statistical variance
         stat_weights = 1.0 / improved_stat_variance
 
         # Combined statistical uncertainty from inverse-variance formula
         combined_stat_unc = np.sqrt(1.0 / stat_weights.sum(dim="calibration_prod"))
 
-        # Use total uncertainty weights for flux combination
+        # Use total variance weights for flux combination
+        flux_weights = 1.0 / total_variance
         weighted_flux_sum = (ena_flux * flux_weights).sum(dim="calibration_prod")
         combined_flux = weighted_flux_sum / flux_weights.sum(dim="calibration_prod")
 
     map_ds["ena_intensity"] = combined_flux
     map_ds["ena_intensity_stat_unc"] = combined_stat_unc
-    # For systematic error, take root sum of squares
+    # For systematic error, just do quadrature sum over the systematic error for
+    # each calibration product.
     map_ds["ena_intensity_sys_err"] = np.sqrt((sys_err**2).sum(dim="calibration_prod"))
 
     return map_ds
@@ -341,7 +343,7 @@ def _calculate_improved_stat_variance(
     esa_energies: xr.DataArray,
 ) -> xr.DataArray:
     """
-    Calculate improved statistical uncertainties using geometric factor ratios.
+    Calculate improved statistical variances using geometric factor ratios.
 
     This implements the algorithm from Hi Algorithm Document Section 3.1.2:
     For calibration product X, replace N_X in the uncertainty calculation with
@@ -361,14 +363,14 @@ def _calculate_improved_stat_variance(
 
     Returns
     -------
-    improved_unc : xr.DataArray
-        Improved statistical uncertainty estimates.
+    improved_variance : xr.DataArray
+        Improved statistical variance estimates.
     """
     n_calib_prods = map_ds["ena_intensity"].sizes.get("calibration_prod", 1)
 
     if n_calib_prods <= 1:
         # No improvement possible with single calibration product
-        return map_ds["ena_intensity_stat_unc"]
+        return map_ds["ena_intensity_stat_unc"] ** 2
 
     logger.debug("Computing geometric factor normalized signal rates")
 

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -328,7 +328,9 @@ def combine_calibration_products(
         combined_flux = weighted_flux_sum / weight_sum
 
     map_ds["ena_intensity"] = combined_flux
-    map_ds["ena_intensity_stat_unc"] = improved_stat_unc
+    map_ds["ena_intensity_stat_unc"] = np.sqrt(
+        (improved_stat_unc**2).sum(dim="calibration_prod")
+    )
     # For systematic error, take root sum of squares
     map_ds["ena_intensity_sys_err"] = np.sqrt((sys_err**2).sum(dim="calibration_prod"))
 
@@ -364,16 +366,17 @@ def _calculate_improved_uncertainties(
     improved_unc : xr.DataArray
         Improved statistical uncertainty estimates.
     """
-    n_calib_prods = map_ds["ena_intensity"].sizes["calibration_prod"]
+    n_calib_prods = map_ds["ena_intensity"].sizes.get("calibration_prod", 1)
 
     if n_calib_prods <= 1:
         # No improvement possible with single calibration product
         return map_ds["ena_intensity_stat_unc"]
 
+    logger.debug("Computing geometric factor normalized signal rates")
     # Convert flux back to signal rates: signal_rate = flux * geom_factor
     signal_rates = map_ds["ena_signal_rates"]
 
-    # Compute geometric factor normalized signal rate
+    # Compute geometric factor normalized signal rate (vectorized approach)
     # This represents the weighted average signal rate per unit geometric factor
     geometric_factor_norm_signal_rates = signal_rates.sum(
         dim="calibration_prod"
@@ -383,6 +386,7 @@ def _calculate_improved_uncertainties(
     # averaged_signal_rate_i = geometric_factor_norm_signal_rates * geometric_factor_i
     averaged_signal_rates = geometric_factor_norm_signal_rates * geometric_factors
 
+    logger.debug("Including background rates in uncertainty calculation")
     # Convert averaged signal rates back to flux uncertainties
     # Total count rates for Poisson uncertainty calculation
     total_count_rates_for_uncertainty = averaged_signal_rates + map_ds["bg_rates"]
@@ -392,8 +396,8 @@ def _calculate_improved_uncertainties(
         total_count_rates_for_uncertainty < 1, 1, total_count_rates_for_uncertainty
     )
 
+    logger.debug("Computing improved flux uncertainties")
     # Statistical uncertainty:
-    #     sqrt(total_counts / (exposure_time * geom_factor * esa_energies)
     with np.errstate(divide="ignore", invalid="ignore"):
         improved_unc = np.sqrt(
             total_count_rates_for_uncertainty

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -304,21 +304,21 @@ def combine_calibration_products(
 
     # Calculate improved uncertainty estimates using geometric factor ratios
     # to reduce bias from Poisson uncertainty estimation
-    improved_stat_unc_sq = _calculate_improved_uncertainties(
+    improved_stat_variance = _calculate_improved_stat_variance(
         map_ds, geometric_factors, esa_energies
     )
 
     # Calculate total uncertainty (quadrature sum of statistical and systematic)
-    total_unc_squared = improved_stat_unc_sq + sys_err**2
+    total_variance = improved_stat_variance + sys_err**2
 
     # Perform inverse-variance weighted averaging
     # Handle divide by zero and invalid values
     with np.errstate(divide="ignore", invalid="ignore"):
-        flux_weights = 1.0 / total_unc_squared
+        flux_weights = 1.0 / total_variance
 
         # Calculate weights for statistical uncertainty combination using only
         # statistical uncertainty
-        stat_weights = 1.0 / improved_stat_unc_sq
+        stat_weights = 1.0 / improved_stat_variance
 
         # Combined statistical uncertainty from inverse-variance formula
         combined_stat_unc = np.sqrt(1.0 / stat_weights.sum(dim="calibration_prod"))
@@ -335,7 +335,7 @@ def combine_calibration_products(
     return map_ds
 
 
-def _calculate_improved_uncertainties(
+def _calculate_improved_stat_variance(
     map_ds: xr.Dataset,
     geometric_factors: xr.DataArray,
     esa_energies: xr.DataArray,
@@ -391,7 +391,7 @@ def _calculate_improved_uncertainties(
     logger.debug("Including background rates in uncertainty calculation")
     # Convert averaged signal rates back to flux uncertainties
     # Total count rates for Poisson uncertainty calculation
-    total_count_rates_for_uncertainty = averaged_signal_rates + map_ds["bg_rates"]
+    total_count_rates_for_uncertainty = map_ds["bg_rates"] + averaged_signal_rates
 
     # Ensure non-negative values for sqrt and minimum of 1 for uncertainty calculation
     total_count_rates_for_uncertainty = xr.where(
@@ -399,21 +399,20 @@ def _calculate_improved_uncertainties(
     )
 
     logger.debug("Computing improved flux uncertainties")
-    # Statistical uncertainty:
+    # Statistical variance:
     with np.errstate(divide="ignore", invalid="ignore"):
-        improved_unc = np.sqrt(
-            total_count_rates_for_uncertainty
-            / (map_ds["exposure_factor"] * (geometric_factors * esa_energies))
+        improved_variance = total_count_rates_for_uncertainty / (
+            map_ds["exposure_factor"] * (geometric_factors * esa_energies)
         )
 
     # Handle invalid cases by falling back to original uncertainties
-    improved_unc = xr.where(
-        ~np.isfinite(improved_unc) | (geometric_factors == 0),
+    improved_variance = xr.where(
+        ~np.isfinite(improved_variance) | (geometric_factors == 0),
         map_ds["ena_intensity_stat_unc"],
-        improved_unc,
+        improved_variance,
     )
 
-    return improved_unc
+    return improved_variance
 
 
 def esa_energy_df(

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -141,10 +141,8 @@ def generate_hi_map(
             output_map.data_1d[var] /= output_map.data_1d["exposure_factor"]
 
     output_map.data_1d.update(calculate_ena_signal_rates(output_map.data_1d))
-    output_map.data_1d.update(
-        calculate_ena_intensity(
-            output_map.data_1d, geometric_factors_path, esa_energies_path
-        )
+    output_map.data_1d = calculate_ena_intensity(
+        output_map.data_1d, geometric_factors_path, esa_energies_path
     )
 
     output_map.data_1d["obs_date"].data = output_map.data_1d["obs_date"].data.astype(
@@ -224,7 +222,7 @@ def calculate_ena_intensity(
     map_ds: xr.Dataset,
     geometric_factors_path: str | Path,
     esa_energies_path: str | Path,
-) -> dict[str, xr.DataArray]:
+) -> xr.Dataset:
     """
     Calculate the ena intensities.
 
@@ -239,8 +237,9 @@ def calculate_ena_intensity(
 
     Returns
     -------
-    intensity_vars : dict[str, xarray.DataArray]
-        ENA Intensity with statistical and systematic uncertainties.
+    map_ds : xarray.DataSet
+        Map dataset with new variables: ena_intensity, ena_intensity_stat_unc,
+        ena_intensity_sys_err.
     """
     # read calibration product configuration file
     cal_prod_df = CalibrationProductConfig.from_csv(geometric_factors_path)
@@ -255,29 +254,160 @@ def calculate_ena_intensity(
 
     # Convert ENA Signal Rate to Flux
     flux_conversion_divisor = geometric_factor * esa_energy
-    intensity_vars = {
-        "ena_intensity": map_ds["ena_signal_rates"] / flux_conversion_divisor,
-        "ena_intensity_stat_unc": map_ds["ena_signal_rate_stat_unc"]
-        / flux_conversion_divisor,
-        "ena_intensity_sys_err": map_ds["bg_rates_unc"] / flux_conversion_divisor,
-    }
+    map_ds["ena_intensity"] = map_ds["ena_signal_rates"] / flux_conversion_divisor
+    map_ds["ena_intensity_stat_unc"] = (
+        map_ds["ena_signal_rate_stat_unc"] / flux_conversion_divisor
+    )
+    map_ds["ena_intensity_sys_err"] = map_ds["bg_rates_unc"] / flux_conversion_divisor
 
-    # TODO: Correctly implement combining of calibration products. For now, just sum
-    # Hi groups direct events into distinct calibration products based on coincidence
-    # type. (See L1B processing and Hi Algorithm Document section 6.1.2) When adding
-    # together different calibration products, a different weighting must be used
-    # than exposure time. (See Hi Algorithm Document Section 3.1.2)
-    intensity_vars["ena_intensity"] = intensity_vars["ena_intensity"].sum(
+    # Combine calibration products using proper weighted averaging
+    # as described in Hi Algorithm Document Section 3.1.2
+    map_ds = combine_calibration_products(
+        map_ds,
+        geometric_factor,
+        esa_energy,
+    )
+
+    return map_ds
+
+
+def combine_calibration_products(
+    map_ds: xr.Dataset,
+    geometric_factors: xr.DataArray,
+    esa_energies: xr.DataArray,
+) -> xr.Dataset:
+    """
+    Combine calibration products using weighted averaging.
+
+    Implements the algorithm described in Hi Algorithm Document Section 3.1.2
+    for properly combining data from multiple calibration products.
+
+    Parameters
+    ----------
+    map_ds : xarray.Dataset
+        Map dataset that has preliminary intensity variables computed for each
+        calibration product.
+    geometric_factors : xarray.DataArray
+        Geometric factors for each calibration product and energy step.
+    esa_energies : xarray.DataArray
+        Central energies for each energy step.
+
+    Returns
+    -------
+    map_ds : xarray.DataSet
+        Map dataset with updated variables: ena_intensity, ena_intensity_stat_unc,
+        ena_intensity_sys_err now combined across calibration products at each
+        energy level.
+    """
+    ena_flux = map_ds["ena_intensity"]
+    sys_err = map_ds["ena_intensity_sys_err"]
+
+    # Calculate improved uncertainty estimates using geometric factor ratios
+    # to reduce bias from Poisson uncertainty estimation
+    improved_stat_unc = _calculate_improved_uncertainties(
+        map_ds, geometric_factors, esa_energies
+    )
+
+    # Calculate total uncertainty (quadrature sum of statistical and systematic)
+    total_unc_squared = improved_stat_unc**2 + sys_err**2
+
+    # Perform inverse-variance weighted averaging
+    # Handle divide by zero and invalid values
+    with np.errstate(divide="ignore", invalid="ignore"):
+        weights = 1.0 / total_unc_squared
+        # Set weights to 0 where uncertainty is 0, inf, or nan
+        weights = xr.where(
+            (total_unc_squared == 0) | ~np.isfinite(total_unc_squared), 0, weights
+        )
+
+        # Weighted sum and sum of weights
+        weighted_flux_sum = (ena_flux * weights).sum(dim="calibration_prod")
+        weight_sum = weights.sum(dim="calibration_prod")
+
+        # Combined flux
+        combined_flux = weighted_flux_sum / weight_sum
+
+    map_ds["ena_intensity"] = combined_flux
+    map_ds["ena_intensity_stat_unc"] = improved_stat_unc
+    # For systematic error, take root sum of squares
+    map_ds["ena_intensity_sys_err"] = np.sqrt((sys_err**2).sum(dim="calibration_prod"))
+
+    return map_ds
+
+
+def _calculate_improved_uncertainties(
+    map_ds: xr.Dataset,
+    geometric_factors: xr.DataArray,
+    esa_energies: xr.DataArray,
+) -> xr.DataArray:
+    """
+    Calculate improved statistical uncertainties using geometric factor ratios.
+
+    This implements the algorithm from Hi Algorithm Document Section 3.1.2:
+    For calibration product X, replace N_X in the uncertainty calculation with
+    an improved estimate using geometric factor ratios from all calibration products.
+
+    The key insight is that we can vectorize this by first computing a geometric
+    factor normalized signal rate, then scaling it back for each calibration product.
+
+    Parameters
+    ----------
+    map_ds : xarray.Dataset
+        Map dataset.
+    geometric_factors : xr.DataArray
+        Geometric factors for each calibration product.
+    esa_energies : xarray.DataArray
+        Central energies for each energy step.
+
+    Returns
+    -------
+    improved_unc : xr.DataArray
+        Improved statistical uncertainty estimates.
+    """
+    n_calib_prods = map_ds["ena_intensity"].sizes["calibration_prod"]
+
+    if n_calib_prods <= 1:
+        # No improvement possible with single calibration product
+        return map_ds["ena_intensity_stat_unc"]
+
+    # Convert flux back to signal rates: signal_rate = flux * geom_factor
+    signal_rates = map_ds["ena_signal_rates"]
+
+    # Compute geometric factor normalized signal rate
+    # This represents the weighted average signal rate per unit geometric factor
+    geometric_factor_norm_signal_rates = signal_rates.sum(
         dim="calibration_prod"
-    )
-    intensity_vars["ena_intensity_stat_unc"] = np.sqrt(
-        (intensity_vars["ena_intensity_stat_unc"] ** 2).sum(dim="calibration_prod")
-    )
-    intensity_vars["ena_intensity_sys_err"] = np.sqrt(
-        (intensity_vars["ena_intensity_sys_err"] ** 2).sum(dim="calibration_prod")
+    ) / geometric_factors.sum(dim="calibration_prod")
+
+    # For each calibration product, the averaged signal rate estimate is:
+    # averaged_signal_rate_i = geometric_factor_norm_signal_rates * geometric_factor_i
+    averaged_signal_rates = geometric_factor_norm_signal_rates * geometric_factors
+
+    # Convert averaged signal rates back to flux uncertainties
+    # Total count rates for Poisson uncertainty calculation
+    total_count_rates_for_uncertainty = averaged_signal_rates + map_ds["bg_rates"]
+
+    # Ensure non-negative values for sqrt and minimum of 1 for uncertainty calculation
+    total_count_rates_for_uncertainty = xr.where(
+        total_count_rates_for_uncertainty < 1, 1, total_count_rates_for_uncertainty
     )
 
-    return intensity_vars
+    # Statistical uncertainty:
+    #     sqrt(total_counts / (exposure_time * geom_factor * esa_energies)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        improved_unc = np.sqrt(
+            total_count_rates_for_uncertainty
+            / (map_ds["exposure_factor"] * (geometric_factors * esa_energies))
+        )
+
+    # Handle invalid cases by falling back to original uncertainties
+    improved_unc = xr.where(
+        ~np.isfinite(improved_unc) | (geometric_factors == 0),
+        map_ds["ena_intensity_stat_unc"],
+        improved_unc,
+    )
+
+    return improved_unc
 
 
 def esa_energy_df(

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -314,23 +314,21 @@ def combine_calibration_products(
     # Perform inverse-variance weighted averaging
     # Handle divide by zero and invalid values
     with np.errstate(divide="ignore", invalid="ignore"):
-        weights = 1.0 / total_unc_squared
-        # Set weights to 0 where uncertainty is 0, inf, or nan
-        weights = xr.where(
-            (total_unc_squared == 0) | ~np.isfinite(total_unc_squared), 0, weights
-        )
+        flux_weights = 1.0 / total_unc_squared
 
-        # Weighted sum and sum of weights
-        weighted_flux_sum = (ena_flux * weights).sum(dim="calibration_prod")
-        weight_sum = weights.sum(dim="calibration_prod")
+        # Calculate weights for statistical uncertainty combination using only
+        # statistical uncertainty
+        stat_weights = 1.0 / (improved_stat_unc**2)
 
-        # Combined flux
-        combined_flux = weighted_flux_sum / weight_sum
+        # Combined statistical uncertainty from inverse-variance formula
+        combined_stat_unc = np.sqrt(1.0 / stat_weights.sum(dim="calibration_prod"))
+
+        # Use total uncertainty weights for flux combination
+        weighted_flux_sum = (ena_flux * flux_weights).sum(dim="calibration_prod")
+        combined_flux = weighted_flux_sum / flux_weights.sum(dim="calibration_prod")
 
     map_ds["ena_intensity"] = combined_flux
-    map_ds["ena_intensity_stat_unc"] = np.sqrt(
-        (improved_stat_unc**2).sum(dim="calibration_prod")
-    )
+    map_ds["ena_intensity_stat_unc"] = combined_stat_unc
     # For systematic error, take root sum of squares
     map_ds["ena_intensity_sys_err"] = np.sqrt((sys_err**2).sum(dim="calibration_prod"))
 
@@ -373,17 +371,21 @@ def _calculate_improved_uncertainties(
         return map_ds["ena_intensity_stat_unc"]
 
     logger.debug("Computing geometric factor normalized signal rates")
-    # Convert flux back to signal rates: signal_rate = flux * geom_factor
+
+    # signal_rates = counts / exposure_factor - bg_rates
+    # signal_rates shape is: (n_epoch, n_energy, n_cal_prod, n_spatial_pixels)
     signal_rates = map_ds["ena_signal_rates"]
 
     # Compute geometric factor normalized signal rate (vectorized approach)
     # This represents the weighted average signal rate per unit geometric factor
+    # geometric_factor_norm_signal_rates shape is: (n_epoch, n_energy, n_spatial_pixels)
     geometric_factor_norm_signal_rates = signal_rates.sum(
         dim="calibration_prod"
     ) / geometric_factors.sum(dim="calibration_prod")
 
     # For each calibration product, the averaged signal rate estimate is:
     # averaged_signal_rate_i = geometric_factor_norm_signal_rates * geometric_factor_i
+    # averaged_signal_rates shape is: (n_epoch, n_energy, n_cal_prod, n_spatial_pixels)
     averaged_signal_rates = geometric_factor_norm_signal_rates * geometric_factors
 
     logger.debug("Including background rates in uncertainty calculation")

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -237,7 +237,7 @@ def calculate_ena_intensity(
 
     Returns
     -------
-    map_ds : xarray.DataSet
+    map_ds : xarray.Dataset
         Map dataset with new variables: ena_intensity, ena_intensity_stat_unc,
         ena_intensity_sys_err.
     """
@@ -294,7 +294,7 @@ def combine_calibration_products(
 
     Returns
     -------
-    map_ds : xarray.DataSet
+    map_ds : xarray.Dataset
         Map dataset with updated variables: ena_intensity, ena_intensity_stat_unc,
         ena_intensity_sys_err now combined across calibration products at each
         energy level.

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -304,12 +304,12 @@ def combine_calibration_products(
 
     # Calculate improved uncertainty estimates using geometric factor ratios
     # to reduce bias from Poisson uncertainty estimation
-    improved_stat_unc = _calculate_improved_uncertainties(
+    improved_stat_unc_sq = _calculate_improved_uncertainties(
         map_ds, geometric_factors, esa_energies
     )
 
     # Calculate total uncertainty (quadrature sum of statistical and systematic)
-    total_unc_squared = improved_stat_unc**2 + sys_err**2
+    total_unc_squared = improved_stat_unc_sq + sys_err**2
 
     # Perform inverse-variance weighted averaging
     # Handle divide by zero and invalid values
@@ -318,7 +318,7 @@ def combine_calibration_products(
 
         # Calculate weights for statistical uncertainty combination using only
         # statistical uncertainty
-        stat_weights = 1.0 / (improved_stat_unc**2)
+        stat_weights = 1.0 / improved_stat_unc_sq
 
         # Combined statistical uncertainty from inverse-variance formula
         combined_stat_unc = np.sqrt(1.0 / stat_weights.sum(dim="calibration_prod"))

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -119,6 +119,17 @@ def test_genarate_hi_map(
         {"nominal_central_energy": y, "bandpass_fwhm": np.ones_like(y)}
     )
 
+    def add_zero_intensities(ds, *args):
+        zeros_array = xr.zeros_like(ds["ena_signal_rates"].sum(dim="calibration_prod"))
+        intensity_vars = {
+            "ena_intensity": zeros_array,
+            "ena_intensity_stat_unc": zeros_array,
+            "ena_intensity_sys_err": zeros_array,
+        }
+        return ds.update(intensity_vars)
+
+    mock_calc_ena_intensity.side_effect = add_zero_intensities
+
     kernels = [
         "imap_sclk_0000.tsc",
         "imap_science_100.tf",
@@ -218,6 +229,11 @@ def test_calculate_ena_intensity(
                 np.arange(np.prod(tuple(map_ds.sizes.values()))).reshape(var_shape) % 4
                 + 1,
                 name="ena_signal_rate_stat_unc",
+                dims=list(map_ds.sizes.keys()),
+            ),
+            "bg_rates": xr.DataArray(
+                np.arange(np.prod(tuple(map_ds.sizes.values()))).reshape(var_shape) % 3,
+                name="bg_rates_unc",
                 dims=list(map_ds.sizes.keys()),
             ),
             "bg_rates_unc": xr.DataArray(

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -387,8 +387,8 @@ def test_combine_calibration_products(sample_map_dataset):
     )
 
 
-def test_calculate_improved_uncertainties(sample_map_dataset):
-    """Test _calculate_improved_uncertainties function"""
+def test_calculate_improved_variance(sample_map_dataset):
+    """Test _calculate_improved_stat_variance function"""
     test_ds, geometric_factors, esa_energies = sample_map_dataset
 
     improved_unc = _calculate_improved_stat_variance(
@@ -404,8 +404,8 @@ def test_calculate_improved_uncertainties(sample_map_dataset):
     assert np.all(np.isfinite(improved_unc.values))
 
 
-def test_calculate_improved_uncertainties_single_product():
-    """Test improved uncertainties with single calibration product"""
+def test_calculate_improved_variance_single_product():
+    """Test improved variance with single calibration product"""
     coords = {
         "epoch": 1,
         "esa_energy_step": 1,
@@ -431,13 +431,13 @@ def test_calculate_improved_uncertainties_single_product():
         }
     )
 
-    improved_unc = _calculate_improved_stat_variance(
+    improved_var = _calculate_improved_stat_variance(
         test_ds, geom_factors, esa_energies
     )
 
     # With single product, should return original uncertainties
     np.testing.assert_array_equal(
-        improved_unc.values, test_ds["ena_intensity_stat_unc"].values
+        improved_var.values, test_ds["ena_intensity_stat_unc"].values ** 2
     )
 
 

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -11,8 +11,10 @@ import xarray as xr
 from imap_processing.cdf.utils import write_cdf
 from imap_processing.ena_maps.ena_maps import RectangularSkyMap
 from imap_processing.hi.hi_l2 import (
+    _calculate_improved_stat_variance,
     calculate_ena_intensity,
     calculate_ena_signal_rates,
+    combine_calibration_products,
     esa_energy_df,
     generate_hi_map,
     hi_l2,
@@ -51,6 +53,74 @@ def esa_energies_lut_path(hi_l1_test_data_path):
 @pytest.fixture
 def geometric_factors_path(hi_l1_test_data_path):
     return hi_l1_test_data_path / "imap_hi_90sensor-cal-prod_20240101_v001.csv"
+
+
+@pytest.fixture
+def sample_map_dataset():
+    """Generate a realistic map dataset for testing calibration product combining"""
+    coords = {
+        "epoch": 1,
+        "esa_energy_step": 3,
+        "calibration_prod": 3,
+        "longitude": 4,
+        "latitude": 2,
+    }
+
+    coords = {
+        k: xr.DataArray(
+            np.arange(v) + 1 if k == "esa_energy_step" else np.arange(v),
+            name=k,
+            dims=[k],
+        )
+        for k, v in coords.items()
+    }
+
+    # Create fake geometric factors (different sensitivities)
+    geometric_factors = xr.DataArray(
+        np.array([[1.0, 2.0, 0.5], [1.5, 3.0, 0.75], [2.0, 4.0, 1.0]]),
+        dims=["esa_energy_step", "calibration_prod"],
+    )
+
+    # ESA energies
+    esa_energies = xr.DataArray(
+        np.array([0.5, 0.75, 1.1]),
+        dims=["esa_energy_step"],
+    )
+
+    # Create sample data with some realistic structure
+    shape = tuple(darray.size for darray in coords.values())
+
+    np.random.seed(42)  # For reproducible tests
+
+    # Create test dataset
+    test_ds = xr.Dataset(
+        {
+            "ena_signal_rates": xr.DataArray(
+                np.random.rand(*shape) * 1000 + 100, dims=list(coords.keys())
+            ),
+            "ena_intensity": xr.DataArray(
+                np.random.rand(*shape) * 100 + 50, dims=list(coords.keys())
+            ),
+            "ena_intensity_stat_unc": xr.DataArray(
+                np.random.rand(*shape) * 10 + 5, dims=list(coords.keys())
+            ),
+            "ena_intensity_sys_err": xr.DataArray(
+                np.random.rand(*shape) * 5 + 1, dims=list(coords.keys())
+            ),
+            "bg_rates": xr.DataArray(
+                np.random.rand(*shape) * 20 + 5, dims=list(coords.keys())
+            ),
+            "bg_rates_unc": xr.DataArray(
+                np.random.rand(*shape) * 2 + 1, dims=list(coords.keys())
+            ),
+            "exposure_factor": xr.DataArray(
+                np.random.rand(*shape) * 5 + 1, dims=list(coords.keys())
+            ),
+        },
+        coords=coords,
+    )
+
+    return test_ds, geometric_factors, esa_energies
 
 
 @pytest.mark.external_test_data
@@ -118,17 +188,7 @@ def test_genarate_hi_map(
     mock_esa_energy_lookup.side_effect = lambda x, y: pd.DataFrame(
         {"nominal_central_energy": y, "bandpass_fwhm": np.ones_like(y)}
     )
-
-    def add_zero_intensities(ds, *args):
-        zeros_array = xr.zeros_like(ds["ena_signal_rates"].sum(dim="calibration_prod"))
-        intensity_vars = {
-            "ena_intensity": zeros_array,
-            "ena_intensity_stat_unc": zeros_array,
-            "ena_intensity_sys_err": zeros_array,
-        }
-        return ds.update(intensity_vars)
-
-    mock_calc_ena_intensity.side_effect = add_zero_intensities
+    mock_calc_ena_intensity.side_effect = lambda x, y, z: x
 
     kernels = [
         "imap_sclk_0000.tsc",
@@ -210,10 +270,22 @@ def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):
     assert np.nanmin(signal_rates_vars["ena_signal_rate_stat_unc"].values) == 1 / 2
 
 
+@patch("imap_processing.hi.utils.CalibrationProductConfig.from_csv")
 def test_calculate_ena_intensity(
-    empty_rectangular_map_dataset, esa_energies_lut_path, geometric_factors_path
+    mock_cal_prod_config, empty_rectangular_map_dataset, esa_energies_lut_path
 ):
     """Test coverage for calculate_ena_intensity"""
+    # Mock the calibration product configuration
+    mock_cal_prod_instance = Mock()
+    mock_xarray = Mock()
+    mock_xarray.reindex_like.return_value = {
+        "geometric_factor": xr.DataArray(
+            np.ones((3, 2)), dims=["esa_energy_step", "calibration_prod"]
+        )
+    }
+    mock_cal_prod_instance.to_xarray.return_value = mock_xarray
+    mock_cal_prod_config.return_value = mock_cal_prod_instance
+
     # Start with an empty (coords only) dataset
     map_ds = empty_rectangular_map_dataset
     # Add some data_vars needed for the ena intensity calculations
@@ -231,41 +303,315 @@ def test_calculate_ena_intensity(
                 name="ena_signal_rate_stat_unc",
                 dims=list(map_ds.sizes.keys()),
             ),
-            "bg_rates": xr.DataArray(
-                np.arange(np.prod(tuple(map_ds.sizes.values()))).reshape(var_shape) % 3,
-                name="bg_rates_unc",
-                dims=list(map_ds.sizes.keys()),
-            ),
             "bg_rates_unc": xr.DataArray(
                 np.arange(np.prod(tuple(map_ds.sizes.values()))).reshape(var_shape) % 3,
                 name="bg_rates_unc",
                 dims=list(map_ds.sizes.keys()),
             ),
+        }
+    )
+
+    # Add required background data
+    bg_shape = tuple(
+        map_ds.sizes[k] for k in map_ds.sizes.keys() if k != "calibration_prod"
+    )
+    map_ds.update(
+        {
+            "bg_rates": xr.DataArray(
+                np.ones(bg_shape) * 5.0,
+                dims=[d for d in map_ds.sizes.keys() if d != "calibration_prod"],
+            ),
             "exposure_factor": xr.DataArray(
-                np.arange(np.prod(tuple(map_ds.sizes.values()))).reshape(var_shape) % 7,
-                name="bg_rates_unc",
-                dims=list(map_ds.sizes.keys()),
+                np.ones(bg_shape) * 2.0,
+                dims=[d for d in map_ds.sizes.keys() if d != "calibration_prod"],
             ),
         }
     )
-    ena_intesity_vars = calculate_ena_intensity(
-        map_ds, geometric_factors_path, esa_energies_lut_path
+
+    result_ds = calculate_ena_intensity(
+        map_ds, "dummy_geom_path", esa_energies_lut_path
     )
 
-    # TODO: add value/functional test checks once the full algorithm is implemented
     for var_name in [
         "ena_intensity",
         "ena_intensity_stat_unc",
         "ena_intensity_sys_err",
     ]:
-        assert var_name in ena_intesity_vars
+        assert var_name in result_ds
+        # Check that calibration_prod dimension has been removed
+        assert "calibration_prod" not in result_ds[var_name].dims
+
+
+def test_combine_calibration_products(sample_map_dataset):
+    """Test coverage for combine_calibration_products"""
+    test_ds, geometric_factors, esa_energies = sample_map_dataset
+
+    # Make a copy to avoid modifying the fixture
+    test_ds_copy = test_ds.copy(deep=True)
+
+    result_ds = combine_calibration_products(
+        test_ds_copy, geometric_factors, esa_energies
+    )
+
+    # Check that all expected variables are present
+    expected_vars = ["ena_intensity", "ena_intensity_stat_unc", "ena_intensity_sys_err"]
+    for var_name in expected_vars:
+        assert var_name in result_ds
+        # Check that calibration_prod dimension has been removed
+        assert "calibration_prod" not in result_ds[var_name].dims
+        # Check that other dimensions are preserved
+        expected_dims = [
+            d for d in test_ds["ena_intensity"].dims if d != "calibration_prod"
+        ]
+        assert list(result_ds[var_name].dims) == expected_dims
+
+    # Check that combined flux is finite where input data is valid
+    combined_flux = result_ds["ena_intensity"]
+    assert np.any(np.isfinite(combined_flux.values)), (
+        "No valid combined flux values produced"
+    )
+
+    # Check that combined uncertainty is reasonable
+    combined_unc = result_ds["ena_intensity_stat_unc"]
+    assert np.all(combined_unc.values[np.isfinite(combined_unc.values)] >= 0), (
+        "Combined uncertainty should be non-negative"
+    )
+
+    # Check systematic error combination (root sum of squares)
+    input_sys_err = test_ds["ena_intensity_sys_err"]
+    expected_sys_err = np.sqrt((input_sys_err**2).sum(dim="calibration_prod"))
+    combined_sys_err = result_ds["ena_intensity_sys_err"]
+
+    np.testing.assert_array_almost_equal(
+        combined_sys_err.values, expected_sys_err.values, decimal=10
+    )
+
+
+def test_calculate_improved_uncertainties(sample_map_dataset):
+    """Test _calculate_improved_uncertainties function"""
+    test_ds, geometric_factors, esa_energies = sample_map_dataset
+
+    improved_unc = _calculate_improved_stat_variance(
+        test_ds, geometric_factors, esa_energies
+    )
+
+    # Check that result has same shape as input statistical uncertainties
+    original_unc = test_ds["ena_intensity_stat_unc"]
+    assert improved_unc.shape == original_unc.shape
+
+    # Check that improved uncertainties are finite and non-negative
+    assert np.all(improved_unc.values >= 0)
+    assert np.all(np.isfinite(improved_unc.values))
+
+
+def test_calculate_improved_uncertainties_single_product():
+    """Test improved uncertainties with single calibration product"""
+    coords = {
+        "epoch": 1,
+        "esa_energy_step": 1,
+        "calibration_prod": 1,
+        "longitude": 1,
+        "latitude": 1,
+    }
+
+    geom_factors = xr.DataArray(
+        np.array([[1.0]]), dims=["esa_energy_step", "calibration_prod"]
+    )
+
+    esa_energies = xr.DataArray(np.array([1.0]), dims=["esa_energy_step"])
+
+    test_ds = xr.Dataset(
+        {
+            "ena_intensity": xr.DataArray(
+                np.array([[[[[100.0]]]]]), dims=list(coords.keys())
+            ),
+            "ena_intensity_stat_unc": xr.DataArray(
+                np.array([[[[[10.0]]]]]), dims=list(coords.keys())
+            ),
+        }
+    )
+
+    improved_unc = _calculate_improved_stat_variance(
+        test_ds, geom_factors, esa_energies
+    )
+
+    # With single product, should return original uncertainties
+    np.testing.assert_array_equal(
+        improved_unc.values, test_ds["ena_intensity_stat_unc"].values
+    )
 
 
 def test_esa_energy_lookup(esa_energies_lut_path):
-    """Test coverage for esa_energy_lookup()"""
+    """Test coverage for esa_energy_df()"""
     esa_energy_steps = np.array([1, 2, 3, 3, 7, 8, 9])
     expected_energies = np.array([0.5, 0.75, 1.1, 1.1, 5.7, 8.52, 12.8])
     energy_df = esa_energy_df(esa_energies_lut_path, esa_energy_steps)
     retrieved_energies = energy_df["nominal_central_energy"].values
     np.testing.assert_array_equal(retrieved_energies, expected_energies)
     assert "bandpass_fwhm" in energy_df
+
+
+def test_weighted_average_mathematical_correctness():
+    """Test mathematical properties of the weighted average"""
+    # Create a simple test case where we can verify the weighted average manually
+    coords = {
+        "epoch": 1,
+        "esa_energy_step": 1,
+        "calibration_prod": 2,
+        "longitude": 1,
+        "latitude": 1,
+    }
+
+    # Simple test data
+    flux_values = np.array([100.0, 200.0]).reshape(1, 1, 2, 1, 1)
+    stat_unc_values = np.array([10.0, 20.0]).reshape(1, 1, 2, 1, 1)
+    sys_err_values = np.array([5.0, 10.0]).reshape(1, 1, 2, 1, 1)
+
+    test_ds = xr.Dataset(
+        {
+            "ena_intensity": xr.DataArray(flux_values, dims=list(coords.keys())),
+            "ena_intensity_stat_unc": xr.DataArray(
+                stat_unc_values, dims=list(coords.keys())
+            ),
+            "ena_intensity_sys_err": xr.DataArray(
+                sys_err_values, dims=list(coords.keys())
+            ),
+            "ena_signal_rates": xr.DataArray(
+                np.array([100.0, 400.0]).reshape(1, 1, 2, 1, 1),
+                dims=list(coords.keys()),
+            ),
+            "bg_rates": xr.DataArray(
+                np.array([5.0]).reshape(1, 1, 1, 1),
+                dims=[d for d in coords.keys() if d != "calibration_prod"],
+            ),
+            "exposure_factor": xr.DataArray(
+                np.array([2.0]).reshape(1, 1, 1, 1),
+                dims=[d for d in coords.keys() if d != "calibration_prod"],
+            ),
+        }
+    )
+
+    geom_factors = xr.DataArray(
+        np.array([[1.0, 2.0]]), dims=["esa_energy_step", "calibration_prod"]
+    )
+
+    esa_energies = xr.DataArray(np.array([1.0]), dims=["esa_energy_step"])
+
+    result_ds = combine_calibration_products(test_ds, geom_factors, esa_energies)
+
+    # Check that results are finite and reasonable
+    assert np.isfinite(result_ds["ena_intensity"].values[0, 0, 0, 0])
+    assert result_ds["ena_intensity_stat_unc"].values[0, 0, 0, 0] > 0
+    assert result_ds["ena_intensity_sys_err"].values[0, 0, 0, 0] > 0
+
+    # Systematic error should be root sum of squares
+    expected_sys_err = np.sqrt(5.0**2 + 10.0**2)
+    np.testing.assert_almost_equal(
+        result_ds["ena_intensity_sys_err"].values[0, 0, 0, 0],
+        expected_sys_err,
+        decimal=10,
+    )
+
+
+def test_statistical_uncertainty_combination_correctness():
+    """Test that statistical uncertainties are combined correctly."""
+    coords = {
+        "epoch": 1,
+        "esa_energy_step": 1,
+        "calibration_prod": 2,
+        "longitude": 1,
+        "latitude": 1,
+    }
+
+    # Create simple case with known statistical uncertainties
+    stat_unc_values = np.array([5.0, 10.0]).reshape(1, 1, 2, 1, 1)
+    sys_err_values = np.array([2.0, 4.0]).reshape(1, 1, 2, 1, 1)
+    flux_values = np.array([100.0, 200.0]).reshape(1, 1, 2, 1, 1)
+
+    test_ds = xr.Dataset(
+        {
+            "ena_intensity": xr.DataArray(flux_values, dims=list(coords.keys())),
+            "ena_intensity_stat_unc": xr.DataArray(
+                stat_unc_values, dims=list(coords.keys())
+            ),
+            "ena_intensity_sys_err": xr.DataArray(
+                sys_err_values, dims=list(coords.keys())
+            ),
+            "ena_signal_rates": xr.DataArray(flux_values, dims=list(coords.keys())),
+            "bg_rates": xr.DataArray(
+                np.array([1.0, 1.0]).reshape(1, 1, 2, 1, 1), dims=list(coords.keys())
+            ),
+            "exposure_factor": xr.DataArray(
+                np.array([1.0, 1.0]).reshape(1, 1, 2, 1, 1), dims=list(coords.keys())
+            ),
+        }
+    )
+
+    geom_factors = xr.DataArray(
+        np.array([[1.0, 1.0]]),  # Equal geometric factors for simplicity
+        dims=["esa_energy_step", "calibration_prod"],
+    )
+
+    esa_energies = xr.DataArray(np.array([1.0]), dims=["esa_energy_step"])
+
+    result_ds = combine_calibration_products(test_ds, geom_factors, esa_energies)
+
+    # Manual calculation of expected statistical uncertainty combination
+    # stat_weights = 1/σ² = [1/151, 1/151]
+    # combined_stat_unc = sqrt(1/sum(stat_weights)) = sqrt(2/151) = sqrt(20) ≈ 4.47
+    stat_weights = 1.0 / (np.array([151, 151]))
+    expected_combined_stat_unc = np.sqrt(1.0 / np.sum(stat_weights))
+    flux_weights = 1.0 / (np.array([151, 151]) + np.array([4, 16]))
+    expected_flux = np.sum(flux_values.squeeze() * flux_weights) / np.sum(flux_weights)
+
+    np.testing.assert_almost_equal(
+        result_ds["ena_intensity_stat_unc"].values,
+        expected_combined_stat_unc,
+        decimal=10,
+    )
+
+    np.testing.assert_almost_equal(
+        result_ds["ena_intensity"].values, expected_flux, decimal=10
+    )
+
+
+def test_combine_calibration_products_edge_cases():
+    """Test edge cases for combine_calibration_products"""
+    # Test with single calibration product
+    coords = {
+        "epoch": 1,
+        "esa_energy_step": 1,
+        "calibration_prod": 1,
+        "longitude": 1,
+        "latitude": 1,
+    }
+
+    test_ds = xr.Dataset(
+        {
+            "ena_intensity": xr.DataArray(
+                np.array([100.0]).reshape(1, 1, 1, 1, 1), dims=list(coords.keys())
+            ),
+            "ena_intensity_stat_unc": xr.DataArray(
+                np.array([10.0]).reshape(1, 1, 1, 1, 1), dims=list(coords.keys())
+            ),
+            "ena_intensity_sys_err": xr.DataArray(
+                np.array([5.0]).reshape(1, 1, 1, 1, 1), dims=list(coords.keys())
+            ),
+        }
+    )
+
+    geom_factors = xr.DataArray(
+        np.array([[1.0]]), dims=["esa_energy_step", "calibration_prod"]
+    )
+
+    esa_energies = xr.DataArray(np.array([1.0]), dims=["esa_energy_step"])
+
+    result_ds = combine_calibration_products(test_ds, geom_factors, esa_energies)
+
+    # With single calibration product, should return dataset unchanged
+    # (but without calib_prod dim). The intensity value should be the same.
+    np.testing.assert_almost_equal(result_ds["ena_intensity"].values[0, 0, 0, 0], 100.0)
+
+    # Check that calibration_prod dimension was removed
+    for var in ["ena_intensity", "ena_intensity_stat_unc", "ena_intensity_sys_err"]:
+        assert "calibration_prod" not in result_ds[var].dims

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -241,6 +241,11 @@ def test_calculate_ena_intensity(
                 name="bg_rates_unc",
                 dims=list(map_ds.sizes.keys()),
             ),
+            "exposure_factor": xr.DataArray(
+                np.arange(np.prod(tuple(map_ds.sizes.values()))).reshape(var_shape) % 7,
+                name="bg_rates_unc",
+                dims=list(map_ds.sizes.keys()),
+            ),
         }
     )
     ena_intesity_vars = calculate_ena_intensity(


### PR DESCRIPTION
# Change Summary

## Overview
This implements the algorithm for combining calibration products. The correctness of the algorithm is in review by Paul. Claude (AI) was used to help write test coverage.

## Updated Files
- imap_processing/hi/hi_l2.py
   - Have `calculate_ena_intensity` modify the data_1d dataset directly.
   - Add function `combine_calibration_products` to correctly combine fluxes from different calibration products.
   - Add `_calculate_improved_stat_variance` helper function for combining calibration product fluxes.
- imap_processing/tests/hi/test_hi_l2.py
   - Used claude (AI) to help wrtie test coverage for new functions in hi_l2.py

Closes: #2138 
