### PR TITLE
2282 pre binning calculations on PSET

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1315,7 +1315,7 @@ class RectangularSkyMap(AbstractSkyMap):
             if ("L2" in name)
         ]
         l2_coords.append(CoordNames.TIME.value)
-        for map_coord in cdf_ds.sizes.keys():
+        for map_coord in cdf_ds.dims:
             if map_coord not in l2_coords:
                 cdf_ds = cdf_ds.drop_dims(map_coord)
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -655,7 +655,7 @@ class HiPointingSet(LoHiBasePointingSet):
         super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.ECLIPJ2000)
 
         # Filter out ENAs from non-selected portions of the spin.
-        if spin_phase not in ["full", "ram", "anti-ram"]:
+        if spin_phase not in ["full", "ram", "anti"]:
             raise ValueError(f"Unrecognized spin_phase value: {spin_phase}.")
         # ram only includes spin-phase interval [0, 0.5)
         # which is the first half of the spin_angle_bins
@@ -665,7 +665,7 @@ class HiPointingSet(LoHiBasePointingSet):
             )
         # anti-ram includes spin-phase interval [0.5, 1)
         # which is the second half of the spin_angle_bins
-        elif spin_phase == "anti-ram":
+        elif spin_phase == "anti":
             self.data = self.data.isel(
                 spin_angle_bin=slice(self.data["spin_angle_bin"].data.size // 2, None)
             )
@@ -1315,7 +1315,7 @@ class RectangularSkyMap(AbstractSkyMap):
             if ("L2" in name)
         ]
         l2_coords.append(CoordNames.TIME.value)
-        for map_coord in cdf_ds.dims.keys():
+        for map_coord in cdf_ds.sizes.keys():
             if map_coord not in l2_coords:
                 cdf_ds = cdf_ds.drop_dims(map_coord)
 

--- a/imap_processing/ena_maps/utils/coordinates.py
+++ b/imap_processing/ena_maps/utils/coordinates.py
@@ -21,3 +21,5 @@ class CoordNames(Enum):
 
     # Common name for dimension along azimuth/elevation vector
     AZ_EL_VECTOR = "az_el"
+    # Commoon name for dimension along Cartesian vector
+    CARTESIAN_VECTOR = "x_y_z"

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -4,7 +4,16 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 from numpy.polynomial import Polynomial
+
+from imap_processing.ena_maps.ena_maps import LoHiBasePointingSet
+from imap_processing.ena_maps.utils.coordinates import CoordNames
+from imap_processing.spice import geometry
+
+# Physical constants for Compton-Getting correction
+ERG_PER_EV = 1.6e-12  # erg per eV - unit conversion factor
+PROTON_MASS_GRAMS = 1.67e-24  # proton mass in grams
 
 
 class PowerLawFluxCorrector:
@@ -289,3 +298,227 @@ class PowerLawFluxCorrector:
             )
 
         return corrected_flux, corrected_flux_stat_unc
+
+
+def _add_spacecraft_velocity_to_pset(pset: LoHiBasePointingSet, et: float) -> None:
+    """
+    Calculate and add spacecraft velocity data to pointing set.
+
+    Parameters
+    ----------
+    pset : LoHiBasePointingSet
+        Pointing set object to be updated.
+    et : float
+        Ephemeris time in seconds past J2000.
+
+    Notes
+    -----
+    Adds the following DataArrays to pset.data:
+    - "sc_velocity": Spacecraft velocity vector (km/s) with dims ["x_y_z"]
+    - "sc_direction_vector": Spacecraft velocity unit vector with dims ["x_y_z"]
+    """
+    # Get spacecraft state in HAE frame
+    sc_state = geometry.imap_state(et, ref_frame=geometry.SpiceFrame.IMAP_HAE)
+    sc_velocity_vector = sc_state[3:6]
+
+    # Store spacecraft velocity as DataArray
+    pset.data["sc_velocity"] = xr.DataArray(
+        sc_velocity_vector, dims=[CoordNames.CARTESIAN_VECTOR.value]
+    )
+
+    # Calculate spacecraft speed and direction
+    sc_velocity_km_per_sec = np.linalg.norm(
+        pset.data["sc_velocity"], axis=-1, keepdims=True
+    )
+    pset.data["sc_direction_vector"] = pset.data["sc_velocity"] / sc_velocity_km_per_sec
+
+
+def _add_cartesian_look_direction(pset: LoHiBasePointingSet) -> None:
+    """
+    Calculate and add look direction vectors to pointing set.
+
+    Parameters
+    ----------
+    pset : LoHiBasePointingSet
+        Pointing set object to be updated.
+
+    Notes
+    -----
+    Adds the following DataArray to pset.data:
+    - "look_direction": Cartesian unit vectors with dims [...spatial_dims, "x_y_z"]
+    """
+    longitudes = pset.data["hae_longitude"]
+    latitudes = pset.data["hae_latitude"]
+
+    # Stack spherical coordinates (r=1 for unit vectors, azimuth, elevation)
+    spherical_coords = np.stack(
+        [
+            np.ones_like(longitudes),  # r = 1 for unit vectors
+            longitudes,  # azimuth = longitude
+            latitudes,  # elevation = latitude
+        ],
+        axis=-1,
+    )
+
+    # Convert to Cartesian coordinates and store as DataArray
+    pset.data["look_direction"] = xr.DataArray(
+        geometry.spherical_to_cartesian(spherical_coords),
+        dims=[*longitudes.dims, CoordNames.CARTESIAN_VECTOR.value],
+    )
+
+
+def _calculate_compton_getting_transform(
+    pset: LoHiBasePointingSet,
+    energies_hf: xr.DataArray,
+) -> None:
+    """
+    Apply Compton-Getting transformation to compute ENA source directions.
+
+    This implements the Compton-Getting velocity transformation to correct
+    for the motion of the spacecraft through the heliosphere. The transformation
+    accounts for the Doppler shift of ENA energies and the aberration of
+    arrival directions.
+
+    All calculations are performed using xarray DataArrays to preserve
+    dimension information throughout the computation.
+
+    Parameters
+    ----------
+    pset : LoHiBasePointingSet
+        Pointing set object with sc_velocity, sc_direction_vector, and
+        look_direction already added.
+    energies_hf : xr.DataArray
+        ENA energies in the heliosphere frame in eV.
+
+    Notes
+    -----
+    The algorithm is based on the "Appendix A. The IMAP-Lo Mapping Algorithms"
+    document.
+    Adds the following DataArrays to pset.data:
+    - "energy_sc": ENA energies in spacecraft frame (eV)
+    - "ena_source_hae_longitude": ENA source longitudes in heliosphere frame (degrees)
+    - "ena_source_hae_latitude": ENA source latitudes in heliosphere frame (degrees)
+    """
+    # Store heliosphere frame energies
+    pset.data["hf_energy"] = energies_hf
+
+    # Calculate spacecraft speed
+    sc_velocity_km_per_sec = np.linalg.norm(
+        pset.data["sc_velocity"], axis=-1, keepdims=True
+    )
+
+    # Calculate dot product between look directions and spacecraft direction vector
+    # Use Einstein summation for efficient vectorized dot product
+    dot_product = xr.DataArray(
+        np.einsum(
+            "...i,...i->...",
+            pset.data["look_direction"],
+            pset.data["sc_direction_vector"],
+        ),
+        dims=pset.data["look_direction"].dims[:-1],
+    )
+
+    # Calculate the kinetic energy of a hydrogen ENA traveling at spacecraft velocity
+    # E_u = (1/2) * m * U_sc^2 in eV
+    energy_u = (
+        0.5 * PROTON_MASS_GRAMS * (sc_velocity_km_per_sec * 1e5) ** 2 / ERG_PER_EV
+    )
+
+    # Calculate y values for each energy level (Equation 61)
+    # y_k = sqrt(E^h_k / E^u)
+    y = np.sqrt(pset.data["hf_energy"] / energy_u)
+
+    # Velocity magnitude factor calculation (Equation 62)
+    # x_k = (êₛ · û_sc) + sqrt(y² + (êₛ · û_sc)² - 1)
+    x = dot_product + np.sqrt(y**2 + dot_product**2 - 1)
+
+    # Calculate ENA speed in the spacecraft frame
+    # |v⃗_sc| = x_k * U_sc
+    velocity_sc = x * sc_velocity_km_per_sec
+
+    # Calculate the kinetic energy in the spacecraft frame
+    # E_sc = (1/2) * M_p * v_sc² (convert km/s to cm/s with 1.0e5 factor)
+    pset.data["energy_sc"] = (
+        0.5 * PROTON_MASS_GRAMS * (velocity_sc * 1e5) ** 2 / ERG_PER_EV
+    )
+
+    # Calculate the velocity vector in the spacecraft frame
+    # v⃗_sc = |v_sc| * êₛ (velocity direction follows look direction)
+    velocity_vector_sc = velocity_sc * pset.data["look_direction"]
+
+    # Calculate the ENA velocity vector in the heliosphere frame
+    # v⃗_helio = v⃗_sc - U⃗_sc (simple velocity addition)
+    velocity_vector_helio = velocity_vector_sc - pset.data["sc_velocity"]
+
+    # Convert to spherical coordinates to get ENA source directions
+    ena_source_direction_helio = geometry.cartesian_to_spherical(
+        velocity_vector_helio.data
+    )
+
+    # Update the PSET hae_longitude and hae_latitude variables with the new
+    # energy-dependent values.
+    pset.data["hae_longitude"] = (
+        pset.data["energy_sc"].dims,
+        ena_source_direction_helio[..., 1],
+    )
+    pset.data["hae_latitude"] = (
+        pset.data["energy_sc"].dims,
+        ena_source_direction_helio[..., 2],
+    )
+
+
+def apply_compton_getting_correction(
+    pset: LoHiBasePointingSet,
+    et: float,
+    energies_hf: xr.DataArray,
+) -> None:
+    """
+    Apply Compton-Getting correction to a pointing set and update coordinates.
+
+    This function performs the Compton-Getting velocity transformation to correct
+    ENA observations for the motion of the spacecraft through the heliosphere.
+    The corrected coordinates represent the true source directions of the ENAs
+    in the heliosphere frame.
+
+    The pointing set is modified in-place: new variables are added to the dataset
+    for the corrected coordinates and energies, and the az_el_points attribute
+    is updated to use the corrected coordinates for binning.
+
+    All calculations are performed using xarray DataArrays to preserve dimension
+    information throughout the computation.
+
+    Parameters
+    ----------
+    pset : LoHiBasePointingSet
+        Pointing set object containing HAE longitude/latitude coordinates.
+    et : float
+        Ephemeris time in seconds past J2000 for SPICE calculations.
+    energies_hf : xr.DataArray
+        ENA energies in the heliosphere frame in eV. Must be 1D with an
+        energy dimension.
+
+    Notes
+    -----
+    This function adds the following variables to the pointing set dataset:
+    - "sc_velocity": Spacecraft velocity vector (km/s)
+    - "sc_direction_vector": Spacecraft velocity unit vector
+    - "look_direction": Cartesian unit vectors of observation directions
+    - "hf_energy": ENA energies in heliosphere frame (eV)
+    - "energy_sc": ENA energies in spacecraft frame (eV)
+    - "ena_source_hae_longitude": ENA source longitudes in heliosphere frame (degrees)
+    - "ena_source_hae_latitude": ENA source latitudes in heliosphere frame (degrees)
+
+    The az_el_points attribute is updated to use the corrected coordinates,
+    which will be used for subsequent binning operations.
+    """
+    # Step 1: Add spacecraft velocity and direction to pset
+    _add_spacecraft_velocity_to_pset(pset, et)
+
+    # Step 2: Calculate and add look direction vectors to pset
+    _add_cartesian_look_direction(pset)
+
+    # Step 3: Apply Compton-Getting transformation
+    _calculate_compton_getting_transform(pset, energies_hf)
+
+    # Step 4: Update az_el_points to use the corrected coordinates
+    pset.update_az_el_points()

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -466,6 +466,20 @@ def _calculate_compton_getting_transform(
         ena_source_direction_helio[..., 2],
     )
 
+    # For ram/anti-ram filtering we can use the sign of the scalar projection
+    # of the ENA source direction onto the spacecraft velocity vector.
+    # ram_mask = (v⃗_helio · û_sc) >= 0
+    ram_mask = (
+        np.einsum(
+            "...i,...i->...", velocity_vector_helio, pset.data["sc_direction_vector"]
+        )
+        >= 0
+    )
+    pset.data["ram_mask"] = xr.DataArray(
+        ram_mask,
+        dims=velocity_vector_helio.dims[:-1],
+    )
+
 
 def apply_compton_getting_correction(
     pset: LoHiBasePointingSet,

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -6,14 +6,16 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from numpy.polynomial import Polynomial
+from scipy.constants import electron_volt, erg, proton_mass
 
 from imap_processing.ena_maps.ena_maps import LoHiBasePointingSet
 from imap_processing.ena_maps.utils.coordinates import CoordNames
 from imap_processing.spice import geometry
+from imap_processing.spice.time import ttj2000ns_to_et
 
 # Physical constants for Compton-Getting correction
-ERG_PER_EV = 1.6e-12  # erg per eV - unit conversion factor
-PROTON_MASS_GRAMS = 1.67e-24  # proton mass in grams
+ERG_PER_EV = electron_volt / erg  # erg per eV - unit conversion factor
+PROTON_MASS_GRAMS = proton_mass * 1e3  # proton mass in grams
 
 
 class PowerLawFluxCorrector:
@@ -300,7 +302,7 @@ class PowerLawFluxCorrector:
         return corrected_flux, corrected_flux_stat_unc
 
 
-def _add_spacecraft_velocity_to_pset(pset: LoHiBasePointingSet, et: float) -> None:
+def _add_spacecraft_velocity_to_pset(pset: LoHiBasePointingSet) -> None:
     """
     Calculate and add spacecraft velocity data to pointing set.
 
@@ -308,8 +310,6 @@ def _add_spacecraft_velocity_to_pset(pset: LoHiBasePointingSet, et: float) -> No
     ----------
     pset : LoHiBasePointingSet
         Pointing set object to be updated.
-    et : float
-        Ephemeris time in seconds past J2000.
 
     Notes
     -----
@@ -317,6 +317,11 @@ def _add_spacecraft_velocity_to_pset(pset: LoHiBasePointingSet, et: float) -> No
     - "sc_velocity": Spacecraft velocity vector (km/s) with dims ["x_y_z"]
     - "sc_direction_vector": Spacecraft velocity unit vector with dims ["x_y_z"]
     """
+    # Compute ephemeris time (J2000 seconds) of PSET midpoint time
+    # TODO: Use the Pointing midpoint time. Epoch should be start time
+    #     but use it until we can make Lo and Hi PSETs have a consistent
+    #     variable to hold the midpoint time.
+    et = ttj2000ns_to_et(pset.data["epoch"].values[0])
     # Get spacecraft state in HAE frame
     sc_state = geometry.imap_state(et, ref_frame=geometry.SpiceFrame.IMAP_HAE)
     sc_velocity_vector = sc_state[3:6]
@@ -483,7 +488,6 @@ def _calculate_compton_getting_transform(
 
 def apply_compton_getting_correction(
     pset: LoHiBasePointingSet,
-    et: float,
     energies_hf: xr.DataArray,
 ) -> None:
     """
@@ -505,8 +509,6 @@ def apply_compton_getting_correction(
     ----------
     pset : LoHiBasePointingSet
         Pointing set object containing HAE longitude/latitude coordinates.
-    et : float
-        Ephemeris time in seconds past J2000 for SPICE calculations.
     energies_hf : xr.DataArray
         ENA energies in the heliosphere frame in eV. Must be 1D with an
         energy dimension.
@@ -526,7 +528,7 @@ def apply_compton_getting_correction(
     which will be used for subsequent binning operations.
     """
     # Step 1: Add spacecraft velocity and direction to pset
-    _add_spacecraft_velocity_to_pset(pset, et)
+    _add_spacecraft_velocity_to_pset(pset)
 
     # Step 2: Calculate and add look direction vectors to pset
     _add_cartesian_look_direction(pset)

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -374,7 +374,7 @@ def _add_cartesian_look_direction(pset: LoHiBasePointingSet) -> None:
 
 def _calculate_compton_getting_transform(
     pset: LoHiBasePointingSet,
-    energies_hf: xr.DataArray,
+    energy_hf: xr.DataArray,
 ) -> None:
     """
     Apply Compton-Getting transformation to compute ENA source directions.
@@ -392,7 +392,7 @@ def _calculate_compton_getting_transform(
     pset : LoHiBasePointingSet
         Pointing set object with sc_velocity, sc_direction_vector, and
         look_direction already added.
-    energies_hf : xr.DataArray
+    energy_hf : xr.DataArray
         ENA energies in the heliosphere frame in eV.
 
     Notes
@@ -405,7 +405,7 @@ def _calculate_compton_getting_transform(
     - "ena_source_hae_latitude": ENA source latitudes in heliosphere frame (degrees)
     """
     # Store heliosphere frame energies
-    pset.data["hf_energy"] = energies_hf
+    pset.data["energy_hf"] = energy_hf
 
     # Calculate spacecraft speed
     sc_velocity_km_per_sec = np.linalg.norm(
@@ -424,14 +424,14 @@ def _calculate_compton_getting_transform(
     )
 
     # Calculate the kinetic energy of a hydrogen ENA traveling at spacecraft velocity
-    # E_u = (1/2) * m * U_sc^2 in eV
+    # E_u = (1/2) * m * U_sc^2 (convert km/s to cm/s with 1.0e5 factor)
     energy_u = (
         0.5 * PROTON_MASS_GRAMS * (sc_velocity_km_per_sec * 1e5) ** 2 / ERG_PER_EV
     )
 
     # Calculate y values for each energy level (Equation 61)
     # y_k = sqrt(E^h_k / E^u)
-    y = np.sqrt(pset.data["hf_energy"] / energy_u)
+    y = np.sqrt(pset.data["energy_hf"] / energy_u)
 
     # Velocity magnitude factor calculation (Equation 62)
     # x_k = (êₛ · û_sc) + sqrt(y² + (êₛ · û_sc)² - 1)
@@ -488,7 +488,7 @@ def _calculate_compton_getting_transform(
 
 def apply_compton_getting_correction(
     pset: LoHiBasePointingSet,
-    energies_hf: xr.DataArray,
+    energy_hf: xr.DataArray,
 ) -> None:
     """
     Apply Compton-Getting correction to a pointing set and update coordinates.
@@ -509,7 +509,7 @@ def apply_compton_getting_correction(
     ----------
     pset : LoHiBasePointingSet
         Pointing set object containing HAE longitude/latitude coordinates.
-    energies_hf : xr.DataArray
+    energy_hf : xr.DataArray
         ENA energies in the heliosphere frame in eV. Must be 1D with an
         energy dimension.
 
@@ -519,7 +519,7 @@ def apply_compton_getting_correction(
     - "sc_velocity": Spacecraft velocity vector (km/s)
     - "sc_direction_vector": Spacecraft velocity unit vector
     - "look_direction": Cartesian unit vectors of observation directions
-    - "hf_energy": ENA energies in heliosphere frame (eV)
+    - "energy_hf": ENA energies in heliosphere frame (eV)
     - "energy_sc": ENA energies in spacecraft frame (eV)
     - "ena_source_hae_longitude": ENA source longitudes in heliosphere frame (degrees)
     - "ena_source_hae_latitude": ENA source latitudes in heliosphere frame (degrees)
@@ -534,7 +534,7 @@ def apply_compton_getting_correction(
     _add_cartesian_look_direction(pset)
 
     # Step 3: Apply Compton-Getting transformation
-    _calculate_compton_getting_transform(pset, energies_hf)
+    _calculate_compton_getting_transform(pset, energy_hf)
 
     # Step 4: Update az_el_points to use the corrected coordinates
     pset.update_az_el_points()

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -429,6 +429,20 @@ def _calculate_compton_getting_transform(
         0.5 * PROTON_MASS_GRAMS * (sc_velocity_km_per_sec * 1e5) ** 2 / ERG_PER_EV
     )
 
+    # Note: Tim thinks that this approach seems backwards. Here, we are assuming
+    #     that ENAs are observed in the heliosphere frame at the ESA energy levels.
+    #     We then calculate the velocity that said ENAs would have in the spacecraft
+    #     frame as well as the CG corrected energy level in the spacecraft frame.
+    #     We then use this velocity to calculate and the velocity of the spacecraft
+    #     to do the vector math which determines the ENA source direction in the
+    #     heliosphere frame.
+    #     The ENAs are in fact observed in the spacecraft frame at a known energy
+    #     level in the spacecraft frame. Why don't we use that energy level to
+    #     calculate the source direction in the spacecraft frame and then do the
+    #     vector math to find the source direction in the heliosphere frame? We
+    #     would also need to calculate the CG corrected ENA energy in the heliosphere
+    #     frame and keep track of that when binning.
+
     # Calculate y values for each energy level (Equation 61)
     # y_k = sqrt(E^h_k / E^u)
     y = np.sqrt(pset.data["energy_hf"] / energy_u)

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -14,7 +14,12 @@ from imap_processing.spice import geometry
 from imap_processing.spice.time import ttj2000ns_to_et
 
 # Physical constants for Compton-Getting correction
+# Units: electron_volt = [J / eV]
+#        erg = [J / erg]
+# To get [erg / eV], => electron_volt [J / eV] / erg [J / erg] = erg_per_ev [erg / eV]
 ERG_PER_EV = electron_volt / erg  # erg per eV - unit conversion factor
+# Units: proton_mass = [kg]
+# Here, we convert proton_mass to grams
 PROTON_MASS_GRAMS = proton_mass * 1e3  # proton mass in grams
 
 

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -280,15 +280,20 @@ def mock_hi_pset():
 class TestComptonGettingCorrection:
     """Test suite for Compton-Getting correction functions."""
 
+    @mock.patch("imap_processing.ena_maps.utils.corrections.ttj2000ns_to_et")
     @mock.patch("imap_processing.ena_maps.utils.corrections.geometry.imap_state")
-    def test_add_spacecraft_velocity_to_pset(self, mock_imap_state, mock_hi_pset):
+    def test_add_spacecraft_velocity_to_pset(
+        self, mock_imap_state, mock_ttj2000_to_et, mock_hi_pset
+    ):
         """Test that spacecraft velocity is correctly added to pointing set."""
+        # Mock conversion from TTJ2000ns to ET
+        et = 1000.0
+        mock_ttj2000_to_et.return_value = et
         # Mock spacecraft state vector (position + velocity in HAE frame)
         mock_sc_state = np.array([1e8, 2e8, 3e8, 10.0, 20.0, 30.0])  # km and km/s
         mock_imap_state.return_value = mock_sc_state
 
-        et = 1000.0
-        _add_spacecraft_velocity_to_pset(mock_hi_pset, et)
+        _add_spacecraft_velocity_to_pset(mock_hi_pset)
 
         # Verify SPICE was called correctly
         mock_imap_state.assert_called_once_with(
@@ -332,8 +337,7 @@ class TestComptonGettingCorrection:
         mock_sc_state = np.array([1e8, 2e8, 3e8, 10.0, 20.0, 30.0])
         mock_imap_state.return_value = mock_sc_state
 
-        et = 1000.0
-        _add_spacecraft_velocity_to_pset(mock_hi_pset, et)
+        _add_spacecraft_velocity_to_pset(mock_hi_pset)
         _add_cartesian_look_direction(mock_hi_pset)
 
         # Create energy array
@@ -394,10 +398,8 @@ class TestComptonGettingCorrection:
             coords={"esa_energy_step": [1, 2, 3]},
         )
 
-        et = 1000.0
-
         # Apply the full correction
-        apply_compton_getting_correction(mock_hi_pset, et, energies_hf)
+        apply_compton_getting_correction(mock_hi_pset, energies_hf)
 
         # Verify all intermediate variables were added
         assert "sc_velocity" in mock_hi_pset.data
@@ -436,10 +438,8 @@ class TestComptonGettingCorrection:
             coords={"esa_energy_step": np.arange(1, 10)},
         )
 
-        et = 797949131184.0  # Convert from ns to seconds
-
         # Apply correction
-        apply_compton_getting_correction(hi_pset, et, energies_hf)
+        apply_compton_getting_correction(hi_pset, energies_hf)
 
         # Verify coordinates were modified
         corrected_lon = hi_pset.data["hae_longitude"]

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -341,24 +341,24 @@ class TestComptonGettingCorrection:
         _add_cartesian_look_direction(mock_hi_pset)
 
         # Create energy array
-        energies_hf = xr.DataArray(
+        energy_hf = xr.DataArray(
             np.array([500.0, 1000.0, 2000.0]),
             dims=["esa_energy_step"],
             coords={"esa_energy_step": [1, 2, 3]},
         )
 
-        _calculate_compton_getting_transform(mock_hi_pset, energies_hf)
+        _calculate_compton_getting_transform(mock_hi_pset, energy_hf)
 
         # Verify required variables were added
-        assert "hf_energy" in mock_hi_pset.data
+        assert "energy_hf" in mock_hi_pset.data
         assert "energy_sc" in mock_hi_pset.data
         assert "hae_longitude" in mock_hi_pset.data
         assert "hae_latitude" in mock_hi_pset.data
         assert "ram_mask" in mock_hi_pset.data
 
-        # Verify hf_energy matches input
+        # Verify energy_hf matches input
         np.testing.assert_array_equal(
-            mock_hi_pset.data["hf_energy"].values, energies_hf.values
+            mock_hi_pset.data["energy_hf"].values, energy_hf.values
         )
 
         # Verify energy_sc has correct shape
@@ -392,20 +392,20 @@ class TestComptonGettingCorrection:
         mock_imap_state.return_value = mock_sc_state
 
         # Create energy array
-        energies_hf = xr.DataArray(
+        energy_hf = xr.DataArray(
             np.array([500.0, 1000.0, 2000.0]),
             dims=["esa_energy_step"],
             coords={"esa_energy_step": [1, 2, 3]},
         )
 
         # Apply the full correction
-        apply_compton_getting_correction(mock_hi_pset, energies_hf)
+        apply_compton_getting_correction(mock_hi_pset, energy_hf)
 
         # Verify all intermediate variables were added
         assert "sc_velocity" in mock_hi_pset.data
         assert "sc_direction_vector" in mock_hi_pset.data
         assert "look_direction" in mock_hi_pset.data
-        assert "hf_energy" in mock_hi_pset.data
+        assert "energy_hf" in mock_hi_pset.data
         assert "energy_sc" in mock_hi_pset.data
         assert "hae_longitude" in mock_hi_pset.data
         assert "hae_latitude" in mock_hi_pset.data
@@ -430,7 +430,7 @@ class TestComptonGettingCorrection:
         mock_imap_state.return_value = mock_sc_state
 
         # Create energy array (Hi has 9 energy steps)
-        energies_hf = xr.DataArray(
+        energy_hf = xr.DataArray(
             np.array(
                 [500.0, 750.0, 1100.0, 1650.0, 2500.0, 3750.0, 5700.0, 8520.0, 12800.0]
             ),
@@ -439,7 +439,7 @@ class TestComptonGettingCorrection:
         )
 
         # Apply correction
-        apply_compton_getting_correction(hi_pset, energies_hf)
+        apply_compton_getting_correction(hi_pset, energy_hf)
 
         # Verify coordinates were modified
         corrected_lon = hi_pset.data["hae_longitude"]
@@ -485,9 +485,9 @@ class TestComptonGettingCorrection:
         _add_cartesian_look_direction(mock_hi_pset)
 
         # Single energy level
-        energies_hf = xr.DataArray(np.array([1000.0]), dims=["esa_energy_step"])
+        energy_hf = xr.DataArray(np.array([1000.0]), dims=["esa_energy_step"])
 
-        _calculate_compton_getting_transform(mock_hi_pset, energies_hf)
+        _calculate_compton_getting_transform(mock_hi_pset, energy_hf)
 
         # Physical checks:
         # 1. Energy in spacecraft frame should be higher for particles coming
@@ -544,10 +544,10 @@ class TestComptonGettingCorrection:
         _add_cartesian_look_direction(pset)
 
         # Single energy level
-        energies_hf = xr.DataArray(np.array([1000.0]), dims=["esa_energy_step"])
+        energy_hf = xr.DataArray(np.array([1000.0]), dims=["esa_energy_step"])
 
         # Calculate CG transform
-        _calculate_compton_getting_transform(pset, energies_hf)
+        _calculate_compton_getting_transform(pset, energy_hf)
 
         # Verify ram_mask exists
         assert "ram_mask" in pset.data

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -350,6 +350,7 @@ class TestComptonGettingCorrection:
         assert "energy_sc" in mock_hi_pset.data
         assert "hae_longitude" in mock_hi_pset.data
         assert "hae_latitude" in mock_hi_pset.data
+        assert "ram_mask" in mock_hi_pset.data
 
         # Verify hf_energy matches input
         np.testing.assert_array_equal(
@@ -372,6 +373,12 @@ class TestComptonGettingCorrection:
         assert np.all(mock_hi_pset.data["hae_longitude"].values <= 360)
         assert np.all(mock_hi_pset.data["hae_latitude"].values >= -90)
         assert np.all(mock_hi_pset.data["hae_latitude"].values <= 90)
+
+        # Verify ram_mask properties
+        ram_mask = mock_hi_pset.data["ram_mask"]
+        assert isinstance(ram_mask, xr.DataArray)
+        assert ram_mask.dtype == bool
+        assert ram_mask.shape == mock_hi_pset.data["energy_sc"].shape
 
     @mock.patch("imap_processing.ena_maps.utils.corrections.geometry.imap_state")
     def test_apply_compton_getting_correction(self, mock_imap_state, mock_hi_pset):
@@ -400,6 +407,7 @@ class TestComptonGettingCorrection:
         assert "energy_sc" in mock_hi_pset.data
         assert "hae_longitude" in mock_hi_pset.data
         assert "hae_latitude" in mock_hi_pset.data
+        assert "ram_mask" in mock_hi_pset.data
 
         # Verify update_az_el_points was called
         mock_hi_pset.update_az_el_points.assert_called_once()
@@ -456,6 +464,13 @@ class TestComptonGettingCorrection:
         assert hi_pset.az_el_points is not None
         assert isinstance(hi_pset.az_el_points, xr.DataArray)
 
+        # Verify ram_mask was added and has correct properties
+        assert "ram_mask" in hi_pset.data
+        ram_mask = hi_pset.data["ram_mask"]
+        assert isinstance(ram_mask, xr.DataArray)
+        assert ram_mask.dtype == bool
+        assert ram_mask.shape == hi_pset.data["energy_sc"].shape
+
     def test_compton_getting_physical_consistency(self, mock_hi_pset):
         """Test physical consistency of Compton-Getting correction."""
         # Set up a known spacecraft velocity
@@ -488,3 +503,80 @@ class TestComptonGettingCorrection:
 
         # 4. Energy variation should exist across different look directions
         assert energy_sc.values.std() > 0
+
+    def test_ram_mask_calculation(self):
+        """Test ram_mask correctly identifies ram and anti-ram directions."""
+        # Create a simple mock pset with specific look directions
+        n_directions = 4
+        data = xr.Dataset(
+            {
+                "epoch": (["epoch"], np.array([797949131184000000])),
+                # Set up specific look directions:
+                # 0 degrees lon, 0 lat = +X direction (ram)
+                # 180 degrees lon, 0 lat = -X direction (anti-ram)
+                # 90 degrees lon, 0 lat = +Y direction (perpendicular)
+                # 270 degrees lon, 0 lat = -Y direction (perpendicular)
+                "hae_longitude": (
+                    ["epoch", "direction"],
+                    np.array([[0.0, 180.0, 90.0, 270.0]]),
+                ),
+                "hae_latitude": (
+                    ["epoch", "direction"],
+                    np.array([[0.0, 0.0, 0.0, 0.0]]),
+                ),
+                "direction": (["direction"], np.arange(n_directions)),
+            }
+        ).transpose("epoch", "direction")
+
+        pset = mock.MagicMock(spec=ena_maps.LoHiBasePointingSet)
+        pset.data = data
+        pset.spatial_coords = ("direction",)
+        pset.spice_reference_frame = geometry.SpiceFrame.IMAP_HAE
+
+        # Set up spacecraft velocity in +X direction
+        sc_velocity = np.array([30.0, 0.0, 0.0])  # km/s
+        pset.data["sc_velocity"] = xr.DataArray(sc_velocity, dims=["x_y_z"])
+        pset.data["sc_direction_vector"] = xr.DataArray(
+            sc_velocity / np.linalg.norm(sc_velocity), dims=["x_y_z"]
+        )
+
+        # Add look directions
+        _add_cartesian_look_direction(pset)
+
+        # Single energy level
+        energies_hf = xr.DataArray(np.array([1000.0]), dims=["esa_energy_step"])
+
+        # Calculate CG transform
+        _calculate_compton_getting_transform(pset, energies_hf)
+
+        # Verify ram_mask exists
+        assert "ram_mask" in pset.data
+        ram_mask = pset.data["ram_mask"]
+
+        # Verify dimensions
+        assert set(ram_mask.dims) == {"epoch", "esa_energy_step", "direction"}
+
+        # Extract the mask values for easier checking
+        mask_values = ram_mask.values.squeeze()
+
+        # Direction 0 (0 deg lon, 0 lat = +X): Should be ram (True)
+        # Direction 1 (180 deg lon, 0 lat = -X): Should be anti-ram (False)
+        # Directions 2 and 3 (perpendicular): Will always be anti-ram (False)
+
+        # The key test: particles coming from the spacecraft's direction of motion
+        # (opposite to velocity) should be anti-ram (False)
+        assert not mask_values[1], (
+            "Particles from -X (opposite velocity) should be anti-ram"
+        )
+
+        # Particles coming from the direction the spacecraft is moving toward
+        # should be ram (True)
+        assert mask_values[0], "Particles from +X (along velocity) should be ram"
+
+        # Particles coming from the perpendicular direction should always shift
+        # to be coming from a slightly anti-ram direction
+        assert not mask_values[2], "Particles from +Y should be anti-ram"
+        assert not mask_values[3], "Particles from -Y should be anti-ram"
+
+        # Verify all values are boolean
+        assert ram_mask.dtype == bool

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -4,8 +4,18 @@ from unittest import mock
 
 import numpy as np
 import pytest
+import xarray as xr
 
-from imap_processing.ena_maps.utils.corrections import PowerLawFluxCorrector
+from imap_processing.cdf.utils import load_cdf
+from imap_processing.ena_maps import ena_maps
+from imap_processing.ena_maps.utils.corrections import (
+    PowerLawFluxCorrector,
+    _add_cartesian_look_direction,
+    _add_spacecraft_velocity_to_pset,
+    _calculate_compton_getting_transform,
+    apply_compton_getting_correction,
+)
+from imap_processing.spice import geometry
 
 
 @pytest.fixture
@@ -228,3 +238,253 @@ class TestPowerLawFluxCorrector:
         )
         np.testing.assert_array_equal(corrected_flux, flux * 2)
         np.testing.assert_array_equal(corrected_delta_flux, delta_flux / 2)
+
+
+@pytest.fixture
+def hi_pset_cdf_path(imap_tests_path):
+    """Path to test Hi PSET CDF file."""
+    return imap_tests_path / "hi/data/l1/imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
+
+
+@pytest.fixture
+def mock_hi_pset():
+    """Create a minimal mock Hi pointing set for testing."""
+    # Create a simple dataset with necessary fields
+    n_epoch = 1
+    n_spin = 100
+
+    data = xr.Dataset(
+        {
+            "epoch": (["epoch"], np.array([797949131184000000])),
+            "hae_longitude": (
+                ["epoch", "spin_angle_bin"],
+                np.linspace(0, 360, n_spin, endpoint=False).reshape(n_epoch, n_spin),
+            ),
+            "hae_latitude": (
+                ["epoch", "spin_angle_bin"],
+                np.linspace(-90, 90, n_spin).reshape(n_epoch, n_spin),
+            ),
+            "spin_angle_bin": (["spin_angle_bin"], np.arange(n_spin)),
+        }
+    )
+
+    # Create a mock pointing set object
+    pset = mock.MagicMock(spec=ena_maps.LoHiBasePointingSet)
+    pset.data = data
+    pset.spatial_coords = ("spin_angle_bin",)
+    pset.spice_reference_frame = geometry.SpiceFrame.IMAP_HAE
+
+    return pset
+
+
+class TestComptonGettingCorrection:
+    """Test suite for Compton-Getting correction functions."""
+
+    @mock.patch("imap_processing.ena_maps.utils.corrections.geometry.imap_state")
+    def test_add_spacecraft_velocity_to_pset(self, mock_imap_state, mock_hi_pset):
+        """Test that spacecraft velocity is correctly added to pointing set."""
+        # Mock spacecraft state vector (position + velocity in HAE frame)
+        mock_sc_state = np.array([1e8, 2e8, 3e8, 10.0, 20.0, 30.0])  # km and km/s
+        mock_imap_state.return_value = mock_sc_state
+
+        et = 1000.0
+        _add_spacecraft_velocity_to_pset(mock_hi_pset, et)
+
+        # Verify SPICE was called correctly
+        mock_imap_state.assert_called_once_with(
+            et, ref_frame=geometry.SpiceFrame.IMAP_HAE
+        )
+
+        # Verify sc_velocity was added
+        assert "sc_velocity" in mock_hi_pset.data
+        assert isinstance(mock_hi_pset.data["sc_velocity"], xr.DataArray)
+        np.testing.assert_array_equal(
+            mock_hi_pset.data["sc_velocity"].values, np.array([10.0, 20.0, 30.0])
+        )
+
+        # Verify sc_direction_vector was added
+        assert "sc_direction_vector" in mock_hi_pset.data
+        expected_speed = np.sqrt(10**2 + 20**2 + 30**2)
+        expected_direction = np.array([10.0, 20.0, 30.0]) / expected_speed
+        np.testing.assert_allclose(
+            mock_hi_pset.data["sc_direction_vector"].values, expected_direction
+        )
+
+    def test_add_cartesian_look_direction(self, mock_hi_pset):
+        """Test that look directions are correctly calculated and added."""
+        _add_cartesian_look_direction(mock_hi_pset)
+
+        # _add_cartesian_look_direction is just a wrapper around
+        # geometry.spherical_to_cartesian. We only need to test that the
+        # look_direction variable was added and has the correct shape.
+        # Verify look_direction was added
+        assert "look_direction" in mock_hi_pset.data
+        assert isinstance(mock_hi_pset.data["look_direction"], xr.DataArray)
+
+        # Verify shape
+        expected_shape = (1, 100, 3)  # (epoch, spin_angle_bin, x_y_z)
+        assert mock_hi_pset.data["look_direction"].shape == expected_shape
+
+    @mock.patch("imap_processing.ena_maps.utils.corrections.geometry.imap_state")
+    def test_calculate_compton_getting_transform(self, mock_imap_state, mock_hi_pset):
+        """Test Compton-Getting transformation calculations."""
+        # Set up spacecraft velocity
+        mock_sc_state = np.array([1e8, 2e8, 3e8, 10.0, 20.0, 30.0])
+        mock_imap_state.return_value = mock_sc_state
+
+        et = 1000.0
+        _add_spacecraft_velocity_to_pset(mock_hi_pset, et)
+        _add_cartesian_look_direction(mock_hi_pset)
+
+        # Create energy array
+        energies_hf = xr.DataArray(
+            np.array([500.0, 1000.0, 2000.0]),
+            dims=["esa_energy_step"],
+            coords={"esa_energy_step": [1, 2, 3]},
+        )
+
+        _calculate_compton_getting_transform(mock_hi_pset, energies_hf)
+
+        # Verify required variables were added
+        assert "hf_energy" in mock_hi_pset.data
+        assert "energy_sc" in mock_hi_pset.data
+        assert "hae_longitude" in mock_hi_pset.data
+        assert "hae_latitude" in mock_hi_pset.data
+
+        # Verify hf_energy matches input
+        np.testing.assert_array_equal(
+            mock_hi_pset.data["hf_energy"].values, energies_hf.values
+        )
+
+        # Verify energy_sc has correct shape
+        # The transformation should broadcast across energy and spatial dimensions
+        assert "energy_sc" in mock_hi_pset.data
+        energy_sc = mock_hi_pset.data["energy_sc"]
+        # Shape should include energy dimension
+        assert len(energy_sc.dims) >= 2
+
+        # Verify energy_sc values are positive and reasonable
+        assert np.all(energy_sc.values > 0)
+        assert np.all(np.isfinite(energy_sc.values))
+
+        # Verify corrected coordinates are within valid ranges
+        assert np.all(mock_hi_pset.data["hae_longitude"].values >= 0)
+        assert np.all(mock_hi_pset.data["hae_longitude"].values <= 360)
+        assert np.all(mock_hi_pset.data["hae_latitude"].values >= -90)
+        assert np.all(mock_hi_pset.data["hae_latitude"].values <= 90)
+
+    @mock.patch("imap_processing.ena_maps.utils.corrections.geometry.imap_state")
+    def test_apply_compton_getting_correction(self, mock_imap_state, mock_hi_pset):
+        """Test full Compton-Getting correction pipeline."""
+        # Set up spacecraft velocity
+        mock_sc_state = np.array([1e8, 2e8, 3e8, 10.0, 20.0, 30.0])
+        mock_imap_state.return_value = mock_sc_state
+
+        # Create energy array
+        energies_hf = xr.DataArray(
+            np.array([500.0, 1000.0, 2000.0]),
+            dims=["esa_energy_step"],
+            coords={"esa_energy_step": [1, 2, 3]},
+        )
+
+        et = 1000.0
+
+        # Apply the full correction
+        apply_compton_getting_correction(mock_hi_pset, et, energies_hf)
+
+        # Verify all intermediate variables were added
+        assert "sc_velocity" in mock_hi_pset.data
+        assert "sc_direction_vector" in mock_hi_pset.data
+        assert "look_direction" in mock_hi_pset.data
+        assert "hf_energy" in mock_hi_pset.data
+        assert "energy_sc" in mock_hi_pset.data
+        assert "hae_longitude" in mock_hi_pset.data
+        assert "hae_latitude" in mock_hi_pset.data
+
+        # Verify update_az_el_points was called
+        mock_hi_pset.update_az_el_points.assert_called_once()
+
+    @pytest.mark.external_test_data
+    @mock.patch("imap_processing.ena_maps.utils.corrections.geometry.imap_state")
+    def test_compton_getting_with_real_pset(self, mock_imap_state, hi_pset_cdf_path):
+        """Test Compton-Getting correction with real Hi PSET data."""
+        # Load real pointing set
+        pset_ds = load_cdf(hi_pset_cdf_path)
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+
+        # Store original coordinates for comparison
+        original_lon = hi_pset.data["hae_longitude"].copy()
+
+        # Mock spacecraft state
+        mock_sc_state = np.array([1e8, 2e8, 3e8, 12.0, -27.0, 0.02])  # km and km/s
+        mock_imap_state.return_value = mock_sc_state
+
+        # Create energy array (Hi has 9 energy steps)
+        energies_hf = xr.DataArray(
+            np.array(
+                [500.0, 750.0, 1100.0, 1650.0, 2500.0, 3750.0, 5700.0, 8520.0, 12800.0]
+            ),
+            dims=["esa_energy_step"],
+            coords={"esa_energy_step": np.arange(1, 10)},
+        )
+
+        et = 797949131184.0  # Convert from ns to seconds
+
+        # Apply correction
+        apply_compton_getting_correction(hi_pset, et, energies_hf)
+
+        # Verify coordinates were modified
+        corrected_lon = hi_pset.data["hae_longitude"]
+        corrected_lat = hi_pset.data["hae_latitude"]
+
+        # Shape should now include energy dimension
+        assert "esa_energy_step" in corrected_lon.dims
+        assert "esa_energy_step" in corrected_lat.dims
+
+        # Verify the correction changes the coordinates
+        # (at least some points should be different)
+        # Note: We can't directly compare because dimensions changed
+        assert corrected_lon.shape != original_lon.shape
+
+        # Verify all values are in valid ranges
+        assert np.all(corrected_lon.values >= 0)
+        assert np.all(corrected_lon.values <= 360)
+        assert np.all(corrected_lat.values >= -90)
+        assert np.all(corrected_lat.values <= 90)
+
+        # Verify az_el_points was updated
+        assert hi_pset.az_el_points is not None
+        assert isinstance(hi_pset.az_el_points, xr.DataArray)
+
+    def test_compton_getting_physical_consistency(self, mock_hi_pset):
+        """Test physical consistency of Compton-Getting correction."""
+        # Set up a known spacecraft velocity
+        sc_velocity = np.array([30.0, 0.0, 0.0])  # Moving in +X direction at 30 km/s
+
+        mock_hi_pset.data["sc_velocity"] = xr.DataArray(sc_velocity, dims=["x_y_z"])
+        mock_hi_pset.data["sc_direction_vector"] = xr.DataArray(
+            sc_velocity / np.linalg.norm(sc_velocity), dims=["x_y_z"]
+        )
+
+        # Set up simple look directions
+        _add_cartesian_look_direction(mock_hi_pset)
+
+        # Single energy level
+        energies_hf = xr.DataArray(np.array([1000.0]), dims=["esa_energy_step"])
+
+        _calculate_compton_getting_transform(mock_hi_pset, energies_hf)
+
+        # Physical checks:
+        # 1. Energy in spacecraft frame should be higher for particles coming
+        #    from the direction of spacecraft motion (ram direction)
+        energy_sc = mock_hi_pset.data["energy_sc"]
+
+        # 2. All energies should be positive
+        assert np.all(energy_sc.values > 0)
+
+        # 3. The spacecraft frame energy should differ from heliosphere frame
+        # (they should not all be exactly 1000 eV)
+        assert not np.allclose(energy_sc.values, 1000.0)
+
+        # 4. Energy variation should exist across different look directions
+        assert energy_sc.values.std() > 0

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -173,7 +173,7 @@ class TestHiPointingSet:
         )
 
         # Test anti-ram direction
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="anti-ram")
+        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="anti")
         assert hi_pset.num_points == 1800
         np.testing.assert_array_equal(
             hi_pset.data["spin_angle_bin"].data, np.arange(1800) + 1800


### PR DESCRIPTION
# Change Summary

## Overview
This adds CG calculations that need to be done on each PSET prior to binning. I expect to need to make a few minor changes as I integrate this code into the Hi and Lo L2 pipelines.
I also snuck in a fix to Hi anti-ram filtering.

## Updated Files
- imap_processing/ena_maps/ena_maps.py
   - fix anti-ram filtering by checking for "anti"
- imap_processing/ena_maps/utils/coordinates.py
   - add a generic coordinate for Cartesian vectors
- imap_processing/ena_maps/utils/corrections.py
   - Add CG calculations needed to be done for each PSET prior to binning to a SkyMap
- imap_processing/tests/ena_maps/test_corrections.py
   - Claude aided addition of test coverage for new functions

Closes: #2282 
