### PR TITLE
Update common  map variable metadata

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -113,37 +113,22 @@ epoch_delta:
 # in the tiling-specific YAML files.
 longitude:
   <<: *default_float32
-  CATDESC: Pixel center longitude
   FIELDNAM: "{frame} Longitude"
-  LABLAXIS: Longitude
-  FORMAT: I3
+  LABLAXIS: "{frame} Longitude"
   UNITS: deg
   VAR_TYPE: support_data
   VALIDMIN: 0
   VALIDMAX: 360
-  LABL_PTR_1: longitude_label
-  SCALETYP: linear
-  MONOTON: INCREASE
-  DELTA_PLUS_VAR: longitude_delta
-  DELTA_MINUS_VAR: longitude_delta
   DICT_KEY: SPASE>Support>SupportQuantity:Orientation,Qualifier:DirectionAngle.AzimuthAngle,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 latitude:
   <<: *default_float32
-  CATDESC: Pixel center latitude
   FIELDNAM: "{frame} Latitude"
-  LABLAXIS: Latitude
-  FORMAT: I2
+  LABLAXIS: "{frame} Latitude"
   UNITS: deg
   VAR_TYPE: support_data
   VALIDMIN: -90
   VALIDMAX: 90
-  LABL_PTR_1: latitude_label
-  SCALETYP: linear
-  BIN_LOCATION: 0.5
-  MONOTON: INCREASE
-  DELTA_PLUS_VAR: latitude_delta
-  DELTA_MINUS_VAR: latitude_delta
   DICT_KEY: SPASE>Support>SupportQuantity:Orientation,Qualifier:DirectionAngle.ElevationAngle,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 # Define Data variables, but not their pixel-level DEPENDs
@@ -297,7 +282,7 @@ obs_date_range:
   <<: *default_int64
   datatype: int64
   CATDESC: Standard deviation of the observation date.
-  FIELDNAM: J2000 Nanoseconds
+  FIELDNAM: Observation date range
   UNITS: ns
   DEPEND_0: epoch
   VAR_TYPE: support_data

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -81,20 +81,6 @@ energy_delta_plus:
 epoch:
   CATDESC: Map time range start, number of nanoseconds since J2000 with leap seconds included
   FIELDNAM: J2000 Nanoseconds
-  LABLAXIS: epoch
-  FILLVAL: -9223372036854775808
-  FORMAT: " " # Supposedly not required, fails in xarray_to_cdf
-  VALIDMIN: 315576066184000000   # 2010-01-01T00:00:00 mission start (APL 0 epoch)
-  VALIDMAX: 3155716869184000000  # 2100-01-01T00:00:00 mission end
-  UNITS: ns
-  VAR_TYPE: support_data
-  SCALETYP: linear
-  MONOTON: INCREASE
-  TIME_BASE: J2000
-  TIME_SCALE: Terrestrial Time
-  REFERENCE_POSITION: Rotating Earth Geoid
-  RESOLUTION: ' '
-  DICT_KEY: "SPASE>Support>SupportQuantity:Temporal"
   DELTA_PLUS_VAR: epoch_delta
   BIN_LOCATION: 0
 

--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -41,7 +41,7 @@ energy:
   LABLAXIS: Energy bin geometric mean
   UNITS: KeV
   VAR_TYPE: support_data
-  SCALE_TYP: linear
+  SCALETYP: linear
   # We might not have these set up yet
   DELTA_MINUS_VAR: energy_delta_minus
   DELTA_PLUS_VAR: energy_delta_plus
@@ -49,8 +49,8 @@ energy:
 
 energy_label:
   VAR_TYPE: metadata
-  CATDESC: Geometric mean of energy bin.
-  FIELDNAM: energy_bin_geometric_mean
+  CATDESC: Label variable for energy coordinate
+  FIELDNAM: energy label
   FORMAT: A16
   DEPEND_1: energy
 
@@ -60,7 +60,7 @@ energy_delta_minus:
   CATDESC: Difference between the energy bin center and lower edge.
   LABLAXIS: energy
   UNITS: KeV
-  FIELDNAM: energy_bin_delta_minus
+  FIELDNAM: energy delta minus
   DISPLAY_TYPE: no_plot
   DEPEND_1: energy
   LABL_PTR_1: energy_label
@@ -72,16 +72,36 @@ energy_delta_plus:
   CATDESC: Difference between the energy bin center and upper edge.
   LABLAXIS: energy
   UNITS: KeV
-  FIELDNAM: energy_bin_delta_plus
+  FIELDNAM: energy delta plus
   DISPLAY_TYPE: no_plot
   DEPEND_1: energy
   LABL_PTR_1: energy_label
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:Energy,Qualifier:Uncertainty
 
+epoch:
+  CATDESC: Map time range start, number of nanoseconds since J2000 with leap seconds included
+  FIELDNAM: J2000 Nanoseconds
+  LABLAXIS: epoch
+  FILLVAL: -9223372036854775808
+  FORMAT: " " # Supposedly not required, fails in xarray_to_cdf
+  VALIDMIN: 315576066184000000   # 2010-01-01T00:00:00 mission start (APL 0 epoch)
+  VALIDMAX: 3155716869184000000  # 2100-01-01T00:00:00 mission end
+  UNITS: ns
+  VAR_TYPE: support_data
+  SCALETYP: linear
+  MONOTON: INCREASE
+  TIME_BASE: J2000
+  TIME_SCALE: Terrestrial Time
+  REFERENCE_POSITION: Rotating Earth Geoid
+  RESOLUTION: ' '
+  DICT_KEY: "SPASE>Support>SupportQuantity:Temporal"
+  DELTA_PLUS_VAR: epoch_delta
+  BIN_LOCATION: 0
+
 epoch_delta:
   <<: *default_int64
   CATDESC: Number of nanoseconds covered by data included in this map product.
-  FIELDNAM: epoch_delta
+  FIELDNAM: epoch delta
   UNITS: ns
   VAR_TYPE: support_data
   DISPLAY_TYPE: no_plot
@@ -93,24 +113,37 @@ epoch_delta:
 # in the tiling-specific YAML files.
 longitude:
   <<: *default_float32
-  CATDESC: "Pixel center longitude in {frame} reference frame in the range [0, 360]."
+  CATDESC: Pixel center longitude
   FIELDNAM: "{frame} Longitude"
-  LABLAXIS: "{frame} Longitude"
-  UNITS: degrees
+  LABLAXIS: Longitude
+  FORMAT: I3
+  UNITS: deg
   VAR_TYPE: support_data
   VALIDMIN: 0
   VALIDMAX: 360
+  LABL_PTR_1: longitude_label
+  SCALETYP: linear
+  MONOTON: INCREASE
+  DELTA_PLUS_VAR: longitude_delta
+  DELTA_MINUS_VAR: longitude_delta
   DICT_KEY: SPASE>Support>SupportQuantity:Orientation,Qualifier:DirectionAngle.AzimuthAngle,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 latitude:
   <<: *default_float32
-  CATDESC: "Pixel center latitude in {frame} reference frame in the range [-90, 90]."
+  CATDESC: Pixel center latitude
   FIELDNAM: "{frame} Latitude"
-  LABLAXIS: "{frame} Latitude"
-  UNITS: degrees
+  LABLAXIS: Latitude
+  FORMAT: I2
+  UNITS: deg
   VAR_TYPE: support_data
   VALIDMIN: -90
   VALIDMAX: 90
+  LABL_PTR_1: latitude_label
+  SCALETYP: linear
+  BIN_LOCATION: 0.5
+  MONOTON: INCREASE
+  DELTA_PLUS_VAR: latitude_delta
+  DELTA_MINUS_VAR: latitude_delta
   DICT_KEY: SPASE>Support>SupportQuantity:Orientation,Qualifier:DirectionAngle.ElevationAngle,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 # Define Data variables, but not their pixel-level DEPENDs
@@ -120,7 +153,7 @@ ena_intensity:
   <<: *default_float32
   CATDESC: Mono-energetic ENA intensity.
   FIELDNAM: Intensity
-  UNITS: counts/(s * cm^2 * Sr * KeV)
+  UNITS: cm -2 s -1 sr -1 keV -1
   DELTA_MINUS_VAR: ena_intensity_stat_uncert
   DELTA_PLUS_VAR: ena_intensity_stat_uncert
   DEPEND_0: epoch
@@ -133,7 +166,7 @@ ena_intensity_stat_uncert:
   <<: *default_float32
   CATDESC: ENA intensity statistical uncertainty.
   FIELDNAM: Intensity stat unc
-  UNITS: counts/(s * cm^2 * Sr * KeV)
+  UNITS: cm -2 s -1 sr -1 keV -1
   DEPEND_0: epoch
   VAR_TYPE: support_data
   LABLAXIS: Statistical Unc
@@ -144,10 +177,10 @@ ena_intensity_sys_err:
   <<: *default_float32
   CATDESC: ENA intensity non-statistical error.
   FIELDNAM: Intensity non-stat error
-  UNITS: counts/(s * cm^2 * Sr * KeV)
+  UNITS: cm -2 s -1 sr -1 keV -1
   DEPEND_0: epoch
   VAR_TYPE: support_data
-  LABLAXIS: Non-Statistical Err
+  LABLAXIS: Non-statistical Error
   DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
@@ -164,13 +197,14 @@ ena_rate:
 
 bg_rate:
   <<: *default_float32
-  CATDESC: Estimated background count rate.
+  CATDESC: Total background count rate from non-ENA (non-heliospheric) sources, as calculated by ground processing; makes sense only for "uncombined" calibration products.
   FIELDNAM: Background Rate
-  UNITS: counts/s
+  UNITS: count s-1
   DEPEND_0: epoch
   VAR_TYPE: data
   LABLAXIS: Rate
   DISPLAY_TYPE: map_image
+  FORMAT: F6.3
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 ena_count:
@@ -186,7 +220,7 @@ ena_count:
 
 sensitivity:
   <<: *default_float32
-  CATDESC: Averaged instrument sensitive area.
+  CATDESC: Averaged instrument sensitive area
   FIELDNAM: Sensitivity
   UNITS: cm^2
   VAR_TYPE: support_data
@@ -203,6 +237,8 @@ exposure_factor: &exposure_factor
   VAR_TYPE: data
   LABLAXIS: Exposure
   DISPLAY_TYPE: no_plot
+  FORMAT: F5.2
+  VAR_NOTES: Exact or approximate exposure time over which counts in a pixel are accumulated.  Used as a weighting factor for combining data quantities sensibly.
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal
 
 geometric_function:
@@ -217,7 +253,7 @@ geometric_function:
 
 efficiency:
   <<: *default_float32
-  CATDESC: Efficiency of the instrument in converting ENAs to valid events.
+  CATDESC: Efficiency of the instrument in converting ENAs to valid events
   FIELDNAM: Efficiency
   UNITS: " "
   VAR_TYPE: support_data
@@ -227,7 +263,7 @@ efficiency:
 
 positional_uncert_theta:
   <<: *default_float32
-  CATDESC: Averaged position uncertainty along the theta dimension of the instrument.
+  CATDESC: Averaged position uncertainty along the theta dimension of the instrument
   FIELDNAM: Positional Uncertainty Theta
   UNITS: degrees
   VAR_TYPE: support_data
@@ -237,7 +273,7 @@ positional_uncert_theta:
 
 positional_uncert_phi:
   <<: *default_float32
-  CATDESC: Averaged position uncertainty along the phi dimension of the instrument.
+  CATDESC: Averaged position uncertainty along the phi dimension of the instrument
   FIELDNAM: Positional Uncertainty Phi
   UNITS: degrees
   VAR_TYPE: support_data
@@ -248,7 +284,7 @@ positional_uncert_phi:
 obs_date: &obs_date
   <<: *default_int64
   datatype: int64
-  CATDESC: Exposure time weighted mean collection date of data in a pixel.
+  CATDESC: Mean collection date of data in a pixel
   FIELDNAM: J2000 Nanoseconds
   UNITS: ns
   DEPEND_0: epoch
@@ -261,7 +297,7 @@ obs_date_range:
   <<: *default_int64
   datatype: int64
   CATDESC: Standard deviation of the observation date.
-  FIELDNAM: Observation date range
+  FIELDNAM: J2000 Nanoseconds
   UNITS: ns
   DEPEND_0: epoch
   VAR_TYPE: support_data

--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -39,10 +39,12 @@ pixel_index_label:
 # (longitude, latitude are not dimension coordinates for healpix tiling, but rather
 # describe the lon/lat coordinate of the Healpix pixel center)
 longitude:
+  CATDESC: "HEALPix Pixel center longitude in {frame} reference frame in the range [0, 360]"
   DEPEND_1: pixel_index
   LABL_PTR_1: pixel_index_label
 
 latitude:
+  CATDESC: "HEALPix Pixel center latitude in {frame} reference frame in the range [-90, 90]"
   DEPEND_1: pixel_index
   LABL_PTR_1: pixel_index_label
 

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -49,14 +49,24 @@ latitude_delta:
 # attributes file, imap_enamaps_l2-common_variable_attrs.yaml
 
 longitude:
+  CATDESC: "Pixel center longitude in {frame} reference frame in the range [0, 360]"
   DELTA_MINUS_VAR: longitude_delta
   DELTA_PLUS_VAR: longitude_delta
-  SCALE_TYP: linear
+  SCALETYP: linear
+  LABL_PTR_1: longitude_label
+  MONOTON: INCREASE
+  FORMAT: I3
+
 
 latitude:
+  CATDESC: "Pixel center latitude in {frame} reference frame in the range [-90, 90]"
   DELTA_MINUS_VAR: latitude_delta
   DELTA_PLUS_VAR: latitude_delta
-  SCALE_TYP: linear
+  SCALETYP: linear
+  LABL_PTR_1: latitude_label
+  MONOTON: INCREASE
+  BIN_LOCATION: 0.5
+  FORMAT: I2
 
 # Define Data variables
 ena_intensity:

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -524,7 +524,7 @@ class TestUltraL2:
                 assert (
                     ena_intensity_attrs[f"LABL_PTR_{depend_num}"] == f"{depend}_label"
                 )
-        assert ena_intensity_attrs["UNITS"] == "counts/(s * cm^2 * Sr * KeV)"
+        assert ena_intensity_attrs["UNITS"] == "cm -2 s -1 sr -1 keV -1"
 
         exposure_attrs = rect_map_dataset["exposure_factor"].attrs
         assert exposure_attrs["VAR_TYPE"] == "data"


### PR DESCRIPTION
# Change Summary
Updated the common map metadata per the definition [here](https://o365coloradoedu-my.sharepoint.com/:x:/g/personal/plummert_colorado_edu/EX8IRmgRKw5Hpik9wPAXZQABBgOemDqOv-uLMlRxZLJaTw?rtime=8JL00J0F3kg)

Note that many of the variables in the green section of the spreadsheet were missing from the existing definition and these were not added in this PR. (bg_rate_uncert, bg_intensity, ...). We believe ena_rate, and ena_count have been renamed to ena_count_rate, and counts, but believe this change will require updates to the code so is not included here.

## Updated Files
- imap_enamaps_l2-common_variable_attrs.yaml
  - Changed metadata for already present variables