### PR TITLE
I-ALiRT - Updated frame of reference

### DIFF
--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -77,7 +77,9 @@ def generate_coverage(
                 dsn_outage_mask |= (time_range >= start_et) & (time_range <= end_et)
 
     for station_name, (lon, lat, alt, min_elevation) in stations.items():
-        _azimuth, elevation = calculate_azimuth_and_elevation(lon, lat, alt, time_range)
+        _azimuth, elevation = calculate_azimuth_and_elevation(
+            lon, lat, alt, time_range, obsref="IAU_EARTH"
+        )
         visible = elevation > min_elevation
 
         outage_mask = np.zeros(time_range.shape, dtype=bool)

--- a/imap_processing/ialirt/process_ephemeris.py
+++ b/imap_processing/ialirt/process_ephemeris.py
@@ -72,6 +72,7 @@ def calculate_azimuth_and_elevation(
     altitude: float,
     observation_time: float | np.ndarray,
     target: str = SpiceBody.IMAP.name,
+    obsref: str = "IAU_EARTH",
 ) -> tuple:
     """
     Calculate azimuth and elevation.
@@ -91,6 +92,9 @@ def calculate_azimuth_and_elevation(
         is to be computed. Expressed as ephemeris time, seconds past J2000 TDB.
     target : str (Optional)
         The target body. Default is "IMAP".
+    obsref : str (Optional)
+        Body-fixed, body-centered reference frame wrt
+        observer's center.
 
     Returns
     -------
@@ -120,7 +124,7 @@ def calculate_azimuth_and_elevation(
             elplsz=True,  # Elevation increases from the XY plane toward +Z
             obspos=ground_station_position_ecef,  # observer pos. to center of motion
             obsctr="EARTH",  # Name of the center of motion
-            obsref="ITRF93",  # Body-fixed, body-centered reference frame wrt
+            obsref=obsref,  # Body-fixed, body-centered reference frame wrt
             # observer's center
         )
         azimuth.append(np.rad2deg(azel_results[0][1]))
@@ -223,7 +227,7 @@ def build_output(
 
     # For now, assume that kernel management will be handled by ensure_spice
     azimuth, elevation = calculate_azimuth_and_elevation(
-        longitude, latitude, altitude, time_range
+        longitude, latitude, altitude, time_range, obsref="ITRF93"
     )
 
     output_dict["time"] = et_to_utc(time_range, format_str="ISOC")

--- a/imap_processing/ialirt/process_ephemeris.py
+++ b/imap_processing/ialirt/process_ephemeris.py
@@ -72,7 +72,7 @@ def calculate_azimuth_and_elevation(
     altitude: float,
     observation_time: float | np.ndarray,
     target: str = SpiceBody.IMAP.name,
-    obsref: str = "IAU_EARTH",
+    obsref: str = "ITRF93",
 ) -> tuple:
     """
     Calculate azimuth and elevation.

--- a/imap_processing/ialirt/process_ephemeris.py
+++ b/imap_processing/ialirt/process_ephemeris.py
@@ -120,7 +120,7 @@ def calculate_azimuth_and_elevation(
             elplsz=True,  # Elevation increases from the XY plane toward +Z
             obspos=ground_station_position_ecef,  # observer pos. to center of motion
             obsctr="EARTH",  # Name of the center of motion
-            obsref="IAU_EARTH",  # Body-fixed, body-centered reference frame wrt
+            obsref="ITRF93",  # Body-fixed, body-centered reference frame wrt
             # observer's center
         )
         azimuth.append(np.rad2deg(azel_results[0][1]))

--- a/imap_processing/tests/ialirt/unit/test_process_ephemeris.py
+++ b/imap_processing/tests/ialirt/unit/test_process_ephemeris.py
@@ -80,17 +80,18 @@ def test_calculate_azimuth_and_elevation(furnish_kernels):
         "pck00011.tpc",
         "de440s.bsp",
         "imap_spk_demo.bsp",
+        "earth_latest_high_prec.bpc",
     ]
     with furnish_kernels(kernels):
         azimuth_result, elevation_result = (
             process_ephemeris.calculate_azimuth_and_elevation(
-                longitude, latitude, altitude, observation_time
+                longitude, latitude, altitude, observation_time, obsref="ITRF93"
             )
         )
         assert azimuth_result, elevation_result is not None
 
         # test array of observation times
-        time_endpoints = ("2026 SEP 22 00:00:00", "2026 SEP 22 23:59:59")
+        time_endpoints = ("2025 JUL 14 00:00:00", "2025 JUL 14 23:59:59")
         time_interval = int(1e3)  # seconds between data points
         observation_time = np.arange(
             str_to_et(time_endpoints[0]), str_to_et(time_endpoints[1]), time_interval
@@ -98,7 +99,7 @@ def test_calculate_azimuth_and_elevation(furnish_kernels):
     with furnish_kernels(kernels):
         azimuth_result, elevation_result = (
             process_ephemeris.calculate_azimuth_and_elevation(
-                longitude, latitude, altitude, observation_time
+                longitude, latitude, altitude, observation_time, obsref="ITRF93"
             )
         )
     assert len(azimuth_result) == len(observation_time)


### PR DESCRIPTION
# Change Summary

## Overview
I did a sanity check with APL for this pointing code since we are providing this information to international ground station partners. We had values that were different enough that I started to look into why it would be. When I changed the obsref to ITRF93 our values agreed much better:

Max azimuth difference compared w/ APL = 0.006 degrees
Max elevation difference compared w/ APL = 0.00009 degrees

Whereas before the elevation was off by 10ths of a degree and azimuth was off by 100ths of a degree. 

A ground station with a 7m dish needs the pointing to have an accuracy of < ~0.03 degrees to have strong signal strength. I think I now feel confident about these calculations, but want an opinion from @subagonsouth . Note that this will be sent to our ground station partner in Brazil after this review.

## Updated Files
- process_ephemeris.py
   - Changed to ITRF93

## Testing
[manaus_pointing_schedule_20251023.txt](https://github.com/user-attachments/files/23027455/manaus_pointing_schedule_20251023.txt)


