### PR TITLE
2253 ena maps   allow pset az el coordinates to have energy dimension

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -97,7 +97,7 @@ def match_coords_to_indices(
     Parameters
     ----------
     input_object : PointingSet | AbstractSkyMap
-        An object containing 1D spatial pixel centers in azimuth and elevation,
+        An object containing spatial pixel centers in azimuth and elevation,
         which will be matched to 1D indices of spatial pixels in the output frame.
         Must contain the Spice frame in which the pixel centers are defined.
     output_object : PointingSet | AbstractSkyMap
@@ -115,10 +115,13 @@ def match_coords_to_indices(
     Returns
     -------
     flat_indices_input_grid_output_frame : NDArray
-        1D array of pixel indices of the output object corresponding to each pixel in
-        the input object. The length of the array is equal to the number of pixels in
-        the input object, and may contain 0, 1, or multiple occurrences of the same
-        output index.
+        Array of pixel indices mapping each input object pixel center to a pixel
+        in the output object. If the input object has multi-dimensional coordinates
+        defines, the output indices with also be multi-dimensional. The shape of
+        the output array is (..., n) where ... matches the non-spatial dimensions
+        of the input object and n is the number of spatial pixels in the input
+        object. Output indices may contain 0, 1, or multiple occurrences of the
+        same output index.
 
     Raises
     ------
@@ -166,14 +169,14 @@ def match_coords_to_indices(
         # use ravel_multi_index to get the 1D indices of the pixels in the output frame.
         az_indices = (
             np.digitize(
-                input_obj_az_el_output_frame[:, 0],
+                input_obj_az_el_output_frame[..., 0],
                 output_object.sky_grid.az_bin_edges,
             )
             - 1
         )
         el_indices = (
             np.digitize(
-                input_obj_az_el_output_frame[:, 1],
+                input_obj_az_el_output_frame[..., 1],
                 output_object.sky_grid.el_bin_edges,
             )
             - 1
@@ -191,8 +194,8 @@ def match_coords_to_indices(
         # which directly returns the index on the output frame's Healpix tessellation.
         flat_indices_input_grid_output_frame = hp.ang2pix(
             nside=output_object.nside,
-            theta=input_obj_az_el_output_frame[:, 0],  # Lon in degrees
-            phi=input_obj_az_el_output_frame[:, 1],  # Lat in degrees
+            theta=input_obj_az_el_output_frame[..., 0],  # Lon in degrees
+            phi=input_obj_az_el_output_frame[..., 1],  # Lat in degrees
             nest=output_object.nested,
             lonlat=True,
         )

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -117,7 +117,7 @@ def match_coords_to_indices(
     flat_indices_input_grid_output_frame : NDArray
         Array of pixel indices mapping each input object pixel center to a pixel
         in the output object. If the input object has multi-dimensional coordinates
-        defines, the output indices with also be multi-dimensional. The shape of
+        defined, the output indices will also be multi-dimensional. The shape of
         the output array is (..., n) where ... matches the non-spatial dimensions
         of the input object and n is the number of spatial pixels in the input
         object. Output indices may contain 0, 1, or multiple occurrences of the

--- a/imap_processing/ena_maps/utils/map_utils.py
+++ b/imap_processing/ena_maps/utils/map_utils.py
@@ -10,6 +10,92 @@ from numpy.typing import NDArray
 logger = logging.getLogger(__name__)
 
 
+def vectorized_bincount(
+    indices: NDArray, weights: NDArray | None = None, minlength: int = 0
+) -> NDArray:
+    """
+    Vectorized version of np.bincount for multi-dimensional arrays.
+
+    This function applies np.bincount across multi-dimensional input arrays by
+    adding offsets to the indices and flattening, then reshaping the result.
+    This approach allows broadcasting between indices and weights.
+
+    Parameters
+    ----------
+    indices : NDArray
+        Array of non-negative integers to be binned. Can be multi-dimensional.
+        If multi-dimensional, bincount is applied independently along each
+        leading dimension.
+    weights : NDArray, optional
+        Array of weights that is broadcastable with indices. If provided, each
+        weight is accumulated into its corresponding bin. If None (default),
+        each index contributes a count of 1.
+    minlength : int, optional
+        Minimum number of bins in the output array. Applied to each independent
+        bincount operation. Default is 0.
+
+    Returns
+    -------
+    NDArray
+        Array of binned values with the same leading dimensions as the input
+        arrays, and a final dimension of size minlength (or the maximum index + 1,
+        whichever is larger).
+
+    See Also
+    --------
+    numpy.bincount : The underlying function being vectorized.
+
+    Examples
+    --------
+    >>> indices = np.array([[0, 1, 1], [2, 2, 3]])
+    >>> vectorized_bincount(indices, minlength=4)
+    array([[1., 2., 0., 0.],
+           [0., 0., 2., 1.]])
+    """
+    # Handle 1D case directly
+    if indices.ndim == 1 and weights.ndim == 1:
+        return np.bincount(indices, weights=weights, minlength=minlength)
+
+    # For multi-dimensional arrays, broadcast indices and weights
+    if weights is not None:
+        indices_bc, weights_bc = np.broadcast_arrays(indices, weights)
+    else:
+        indices_bc = indices
+        weights_bc = None
+
+    # Get the shape for reshaping output
+    output_shape = indices_bc.shape[:-1]
+    n_samples = np.prod(output_shape)
+
+    # Determine actual minlength if not specified
+    if minlength == 0:
+        minlength = int(np.max(indices_bc)) + 1
+
+    # Add offsets to indices to separate each sample's bins
+    # Each sample gets its own set of bins: sample 0 uses bins [0, minlength),
+    # sample 1 uses bins [minlength, 2*minlength), etc.
+    offsets = np.arange(n_samples).reshape(*output_shape, 1) * minlength
+    indices_offset = (indices_bc + offsets).ravel()
+
+    # Flatten weights if provided
+    if weights_bc is not None:
+        weights_flat = weights_bc.ravel()
+    else:
+        weights_flat = None
+
+    # Single bincount call with offset indices
+    binned_flat = np.bincount(
+        indices_offset, weights=weights_flat, minlength=n_samples * minlength
+    )
+
+    # Reshape to separate each sample's bins
+    binned_values = binned_flat.reshape(n_samples, -1)[:, :minlength].reshape(
+        *output_shape, minlength
+    )
+
+    return binned_values
+
+
 def bin_single_array_at_indices(
     value_array: NDArray,
     projection_grid_shape: tuple[int, ...],
@@ -25,7 +111,7 @@ def bin_single_array_at_indices(
     Parameters
     ----------
     value_array : NDArray
-        Array of values to bin. The final axis be the one and only spatial axis.
+        Array of values to bin. The final axis is the one and only spatial axis.
         If other axes are present, they will be binned independently
         along the spatial axis.
     projection_grid_shape : tuple[int, ...]
@@ -34,71 +120,89 @@ def bin_single_array_at_indices(
         or just (number of bins,) if the grid is 1D.
     projection_indices : NDArray
         Ordered indices for projection grid, corresponding to indices in input grid.
-        1 dimensional. May be non-unique, depending on the projection method.
+        Can be 1-dimensional or multi-dimensional. If multi-dimensional, must be
+        broadcastable with value_array. May contain non-unique indices, depending
+        on the projection method.
     input_indices : NDArray
         Ordered indices for input grid, corresponding to indices in projection grid.
         1 dimensional. May be non-unique, depending on the projection method.
-        If None (default), an arange of the same length as the
-        final axis of value_array is used.
+        If None (default), an numpy.arange of the same length as the final axis of
+        value_array is used.
     input_valid_mask : NDArray, optional
         Boolean mask array for valid values in input grid.
         If None, all pixels are considered valid. Default is None.
+        Must be broadcastable with value_array and projection_indices.
 
     Returns
     -------
     NDArray
-        Binned values on the projection grid.
+        Binned values on the projection grid. The output shape depends on the
+        input shapes after broadcasting:
+        - If value_array is 1D: returns 1D array of shape (num_projection_indices,)
+        - If value_array is multi-dimensional: returns array with shape
+          (*value_array.shape[:-1], num_projection_indices), where the leading
+          dimensions match value_array's non-spatial dimensions and the final
+          dimension contains the binned values for each projection grid position.
+        - If projection_indices is multi-dimensional and broadcasts with value_array,
+          the output shape will be (broadcasted_shape[:-1], num_projection_indices).
 
     Raises
     ------
     ValueError
-        If the input and projection indices are not 1D arrays
-        with the same number of elements.
-    NotImplementedError
-        If the input value_array has dimensionality less than 1.
+        If input_indices is not a 1D array, or if the arrays cannot be
+        broadcast together.
     """
+    # Set and check input_indices
     if input_indices is None:
         input_indices = np.arange(value_array.shape[-1])
-    if input_valid_mask is None:
-        input_valid_mask = np.ones(value_array.shape[-1], dtype=bool)
-
-    # Both sets of indices must be 1D with the same number of elements
-    if input_indices.ndim != 1 or projection_indices.ndim != 1:
+    # input_indices must be 1D
+    if input_indices.ndim != 1:
         raise ValueError(
-            "Indices must be 1D arrays. "
+            "input_indices must be a 1D array. "
             "If using a rectangular grid, the indices must be unwrapped."
         )
-    if input_indices.size != projection_indices.size:
+
+    # Verify projection_indices is broadcastable with value_array
+    try:
+        broadcasted_shape = np.broadcast_shapes(
+            projection_indices.shape, value_array.shape
+        )
+    except ValueError as e:
         raise ValueError(
-            "The number of input and projection indices must be the same. \n"
-            f"Received {input_indices.size} input indices and {projection_indices.size}"
-            " projection indices."
-        )
+            f"projection_indices shape {projection_indices.shape} must be "
+            f"broadcastable with value_array shape {value_array.shape}"
+        ) from e
 
-    input_valid_mask = np.asarray(input_valid_mask, dtype=bool)
-    mask_idx = input_valid_mask[input_indices]
+    # Set and check input_valid_mask
+    if input_valid_mask is None:
+        input_valid_mask = np.ones(value_array.shape[-1], dtype=bool)
+    else:
+        input_valid_mask = np.asarray(input_valid_mask, dtype=bool)
+    # Verify input_valid_mask is broadcastable with value_array
+    try:
+        np.broadcast_shapes(input_valid_mask.shape, value_array.shape)
+    except ValueError as e:
+        raise ValueError(
+            f"input_valid_mask shape {input_valid_mask.shape} must be "
+            f"broadcastable with value_array shape {value_array.shape}"
+        ) from e
 
-    num_projection_indices = np.prod(projection_grid_shape)
+    # Broadcast input_valid_mask to match value_array shape if needed
+    input_valid_mask_bc = np.broadcast_to(input_valid_mask, broadcasted_shape)
 
-    # Only valid values are summed into bins.
-    if value_array.ndim == 1:
-        values = value_array[input_indices]
-        binned_values = np.bincount(
-            projection_indices[mask_idx],
-            weights=values[mask_idx],
-            minlength=num_projection_indices,
-        )
-    elif value_array.ndim >= 2:
-        # Apply bincount to each row independently
-        binned_values = np.apply_along_axis(
-            lambda x: np.bincount(
-                projection_indices[mask_idx],
-                weights=x[..., input_indices][mask_idx],
-                minlength=num_projection_indices,
-            ),
-            axis=-1,
-            arr=value_array,
-        )
+    # Select values at input_indices positions along the spatial axis
+    values = value_array[..., input_indices]
+
+    # Apply mask: set invalid values to 0
+    values_masked = np.where(input_valid_mask_bc, values, 0)
+
+    num_projection_indices = int(np.prod(projection_grid_shape))
+
+    # Use vectorized_bincount to handle arbitrary dimensions
+    binned_values = vectorized_bincount(
+        projection_indices, weights=values_masked, minlength=num_projection_indices
+    )
+
     return binned_values
 
 

--- a/imap_processing/ena_maps/utils/map_utils.py
+++ b/imap_processing/ena_maps/utils/map_utils.py
@@ -59,38 +59,35 @@ def vectorized_bincount(
     # For multi-dimensional arrays, broadcast indices and weights
     if weights is not None:
         indices_bc, weights_bc = np.broadcast_arrays(indices, weights)
+        weights_flat = weights_bc.ravel()
     else:
         indices_bc = indices
-        weights_bc = None
+        weights_flat = None
 
     # Get the shape for reshaping output
-    output_shape = indices_bc.shape[:-1]
-    n_samples = np.prod(output_shape)
+    non_spatial_shape = indices_bc.shape[:-1]
+    n_binsets = np.prod(non_spatial_shape)
 
     # Determine actual minlength if not specified
     if minlength == 0:
         minlength = int(np.max(indices_bc)) + 1
 
-    # Add offsets to indices to separate each sample's bins
-    # Each sample gets its own set of bins: sample 0 uses bins [0, minlength),
-    # sample 1 uses bins [minlength, 2*minlength), etc.
-    offsets = np.arange(n_samples).reshape(*output_shape, 1) * minlength
-    indices_offset = (indices_bc + offsets).ravel()
+    # We want to flatten the multi-dimensional bincount problem into a 1D problem.
+    # This can be done by offsetting the indices for each element of each additional
+    # dimension by an integer multiple of the number of bins. Doing so gives
+    # each element in the additional dimensions its own set of 1D bins: index 0
+    # uses bins [0, minlength), index 1 uses bins [minlength, 2*minlength), etc.
+    offsets = np.arange(n_binsets).reshape(*non_spatial_shape, 1) * minlength
+    indices_flat = (indices_bc + offsets).ravel()
 
-    # Flatten weights if provided
-    if weights_bc is not None:
-        weights_flat = weights_bc.ravel()
-    else:
-        weights_flat = None
-
-    # Single bincount call with offset indices
+    # Single bincount call with flattened data
     binned_flat = np.bincount(
-        indices_offset, weights=weights_flat, minlength=n_samples * minlength
+        indices_flat, weights=weights_flat, minlength=n_binsets * minlength
     )
 
     # Reshape to separate each sample's bins
-    binned_values = binned_flat.reshape(n_samples, -1)[:, :minlength].reshape(
-        *output_shape, minlength
+    binned_values = binned_flat.reshape(n_binsets, -1)[:, :minlength].reshape(
+        *non_spatial_shape, minlength
     )
 
     return binned_values

--- a/imap_processing/ena_maps/utils/map_utils.py
+++ b/imap_processing/ena_maps/utils/map_utils.py
@@ -53,7 +53,7 @@ def vectorized_bincount(
            [0., 0., 2., 1.]])
     """
     # Handle 1D case directly
-    if indices.ndim == 1 and weights.ndim == 1:
+    if indices.ndim == 1 and (weights is None or weights.ndim == 1):
         return np.bincount(indices, weights=weights, minlength=minlength)
 
     # For multi-dimensional arrays, broadcast indices and weights

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -129,7 +129,7 @@ def imap_state(
     -------
     state : np.ndarray
      The Cartesian state vector representing the position and velocity of the
-     IMAP spacecraft.
+     IMAP spacecraft. Units are km and km/s.
     """
     state, _ = spiceypy.spkezr(
         SpiceBody.IMAP.name, et, ref_frame.name, abcorr, observer.name
@@ -323,6 +323,7 @@ def frame_transform_az_el(
         Ephemeris time(s) corresponding to position(s).
     az_el :  np.ndarray
         <azimuth, elevation> vector or array of vectors in reference frame `from_frame`.
+        Azimuth and elevation pairs are always the final dimension of the array.
         There are several possible shapes for the input az_el and et:
         1. A single az_el vector may be provided for multiple `et` query times
         2. A single `et` may be provided for multiple az_el vectors,
@@ -340,15 +341,16 @@ def frame_transform_az_el(
     to_frame_az_el : np.ndarray
         Azimuth/elevation coordinates in reference frame `to_frame`. This
         output coordinate vector will have shape (2,) if a single `az_el` position
-        vector and single `et` time are input. Otherwise, it will have shape (n, 2)
-        where n is the number of input position vector or ephemeris times. The last
-        axis of the output vector contains azimuth in the 0th position and elevation
-        in the 1st position.
+        vector and single `et` time are input. Otherwise, it will have shape (..., 2)
+        where ... matches the leading dimensions of the input position vector or
+        ephemeris times. The last axis of the output vector contains azimuth in
+        the 0th position and elevation in the 1st position.
     """
     # Convert input az/el to Cartesian vectors
-    spherical_coords_in = np.array(
-        [np.ones_like(az_el[..., 0]), az_el[..., 0], az_el[..., 1]]
-    ).T
+    spherical_coords_in = np.stack(
+        [np.ones_like(az_el[..., 0]), az_el[..., 0], az_el[..., 1]],
+        axis=-1,
+    )
     from_frame_cartesian = spherical_to_cartesian(spherical_coords_in)
     # Transform to to_frame
     to_frame_cartesian = frame_transform(et, from_frame_cartesian, from_frame, to_frame)
@@ -531,7 +533,7 @@ def cartesian_to_spherical(
         az = np.degrees(az)
         el = np.degrees(el)
 
-    spherical_coords = np.stack((np.squeeze(magnitude_v), az, el), axis=-1)
+    spherical_coords = np.stack((np.squeeze(magnitude_v, -1), az, el), axis=-1)
 
     return spherical_coords
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -1293,6 +1293,77 @@ class TestIndexMatching:
             atol=map_spacing_deg,
         )
 
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_match_coords_to_indices_multi_dimensional_input(
+        self, mock_frame_transform_az_el
+    ):
+        """Test that match_coords_to_indices works for multi-dimensional arrays."""
+        map_spacing_deg = 6
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        # Mock a PSET, overriding the az/el points
+        mock_pset_input_frame = ena_maps.RectangularPointingSet(
+            self.rectangular_l1c_pset_products[0],
+            spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
+        )
+        # Create multi-dimensional az_el coordinates
+        multi_dim_az_el_coords = np.array(
+            [
+                list(
+                    zip(
+                        np.linspace(0, 359.9, 20),
+                        np.linspace(-90, 89.9, 20),
+                        strict=False,
+                    )
+                ),
+                list(
+                    zip(
+                        np.linspace(359.9, 0, 20),
+                        np.linspace(89.9, -90, 20),
+                        strict=False,
+                    )
+                ),
+            ]
+        )
+        mock_pset_input_frame.az_el_points = multi_dim_az_el_coords
+
+        # Manually calculate the resulting 1D pixel indices for each az/el pair
+        # (num of pixels in an az row spanning 180 deg of elevation) * (current az row)
+        # + (pixel along in current az row)
+        expected_output_pixel = np.array(
+            [
+                (az // map_spacing_deg) * (180 // map_spacing_deg)
+                + ((90 + el) // map_spacing_deg)
+                for [az, el] in multi_dim_az_el_coords.reshape(-1, 2)
+            ]
+        ).reshape(2, -1)
+
+        # Create the rectangular map and check the output values
+        rect_map = ena_maps.RectangularSkyMap(
+            spacing_deg=map_spacing_deg,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+        flat_indices_input_grid_output_frame = ena_maps.match_coords_to_indices(
+            mock_pset_input_frame, rect_map
+        )
+        np.testing.assert_equal(
+            flat_indices_input_grid_output_frame, expected_output_pixel
+        )
+
+        # Test that healpix binning also works with multi-dimensional input
+        healpix_map = ena_maps.HealpixSkyMap(
+            nside=32, spice_frame=geometry.SpiceFrame.ECLIPJ2000, nested=False
+        )
+        healpix_indices = ena_maps.match_coords_to_indices(
+            mock_pset_input_frame, healpix_map
+        )
+        assert healpix_indices.shape == expected_output_pixel.shape
+        # indices should be reversed in the second set
+        np.testing.assert_equal(healpix_indices[0, :], healpix_indices[1, ::-1])
+
     @pytest.mark.parametrize(
         "nside,degree_tolerance",
         [

--- a/imap_processing/tests/ena_maps/test_map_utils.py
+++ b/imap_processing/tests/ena_maps/test_map_utils.py
@@ -4,6 +4,58 @@ import pytest
 from imap_processing.ena_maps.utils import map_utils
 
 
+class TestVectorizedBincount:
+    def test_vectorized_bincount_1d(self):
+        """Test vectorized_bincount with 1D input (equivalent to np.bincount)."""
+        indices = np.array([0, 1, 1, 2, 2, 2])
+        result = map_utils.vectorized_bincount(indices, minlength=4)
+        expected = np.array([1.0, 2.0, 3.0, 0.0])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_vectorized_bincount_1d_with_weights(self):
+        """Test vectorized_bincount with 1D input and weights."""
+        indices = np.array([0, 1, 1, 2, 2, 2])
+        weights = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        result = map_utils.vectorized_bincount(indices, weights=weights, minlength=4)
+        expected = np.array([1.0, 5.0, 15.0, 0.0])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_vectorized_bincount_2d(self):
+        """Test vectorized_bincount with 2D input (multiple 1D bincounts)."""
+        indices = np.array([[0, 1, 1], [2, 2, 3]])
+        result = map_utils.vectorized_bincount(indices, minlength=4)
+        expected = np.array([[1.0, 2.0, 0.0, 0.0], [0.0, 0.0, 2.0, 1.0]])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_vectorized_bincount_2d_with_weights(self):
+        """Test vectorized_bincount with 2D input and weights."""
+        indices = np.array([[0, 1, 1], [2, 2, 3]])
+        weights = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        result = map_utils.vectorized_bincount(indices, weights=weights, minlength=4)
+        expected = np.array([[1.0, 5.0, 0.0, 0.0], [0.0, 0.0, 9.0, 6.0]])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_vectorized_bincount_3d(self):
+        """Test vectorized_bincount with 3D input."""
+        indices = np.array([[[0, 1], [1, 2]], [[2, 3], [3, 0]]])
+        result = map_utils.vectorized_bincount(indices, minlength=4)
+        expected = np.array(
+            [
+                [[1.0, 1.0, 0.0, 0.0], [0.0, 1.0, 1.0, 0.0]],
+                [[0.0, 0.0, 1.0, 1.0], [1.0, 0.0, 0.0, 1.0]],
+            ]
+        )
+        np.testing.assert_array_equal(result, expected)
+
+    def test_vectorized_bincount_no_minlength(self):
+        """Test vectorized_bincount without specifying minlength."""
+        indices = np.array([[0, 1, 1], [2, 2, 3]])
+        result = map_utils.vectorized_bincount(indices)
+        # Without minlength, output size is max(indices) + 1 = 4
+        expected = np.array([[1.0, 2.0, 0.0, 0.0], [0.0, 0.0, 2.0, 1.0]])
+        np.testing.assert_array_equal(result, expected)
+
+
 class TestENAMapMappingUtils:
     def test_bin_single_array_at_indices(
         self,
@@ -28,19 +80,22 @@ class TestENAMapMappingUtils:
         """Test coverage for bin_single_array_at_indices function w/ simple 2D input,
         Corresponding to an extra axis that is not spatially binned.
         """
-        # Binning will occur along axis 1 seen below
-        # (combining 1, 2, 3 and 4, 5, 6 separately).
+        # value_array has shape (2, 4) - 2 energy bins, 4 spatial positions
+        # Binning will occur along the spatial axis (axis 1)
         value_array = np.array(
             [
-                [1, 2, 3],
-                [4, 5, 6],
+                [1, 2, 3, 4],
+                [10, 20, 30, 40],
             ]
         )
-        input_indices = np.array([0, 1, 2, 2])
+        # Select input positions 0, 1, 2, 3 and map to projection positions
+        input_indices = np.array([0, 1, 2, 3])
         projection_indices = np.array([1, 0, 1, 6])
-        projection_grid_shape = (7, 1)
+        projection_grid_shape = (7,)
+        # Row 0: proj[0]=2, proj[1]=1+3=4, proj[6]=4
+        # Row 1: proj[0]=20, proj[1]=10+30=40, proj[6]=40
         expected_projection_values = np.array(
-            [[2, 4, 0, 0, 0, 0, 3], [5, 10, 0, 0, 0, 0, 6]]
+            [[2, 4, 0, 0, 0, 0, 4], [20, 40, 0, 0, 0, 0, 40]]
         )
         projection_values = map_utils.bin_single_array_at_indices(
             value_array,
@@ -50,88 +105,6 @@ class TestENAMapMappingUtils:
         )
 
         np.testing.assert_equal(projection_values, expected_projection_values)
-
-    @pytest.mark.parametrize(
-        "projection_grid_shape", [(1, 1), (10, 10), (180, 360), (360, 720), (360, 180)]
-    )
-    @pytest.mark.parametrize(
-        "input_grid_shape", [(1, 1), (10, 10), (180, 360), (360, 720), (360, 180)]
-    )
-    def test_bin_single_array_at_indices_complex_2d(
-        self, projection_grid_shape, input_grid_shape
-    ):
-        """Test coverage for bin_single_array_at_indices function w/ complex 2D input,
-        Corresponding to an extra axis that is not spatially binned.
-        Parameterized across different input and projection grid shapes.
-        """
-        np.random.seed(0)
-        extra_axis_size = 11  # Another axis which is not spatially binned, e.g. energy
-        input_grid_size = np.prod(input_grid_shape)
-        projection_grid_size = np.prod(projection_grid_shape)
-        value_array = np.random.rand(extra_axis_size, input_grid_size)
-        input_indices = np.random.randint(0, input_grid_size, size=1000)
-        projection_indices = np.random.randint(0, projection_grid_size, size=1000)
-        projection_values = map_utils.bin_single_array_at_indices(
-            value_array,
-            input_indices=input_indices,
-            projection_indices=projection_indices,
-            projection_grid_shape=projection_grid_shape,
-        )
-
-        # Explicitly check that the shape of the output is the same as projection grid
-        np.testing.assert_equal(
-            projection_values.shape,
-            (
-                extra_axis_size,
-                projection_grid_size,
-            ),
-        )
-
-        # Create the expected projection values by summing the input values in a loop
-        # This is different from the binning function, which uses np.bincount
-        expected_projection_values = np.zeros((extra_axis_size, projection_grid_size))
-        for ii, ip in zip(input_indices, projection_indices, strict=False):
-            expected_projection_values[:, ip] += value_array[:, ii]
-
-        np.testing.assert_allclose(projection_values, expected_projection_values)
-
-    @pytest.mark.parametrize("projection_grid_shape", [(1, 1), (10, 10), (180, 360)])
-    @pytest.mark.parametrize("input_grid_shape", [(1, 1), (10, 10), (180, 360)])
-    @pytest.mark.parametrize("num_extra_dims", [1, 2, 3, 5])
-    def test_bin_single_array_at_indices_complex_3d(
-        self, projection_grid_shape, input_grid_shape, num_extra_dims
-    ):
-        """Test coverage for bin_single_array_at_indices function w/ complex N-Dim input
-        Corresponding to 2 extra axes that are not spatially binned.
-        Parameterized across different input and projection grid shapes.
-        """
-        np.random.seed(0)
-        extra_axes_sizes = np.full(num_extra_dims, 3, dtype=int).tolist()
-        input_grid_size = np.prod(input_grid_shape)
-        projection_grid_size = np.prod(projection_grid_shape)
-        value_array = np.random.rand(*extra_axes_sizes, input_grid_size)
-        input_indices = np.random.randint(0, input_grid_size, size=1000)
-        projection_indices = np.random.randint(0, projection_grid_size, size=1000)
-        projection_values = map_utils.bin_single_array_at_indices(
-            value_array,
-            input_indices=input_indices,
-            projection_indices=projection_indices,
-            projection_grid_shape=projection_grid_shape,
-        )
-
-        # Explicitly check that the shape of the output is the same as projection grid
-        np.testing.assert_equal(
-            projection_values.shape,
-            (*extra_axes_sizes, projection_grid_size),
-        )
-
-        # Create the expected projection values by summing the input values in a loop
-        # This is different from the binning function, which uses np.bincount
-        expected_projection_values = np.zeros((*extra_axes_sizes, projection_grid_size))
-        for ii, ip in zip(input_indices, projection_indices, strict=False):
-            expected_projection_values[..., ip] += value_array[..., ii]
-
-        np.testing.assert_allclose(projection_values, expected_projection_values)
 
     # Parameterize by the size of the projection grid,
     # which is not necessarily same size as input grid
@@ -267,8 +240,8 @@ class TestENAMapMappingUtils:
             output_dict["sum_variable_3d"], expected_projection_values_3d
         )
 
-    def test_bin_values_at_indices_2d_indices_raises(self):
-        """2D indices are not supported for binning.
+    def test_bin_single_array_at_indices_2d_input_indices_raises(self):
+        """2D input_indices are not supported for binning.
         Test that ValueError is raised."""
         input_values = np.array([1, 2, 3])
         input_indices = np.array([[0, 1], [1, 2]])
@@ -278,7 +251,7 @@ class TestENAMapMappingUtils:
         with pytest.raises(
             ValueError,
             match=(
-                "Indices must be 1D arrays. If using a rectangular grid, "
+                "input_indices must be a 1D array. If using a rectangular grid, "
                 "the indices must be unwrapped."
             ),
         ):
@@ -289,21 +262,250 @@ class TestENAMapMappingUtils:
                 projection_grid_shape=projection_grid_shape,
             )
 
-    def test_bin_values_at_indices_mismatched_sizes_raises(self):
-        """Mismatched input and projection indices should raise an error.
-        Test that ValueError is raised."""
-        input_values = np.array([1, 2, 3])
-        input_indices = np.array([0, 1, 0, 1])
-        projection_indices = np.array([0, 1, 2])
+    def test_bin_single_array_at_indices_multidim_projection_indices(self):
+        """Test bin_single_array_at_indices multi-dimensional projection_indices."""
+        # 2D value_array with shape (3, 4) - 3 energy bins, 4 spatial positions
+        value_array = np.array(
+            [
+                [1.0, 2.0, 3.0, 4.0],
+                [10.0, 20.0, 30.0, 40.0],
+                [100.0, 200.0, 300.0, 400.0],
+            ]
+        )
+        # 2D projection_indices with shape (3, 4) - different mapping per energy
+        projection_indices = np.array([[0, 1, 1, 2], [1, 0, 2, 2], [2, 2, 1, 0]])
+        input_indices = np.array([0, 1, 2, 3])
         projection_grid_shape = (3,)
+
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+        )
+
+        # Expected output shape: (3, 3) - 3 energy bins, 3 projection bins
+        # Energy 0: [[0,0]=1, [0,1]+[0,2]=2+3=5, [0,3]=4]
+        # Energy 1: [[1,1]=20, [1,0]=10, [1,2]+[1,3]=30+40=70]
+        # Energy 2: [[2,3]=400, [2,2]=300, [2,0]+[2,1]=100+200=300]
+        expected_projection_values = np.array(
+            [[1.0, 5.0, 4.0], [20.0, 10.0, 70.0], [400.0, 300.0, 300.0]]
+        )
+
+        np.testing.assert_equal(projection_values.shape, (3, 3))
+        np.testing.assert_allclose(projection_values, expected_projection_values)
+
+    def test_bin_single_array_at_indices_broadcasting(self):
+        """Test broadcasting between 1D projection_indices and 2D value_array."""
+        # 2D value_array with shape (2, 4)
+        value_array = np.array([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]])
+        # 1D projection_indices with shape (3,) - broadcasts to (2, 3)
+        projection_indices = np.array([0, 1, 0])
+        input_indices = np.array([0, 1, 2])
+        projection_grid_shape = (2,)
+
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+        )
+
+        # Expected: both rows use same projection_indices
+        # Row 0: bin 0 gets value[0,0]+value[0,2]=1+3=4, bin 1 gets value[0,1]=2
+        # Row 1: bin 0 gets value[1,0]+value[1,2]=10+30=40, bin 1 gets value[1,1]=20
+        expected_projection_values = np.array([[4.0, 2.0], [40.0, 20.0]])
+
+        np.testing.assert_equal(projection_values.shape, (2, 2))
+        np.testing.assert_allclose(projection_values, expected_projection_values)
+
+    def test_bin_single_array_at_indices_with_1d_mask(self):
+        """Test bin_single_array_at_indices with 1D input_valid_mask."""
+        value_array = np.array([1, 2, 3, 4, 5, 6])
+        input_indices = np.array([0, 1, 2, 2, 1, 0])
+        projection_indices = np.array([1, 2, 3, 1, 2, 3])
+        projection_grid_shape = (5,)
+        # Mask out indices 1 and 4 (values 2 and 5)
+        input_valid_mask = np.array([True, False, True, True, False, False])
+
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+            input_valid_mask=input_valid_mask,
+        )
+
+        # Without mask: [0, 4, 4, 4, 0]
+        # With mask (excluding indices 1,4,5 -> values 2,2,1): [0, 4, 0, 3, 0]
+        expected_projection_values = np.array([0, 4, 0, 3, 0])
+        np.testing.assert_equal(projection_values, expected_projection_values)
+
+    def test_bin_single_array_at_indices_with_2d_mask(self):
+        """
+        Test bin_single_array_at_indices with 2D input_valid_mask.
+
+        input_valid_mask matches value_array shape.
+        """
+        # 2D value_array with shape (2, 6)
+        value_array = np.array(
+            [
+                [1, 2, 3, 4, 5, 6],
+                [10, 20, 30, 40, 50, 60],
+            ]
+        )
+        input_indices = np.array([0, 1, 2, 2, 1, 0])
+        projection_indices = np.array([1, 2, 3, 1, 2, 3])
+        projection_grid_shape = (5,)
+        # Mask with different patterns for each row
+        input_valid_mask = np.array(
+            [
+                [True, False, True, True, False, True],  # Row 0: mask out 2, 5
+                [True, True, False, True, True, False],  # Row 1: mask out 3, 6
+            ]
+        )
+
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+            input_valid_mask=input_valid_mask,
+        )
+
+        # Row 0: mask excludes values 2,5 -> [0, 4, 0, 4, 0]
+        # Row 1: mask excludes values 30,60 -> [0, 40, 40, 0, 0]
+        expected_projection_values = np.array([[0, 4, 0, 4, 0], [0, 40, 40, 0, 0]])
+        np.testing.assert_equal(projection_values, expected_projection_values)
+
+    def test_bin_single_array_at_indices_with_broadcast_mask(self):
+        """Test bin_single_array_at_indices with 1D mask, 2D value_array."""
+        # 2D value_array with shape (2, 6)
+        value_array = np.array(
+            [
+                [1, 2, 3, 4, 5, 6],
+                [10, 20, 30, 40, 50, 60],
+            ]
+        )
+        input_indices = np.array([0, 1, 2, 2, 1, 0])
+        projection_indices = np.array([1, 2, 3, 1, 2, 3])
+        projection_grid_shape = (5,)
+        # 1D mask that broadcasts to both rows
+        input_valid_mask = np.array([True, False, True, True, False, True])
+
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+            input_valid_mask=input_valid_mask,
+        )
+
+        # Same mask applied to both rows: exclude indices 1,4
+        # Row 0: mask excludes values 2,5 -> [0, 4, 0, 4, 0]
+        # Row 1: mask excludes values 30,60 -> [0, 40, 0, 40, 0]
+        expected_projection_values = np.array([[0, 4, 0, 4, 0], [0, 40, 0, 40, 0]])
+        np.testing.assert_equal(projection_values, expected_projection_values)
+
+    def test_bin_single_array_at_indices_mask_all_invalid(self):
+        """Test bin_single_array_at_indices with all values masked out."""
+        value_array = np.array([1, 2, 3, 4, 5, 6])
+        input_indices = np.array([0, 1, 2, 2, 1, 0])
+        projection_indices = np.array([1, 2, 3, 1, 2, 3])
+        projection_grid_shape = (5,)
+        # Mask out all values
+        input_valid_mask = np.array([False, False, False, False, False, False])
+
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            input_indices=input_indices,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+            input_valid_mask=input_valid_mask,
+        )
+
+        # All values masked -> all zeros
+        expected_projection_values = np.array([0, 0, 0, 0, 0])
+        np.testing.assert_equal(projection_values, expected_projection_values)
+
+    def test_bin_single_array_at_indices_mask_shape_mismatch_raises(self):
+        """Test that ValueError is raised when shapes are incompatible."""
+        value_array = np.array([1, 2, 3, 4, 5, 6])
+        input_indices = np.array([0, 1, 2])
+        projection_indices = np.array([1, 2, 3])
+        projection_grid_shape = (5,)
+        # Incompatible mask shape
+        input_valid_mask = np.array([True, False, True])
 
         with pytest.raises(
             ValueError,
-            match=("The number of input and projection indices must be the same"),
+            match="projection_indices shape .* must be broadcastable "
+            "with value_array shape",
         ):
             map_utils.bin_single_array_at_indices(
-                input_values,
+                value_array,
                 input_indices=input_indices,
                 projection_indices=projection_indices,
                 projection_grid_shape=projection_grid_shape,
+                input_valid_mask=input_valid_mask,
             )
+        with pytest.raises(
+            ValueError,
+            match="input_valid_mask shape .* must be broadcastable "
+            "with value_array shape",
+        ):
+            map_utils.bin_single_array_at_indices(
+                value_array,
+                input_indices=input_indices,
+                projection_indices=np.arange(6),
+                projection_grid_shape=projection_grid_shape,
+                input_valid_mask=input_valid_mask,
+            )
+
+    def test_bin_single_array_at_indices_mask_default_input_indices(self):
+        """Test bin_single_array_at_indices with mask and default input_indices=None."""
+        # Test that when input_indices is not provided, the function uses
+        # np.arange(value_array.shape[-1]) and masking works correctly
+        value_array = np.array([1, 2, 3, 4, 5, 6])
+        projection_indices = np.array([0, 1, 1, 2, 2, 0])
+        projection_grid_shape = (3,)
+        # Mask out values at positions 1, 3, 5 (values 2, 4, 6)
+        input_valid_mask = np.array([True, False, True, False, True, False])
+
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+            input_valid_mask=input_valid_mask,
+        )
+
+        # Without mask: bin[0]=1+6=7, bin[1]=2+3=5, bin[2]=4+5=9
+        # With mask: bin[0]=1+0=1, bin[1]=0+3=3, bin[2]=0+5=5
+        expected_projection_values = np.array([1, 3, 5])
+        np.testing.assert_equal(projection_values, expected_projection_values)
+
+    def test_bin_single_array_at_indices_mask_default_input_indices_2d(self):
+        """Test with mask, default input_indices, and 2D value_array."""
+        # 2D value_array with shape (2, 6)
+        value_array = np.array(
+            [
+                [1, 2, 3, 4, 5, 6],
+                [10, 20, 30, 40, 50, 60],
+            ]
+        )
+        projection_indices = np.array([0, 1, 1, 2, 2, 0])
+        projection_grid_shape = (3,)
+        # 1D mask broadcasting to both rows
+        input_valid_mask = np.array([True, False, True, False, True, False])
+
+        projection_values = map_utils.bin_single_array_at_indices(
+            value_array,
+            projection_indices=projection_indices,
+            projection_grid_shape=projection_grid_shape,
+            input_valid_mask=input_valid_mask,
+        )
+
+        # Row 0: bin[0]=1, bin[1]=3, bin[2]=5
+        # Row 1: bin[0]=10, bin[1]=30, bin[2]=50
+        expected_projection_values = np.array([[1, 3, 5], [10, 30, 50]])
+        np.testing.assert_equal(projection_values, expected_projection_values)

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -284,6 +284,48 @@ def test_frame_transform_az_el_same_frame(spice_frame):
     np.testing.assert_allclose(result, az_el_points)
 
 
+def test_frame_transform_az_el_3d_input(furnish_kernels):
+    """Test frame_transform_az_el with 3D input array."""
+    kernels = [
+        "naif0012.tls",
+        "imap_001.tf",
+        "imap_sclk_0000.tsc",
+        "imap_science_100.tf",
+        "sim_1yr_imap_attitude.bc",
+        "sim_1yr_imap_pointing_frame.bc",
+    ]
+    with furnish_kernels(kernels):
+        et = spiceypy.utc2et("2025-06-12T12:00:00.000")
+
+        # Create 3D az_el array with shape (3, 4, 2)
+        # This represents 3 energy bins with 4 az/el positions each
+        az_el_3d = np.array(
+            [
+                [[0, 0], [90, 0], [180, 0], [270, 0]],
+                [[45, 30], [135, 30], [225, 30], [315, 30]],
+                [[0, -45], [90, -45], [180, -45], [270, -45]],
+            ]
+        )
+
+        result = frame_transform_az_el(
+            et, az_el_3d, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.IMAP_DPS, degrees=True
+        )
+
+        # Check that output shape matches input shape
+        assert result.shape == az_el_3d.shape
+
+        # Verify by comparing against processing each 2D slice independently
+        for i in range(az_el_3d.shape[0]):
+            expected_slice = frame_transform_az_el(
+                et,
+                az_el_3d[i],
+                SpiceFrame.IMAP_SPACECRAFT,
+                SpiceFrame.IMAP_DPS,
+                degrees=True,
+            )
+            np.testing.assert_allclose(result[i], expected_slice, atol=1e-10)
+
+
 @pytest.mark.external_kernel
 def test_get_rotation_matrix(furnish_kernels):
     """Test coverage for get_rotation_matrix()."""


### PR DESCRIPTION
# Change Summary

## Overview
The two changes here support the ability for PSET bins at different energy levels project (bin) into unique map pixels. This is needed for the Hi/Lo CG correction.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/ena_maps/ena_maps.py
   - Support input_obj with multi-dimensional azimuth and elevation coordinates in the `match_coords_to_indices` function. The leading dimension would correspond to energy. In this way, we can map a single pset bin to unique map bin at each energy level.
- imap_processing/ena_maps/utils/map_utils.py
   - Allow multidimensional inputs to `bin_single_array_at_indices` function and support broadcasting.
   - New `vectorized_bincount` function supports the above change. Multi-dimensional binning is supported by making it a 1D problem and adjusting the projection indices accordingly. This allows binning to be done in 1D objects which then get reshaped into 2D objects.
   - imap_processing/tests/ena_maps/test_ena_maps.py
   - Add test coverage for changes to `match_coords_to_indices` function.
   - imap_processing/tests/ena_maps/test_map_utils.py
   - Add test coverage for new `vectorized_bincount` function
   - Update test coverage for `bin_single_array_at_indices` function to include many combinations of 1D and 2D inputs in order to check that broadcasting works as expected.

Closes: #2253
