### PR TITLE
I-ALiRT - CoDICE l1a

### DIFF
--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import xarray as xr
 
+from imap_processing.ialirt.utils.grouping import find_groups
+
 logger = logging.getLogger(__name__)
 
 FILLVAL_FLOAT32 = Decimal(str(-1.0e31))
@@ -35,6 +37,7 @@ def process_codice(
     - Calculate L2 CoDICE pseudodensities (pg 37 of Algorithm Document)
     - Calculate the public data products
     """
+    grouped_cod_lo_data = find_groups(dataset, (0, 232), "cod_lo_counter", "cod_lo_acq")
     # For I-ALiRT SIT, the test data being used has all zeros and thus no
     # groups can be found, thus there is no data to process
     # TODO: Once I-ALiRT test data is acquired that actually has data in it,

--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -13,11 +13,15 @@ logger = logging.getLogger(__name__)
 
 FILLVAL_UINT8 = 255
 FILLVAL_FLOAT32 = Decimal(str(-1.0e31))
-COD_LO_COUNTER = np.uint8(232)
+COD_LO_COUNTER = 232
+COD_HI_COUNTER = 197
 COD_LO_RANGE = range(0, 15)
+COD_HI_RANGE = range(0, 5)
 
 
-def concatenate_bytes(grouped_cod_lo_data: xr.Dataset, group: int) -> bytearray:
+def concatenate_bytes(
+    grouped_cod_lo_data: xr.Dataset, group: int, sensor: str
+) -> bytearray:
     """
     Concatenate all cod_lo_data fields for a specific group into a single bytearray.
 
@@ -27,6 +31,8 @@ def concatenate_bytes(grouped_cod_lo_data: xr.Dataset, group: int) -> bytearray:
         The grouped CoDICE-Lo dataset containing cod_lo_data_XX variables.
     group : int
         The group number to extract.
+    sensor : str
+        The sensor type, either 'lo' or 'hi'.
 
     Returns
     -------
@@ -34,13 +40,18 @@ def concatenate_bytes(grouped_cod_lo_data: xr.Dataset, group: int) -> bytearray:
         The concatenated data stream for the selected group.
     """
     current_data_stream = bytearray()
-
-    # Filter to only the rows for this group
     group_mask = (grouped_cod_lo_data["group"] == group).values
 
-    # Loop through all cod_lo_data fields (e.g., cod_lo_data_00 … cod_lo_data_14)
-    for field in COD_LO_RANGE:  # e.g., range(15)
-        data_array = grouped_cod_lo_data[f"cod_lo_data_{field:02}"].values[group_mask]
+    cod_ranges = {
+        "lo": COD_LO_RANGE,
+        "hi": COD_HI_RANGE,
+    }
+
+    # Loop through all data fields.
+    for field in cod_ranges[sensor]:
+        data_array = grouped_cod_lo_data[f"cod_{sensor}_data_{field:02}"].values[
+            group_mask
+        ]
 
         # Convert each value to uint8 and extend the byte stream
         current_data_stream.extend(np.uint8(data_array).tobytes())
@@ -75,10 +86,17 @@ def process_codice(
     grouped_cod_lo_data = find_groups(
         dataset, (0, COD_LO_COUNTER), "cod_lo_counter", "cod_lo_acq"
     )
+    grouped_cod_hi_data = find_groups(
+        dataset, (0, COD_HI_COUNTER), "cod_hi_counter", "cod_hi_acq"
+    )
     unique_cod_lo_groups = np.unique(grouped_cod_lo_data["group"])
+    unique_cod_hi_groups = np.unique(grouped_cod_hi_data["group"])
 
     for group in unique_cod_lo_groups:
-        current_data_stream = concatenate_bytes(grouped_cod_lo_data, group)
+        cod_lo_data_stream = concatenate_bytes(grouped_cod_lo_data, group, "lo")
+
+    for group in unique_cod_hi_groups:
+        cod_hi_data_stream = concatenate_bytes(grouped_cod_hi_data, group, "lo")
 
         print("hi")
 

--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 import xarray as xr
 
+from imap_processing.codice import decompress
 from imap_processing.ialirt.utils.grouping import find_groups
 
 logger = logging.getLogger(__name__)
@@ -19,16 +20,14 @@ COD_LO_RANGE = range(0, 15)
 COD_HI_RANGE = range(0, 5)
 
 
-def concatenate_bytes(
-    grouped_cod_lo_data: xr.Dataset, group: int, sensor: str
-) -> bytearray:
+def concatenate_bytes(grouped_data: xr.Dataset, group: int, sensor: str) -> bytearray:
     """
     Concatenate all cod_lo_data fields for a specific group into a single bytearray.
 
     Parameters
     ----------
-    grouped_cod_lo_data : xr.Dataset
-        The grouped CoDICE-Lo dataset containing cod_lo_data_XX variables.
+    grouped_data : xr.Dataset
+        The grouped CoDICE dataset containing cod_{sensor}_data_XX variables.
     group : int
         The group number to extract.
     sensor : str
@@ -36,11 +35,11 @@ def concatenate_bytes(
 
     Returns
     -------
-    bytearray
+    current_data_stream: bytearray
         The concatenated data stream for the selected group.
     """
     current_data_stream = bytearray()
-    group_mask = (grouped_cod_lo_data["group"] == group).values
+    group_mask = (grouped_data["group"] == group).values
 
     cod_ranges = {
         "lo": COD_LO_RANGE,
@@ -49,9 +48,7 @@ def concatenate_bytes(
 
     # Loop through all data fields.
     for field in cod_ranges[sensor]:
-        data_array = grouped_cod_lo_data[f"cod_{sensor}_data_{field:02}"].values[
-            group_mask
-        ]
+        data_array = grouped_data[f"cod_{sensor}_data_{field:02}"].values[group_mask]
 
         # Convert each value to uint8 and extend the byte stream
         current_data_stream.extend(np.uint8(data_array).tobytes())
@@ -95,10 +92,14 @@ def process_codice(
     for group in unique_cod_lo_groups:
         cod_lo_data_stream = concatenate_bytes(grouped_cod_lo_data, group, "lo")
 
+        # Decompress binary stream
+        decompressed_data = decompress._apply_pack_24_bit(cod_lo_data_stream)
+
     for group in unique_cod_hi_groups:
         cod_hi_data_stream = concatenate_bytes(grouped_cod_hi_data, group, "lo")
 
-        print("hi")
+        # Decompress binary stream
+        decompressed_data = decompress._apply_loggy_a(cod_hi_data_stream)  # noqa
 
     # For I-ALiRT SIT, the test data being used has all zeros and thus no
     # groups can be found, thus there is no data to process

--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -93,13 +93,13 @@ def process_codice(
         cod_lo_data_stream = concatenate_bytes(grouped_cod_lo_data, group, "lo")
 
         # Decompress binary stream
-        decompressed_data = decompress._apply_pack_24_bit(cod_lo_data_stream)
+        decompressed_data = decompress._apply_pack_24_bit(bytes(cod_lo_data_stream))
 
     for group in unique_cod_hi_groups:
         cod_hi_data_stream = concatenate_bytes(grouped_cod_hi_data, group, "lo")
 
         # Decompress binary stream
-        decompressed_data = decompress._apply_loggy_a(cod_hi_data_stream)  # noqa
+        decompressed_data = decompress._apply_loggy_a(bytes(cod_hi_data_stream))  # noqa
 
     # For I-ALiRT SIT, the test data being used has all zeros and thus no
     # groups can be found, thus there is no data to process

--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -4,13 +4,48 @@ import logging
 from decimal import Decimal
 from typing import Any
 
+import numpy as np
 import xarray as xr
 
 from imap_processing.ialirt.utils.grouping import find_groups
 
 logger = logging.getLogger(__name__)
 
+FILLVAL_UINT8 = 255
 FILLVAL_FLOAT32 = Decimal(str(-1.0e31))
+COD_LO_COUNTER = np.uint8(232)
+COD_LO_RANGE = range(0, 15)
+
+
+def concatenate_bytes(grouped_cod_lo_data: xr.Dataset, group: int) -> bytearray:
+    """
+    Concatenate all cod_lo_data fields for a specific group into a single bytearray.
+
+    Parameters
+    ----------
+    grouped_cod_lo_data : xr.Dataset
+        The grouped CoDICE-Lo dataset containing cod_lo_data_XX variables.
+    group : int
+        The group number to extract.
+
+    Returns
+    -------
+    bytearray
+        The concatenated data stream for the selected group.
+    """
+    current_data_stream = bytearray()
+
+    # Filter to only the rows for this group
+    group_mask = (grouped_cod_lo_data["group"] == group).values
+
+    # Loop through all cod_lo_data fields (e.g., cod_lo_data_00 … cod_lo_data_14)
+    for field in COD_LO_RANGE:  # e.g., range(15)
+        data_array = grouped_cod_lo_data[f"cod_lo_data_{field:02}"].values[group_mask]
+
+        # Convert each value to uint8 and extend the byte stream
+        current_data_stream.extend(np.uint8(data_array).tobytes())
+
+    return current_data_stream
 
 
 def process_codice(
@@ -37,7 +72,16 @@ def process_codice(
     - Calculate L2 CoDICE pseudodensities (pg 37 of Algorithm Document)
     - Calculate the public data products
     """
-    grouped_cod_lo_data = find_groups(dataset, (0, 232), "cod_lo_counter", "cod_lo_acq")
+    grouped_cod_lo_data = find_groups(
+        dataset, (0, COD_LO_COUNTER), "cod_lo_counter", "cod_lo_acq"
+    )
+    unique_cod_lo_groups = np.unique(grouped_cod_lo_data["group"])
+
+    for group in unique_cod_lo_groups:
+        current_data_stream = concatenate_bytes(grouped_cod_lo_data, group)
+
+        print("hi")
+
     # For I-ALiRT SIT, the test data being used has all zeros and thus no
     # groups can be found, thus there is no data to process
     # TODO: Once I-ALiRT test data is acquired that actually has data in it,

--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -22,7 +22,7 @@ COD_HI_RANGE = range(0, 5)
 
 def concatenate_bytes(grouped_data: xr.Dataset, group: int, sensor: str) -> bytearray:
     """
-    Concatenate all cod_lo_data fields for a specific group into a single bytearray.
+    Concatenate all data fields for a specific group into a single bytearray.
 
     Parameters
     ----------

--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -99,7 +99,7 @@ def process_codice(
         cod_hi_data_stream = concatenate_bytes(grouped_cod_hi_data, group, "lo")
 
         # Decompress binary stream
-        decompressed_data = decompress._apply_loggy_a(bytes(cod_hi_data_stream))  # noqa
+        decompressed_data = decompress._apply_lossy_a(bytes(cod_hi_data_stream))  # noqa
 
     # For I-ALiRT SIT, the test data being used has all zeros and thus no
     # groups can be found, thus there is no data to process

--- a/imap_processing/tests/ialirt/unit/test_process_codice.py
+++ b/imap_processing/tests/ialirt/unit/test_process_codice.py
@@ -6,10 +6,13 @@ code.
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from imap_processing import imap_module_directory
+from imap_processing.codice.codice_l1a import group_ialirt_data
 from imap_processing.ialirt.l0.process_codice import process_codice
+from imap_processing.ialirt.utils.grouping import find_groups
 from imap_processing.utils import packet_file_to_datasets
 
 pytestmark = pytest.mark.external_test_data
@@ -33,9 +36,60 @@ def test_datasets(l0_test_file):
     return datasets
 
 
+@pytest.fixture(scope="session")
+def cod_lo_test_file():
+    return Path(
+        imap_module_directory
+        / "tests"
+        / "codice"
+        / "data"
+        / "l1a_input"
+        / "imap_codice_lo-ialirt_20250814_v001.pkts"
+    )
+
+
+@pytest.fixture(scope="session")
+def cod_lo_test_dataset(cod_lo_test_file):
+    xtce_packet_definition = Path(
+        imap_module_directory / "ialirt" / "packet_definitions" / "ialirt_codicelo.xml"
+    )
+
+    datasets = packet_file_to_datasets(cod_lo_test_file, xtce_packet_definition)
+
+    return datasets
+
+
 @pytest.fixture
 def codice_test_data(test_datasets):
     return test_datasets[478]
+
+
+@pytest.mark.external_test_data
+def test_group_ialirt_cod_lo(cod_lo_test_dataset):
+    max_valid_counter = 232
+    fill_value = 255
+
+    grouped_cod_lo_data = find_groups(
+        cod_lo_test_dataset, (0, max_valid_counter), "cod_lo_counter", "cod_lo_acq"
+    )
+
+    # Verify that we grouped the values properly.
+    counter_values = cod_lo_test_dataset["cod_lo_counter"].data
+    valid_values = counter_values[counter_values != fill_value]
+    resets = np.where(valid_values == max_valid_counter)
+
+    count = increment = 0
+    for reset in resets[0]:
+        group = valid_values[increment : reset + 1]
+        np.testing.assert_array_equal(
+            group, np.arange(0, max_valid_counter + 1, dtype=np.uint8)
+        )
+        increment = reset + 1
+        count = count + 1
+
+    assert count == int(grouped_cod_lo_data.group.max())
+
+    grouped_data = group_ialirt_data(grouped_cod_lo_data, range(0, 15), "cod_lo")
 
 
 def test_process_codice(codice_test_data, caplog):

--- a/imap_processing/tests/ialirt/unit/test_process_codice.py
+++ b/imap_processing/tests/ialirt/unit/test_process_codice.py
@@ -11,6 +11,9 @@ import pytest
 
 from imap_processing import imap_module_directory
 from imap_processing.ialirt.l0.process_codice import (
+    COD_HI_COUNTER,
+    COD_HI_RANGE,
+    COD_LO_COUNTER,
     COD_LO_RANGE,
     FILLVAL_UINT8,
     concatenate_bytes,
@@ -65,6 +68,31 @@ def cod_lo_test_dataset(cod_lo_test_file):
     return datasets
 
 
+@pytest.fixture(scope="session")
+def cod_hi_test_file():
+    return Path(
+        imap_module_directory
+        / "tests"
+        / "codice"
+        / "data"
+        / "l1a_input"
+        / "imap_codice_hi-ialirt_20250814_v001.pkts"
+    )
+
+
+@pytest.fixture(scope="session")
+def cod_hi_test_dataset(cod_hi_test_file):
+    xtce_packet_definition = Path(
+        imap_module_directory / "ialirt" / "packet_definitions" / "ialirt_codicehi.xml"
+    )
+
+    datasets = packet_file_to_datasets(
+        cod_hi_test_file, xtce_packet_definition, use_derived_value=True
+    )[1168]
+
+    return datasets
+
+
 @pytest.fixture
 def codice_test_data(test_datasets):
     return test_datasets[478]
@@ -74,21 +102,20 @@ def codice_test_data(test_datasets):
 def test_group_ialirt_cod_lo(cod_lo_test_dataset):
     "Test that I-ALiRT CoDICE-Lo data can be grouped properly."
 
-    max_valid_counter = 232
     grouped_cod_lo_data = find_groups(
-        cod_lo_test_dataset, (0, max_valid_counter), "cod_lo_counter", "cod_lo_acq"
+        cod_lo_test_dataset, (0, COD_LO_COUNTER), "cod_lo_counter", "cod_lo_acq"
     )
 
     # Verify that we grouped the values properly.
     counter_values = cod_lo_test_dataset["cod_lo_counter"].data
     valid_values = counter_values[counter_values != FILLVAL_UINT8]
-    resets = np.where(valid_values == max_valid_counter)
+    resets = np.where(valid_values == COD_LO_COUNTER)
 
     count = increment = 0
     for reset in resets[0]:
         group = valid_values[increment : reset + 1]
         np.testing.assert_array_equal(
-            group, np.arange(0, max_valid_counter + 1, dtype=np.uint8)
+            group, np.arange(0, COD_LO_COUNTER + 1, dtype=np.uint8)
         )
         increment = reset + 1
         count = count + 1
@@ -98,10 +125,43 @@ def test_group_ialirt_cod_lo(cod_lo_test_dataset):
     unique_groups = np.unique(grouped_cod_lo_data["group"])
 
     for group in unique_groups:
-        grouped_data = concatenate_bytes(grouped_cod_lo_data, group)
+        grouped_data = concatenate_bytes(grouped_cod_lo_data, group, "lo")
         byte_data = np.frombuffer(grouped_data, dtype=np.uint8)
         num_bits = byte_data.size * 8
-        assert num_bits == (max_valid_counter + 1) * len(COD_LO_RANGE) * 8
+        assert num_bits == (COD_LO_COUNTER + 1) * len(COD_LO_RANGE) * 8
+
+
+@pytest.mark.external_test_data
+def test_group_ialirt_cod_hi(cod_hi_test_dataset):
+    "Test that I-ALiRT CoDICE-Lo data can be grouped properly."
+
+    grouped_cod_hi_data = find_groups(
+        cod_hi_test_dataset, (0, COD_HI_COUNTER), "cod_hi_counter", "cod_hi_acq"
+    )
+
+    # Verify that we grouped the values properly.
+    counter_values = cod_hi_test_dataset["cod_hi_counter"].data
+    valid_values = counter_values[counter_values != FILLVAL_UINT8]
+    resets = np.where(valid_values == COD_HI_COUNTER)
+
+    count = increment = 0
+    for reset in resets[0]:
+        group = valid_values[increment : reset + 1]
+        np.testing.assert_array_equal(
+            group, np.arange(0, COD_HI_COUNTER + 1, dtype=np.uint8)
+        )
+        increment = reset + 1
+        count = count + 1
+
+    assert count == int(grouped_cod_hi_data.group.max())
+
+    unique_groups = np.unique(grouped_cod_hi_data["group"])
+
+    for group in unique_groups:
+        grouped_data = concatenate_bytes(grouped_cod_hi_data, group, "hi")
+        byte_data = np.frombuffer(grouped_data, dtype=np.uint8)
+        num_bits = byte_data.size * 8
+        assert num_bits == (COD_HI_COUNTER + 1) * len(COD_HI_RANGE) * 8
 
 
 def test_process_codice(codice_test_data, caplog):

--- a/imap_processing/tests/ialirt/unit/test_process_codice.py
+++ b/imap_processing/tests/ialirt/unit/test_process_codice.py
@@ -10,8 +10,12 @@ import numpy as np
 import pytest
 
 from imap_processing import imap_module_directory
-from imap_processing.codice.codice_l1a import group_ialirt_data
-from imap_processing.ialirt.l0.process_codice import process_codice
+from imap_processing.ialirt.l0.process_codice import (
+    COD_LO_RANGE,
+    FILLVAL_UINT8,
+    concatenate_bytes,
+    process_codice,
+)
 from imap_processing.ialirt.utils.grouping import find_groups
 from imap_processing.utils import packet_file_to_datasets
 
@@ -54,7 +58,9 @@ def cod_lo_test_dataset(cod_lo_test_file):
         imap_module_directory / "ialirt" / "packet_definitions" / "ialirt_codicelo.xml"
     )
 
-    datasets = packet_file_to_datasets(cod_lo_test_file, xtce_packet_definition)
+    datasets = packet_file_to_datasets(
+        cod_lo_test_file, xtce_packet_definition, use_derived_value=True
+    )[1152]
 
     return datasets
 
@@ -66,16 +72,16 @@ def codice_test_data(test_datasets):
 
 @pytest.mark.external_test_data
 def test_group_ialirt_cod_lo(cod_lo_test_dataset):
-    max_valid_counter = 232
-    fill_value = 255
+    "Test that I-ALiRT CoDICE-Lo data can be grouped properly."
 
+    max_valid_counter = 232
     grouped_cod_lo_data = find_groups(
         cod_lo_test_dataset, (0, max_valid_counter), "cod_lo_counter", "cod_lo_acq"
     )
 
     # Verify that we grouped the values properly.
     counter_values = cod_lo_test_dataset["cod_lo_counter"].data
-    valid_values = counter_values[counter_values != fill_value]
+    valid_values = counter_values[counter_values != FILLVAL_UINT8]
     resets = np.where(valid_values == max_valid_counter)
 
     count = increment = 0
@@ -89,7 +95,13 @@ def test_group_ialirt_cod_lo(cod_lo_test_dataset):
 
     assert count == int(grouped_cod_lo_data.group.max())
 
-    grouped_data = group_ialirt_data(grouped_cod_lo_data, range(0, 15), "cod_lo")
+    unique_groups = np.unique(grouped_cod_lo_data["group"])
+
+    for group in unique_groups:
+        grouped_data = concatenate_bytes(grouped_cod_lo_data, group)
+        byte_data = np.frombuffer(grouped_data, dtype=np.uint8)
+        num_bits = byte_data.size * 8
+        assert num_bits == (max_valid_counter + 1) * len(COD_LO_RANGE) * 8
 
 
 def test_process_codice(codice_test_data, caplog):

--- a/imap_processing/tests/ialirt/unit/test_process_codice.py
+++ b/imap_processing/tests/ialirt/unit/test_process_codice.py
@@ -99,7 +99,7 @@ def codice_test_data(test_datasets):
 
 
 @pytest.mark.external_test_data
-def test_group_ialirt_cod_lo(cod_lo_test_dataset):
+def test_group_and_decompress_ialirt_cod_lo(cod_lo_test_dataset):
     "Test that I-ALiRT CoDICE-Lo data can be grouped properly."
 
     grouped_cod_lo_data = find_groups(
@@ -125,15 +125,17 @@ def test_group_ialirt_cod_lo(cod_lo_test_dataset):
     unique_groups = np.unique(grouped_cod_lo_data["group"])
 
     for group in unique_groups:
-        grouped_data = concatenate_bytes(grouped_cod_lo_data, group, "lo")
-        byte_data = np.frombuffer(grouped_data, dtype=np.uint8)
+        compressed_data = concatenate_bytes(grouped_cod_lo_data, group, "lo")
+        byte_data = np.frombuffer(compressed_data, dtype=np.uint8)
         num_bits = byte_data.size * 8
         assert num_bits == (COD_LO_COUNTER + 1) * len(COD_LO_RANGE) * 8
+        # TODO: left off here. Need to validate decompression with test data.
+        # decompressed_data = decompress._apply_pack_24_bit(compressed_data)
 
 
 @pytest.mark.external_test_data
-def test_group_ialirt_cod_hi(cod_hi_test_dataset):
-    "Test that I-ALiRT CoDICE-Lo data can be grouped properly."
+def test_group_and_decompress_ialirt_cod_hi(cod_hi_test_dataset):
+    "Test that I-ALiRT CoDICE-Hi data can be grouped properly."
 
     grouped_cod_hi_data = find_groups(
         cod_hi_test_dataset, (0, COD_HI_COUNTER), "cod_hi_counter", "cod_hi_acq"
@@ -158,10 +160,12 @@ def test_group_ialirt_cod_hi(cod_hi_test_dataset):
     unique_groups = np.unique(grouped_cod_hi_data["group"])
 
     for group in unique_groups:
-        grouped_data = concatenate_bytes(grouped_cod_hi_data, group, "hi")
-        byte_data = np.frombuffer(grouped_data, dtype=np.uint8)
+        compressed_data = concatenate_bytes(grouped_cod_hi_data, group, "hi")
+        byte_data = np.frombuffer(compressed_data, dtype=np.uint8)
         num_bits = byte_data.size * 8
         assert num_bits == (COD_HI_COUNTER + 1) * len(COD_HI_RANGE) * 8
+        # TODO: left off here. Need to validate decompression with test data.
+        # decompressed_data = decompress._apply_loggy_a(compressed_data)
 
 
 def test_process_codice(codice_test_data, caplog):


### PR DESCRIPTION
# Change Summary

## Overview
Initial steps for l1a decompression (need to add test data).

## Updated Files
- process_codice.py

From our meeting (Note that the number of packets has changed)
L1a - put 15 bytes together 232 times (0-231) - coming from counter (concatenate) - Lo; 232 is number of packets
L1a - put 5 bytes together 240 times (0-239)  - Hi; 240 is number of packets

232 * 15 * 8 = 27840 bits - Lo
Lo - 24 bits to 32 bits int
Hi - lossy A only

Binary stream will need to be decompressed (input to code)
Lo - Use function that Joey wrote: _apply_pack_24_bit() in  decompress.py
Hi - Lossy A (use the function from Matthew) : _apply_loggy_a() in decompress.py

## Testing
- test_process_codice.py