### PR TITLE
2270 hi lo l2 cg correction   fix binning when additional dimensions are present

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -87,7 +87,7 @@ def match_coords_to_indices(
     This function always "pushes" the pixels of the input object to corresponding pixels
     in the output object's unwrapped rectangular grid or healpix tessellation;
     however, by swapping the input and output objects, one can apply the "pull" method
-    of index  matching.
+    of index matching.
 
     At present, the allowable inputs are either:
     - A PointingSet object and a SkyMap object, in either order of input/output.
@@ -100,8 +100,6 @@ def match_coords_to_indices(
         An object containing spatial pixel centers in azimuth and elevation,
         which will be matched to 1D indices of spatial pixels in the output frame.
         Must contain the Spice frame in which the pixel centers are defined.
-        If the input object has multi-dimensional az_el_points (as xr.DataArray),
-        the dimensions will be preserved in the output indices.
     output_object : PointingSet | AbstractSkyMap
         The object containing a grid or tessellation of spatial pixels
         into which the input spatial pixel centers will 'land', and be matched to
@@ -116,14 +114,13 @@ def match_coords_to_indices(
 
     Returns
     -------
-    flat_indices_input_grid_output_frame : NDArray | xr.DataArray
+    flat_indices_input_grid_output_frame : xr.DataArray
         Array of pixel indices mapping each input object pixel center to a pixel
-        in the output object. If the input object has multi-dimensional coordinates
-        defined (az_el_points is an xr.DataArray), the output will be an xr.DataArray
-        with dimension labels preserved. The shape of the output array is (..., n)
-        where ... matches the non-spatial dimensions of the input object and n is the
-        number of spatial pixels in the input object. Output indices may contain 0, 1,
-        or multiple occurrences of the same output index.
+        in the output object. The output xr.DataArray will have the same leading
+        dimension labels preserved. The shape of the output array is (..., n)
+        where ... matches the non-spatial dimensions of the input object, and n
+        is the number of spatial pixels in the input object. Output indices may
+        contain 0, 1, or multiple occurrences of the same output index.
 
     Raises
     ------
@@ -154,12 +151,6 @@ def match_coords_to_indices(
 
     # Az/El pixel center coords of the input object in its own frame
     input_obj_az_el_input_frame = input_object.az_el_points
-
-    # Check if az_el_points is an xarray.DataArray to preserve dimension information
-    is_xarray = isinstance(input_obj_az_el_input_frame, xr.DataArray)
-    if is_xarray:
-        # Extract dimensions (all but the last az_el_coord dimension)
-        input_dims = input_obj_az_el_input_frame.dims[:-1]
 
     # Transform the input pixel centers to the output frame
     input_obj_az_el_output_frame = geometry.frame_transform_az_el(
@@ -213,13 +204,13 @@ def match_coords_to_indices(
             f"Received: {output_object.tiling_type}"
         )
 
-    # If input was an xarray.DataArray, wrap the output indices in a DataArray
-    # with the same dimensions to preserve broadcasting information
-    if is_xarray:
-        flat_indices_input_grid_output_frame = xr.DataArray(
-            flat_indices_input_grid_output_frame,
-            dims=input_dims,
-        )
+    # Wrap the output indices in a DataArray with the same leading dimensions as
+    # the input object az_el_points to preserve broadcasting information
+    input_dims = input_obj_az_el_input_frame.dims[:-1]
+    flat_indices_input_grid_output_frame = xr.DataArray(
+        flat_indices_input_grid_output_frame,
+        dims=input_dims,
+    )
 
     return flat_indices_input_grid_output_frame
 
@@ -620,30 +611,25 @@ class LoHiBasePointingSet(PointingSet):
 
     tiling_type: SkyTilingType = SkyTilingType.RECTANGULAR
 
-    def update_az_el_points(
-        self, az_variable: xr.DataArray, el_variable: xr.DataArray
-    ) -> None:
+    def update_az_el_points(self) -> None:
         """
         Update the az_el_points instance variable with new az/el coordinates.
 
-        Parameters
-        ----------
-        az_variable : xarray.DataArray
-            Azimuth coordinates with PSET coordinates unchanged. The leading
-            dimensions are the non-spatial dimensions (epoch, energy, etc.), and
-            the final dimension(s) are the spatial dimension(s).
-        el_variable : xarray.DataArray
-            Elevation coordinates with PSET coordinates unchanged. Dimensions
-            match those of az_variable.
+        The values store in the "hae_longitude" and "hae_latitude" variables
+        are used to construct the azimuth and elevation coordinates.
         """
         # Get lon/lat coordinates, squeeze the epoch dimension and stack along
         # the spatial dimensions. xarray.stack() takes possibly multiple spatial
         # dimensions and reshapes those into a single dimension.
-        az_stacked = az_variable.squeeze("epoch").stack(
-            {CoordNames.GENERIC_PIXEL.value: self.spatial_coords}
+        az_stacked = (
+            self.data["hae_longitude"]
+            .squeeze("epoch")
+            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
         )
-        el_stacked = el_variable.squeeze("epoch").stack(
-            {CoordNames.GENERIC_PIXEL.value: self.spatial_coords}
+        el_stacked = (
+            self.data["hae_latitude"]
+            .squeeze("epoch")
+            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
         )
 
         # Stack lon/lat along last axis to create shape (..., 2)
@@ -701,7 +687,7 @@ class HiPointingSet(LoHiBasePointingSet):
         self.spatial_coords = ("spin_angle_bin",)
 
         # Update az_el_points using the base class method
-        self.update_az_el_points(self.data["hae_longitude"], self.data["hae_latitude"])
+        self.update_az_el_points()
 
 
 class LoPointingSet(LoHiBasePointingSet):
@@ -720,7 +706,7 @@ class LoPointingSet(LoHiBasePointingSet):
         self.spatial_coords = ("spin_angle", "off_angle")
 
         # Update az_el_points using the base class method
-        self.update_az_el_points(self.data["hae_longitude"], self.data["hae_latitude"])
+        self.update_az_el_points()
 
 
 # Define the Map classes
@@ -754,10 +740,10 @@ class AbstractSkyMap(ABC):
     max_epoch: int
 
     # ======== Attributes required to be set in a subclass ========
-    # Azimuth and elevation coordinates of each spatial pixel. The ndarray should
-    # have the shape (n, 2) where n is the number of spatial pixels.
+    # Azimuth and elevation coordinates of each spatial pixel. The xarray.DataArray
+    # should have the shape (n, 2) where n is the number of spatial pixels.
     # Always a simple numpy array for maps (no need for multi-dimensional coords).
-    az_el_points: np.ndarray
+    az_el_points: xr.DataArray
     # Type of sky tiling
     tiling_type: SkyTilingType
     # Dictionary of xr.DataArray objects for each non-spatial coordinate in the SkyMap
@@ -1179,7 +1165,10 @@ class RectangularSkyMap(AbstractSkyMap):
         el_points = self.sky_grid.el_grid.ravel()
 
         # Stack so axis 0 is different pixels, and axis 1 is (az, el) of the pixel
-        self.az_el_points = np.column_stack((az_points, el_points))
+        self.az_el_points = xr.DataArray(
+            np.column_stack((az_points, el_points)),
+            dims=[CoordNames.GENERIC_PIXEL.value, "az_el_coord"],
+        )
 
         # Calculate solid angles of each pixel in the map grid in units of steradians
         self.solid_angle_grid = spatial_utils.build_solid_angle_map(
@@ -1490,7 +1479,10 @@ class HealpixSkyMap(AbstractSkyMap):
             nside=nside, ipix=np.arange(hp.nside2npix(nside)), nest=nested, lonlat=True
         )
         # Stack so axis 0 is different pixels, and axis 1 is (az, el) of the pixel
-        self.az_el_points = np.column_stack((pixel_az, pixel_el))
+        self.az_el_points = xr.DataArray(
+            np.column_stack((pixel_az, pixel_el)),
+            dims=[CoordNames.GENERIC_PIXEL.value, "az_el_coord"],
+        )
 
         self.spatial_coords = {
             CoordNames.HEALPIX_INDEX.value: xr.DataArray(
@@ -1826,7 +1818,7 @@ class HealpixSkyMap(AbstractSkyMap):
                     value_array=healpix_values_array,
                     max_subdivision_depth=max_subdivision_depth,
                 )
-                for lon_lat in rect_map.az_el_points
+                for lon_lat in rect_map.az_el_points.values
             ]
 
             # Separate the best value and the recursion depth for each pixel

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -73,7 +73,7 @@ def match_coords_to_indices(
     input_object: PointingSet | AbstractSkyMap,
     output_object: PointingSet | AbstractSkyMap,
     event_et: float | None = None,
-) -> NDArray:
+) -> NDArray | xr.DataArray:
     """
     Find the output indices corresponding to each input coord between 2 spatial objects.
 
@@ -100,6 +100,8 @@ def match_coords_to_indices(
         An object containing spatial pixel centers in azimuth and elevation,
         which will be matched to 1D indices of spatial pixels in the output frame.
         Must contain the Spice frame in which the pixel centers are defined.
+        If the input object has multi-dimensional az_el_points (as xr.DataArray),
+        the dimensions will be preserved in the output indices.
     output_object : PointingSet | AbstractSkyMap
         The object containing a grid or tessellation of spatial pixels
         into which the input spatial pixel centers will 'land', and be matched to
@@ -114,14 +116,14 @@ def match_coords_to_indices(
 
     Returns
     -------
-    flat_indices_input_grid_output_frame : NDArray
+    flat_indices_input_grid_output_frame : NDArray | xr.DataArray
         Array of pixel indices mapping each input object pixel center to a pixel
         in the output object. If the input object has multi-dimensional coordinates
-        defined, the output indices will also be multi-dimensional. The shape of
-        the output array is (..., n) where ... matches the non-spatial dimensions
-        of the input object and n is the number of spatial pixels in the input
-        object. Output indices may contain 0, 1, or multiple occurrences of the
-        same output index.
+        defined (az_el_points is an xr.DataArray), the output will be an xr.DataArray
+        with dimension labels preserved. The shape of the output array is (..., n)
+        where ... matches the non-spatial dimensions of the input object and n is the
+        number of spatial pixels in the input object. Output indices may contain 0, 1,
+        or multiple occurrences of the same output index.
 
     Raises
     ------
@@ -152,6 +154,12 @@ def match_coords_to_indices(
 
     # Az/El pixel center coords of the input object in its own frame
     input_obj_az_el_input_frame = input_object.az_el_points
+
+    # Check if az_el_points is an xarray.DataArray to preserve dimension information
+    is_xarray = isinstance(input_obj_az_el_input_frame, xr.DataArray)
+    if is_xarray:
+        # Extract dimensions (all but the last az_el_coord dimension)
+        input_dims = input_obj_az_el_input_frame.dims[:-1]
 
     # Transform the input pixel centers to the output frame
     input_obj_az_el_output_frame = geometry.frame_transform_az_el(
@@ -205,6 +213,14 @@ def match_coords_to_indices(
             f"Received: {output_object.tiling_type}"
         )
 
+    # If input was an xarray.DataArray, wrap the output indices in a DataArray
+    # with the same dimensions to preserve broadcasting information
+    if is_xarray:
+        flat_indices_input_grid_output_frame = xr.DataArray(
+            flat_indices_input_grid_output_frame,
+            dims=input_dims,
+        )
+
     return flat_indices_input_grid_output_frame
 
 
@@ -239,9 +255,10 @@ class PointingSet(ABC):
     spice_reference_frame: geometry.SpiceFrame
 
     # ======== Attributes required to be set in a subclass ========
-    # Azimuth and elevation coordinates of each spatial pixel. The ndarray should
-    # have the shape (n, 2) where n is the number of spatial pixels
-    az_el_points: np.ndarray
+    # Azimuth and elevation coordinates of each spatial pixel. Must be an
+    # xr.DataArray with dimensions (..., spatial_dim, az_el_coord) to preserve
+    # dimension labels
+    az_el_points: xr.DataArray
     # Tuple containing the names of each spatial coordinate of the xarray.Dataset
     # stored in the data attribute
     spatial_coords: tuple[str, ...]
@@ -277,7 +294,7 @@ class PointingSet(ABC):
         num_points: int
             The number of spatial pixels in the pointing set.
         """
-        return self.az_el_points.shape[0]
+        return self.az_el_points.shape[-2]
 
     @property
     def epoch(self) -> int:
@@ -433,11 +450,12 @@ class RectangularPointingSet(PointingSet):
         # into shape (number of points in tiling of the sky, 2) where
         # column 0 (az_el_points[:, 0]) is the azimuth of that point and
         # column 1 (az_el_points[:, 1]) is the elevation of that point.
-        self.az_el_points = np.column_stack(
-            (
-                self.sky_grid.az_grid.ravel(),
-                self.sky_grid.el_grid.ravel(),
-            )
+        self.az_el_points = xr.DataArray(
+            np.stack(
+                (self.sky_grid.az_grid.ravel(), self.sky_grid.el_grid.ravel()),
+                axis=-1,
+            ),
+            dims=[CoordNames.GENERIC_PIXEL.value, "az_el_coord"],
         )
 
 
@@ -543,8 +561,9 @@ class UltraPointingSet(HealpixPointingSet):
         # The coordinates of the healpix pixel centers are stored as a 2D array
         # of shape (num_points, 2) where column 0 is the lon/az
         # and column 1 is the lat/el.
-        self.az_el_points = np.column_stack(
-            (azimuth_pixel_center, elevation_pixel_center)
+        self.az_el_points = xr.DataArray(
+            np.stack((azimuth_pixel_center, elevation_pixel_center), axis=-1),
+            dims=[CoordNames.GENERIC_PIXEL.value, "az_el_coord"],
         )
 
     @property
@@ -634,13 +653,25 @@ class HiPointingSet(PointingSet):
             self.data["exposure_factor"], self.data["epoch"].values[0]
         )
 
-        self.az_el_points = np.column_stack(
-            (
-                np.squeeze(self.data["hae_longitude"]),
-                np.squeeze(self.data["hae_latitude"]),
-            )
-        )
         self.spatial_coords = ("spin_angle_bin",)
+
+        # Get lon/lat coordinates and squeeze the epoch dimension
+        hae_lon = (
+            self.data["hae_longitude"]
+            .squeeze("epoch")
+            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
+        )
+        hae_lat = (
+            self.data["hae_latitude"]
+            .squeeze("epoch")
+            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
+        )
+
+        # Stack lon/lat along last axis to create shape (..., 2)
+        self.az_el_points = xr.DataArray(
+            np.stack([hae_lon.values, hae_lat.values], axis=-1),
+            dims=[*hae_lon.dims, "az_el_coord"],
+        )
 
 
 class LoPointingSet(PointingSet):
@@ -656,14 +687,23 @@ class LoPointingSet(PointingSet):
     def __init__(self, dataset: xr.Dataset):
         super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.IMAP_HAE)
 
-        # The HAE centers are stored in the pset as (1, 3600, 40) arrays
-        self.az_el_points = np.column_stack(
-            (
-                np.squeeze(self.data["hae_longitude"]).values.ravel(),
-                np.squeeze(self.data["hae_latitude"]).values.ravel(),
-            )
-        )
         self.spatial_coords = ("spin_angle", "off_angle")
+
+        # The HAE centers are stored in the pset as (1, 3600, 40) arrays
+        hae_lon = (
+            self.data["hae_longitude"]
+            .squeeze("epoch")
+            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
+        )
+        hae_lat = (
+            self.data["hae_latitude"]
+            .squeeze("epoch")
+            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
+        )
+        self.az_el_points = xr.DataArray(
+            np.stack([hae_lon.values, hae_lat.values], axis=-1),
+            dims=[*hae_lon.dims, "az_el_coord"],
+        )
 
 
 # Define the Map classes
@@ -698,7 +738,8 @@ class AbstractSkyMap(ABC):
 
     # ======== Attributes required to be set in a subclass ========
     # Azimuth and elevation coordinates of each spatial pixel. The ndarray should
-    # have the shape (n, 2) where n is the number of spatial pixels
+    # have the shape (n, 2) where n is the number of spatial pixels.
+    # Always a simple numpy array for maps (no need for multi-dimensional coords).
     az_el_points: np.ndarray
     # Type of sky tiling
     tiling_type: SkyTilingType
@@ -832,19 +873,11 @@ class AbstractSkyMap(ABC):
             )
 
         for value_key in value_keys:
-            pset_values = pointing_set.data[value_key]
-
             # If multiple spatial axes present
             # (i.e (az, el) for rectangular coordinate PSET),
             # flatten them in the values array to match the raveled indices
-            non_spatial_axes_shape = tuple(
-                size
-                for key, size in pset_values.sizes.items()
-                if key not in pointing_set.spatial_coords
-            )
-            raveled_pset_data = pset_values.data.reshape(
-                *non_spatial_axes_shape,
-                pointing_set.num_points,
+            raveled_pset_data = pointing_set.data[value_key].stack(
+                {CoordNames.GENERIC_PIXEL.value: pointing_set.spatial_coords}
             )
 
             if value_key not in self.data_1d.data_vars:
@@ -867,10 +900,16 @@ class AbstractSkyMap(ABC):
             if index_match_method is IndexMatchMethod.PUSH:
                 # Bin the values at the matched indices. There may be multiple
                 # pointing set pixels that correspond to the same sky map pixel.
+                # Broadcast all arrays together using xarray dimension alignment
+                data_bc, indices_bc = xr.broadcast(
+                    raveled_pset_data, matched_indices_push
+                )
+
+                # Extract numpy arrays for bincount operation
                 pointing_projected_values = map_utils.bin_single_array_at_indices(
-                    value_array=raveled_pset_data,
+                    value_array=data_bc.values,
                     projection_grid_shape=self.binning_grid_shape,
-                    projection_indices=matched_indices_push,
+                    projection_indices=indices_bc.values,
                     input_valid_mask=pset_valid_mask,
                 )
                 # TODO: we may need to allow for unweighted/weighted means here by
@@ -882,7 +921,7 @@ class AbstractSkyMap(ABC):
                 valid_map_mask = pset_valid_mask[matched_indices_pull]
                 # We know that there will only be one value per sky map pixel,
                 # so we can use the matched indices directly
-                pointing_projected_values = raveled_pset_data[
+                pointing_projected_values = raveled_pset_data.values[
                     ..., matched_indices_pull[valid_map_mask]
                 ]
                 # TODO: we may need to allow for unweighted/weighted means here by

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -448,7 +448,7 @@ class RectangularPointingSet(PointingSet):
                 (self.sky_grid.az_grid.ravel(), self.sky_grid.el_grid.ravel()),
                 axis=-1,
             ),
-            dims=[CoordNames.GENERIC_PIXEL.value, "az_el_coord"],
+            dims=[CoordNames.GENERIC_PIXEL.value, CoordNames.AZ_EL_VECTOR.value],
         )
 
 
@@ -556,7 +556,7 @@ class UltraPointingSet(HealpixPointingSet):
         # and column 1 is the lat/el.
         self.az_el_points = xr.DataArray(
             np.stack((azimuth_pixel_center, elevation_pixel_center), axis=-1),
-            dims=[CoordNames.GENERIC_PIXEL.value, "az_el_coord"],
+            dims=[CoordNames.GENERIC_PIXEL.value, CoordNames.AZ_EL_VECTOR.value],
         )
 
     @property
@@ -635,7 +635,7 @@ class LoHiBasePointingSet(PointingSet):
         # Stack lon/lat along last axis to create shape (..., 2)
         self.az_el_points = xr.DataArray(
             np.stack([az_stacked.values, el_stacked.values], axis=-1),
-            dims=[*az_stacked.dims, "az_el_coord"],
+            dims=[*az_stacked.dims, CoordNames.AZ_EL_VECTOR.value],
         )
 
 
@@ -1167,7 +1167,7 @@ class RectangularSkyMap(AbstractSkyMap):
         # Stack so axis 0 is different pixels, and axis 1 is (az, el) of the pixel
         self.az_el_points = xr.DataArray(
             np.column_stack((az_points, el_points)),
-            dims=[CoordNames.GENERIC_PIXEL.value, "az_el_coord"],
+            dims=[CoordNames.GENERIC_PIXEL.value, CoordNames.AZ_EL_VECTOR.value],
         )
 
         # Calculate solid angles of each pixel in the map grid in units of steradians
@@ -1481,7 +1481,7 @@ class HealpixSkyMap(AbstractSkyMap):
         # Stack so axis 0 is different pixels, and axis 1 is (az, el) of the pixel
         self.az_el_points = xr.DataArray(
             np.column_stack((pixel_az, pixel_el)),
-            dims=[CoordNames.GENERIC_PIXEL.value, "az_el_coord"],
+            dims=[CoordNames.GENERIC_PIXEL.value, CoordNames.AZ_EL_VECTOR.value],
         )
 
         self.spatial_coords = {

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -294,6 +294,8 @@ class PointingSet(ABC):
         num_points: int
             The number of spatial pixels in the pointing set.
         """
+        # Last dimension is az/el vector, the second to last dimension is
+        # the number of pixels.
         return self.az_el_points.shape[-2]
 
     @property

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -610,7 +610,50 @@ class UltraPointingSet(HealpixPointingSet):
         )
 
 
-class HiPointingSet(PointingSet):
+class LoHiBasePointingSet(PointingSet):
+    """
+    Base class for Lo and Hi pointing sets with HAE coordinate data.
+
+    This class provides common functionality for pointing sets that contain
+    hae_longitude and hae_latitude coordinates in the dataset.
+    """
+
+    tiling_type: SkyTilingType = SkyTilingType.RECTANGULAR
+
+    def update_az_el_points(
+        self, az_variable: xr.DataArray, el_variable: xr.DataArray
+    ) -> None:
+        """
+        Update the az_el_points instance variable with new az/el coordinates.
+
+        Parameters
+        ----------
+        az_variable : xarray.DataArray
+            Azimuth coordinates with PSET coordinates unchanged. The leading
+            dimensions are the non-spatial dimensions (epoch, energy, etc.), and
+            the final dimension(s) are the spatial dimension(s).
+        el_variable : xarray.DataArray
+            Elevation coordinates with PSET coordinates unchanged. Dimensions
+            match those of az_variable.
+        """
+        # Get lon/lat coordinates, squeeze the epoch dimension and stack along
+        # the spatial dimensions. xarray.stack() takes possibly multiple spatial
+        # dimensions and reshapes those into a single dimension.
+        az_stacked = az_variable.squeeze("epoch").stack(
+            {CoordNames.GENERIC_PIXEL.value: self.spatial_coords}
+        )
+        el_stacked = el_variable.squeeze("epoch").stack(
+            {CoordNames.GENERIC_PIXEL.value: self.spatial_coords}
+        )
+
+        # Stack lon/lat along last axis to create shape (..., 2)
+        self.az_el_points = xr.DataArray(
+            np.stack([az_stacked.values, el_stacked.values], axis=-1),
+            dims=[*az_stacked.dims, "az_el_coord"],
+        )
+
+
+class HiPointingSet(LoHiBasePointingSet):
     """
     PointingSet object specific to Hi L1C PSet data.
 
@@ -657,26 +700,11 @@ class HiPointingSet(PointingSet):
 
         self.spatial_coords = ("spin_angle_bin",)
 
-        # Get lon/lat coordinates and squeeze the epoch dimension
-        hae_lon = (
-            self.data["hae_longitude"]
-            .squeeze("epoch")
-            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
-        )
-        hae_lat = (
-            self.data["hae_latitude"]
-            .squeeze("epoch")
-            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
-        )
-
-        # Stack lon/lat along last axis to create shape (..., 2)
-        self.az_el_points = xr.DataArray(
-            np.stack([hae_lon.values, hae_lat.values], axis=-1),
-            dims=[*hae_lon.dims, "az_el_coord"],
-        )
+        # Update az_el_points using the base class method
+        self.update_az_el_points(self.data["hae_longitude"], self.data["hae_latitude"])
 
 
-class LoPointingSet(PointingSet):
+class LoPointingSet(LoHiBasePointingSet):
     """
     PointingSet object specific to Lo L1C PSet data.
 
@@ -691,21 +719,8 @@ class LoPointingSet(PointingSet):
 
         self.spatial_coords = ("spin_angle", "off_angle")
 
-        # The HAE centers are stored in the pset as (1, 3600, 40) arrays
-        hae_lon = (
-            self.data["hae_longitude"]
-            .squeeze("epoch")
-            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
-        )
-        hae_lat = (
-            self.data["hae_latitude"]
-            .squeeze("epoch")
-            .stack({CoordNames.GENERIC_PIXEL.value: self.spatial_coords})
-        )
-        self.az_el_points = xr.DataArray(
-            np.stack([hae_lon.values, hae_lat.values], axis=-1),
-            dims=[*hae_lon.dims, "az_el_coord"],
-        )
+        # Update az_el_points using the base class method
+        self.update_az_el_points(self.data["hae_longitude"], self.data["hae_latitude"])
 
 
 # Define the Map classes

--- a/imap_processing/ena_maps/utils/coordinates.py
+++ b/imap_processing/ena_maps/utils/coordinates.py
@@ -18,3 +18,6 @@ class CoordNames(Enum):
     ELEVATION_L1C = "latitude"
     AZIMUTH_L2 = "longitude"
     ELEVATION_L2 = "latitude"
+
+    # Common name for dimension along azimuth/elevation vector
+    AZ_EL_VECTOR = "az_el"

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -290,6 +290,154 @@ class TestLoPointingSet:
         assert rect_map.data_1d["h_counts"].max() > 0
 
 
+@pytest.mark.external_test_data
+class TestLoHiBasePointingSet:
+    """Test suite for LoHiBasePointingSet class and its subclasses."""
+
+    def test_hi_az_el_points_is_dataarray(self, hi_pset_cdf_path):
+        """Test that HiPointingSet.az_el_points is an xarray.DataArray."""
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
+
+        # Verify az_el_points is a DataArray
+        assert isinstance(hi_pset.az_el_points, xr.DataArray)
+
+        # Verify dimensions
+        assert hi_pset.az_el_points.dims == ("pixel", "az_el_coord")
+
+        # Verify shape
+        assert hi_pset.az_el_points.shape == (3600, 2)
+
+    def test_lo_az_el_points_is_dataarray(self, lo_pset_ds):
+        """Test that LoPointingSet.az_el_points is an xarray.DataArray."""
+        lo_pset = ena_maps.LoPointingSet(lo_pset_ds)
+
+        # Verify az_el_points is a DataArray
+        assert isinstance(lo_pset.az_el_points, xr.DataArray)
+
+        # Verify dimensions
+        assert lo_pset.az_el_points.dims == ("pixel", "az_el_coord")
+
+        # Verify shape
+        assert lo_pset.az_el_points.shape == (144000, 2)
+
+    def test_inheritance(self, hi_pset_cdf_path, lo_pset_ds):
+        """Test that Hi and Lo pointing sets inherit from LoHiBasePointingSet."""
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
+        lo_pset = ena_maps.LoPointingSet(lo_pset_ds)
+
+        # Verify inheritance
+        assert isinstance(hi_pset, ena_maps.LoHiBasePointingSet)
+        assert isinstance(lo_pset, ena_maps.LoHiBasePointingSet)
+
+        # Verify tiling type is set correctly
+        assert hi_pset.tiling_type == ena_maps.SkyTilingType.RECTANGULAR
+        assert lo_pset.tiling_type == ena_maps.SkyTilingType.RECTANGULAR
+
+    def test_update_az_el_points_multidimensional(self, hi_pset_cdf_path):
+        """Test update_az_el_points with multi-dimensional coordinates."""
+        pset_ds = load_cdf(hi_pset_cdf_path)
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+
+        # Create mock multi-dimensional coordinates with an energy dimension
+        # Shape: (epoch, hf_energy, spin_angle_bin) = (1, 9, 3600)
+        mock_lon = xr.DataArray(
+            np.random.uniform(0, 360, (1, 9, 3600)),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+        mock_lat = xr.DataArray(
+            np.random.uniform(-90, 90, (1, 9, 3600)),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+
+        # Update az_el_points with multi-dimensional coordinates
+        hi_pset.update_az_el_points(mock_lon, mock_lat)
+
+        # Verify az_el_points is still a DataArray
+        assert isinstance(hi_pset.az_el_points, xr.DataArray)
+
+        # Verify dimensions are preserved (epoch squeezed, pixel stacked)
+        assert hi_pset.az_el_points.dims == ("hf_energy", "pixel", "az_el_coord")
+
+        # Verify shape
+        assert hi_pset.az_el_points.shape == (9, 3600, 2)
+
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_multidim_az_el_points_with_match_coords(
+        self, mock_frame_transform, hi_pset_cdf_path
+    ):
+        """Test multi-dimensional az_el_points with match_coords_to_indices."""
+        # Mock frame_transform to return az_el unchanged
+        mock_frame_transform.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        pset_ds = load_cdf(hi_pset_cdf_path)
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+
+        # Create multi-dimensional az_el_points (energy, pixel, az_el_coord)
+        mock_lon = xr.DataArray(
+            np.random.uniform(0, 360, (1, 9, 3600)),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+        mock_lat = xr.DataArray(
+            np.random.uniform(-90, 90, (1, 9, 3600)),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+        hi_pset.update_az_el_points(mock_lon, mock_lat)
+
+        # Create a rectangular map
+        rect_map = ena_maps.RectangularSkyMap(
+            spacing_deg=6, spice_frame=geometry.SpiceFrame.ECLIPJ2000
+        )
+
+        # Match coordinates to indices
+        indices = ena_maps.match_coords_to_indices(hi_pset, rect_map)
+
+        # Verify output is DataArray with preserved dimensions
+        assert isinstance(indices, xr.DataArray)
+        assert indices.dims == ("hf_energy", "pixel")
+        assert indices.shape == (9, 3600)
+
+    def test_broadcasting_with_multidim_pset(self, hi_pset_cdf_path):
+        """Test xr broadcasting in project_pset_values_to_map with multi-dim PSET."""
+        pset_ds = load_cdf(hi_pset_cdf_path)
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+
+        # Add a mock multi-dimensional variable to the PSET
+        # Shape: (epoch, hf_energy, spin_angle_bin)
+        hi_pset.data["mock_flux"] = xr.DataArray(
+            np.random.uniform(0, 100, (1, 9, 3600)),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+
+        # Create multi-dimensional az_el_points
+        mock_lon = xr.DataArray(
+            np.random.uniform(0, 360, (1, 9, 3600)),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+        mock_lat = xr.DataArray(
+            np.random.uniform(-90, 90, (1, 9, 3600)),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+        hi_pset.update_az_el_points(mock_lon, mock_lat)
+
+        # Create a rectangular map
+        rect_map = ena_maps.RectangularSkyMap(
+            spacing_deg=6, spice_frame=geometry.SpiceFrame.ECLIPJ2000
+        )
+
+        # Project the multi-dimensional data to the map
+        rect_map.project_pset_values_to_map(hi_pset, ["mock_flux"])
+
+        # Verify the projection succeeded and has correct dimensions
+        assert "mock_flux" in rect_map.data_1d
+        # Expected dims: (epoch, hf_energy, pixel)
+        assert rect_map.data_1d["mock_flux"].dims == ("epoch", "hf_energy", "pixel")
+        assert rect_map.data_1d["mock_flux"].shape[0] == 1  # epoch
+        assert rect_map.data_1d["mock_flux"].shape[1] == 9  # hf_energy
+        assert rect_map.data_1d["mock_flux"].shape[2] == rect_map.num_points  # pixel
+
+
 class TestRectangularSkyMap:
     @pytest.fixture(autouse=True)
     def _setup_ultra_l1c_pset_products(self, setup_all_pset_products):

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -335,7 +335,7 @@ class TestLoHiBasePointingSet:
         assert isinstance(hi_pset.az_el_points, xr.DataArray)
 
         # Verify dimensions
-        assert hi_pset.az_el_points.dims == ("pixel", "az_el_coord")
+        assert hi_pset.az_el_points.dims == ("pixel", CoordNames.AZ_EL_VECTOR.value)
 
         # Verify shape
         assert hi_pset.az_el_points.shape == (3600, 2)
@@ -348,7 +348,7 @@ class TestLoHiBasePointingSet:
         assert isinstance(lo_pset.az_el_points, xr.DataArray)
 
         # Verify dimensions
-        assert lo_pset.az_el_points.dims == ("pixel", "az_el_coord")
+        assert lo_pset.az_el_points.dims == ("pixel", CoordNames.AZ_EL_VECTOR.value)
 
         # Verify shape
         assert lo_pset.az_el_points.shape == (144000, 2)
@@ -374,7 +374,11 @@ class TestLoHiBasePointingSet:
         assert isinstance(hi_pset.az_el_points, xr.DataArray)
 
         # Verify dimensions are preserved (epoch squeezed, pixel stacked)
-        assert hi_pset.az_el_points.dims == ("hf_energy", "pixel", "az_el_coord")
+        assert hi_pset.az_el_points.dims == (
+            "hf_energy",
+            "pixel",
+            CoordNames.AZ_EL_VECTOR.value,
+        )
 
         # Verify shape
         assert hi_pset.az_el_points.shape == (9, 3600, 2)

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -294,6 +294,39 @@ class TestLoPointingSet:
 class TestLoHiBasePointingSet:
     """Test suite for LoHiBasePointingSet class and its subclasses."""
 
+    @staticmethod
+    def create_hi_pset_with_multidim_coords(
+        hi_pset_cdf_path: str, shape: tuple[int, int, int] = (1, 9, 3600)
+    ) -> ena_maps.HiPointingSet:
+        """
+        Create a HiPointingSet with multi-dimensional coordinates.
+
+        Parameters
+        ----------
+        hi_pset_cdf_path : str
+            Path to the Hi PSET CDF file.
+        shape : tuple[int, int, int], optional
+            Shape of the coordinates (epoch, hf_energy, spin_angle_bin).
+            Default is (1, 9, 3600).
+
+        Returns
+        -------
+        ena_maps.HiPointingSet
+            HiPointingSet with multi-dimensional az_el_points.
+        """
+        pset_ds = load_cdf(hi_pset_cdf_path)
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+        hi_pset.data["hae_longitude"] = xr.DataArray(
+            np.random.uniform(0, 360, shape),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+        hi_pset.data["hae_latitude"] = xr.DataArray(
+            np.random.uniform(-90, 90, shape),
+            dims=["epoch", "hf_energy", "spin_angle_bin"],
+        )
+        hi_pset.update_az_el_points()
+        return hi_pset
+
     def test_hi_az_el_points_is_dataarray(self, hi_pset_cdf_path):
         """Test that HiPointingSet.az_el_points is an xarray.DataArray."""
         hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
@@ -335,22 +368,7 @@ class TestLoHiBasePointingSet:
 
     def test_update_az_el_points_multidimensional(self, hi_pset_cdf_path):
         """Test update_az_el_points with multi-dimensional coordinates."""
-        pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
-
-        # Create mock multi-dimensional coordinates with an energy dimension
-        # Shape: (epoch, hf_energy, spin_angle_bin) = (1, 9, 3600)
-        mock_lon = xr.DataArray(
-            np.random.uniform(0, 360, (1, 9, 3600)),
-            dims=["epoch", "hf_energy", "spin_angle_bin"],
-        )
-        mock_lat = xr.DataArray(
-            np.random.uniform(-90, 90, (1, 9, 3600)),
-            dims=["epoch", "hf_energy", "spin_angle_bin"],
-        )
-
-        # Update az_el_points with multi-dimensional coordinates
-        hi_pset.update_az_el_points(mock_lon, mock_lat)
+        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
 
         # Verify az_el_points is still a DataArray
         assert isinstance(hi_pset.az_el_points, xr.DataArray)
@@ -371,19 +389,7 @@ class TestLoHiBasePointingSet:
             lambda et, az_el, from_frame, to_frame, degrees: az_el
         )
 
-        pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
-
-        # Create multi-dimensional az_el_points (energy, pixel, az_el_coord)
-        mock_lon = xr.DataArray(
-            np.random.uniform(0, 360, (1, 9, 3600)),
-            dims=["epoch", "hf_energy", "spin_angle_bin"],
-        )
-        mock_lat = xr.DataArray(
-            np.random.uniform(-90, 90, (1, 9, 3600)),
-            dims=["epoch", "hf_energy", "spin_angle_bin"],
-        )
-        hi_pset.update_az_el_points(mock_lon, mock_lat)
+        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
 
         # Create a rectangular map
         rect_map = ena_maps.RectangularSkyMap(
@@ -400,8 +406,7 @@ class TestLoHiBasePointingSet:
 
     def test_broadcasting_with_multidim_pset(self, hi_pset_cdf_path):
         """Test xr broadcasting in project_pset_values_to_map with multi-dim PSET."""
-        pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
 
         # Add a mock multi-dimensional variable to the PSET
         # Shape: (epoch, hf_energy, spin_angle_bin)
@@ -409,17 +414,6 @@ class TestLoHiBasePointingSet:
             np.random.uniform(0, 100, (1, 9, 3600)),
             dims=["epoch", "hf_energy", "spin_angle_bin"],
         )
-
-        # Create multi-dimensional az_el_points
-        mock_lon = xr.DataArray(
-            np.random.uniform(0, 360, (1, 9, 3600)),
-            dims=["epoch", "hf_energy", "spin_angle_bin"],
-        )
-        mock_lat = xr.DataArray(
-            np.random.uniform(-90, 90, (1, 9, 3600)),
-            dims=["epoch", "hf_energy", "spin_angle_bin"],
-        )
-        hi_pset.update_az_el_points(mock_lon, mock_lat)
 
         # Create a rectangular map
         rect_map = ena_maps.RectangularSkyMap(
@@ -1390,20 +1384,23 @@ class TestIndexMatching:
             self.rectangular_l1c_pset_products[0],
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
-        manual_az_el_coords = np.array(
-            [
-                [0, -90],  # always -> RectangularSkyMap pixel 0
-                [0.4999999, -90],
-                [180.5, -89.5],
-                [359.5, -89.5],
-                [0.5, 0],
-                [180.5, 0],
-                [359.5, 0],
-                [0.5, 89.5],
-                [180.5, 89.5],
-                [359.5, 89.5],
-                [359.999999, 89.99999],
-            ]
+        manual_az_el_coords = xr.DataArray(
+            np.array(
+                [
+                    [0, -90],  # always -> RectangularSkyMap pixel 0
+                    [0.4999999, -90],
+                    [180.5, -89.5],
+                    [359.5, -89.5],
+                    [0.5, 0],
+                    [180.5, 0],
+                    [359.5, 0],
+                    [0.5, 89.5],
+                    [180.5, 89.5],
+                    [359.5, 89.5],
+                    [359.999999, 89.99999],
+                ]
+            ),
+            dims=["pixel", "az_el_coords"],
         )
         mock_pset_input_frame.az_el_points = manual_az_el_coords
 
@@ -1458,23 +1455,26 @@ class TestIndexMatching:
             spice_reference_frame=geometry.SpiceFrame.IMAP_DPS,
         )
         # Create multi-dimensional az_el coordinates
-        multi_dim_az_el_coords = np.array(
-            [
-                list(
-                    zip(
-                        np.linspace(0, 359.9, 20),
-                        np.linspace(-90, 89.9, 20),
-                        strict=False,
-                    )
-                ),
-                list(
-                    zip(
-                        np.linspace(359.9, 0, 20),
-                        np.linspace(89.9, -90, 20),
-                        strict=False,
-                    )
-                ),
-            ]
+        multi_dim_az_el_coords = xr.DataArray(
+            np.array(
+                [
+                    list(
+                        zip(
+                            np.linspace(0, 359.9, 20),
+                            np.linspace(-90, 89.9, 20),
+                            strict=False,
+                        )
+                    ),
+                    list(
+                        zip(
+                            np.linspace(359.9, 0, 20),
+                            np.linspace(89.9, -90, 20),
+                            strict=False,
+                        )
+                    ),
+                ]
+            ),
+            dims=["energy", "pixel", "az_el_coords"],
         )
         mock_pset_input_frame.az_el_points = multi_dim_az_el_coords
 
@@ -1485,7 +1485,7 @@ class TestIndexMatching:
             [
                 (az // map_spacing_deg) * (180 // map_spacing_deg)
                 + ((90 + el) // map_spacing_deg)
-                for [az, el] in multi_dim_az_el_coords.reshape(-1, 2)
+                for [az, el] in multi_dim_az_el_coords.values.reshape(-1, 2)
             ]
         ).reshape(2, -1)
 
@@ -1510,7 +1510,9 @@ class TestIndexMatching:
         )
         assert healpix_indices.shape == expected_output_pixel.shape
         # indices should be reversed in the second set
-        np.testing.assert_equal(healpix_indices[0, :], healpix_indices[1, ::-1])
+        np.testing.assert_equal(
+            healpix_indices.values[0, :], healpix_indices.values[1, ::-1]
+        )
 
     @pytest.mark.parametrize(
         "nside,degree_tolerance",


### PR DESCRIPTION
# Change Summary

## Overview
In prototyping the Hi CG correction code, I identified one last deficiency in the ena_mapping code. The multidimensional binning was still not working because Hi input data has an extra calibration_prod dimension. The numpy broadcasting doesn't know how to insert a singular dimension where needed, but xarray does. For this reason, I added xarray broadcasting support to the binning methods. This also meant that I had to update the PointingSet.az_el_points to be an xarray.DataArray object rather than just a np.ndarray.

## Updated Files
- imap_processing/ena_maps/ena_maps.py
   - Add xr.DataArray support to `match_coords_to_indices`. If the input coordinates are a DataArray, then output indices in a DataArray with the same non-spatial dimensions.
   - Change `PointingSet.az_el_points` instance variable to be an xr.DataArray.
   - Update property retriever function `num_points` to return second to last dimension size. This allows there to be preceding non-spatial dimensions.
   - Add `LoHiBasePointingSet`, common base class for Hi and Lo PointingSet
   - Use xarray broadcasting in `AbstractSkyMap.project_pset_values_to_map`
- imap_processing/tests/ena_maps/test_ena_maps.py
   - Claude helped me add this test coverage.

Close: #2270 
