### PR TITLE
2249 hi lo cg correction   bin pset data 1

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -652,15 +652,16 @@ class HiPointingSet(LoHiBasePointingSet):
     def __init__(self, dataset: xr.Dataset | str | Path):
         super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.IMAP_HAE)
 
+        self.spatial_coords = ("spin_angle_bin",)
+
         # Naively generate the ram_mask variable assuming spacecraft frame
         # binning. The ram_mask variable gets updated in the CG correction
         # code if the CG correction is applied.
-        self.data["ram_mask"] = xr.zeros_like(self.data["spin_angle_bin"], dtype=bool)
+        ram_mask = xr.zeros_like(self.data["spin_angle_bin"], dtype=bool)
         # ram only includes spin-phase interval [0, 0.5)
         # which is the first half of the spin_angle_bins
-        self.data["ram_mask"][slice(0, self.data["spin_angle_bin"].data.size // 2)] = (
-            True
-        )
+        ram_mask[slice(0, self.data["spin_angle_bin"].data.size // 2)] = True
+        self.data["ram_mask"] = ram_mask
 
         # Rename some PSET vars to match L2 variables
         self.data = self.data.rename(
@@ -675,8 +676,6 @@ class HiPointingSet(LoHiBasePointingSet):
         self.data["obs_date"] = xr.full_like(
             self.data["exposure_factor"], self.data["epoch"].values[0]
         )
-
-        self.spatial_coords = ("spin_angle_bin",)
 
         # Update az_el_points using the base class method
         self.update_az_el_points()
@@ -802,12 +801,12 @@ class AbstractSkyMap(ABC):
         """
         return self.az_el_points.shape[0]
 
-    def project_pset_values_to_map(
+    def project_pset_values_to_map(  # noqa: PLR0912
         self,
         pointing_set: PointingSet,
         value_keys: list[str] | None = None,
         index_match_method: IndexMatchMethod = IndexMatchMethod.PUSH,
-        pset_valid_mask: NDArray | None = None,
+        pset_valid_mask: NDArray | xr.DataArray | None = None,
     ) -> None:
         """
         Project a pointing set's values to the map grid.
@@ -829,7 +828,7 @@ class AbstractSkyMap(ABC):
         index_match_method : IndexMatchMethod, optional
             The method of index matching to use for all values.
             Default is IndexMatchMethod.PUSH.
-        pset_valid_mask : NDArray, optional
+        pset_valid_mask : xarray.DataArray or NDArray, optional
             A boolean mask of shape (number of pointing set pixels,) indicating
             which pixels in the pointing set should be considered valid for projection.
             If None, all pixels are considered valid. Default is None.
@@ -896,16 +895,26 @@ class AbstractSkyMap(ABC):
                 # Bin the values at the matched indices. There may be multiple
                 # pointing set pixels that correspond to the same sky map pixel.
                 # Broadcast all arrays together using xarray dimension alignment
-                data_bc, indices_bc = xr.broadcast(
-                    raveled_pset_data, matched_indices_push
-                )
+                (
+                    data_bc,
+                    indices_bc,
+                ) = xr.broadcast(raveled_pset_data, matched_indices_push)
+                # If the valid mask is a xr.DataArray, broadcast it to the same shape
+                if isinstance(pset_valid_mask, xr.DataArray):
+                    stacked_valid_mask = pset_valid_mask.stack(
+                        {CoordNames.GENERIC_PIXEL.value: pointing_set.spatial_coords}
+                    )
+                    pset_valid_mask_bc, _ = xr.broadcast(data_bc, stacked_valid_mask)
+                    pset_valid_mask_values = pset_valid_mask_bc.values
+                else:
+                    pset_valid_mask_values = pset_valid_mask
 
                 # Extract numpy arrays for bincount operation
                 pointing_projected_values = map_utils.bin_single_array_at_indices(
                     value_array=data_bc.values,
                     projection_grid_shape=self.binning_grid_shape,
                     projection_indices=indices_bc.values,
-                    input_valid_mask=pset_valid_mask,
+                    input_valid_mask=pset_valid_mask_values,
                 )
                 # TODO: we may need to allow for unweighted/weighted means here by
                 # dividing pointing_projected_values by some binned weights.

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -11,7 +11,6 @@ from typing import TypeVar
 
 import astropy_healpix.healpy as hp
 import numpy as np
-import pandas as pd
 import xarray as xr
 from numpy.typing import NDArray
 
@@ -648,21 +647,10 @@ class HiPointingSet(LoHiBasePointingSet):
     ----------
     dataset : xarray.Dataset | str | Path
         Hi L1C pointing set data loaded in a xarray.DataArray.
-    esa_df : pandas.DataFrame
-        Lookup table containing nominal central energy values for each
-        esa_energy_step.
     """
 
-    def __init__(self, dataset: xr.Dataset | str | Path, esa_df: pd.DataFrame):
+    def __init__(self, dataset: xr.Dataset | str | Path):
         super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.IMAP_HAE)
-
-        # Rename and convert coordinate from esa_energy_step to energy
-        self.data = self.data.rename({"esa_energy_step": "energy"})
-        self.data = self.data.assign_coords(
-            energy=esa_df.loc[self.data["energy"].values][
-                "nominal_central_energy"
-            ].values
-        )
 
         # Naively generate the ram_mask variable assuming spacecraft frame
         # binning. The ram_mask variable gets updated in the CG correction

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -801,7 +801,7 @@ class AbstractSkyMap(ABC):
         """
         return self.az_el_points.shape[0]
 
-    def project_pset_values_to_map(
+    def project_pset_values_to_map(  # noqa: PLR0912
         self,
         pointing_set: PointingSet,
         value_keys: list[str] | None = None,
@@ -840,6 +840,9 @@ class AbstractSkyMap(ABC):
         """
         if value_keys is None:
             value_keys = list(pointing_set.data.data_vars.keys())
+
+        if missing_keys := set(value_keys) - set(pointing_set.data.data_vars):
+            raise KeyError(f"Value keys not found in pointing set: {missing_keys}")
 
         if pset_valid_mask is None:
             pset_valid_mask = np.ones(pointing_set.num_points, dtype=bool)

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -895,10 +895,9 @@ class AbstractSkyMap(ABC):
                 # Bin the values at the matched indices. There may be multiple
                 # pointing set pixels that correspond to the same sky map pixel.
                 # Broadcast all arrays together using xarray dimension alignment
-                (
-                    data_bc,
-                    indices_bc,
-                ) = xr.broadcast(raveled_pset_data, matched_indices_push)
+                data_bc, indices_bc = xr.broadcast(
+                    raveled_pset_data, matched_indices_push
+                )
                 # If the valid mask is a xr.DataArray, broadcast it to the same shape
                 if isinstance(pset_valid_mask, xr.DataArray):
                     stacked_valid_mask = pset_valid_mask.stack(

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -11,6 +11,7 @@ from typing import TypeVar
 
 import astropy_healpix.healpy as hp
 import numpy as np
+import pandas as pd
 import xarray as xr
 from numpy.typing import NDArray
 
@@ -647,28 +648,31 @@ class HiPointingSet(LoHiBasePointingSet):
     ----------
     dataset : xarray.Dataset | str | Path
         Hi L1C pointing set data loaded in a xarray.DataArray.
-    spin_phase : str
-        Include ENAs from "full", "ram" or "anti-ram" phases of the spin.
+    esa_df : pandas.DataFrame
+        Lookup table containing nominal central energy values for each
+        esa_energy_step.
     """
 
-    def __init__(self, dataset: xr.Dataset | str | Path, spin_phase: str):
-        super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.ECLIPJ2000)
+    def __init__(self, dataset: xr.Dataset | str | Path, esa_df: pd.DataFrame):
+        super().__init__(dataset, spice_reference_frame=geometry.SpiceFrame.IMAP_HAE)
 
-        # Filter out ENAs from non-selected portions of the spin.
-        if spin_phase not in ["full", "ram", "anti"]:
-            raise ValueError(f"Unrecognized spin_phase value: {spin_phase}.")
+        # Rename and convert coordinate from esa_energy_step to energy
+        self.data = self.data.rename({"esa_energy_step": "energy"})
+        self.data = self.data.assign_coords(
+            energy=esa_df.loc[self.data["energy"].values][
+                "nominal_central_energy"
+            ].values
+        )
+
+        # Naively generate the ram_mask variable assuming spacecraft frame
+        # binning. The ram_mask variable gets updated in the CG correction
+        # code if the CG correction is applied.
+        self.data["ram_mask"] = xr.zeros_like(self.data["spin_angle_bin"], dtype=bool)
         # ram only includes spin-phase interval [0, 0.5)
         # which is the first half of the spin_angle_bins
-        elif spin_phase == "ram":
-            self.data = self.data.isel(
-                spin_angle_bin=slice(0, self.data["spin_angle_bin"].data.size // 2)
-            )
-        # anti-ram includes spin-phase interval [0.5, 1)
-        # which is the second half of the spin_angle_bins
-        elif spin_phase == "anti":
-            self.data = self.data.isel(
-                spin_angle_bin=slice(self.data["spin_angle_bin"].data.size // 2, None)
-            )
+        self.data["ram_mask"][slice(0, self.data["spin_angle_bin"].data.size // 2)] = (
+            True
+        )
 
         # Rename some PSET vars to match L2 variables
         self.data = self.data.rename(

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -801,7 +801,7 @@ class AbstractSkyMap(ABC):
         """
         return self.az_el_points.shape[0]
 
-    def project_pset_values_to_map(  # noqa: PLR0912
+    def project_pset_values_to_map(
         self,
         pointing_set: PointingSet,
         value_keys: list[str] | None = None,
@@ -840,9 +840,6 @@ class AbstractSkyMap(ABC):
         """
         if value_keys is None:
             value_keys = list(pointing_set.data.data_vars.keys())
-        for value_key in value_keys:
-            if value_key not in pointing_set.data.data_vars:
-                raise ValueError(f"Value key {value_key} not found in pointing set.")
 
         if pset_valid_mask is None:
             pset_valid_mask = np.ones(pointing_set.num_points, dtype=bool)
@@ -867,9 +864,12 @@ class AbstractSkyMap(ABC):
             )
 
         for value_key in value_keys:
+            if value_key not in pointing_set.data.data_vars:
+                raise ValueError(f"Value key {value_key} not found in pointing set.")
+
             # If multiple spatial axes present
             # (i.e (az, el) for rectangular coordinate PSET),
-            # flatten them in the values array to match the raveled indices
+            # stack them into a single coordinate to match the raveled indices
             raveled_pset_data = pointing_set.data[value_key].stack(
                 {CoordNames.GENERIC_PIXEL.value: pointing_set.spatial_coords}
             )
@@ -934,10 +934,6 @@ class AbstractSkyMap(ABC):
                 # that correspond to each map pixel as the weights.
                 self.data_1d[value_key].values[..., valid_map_mask] += (
                     pointing_projected_values
-                )
-            else:
-                raise NotImplementedError(
-                    "Only PUSH and PULL index matching methods are supported."
                 )
 
         # TODO: The max epoch needs to include the pset duration. Right now it

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -19,7 +19,7 @@ from imap_processing.spice.time import ttj2000ns_to_et
 # Create a TypeVar to represent the specific class being passed in
 # Bound to LoHiBasePointingSet, meaning it must be LoHiBasePointingSet
 # or a subclass of it
-T = TypeVar("T", bound=LoHiBasePointingSet)
+LoHiBasePsetSubclass = TypeVar("LoHiBasePsetSubclass", bound=LoHiBasePointingSet)
 
 # Physical constants for Compton-Getting correction
 # Units: electron_volt = [J / eV]
@@ -315,7 +315,9 @@ class PowerLawFluxCorrector:
         return corrected_flux, corrected_flux_stat_unc
 
 
-def _add_spacecraft_velocity_to_pset(pset: T) -> T:
+def _add_spacecraft_velocity_to_pset(
+    pset: LoHiBasePsetSubclass,
+) -> LoHiBasePsetSubclass:
     """
     Calculate and add spacecraft velocity data to pointing set.
 
@@ -358,7 +360,7 @@ def _add_spacecraft_velocity_to_pset(pset: T) -> T:
     return pset
 
 
-def _add_cartesian_look_direction(pset: T) -> T:
+def _add_cartesian_look_direction(pset: LoHiBasePsetSubclass) -> LoHiBasePsetSubclass:
     """
     Calculate and add look direction vectors to pointing set.
 
@@ -400,9 +402,9 @@ def _add_cartesian_look_direction(pset: T) -> T:
 
 
 def _calculate_compton_getting_transform(
-    pset: T,
+    pset: LoHiBasePsetSubclass,
     energy_hf: xr.DataArray,
-) -> T:
+) -> LoHiBasePsetSubclass:
     """
     Apply Compton-Getting transformation to compute ENA source directions.
 
@@ -542,9 +544,9 @@ def _calculate_compton_getting_transform(
 
 
 def apply_compton_getting_correction(
-    pset: T,
+    pset: LoHiBasePsetSubclass,
     energy_hf: xr.DataArray,
-) -> T:
+) -> LoHiBasePsetSubclass:
     """
     Apply Compton-Getting correction to a pointing set and update coordinates.
 

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -1,6 +1,7 @@
 """L2 corrections common to multiple IMAP ENA instruments."""
 
 from pathlib import Path
+from typing import TypeVar
 
 import numpy as np
 import pandas as pd
@@ -8,10 +9,17 @@ import xarray as xr
 from numpy.polynomial import Polynomial
 from scipy.constants import electron_volt, erg, proton_mass
 
-from imap_processing.ena_maps.ena_maps import LoHiBasePointingSet
+from imap_processing.ena_maps.ena_maps import (
+    LoHiBasePointingSet,
+)
 from imap_processing.ena_maps.utils.coordinates import CoordNames
 from imap_processing.spice import geometry
 from imap_processing.spice.time import ttj2000ns_to_et
+
+# Create a TypeVar to represent the specific class being passed in
+# Bound to LoHiBasePointingSet, meaning it must be LoHiBasePointingSet
+# or a subclass of it
+T = TypeVar("T", bound=LoHiBasePointingSet)
 
 # Physical constants for Compton-Getting correction
 # Units: electron_volt = [J / eV]
@@ -307,7 +315,7 @@ class PowerLawFluxCorrector:
         return corrected_flux, corrected_flux_stat_unc
 
 
-def _add_spacecraft_velocity_to_pset(pset: LoHiBasePointingSet) -> None:
+def _add_spacecraft_velocity_to_pset(pset: T) -> T:
     """
     Calculate and add spacecraft velocity data to pointing set.
 
@@ -315,6 +323,11 @@ def _add_spacecraft_velocity_to_pset(pset: LoHiBasePointingSet) -> None:
     ----------
     pset : LoHiBasePointingSet
         Pointing set object to be updated.
+
+    Returns
+    -------
+    pset : LoHiBasePointingSet
+        Pointing set object with spacecraft velocity data added.
 
     Notes
     -----
@@ -342,8 +355,10 @@ def _add_spacecraft_velocity_to_pset(pset: LoHiBasePointingSet) -> None:
     )
     pset.data["sc_direction_vector"] = pset.data["sc_velocity"] / sc_velocity_km_per_sec
 
+    return pset
 
-def _add_cartesian_look_direction(pset: LoHiBasePointingSet) -> None:
+
+def _add_cartesian_look_direction(pset: T) -> T:
     """
     Calculate and add look direction vectors to pointing set.
 
@@ -351,6 +366,11 @@ def _add_cartesian_look_direction(pset: LoHiBasePointingSet) -> None:
     ----------
     pset : LoHiBasePointingSet
         Pointing set object to be updated.
+
+    Returns
+    -------
+    pset : LoHiBasePointingSet
+        Pointing set object with look direction vectors added.
 
     Notes
     -----
@@ -376,11 +396,13 @@ def _add_cartesian_look_direction(pset: LoHiBasePointingSet) -> None:
         dims=[*longitudes.dims, CoordNames.CARTESIAN_VECTOR.value],
     )
 
+    return pset
+
 
 def _calculate_compton_getting_transform(
-    pset: LoHiBasePointingSet,
+    pset: T,
     energy_hf: xr.DataArray,
-) -> None:
+) -> T:
     """
     Apply Compton-Getting transformation to compute ENA source directions.
 
@@ -400,14 +422,24 @@ def _calculate_compton_getting_transform(
     energy_hf : xr.DataArray
         ENA energies in the heliosphere frame in eV.
 
+    Returns
+    -------
+    pset : LoHiBasePointingSet
+        Pointing set object with Compton-Getting related variables added and
+        updated az_el_points.
+
     Notes
     -----
     The algorithm is based on the "Appendix A. The IMAP-Lo Mapping Algorithms"
     document.
     Adds the following DataArrays to pset.data:
     - "energy_sc": ENA energies in spacecraft frame (eV)
-    - "ena_source_hae_longitude": ENA source longitudes in heliosphere frame (degrees)
-    - "ena_source_hae_latitude": ENA source latitudes in heliosphere frame (degrees)
+    - "energy_hf": ENA energies in the heliosphere frame (eV)
+    - "ram_mask": Mask indicating whether ENA source direction is from the ram
+      direction.
+    Updates the following DataArrays in pset.data:
+    - "hae_longitude": ENA source longitudes in heliosphere frame (degrees)
+    - "hae_latitude": ENA source latitudes in heliosphere frame (degrees)
     """
     # Store heliosphere frame energies
     pset.data["energy_hf"] = energy_hf
@@ -455,6 +487,8 @@ def _calculate_compton_getting_transform(
     # Velocity magnitude factor calculation (Equation 62)
     # x_k = (êₛ · û_sc) + sqrt(y² + (êₛ · û_sc)² - 1)
     x = dot_product + np.sqrt(y**2 + dot_product**2 - 1)
+    # Get the dimensions in the right order so that spatial is last
+    x = x.transpose(dot_product.dims[0], y.dims[0], dot_product.dims[1])
 
     # Calculate ENA speed in the spacecraft frame
     # |v⃗_sc| = x_k * U_sc
@@ -504,11 +538,13 @@ def _calculate_compton_getting_transform(
         dims=velocity_vector_helio.dims[:-1],
     )
 
+    return pset
+
 
 def apply_compton_getting_correction(
-    pset: LoHiBasePointingSet,
+    pset: T,
     energy_hf: xr.DataArray,
-) -> None:
+) -> T:
     """
     Apply Compton-Getting correction to a pointing set and update coordinates.
 
@@ -532,6 +568,11 @@ def apply_compton_getting_correction(
         ENA energies in the heliosphere frame in eV. Must be 1D with an
         energy dimension.
 
+    Returns
+    -------
+    pset : LoHiBasePointingSet
+        Updated pointing set object with Compton-Getting related variables added.
+
     Notes
     -----
     This function adds the following variables to the pointing set dataset:
@@ -540,20 +581,23 @@ def apply_compton_getting_correction(
     - "look_direction": Cartesian unit vectors of observation directions
     - "energy_hf": ENA energies in heliosphere frame (eV)
     - "energy_sc": ENA energies in spacecraft frame (eV)
-    - "ena_source_hae_longitude": ENA source longitudes in heliosphere frame (degrees)
-    - "ena_source_hae_latitude": ENA source latitudes in heliosphere frame (degrees)
+    This function modifies the following variables in the pointing set dataset:
+    - "hae_longitude": ENA source longitudes in heliosphere frame (degrees)
+    - "hae_latitude": ENA source latitudes in heliosphere frame (degrees)
 
     The az_el_points attribute is updated to use the corrected coordinates,
     which will be used for subsequent binning operations.
     """
     # Step 1: Add spacecraft velocity and direction to pset
-    _add_spacecraft_velocity_to_pset(pset)
+    pset = _add_spacecraft_velocity_to_pset(pset)
 
     # Step 2: Calculate and add look direction vectors to pset
-    _add_cartesian_look_direction(pset)
+    pset = _add_cartesian_look_direction(pset)
 
     # Step 3: Apply Compton-Getting transformation
-    _calculate_compton_getting_transform(pset, energy_hf)
+    pset = _calculate_compton_getting_transform(pset, energy_hf)
 
     # Step 4: Update az_el_points to use the corrected coordinates
     pset.update_az_el_points()
+
+    return pset

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -20,8 +20,16 @@ from imap_processing.hi.utils import CalibrationProductConfig
 
 logger = logging.getLogger(__name__)
 
+SC_FRAME_VARS_TO_PROJECT = {
+    "counts",
+    "exposure_factor",
+    "bg_rates",
+    "bg_rates_unc",
+    "obs_date",
+}
+HELIO_FRAME_VARS_TO_PROJECT = SC_FRAME_VARS_TO_PROJECT | {"energy_sc"}
 # TODO: is an exposure time weighted average for obs_date appropriate?
-VARS_TO_EXPOSURE_TIME_AVERAGE = ["bg_rates", "bg_rates_unc", "obs_date", "energy_sc"]
+FULL_EXPOSURE_TIME_AVERAGE_SET = {"bg_rates", "bg_rates_unc", "obs_date", "energy_sc"}
 
 
 def hi_l2(
@@ -101,10 +109,12 @@ def generate_hi_map(
         The sky map with all the PSET data projected into the map.
     """
     output_map = descriptor.to_empty_map()
-    vars_to_bin = ["counts", "exposure_factor", "bg_rates", "bg_rates_unc", "obs_date"]
-
-    if descriptor.frame_descriptor == "hf":
-        vars_to_bin.append("energy_sc")
+    vars_to_bin = (
+        HELIO_FRAME_VARS_TO_PROJECT
+        if descriptor.frame_descriptor == "hf"
+        else SC_FRAME_VARS_TO_PROJECT
+    )
+    vars_to_exposure_time_average = FULL_EXPOSURE_TIME_AVERAGE_SET & vars_to_bin
 
     if not isinstance(output_map, RectangularSkyMap):
         raise NotImplementedError("Healpix map output not supported for Hi")
@@ -117,6 +127,7 @@ def generate_hi_map(
 
         # Store the first PSET esa_energy_step values and make sure every PSET
         # contains the same set of esa_energy_step values.
+        # TODO: Correctly handle PSETs with different esa_energy_step values.
         if cached_esa_steps is None:
             cached_esa_steps = pset.data["esa_energy_step"].values.copy()
             esa_ds = esa_energy_df(
@@ -136,9 +147,8 @@ def generate_hi_map(
 
         # Multiply variables that need to be exposure time weighted average by
         # exposure factor.
-        for var in VARS_TO_EXPOSURE_TIME_AVERAGE:
+        for var in vars_to_exposure_time_average:
             if var in pset.data:
-                print(var)
                 pset.data[var] *= pset.data["exposure_factor"]
 
         # Set the mask used to filter ram/anti-ram pixels
@@ -150,15 +160,14 @@ def generate_hi_map(
 
         # Project (bin) the PSET variables into the map pixels
         output_map.project_pset_values_to_map(
-            pset, vars_to_bin, pset_valid_mask=pset_valid_mask
+            pset, list(vars_to_bin), pset_valid_mask=pset_valid_mask
         )
 
     # Finish the exposure time weighted mean calculation of backgrounds
     # Allow divide by zero to fill set pixels with zero exposure time to NaN
     with np.errstate(divide="ignore"):
-        for var in VARS_TO_EXPOSURE_TIME_AVERAGE:
-            if var in output_map.data_1d:
-                output_map.data_1d[var] /= output_map.data_1d["exposure_factor"]
+        for var in vars_to_exposure_time_average:
+            output_map.data_1d[var] /= output_map.data_1d["exposure_factor"]
 
     output_map.data_1d.update(calculate_ena_signal_rates(output_map.data_1d))
     output_map.data_1d = calculate_ena_intensity(
@@ -440,7 +449,7 @@ def _calculate_improved_stat_variance(
 
 
 def esa_energy_df(
-    esa_energies_path: str | Path, esa_energy_steps: np.ndarray | None = None
+    esa_energies_path: str | Path, esa_energy_steps: np.ndarray | slice | None = None
 ) -> pd.DataFrame:
     """
     Lookup the nominal central energy values for given esa energy steps.
@@ -449,7 +458,7 @@ def esa_energy_df(
     ----------
     esa_energies_path : str or pathlib.Path
         Location of the calibration csv file containing the lookup data.
-    esa_energy_steps : numpy.ndarray, optional
+    esa_energy_steps : numpy.ndarray or slice, optional
         The ESA energy steps to get energies for. If not provided, the full
         dataframe is returned.
 
@@ -459,9 +468,9 @@ def esa_energy_df(
         Full data frame from the csv file filtered to only include the
         esa_energy_steps input.
     """
+    if esa_energy_steps is None:
+        esa_energy_steps = slice(None)
     esa_energies_lut = pd.read_csv(
         esa_energies_path, comment="#", index_col="esa_energy_step"
     )
-    if esa_energy_steps is None:
-        return esa_energies_lut
     return esa_energies_lut.loc[esa_energy_steps]

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -11,14 +11,17 @@ from imap_processing.ena_maps.ena_maps import (
     HiPointingSet,
     RectangularSkyMap,
 )
-from imap_processing.ena_maps.utils.corrections import PowerLawFluxCorrector
+from imap_processing.ena_maps.utils.corrections import (
+    PowerLawFluxCorrector,
+    apply_compton_getting_correction,
+)
 from imap_processing.ena_maps.utils.naming import MapDescriptor
 from imap_processing.hi.utils import CalibrationProductConfig
 
 logger = logging.getLogger(__name__)
 
 # TODO: is an exposure time weighted average for obs_date appropriate?
-VARS_TO_EXPOSURE_TIME_AVERAGE = ["bg_rates", "bg_rates_unc", "obs_date"]
+VARS_TO_EXPOSURE_TIME_AVERAGE = ["bg_rates", "bg_rates_unc", "obs_date", "energy_sc"]
 
 
 def hi_l2(
@@ -98,34 +101,64 @@ def generate_hi_map(
         The sky map with all the PSET data projected into the map.
     """
     output_map = descriptor.to_empty_map()
+    vars_to_bin = ["counts", "exposure_factor", "bg_rates", "bg_rates_unc", "obs_date"]
+
+    if descriptor.frame_descriptor == "hf":
+        vars_to_bin.append("energy_sc")
 
     if not isinstance(output_map, RectangularSkyMap):
         raise NotImplementedError("Healpix map output not supported for Hi")
 
-    # TODO: Implement Compton-Getting correction
-    if descriptor.frame_descriptor != "sf":
-        raise NotImplementedError("CG correction not implemented for Hi")
+    cached_esa_steps = None
 
     for pset_path in psets:
         logger.info(f"Processing {pset_path}")
-        pset = HiPointingSet(pset_path, spin_phase=descriptor.spin_phase)
+        pset = HiPointingSet(pset_path)
 
-        # Background rate and uncertainty are exposure time weighted means in
-        # the map.
+        # Store the first PSET esa_energy_step values and make sure every PSET
+        # contains the same set of esa_energy_step values.
+        if cached_esa_steps is None:
+            cached_esa_steps = pset.data["esa_energy_step"].values.copy()
+            esa_ds = esa_energy_df(
+                l2_ancillary_path_dict["esa-energies"],
+                pset.data["esa_energy_step"].values,
+            ).to_xarray()
+            energy_kev = esa_ds["nominal_central_energy"]
+        if not np.array_equal(cached_esa_steps, pset.data["esa_energy_step"].values):
+            raise ValueError(
+                "All PSETs must have the same set of esa_energy_step values."
+            )
+
+        if descriptor.frame_descriptor == "hf":
+            # convert esa nominal central energy from keV to eV
+            esa_energy_ev = energy_kev * 1000
+            pset = apply_compton_getting_correction(pset, esa_energy_ev)
+
+        # Multiply variables that need to be exposure time weighted average by
+        # exposure factor.
         for var in VARS_TO_EXPOSURE_TIME_AVERAGE:
-            pset.data[var] *= pset.data["exposure_factor"]
+            if var in pset.data:
+                print(var)
+                pset.data[var] *= pset.data["exposure_factor"]
+
+        # Set the mask used to filter ram/anti-ram pixels
+        pset_valid_mask = None  # Default to no mask (full spin)
+        if descriptor.spin_phase == "ram":
+            pset_valid_mask = pset.data["ram_mask"]
+        elif descriptor.spin_phase == "anti":
+            pset_valid_mask = ~pset.data["ram_mask"]
 
         # Project (bin) the PSET variables into the map pixels
         output_map.project_pset_values_to_map(
-            pset,
-            ["counts", "exposure_factor", "bg_rates", "bg_rates_unc", "obs_date"],
+            pset, vars_to_bin, pset_valid_mask=pset_valid_mask
         )
 
     # Finish the exposure time weighted mean calculation of backgrounds
     # Allow divide by zero to fill set pixels with zero exposure time to NaN
     with np.errstate(divide="ignore"):
         for var in VARS_TO_EXPOSURE_TIME_AVERAGE:
-            output_map.data_1d[var] /= output_map.data_1d["exposure_factor"]
+            if var in output_map.data_1d:
+                output_map.data_1d[var] /= output_map.data_1d["exposure_factor"]
 
     output_map.data_1d.update(calculate_ena_signal_rates(output_map.data_1d))
     output_map.data_1d = calculate_ena_intensity(
@@ -138,27 +171,14 @@ def generate_hi_map(
     # TODO: Figure out how to compute obs_date_range (stddev of obs_date)
     output_map.data_1d["obs_date_range"] = xr.zeros_like(output_map.data_1d["obs_date"])
 
-    # Rename and convert coordinate from esa_energy_step energy
-    esa_df = esa_energy_df(
-        l2_ancillary_path_dict["esa-energies"],
-        output_map.data_1d["esa_energy_step"].data,
-    )
-    output_map.data_1d = output_map.data_1d.rename({"esa_energy_step": "energy"})
-    output_map.data_1d = output_map.data_1d.assign_coords(
-        energy=esa_df["nominal_central_energy"].values
-    )
     # Set the energy_step_delta values to the energy bandpass half-width-half-max
-    energy_delta = esa_df["bandpass_fwhm"].values / 2
-    output_map.data_1d["energy_delta_minus"] = xr.DataArray(
-        energy_delta,
-        name="energy_delta_minus",
-        dims=["energy"],
-    )
-    output_map.data_1d["energy_delta_plus"] = xr.DataArray(
-        energy_delta,
-        name="energy_delta_plus",
-        dims=["energy"],
-    )
+    energy_delta = esa_ds["bandpass_fwhm"] / 2
+    output_map.data_1d["energy_delta_minus"] = energy_delta
+    output_map.data_1d["energy_delta_plus"] = energy_delta
+
+    # Rename and convert coordinate from esa_energy_step energy
+    output_map.data_1d = output_map.data_1d.rename({"esa_energy_step": "energy"})
+    output_map.data_1d = output_map.data_1d.assign_coords(energy=energy_kev.values)
 
     output_map.data_1d = output_map.data_1d.drop("esa_energy_step_label")
 
@@ -420,7 +440,7 @@ def _calculate_improved_stat_variance(
 
 
 def esa_energy_df(
-    esa_energies_path: str | Path, esa_energy_steps: np.ndarray
+    esa_energies_path: str | Path, esa_energy_steps: np.ndarray | None = None
 ) -> pd.DataFrame:
     """
     Lookup the nominal central energy values for given esa energy steps.
@@ -429,8 +449,9 @@ def esa_energy_df(
     ----------
     esa_energies_path : str or pathlib.Path
         Location of the calibration csv file containing the lookup data.
-    esa_energy_steps : numpy.ndarray
-        The ESA energy steps to get energies for.
+    esa_energy_steps : numpy.ndarray, optional
+        The ESA energy steps to get energies for. If not provided, the full
+        dataframe is returned.
 
     Returns
     -------
@@ -441,4 +462,6 @@ def esa_energy_df(
     esa_energies_lut = pd.read_csv(
         esa_energies_path, comment="#", index_col="esa_energy_step"
     )
+    if esa_energy_steps is None:
+        return esa_energies_lut
     return esa_energies_lut.loc[esa_energy_steps]

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -458,9 +458,9 @@ def esa_energy_df(
     ----------
     esa_energies_path : str or pathlib.Path
         Location of the calibration csv file containing the lookup data.
-    esa_energy_steps : numpy.ndarray or slice, optional
-        The ESA energy steps to get energies for. If not provided, the full
-        dataframe is returned.
+    esa_energy_steps : numpy.ndarray, slice, or None
+        The ESA energy steps to get energies for. If not provided (default is None),
+        the full dataframe is returned.
 
     Returns
     -------

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -420,7 +420,7 @@ class TestComptonGettingCorrection:
         """Test Compton-Getting correction with real Hi PSET data."""
         # Load real pointing set
         pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+        hi_pset = ena_maps.HiPointingSet(pset_ds)
 
         # Store original coordinates for comparison
         original_lon = hi_pset.data["hae_longitude"].copy()

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -293,7 +293,7 @@ class TestComptonGettingCorrection:
         mock_sc_state = np.array([1e8, 2e8, 3e8, 10.0, 20.0, 30.0])  # km and km/s
         mock_imap_state.return_value = mock_sc_state
 
-        _add_spacecraft_velocity_to_pset(mock_hi_pset)
+        mock_hi_pset = _add_spacecraft_velocity_to_pset(mock_hi_pset)
 
         # Verify SPICE was called correctly
         mock_imap_state.assert_called_once_with(
@@ -317,7 +317,7 @@ class TestComptonGettingCorrection:
 
     def test_add_cartesian_look_direction(self, mock_hi_pset):
         """Test that look directions are correctly calculated and added."""
-        _add_cartesian_look_direction(mock_hi_pset)
+        mock_hi_pset = _add_cartesian_look_direction(mock_hi_pset)
 
         # _add_cartesian_look_direction is just a wrapper around
         # geometry.spherical_to_cartesian. We only need to test that the
@@ -337,8 +337,8 @@ class TestComptonGettingCorrection:
         mock_sc_state = np.array([1e8, 2e8, 3e8, 10.0, 20.0, 30.0])
         mock_imap_state.return_value = mock_sc_state
 
-        _add_spacecraft_velocity_to_pset(mock_hi_pset)
-        _add_cartesian_look_direction(mock_hi_pset)
+        mock_hi_pset = _add_spacecraft_velocity_to_pset(mock_hi_pset)
+        mock_hi_pset = _add_cartesian_look_direction(mock_hi_pset)
 
         # Create energy array
         energy_hf = xr.DataArray(
@@ -347,7 +347,7 @@ class TestComptonGettingCorrection:
             coords={"esa_energy_step": [1, 2, 3]},
         )
 
-        _calculate_compton_getting_transform(mock_hi_pset, energy_hf)
+        mock_hi_pset = _calculate_compton_getting_transform(mock_hi_pset, energy_hf)
 
         # Verify required variables were added
         assert "energy_hf" in mock_hi_pset.data
@@ -399,7 +399,7 @@ class TestComptonGettingCorrection:
         )
 
         # Apply the full correction
-        apply_compton_getting_correction(mock_hi_pset, energy_hf)
+        mock_hi_pset = apply_compton_getting_correction(mock_hi_pset, energy_hf)
 
         # Verify all intermediate variables were added
         assert "sc_velocity" in mock_hi_pset.data
@@ -439,7 +439,7 @@ class TestComptonGettingCorrection:
         )
 
         # Apply correction
-        apply_compton_getting_correction(hi_pset, energy_hf)
+        hi_pset = apply_compton_getting_correction(hi_pset, energy_hf)
 
         # Verify coordinates were modified
         corrected_lon = hi_pset.data["hae_longitude"]
@@ -448,11 +448,11 @@ class TestComptonGettingCorrection:
         # Shape should now include energy dimension
         assert "esa_energy_step" in corrected_lon.dims
         assert "esa_energy_step" in corrected_lat.dims
-
-        # Verify the correction changes the coordinates
-        # (at least some points should be different)
-        # Note: We can't directly compare because dimensions changed
-        assert corrected_lon.shape != original_lon.shape
+        assert corrected_lon.dims == (
+            original_lon.dims[0],
+            "esa_energy_step",
+            original_lon.dims[1],
+        )
 
         # Verify all values are in valid ranges
         assert np.all(corrected_lon.values >= 0)
@@ -482,7 +482,7 @@ class TestComptonGettingCorrection:
         )
 
         # Set up simple look directions
-        _add_cartesian_look_direction(mock_hi_pset)
+        mock_hi_pset = _add_cartesian_look_direction(mock_hi_pset)
 
         # Single energy level
         energy_hf = xr.DataArray(np.array([1000.0]), dims=["esa_energy_step"])
@@ -541,13 +541,13 @@ class TestComptonGettingCorrection:
         )
 
         # Add look directions
-        _add_cartesian_look_direction(pset)
+        pset = _add_cartesian_look_direction(pset)
 
         # Single energy level
         energy_hf = xr.DataArray(np.array([1000.0]), dims=["esa_energy_step"])
 
         # Calculate CG transform
-        _calculate_compton_getting_transform(pset, energy_hf)
+        pset = _calculate_compton_getting_transform(pset, energy_hf)
 
         # Verify ram_mask exists
         assert "ram_mask" in pset.data

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -640,7 +640,7 @@ class TestRectangularSkyMap:
         )
 
         # An error should be raised if a key is not found in the PSET
-        with pytest.raises(ValueError, match="Value key invalid not found"):
+        with pytest.raises(KeyError, match="Value keys not found in pointing set:"):
             rectangular_map.project_pset_values_to_map(
                 self.ultra_psets[0],
                 value_keys=["invalid"],

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -10,7 +10,6 @@ from unittest import mock
 
 import astropy_healpix.healpy as hp
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
 
@@ -141,24 +140,14 @@ def hi_pset_cdf_path(imap_tests_path):
     return imap_tests_path / "hi/data/l1/imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
 
 
-@pytest.fixture(scope="module")
-def hi_esa_energies_df():
-    s = pd.Series(
-        [0.50, 0.75, 1.10, 1.65, 2.50, 3.75, 5.70, 8.52, 12.8], index=np.arange(9) + 1
-    )
-    d = {"nominal_central_energy": s}
-    esa_df = pd.DataFrame(data=d, index=np.arange(9) + 1)
-    return esa_df
-
-
 @pytest.mark.external_test_data
 class TestHiPointingSet:
     """Test suite for HiPointingSet class."""
 
-    def test_init(self, hi_pset_cdf_path, hi_esa_energies_df):
+    def test_init(self, hi_pset_cdf_path):
         """Test coverage for __init__ method."""
         pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds, hi_esa_energies_df)
+        hi_pset = ena_maps.HiPointingSet(pset_ds)
         assert isinstance(hi_pset, ena_maps.HiPointingSet)
         assert hi_pset.spice_reference_frame == geometry.SpiceFrame.IMAP_HAE
         assert hi_pset.num_points == 3600
@@ -167,17 +156,17 @@ class TestHiPointingSet:
         for var_name in ["exposure_factor", "bg_rates", "bg_rates_unc"]:
             assert var_name in hi_pset.data
 
-    def test_from_cdf(self, hi_pset_cdf_path, hi_esa_energies_df):
+    def test_from_cdf(self, hi_pset_cdf_path):
         """Test coverage for instantiating HiPointingSet from cdf."""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, hi_esa_energies_df)
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path)
         assert isinstance(hi_pset, ena_maps.HiPointingSet)
 
-    def test_spin_phase_filtering(self, hi_pset_cdf_path, hi_esa_energies_df):
+    def test_spin_phase_filtering(self, hi_pset_cdf_path):
         """Test coverage for filtering pset data by ram or anti-ram directions."""
         pset_ds = load_cdf(hi_pset_cdf_path)
 
         # Test ram mask is first 1800 elements
-        hi_pset = ena_maps.HiPointingSet(pset_ds, hi_esa_energies_df)
+        hi_pset = ena_maps.HiPointingSet(pset_ds)
         np.testing.assert_array_equal(
             np.nonzero(hi_pset.data["ram_mask"].values)[0], np.arange(1800)
         )
@@ -187,11 +176,9 @@ class TestHiPointingSet:
             np.nonzero(~hi_pset.data["ram_mask"].values)[0], np.arange(1800) + 1800
         )
 
-    def test_plays_nice_with_rectangular_sky_map(
-        self, hi_pset_cdf_path, hi_esa_energies_df
-    ):
+    def test_plays_nice_with_rectangular_sky_map(self, hi_pset_cdf_path):
         """Test that HiPointingSet works with RectangularSkyMap"""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, hi_esa_energies_df)
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path)
         rect_map = ena_maps.RectangularSkyMap(
             spacing_deg=2, spice_frame=geometry.SpiceFrame.IMAP_HAE
         )
@@ -303,7 +290,6 @@ class TestLoHiBasePointingSet:
     @staticmethod
     def create_hi_pset_with_multidim_coords(
         hi_pset_cdf_path: str,
-        hi_esa_energies_df,
         shape: tuple[int, int, int] = (1, 9, 3600),
     ) -> ena_maps.HiPointingSet:
         """
@@ -323,7 +309,7 @@ class TestLoHiBasePointingSet:
             HiPointingSet with multi-dimensional az_el_points.
         """
         pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds, hi_esa_energies_df)
+        hi_pset = ena_maps.HiPointingSet(pset_ds)
         hi_pset.data["hae_longitude"] = xr.DataArray(
             np.random.uniform(0, 360, shape),
             dims=["epoch", "hf_energy", "spin_angle_bin"],
@@ -335,9 +321,9 @@ class TestLoHiBasePointingSet:
         hi_pset.update_az_el_points()
         return hi_pset
 
-    def test_hi_az_el_points_is_dataarray(self, hi_pset_cdf_path, hi_esa_energies_df):
+    def test_hi_az_el_points_is_dataarray(self, hi_pset_cdf_path):
         """Test that HiPointingSet.az_el_points is an xarray.DataArray."""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, hi_esa_energies_df)
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path)
 
         # Verify az_el_points is a DataArray
         assert isinstance(hi_pset.az_el_points, xr.DataArray)
@@ -361,9 +347,9 @@ class TestLoHiBasePointingSet:
         # Verify shape
         assert lo_pset.az_el_points.shape == (144000, 2)
 
-    def test_inheritance(self, hi_pset_cdf_path, lo_pset_ds, hi_esa_energies_df):
+    def test_inheritance(self, hi_pset_cdf_path, lo_pset_ds):
         """Test that Hi and Lo pointing sets inherit from LoHiBasePointingSet."""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, hi_esa_energies_df)
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path)
         lo_pset = ena_maps.LoPointingSet(lo_pset_ds)
 
         # Verify inheritance
@@ -374,13 +360,9 @@ class TestLoHiBasePointingSet:
         assert hi_pset.tiling_type == ena_maps.SkyTilingType.RECTANGULAR
         assert lo_pset.tiling_type == ena_maps.SkyTilingType.RECTANGULAR
 
-    def test_update_az_el_points_multidimensional(
-        self, hi_pset_cdf_path, hi_esa_energies_df
-    ):
+    def test_update_az_el_points_multidimensional(self, hi_pset_cdf_path):
         """Test update_az_el_points with multi-dimensional coordinates."""
-        hi_pset = self.create_hi_pset_with_multidim_coords(
-            hi_pset_cdf_path, hi_esa_energies_df
-        )
+        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
 
         # Verify az_el_points is still a DataArray
         assert isinstance(hi_pset.az_el_points, xr.DataArray)
@@ -397,7 +379,7 @@ class TestLoHiBasePointingSet:
 
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
     def test_multidim_az_el_points_with_match_coords(
-        self, mock_frame_transform, hi_pset_cdf_path, hi_esa_energies_df
+        self, mock_frame_transform, hi_pset_cdf_path
     ):
         """Test multi-dimensional az_el_points with match_coords_to_indices."""
         # Mock frame_transform to return az_el unchanged
@@ -405,9 +387,7 @@ class TestLoHiBasePointingSet:
             lambda et, az_el, from_frame, to_frame, degrees: az_el
         )
 
-        hi_pset = self.create_hi_pset_with_multidim_coords(
-            hi_pset_cdf_path, hi_esa_energies_df
-        )
+        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
 
         # Create a rectangular map
         rect_map = ena_maps.RectangularSkyMap(
@@ -424,7 +404,7 @@ class TestLoHiBasePointingSet:
 
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
     def test_broadcasting_with_multidim_pset(
-        self, mock_frame_transform, hi_pset_cdf_path, hi_esa_energies_df
+        self, mock_frame_transform, hi_pset_cdf_path
     ):
         """Test xr broadcasting in project_pset_values_to_map with multi-dim PSET."""
         # Mock frame_transform to return az_el unchanged
@@ -432,9 +412,7 @@ class TestLoHiBasePointingSet:
             lambda et, az_el, from_frame, to_frame, degrees: az_el
         )
 
-        hi_pset = self.create_hi_pset_with_multidim_coords(
-            hi_pset_cdf_path, hi_esa_energies_df
-        )
+        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
 
         # Add a mock multi-dimensional variable to the PSET
         # Shape: (epoch, hf_energy, spin_angle_bin)

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -641,6 +641,117 @@ class TestRectangularSkyMap:
                 index_match_method=index_matching_method,
             )
 
+    @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_project_pset_with_valid_mask_push(self, mock_frame_transform_az_el):
+        """Test projection with pset_valid_mask using PUSH method."""
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        rectangular_map = ena_maps.RectangularSkyMap(
+            spacing_deg=2,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+
+        ultra_pset = self.ultra_psets[0]
+        ultra_pset.data["counts"] = xr.ones_like(ultra_pset.data["counts"])
+
+        # Create a mask that only allows half of the pixels
+        valid_mask = np.zeros(ultra_pset.num_points, dtype=bool)
+        valid_mask[: ultra_pset.num_points // 2] = True
+
+        # Project with mask
+        rectangular_map.project_pset_values_to_map(
+            ultra_pset,
+            value_keys=["counts"],
+            index_match_method=ena_maps.IndexMatchMethod.PUSH,
+            pset_valid_mask=valid_mask,
+        )
+
+        # Total counts in map should be less than total counts in pset
+        map_total_counts = rectangular_map.data_1d["counts"].sum()
+        pset_total_counts = ultra_pset.data["counts"].sum()
+
+        # With mask, map should have approximately half the counts
+        assert map_total_counts < pset_total_counts
+        np.testing.assert_allclose(
+            map_total_counts,
+            pset_total_counts / 2,
+            rtol=0.1,
+        )
+
+    @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_project_pset_with_dataarray_mask_push(self, mock_frame_transform_az_el):
+        """Test projection with xr.DataArray mask using PUSH method."""
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        rectangular_map = ena_maps.RectangularSkyMap(
+            spacing_deg=10,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+
+        rect_pset = self.rectangular_psets[0]
+
+        # Create a DataArray mask matching the pset spatial dimensions
+        valid_mask = xr.DataArray(
+            np.ones(rect_pset.data["counts"].shape[2:], dtype=bool),
+            dims=rect_pset.spatial_coords,
+        )
+        # Mask out one quadrant
+        # valid_mask[:90, :90] = False
+
+        # Project with DataArray mask
+        rectangular_map.project_pset_values_to_map(
+            rect_pset,
+            value_keys=["counts"],
+            index_match_method=ena_maps.IndexMatchMethod.PUSH,
+            pset_valid_mask=valid_mask,
+        )
+
+        # Map should have data
+        assert "counts" in rectangular_map.data_1d
+        assert rectangular_map.data_1d["counts"].sum() > 0
+
+    @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_project_pset_with_valid_mask_pull(self, mock_frame_transform_az_el):
+        """Test projection with pset_valid_mask using PULL method."""
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        rectangular_map = ena_maps.RectangularSkyMap(
+            spacing_deg=10,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+        )
+
+        rect_pset = self.rectangular_psets[0]
+
+        # Create a mask that masks out some pixels
+        valid_mask = np.ones(rect_pset.num_points, dtype=bool)
+        valid_mask[: rect_pset.num_points // 4] = False
+
+        # Project with mask using PULL method
+        rectangular_map.project_pset_values_to_map(
+            rect_pset,
+            value_keys=["counts"],
+            index_match_method=ena_maps.IndexMatchMethod.PULL,
+            pset_valid_mask=valid_mask,
+        )
+
+        # Map should have data, but some pixels should be zero due to mask
+        assert "counts" in rectangular_map.data_1d
+        assert rectangular_map.data_1d["counts"].sum() > 0
+        # Some pixels should be zero
+        assert (rectangular_map.data_1d["counts"] == 0).any()
+
     @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
     def test_project_rect_pset_values_to_map_pull_method(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import astropy_healpix.healpy as hp
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 
@@ -140,54 +141,59 @@ def hi_pset_cdf_path(imap_tests_path):
     return imap_tests_path / "hi/data/l1/imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
 
 
+@pytest.fixture(scope="module")
+def hi_esa_energies_df():
+    s = pd.Series(
+        [0.50, 0.75, 1.10, 1.65, 2.50, 3.75, 5.70, 8.52, 12.8], index=np.arange(9) + 1
+    )
+    d = {"nominal_central_energy": s}
+    esa_df = pd.DataFrame(data=d, index=np.arange(9) + 1)
+    return esa_df
+
+
 @pytest.mark.external_test_data
 class TestHiPointingSet:
     """Test suite for HiPointingSet class."""
 
-    def test_init(self, hi_pset_cdf_path):
+    def test_init(self, hi_pset_cdf_path, hi_esa_energies_df):
         """Test coverage for __init__ method."""
         pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+        hi_pset = ena_maps.HiPointingSet(pset_ds, hi_esa_energies_df)
         assert isinstance(hi_pset, ena_maps.HiPointingSet)
-        assert hi_pset.spice_reference_frame == geometry.SpiceFrame.ECLIPJ2000
+        assert hi_pset.spice_reference_frame == geometry.SpiceFrame.IMAP_HAE
         assert hi_pset.num_points == 3600
         np.testing.assert_array_equal(hi_pset.az_el_points.shape, (3600, 2))
 
         for var_name in ["exposure_factor", "bg_rates", "bg_rates_unc"]:
             assert var_name in hi_pset.data
 
-    def test_from_cdf(self, hi_pset_cdf_path):
+    def test_from_cdf(self, hi_pset_cdf_path, hi_esa_energies_df):
         """Test coverage for instantiating HiPointingSet from cdf."""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, hi_esa_energies_df)
         assert isinstance(hi_pset, ena_maps.HiPointingSet)
 
-    def test_spin_phase_filtering(self, hi_pset_cdf_path):
+    def test_spin_phase_filtering(self, hi_pset_cdf_path, hi_esa_energies_df):
         """Test coverage for filtering pset data by ram or anti-ram directions."""
         pset_ds = load_cdf(hi_pset_cdf_path)
 
-        # Test ram only direction
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="ram")
-        assert hi_pset.num_points == 1800
+        # Test ram mask is first 1800 elements
+        hi_pset = ena_maps.HiPointingSet(pset_ds, hi_esa_energies_df)
         np.testing.assert_array_equal(
-            hi_pset.data["spin_angle_bin"].data, np.arange(1800)
+            np.nonzero(hi_pset.data["ram_mask"].values)[0], np.arange(1800)
         )
 
         # Test anti-ram direction
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="anti")
-        assert hi_pset.num_points == 1800
         np.testing.assert_array_equal(
-            hi_pset.data["spin_angle_bin"].data, np.arange(1800) + 1800
+            np.nonzero(~hi_pset.data["ram_mask"].values)[0], np.arange(1800) + 1800
         )
 
-        # Test value error
-        with pytest.raises(ValueError, match="Unrecognized spin_phase value:"):
-            _ = ena_maps.HiPointingSet(pset_ds, spin_phase="foo-phase")
-
-    def test_plays_nice_with_rectangular_sky_map(self, hi_pset_cdf_path):
+    def test_plays_nice_with_rectangular_sky_map(
+        self, hi_pset_cdf_path, hi_esa_energies_df
+    ):
         """Test that HiPointingSet works with RectangularSkyMap"""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, hi_esa_energies_df)
         rect_map = ena_maps.RectangularSkyMap(
-            spacing_deg=2, spice_frame=geometry.SpiceFrame.ECLIPJ2000
+            spacing_deg=2, spice_frame=geometry.SpiceFrame.IMAP_HAE
         )
         rect_map.project_pset_values_to_map(hi_pset, ["counts", "exposure_factor"])
         assert rect_map.data_1d["counts"].max() > 0
@@ -296,7 +302,9 @@ class TestLoHiBasePointingSet:
 
     @staticmethod
     def create_hi_pset_with_multidim_coords(
-        hi_pset_cdf_path: str, shape: tuple[int, int, int] = (1, 9, 3600)
+        hi_pset_cdf_path: str,
+        hi_esa_energies_df,
+        shape: tuple[int, int, int] = (1, 9, 3600),
     ) -> ena_maps.HiPointingSet:
         """
         Create a HiPointingSet with multi-dimensional coordinates.
@@ -315,7 +323,7 @@ class TestLoHiBasePointingSet:
             HiPointingSet with multi-dimensional az_el_points.
         """
         pset_ds = load_cdf(hi_pset_cdf_path)
-        hi_pset = ena_maps.HiPointingSet(pset_ds, spin_phase="full")
+        hi_pset = ena_maps.HiPointingSet(pset_ds, hi_esa_energies_df)
         hi_pset.data["hae_longitude"] = xr.DataArray(
             np.random.uniform(0, 360, shape),
             dims=["epoch", "hf_energy", "spin_angle_bin"],
@@ -327,9 +335,9 @@ class TestLoHiBasePointingSet:
         hi_pset.update_az_el_points()
         return hi_pset
 
-    def test_hi_az_el_points_is_dataarray(self, hi_pset_cdf_path):
+    def test_hi_az_el_points_is_dataarray(self, hi_pset_cdf_path, hi_esa_energies_df):
         """Test that HiPointingSet.az_el_points is an xarray.DataArray."""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, hi_esa_energies_df)
 
         # Verify az_el_points is a DataArray
         assert isinstance(hi_pset.az_el_points, xr.DataArray)
@@ -353,9 +361,9 @@ class TestLoHiBasePointingSet:
         # Verify shape
         assert lo_pset.az_el_points.shape == (144000, 2)
 
-    def test_inheritance(self, hi_pset_cdf_path, lo_pset_ds):
+    def test_inheritance(self, hi_pset_cdf_path, lo_pset_ds, hi_esa_energies_df):
         """Test that Hi and Lo pointing sets inherit from LoHiBasePointingSet."""
-        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, spin_phase="full")
+        hi_pset = ena_maps.HiPointingSet(hi_pset_cdf_path, hi_esa_energies_df)
         lo_pset = ena_maps.LoPointingSet(lo_pset_ds)
 
         # Verify inheritance
@@ -366,9 +374,13 @@ class TestLoHiBasePointingSet:
         assert hi_pset.tiling_type == ena_maps.SkyTilingType.RECTANGULAR
         assert lo_pset.tiling_type == ena_maps.SkyTilingType.RECTANGULAR
 
-    def test_update_az_el_points_multidimensional(self, hi_pset_cdf_path):
+    def test_update_az_el_points_multidimensional(
+        self, hi_pset_cdf_path, hi_esa_energies_df
+    ):
         """Test update_az_el_points with multi-dimensional coordinates."""
-        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
+        hi_pset = self.create_hi_pset_with_multidim_coords(
+            hi_pset_cdf_path, hi_esa_energies_df
+        )
 
         # Verify az_el_points is still a DataArray
         assert isinstance(hi_pset.az_el_points, xr.DataArray)
@@ -385,7 +397,7 @@ class TestLoHiBasePointingSet:
 
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
     def test_multidim_az_el_points_with_match_coords(
-        self, mock_frame_transform, hi_pset_cdf_path
+        self, mock_frame_transform, hi_pset_cdf_path, hi_esa_energies_df
     ):
         """Test multi-dimensional az_el_points with match_coords_to_indices."""
         # Mock frame_transform to return az_el unchanged
@@ -393,7 +405,9 @@ class TestLoHiBasePointingSet:
             lambda et, az_el, from_frame, to_frame, degrees: az_el
         )
 
-        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
+        hi_pset = self.create_hi_pset_with_multidim_coords(
+            hi_pset_cdf_path, hi_esa_energies_df
+        )
 
         # Create a rectangular map
         rect_map = ena_maps.RectangularSkyMap(
@@ -408,9 +422,19 @@ class TestLoHiBasePointingSet:
         assert indices.dims == ("hf_energy", "pixel")
         assert indices.shape == (9, 3600)
 
-    def test_broadcasting_with_multidim_pset(self, hi_pset_cdf_path):
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_broadcasting_with_multidim_pset(
+        self, mock_frame_transform, hi_pset_cdf_path, hi_esa_energies_df
+    ):
         """Test xr broadcasting in project_pset_values_to_map with multi-dim PSET."""
-        hi_pset = self.create_hi_pset_with_multidim_coords(hi_pset_cdf_path)
+        # Mock frame_transform to return az_el unchanged
+        mock_frame_transform.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
+        hi_pset = self.create_hi_pset_with_multidim_coords(
+            hi_pset_cdf_path, hi_esa_energies_df
+        )
 
         # Add a mock multi-dimensional variable to the PSET
         # Shape: (epoch, hf_energy, spin_angle_bin)

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -701,10 +701,13 @@ class TestRectangularSkyMap:
         # Create a DataArray mask matching the pset spatial dimensions
         valid_mask = xr.DataArray(
             np.ones(rect_pset.data["counts"].shape[2:], dtype=bool),
-            dims=rect_pset.spatial_coords,
+            coords={
+                "longitude": rect_pset.data["longitude"],
+                "latitude": rect_pset.data["latitude"],
+            },
         )
         # Mask out one quadrant
-        # valid_mask[:90, :90] = False
+        valid_mask[:90, :90] = False
 
         # Project with DataArray mask
         rectangular_map.project_pset_values_to_map(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -626,7 +626,13 @@ class TestRectangularSkyMap:
         )
 
     @pytest.mark.usefixtures("_setup_ultra_l1c_pset_products")
-    def test_project_pset_values_to_map_errors(self):
+    @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")
+    def test_project_pset_values_to_map_errors(self, mock_frame_transform_az_el):
+        # Mock frame_transform to return the az and el unchanged
+        mock_frame_transform_az_el.side_effect = (
+            lambda et, az_el, from_frame, to_frame, degrees: az_el
+        )
+
         index_matching_method = ena_maps.IndexMatchMethod.PUSH
         rectangular_map = ena_maps.RectangularSkyMap(
             spacing_deg=1,

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -4,7 +4,6 @@ from unittest import mock
 from unittest.mock import patch
 
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
 
@@ -201,21 +200,24 @@ def test_hi_l2_uses_descriptor_to_setup_map(
     )
 
 
+@pytest.mark.parametrize(
+    "descriptor_str",
+    [
+        "h90-ena-h-sf-nsp-full-gcs-6deg-3mo",
+        "h90-ena-h-sf-nsp-ram-gcs-6deg-3mo",
+        "h90-ena-h-hf-nsp-ram-gcs-6deg-3mo",
+    ],
+)
 @mock.patch("imap_processing.hi.hi_l2.calculate_ena_intensity", autospec=True)
-@mock.patch("imap_processing.hi.hi_l2.esa_energy_df", autospec=True)
 @pytest.mark.external_test_data
 def test_genarate_hi_map(
-    mock_esa_energy_lookup,
     mock_calc_ena_intensity,
     hi_l1_test_data_path,
     anc_path_dict,
     furnish_kernels,
+    descriptor_str,
 ):
     """Test coverage for genarate_hi_map()"""
-
-    mock_esa_energy_lookup.side_effect = lambda x, y: pd.DataFrame(
-        {"nominal_central_energy": y, "bandpass_fwhm": np.ones_like(y)}
-    )
     mock_calc_ena_intensity.side_effect = lambda x, y, z: x
 
     kernels = [
@@ -223,11 +225,11 @@ def test_genarate_hi_map(
         "imap_science_100.tf",
         "naif0012.tls",
         "imap_spk_demo.bsp",
+        "de440s.bsp",
     ]
     with furnish_kernels(kernels):
         pset_path = hi_l1_test_data_path / "imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
 
-        descriptor_str = "h90-ena-h-sf-nsp-full-gcs-6deg-3mo"
         rect_map = MapDescriptor.from_string(descriptor_str)
         sky_map = generate_hi_map(
             [pset_path],
@@ -245,24 +247,11 @@ def test_genarate_hi_map(
     for var_name in ["counts", "exposure_factor", "obs_date"]:
         assert var_name in sky_map.data_1d.data_vars
         assert np.nanmax(sky_map.data_1d[var_name].data) > 0
-
-
-def test_generate_hi_map_not_implemented():
-    """Test that the generate_hi_map function raises NotImplementedError."""
-    # Test that trying to produce Healpix raises
-    with pytest.raises(
-        NotImplementedError, match="Healpix map output not supported for Hi"
-    ):
-        _ = generate_hi_map(
-            [], {}, MapDescriptor.from_string("h90-ena-h-sf-nsp-full-gcs-nside32-3mo")
-        )
-    # Temporary test for CG correction not implemented
-    with pytest.raises(
-        NotImplementedError, match="CG correction not implemented for Hi"
-    ):
-        _ = generate_hi_map(
-            [], {}, MapDescriptor.from_string("h90-ena-h-hf-nsp-full-gcs-6deg-3mo")
-        )
+    # If the CG correction ran, check that the energy_sc variable is present
+    # in the map
+    if "-hf-" in descriptor_str:
+        assert "energy_sc" in sky_map.data_1d.data_vars
+        assert np.nanmax(sky_map.data_1d["energy_sc"].data) > 0
 
 
 def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):


### PR DESCRIPTION
# Change Summary

## Overview
This PR includes changes needed to get Hi PSET data through the projection step of L2 processing with a CG correction. Major updates are:
- Add a ram_mask boolean variable to the PSET dataset which is used to filter ram/anti-ram pixels during the projection process.
- Enable xarray broadcasting of valid_pixel_mask during map projection. This is to support having a ram_mask that is different for each energy step.
- Modify CG correction functions to return the modified LoHiBasePointingSet object to make it obvious that they mutate the input PSET object.
- Update Hi L2 code to call CG correction function if the map descriptor calls for it.

## Updated Files
- imap_processing/ena_maps/ena_maps.py
   - Add `ram_mask` variable to HiPointingSet class.
   - support xarray.DataArray input and xarray broadcasting for pset_valid_mask argument in `project_pset_values_to_map` function.
- imap_processing/ena_maps/utils/corrections.py
   - Return mutated PointingSet object from CG correction functions
   - Acrobatics to get mypy type checking happy
 - imap_processing/hi/hi_l2.py
   - Add check that all input pointing sets contain the same set of esa_energy_steps.
   - Add call to CG correction functions that act on PSET data before projecting.
   - Set pass appropriate `valid_pixel_mask` in to projection function so that ram/anti-ram filtering will work.
 - imap_processing/tests/ena_maps/test_corrections.py
   - update calls to CG correction functions with mutated pset as output
 - imap_processing/tests/ena_maps/test_ena_maps.py
   - Add test coverage for projecting with xarray.DataArray pset_valid_pixel mask.
 - imap_processing/tests/hi/test_hi_l2.py
   - Add testing of ram, anti, and helio frame maps

Closes: #2249 