### PR TITLE
ULTRA l2 handle pointing independent vars 

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -190,8 +190,7 @@ sensitivity:
   CATDESC: Averaged instrument sensitive area.
   FIELDNAM: Sensitivity
   UNITS: cm^2
-  DEPEND_0: epoch
-  VAR_TYPE: data
+  VAR_TYPE: support_data
   LABLAXIS: sensitivity
   DISPLAY_TYPE: image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:GeometricFactor,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
@@ -222,8 +221,7 @@ efficiency:
   CATDESC: Efficiency of the instrument in converting ENAs to valid events.
   FIELDNAM: Efficiency
   UNITS: " "
-  DEPEND_0: epoch
-  VAR_TYPE: data
+  VAR_TYPE: support_data
   LABLAXIS: Efficiency
   DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:Other

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -68,7 +68,6 @@ sensitivity:
   CATDESC: Averaged instrument sensitive area.
   FIELDNAM: sensitivity
   LABLAXIS: sensitivity
-  DEPEND_0: epoch
   # TODO: come back to format
   UNITS: cm^2
 
@@ -86,7 +85,6 @@ efficiency:
   FIELDNAM: efficiency
   LABLAXIS: Efficiency
   UNITS: " "
-  DEPEND_0: epoch
   VALIDMIN: 0.0
   VALIDMAX: 1.0
 

--- a/imap_processing/tests/ultra/mock_data.py
+++ b/imap_processing/tests/ultra/mock_data.py
@@ -317,8 +317,8 @@ def mock_l1c_pset_product_healpix(
     counts = counts.astype(int)
     # add an epoch dimension
     counts = np.expand_dims(counts, axis=0)
-    sensitivity = np.ones_like(counts)
-    geometric_function = sensitivity[0]  # pointing independent
+    sensitivity = np.ones_like(counts)[0]  # pointing independent
+    geometric_function = sensitivity  # pointing independent
 
     # Determine the epoch, which is TT time in nanoseconds since J2000 epoch
     tdb_et = str_to_et(timestr)
@@ -353,7 +353,6 @@ def mock_l1c_pset_product_healpix(
             ),
             "sensitivity": (
                 [
-                    CoordNames.TIME.value,
                     CoordNames.ENERGY_ULTRA_L1C.value,
                     CoordNames.HEALPIX_INDEX.value,
                 ],

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -70,8 +70,8 @@ class TestUltraL2:
             # Add extra ultra specific variables to each pset
             for pset in self.ultra_psets:
                 pset["efficiency"] = xr.ones_like(pset["sensitivity"])
-                pset["scatter_theta"] = xr.ones_like(pset["geometric_function"])
-                pset["scatter_phi"] = xr.ones_like(pset["geometric_function"])
+                pset["scatter_theta"] = xr.ones_like(pset["sensitivity"])
+                pset["scatter_phi"] = xr.ones_like(pset["sensitivity"])
 
         self.psets_total_counts = np.sum(
             [pset["counts"].values.sum() for pset in self.ultra_psets]
@@ -106,13 +106,11 @@ class TestUltraL2:
         pset["exposure_factor"].values = np.ones_like(pset["exposure_factor"])
         pset["background_rates"].values = np.ones_like(pset["background_rates"].values)
         pset["sensitivity"].values = np.ones_like(pset["sensitivity"].values)
-        pset["geometric_function"].values = np.ones_like(
-            pset["geometric_function"].values
-        )
+        pset["geometric_function"].values = np.ones_like(pset["sensitivity"].values)
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
         pset["efficiency"] = xr.ones_like(pset["sensitivity"])
-        pset["scatter_theta"] = xr.ones_like(pset["geometric_function"])
-        pset["scatter_phi"] = xr.ones_like(pset["geometric_function"])
+        pset["scatter_theta"] = xr.ones_like(pset["sensitivity"])
+        pset["scatter_phi"] = xr.ones_like(pset["sensitivity"])
 
         pset["energy_bin_delta"].values = np.ones_like(pset["energy_bin_delta"].values)
         if epoch_dim_for_energy_delta:
@@ -355,10 +353,10 @@ class TestUltraL2:
         assert hp_skymap.data_1d["ena_intensity"].dims == counts_dims
         assert hp_skymap.data_1d["ena_intensity_stat_unc"].dims == counts_dims
         assert hp_skymap.data_1d["exposure_factor"].dims == counts_dims
-        assert hp_skymap.data_1d["sensitivity"].dims == counts_dims
         assert hp_skymap.data_1d["background_rates"].dims == counts_dims
-        assert hp_skymap.data_1d["efficiency"].dims == counts_dims
 
+        assert hp_skymap.data_1d["sensitivity"].dims == pointing_independent_dims
+        assert hp_skymap.data_1d["efficiency"].dims == pointing_independent_dims
         assert hp_skymap.data_1d["geometric_function"].dims == pointing_independent_dims
         assert hp_skymap.data_1d["scatter_theta"].dims == pointing_independent_dims
         assert hp_skymap.data_1d["scatter_phi"].dims == pointing_independent_dims

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -181,8 +181,8 @@ def calculate_helio_pset(
     pset_dict["energy_bin_delta"] = np.diff(intervals, axis=1).squeeze()[
         np.newaxis, ...
     ]
-    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
-    pset_dict["efficiency"] = efficiencies[np.newaxis, ...]
+    pset_dict["sensitivity"] = sensitivity
+    pset_dict["efficiency"] = efficiencies
     pset_dict["geometric_function"] = geometric_function
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -191,8 +191,8 @@ def calculate_spacecraft_pset(
     ]
     pset_dict["quality_flags"] = spacecraft_pset_quality_flags[np.newaxis, ...]
 
-    pset_dict["sensitivity"] = sensitivity[np.newaxis, ...]
-    pset_dict["efficiency"] = efficiencies[np.newaxis, ...]
+    pset_dict["sensitivity"] = sensitivity
+    pset_dict["efficiency"] = efficiencies
     pset_dict["geometric_function"] = geometric_function
     pset_dict["dead_time_ratio"] = deadtime_ratios
     pset_dict["spin_phase_step"] = np.arange(len(deadtime_ratios))

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -56,20 +56,18 @@ REQUIRED_L1C_VARIABLES_PUSH = [
 ]
 REQUIRED_L1C_VARIABLES_PULL = [
     "exposure_factor",
-    "sensitivity",
     "background_rates",
     "obs_date",
 ]
 # These variables are expected but not strictly required. In certain test scenarios,
 # they may be missing, in which case we will raise a warning and continue.
 # All psets must be consistent and either have these variables or not.
-EXPECTED_L1C_VARIABLES_PULL = [
-    "efficiency",
-]
 EXPECTED_L1C_POINTING_INDEPENDENT_VARIABLES_PULL = [
     "geometric_function",
     "scatter_theta",
     "scatter_phi",
+    "sensitivity",
+    "efficiency",
 ]
 # These variables are projected to the map as the mean of pointing set pixels value,
 # weighted by that pointing set pixel's exposure and solid angle
@@ -77,6 +75,9 @@ VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE = [
     "sensitivity",
     "background_rates",
     "obs_date",
+    "scatter_theta",
+    "scatter_phi",
+    "geometric_function",
     "efficiency",
 ]
 
@@ -250,21 +251,12 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
     # TODO remove this in the future once all test data includes these variables
     # Add expected but not required variables to the pull projection list
     # Log a warning if they are missing from any PSET but continue processing.
-    expected_present_vars = []
     expected_present_vars_pointing_ind = []
     first_pset = (
         load_cdf(ultra_l1c_psets[0])
         if isinstance(ultra_l1c_psets[0], (str, Path))
         else ultra_l1c_psets[0]
     )
-    for var in EXPECTED_L1C_VARIABLES_PULL:
-        if var not in first_pset.variables:
-            logger.warning(
-                f"Expected variable {var} not found in the first L1C PSET. "
-                "This variable will not be projected to the map."
-            )
-        else:
-            expected_present_vars.append(var)
 
     for var in EXPECTED_L1C_POINTING_INDEPENDENT_VARIABLES_PULL:
         if var not in first_pset.variables:
@@ -275,12 +267,24 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
         else:
             expected_present_vars_pointing_ind.append(var)
 
+    # Get existing variables that should be weighted by exposure and solid angle
+    existing_vars_to_weight = []
+    pointing_indep_vars = []
+    for var in VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE:
+        if var in first_pset:
+            existing_vars_to_weight.append(var)
+            if "epoch" not in first_pset[var].dims:
+                pointing_indep_vars.append(var)
+
     output_map_structure.values_to_pull_project = list(
-        set(output_map_structure.values_to_pull_project + expected_present_vars)
+        set(
+            output_map_structure.values_to_pull_project
+            + expected_present_vars_pointing_ind
+        )
     )
 
     all_pset_epochs = []
-    for i, ultra_l1c_pset in enumerate(ultra_l1c_psets):
+    for ultra_l1c_pset in ultra_l1c_psets:
         pointing_set = ena_maps.UltraPointingSet(ultra_l1c_pset)
         all_pset_epochs.append(pointing_set.epoch)
         logger.info(
@@ -323,12 +327,11 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
             pointing_set.data["exposure_factor"] * pointing_set.solid_angle
         )
 
-        # Get variables that should be weighted by exposure and solid angle
-        existing_vars_to_weight = []
-        for var in VARIABLES_TO_WEIGHT_BY_POINTING_SET_EXPOSURE_TIMES_SOLID_ANGLE:
-            if var in pointing_set.data:
-                existing_vars_to_weight.append(var)
-
+        # if the variable does not have an epoch dimension, add one temporarily
+        # to allow for correct broadcasting during weighting.
+        # Keep track of which variables were modified so we can revert them later.
+        for var in pointing_indep_vars:
+            pointing_set.data[var] = pointing_set.data[var].expand_dims("epoch", axis=0)
         # Initial processing for weighted quantities at PSET level
         # Weight the values by exposure and solid angle
         # Ensure only valid pointing set pixels contribute to the weighted mean.
@@ -352,19 +355,14 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
             index_match_method=ena_maps.IndexMatchMethod.PULL,
             pset_valid_mask=good_pixel_mask,
         )
-        if i == 0:
-            # Pull pointing independent variables if they exist in the PSETs
-            # Use first pset
-            skymap.project_pset_values_to_map(
-                pointing_set=pointing_set,
-                value_keys=expected_present_vars_pointing_ind,
-                index_match_method=ena_maps.IndexMatchMethod.PULL,
-                pset_valid_mask=good_pixel_mask,
-            )
+
     # Subsequent processing for weighted quantities at SkyMap level
     skymap.data_1d[existing_vars_to_weight] /= skymap.data_1d[
         "pointing_set_exposure_times_solid_angle"
     ]
+    # Revert any pointing independent variables back to their original dims
+    for var in pointing_indep_vars:
+        skymap.data_1d[var] = skymap.data_1d[var].squeeze("epoch", drop=True)
 
     # Background rates must be scaled by the ratio of the solid angles of the
     # map pixel / pointing set pixel

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -326,7 +326,7 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
         pointing_set.data["pointing_set_exposure_times_solid_angle"] = (
             pointing_set.data["exposure_factor"] * pointing_set.solid_angle
         )
-
+        # TODO add generalized code in ena_maps to handle this
         # if the variable does not have an epoch dimension, add one temporarily
         # to allow for correct broadcasting during weighting.
         # Keep track of which variables were modified so we can revert them later.

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -148,8 +148,6 @@ def create_dataset(  # noqa: PLR0912
             "background_rates",
             "exposure_factor",
             "helio_exposure_factor",
-            "sensitivity",
-            "efficiency",
         }:
             dataset[key] = xr.DataArray(
                 data,
@@ -160,6 +158,8 @@ def create_dataset(  # noqa: PLR0912
             "geometric_function",
             "scatter_theta",
             "scatter_phi",
+            "sensitivity",
+            "efficiency",
         }:
             dataset[key] = xr.DataArray(
                 data,


### PR DESCRIPTION
# Change Summary

## Overview
I had misunderstood a conversation with the IT team (Nick) and thought that efficiency and sensitivity were pointing dependent. After a slack thread discussion about this (over 100 😄  - new record for me), I have all of the new variables set and feel confident. Since efficiency and sensitivity are no longer pointing dependent AND they need to be weighted by exposure factor, this required some slightly refactor to allow for broadcasting. 

I also misunderstood how pointing independent vars should be projected to the map. I had only pushed them once but they should also be accumulated and weighted: 
<img width="894" height="819" alt="Screenshot 2025-09-17 at 3 30 55 PM" src="https://github.com/user-attachments/assets/eb4de983-f86d-4889-b263-b1588a8fd684" />


From Nick: 

"You have to sum all that stuff with exposure time (and solid angle if the maps / pixels are different sizes)
then divide out by the total
It's a weighted mean, where the exposure is the weighting factor
efficiency shouldn't change per Pointing, neither should the sensitivity.  I think the only thing that will really is the exposure time" 


## Updated Files
- imap_processing/ultra/l2/ultra_l2.py
   - Add handling of pointing independent vars. 
   - Removed handling to only push pointing independent vars once. They should still be accumulated and weighted 

## Testing
Fix arrays to have correct dims
