### PR TITLE
SWE - update geometric factors

### DIFF
--- a/imap_processing/swe/utils/swe_constants.py
+++ b/imap_processing/swe/utils/swe_constants.py
@@ -16,13 +16,13 @@ ENERGY_CONVERSION_FACTOR = 4.75
 # 7 CEMs geometric factors in cm^2 sr eV/eV units.
 GEOMETRIC_FACTORS = np.array(
     [
-        435e-6,
-        599e-6,
-        808e-6,
-        781e-6,
-        876e-6,
-        548e-6,
-        432e-6,
+        424.4e-6,
+        564.5e-6,
+        763.8e-6,
+        916.9e-6,
+        792.0e-6,
+        667.7e-6,
+        425.2e-6,
     ]
 )
 

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -24,6 +24,18 @@ from imap_processing.swe.utils import swe_constants
 
 pytestmark = pytest.mark.external_test_data
 
+OLD_GEOMETRIC_FACTORS = np.array(
+    [
+        435e-6,
+        599e-6,
+        808e-6,
+        781e-6,
+        876e-6,
+        548e-6,
+        432e-6,
+    ]
+)
+
 
 @patch(
     "imap_processing.swe.utils.swe_constants.GEOMETRIC_FACTORS",
@@ -255,6 +267,10 @@ def test_put_data_into_angle_bins():
     np.testing.assert_array_equal(even_col_mean_data, expected_mean_data)
 
 
+@patch(
+    "imap_processing.swe.utils.swe_constants.GEOMETRIC_FACTORS",
+    new=OLD_GEOMETRIC_FACTORS,
+)
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
 @patch(
     "imap_processing.spice.spin.get_spacecraft_to_instrument_spin_phase_offset",
@@ -364,6 +380,10 @@ def test_swe_l2_15sec(
     np.testing.assert_allclose(bin_psd_data, bin_psd_val, rtol=1e-6)
 
 
+@patch(
+    "imap_processing.swe.utils.swe_constants.GEOMETRIC_FACTORS",
+    new=OLD_GEOMETRIC_FACTORS,
+)
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
 @patch(
     "imap_processing.spice.spin.get_spacecraft_to_instrument_spin_phase_offset",


### PR DESCRIPTION
# Change Summary

## Overview
Based on Ruth's email:

Tenzin, Laura,

After further analysis (and correcting an error!), I have updated values for the SWE geometric factors.

The latest and greatest geometric factors for CEMs 1-7 in that order are:

424.4 x 10^-6 cm^2 sr eV/eV
564.5 x 10^-6
763.8 x 10^-6
916.9 x 10^-6
792.0 x 10^-6
667.7 x 10^-6
425.2 x 10^-6

## Updated Files
- swe_constants
   - Update geometric factors

- test_swe_l2
   - Added patch with old geometric factors.