### PR TITLE
Remove ValueError for non-monotonic timestamps

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1212,8 +1212,9 @@ class Mag(ProcessInstrument):
             if "raw" not in ds.attrs["Logical_source"] and not np.all(
                 ds["epoch"].values[1:] > ds["epoch"].values[:-1]
             ):
-                raise ValueError(
-                    "Timestamps for output file are not monotonically increasing."
+                logger.warning(
+                    f"Timestamps for output file {ds.attrs['Logical_source']} are not "
+                    f"monotonically increasing."
                 )
         return datasets
 


### PR DESCRIPTION
# Change Summary
Remove the value error for non-monotonic timestamps for MAG L1a. This allows us to process the first day of data from the MAG instrument despite inconsistent timestamps. 

We originally thought this was due to duplicate packets from the POC. However, those packets actually should have been removed by already existing de-duplication code. Separately, it looks like the packets have incorrect timestamps which were causing the error to be thrown. However, the MAG team has requested this change so I can disable it for now and we can discuss the anomalous timestamps. 

Here is some basic investigation I did: 

<img width="1200" height="600" alt="mag_20250928" src="https://github.com/user-attachments/assets/ed47dff4-8017-4b11-9f54-a43878810ed2" />

Dataset shape: (11519488,)
Start time: 812374270777501418
End time: 812464265498577770
Duration: 89994.72 seconds
Mean time step: 7.812 ms
Min time step: -3992.155 ms
Max time step: 2007.763 ms

Non-monotonic time points: 2
First 10 non-monotonic indices:
  Index 8996095: diff = -3992155190 ns (times: 812444553772502651 -> 812444549780347461)
  Index 9369343: diff = -3992155190 ns (times: 812447469731879901 -> 812447465739724711)

As you can see, these are not duplicates but actual timestamps that move backwards.

