### PR TITLE
2217 updates to ena l2 attributes

### DIFF
--- a/imap_processing/cdf/config/imap_constant_attrs.yaml
+++ b/imap_processing/cdf/config/imap_constant_attrs.yaml
@@ -19,7 +19,7 @@ epoch:
   TIME_SCALE: Terrestrial Time
   REFERENCE_POSITION: Rotating Earth Geoid
   RESOLUTION: ' '
-  DICT_KEY: "SPASE>Support>SupportQantity:Temporal"
+  DICT_KEY: "SPASE>Support>SupportQuantity:Temporal"
 
 
 # <=== Data Variables ===>

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -127,7 +127,7 @@ ena_intensity:
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: Intensity
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 ena_intensity_stat_uncert:
@@ -138,7 +138,7 @@ ena_intensity_stat_uncert:
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: Statistical Unc
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 ena_intensity_sys_err:
@@ -149,7 +149,7 @@ ena_intensity_sys_err:
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: Non-Statistical Err
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 ena_rate:
@@ -160,7 +160,7 @@ ena_rate:
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: Rate
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 bg_rate:
@@ -171,7 +171,7 @@ bg_rate:
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: Rate
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 ena_count:
@@ -182,7 +182,7 @@ ena_count:
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: Count
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 sensitivity:
@@ -192,7 +192,7 @@ sensitivity:
   UNITS: cm^2
   VAR_TYPE: support_data
   LABLAXIS: sensitivity
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:GeometricFactor,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 exposure_factor: &exposure_factor
@@ -255,7 +255,7 @@ obs_date: &obs_date
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: epoch
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>TemporalDescription:TimeSpan,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 obs_date_range:
@@ -267,7 +267,7 @@ obs_date_range:
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: epoch
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: no_plot
   TIME_SCALE: Terrestrial Time
 
 # These copied metadata vars will allow for variables
@@ -284,12 +284,11 @@ obs_date_range_energy_independent:
 
 solid_angle:
   <<: *default_float32
-  VAR_TYPE: support_data
   CATDESC: Solid angle subtended by each pixel.
   FIELDNAM: Solid Angle
   DEPEND_0: epoch
+  VAR_TYPE: support_data
   UNITS: sr
-  VAR_TYPE: data
   LABLAXIS: Solid Angle
-  DISPLAY_TYPE: image
+  DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Support>SupportQuantity:Other

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -122,15 +122,15 @@ ena_intensity:
   CATDESC: Mono-energetic ENA intensity.
   FIELDNAM: Intensity
   UNITS: counts/(s * cm^2 * Sr * KeV)
-  DELTA_MINUS_VAR: ena_intensity_stat_unc
-  DELTA_PLUS_VAR: ena_intensity_stat_unc
+  DELTA_MINUS_VAR: ena_intensity_stat_uncert
+  DELTA_PLUS_VAR: ena_intensity_stat_uncert
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: Intensity
   DISPLAY_TYPE: image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
-ena_intensity_stat_unc:
+ena_intensity_stat_uncert:
   <<: *default_float32
   CATDESC: ENA intensity statistical uncertainty.
   FIELDNAM: Intensity stat unc

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -93,9 +93,9 @@ epoch_delta:
 # in the tiling-specific YAML files.
 longitude:
   <<: *default_float32
-  CATDESC: Pixel center longitude in {frame} reference frame in the range [0, 360].
-  FIELDNAM: {frame} Longitude
-  LABLAXIS: {frame} Longitude
+  CATDESC: "Pixel center longitude in {frame} reference frame in the range [0, 360]."
+  FIELDNAM: "{frame} Longitude"
+  LABLAXIS: "{frame} Longitude"
   UNITS: degrees
   VAR_TYPE: support_data
   VALIDMIN: 0
@@ -104,9 +104,9 @@ longitude:
 
 latitude:
   <<: *default_float32
-  CATDESC: Pixel center latitude in {frame} reference frame in the range [-90, 90].
-  FIELDNAM: {frame} Latitude
-  LABLAXIS: {frame} Latitude
+  CATDESC: "Pixel center latitude in {frame} reference frame in the range [-90, 90]."
+  FIELDNAM: "{frame} Latitude"
+  LABLAXIS: "{frame} Latitude"
   UNITS: degrees
   VAR_TYPE: support_data
   VALIDMIN: -90

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -54,15 +54,6 @@ energy_label:
   FORMAT: A16
   DEPEND_1: energy
 
-epoch_delta:
-  <<: *default_int64
-  CATDESC: Number of nanoseconds covered by data included in this map product.
-  FIELDNAM: epoch_delta
-  UNITS: ns
-  VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
-  TIME_SCALE: Terrestrial Time
-
 energy_delta_minus:
   <<: *default_float32
   VAR_TYPE: support_data
@@ -87,29 +78,37 @@ energy_delta_plus:
   LABL_PTR_1: energy_label
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:Energy,Qualifier:Uncertainty
 
+epoch_delta:
+  <<: *default_int64
+  CATDESC: Number of nanoseconds covered by data included in this map product.
+  FIELDNAM: epoch_delta
+  UNITS: ns
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  TIME_SCALE: Terrestrial Time
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal
+
 # These two coordinates will be treated differently in the
 # HEALPix and rectangular tilings. They will be substantially overridden
 # in the tiling-specific YAML files.
 longitude:
   <<: *default_float32
-  CATDESC: Pixel center longitude in range [0, 360].
-  FIELDNAM: Longitude
-  LABLAXIS: Longitude
+  CATDESC: Pixel center longitude in {frame} reference frame in the range [0, 360].
+  FIELDNAM: {frame} Longitude
+  LABLAXIS: {frame} Longitude
   UNITS: degrees
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   VALIDMIN: 0
   VALIDMAX: 360
   DICT_KEY: SPASE>Support>SupportQuantity:Orientation,Qualifier:DirectionAngle.AzimuthAngle,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 latitude:
   <<: *default_float32
-  CATDESC: Pixel center latitude in range [-90, 90].
-  FIELDNAM: Latitude
-  LABLAXIS: Latitude
+  CATDESC: Pixel center latitude in {frame} reference frame in the range [-90, 90].
+  FIELDNAM: {frame} Latitude
+  LABLAXIS: {frame} Latitude
   UNITS: degrees
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   VALIDMIN: -90
   VALIDMAX: 90
   DICT_KEY: SPASE>Support>SupportQuantity:Orientation,Qualifier:DirectionAngle.ElevationAngle,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
@@ -136,7 +135,7 @@ ena_intensity_stat_uncert:
   FIELDNAM: Intensity stat unc
   UNITS: counts/(s * cm^2 * Sr * KeV)
   DEPEND_0: epoch
-  VAR_TYPE: data
+  VAR_TYPE: support_data
   LABLAXIS: Statistical Unc
   DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
@@ -147,7 +146,7 @@ ena_intensity_sys_err:
   FIELDNAM: Intensity non-stat error
   UNITS: counts/(s * cm^2 * Sr * KeV)
   DEPEND_0: epoch
-  VAR_TYPE: data
+  VAR_TYPE: support_data
   LABLAXIS: Non-Statistical Err
   DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
@@ -192,7 +191,7 @@ sensitivity:
   UNITS: cm^2
   VAR_TYPE: support_data
   LABLAXIS: sensitivity
-  DISPLAY_TYPE: map_image
+  DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:GeometricFactor,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 exposure_factor: &exposure_factor
@@ -204,7 +203,7 @@ exposure_factor: &exposure_factor
   VAR_TYPE: data
   LABLAXIS: Exposure
   DISPLAY_TYPE: no_plot
-  DICT_KEY: SPASE>TemporalDescription:Exposure,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal
 
 geometric_function:
   <<: *default_float32
@@ -253,7 +252,7 @@ obs_date: &obs_date
   FIELDNAM: J2000 Nanoseconds
   UNITS: ns
   DEPEND_0: epoch
-  VAR_TYPE: data
+  VAR_TYPE: support_data
   LABLAXIS: epoch
   DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>TemporalDescription:TimeSpan,Qualifier:Directional,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
@@ -265,10 +264,11 @@ obs_date_range:
   FIELDNAM: Observation date range
   UNITS: ns
   DEPEND_0: epoch
-  VAR_TYPE: data
+  VAR_TYPE: support_data
   LABLAXIS: epoch
   DISPLAY_TYPE: no_plot
   TIME_SCALE: Terrestrial Time
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal
 
 # These copied metadata vars will allow for variables
 # to be either energy-dependent or independent.
@@ -290,5 +290,5 @@ solid_angle:
   VAR_TYPE: support_data
   UNITS: sr
   LABLAXIS: Solid Angle
-  DISPLAY_TYPE: map_image
+  DISPLAY_TYPE: no_plot
   DICT_KEY: SPASE>Support>SupportQuantity:Other

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -54,7 +54,7 @@ ena_intensity:
   LABL_PTR_2: pixel_index_label
   DISPLAY_TYPE: image
 
-ena_intensity_stat_unc:
+ena_intensity_stat_uncert:
   DEPEND_1: energy
   DEPEND_2: pixel_index
   LABL_PTR_1: energy_label

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -52,7 +52,6 @@ ena_intensity:
   DEPEND_2: pixel_index
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
-  DISPLAY_TYPE: image
 
 ena_intensity_stat_uncert:
   DEPEND_1: energy

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -22,6 +22,7 @@ longitude_delta:
   VAR_TYPE: metadata
   dtype: float32
   CATDESC: Half-width of longitude pixel
+  DEPEND_1: longitude
   FORMAT: F12.6
   UNITS: degrees
   FIELDNAM: longitude delta
@@ -38,6 +39,7 @@ latitude_delta:
   VAR_TYPE: metadata
   dtype: float32
   CATDESC: Half-width of latitude pixel
+  DEPEND_1: latitude
   FORMAT: F12.6
   UNITS: degrees
   FIELDNAM: latitude delta

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -12,7 +12,7 @@ default_float32_attrs: &default_float32
 # Define Coordinates specifically for Rectangular tiling
 
 longitude_label:
-  VAR_TYPE: support_data
+  VAR_TYPE: metadata
   CATDESC: Label variable for longitude.
   FIELDNAM: longitude label
   FORMAT: A8

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -67,7 +67,7 @@ ena_intensity:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
-ena_intensity_stat_unc:
+ena_intensity_stat_uncert:
   DEPEND_1: energy
   DEPEND_2: longitude
   DEPEND_3: latitude

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -12,14 +12,14 @@ default_float32_attrs: &default_float32
 # Define Coordinates specifically for Rectangular tiling
 
 longitude_label:
-  VAR_TYPE: metadata
+  VAR_TYPE: support_data
   CATDESC: Label variable for longitude.
   FIELDNAM: longitude label
   FORMAT: A8
   DEPEND_1: longitude
 
 longitude_delta:
-  VAR_TYPE: metadata
+  VAR_TYPE: support_data
   dtype: float32
   CATDESC: Half-width of longitude pixel
   DEPEND_1: longitude
@@ -36,7 +36,7 @@ latitude_label:
   DEPEND_1: latitude
 
 latitude_delta:
-  VAR_TYPE: metadata
+  VAR_TYPE: support_data
   dtype: float32
   CATDESC: Half-width of latitude pixel
   DEPEND_1: latitude

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1331,25 +1331,23 @@ class RectangularSkyMap(AbstractSkyMap):
         )
         cdf_ds.attrs.update(map_attrs)
 
-        # Set the variable attributes
-        for var in [*cdf_ds.data_vars, *cdf_ds.coords]:
+        # Set the variable and coordinate attributes
+        for name, data_array in {**cdf_ds.data_vars, **cdf_ds.coords}.items():
             try:
-                # Don't check schema on label or delta variables
-                ignore_schema_substrings = ["_label", "_delta"]
-                check_schema = (
-                    False if any(s in var for s in ignore_schema_substrings) else True
-                )
+                # We only check the schema on data variables that include "epoch"
+                # in their list of dimensions.
+                check_schema = "epoch" in data_array.dims
                 var_attrs = cdf_attrs.get_variable_attributes(
-                    variable_name=var,
+                    variable_name=name,
                     check_schema=check_schema,
                 )
             except KeyError as e:
                 raise KeyError(
-                    f"Attributes for variable {var} not found in "
+                    f"Attributes for variable {name} not found in "
                     f"loaded variable attributes."
                 ) from e
 
-            cdf_ds[var].attrs.update(var_attrs)
+            cdf_ds[name].attrs.update(var_attrs)
 
         return cdf_ds
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1350,7 +1350,9 @@ class RectangularSkyMap(AbstractSkyMap):
             cdf_ds[name].attrs.update(var_attrs)
 
         # Manually adjust epoch attributes
-        cdf_ds["epoch"].attrs.update({"DELTA_PLUS_VAR": "epoch_delta"})
+        cdf_ds["epoch"].attrs.update(
+            {"DELTA_PLUS_VAR": "epoch_delta", "BIN_LOCATION": 0}
+        )
 
         return cdf_ds
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1335,8 +1335,8 @@ class RectangularSkyMap(AbstractSkyMap):
         for name, data_array in {**cdf_ds.data_vars, **cdf_ds.coords}.items():
             try:
                 # We only check the schema on data variables that include "epoch"
-                # in their list of dimensions.
-                check_schema = "epoch" in data_array.dims
+                # in their list of dimensions (But not epoch itself).
+                check_schema = name != "epoch" and "epoch" in data_array.dims
                 var_attrs = cdf_attrs.get_variable_attributes(
                     variable_name=name,
                     check_schema=check_schema,

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1349,6 +1349,9 @@ class RectangularSkyMap(AbstractSkyMap):
 
             cdf_ds[name].attrs.update(var_attrs)
 
+        # Manually adjust epoch attributes
+        cdf_ds["epoch"].attrs.update({"DELTA_PLUS_VAR": "epoch_delta"})
+
         return cdf_ds
 
     def to_properties_dict(self) -> dict:

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -229,7 +229,7 @@ def calculate_ena_intensity(
     Returns
     -------
     map_ds : xarray.Dataset
-        Map dataset with new variables: ena_intensity, ena_intensity_stat_unc,
+        Map dataset with new variables: ena_intensity, ena_intensity_stat_uncert,
         ena_intensity_sys_err.
     """
     # read calibration product configuration file
@@ -248,7 +248,7 @@ def calculate_ena_intensity(
     # Convert ENA Signal Rate to Flux
     flux_conversion_divisor = geometric_factor * esa_energy
     map_ds["ena_intensity"] = map_ds["ena_signal_rates"] / flux_conversion_divisor
-    map_ds["ena_intensity_stat_unc"] = (
+    map_ds["ena_intensity_stat_uncert"] = (
         map_ds["ena_signal_rate_stat_unc"] / flux_conversion_divisor
     )
     map_ds["ena_intensity_sys_err"] = map_ds["bg_rates_unc"] / flux_conversion_divisor
@@ -302,7 +302,7 @@ def combine_calibration_products(
     Returns
     -------
     map_ds : xarray.Dataset
-        Map dataset with updated variables: ena_intensity, ena_intensity_stat_unc,
+        Map dataset with updated variables: ena_intensity, ena_intensity_stat_uncert,
         ena_intensity_sys_err now combined across calibration products at each
         energy level.
     """
@@ -336,7 +336,7 @@ def combine_calibration_products(
         combined_flux = weighted_flux_sum / flux_weights.sum(dim="calibration_prod")
 
     map_ds["ena_intensity"] = combined_flux
-    map_ds["ena_intensity_stat_unc"] = combined_stat_unc
+    map_ds["ena_intensity_stat_uncert"] = combined_stat_unc
     # For systematic error, just do quadrature sum over the systematic error for
     # each calibration product.
     map_ds["ena_intensity_sys_err"] = np.sqrt((sys_err**2).sum(dim="calibration_prod"))
@@ -377,7 +377,7 @@ def _calculate_improved_stat_variance(
 
     if n_calib_prods <= 1:
         # No improvement possible with single calibration product
-        return map_ds["ena_intensity_stat_unc"] ** 2
+        return map_ds["ena_intensity_stat_uncert"] ** 2
 
     logger.debug("Computing geometric factor normalized signal rates")
 
@@ -417,7 +417,7 @@ def _calculate_improved_stat_variance(
     # Handle invalid cases by falling back to original uncertainties
     improved_variance = xr.where(
         ~np.isfinite(improved_variance) | (geometric_factors == 0),
-        map_ds["ena_intensity_stat_unc"],
+        map_ds["ena_intensity_stat_uncert"],
         improved_variance,
     )
 

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -268,12 +268,12 @@ def calculate_ena_intensity(
         # dimension by passing the zeroth element.
         corrected_intensity, corrected_stat_unc = corrector.apply_flux_correction(
             map_ds["ena_intensity"].values[0],
-            map_ds["ena_intensity_stat_unc"].values[0],
+            map_ds["ena_intensity_stat_uncert"].values[0],
             esa_energy.data,
         )
         # Add the size 1 epoch dimension back in to the corrected fluxes.
         map_ds["ena_intensity"].data = corrected_intensity[np.newaxis, ...]
-        map_ds["ena_intensity_stat_unc"].data = corrected_stat_unc[np.newaxis, ...]
+        map_ds["ena_intensity_stat_uncert"].data = corrected_stat_unc[np.newaxis, ...]
 
     return map_ds
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -650,12 +650,17 @@ class TestRectangularSkyMap:
         # Check the epoch values
         assert CoordNames.TIME.value in cdf_dataset
         assert cdf_dataset[CoordNames.TIME.value].values[0] == skymap.min_epoch
+        assert (
+            cdf_dataset[CoordNames.TIME.value].attrs["DELTA_PLUS_VAR"] == "epoch_delta"
+        )
+        # Check epoch_delta
         assert f"{CoordNames.TIME.value}_delta" in cdf_dataset
         assert (
             cdf_dataset[f"{CoordNames.TIME.value}_delta"].values[0]
             == skymap.max_epoch - skymap.min_epoch
         )
 
+        # Energy related checks
         assert CoordNames.ENERGY_L2.value in cdf_dataset
         assert f"{CoordNames.ENERGY_L2.value}_delta_plus" in cdf_dataset
         assert f"{CoordNames.ENERGY_L2.value}_delta_minus" in cdf_dataset
@@ -668,6 +673,19 @@ class TestRectangularSkyMap:
         assert CoordNames.ELEVATION_L2.value in cdf_dataset
         assert f"{CoordNames.ELEVATION_L2.value}_delta" in cdf_dataset
         assert f"{CoordNames.ELEVATION_L2.value}_label" in cdf_dataset
+
+        # Check that coordinate variables don't have the following variable attributes
+        not_coord_attrs = ["DEPEND_0", "DISPLAY_TYPE"]
+        for var in [
+            CoordNames.TIME.value,
+            CoordNames.ENERGY_L2.value,
+            CoordNames.AZIMUTH_L2.value,
+            CoordNames.ELEVATION_L2.value,
+        ]:
+            for attr in not_coord_attrs:
+                assert attr not in cdf_dataset[var].attrs, (
+                    f"attr '{attr}' should not be in variable attributes for '{var}'"
+                )
 
     @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
     def test_build_cdf_dataset_key_error(

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -121,7 +121,7 @@ def sample_map_dataset():
             "ena_intensity": xr.DataArray(
                 np.random.rand(*shape) * 100 + 50, dims=list(coords.keys())
             ),
-            "ena_intensity_stat_unc": xr.DataArray(
+            "ena_intensity_stat_uncert": xr.DataArray(
                 np.random.rand(*shape) * 10 + 5, dims=list(coords.keys())
             ),
             "ena_intensity_sys_err": xr.DataArray(
@@ -370,7 +370,7 @@ def test_calculate_ena_intensity(ena_intensity_map_ds, anc_path_dict):
 
     for var_name in [
         "ena_intensity",
-        "ena_intensity_stat_unc",
+        "ena_intensity_stat_uncert",
         "ena_intensity_sys_err",
     ]:
         assert var_name in result_ds
@@ -423,7 +423,11 @@ def test_combine_calibration_products(sample_map_dataset):
     )
 
     # Check that all expected variables are present
-    expected_vars = ["ena_intensity", "ena_intensity_stat_unc", "ena_intensity_sys_err"]
+    expected_vars = [
+        "ena_intensity",
+        "ena_intensity_stat_uncert",
+        "ena_intensity_sys_err",
+    ]
     for var_name in expected_vars:
         assert var_name in result_ds
         # Check that calibration_prod dimension has been removed
@@ -441,7 +445,7 @@ def test_combine_calibration_products(sample_map_dataset):
     )
 
     # Check that combined uncertainty is reasonable
-    combined_unc = result_ds["ena_intensity_stat_unc"]
+    combined_unc = result_ds["ena_intensity_stat_uncert"]
     assert np.all(combined_unc.values[np.isfinite(combined_unc.values)] >= 0), (
         "Combined uncertainty should be non-negative"
     )
@@ -465,7 +469,7 @@ def test_calculate_improved_variance(sample_map_dataset):
     )
 
     # Check that result has same shape as input statistical uncertainties
-    original_unc = test_ds["ena_intensity_stat_unc"]
+    original_unc = test_ds["ena_intensity_stat_uncert"]
     assert improved_unc.shape == original_unc.shape
 
     # Check that improved uncertainties are finite and non-negative
@@ -494,7 +498,7 @@ def test_calculate_improved_variance_single_product():
             "ena_intensity": xr.DataArray(
                 np.array([[[[[100.0]]]]]), dims=list(coords.keys())
             ),
-            "ena_intensity_stat_unc": xr.DataArray(
+            "ena_intensity_stat_uncert": xr.DataArray(
                 np.array([[[[[10.0]]]]]), dims=list(coords.keys())
             ),
         }
@@ -506,7 +510,7 @@ def test_calculate_improved_variance_single_product():
 
     # With single product, should return original uncertainties
     np.testing.assert_array_equal(
-        improved_var.values, test_ds["ena_intensity_stat_unc"].values ** 2
+        improved_var.values, test_ds["ena_intensity_stat_uncert"].values ** 2
     )
 
 
@@ -539,7 +543,7 @@ def test_weighted_average_mathematical_correctness():
     test_ds = xr.Dataset(
         {
             "ena_intensity": xr.DataArray(flux_values, dims=list(coords.keys())),
-            "ena_intensity_stat_unc": xr.DataArray(
+            "ena_intensity_stat_uncert": xr.DataArray(
                 stat_unc_values, dims=list(coords.keys())
             ),
             "ena_intensity_sys_err": xr.DataArray(
@@ -570,7 +574,7 @@ def test_weighted_average_mathematical_correctness():
 
     # Check that results are finite and reasonable
     assert np.isfinite(result_ds["ena_intensity"].values[0, 0, 0, 0])
-    assert result_ds["ena_intensity_stat_unc"].values[0, 0, 0, 0] > 0
+    assert result_ds["ena_intensity_stat_uncert"].values[0, 0, 0, 0] > 0
     assert result_ds["ena_intensity_sys_err"].values[0, 0, 0, 0] > 0
 
     # Systematic error should be root sum of squares
@@ -600,7 +604,7 @@ def test_statistical_uncertainty_combination_correctness():
     test_ds = xr.Dataset(
         {
             "ena_intensity": xr.DataArray(flux_values, dims=list(coords.keys())),
-            "ena_intensity_stat_unc": xr.DataArray(
+            "ena_intensity_stat_uncert": xr.DataArray(
                 stat_unc_values, dims=list(coords.keys())
             ),
             "ena_intensity_sys_err": xr.DataArray(
@@ -634,7 +638,7 @@ def test_statistical_uncertainty_combination_correctness():
     expected_flux = np.sum(flux_values.squeeze() * flux_weights) / np.sum(flux_weights)
 
     np.testing.assert_almost_equal(
-        result_ds["ena_intensity_stat_unc"].values,
+        result_ds["ena_intensity_stat_uncert"].values,
         expected_combined_stat_unc,
         decimal=10,
     )
@@ -660,7 +664,7 @@ def test_combine_calibration_products_edge_cases():
             "ena_intensity": xr.DataArray(
                 np.array([100.0]).reshape(1, 1, 1, 1, 1), dims=list(coords.keys())
             ),
-            "ena_intensity_stat_unc": xr.DataArray(
+            "ena_intensity_stat_uncert": xr.DataArray(
                 np.array([10.0]).reshape(1, 1, 1, 1, 1), dims=list(coords.keys())
             ),
             "ena_intensity_sys_err": xr.DataArray(
@@ -682,5 +686,5 @@ def test_combine_calibration_products_edge_cases():
     np.testing.assert_almost_equal(result_ds["ena_intensity"].values[0, 0, 0, 0], 100.0)
 
     # Check that calibration_prod dimension was removed
-    for var in ["ena_intensity", "ena_intensity_stat_unc", "ena_intensity_sys_err"]:
+    for var in ["ena_intensity", "ena_intensity_stat_uncert", "ena_intensity_sys_err"]:
         assert "calibration_prod" not in result_ds[var].dims

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -156,7 +156,7 @@ class TestUltraL2:
             "background_rates",
             "ena_intensity",
             "obs_date_range",
-            "ena_intensity_stat_unc",
+            "ena_intensity_stat_uncert",
             "exposure_factor",
             "sensitivity",
             "geometric_function",
@@ -191,7 +191,7 @@ class TestUltraL2:
             rtol=rtol,
         )
         np.testing.assert_allclose(
-            hp_skymap.data_1d["ena_intensity_stat_unc"].values,
+            hp_skymap.data_1d["ena_intensity_stat_uncert"].values,
             expected_ena_intensity_unc,
             rtol=rtol,
         )
@@ -265,7 +265,7 @@ class TestUltraL2:
             "background_rates",
             "ena_intensity",
             "obs_date_range",
-            "ena_intensity_stat_unc",
+            "ena_intensity_stat_uncert",
             "exposure_factor",
             "obs_date",
         ]
@@ -334,7 +334,7 @@ class TestUltraL2:
             + ultra_l2.REQUIRED_L1C_VARIABLES_PULL
             + ultra_l2.VARIABLES_TO_DROP_AFTER_INTENSITY_CALCULATION
             + ultra_l2.EXPECTED_L1C_POINTING_INDEPENDENT_VARIABLES_PULL
-            + ["ena_intensity", "ena_intensity_stat_unc"]
+            + ["ena_intensity", "ena_intensity_stat_uncert"]
         )
         for var in expected_vars:
             assert var in hp_skymap.data_1d.data_vars
@@ -351,7 +351,7 @@ class TestUltraL2:
         )
         assert hp_skymap.data_1d["counts"].dims == counts_dims
         assert hp_skymap.data_1d["ena_intensity"].dims == counts_dims
-        assert hp_skymap.data_1d["ena_intensity_stat_unc"].dims == counts_dims
+        assert hp_skymap.data_1d["ena_intensity_stat_uncert"].dims == counts_dims
         assert hp_skymap.data_1d["exposure_factor"].dims == counts_dims
         assert hp_skymap.data_1d["background_rates"].dims == counts_dims
 
@@ -493,7 +493,7 @@ class TestUltraL2:
         )
         assert rect_map_dataset["ena_intensity"].dims == expected_ena_intensity_dims
         assert (
-            rect_map_dataset["ena_intensity_stat_unc"].dims
+            rect_map_dataset["ena_intensity_stat_uncert"].dims
             == expected_ena_intensity_dims
         )
         assert rect_map_dataset["exposure_factor"].dims == expected_ena_intensity_dims

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -160,7 +160,7 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
     This function combines IMAP Ultra L1C pointing sets into a single L2 HealpixSkyMap.
     It handles the projection of values from pointing sets to the map, applies necessary
     weighting and background subtraction, and calculates ena_intensity
-    and ena_intensity_stat_unc.
+    and ena_intensity_stat_uncert.
 
     Parameters
     ----------
@@ -391,7 +391,7 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
             skymap.data_1d["sensitivity"] * skymap.solid_angle * delta_energy
         )
 
-        skymap.data_1d["ena_intensity_stat_unc"] = (
+        skymap.data_1d["ena_intensity_stat_uncert"] = (
             skymap.data_1d["counts"].astype(float) ** 0.5
         ) / (
             skymap.data_1d["exposure_factor"]
@@ -630,7 +630,7 @@ def ultra_l2(
     # Add systematic error as all zeros with shape matching statistical unc
     # TODO: update once we have information from the instrument team
     map_dataset["ena_intensity_sys_err"] = xr.zeros_like(
-        map_dataset["ena_intensity_stat_unc"],
+        map_dataset["ena_intensity_stat_uncert"],
     )
 
     # Add epoch_delta


### PR DESCRIPTION
# Change Summary

## Overview
Changes to the L2 map variables and attributes.
- Variables named with "_unc" -> "_uncert"
- Many attribute changes based on feedback from Andriy

## Updated Files
- imap_processing/cdf/config/imap_constant_attrs.yaml
   - Fix misspelling of Quantity
- imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
   - Rename uncertainty variables to use "_uncert"
   - Put placeholder in place for injecting coordinate frame into lat/lon coordinates. See ticket: #2242
   - Change DISPLAY_TYPE to "map_image" for many variables. This affects how CDAWeb displays things.
   - Some changes to VAR_TYPEs
- imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
   - ena_intensity_stat_unc -> ena_intensity_stat_uncert
- imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
   - ena_intensity_stat_unc -> ena_intensity_stat_uncert
   - Some changes to VAR_TYPEs
- imap_processing/ena_maps/ena_maps.py
   - Update how check_schema is determined. This fixes injection of invalid DEPEND_0 and DISPLAY_TYPE that was occurring.
- imap_processing/hi/hi_l2.py
   - ena_intensity_stat_unc -> ena_intensity_stat_uncert
- imap_processing/tests/ultra/unit/test_ultra_l2.py
   - ena_intensity_stat_unc -> ena_intensity_stat_uncert
- imap_processing/ultra/l2/ultra_l2.py
   - ena_intensity_stat_unc -> ena_intensity_stat_uncert

Closes: #2217 
