### PR TITLE
FIX: Explicitly choose SWAPI science/housekeeping path

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1306,7 +1306,7 @@ class Swapi(ProcessInstrument):
                 )
 
             # process science or housekeeping data
-            datasets = swapi_l1(dependencies)
+            datasets = swapi_l1(dependencies, descriptor=self.descriptor)
         elif self.data_level == "l2":
             if len(dependency_list) != 3:
                 raise ValueError(

--- a/imap_processing/swapi/l1/swapi_l1.py
+++ b/imap_processing/swapi/l1/swapi_l1.py
@@ -727,7 +727,7 @@ def process_swapi_science(
     return dataset
 
 
-def swapi_l1(dependencies: ProcessingInputCollection) -> xr.Dataset:
+def swapi_l1(dependencies: ProcessingInputCollection, descriptor: str) -> xr.Dataset:
     """
     Will process SWAPI level 0 data to level 1.
 
@@ -735,6 +735,9 @@ def swapi_l1(dependencies: ProcessingInputCollection) -> xr.Dataset:
     ----------
     dependencies : ProcessingInputCollection
         Input dependencies needed for L1 processing.
+    descriptor : str
+        Descriptor for the type of data to process.
+        Options are 'hk' or 'sci'.
 
     Returns
     -------
@@ -754,9 +757,11 @@ def swapi_l1(dependencies: ProcessingInputCollection) -> xr.Dataset:
         l0_files[0], xtce_definition, use_derived_value=False
     )
 
-    hk_files = dependencies.get_file_paths(descriptor="hk")
-    if hk_files and l0_unpacked_dict.get(SWAPIAPID.SWP_SCI, None) is not None:
+    if descriptor == "sci":
         logger.info(f"Processing SWAPI science data for {l0_files[0]}.")
+        if SWAPIAPID.SWP_SCI not in l0_unpacked_dict:
+            logger.warning("No SWP_SCI packets found.")
+            return []
         # process science data.
         # First read HK data.
         hk_files = dependencies.get_file_paths(descriptor="hk")
@@ -770,8 +775,11 @@ def swapi_l1(dependencies: ProcessingInputCollection) -> xr.Dataset:
         )
         return [sci_dataset]
 
-    elif l0_unpacked_dict[SWAPIAPID.SWP_HK]:
+    elif descriptor == "hk":
         logger.info(f"Processing HK data for {l0_files[0]}.")
+        if SWAPIAPID.SWP_HK not in l0_unpacked_dict:
+            logger.warning("No SWP_HK packets found.")
+            return []
         # Get L1A and L1B HK data.
         l1a_hk_data = l0_unpacked_dict[SWAPIAPID.SWP_HK]
         l1b_hk_data = packet_file_to_datasets(

--- a/imap_processing/tests/swapi/test_swapi_l1.py
+++ b/imap_processing/tests/swapi/test_swapi_l1.py
@@ -203,7 +203,7 @@ def test_swapi_l1_cdf(mock_get_file_paths, swapi_l0_test_data_path):
     collection_obj.deserialize(
         json.dumps(processing_input),
     )
-    processed_data = swapi_l1(collection_obj)
+    processed_data = swapi_l1(collection_obj, descriptor="hk")
     # hk cdf file
     l1a_hk_cdf_filename = "imap_swapi_l1a_hk_20240924_v999.cdf"
     hk_cdf_path = write_cdf(processed_data[0])
@@ -231,7 +231,7 @@ def test_swapi_l1_cdf(mock_get_file_paths, swapi_l0_test_data_path):
         json.dumps(processing_input),
     )
 
-    processed_data = swapi_l1(collection_obj)
+    processed_data = swapi_l1(collection_obj, descriptor="sci")
 
     assert processed_data[0].attrs["Apid"] == f"{SWAPIAPID.SWP_SCI}"
 

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -82,7 +82,7 @@ def test_swapi_l2_cdf(
         json.dumps(processing_input),
     )
     # Create HK CDF File
-    processed_hk_data = swapi_l1(collection_obj)
+    processed_hk_data = swapi_l1(collection_obj, descriptor="hk")
     hk_cdf_filename = "imap_swapi_l1a_hk_20240924_v999.cdf"
     hk_cdf_path = write_cdf(processed_hk_data[0])
     assert hk_cdf_path.name == hk_cdf_filename
@@ -106,7 +106,7 @@ def test_swapi_l2_cdf(
         json.dumps(processing_input),
     )
     # Create L1 CDF File
-    processed_sci_data = swapi_l1(collection_obj)
+    processed_sci_data = swapi_l1(collection_obj, descriptor="sci")
     cdf_filename = "imap_swapi_l1_sci_20240924_v999.cdf"
     cdf_path = write_cdf(processed_sci_data[0])
     assert cdf_path.name == cdf_filename


### PR DESCRIPTION
If we didn't have science data, we'd fallback to the housekeeping path. This caused issues with a recursive loop where the science dataset created housekeeping datasets and triggered the job again.