### PR TITLE
Lo L1B & L1C - Updated Badtimes and Goodtimes functions to use bin and E-Step columns

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -710,9 +710,6 @@ def set_bad_times(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
     for start, end in zip(badtimes_start, badtimes_end, strict=False):
         badtimes_mask |= (l1b_de["epoch"] >= start) & (l1b_de["epoch"] <= end)
 
-
-
-
     # 1 = badtime, 0 = not badtime
     l1b_de["badtimes"] = xr.DataArray(
         np.zeros(len(l1b_de["epoch"]), dtype=int),

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -5,7 +5,7 @@ from dataclasses import Field
 from pathlib import Path
 
 import numpy as np
-import pandas
+import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
@@ -723,7 +723,7 @@ def set_bad_times(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
 
 
 def set_bad_or_goodtimes(
-    times_df: pandas.DataFrame,
+    times_df: pd.DataFrame,
     epochs: np.ndarray,
     esa_steps: np.ndarray,
     spin_bins: np.ndarray,
@@ -757,6 +757,8 @@ def set_bad_or_goodtimes(
         raise ValueError("DataFrame must contain either BadTime or GoodTime columns.")
 
     # Create masks for time and bin ranges using broadcasting
+    # the bin_start and bin_end are 6 degree bins and need to be converted to
+    # 0.1 degree bins to align with the spin_bins, so multiply by 60
     time_mask = (epochs[:, None] >= times_start) & (epochs[:, None] <= times_end)
     bin_mask = (spin_bins[:, None] >= times_df["bin_start"].values * 60) & (
         spin_bins[:, None] <= times_df["bin_end"].values * 60

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -684,7 +684,7 @@ def identify_species(l1b_de: xr.Dataset) -> xr.Dataset:
     return l1b_de
 
 
-def set_bad_times(l1b_de: xr.Dataset) -> xr.Dataset:
+def set_bad_times(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
     """
     Set the bad times for each direct event.
 
@@ -698,9 +698,21 @@ def set_bad_times(l1b_de: xr.Dataset) -> xr.Dataset:
     l1b_de : xarray.Dataset
         The L1B DE dataset with the bad times added.
     """
-    # Initialize all times as not bad for now
-    # TODO: Update to set badtimes based on criteria that
-    #  will be defined in the algorithm document
+    badtimes_df = lo_ancillary.read_ancillary_file(
+        next(str(s) for s in anc_dependencies if "bad-times" in str(s))
+    )
+
+    badtimes_start = met_to_ttj2000ns(badtimes_df["BadTime_start"])
+    badtimes_end = met_to_ttj2000ns(badtimes_df["BadTime_end"])
+
+    badtimes_mask = np.zeroes_like(l1b_de["epoch"], dtype=bool)
+
+    for start, end in zip(badtimes_start, badtimes_end, strict=False):
+        badtimes_mask |= (l1b_de["epoch"] >= start) & (l1b_de["epoch"] <= end)
+
+
+
+
     # 1 = badtime, 0 = not badtime
     l1b_de["badtimes"] = xr.DataArray(
         np.zeros(len(l1b_de["epoch"]), dtype=int),

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -5,6 +5,7 @@ from dataclasses import Field
 from pathlib import Path
 
 import numpy as np
+import pandas
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
@@ -98,13 +99,13 @@ def lo_l1b(sci_dependencies: dict, anc_dependencies: list) -> list[Path]:
         l1b_de = convert_tofs_to_eu(l1a_de, l1b_de, attr_mgr_l1a, attr_mgr_l1b)
         # set the species for each direct event
         l1b_de = identify_species(l1b_de)
-        # set the badtimes
-        l1b_de = set_bad_times(l1b_de)
         # set the pointing direction for each direct event
         l1b_de = set_pointing_direction(l1b_de)
         # calculate and set the pointing bin based on the spin phase
         # pointing bin is 3600 x 40 bins
         l1b_de = set_pointing_bin(l1b_de)
+        # set the badtimes
+        l1b_de = set_bad_times(l1b_de, anc_dependencies)
 
     return [l1b_de]
 
@@ -692,6 +693,8 @@ def set_bad_times(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
     ----------
     l1b_de : xarray.Dataset
         The L1B DE dataset.
+    anc_dependencies : list
+        List of ancillary file paths.
 
     Returns
     -------
@@ -702,23 +705,78 @@ def set_bad_times(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
         next(str(s) for s in anc_dependencies if "bad-times" in str(s))
     )
 
-    badtimes_start = met_to_ttj2000ns(badtimes_df["BadTime_start"])
-    badtimes_end = met_to_ttj2000ns(badtimes_df["BadTime_end"])
+    esa_steps = l1b_de["esa_step"].values
+    epochs = l1b_de["epoch"].values
+    spin_bins = l1b_de["spin_bin"].values
 
-    badtimes_mask = np.zeroes_like(l1b_de["epoch"], dtype=bool)
-
-    for start, end in zip(badtimes_start, badtimes_end, strict=False):
-        badtimes_mask |= (l1b_de["epoch"] >= start) & (l1b_de["epoch"] <= end)
+    badtimes = set_bad_or_goodtimes(badtimes_df, epochs, esa_steps, spin_bins)
 
     # 1 = badtime, 0 = not badtime
     l1b_de["badtimes"] = xr.DataArray(
-        np.zeros(len(l1b_de["epoch"]), dtype=int),
+        badtimes,
         dims=["epoch"],
         # TODO: Add to yaml
         # attrs=attr_mgr.get_variable_attributes("bad_times"),
     )
 
     return l1b_de
+
+
+def set_bad_or_goodtimes(
+    times_df: pandas.DataFrame,
+    epochs: np.ndarray,
+    esa_steps: np.ndarray,
+    spin_bins: np.ndarray,
+) -> np.ndarray:
+    """
+    Find the good/bad time flags for each epoch based on the provided times DataFrame.
+
+    Parameters
+    ----------
+    times_df : pd.DataFrame
+        Good or Bad times dataframe containing time ranges and corresponding flags.
+    epochs : np.ndarray
+        Array of epochs in TTJ2000ns format.
+    esa_steps : np.ndarray
+        Array of ESA steps corresponding to each epoch.
+    spin_bins : np.ndarray
+        Array of spin bins corresponding to each epoch.
+
+    Returns
+    -------
+    time_flags : np.ndarray
+        Array of time good or bad time flags for each epoch.
+    """
+    if "BadTime_start" in times_df.columns and "BadTime_end" in times_df.columns:
+        times_start = met_to_ttj2000ns(times_df["BadTime_start"])
+        times_end = met_to_ttj2000ns(times_df["BadTime_end"])
+    elif "GoodTime_start" in times_df.columns and "GoodTime_end" in times_df.columns:
+        times_start = met_to_ttj2000ns(times_df["GoodTime_start"])
+        times_end = met_to_ttj2000ns(times_df["GoodTime_end"])
+    else:
+        raise ValueError("DataFrame must contain either BadTime or GoodTime columns.")
+
+    # Create masks for time and bin ranges using broadcasting
+    time_mask = (epochs[:, None] >= times_start) & (epochs[:, None] <= times_end)
+    bin_mask = (spin_bins[:, None] >= times_df["bin_start"].values * 60) & (
+        spin_bins[:, None] <= times_df["bin_end"].values * 60
+    )
+
+    # Combined mask for epochs that fall within the time and bin ranges
+    combined_mask = time_mask & bin_mask
+
+    # Get the time flags for each epoch's esa_step from matching rows
+    time_flags = np.zeros(len(epochs), dtype=int)
+    for epoch_idx in range(len(epochs)):
+        matching_rows = np.where(combined_mask[epoch_idx])[0]
+        if len(matching_rows) > 0:
+            # Use the first matching row
+            row_idx = matching_rows[0]
+            esa_step = esa_steps[epoch_idx]
+            if f"E-Step{esa_step}" in times_df.columns:
+                time_flags[epoch_idx] = times_df[f"E-Step{esa_step}"].iloc[row_idx]
+
+    return time_flags
 
 
 def set_pointing_direction(l1b_de: xr.Dataset) -> xr.Dataset:

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -10,6 +10,7 @@ from scipy.stats import binned_statistic_dd
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.lo import lo_ancillary
+from imap_processing.lo.l1b.lo_l1b import set_bad_or_goodtimes
 from imap_processing.spice.repoint import get_pointing_times
 from imap_processing.spice.spin import get_spin_number
 from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_met
@@ -200,19 +201,17 @@ def filter_goodtimes(l1b_de: xr.Dataset, anc_dependencies: list) -> xr.Dataset:
         next(str(s) for s in anc_dependencies if "good-times" in str(s))
     )
 
-    # convert goodtimes from MET to TTJ2000
-    goodtimes_start = met_to_ttj2000ns(goodtimes_table_df["GoodTime_start"])
-    goodtimes_end = met_to_ttj2000ns(goodtimes_table_df["GoodTime_end"])
+    esa_steps = l1b_de["esa_step"].values
+    epochs = l1b_de["epoch"].values
+    spin_bins = l1b_de["spin_bin"].values
 
-    # Create a mask for epochs within any of the start/end time ranges
-    goodtimes_mask = np.zeros_like(l1b_de["epoch"], dtype=bool)
-
-    # Iterate over the good times and create a mask
-    for start, end in zip(goodtimes_start, goodtimes_end, strict=False):
-        goodtimes_mask |= (l1b_de["epoch"] >= start) & (l1b_de["epoch"] < end)
+    # Get array of bools for each epoch 1 = good time, 0 not good time
+    goodtimes_mask = set_bad_or_goodtimes(
+        goodtimes_table_df, epochs, esa_steps, spin_bins
+    )
 
     # Filter the dataset using the mask
-    filtered_epochs = l1b_de.sel(epoch=goodtimes_mask)
+    filtered_epochs = l1b_de.sel(epoch=goodtimes_mask.astype(bool))
 
     return filtered_epochs
 

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -69,7 +69,7 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         logical_source = "imap_lo_l1c_pset"
         l1b_de = sci_dependencies["imap_lo_l1b_de"]
         l1b_goodtimes_only = filter_goodtimes(l1b_de, anc_dependencies)
-
+        # TODO: Need to handle case where no good times are found
         # Set the pointing start and end times based on the first epoch
         pointing_start_met, pointing_end_met = get_pointing_times(
             ttj2000ns_to_met(l1b_goodtimes_only["epoch"][0].item())

--- a/imap_processing/tests/lo/test_anc/imap_lo_bad-times-small_20250101_20270101_v001.csv
+++ b/imap_processing/tests/lo/test_anc/imap_lo_bad-times-small_20250101_20270101_v001.csv
@@ -1,0 +1,13 @@
+YYYYDDD,BadTime_start,BadTime_end,bin_start,bin_end,Instrument,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,Comment
+2025001,473385600,473389200,30,59,Lo,1,0,0,0,0,0,0,#repointing maneuver
+2025001,473407618,473420896,30,59,Lo,0,0,0,0,0,0,0,#high background
+2025002,473472000,473475600,0,59,Lo,0,0,0,0,0,0,0,#repointing maneuver
+2025002,473526046,473528426,0,59,Lo,0,0,0,0,0,0,0,#spin out of sync
+2025003,473558400,473562000,0,59,Lo,0,0,0,0,0,0,0,#repointing maneuver
+2025004,473644800,473648400,0,59,Lo,0,0,0,0,0,0,0,#repointing maneuver
+2025005,473731200,473734800,0,59,Lo,0,0,0,0,0,0,0,#repointing maneuver
+2025006,473817600,473821200,0,59,Lo,0,0,0,0,0,0,0,#repointing maneuver
+2025007,473904000,473907600,0,59,Lo,0,0,0,0,0,0,0,#repointing maneuver
+2025008,473990400,473994000,0,59,Lo,0,0,0,0,0,0,0,#repointing maneuver
+2025008,474050712,474055891,0,59,Lo,0,0,0,0,0,0,0,#spin out of sync
+2025009,474076800,474080400,0,59,Lo,0,0,0,0,0,0,0,#repointing maneuver

--- a/imap_processing/tests/lo/test_anc/imap_lo_good-times-small_20250101_20270101_v001.csv
+++ b/imap_processing/tests/lo/test_anc/imap_lo_good-times-small_20250101_20270101_v001.csv
@@ -1,0 +1,13 @@
+YYYYDDD,GoodTime_start,GoodTime_end,bin_start,bin_end,Instrument,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,Comment
+2025001,473389200,473407618,30,59,Lo,1,0,1,0,1,0,1,#generated good time
+2025001,473407618,473420896,0,29,Lo,1,1,1,1,1,1,1,#generated good time
+2025001,473420896,473472000,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025002,473475600,473526046,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025002,473528426,473558400,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025003,473562000,473644800,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025004,473648400,473731200,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025005,473734800,473817600,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025006,473821200,473904000,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025007,473907600,473990400,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025008,473994000,474050712,0,59,Lo,1,1,1,1,1,1,1,#generated good time
+2025008,474055891,474076800,0,59,Lo,1,1,1,1,1,1,1,#generated good time

--- a/imap_processing/tests/lo/test_anc/imap_lo_good-times_20250415_v001.csv
+++ b/imap_processing/tests/lo/test_anc/imap_lo_good-times_20250415_v001.csv
@@ -1,3 +1,0 @@
-YYYYDDD,GoodTime_start,GoodTime_end,bin_start,bin_end,Lo,E-Steps,Comments
-2025001,0,558541625.0,0,29,Lo,1 1 1 1 1 1 1,generated good time
-2025001,558541627.0,558541627.0,0,29,Lo,1 1 1 1 1 1 1,generated good time

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -19,6 +19,7 @@ from imap_processing.lo.l1b.lo_l1b import (
     initialize_l1b_de,
     lo_l1b,
     set_avg_spin_durations_per_event,
+    set_bad_or_goodtimes,
     set_bad_times,
     set_coincidence_type,
     set_each_event_epoch,
@@ -28,6 +29,7 @@ from imap_processing.lo.l1b.lo_l1b import (
     set_pointing_direction,
     set_spin_cycle,
 )
+from imap_processing.lo.lo_ancillary import read_ancillary_file
 from imap_processing.spice.time import met_to_ttj2000ns
 
 
@@ -51,7 +53,11 @@ def anc_dependencies():
         str(
             imap_module_directory
             / "tests/lo/test_anc/imap_lo_sweep-table-small_20250101_20260301_v001.csv",
-        )
+        ),
+        str(
+            imap_module_directory
+            / "tests/lo/test_anc/imap_lo_bad-times-small_20250101_20270101_v001.csv",
+        ),
     ]
 
 
@@ -547,22 +553,43 @@ def test_identify_species(attr_mgr_l1b):
     np.testing.assert_array_equal(l1b_de["species"], expected_species)
 
 
-def test_set_bad_times():
+def test_set_bad_times(anc_dependencies):
     # Arrange
     l1b_de = xr.Dataset(
-        {},
+        {
+            "esa_step": ("epoch", [1, 1, 3, 1]),
+            "spin_bin": ("epoch", [1900, 2000, 3000, 2]),
+        },
         coords={
-            "epoch": [0, 1, 2],
+            "epoch": met_to_ttj2000ns([473385599, 473385600, 473385601, 473385602]),
         },
     )
 
-    expected_bad_times = np.array([0, 0, 0])
+    expected_bad_times = np.array([0, 1, 0, 0])
 
     # Act
-    l1b_de = set_bad_times(l1b_de)
+    l1b_de = set_bad_times(l1b_de, anc_dependencies)
 
     # Assert
     np.testing.assert_array_equal(l1b_de["badtimes"], expected_bad_times)
+
+
+def test_set_bad_or_goodtimes(anc_dependencies):
+    # Arrange
+    # badtimes ancillary
+    df = read_ancillary_file(anc_dependencies[1])
+
+    epoch = met_to_ttj2000ns([473385599, 473385600, 473385601, 473385602])
+    esa_step = np.array([1, 1, 3, 1])
+    spin_bin = np.array([1900, 2000, 3000, 2])
+
+    expected_bad_times = np.array([0, 1, 0, 0])
+
+    # Act
+    badtimes = set_bad_or_goodtimes(df, epoch, esa_step, spin_bin)
+
+    # Assert
+    np.testing.assert_array_equal(badtimes, expected_bad_times)
 
 
 @patch(

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -38,6 +38,7 @@ def l1b_de():
             "species": ("epoch", ["H", "O", "H", "H", "O"]),
             "spin_cycle": ("epoch", [1, 2, 3, 4, 5]),
             "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9]),
+            "spin_bin": ("epoch", [1900, 2000, 3000, 3000, 3000]),
         },
         coords={
             "epoch": [
@@ -78,6 +79,7 @@ def l1b_de_spin():
             "species": ("epoch", ["H", "O", "H", "H", "O"]),
             "spin_cycle": ("epoch", [1, 2, 3, 4, 5]),
             "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9]),
+            "spin_bin": ("epoch", [1900, 2000, 3000, 3000, 3000]),
         },
         coords={
             "epoch": met_to_ttj2000ns(np.arange(511000000, 511000000 + 200, 40) + 902),
@@ -187,11 +189,10 @@ def expected_bg():
     return expected_bg
 
 
-@patch(
-    "imap_processing.lo.l1c.lo_l1c.set_background_rates",
-    return_value=(None, None, None),
-)
+@patch("imap_processing.lo.l1c.lo_l1c.set_background_rates")
+@patch("imap_processing.lo.l1c.lo_l1c.filter_goodtimes")
 def test_lo_l1c(
+    mock_filter_goodtimes,
     mock_set_background_rates,
     l1b_de_spin,
     anc_dependencies,
@@ -203,7 +204,8 @@ def test_lo_l1c(
     data = {"imap_lo_l1b_de": l1b_de_spin}
     use_fake_spin_data_for_time(511000000)
     use_fake_repoint_data_for_time(np.arange(511000000, 511000000 + 86400 * 5, 86400))
-
+    mock_set_background_rates.return_value = (None, None, None)
+    mock_filter_goodtimes.return_value = l1b_de_spin
     expected_logical_source = "imap_lo_l1c_pset"
 
     # Act

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -91,7 +91,7 @@ def anc_dependencies():
     anc_dependencies_path = [
         str(
             imap_module_directory
-            / "tests/lo/test_anc/imap_lo_good-times_20250415_v001.csv"
+            / "tests/lo/test_anc/imap_lo_good-times-small_20250101_20270101_v001.csv"
         ),
         str(
             imap_module_directory
@@ -215,37 +215,33 @@ def test_lo_l1c(
 
 def test_filter_goodtimes(l1b_de, anc_dependencies):
     # Arrange
-    l1b_de_with_badtimes = xr.Dataset(
+    l1b_de_all = xr.Dataset(
         {
-            "pointing_bin_lon": ("epoch", [20, 0, 20, 2000, 3500, 200]),
-            "pointing_bin_lat": ("epoch", [20, 20, 20, 20, 20, 40]),
             "esa_step": ("epoch", [1, 2, 1, 4, 5, 2]),
-            "coincidence_type": (
-                "epoch",
-                ["111111", "111100", "111000", "110100", "110000", "000000"],
-            ),
-            "species": ("epoch", ["H", "O", "H", "H", "O", "U"]),
-            "spin_cycle": ("epoch", [1, 2, 3, 4, 5, 12]),
-            "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9, 50]),
+            "spin_bin": ("epoch", [1900, 2000, 3000, 3000, 3000, 3000]),
         },
         coords={
-            "epoch": [
-                7.9794907049e17,
-                7.9794907153e17,
-                7.9794907254e17,
-                7.9794907354e17,
-                7.9794907454e17,
-                8.74117692184e17,
-            ],
+            "epoch": met_to_ttj2000ns(
+                [
+                    473389199,
+                    473389200,
+                    473389201,
+                    473389202,
+                    473389203,
+                    473407619,
+                ]
+            )
         },
     )
-    l1b_de_no_badtimes_expected = l1b_de.copy()
+    expected_goodtimes_mask = [False, False, True, False, True, False]
+
+    l1b_goodtimes_onl_expected = l1b_de_all.isel(epoch=expected_goodtimes_mask)
 
     # Act
-    l1b_no_badtimes = filter_goodtimes(l1b_de_with_badtimes, anc_dependencies)
+    l1b_goodtimes_only = filter_goodtimes(l1b_de_all, anc_dependencies)
 
     # Assert
-    xr.testing.assert_equal(l1b_no_badtimes, l1b_de_no_badtimes_expected)
+    xr.testing.assert_equal(l1b_goodtimes_only, l1b_goodtimes_onl_expected)
 
 
 def test_create_pset_counts(l1b_de):


### PR DESCRIPTION
# Change Summary

## Overview

This PR adds processing to pull determine which epochs/bins/esa_steps are badtimes in L1B and which are goodtimes in L1C using the updated ancillary files.

-  created common function for determining good/bad time value in goodtimes and badtimes ancillary data frames
- using common function in badtimes and goodtimes processing for L1B (badtimes function) and L1C (goodtimes function)
- Added latest good-times and bad-times ancillary test files to repo