### PR TITLE
2252 - bug - hi L2 incorrect statistical uncertainty

### DIFF
--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -323,20 +323,15 @@ def combine_calibration_products(
     # Perform inverse-variance weighted averaging
     # Handle divide by zero and invalid values
     with np.errstate(divide="ignore", invalid="ignore"):
-        # Calculate weights for statistical variance combination using only
-        # statistical variance
-        stat_weights = 1.0 / improved_stat_variance
-
-        # Combined statistical uncertainty from inverse-variance formula
-        combined_stat_unc = np.sqrt(1.0 / stat_weights.sum(dim="calibration_prod"))
-
         # Use total variance weights for flux combination
         flux_weights = 1.0 / total_variance
         weighted_flux_sum = (ena_flux * flux_weights).sum(dim="calibration_prod")
         combined_flux = weighted_flux_sum / flux_weights.sum(dim="calibration_prod")
 
     map_ds["ena_intensity"] = combined_flux
-    map_ds["ena_intensity_stat_uncert"] = combined_stat_unc
+    map_ds["ena_intensity_stat_uncert"] = np.sqrt(
+        (map_ds["ena_intensity_stat_uncert"] ** 2).sum(dim="calibration_prod")
+    )
     # For systematic error, just do quadrature sum over the systematic error for
     # each calibration product.
     map_ds["ena_intensity_sys_err"] = np.sqrt((sys_err**2).sum(dim="calibration_prod"))

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -599,7 +599,7 @@ def test_statistical_uncertainty_combination_correctness():
     # Create simple case with known statistical uncertainties
     stat_unc_values = np.array([5.0, 10.0]).reshape(1, 1, 2, 1, 1)
     sys_err_values = np.array([2.0, 4.0]).reshape(1, 1, 2, 1, 1)
-    flux_values = np.array([100.0, 200.0]).reshape(1, 1, 2, 1, 1)
+    flux_values = np.array([90.0, 210.0]).reshape(1, 1, 2, 1, 1)
 
     test_ds = xr.Dataset(
         {
@@ -612,7 +612,7 @@ def test_statistical_uncertainty_combination_correctness():
             ),
             "ena_signal_rates": xr.DataArray(flux_values, dims=list(coords.keys())),
             "bg_rates": xr.DataArray(
-                np.array([1.0, 1.0]).reshape(1, 1, 2, 1, 1), dims=list(coords.keys())
+                np.array([1.0, 2.0]).reshape(1, 1, 2, 1, 1), dims=list(coords.keys())
             ),
             "exposure_factor": xr.DataArray(
                 np.array([1.0, 1.0]).reshape(1, 1, 2, 1, 1), dims=list(coords.keys())
@@ -621,7 +621,7 @@ def test_statistical_uncertainty_combination_correctness():
     )
 
     geom_factors = xr.DataArray(
-        np.array([[1.0, 1.0]]),  # Equal geometric factors for simplicity
+        np.array([[1.0, 2.0]]),
         dims=["esa_energy_step", "calibration_prod"],
     )
 
@@ -632,9 +632,8 @@ def test_statistical_uncertainty_combination_correctness():
     # Manual calculation of expected statistical uncertainty combination
     # stat_weights = 1/σ² = [1/151, 1/151]
     # combined_stat_unc = sqrt(1/sum(stat_weights)) = sqrt(2/151) = sqrt(20) ≈ 4.47
-    stat_weights = 1.0 / (np.array([151, 151]))
-    expected_combined_stat_unc = np.sqrt(1.0 / np.sum(stat_weights))
-    flux_weights = 1.0 / (np.array([151, 151]) + np.array([4, 16]))
+    expected_combined_stat_unc = np.sqrt(np.sum(stat_unc_values**2))
+    flux_weights = 1.0 / (np.array([101, 101]) + np.array([4, 16]))
     expected_flux = np.sum(flux_values.squeeze() * flux_weights) / np.sum(flux_weights)
 
     np.testing.assert_almost_equal(


### PR DESCRIPTION
Revert how statistical uncertainty is computed until further direction from Hi IT

# Change Summary

## Overview
This is a quick fix to get the statistical uncertainty looking more correct. I am waiting on direction from the Hi IT to clarify in the algorithm document how this should really be calculated when combining calibration products.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_processing/hi/hi_l2.py
   - For now, just add the individual calibration product statistical uncertainties in quadrature
- imap_processing/tests/hi/test_hi_l2.py
   - Fix tests to expect uncertainties added in quadrature

Closes: #2252 
