### PR TITLE
Lo L1C - PSET ESA Binning Fix

### DIFF
--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -302,7 +302,7 @@ def create_pset_counts(
     # Create the histogram with 3600 longitude bins, 40 latitude bins, and 7 energy bins
     lon_edges = np.arange(3601)
     lat_edges = np.arange(41)
-    energy_edges = np.arange(8)
+    energy_edges = np.arange(1, 9)
 
     hist, edges = np.histogramdd(
         data,

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -124,35 +124,36 @@ def counts():
     return np.zeros(PSET_SHAPE)
 
 
+# ESA Indices are ESA step - 1
 @pytest.fixture
 def h_counts(counts):
     h = counts.copy()
-    h[0, 1, 20, 20] = 2
-    h[0, 4, 2000, 20] = 1
+    h[0, 0, 20, 20] = 2
+    h[0, 3, 2000, 20] = 1
     return h
 
 
 @pytest.fixture
 def o_counts(counts):
     o = counts.copy()
-    o[0, 5, 3500, 20] = 1
-    o[0, 2, 0, 20] = 1
+    o[0, 4, 3500, 20] = 1
+    o[0, 1, 0, 20] = 1
     return o
 
 
 @pytest.fixture
 def triples_counts(counts):
     triples = counts.copy()
-    triples[0, 1, 20, 20] = 2
-    triples[0, 2, 0, 20] = 1
+    triples[0, 0, 20, 20] = 2
+    triples[0, 1, 0, 20] = 1
     return triples
 
 
 @pytest.fixture
 def doubles_counts(counts):
     doubles = counts.copy()
-    doubles[0, 4, 2000, 20] = 1
-    doubles[0, 5, 3500, 20] = 1
+    doubles[0, 3, 2000, 20] = 1
+    doubles[0, 4, 3500, 20] = 1
     return doubles
 
 
@@ -256,10 +257,11 @@ def test_filter_goodtimes(l1b_de, anc_dependencies):
 def test_create_pset_counts(l1b_de):
     # Arrange
     expected_counts = np.zeros((1, 7, 3600, 40))
-    expected_counts[0, 1, 20, 20] = 2
-    expected_counts[0, 4, 2000, 20] = 1
-    expected_counts[0, 5, 3500, 20] = 1
-    expected_counts[0, 2, 0, 20] = 1
+    # ESA Indices are ESA step - 1
+    expected_counts[0, 0, 20, 20] = 2
+    expected_counts[0, 3, 2000, 20] = 1
+    expected_counts[0, 4, 3500, 20] = 1
+    expected_counts[0, 1, 0, 20] = 1
 
     # Act
     counts = create_pset_counts(l1b_de)


### PR DESCRIPTION
# Change Summary

## Overview
The ESA steps for the Lo pset counts were being binned incorrectly. The ESA bins were being set as 0-6 to use the indices rather than the actual ESA step 1-7. The binning was updated to use the actual ESA step rather than the index. The unit tests also needed to be updated to use the ESA index rather than the ESA step when creating expected output data.

The code from this PR was used to generate a new pset CDF which appears to match the expected output at a high level of total counts per ESA step for hydrogen and oxygen.