### PR TITLE
Remove need for unique map global attributes based on reference frame

### DIFF
--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -54,8 +54,7 @@ imap_hi_l1c_pset_attrs:
     Logical_source: imap_hi_l1c_{sensor}-pset
     Logical_source_description: IMAP-Hi Instrument Level-1C Pointing Set Data.
 
-# TODO: Finalize these global attributes
-imap_hi_l2_enamap-sf:
+imap_hi_l2_enamap:
     Data_type: L2_{descriptor}>Level-2 ENA Intensity Map for Hi{sensor}
     Logical_source: imap_hi_l2_{descriptor}
     Logical_source_description: IMAP-Hi Instrument Level-2 ENA Intensity Map Data for Hi{sensor} on rectangular tiling.

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1222,7 +1222,6 @@ class RectangularSkyMap(AbstractSkyMap):
         self,
         instrument: str,
         level: str,
-        frame: str,
         descriptor: str,
         sensor: str | None = None,
     ) -> xr.Dataset:
@@ -1235,8 +1234,6 @@ class RectangularSkyMap(AbstractSkyMap):
             Instrument name. "hi", "lo", "ultra".
         level : str
             Product level. "l2" or "l3".
-        frame : str
-            Map frame. "sf", "hf" or "hk".
         descriptor : str
             Descriptor for filename.
         sensor : str, optional
@@ -1318,16 +1315,14 @@ class RectangularSkyMap(AbstractSkyMap):
         )
 
         # Now set global attributes
-        map_attrs = cdf_attrs.get_global_attributes(
-            f"imap_{instrument}_{level}_enamap-{frame}"
-        )
+        map_attrs = cdf_attrs.get_global_attributes(f"imap_{instrument}_{level}_enamap")
         map_attrs["Spacing_degrees"] = str(self.spacing_deg)
         for key in ["Data_type", "Logical_source", "Logical_source_description"]:
             map_attrs[key] = map_attrs[key].format(
                 descriptor=descriptor,
                 sensor=sensor,
             )
-            # Always add the following attributes to the map
+        # Always add the following attributes to the map
         map_attrs.update(
             {
                 "Sky_tiling_type": self.tiling_type.value,

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -66,7 +66,6 @@ def hi_l2(
     l2_ds = sky_map.build_cdf_dataset(
         "hi",
         "l2",
-        map_descriptor.frame_descriptor,
         descriptor,
         sensor=map_descriptor.sensor,
     )

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -642,7 +642,7 @@ class TestRectangularSkyMap:
         skymap.min_epoch = 10
         skymap.max_epoch = 15
         cdf_dataset = skymap.build_cdf_dataset(
-            "hi", "l2", "sf", "foo_descriptor", sensor="45"
+            "hi", "l2", "foo_descriptor", sensor="45"
         )
 
         # Check that expected var gets removed
@@ -694,9 +694,7 @@ class TestRectangularSkyMap:
         with pytest.raises(
             KeyError, match="Attributes for variable no_attrs_var not found"
         ):
-            _ = skymap.build_cdf_dataset(
-                "hi", "l2", "sf", "foo_descriptor", sensor="45"
-            )
+            _ = skymap.build_cdf_dataset("hi", "l2", "foo_descriptor", sensor="45")
 
         # Test that missing energy delta variable raise KeyError
         # Test for missing energy_delta_plus
@@ -706,9 +704,7 @@ class TestRectangularSkyMap:
             KeyError,
             match="Required variable 'energy_delta_plus' not found in cdf Dataset.",
         ):
-            _ = skymap.build_cdf_dataset(
-                "hi", "l2", "sf", "foo_descriptor", sensor="45"
-            )
+            _ = skymap.build_cdf_dataset("hi", "l2", "foo_descriptor", sensor="45")
         # Test for missing energy_delta_minus
         mock_dataset = mock_dataset.drop(["energy_delta_minus"])
         mock_to_dataset.return_value = mock_dataset
@@ -716,9 +712,7 @@ class TestRectangularSkyMap:
             KeyError,
             match="Required variable 'energy_delta_minus' not found in cdf Dataset.",
         ):
-            _ = skymap.build_cdf_dataset(
-                "hi", "l2", "sf", "foo_descriptor", sensor="45"
-            )
+            _ = skymap.build_cdf_dataset("hi", "l2", "foo_descriptor", sensor="45")
 
 
 class TestHealpixSkyMap:

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -197,7 +197,7 @@ def test_hi_l2_uses_descriptor_to_setup_map(
     assert rect_map.spacing_deg == 2.0
 
     mock_map_build_cdf_dataset.assert_called_with(
-        rect_map, "hi", "l2", "sf", descriptor_str, sensor="90"
+        rect_map, "hi", "l2", descriptor_str, sensor="90"
     )
 
 

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -152,6 +152,7 @@ def test_hi_l2(
 ):
     """Integration type test for hi_l2()"""
     pset_path = hi_l1_test_data_path / "imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
+    descriptor = "h90-ena-h-sf-nsp-full-hae-4deg-3mo"
 
     l2_dataset = hi_l2(
         [pset_path],
@@ -159,6 +160,12 @@ def test_hi_l2(
         "h90-ena-h-sf-nsp-full-hae-4deg-3mo",
     )[0]
     assert isinstance(l2_dataset, xr.Dataset)
+
+    # Check some global attributes
+    assert l2_dataset.attrs["Data_type"].startswith(f"L2_{descriptor}")
+    assert l2_dataset.attrs["Logical_source"] == f"imap_hi_l2_{descriptor}"
+    assert "Hi90" in l2_dataset.attrs["Logical_source_description"]
+
     assert len(l2_dataset.data_vars) == 15
     np.testing.assert_array_equal(
         l2_dataset["ena_intensity"].dims, ["epoch", "energy", "longitude", "latitude"]


### PR DESCRIPTION
# Change Summary

## Overview
I thought that more needed to be done for this but was surprised that I had implemented the code to populate the global attributes: `["Data_type", "Logical_source", "Logical_source_description"]`. This PR turned into a simplification of the global attributes... No need to have unique attributes per reference frame.

## Updated Files
- imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
   - Remove frame specification from global attributes.
- imap_processing/ena_maps/ena_maps.py
   - Remove frame parameter from RectangularSkyMap.build_cdf_dataset method.
- imap_processing/hi/hi_l2.py
   - Update call to RectangularSkyMap.build_cdf_dataset to match change in signature.
- imap_processing/tests/ena_maps/test_ena_maps.py
   - Update calls to RectangularSkyMap.build_cdf_dataset
- imap_processing/tests/hi/test_hi_l2.py
   - Add checking that global attributes are correctly populated

Closes: #2198 
