### PR TITLE
2218 hi l2   integrate flux correction

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,6 +107,7 @@ nitpick_ignore_regex = [
     (r"py:.*", r".*CoDICECompression.*"),
     (r"py:.*", r".*RectangularSkyMap.*"),
     (r"py:.*", r".*AbstractSkyMap.*"),
+    (r"py:.*", r".*MapDescriptor.*"),
     (r"py:.*", r".*.lo.l0.utils.*"),
     (r"py:.*", r".*.lo.l0.data_classes.*"),
     (r"py:.*", r".*.hi.*.[A-Z][a-zA-Z]*.*"),  # match any hi CamelCase class

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -809,13 +809,26 @@ class Hi(ProcessInstrument):
             datasets = hi_l1c.hi_l1c(load_cdf(science_paths[0]), anc_paths[0])
         elif self.data_level == "l2":
             science_paths = dependencies.get_file_paths(source="hi", data_type="l1c")
-            # TODO get ancillary paths
-            geometric_factors_path = ""
-            esa_energies_path = ""
+            anc_dependencies = dependencies.get_processing_inputs(data_type="ancillary")
+            if len(anc_dependencies) != 3:
+                raise ValueError(
+                    f"Expected three ancillary dependencies for L2 processing including"
+                    f"cal-prod, esa-energies, and esa-eta-fit-factors."
+                    f"Got {[anc_dep.descriptor for anc_dep in anc_dependencies]}"
+                    "."
+                )
+            # Get individual L2 ancillary dependencies
+            # Strip the "45sensor" or "90sensor" off the ancillary descriptor and
+            # create a mapping from descriptor to path
+            l2_ancillary_path_dict = {
+                "-".join(dep.descriptor.split("-")[1:]): dep.imap_file_paths[
+                    0
+                ].construct_path()
+                for dep in anc_dependencies
+            }
             datasets = hi_l2.hi_l2(
                 science_paths,
-                geometric_factors_path,
-                esa_energies_path,
+                l2_ancillary_path_dict,
                 self.descriptor,
             )
         else:

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -132,7 +132,7 @@ def generate_hi_map(
 
     output_map.data_1d.update(calculate_ena_signal_rates(output_map.data_1d))
     output_map.data_1d = calculate_ena_intensity(
-        output_map.data_1d, l2_ancillary_path_dict
+        output_map.data_1d, l2_ancillary_path_dict, descriptor
     )
 
     output_map.data_1d["obs_date"].data = output_map.data_1d["obs_date"].data.astype(
@@ -212,6 +212,7 @@ def calculate_ena_signal_rates(map_ds: xr.Dataset) -> dict[str, xr.DataArray]:
 def calculate_ena_intensity(
     map_ds: xr.Dataset,
     l2_ancillary_path_dict: dict[str, Path],
+    descriptor: MapDescriptor,
 ) -> xr.Dataset:
     """
     Calculate the ena intensities.
@@ -223,6 +224,10 @@ def calculate_ena_intensity(
     l2_ancillary_path_dict : dict[str, pathlib.Path]
         Mapping containing ancillary file descriptors as keys and file paths as
         values. Require keys are: ["cal-prod", "esa-energies", "esa-eta-fit-factors"].
+    descriptor : imap_processing.ena_maps.utils.naming.MapDescriptor
+        Output filename descriptor. Contains full configuration for the options
+        of how to generate the map. For this function, the principal data string
+        is used to determine if a flux correction should be applied.
 
     Returns
     -------
@@ -259,18 +264,19 @@ def calculate_ena_intensity(
         esa_energy,
     )
 
-    # Flux correction
-    corrector = PowerLawFluxCorrector(l2_ancillary_path_dict["esa-eta-fit-factors"])
-    # FluxCorrector does not accept the size 1 epoch dimension. Remove that
-    # dimension by passing the zeroth element.
-    corrected_intensity, corrected_stat_unc = corrector.apply_flux_correction(
-        map_ds["ena_intensity"].values[0],
-        map_ds["ena_intensity_stat_unc"].values[0],
-        esa_energy.data,
-    )
-    # Add the size 1 epoch dimension back in to the corrected fluxes.
-    map_ds["ena_intensity"].data = corrected_intensity[np.newaxis, ...]
-    map_ds["ena_intensity_stat_unc"].data = corrected_stat_unc[np.newaxis, ...]
+    if "raw" not in descriptor.principal_data:
+        # Flux correction
+        corrector = PowerLawFluxCorrector(l2_ancillary_path_dict["esa-eta-fit-factors"])
+        # FluxCorrector does not accept the size 1 epoch dimension. Remove that
+        # dimension by passing the zeroth element.
+        corrected_intensity, corrected_stat_unc = corrector.apply_flux_correction(
+            map_ds["ena_intensity"].values[0],
+            map_ds["ena_intensity_stat_unc"].values[0],
+            esa_energy.data,
+        )
+        # Add the size 1 epoch dimension back in to the corrected fluxes.
+        map_ds["ena_intensity"].data = corrected_intensity[np.newaxis, ...]
+        map_ds["ena_intensity_stat_unc"].data = corrected_stat_unc[np.newaxis, ...]
 
     return map_ds
 

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -8,7 +8,6 @@ import pandas as pd
 import xarray as xr
 
 from imap_processing.ena_maps.ena_maps import (
-    AbstractSkyMap,
     HiPointingSet,
     RectangularSkyMap,
 )
@@ -52,8 +51,6 @@ def hi_l2(
     )
 
     map_descriptor = MapDescriptor.from_string(descriptor)
-    if "nside" in map_descriptor.resolution_str:
-        raise NotImplementedError("HEALPix map output not supported for Hi")
     if not isinstance(map_descriptor.sensor, str):
         raise ValueError(
             "Invalid map_descriptor. Sensor attribute must be of type str "
@@ -65,8 +62,6 @@ def hi_l2(
         l2_ancillary_path_dict,
         map_descriptor,
     )
-    if not isinstance(sky_map, RectangularSkyMap):
-        raise NotImplementedError("Healpix map output not supported for Hi")
 
     l2_ds = sky_map.build_cdf_dataset(
         "hi",
@@ -83,7 +78,7 @@ def generate_hi_map(
     psets: list[str | Path],
     l2_ancillary_path_dict: dict[str, Path],
     descriptor: MapDescriptor,
-) -> AbstractSkyMap:
+) -> RectangularSkyMap:
     """
     Project Hi PSET data into a sky map.
 
@@ -100,10 +95,13 @@ def generate_hi_map(
 
     Returns
     -------
-    sky_map : AbstractSkyMap
+    sky_map : RectangularSkyMap
         The sky map with all the PSET data projected into the map.
     """
     output_map = descriptor.to_empty_map()
+
+    if not isinstance(output_map, RectangularSkyMap):
+        raise NotImplementedError("Healpix map output not supported for Hi")
 
     # TODO: Implement Compton-Getting correction
     if descriptor.frame_descriptor != "sf":

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -10,6 +10,7 @@ import xarray as xr
 from imap_processing.ena_maps.ena_maps import (
     AbstractSkyMap,
     HiPointingSet,
+    RectangularSkyMap,
 )
 from imap_processing.ena_maps.utils.corrections import PowerLawFluxCorrector
 from imap_processing.ena_maps.utils.naming import MapDescriptor
@@ -64,6 +65,9 @@ def hi_l2(
         l2_ancillary_path_dict,
         map_descriptor,
     )
+    if not isinstance(sky_map, RectangularSkyMap):
+        raise NotImplementedError("Healpix map output not supported for Hi")
+
     l2_ds = sky_map.build_cdf_dataset(
         "hi",
         "l2",

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -33,7 +33,7 @@ def hi_l2(
     ----------
     psets : list of str or pathlib.Path
         List of input PSETs to make a map from.
-    l2_ancillary_path_dict : dict[str, Path]
+    l2_ancillary_path_dict : dict[str, pathlib.Path]
         Mapping containing ancillary file descriptors as keys and file paths as
         values. Require keys are: ["cal-prod", "esa-energies", "esa-eta-fit-factors"].
     descriptor : str
@@ -87,10 +87,10 @@ def generate_hi_map(
     ----------
     psets : list of str or pathlib.Path
         List of input PSETs to make a map from.
-    l2_ancillary_path_dict : dict[str, Path]
+    l2_ancillary_path_dict : dict[str, pathlib.Path]
         Mapping containing ancillary file descriptors as keys and file paths as
         values. Require keys are: ["cal-prod", "esa-energies", "esa-eta-fit-factors"].
-    descriptor : str
+    descriptor : imap_processing.ena_maps.utils.naming.MapDescriptor
         Output filename descriptor. Contains full configuration for the options
         of how to generate the map.
 
@@ -216,7 +216,7 @@ def calculate_ena_intensity(
     ----------
     map_ds : xarray.Dataset
         Map dataset that has ena_signal_rate fields calculated.
-    l2_ancillary_path_dict : dict[str, Path]
+    l2_ancillary_path_dict : dict[str, pathlib.Path]
         Mapping containing ancillary file descriptors as keys and file paths as
         values. Require keys are: ["cal-prod", "esa-energies", "esa-eta-fit-factors"].
 

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -257,11 +257,14 @@ def calculate_ena_intensity(
 
     # Flux correction
     corrector = PowerLawFluxCorrector(l2_ancillary_path_dict["esa-eta-fit-factors"])
+    # FluxCorrector does not accept the size 1 epoch dimension. Remove that
+    # dimension by passing the zeroth element.
     corrected_intensity, corrected_stat_unc = corrector.apply_flux_correction(
         map_ds["ena_intensity"].values[0],
         map_ds["ena_intensity_stat_unc"].values[0],
         esa_energy.data,
     )
+    # Add the size 1 epoch dimension back in to the corrected fluxes.
     map_ds["ena_intensity"].data = corrected_intensity[np.newaxis, ...]
     map_ds["ena_intensity_stat_unc"].data = corrected_stat_unc[np.newaxis, ...]
 

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -10,8 +10,8 @@ import xarray as xr
 from imap_processing.ena_maps.ena_maps import (
     AbstractSkyMap,
     HiPointingSet,
-    RectangularSkyMap,
 )
+from imap_processing.ena_maps.utils.corrections import PowerLawFluxCorrector
 from imap_processing.ena_maps.utils.naming import MapDescriptor
 from imap_processing.hi.utils import CalibrationProductConfig
 
@@ -23,8 +23,7 @@ VARS_TO_EXPOSURE_TIME_AVERAGE = ["bg_rates", "bg_rates_unc", "obs_date"]
 
 def hi_l2(
     psets: list[str | Path],
-    geometric_factors_path: str | Path,
-    esa_energies_path: str | Path,
+    l2_ancillary_path_dict: dict[str, Path],
     descriptor: str,
 ) -> list[xr.Dataset]:
     """
@@ -34,10 +33,9 @@ def hi_l2(
     ----------
     psets : list of str or pathlib.Path
         List of input PSETs to make a map from.
-    geometric_factors_path : str or pathlib.Path
-        Where to get the geometric factors from.
-    esa_energies_path : str or pathlib.Path
-        Where to get the energies from.
+    l2_ancillary_path_dict : dict[str, Path]
+        Mapping containing ancillary file descriptors as keys and file paths as
+        values. Require keys are: ["cal-prod", "esa-energies", "esa-eta-fit-factors"].
     descriptor : str
         Output filename descriptor. Contains full configuration for the options
         of how to generate the map.
@@ -47,22 +45,13 @@ def hi_l2(
     l2_dataset : list[xarray.Dataset]
         Level 2 IMAP-Hi dataset ready to be written to a CDF file.
     """
-    cg_corrected = False
-    map_descriptor = MapDescriptor.from_string(descriptor)
-
-    sky_map = generate_hi_map(
-        psets,
-        geometric_factors_path,
-        esa_energies_path,
-        spin_phase=map_descriptor.spin_phase,
-        output_map=map_descriptor.to_empty_map(),
-        cg_corrected=cg_corrected,
+    logger.info(
+        f"Hi L2 processing running for descriptor: {descriptor} with"
+        f"{len(psets)} PSETs input."
     )
 
-    # Get the map dataset with variables/coordinates in the correct shape
-    # TODO get the correct descriptor and frame
-
-    if not isinstance(sky_map, RectangularSkyMap):
+    map_descriptor = MapDescriptor.from_string(descriptor)
+    if "nside" in map_descriptor.resolution_str:
         raise NotImplementedError("HEALPix map output not supported for Hi")
     if not isinstance(map_descriptor.sensor, str):
         raise ValueError(
@@ -70,6 +59,11 @@ def hi_l2(
             "and be either '45' or '90'"
         )
 
+    sky_map = generate_hi_map(
+        psets,
+        l2_ancillary_path_dict,
+        map_descriptor,
+    )
     l2_ds = sky_map.build_cdf_dataset(
         "hi",
         "l2",
@@ -83,11 +77,8 @@ def hi_l2(
 
 def generate_hi_map(
     psets: list[str | Path],
-    geometric_factors_path: str | Path,
-    esa_energies_path: str | Path,
-    output_map: AbstractSkyMap,
-    cg_corrected: bool = False,
-    spin_phase: str = "full",
+    l2_ancillary_path_dict: dict[str, Path],
+    descriptor: MapDescriptor,
 ) -> AbstractSkyMap:
     """
     Project Hi PSET data into a sky map.
@@ -96,32 +87,27 @@ def generate_hi_map(
     ----------
     psets : list of str or pathlib.Path
         List of input PSETs to make a map from.
-    geometric_factors_path : str or pathlib.Path
-        Where to get the geometric factors from.
-    esa_energies_path : str or pathlib.Path
-        Where to get the energies from.
-    output_map : AbstractSkyMap
-        The map object to collect data into. Determines pixel spacing,
-        coordinate system, etc.
-    cg_corrected : bool, Optional
-        Whether to apply Compton-Getting correction to the energies. Defaults to
-        False.
-    spin_phase : str, Optional
-        Apply filtering to PSET data include ram or anti-ram or full spin data.
-        Defaults to "full".
+    l2_ancillary_path_dict : dict[str, Path]
+        Mapping containing ancillary file descriptors as keys and file paths as
+        values. Require keys are: ["cal-prod", "esa-energies", "esa-eta-fit-factors"].
+    descriptor : str
+        Output filename descriptor. Contains full configuration for the options
+        of how to generate the map.
 
     Returns
     -------
     sky_map : AbstractSkyMap
         The sky map with all the PSET data projected into the map.
     """
+    output_map = descriptor.to_empty_map()
+
     # TODO: Implement Compton-Getting correction
-    if cg_corrected:
-        raise NotImplementedError
+    if descriptor.frame_descriptor != "sf":
+        raise NotImplementedError("CG correction not implemented for Hi")
 
     for pset_path in psets:
         logger.info(f"Processing {pset_path}")
-        pset = HiPointingSet(pset_path, spin_phase=spin_phase)
+        pset = HiPointingSet(pset_path, spin_phase=descriptor.spin_phase)
 
         # Background rate and uncertainty are exposure time weighted means in
         # the map.
@@ -142,7 +128,7 @@ def generate_hi_map(
 
     output_map.data_1d.update(calculate_ena_signal_rates(output_map.data_1d))
     output_map.data_1d = calculate_ena_intensity(
-        output_map.data_1d, geometric_factors_path, esa_energies_path
+        output_map.data_1d, l2_ancillary_path_dict
     )
 
     output_map.data_1d["obs_date"].data = output_map.data_1d["obs_date"].data.astype(
@@ -153,7 +139,8 @@ def generate_hi_map(
 
     # Rename and convert coordinate from esa_energy_step energy
     esa_df = esa_energy_df(
-        esa_energies_path, output_map.data_1d["esa_energy_step"].data
+        l2_ancillary_path_dict["esa-energies"],
+        output_map.data_1d["esa_energy_step"].data,
     )
     output_map.data_1d = output_map.data_1d.rename({"esa_energy_step": "energy"})
     output_map.data_1d = output_map.data_1d.assign_coords(
@@ -220,8 +207,7 @@ def calculate_ena_signal_rates(map_ds: xr.Dataset) -> dict[str, xr.DataArray]:
 
 def calculate_ena_intensity(
     map_ds: xr.Dataset,
-    geometric_factors_path: str | Path,
-    esa_energies_path: str | Path,
+    l2_ancillary_path_dict: dict[str, Path],
 ) -> xr.Dataset:
     """
     Calculate the ena intensities.
@@ -230,10 +216,9 @@ def calculate_ena_intensity(
     ----------
     map_ds : xarray.Dataset
         Map dataset that has ena_signal_rate fields calculated.
-    geometric_factors_path : str or pathlib.Path
-        Where to get the geometric factors from.
-    esa_energies_path : str or pathlib.Path
-        Where to get the esa energies, energy deltas, and geometric factors.
+    l2_ancillary_path_dict : dict[str, Path]
+        Mapping containing ancillary file descriptors as keys and file paths as
+        values. Require keys are: ["cal-prod", "esa-energies", "esa-eta-fit-factors"].
 
     Returns
     -------
@@ -242,14 +227,16 @@ def calculate_ena_intensity(
         ena_intensity_sys_err.
     """
     # read calibration product configuration file
-    cal_prod_df = CalibrationProductConfig.from_csv(geometric_factors_path)
+    cal_prod_df = CalibrationProductConfig.from_csv(l2_ancillary_path_dict["cal-prod"])
     # reindex_like removes esa_energy_steps and calibration products not in the
     # map_ds esa_energy_step and calibration_product coordinates
     geometric_factor = cal_prod_df.to_xarray().reindex_like(map_ds)["geometric_factor"]
     geometric_factor = geometric_factor.transpose(
         *[coord for coord in map_ds.coords if coord in geometric_factor.coords]
     )
-    energy_df = esa_energy_df(esa_energies_path, map_ds["esa_energy_step"].data)
+    energy_df = esa_energy_df(
+        l2_ancillary_path_dict["esa-energies"], map_ds["esa_energy_step"].data
+    )
     esa_energy = energy_df.to_xarray()["nominal_central_energy"]
 
     # Convert ENA Signal Rate to Flux
@@ -267,6 +254,16 @@ def calculate_ena_intensity(
         geometric_factor,
         esa_energy,
     )
+
+    # Flux correction
+    corrector = PowerLawFluxCorrector(l2_ancillary_path_dict["esa-eta-fit-factors"])
+    corrected_intensity, corrected_stat_unc = corrector.apply_flux_correction(
+        map_ds["ena_intensity"].values[0],
+        map_ds["ena_intensity_stat_unc"].values[0],
+        esa_energy.data,
+    )
+    map_ds["ena_intensity"].data = corrected_intensity[np.newaxis, ...]
+    map_ds["ena_intensity_stat_unc"].data = corrected_stat_unc[np.newaxis, ...]
 
     return map_ds
 

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -23,7 +23,7 @@ from imap_processing.hi.hi_l2 import (
 from imap_processing.spice.geometry import SpiceFrame
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def empty_rectangular_map_dataset() -> xr.Dataset:
     """Generate an empty rectangular map Dataset with coords only"""
     coords = {
@@ -209,7 +209,7 @@ def test_genarate_hi_map(
     mock_esa_energy_lookup.side_effect = lambda x, y: pd.DataFrame(
         {"nominal_central_energy": y, "bandpass_fwhm": np.ones_like(y)}
     )
-    mock_calc_ena_intensity.side_effect = lambda x, y: x
+    mock_calc_ena_intensity.side_effect = lambda x, y, z: x
 
     kernels = [
         "imap_sclk_0000.tsc",
@@ -287,10 +287,11 @@ def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):
     assert np.nanmin(signal_rates_vars["ena_signal_rate_stat_unc"].values) == 1 / 2
 
 
-def test_calculate_ena_intensity(empty_rectangular_map_dataset, anc_path_dict):
-    """Test coverage for calculate_ena_intensity"""
+@pytest.fixture(scope="module")
+def ena_intensity_map_ds(empty_rectangular_map_dataset):
+    """Fixture that produces a dataset to use in testing ena_intensity."""
     # Start with an empty (coords only) dataset
-    map_ds = empty_rectangular_map_dataset
+    map_ds = empty_rectangular_map_dataset.copy()
     # Add some data_vars needed for the ena intensity calculations
     var_shape = tuple(map_ds.sizes.values())
     map_ds.update(
@@ -330,7 +331,17 @@ def test_calculate_ena_intensity(empty_rectangular_map_dataset, anc_path_dict):
             ),
         }
     )
-    result_ds = calculate_ena_intensity(map_ds, anc_path_dict)
+    return map_ds
+
+
+def test_calculate_ena_intensity(ena_intensity_map_ds, anc_path_dict):
+    """Test coverage for calculate_ena_intensity"""
+    descriptor_str = "h90-ena-h-sf-nsp-full-gcs-6deg-3mo"
+    map_descriptor = MapDescriptor.from_string(descriptor_str)
+
+    result_ds = calculate_ena_intensity(
+        ena_intensity_map_ds, anc_path_dict, map_descriptor
+    )
 
     for var_name in [
         "ena_intensity",
@@ -340,6 +351,39 @@ def test_calculate_ena_intensity(empty_rectangular_map_dataset, anc_path_dict):
         assert var_name in result_ds
         # Check that calibration_prod dimension has been removed
         assert "calibration_prod" not in result_ds[var_name].dims
+
+
+@pytest.mark.parametrize(
+    "descriptor_str, flux_corrected",
+    [
+        ("h90-ena-h-sf-nsp-anti-gcs-6deg-3mo", True),
+        ("h90-enaraw-h-hf-nsp-ram-gcs-6deg-3mo", False),
+    ],
+)
+@mock.patch("imap_processing.hi.hi_l2.PowerLawFluxCorrector", autospec=True)
+def test_calculate_ena_intensity_flux_correction_logic(
+    mock_flux_corrector_class,
+    descriptor_str,
+    flux_corrected,
+    ena_intensity_map_ds,
+    anc_path_dict,
+):
+    """Test that flux correction is applied based on map descriptor."""
+    # Create a mock instance that will be returned when PowerLawFluxCorrector
+    # is instantiated
+    mock_instance = mock_flux_corrector_class.return_value
+    mock_instance.apply_flux_correction.side_effect = (
+        lambda intensity, stat_unc, energy: (intensity, stat_unc)
+    )
+
+    map_descriptor = MapDescriptor.from_string(descriptor_str)
+    _ = calculate_ena_intensity(ena_intensity_map_ds, anc_path_dict, map_descriptor)
+
+    # Now check if the method was called based on the flux_corrected expectation
+    if flux_corrected:
+        mock_instance.apply_flux_correction.assert_called_once()
+    else:
+        mock_instance.apply_flux_correction.assert_not_called()
 
 
 def test_combine_calibration_products(sample_map_dataset):

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -240,6 +240,24 @@ def test_genarate_hi_map(
         assert np.nanmax(sky_map.data_1d[var_name].data) > 0
 
 
+def test_generate_hi_map_not_implemented():
+    """Test that the generate_hi_map function raises NotImplementedError."""
+    # Test that trying to produce Healpix raises
+    with pytest.raises(
+        NotImplementedError, match="Healpix map output not supported for Hi"
+    ):
+        _ = generate_hi_map(
+            [], {}, MapDescriptor.from_string("h90-ena-h-sf-nsp-full-gcs-nside32-3mo")
+        )
+    # Temporary test for CG correction not implemented
+    with pytest.raises(
+        NotImplementedError, match="CG correction not implemented for Hi"
+    ):
+        _ = generate_hi_map(
+            [], {}, MapDescriptor.from_string("h90-ena-h-hf-nsp-full-gcs-6deg-3mo")
+        )
+
+
 def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):
     """Test coverage for calculate_ena_signal_rates"""
     # Start with an empty (coords only) dataset

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -1,7 +1,7 @@
 """Test coverage for imap_processing.hi.l2.hi_l2.py"""
 
 from unittest import mock
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -287,9 +287,7 @@ def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):
     assert np.nanmin(signal_rates_vars["ena_signal_rate_stat_unc"].values) == 1 / 2
 
 
-def test_calculate_ena_intensity(
-    empty_rectangular_map_dataset, anc_path_dict
-):
+def test_calculate_ena_intensity(empty_rectangular_map_dataset, anc_path_dict):
     """Test coverage for calculate_ena_intensity"""
     # Start with an empty (coords only) dataset
     map_ds = empty_rectangular_map_dataset
@@ -332,9 +330,7 @@ def test_calculate_ena_intensity(
             ),
         }
     )
-    result_ds = calculate_ena_intensity(
-        map_ds, anc_path_dict
-    )
+    result_ds = calculate_ena_intensity(map_ds, anc_path_dict)
 
     for var_name in [
         "ena_intensity",

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -1,7 +1,7 @@
 """Test coverage for imap_processing.hi.l2.hi_l2.py"""
 
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import patch, Mock
 
 import numpy as np
 import pandas as pd
@@ -10,6 +10,7 @@ import xarray as xr
 
 from imap_processing.cdf.utils import write_cdf
 from imap_processing.ena_maps.ena_maps import RectangularSkyMap
+from imap_processing.ena_maps.utils.naming import MapDescriptor
 from imap_processing.hi.hi_l2 import (
     _calculate_improved_stat_variance,
     calculate_ena_intensity,
@@ -27,10 +28,9 @@ def empty_rectangular_map_dataset() -> xr.Dataset:
     """Generate an empty rectangular map Dataset with coords only"""
     coords = {
         "epoch": 1,
-        "esa_energy_step": 3,
+        "esa_energy_step": 9,
         "calibration_prod": 2,
-        "longitude": 9,
-        "latitude": 4,
+        "spatial": 12,
     }
     map_ds = xr.Dataset(
         coords={
@@ -53,6 +53,26 @@ def esa_energies_lut_path(hi_l1_test_data_path):
 @pytest.fixture
 def geometric_factors_path(hi_l1_test_data_path):
     return hi_l1_test_data_path / "imap_hi_90sensor-cal-prod_20240101_v001.csv"
+
+
+@pytest.fixture
+def esa_eta_fit_factors_path(imap_tests_path):
+    return (
+        imap_tests_path
+        / "ena_maps/data/imap_hi_90sensor-esa-eta-fit-factors_20240101_v001.csv"
+    )
+
+
+@pytest.fixture
+def anc_path_dict(
+    esa_energies_lut_path, geometric_factors_path, esa_eta_fit_factors_path
+):
+    path_dict = {
+        "cal-prod": geometric_factors_path,
+        "esa-energies": esa_energies_lut_path,
+        "esa-eta-fit-factors": esa_eta_fit_factors_path,
+    }
+    return path_dict
 
 
 @pytest.fixture
@@ -127,8 +147,7 @@ def sample_map_dataset():
 @pytest.mark.external_kernel
 def test_hi_l2(
     hi_l1_test_data_path,
-    esa_energies_lut_path,
-    geometric_factors_path,
+    anc_path_dict,
     imap_ena_sim_metakernel,
 ):
     """Integration type test for hi_l2()"""
@@ -136,8 +155,7 @@ def test_hi_l2(
 
     l2_dataset = hi_l2(
         [pset_path],
-        geometric_factors_path,
-        esa_energies_lut_path,
+        anc_path_dict,
         "h90-ena-h-sf-nsp-full-hae-4deg-3mo",
     )[0]
     assert isinstance(l2_dataset, xr.Dataset)
@@ -150,27 +168,29 @@ def test_hi_l2(
 
 
 @pytest.mark.external_test_data
+@patch(
+    "imap_processing.ena_maps.ena_maps.RectangularSkyMap.build_cdf_dataset",
+    autospec=True,
+)
 @patch("imap_processing.hi.hi_l2.generate_hi_map")
 def test_hi_l2_uses_descriptor_to_setup_map(
     mock_generate_hi_map,
+    mock_map_build_cdf_dataset,
     hi_l1_test_data_path,
 ):
     pset_path = hi_l1_test_data_path / "imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
     descriptor_str = "h90-ena-h-sf-nsp-full-hnu-2deg-3mo"
-    rect_map = Mock(spec=RectangularSkyMap)
+    rect_map = MapDescriptor.from_string(descriptor_str).to_empty_map()
     mock_generate_hi_map.return_value = rect_map
+    mock_map_build_cdf_dataset.return_value = xr.Dataset()
 
-    _ = hi_l2([pset_path], None, None, descriptor_str)[0]
+    _ = hi_l2([pset_path], None, descriptor_str)[0]
 
-    output_map = mock_generate_hi_map.call_args.kwargs["output_map"]
+    assert rect_map.spice_reference_frame == SpiceFrame.IMAP_HNU
+    assert rect_map.spacing_deg == 2.0
 
-    assert output_map.spice_reference_frame == SpiceFrame.IMAP_HNU
-    assert output_map.spacing_deg == 2.0
-    assert mock_generate_hi_map.call_args.kwargs["spin_phase"] == "full"
-    assert not mock_generate_hi_map.call_args.kwargs["cg_corrected"]
-
-    rect_map.build_cdf_dataset.assert_called_with(
-        "hi", "l2", "sf", descriptor_str, sensor="90"
+    mock_map_build_cdf_dataset.assert_called_with(
+        rect_map, "hi", "l2", "sf", descriptor_str, sensor="90"
     )
 
 
@@ -181,6 +201,7 @@ def test_genarate_hi_map(
     mock_esa_energy_lookup,
     mock_calc_ena_intensity,
     hi_l1_test_data_path,
+    anc_path_dict,
     furnish_kernels,
 ):
     """Test coverage for genarate_hi_map()"""
@@ -188,7 +209,7 @@ def test_genarate_hi_map(
     mock_esa_energy_lookup.side_effect = lambda x, y: pd.DataFrame(
         {"nominal_central_energy": y, "bandpass_fwhm": np.ones_like(y)}
     )
-    mock_calc_ena_intensity.side_effect = lambda x, y, z: x
+    mock_calc_ena_intensity.side_effect = lambda x, y: x
 
     kernels = [
         "imap_sclk_0000.tsc",
@@ -199,16 +220,12 @@ def test_genarate_hi_map(
     with furnish_kernels(kernels):
         pset_path = hi_l1_test_data_path / "imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
 
-        rectangular_sky_map = RectangularSkyMap(
-            spacing_deg=6, spice_frame=SpiceFrame.IMAP_GCS
-        )
+        descriptor_str = "h90-ena-h-sf-nsp-full-gcs-6deg-3mo"
+        rect_map = MapDescriptor.from_string(descriptor_str)
         sky_map = generate_hi_map(
             [pset_path],
-            None,
-            None,
-            rectangular_sky_map,
-            cg_corrected=False,
-            spin_phase="full",
+            anc_path_dict,
+            rect_map,
         )
     assert isinstance(sky_map, RectangularSkyMap)
     assert sky_map.spacing_deg == 6
@@ -270,22 +287,10 @@ def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):
     assert np.nanmin(signal_rates_vars["ena_signal_rate_stat_unc"].values) == 1 / 2
 
 
-@patch("imap_processing.hi.utils.CalibrationProductConfig.from_csv")
 def test_calculate_ena_intensity(
-    mock_cal_prod_config, empty_rectangular_map_dataset, esa_energies_lut_path
+    empty_rectangular_map_dataset, anc_path_dict
 ):
     """Test coverage for calculate_ena_intensity"""
-    # Mock the calibration product configuration
-    mock_cal_prod_instance = Mock()
-    mock_xarray = Mock()
-    mock_xarray.reindex_like.return_value = {
-        "geometric_factor": xr.DataArray(
-            np.ones((3, 2)), dims=["esa_energy_step", "calibration_prod"]
-        )
-    }
-    mock_cal_prod_instance.to_xarray.return_value = mock_xarray
-    mock_cal_prod_config.return_value = mock_cal_prod_instance
-
     # Start with an empty (coords only) dataset
     map_ds = empty_rectangular_map_dataset
     # Add some data_vars needed for the ena intensity calculations
@@ -327,9 +332,8 @@ def test_calculate_ena_intensity(
             ),
         }
     )
-
     result_ds = calculate_ena_intensity(
-        map_ds, "dummy_geom_path", esa_energies_lut_path
+        map_ds, anc_path_dict
     )
 
     for var_name in [

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -309,7 +309,11 @@ def test_post_processing_returns_empty_list_if_invoked_with_no_data(
                 "imap_hi_l1c_90sensor-pset_20250415_v001.cdf",
                 "imap_hi_l1c_90sensor-pset_20250416_v001.cdf",
             ],
-            [],
+            [
+                "imap_hi_calibration-prod-config_20240101_v001.csv",
+                "imap_hi_90sensor-esa-energies_20240101_v001.csv",
+                "imap_hi_90sensor-esa-eta-fit-factors_20240101_v001.csv",
+            ],
             1,
         ),
     ],


### PR DESCRIPTION
# Change Summary

## Overview
This integrates the flux correction into the Hi L2 pipeline. As part of this, I refactored how ancillary files get passed around. In the cli `do_processing` method, I generate a dictionary that uses ancillary file descriptors as keys and the Path as the value. No attempt was made to test values produced by the added flux correction.

## Updated Files
- imap_processing/cli.py
   - Parse ancillary files into dictionary to pass into L2 processing.
- imap_processing/hi/hi_l2.py
   - Modify function signatures to pass dictionary of ancillary files around.
   - Add PowerLawFluxCorrector to final step of L2 processing.
- imap_processing/tests/hi/test_hi_l2.py
   - Add fixtures for producing dictionary of L2 ancillary files.
   - Update tests to include esa-eta-fit_coeffs ancillary file
- imap_processing/tests/test_cli.py
   - Update to L2 test to include the 3 required ancillary files.

Closes: #2218 
