### PR TITLE
I-ALiRT - prevent cdf archive creation from breaking

### DIFF
--- a/imap_processing/ialirt/utils/create_xarray.py
+++ b/imap_processing/ialirt/utils/create_xarray.py
@@ -155,6 +155,7 @@ def create_xarray_from_records(records: list[dict]) -> xr.Dataset:  # noqa: PLR0
                 "sc_velocity_GSM",
                 "sc_velocity_GSE",
                 "mag_hk_status",
+                "spice_kernels",
             ]:
                 continue
             elif key in ["mag_B_GSE", "mag_B_GSM", "mag_B_RTN"]:


### PR DESCRIPTION
# Change Summary

## Overview
Since we added spice kernel metadata to DynamoDB we need to tell the code that creates the xarray to not include it.

Related to:
https://github.com/IMAP-Science-Operations-Center/sds-data-manager/pull/935