### PR TITLE
2251 hi lo l2 cg correction   apply liouvilles theorem

### DIFF
--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -1,5 +1,6 @@
 """L2 corrections common to multiple IMAP ENA instruments."""
 
+import logging
 from pathlib import Path
 from typing import TypeVar
 
@@ -15,6 +16,11 @@ from imap_processing.ena_maps.ena_maps import (
 from imap_processing.ena_maps.utils.coordinates import CoordNames
 from imap_processing.spice import geometry
 from imap_processing.spice.time import ttj2000ns_to_et
+
+logger = logging.getLogger(__name__)
+
+# Tell ruff to ignore ambiguous Greek letters in formulas in this file
+# ruff: noqa: RUF003
 
 # Create a TypeVar to represent the specific class being passed in
 # Bound to LoHiBasePointingSet, meaning it must be LoHiBasePointingSet
@@ -603,3 +609,133 @@ def apply_compton_getting_correction(
     pset.update_az_el_points()
 
     return pset
+
+
+def interpolate_map_flux_to_helio_frame(
+    map_ds: xr.Dataset,
+    esa_energies_ev: xr.DataArray,
+    helio_energies_ev: xr.DataArray,
+) -> xr.Dataset:
+    """
+    Interpolate flux from spacecraft frame to heliocentric frame energies.
+
+    This implements the Compton-Getting interpolation step that transforms
+    flux measurements from the spacecraft frame to the heliocentric frame.
+    The algorithm follows these steps:
+    1. For each spatial pixel and energy step, get the spacecraft energy
+    2. Find bounding ESA energy channels for interpolation
+    3. Perform power-law interpolation between bounding channels to spacecraft energy
+    4. Apply energy scaling transformation to heliocentric frame
+
+    Parameters
+    ----------
+    map_ds : xarray.Dataset
+        Map dataset with `energy_sc` data variable containing the spacecraft
+        frame energies for each spatial pixel and ESA energy step.
+    esa_energies_ev : xarray.DataArray
+        The ESA nominal central energies (in eV).
+    helio_energies_ev : xarray.DataArray
+        The heliocentric frame energies to interpolate to (in eV).
+        In practice, these are the same as esa_energies_ev.
+
+    Returns
+    -------
+    map_ds : xarray.Dataset
+        Updated map dataset with interpolated heliocentric frame fluxes.
+    """
+    logger.info("Performing Compton-Getting interpolation to heliocentric frame")
+
+    # Work with xarray DataArrays to handle arbitrary spatial dimensions
+    energy_sc = map_ds["energy_sc"]
+    intensity = map_ds["ena_intensity"]
+    stat_unc = map_ds["ena_intensity_stat_uncert"]
+    sys_err = map_ds["ena_intensity_sys_err"]
+
+    # Step 1: Find bounding ESA energy indices for each position
+    # Use np.searchsorted on flattened array, then reshape back
+    esa_energy_vals = esa_energies_ev.values
+    energy_sc_flat = energy_sc.values.ravel()
+
+    # Find right bound index for each element (vectorized)
+    right_idx_flat = np.searchsorted(esa_energy_vals, energy_sc_flat, side="right")
+    right_idx_flat = np.clip(right_idx_flat, 1, len(esa_energy_vals) - 1)
+    left_idx_flat = right_idx_flat - 1
+
+    # Reshape indices back to match energy_sc shape
+    right_idx = right_idx_flat.reshape(energy_sc.shape)
+    left_idx = left_idx_flat.reshape(energy_sc.shape)
+
+    # Create DataArrays for indices with same dims as energy_sc
+    # Note: we need to avoid coordinate name conflicts when using isel()
+    # The energy dimension should be present in dims but not as a coordinate
+    # since we're using these as indices into the energy dimension
+    # Create coordinates dict without the energy coordinate
+    coords_without_energy = {k: v for k, v in energy_sc.coords.items() if k != "energy"}
+
+    right_idx_da = xr.DataArray(
+        right_idx, dims=energy_sc.dims, coords=coords_without_energy
+    )
+    left_idx_da = xr.DataArray(
+        left_idx, dims=energy_sc.dims, coords=coords_without_energy
+    )
+
+    # Step 2: Extract flux values at bounding energy channels
+    # Use xarray's advanced indexing to get fluxes at left and right indices
+    flux_left = intensity.isel({"energy": left_idx_da})
+    flux_right = intensity.isel({"energy": right_idx_da})
+    stat_unc_left = stat_unc.isel({"energy": left_idx_da})
+    stat_unc_right = stat_unc.isel({"energy": right_idx_da})
+    sys_err_left = sys_err.isel({"energy": left_idx_da})
+
+    # Get energy values at boundaries - select from esa_energies_ev using indices
+    energy_left = esa_energies_ev.isel({"energy": left_idx_da})
+    energy_right = esa_energies_ev.isel({"energy": right_idx_da})
+
+    # Step 3: Perform power-law interpolation to spacecraft energy
+    # slope = log(f_right/f_left) / log(e_right/e_left)
+    # flux_sc = f_left * (energy_sc / e_left)^slope
+    with np.errstate(divide="ignore", invalid="ignore"):
+        # Calculate slope for power-law interpolation
+        slope = np.log(flux_right / flux_left) / np.log(energy_right / energy_left)
+
+        # Interpolate flux using power-law
+        flux_sc = flux_left * ((energy_sc / energy_left) ** slope)
+
+        # Interpolation factor for uncertainty propagation (Equations 75 & 76)
+        unc_factor = np.log(energy_sc / energy_left) / np.log(
+            energy_right / energy_left
+        )
+
+        # Statistical uncertainty propagation (Equation 75):
+        # δJ = J * sqrt((δJ_left/J_left)^2 * (1 + unc_factor^2) + (δJ_right/J_right)^2)
+        stat_unc_sc = flux_sc * np.sqrt(
+            (stat_unc_left / flux_left) ** 2 * (1.0 + unc_factor**2)
+            + (stat_unc_right / flux_right) ** 2
+        )
+
+        # Systematic uncertainty propagation (Equation 76):
+        # σJ^g = σJ^src_kref * (⟨E^s_kref⟩ / E^ESA_kref)^γ_kref * (E^h / ⟨E^s_kref⟩)
+        # Systematic error scales proportionally with flux during power-law
+        # interpolation
+        sys_err_sc = sys_err_left * ((energy_sc / energy_left) ** slope)
+
+    # Step 4: Energy scaling transformation (Liouville theorem)
+    # flux_helio = flux_sc * (helio_energy / energy_sc)
+    # Use xarray broadcasting - helio_energies_ev will broadcast along esa_energy_step
+    with np.errstate(divide="ignore", invalid="ignore"):
+        energy_ratio = helio_energies_ev / energy_sc
+        flux_helio = flux_sc * energy_ratio
+        stat_unc_helio = stat_unc_sc * energy_ratio
+        sys_err_helio = sys_err_sc * energy_ratio
+
+    # Set any location where the value is not finite to NaN (converts +/-inf to NaN)
+    flux_helio = flux_helio.where(np.isfinite(flux_helio), np.nan)
+    stat_unc_helio = stat_unc_helio.where(np.isfinite(stat_unc_helio), np.nan)
+    sys_err_helio = sys_err_helio.where(np.isfinite(sys_err_helio), np.nan)
+
+    # Update the dataset with interpolated values
+    map_ds["ena_intensity"] = flux_helio
+    map_ds["ena_intensity_stat_uncert"] = stat_unc_helio
+    map_ds["ena_intensity_sys_err"] = sys_err_helio
+
+    return map_ds

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -14,6 +14,7 @@ from imap_processing.ena_maps.ena_maps import (
 from imap_processing.ena_maps.utils.corrections import (
     PowerLawFluxCorrector,
     apply_compton_getting_correction,
+    interpolate_map_flux_to_helio_frame,
 )
 from imap_processing.ena_maps.utils.naming import MapDescriptor
 from imap_processing.hi.utils import CalibrationProductConfig
@@ -190,6 +191,16 @@ def generate_hi_map(
     output_map.data_1d = output_map.data_1d.assign_coords(energy=energy_kev.values)
 
     output_map.data_1d = output_map.data_1d.drop("esa_energy_step_label")
+
+    # Apply Compton-Getting interpolation for heliocentric frame maps
+    if descriptor.frame_descriptor == "hf":
+        esa_energy_ev = esa_energy_ev.rename({"esa_energy_step": "energy"})
+        esa_energy_ev = esa_energy_ev.assign_coords(energy=energy_kev.values)
+        output_map.data_1d = interpolate_map_flux_to_helio_frame(
+            output_map.data_1d,
+            output_map.data_1d["energy"] * 1000,  # Convert ESA energies to eV
+            esa_energy_ev,  # heliocentric energies (same as ESA energies)
+        )
 
     return output_map
 

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -697,9 +697,29 @@ class TestInterpolateMapFluxToHelioFrame:
             map_ds, esa_energies, helio_energies
         )
 
-        # For a perfect power-law, interpolation should recover exact values
-        # After interpolation to E_sc=750 and scaling back to E_helio=1000,
-        # we can verify the intermediate calculations
+        # For a perfect power-law with flux = E^(-2) * spatial_factor:
+        # With n_spatial=1, spatial_factor = 0.5 (from np.linspace(0.5, 1.5, 1))
+        # The interpolation process does:
+        # 1. Interpolates flux at E_sc=750 from values at 500 and 1000
+        #    Expected: 750^(-2) * 0.5
+        # 2. Scales to E_helio=1000: flux * (1000/750)
+        #    = 750^(-2) * 0.5 * (1000/750)
+
+        # Calculate expected result for middle energy channel
+        e_sc = 750.0
+        e_helio = 1000.0
+        spatial_factor = 0.5  # From create_test_map_dataset with n_spatial=1
+        expected_flux_middle = (
+            (e_sc**power_law_slope) * (e_helio / e_sc) * spatial_factor
+        )
+
+        # Compare interpolated result to expected value
+        # (should be very close for a perfect power-law)
+        np.testing.assert_allclose(
+            result_ds["ena_intensity"].values[1, 0],
+            expected_flux_middle,
+            rtol=1e-10,
+        )
 
         # The flux should be finite and positive
         assert np.all(np.isfinite(result_ds["ena_intensity"].values))
@@ -792,6 +812,7 @@ class TestInterpolateMapFluxToHelioFrame:
         assert np.all(np.isfinite(ratio))
         # Most values should be reasonably close to original
         # (exact match not expected due to interpolation)
+        np.testing.assert_allclose(ratio, 1)
 
     def test_infinite_values_converted_to_nan(self):
         """Test that infinite values are converted to NaN."""
@@ -819,9 +840,6 @@ class TestInterpolateMapFluxToHelioFrame:
         assert not np.any(np.isinf(flux))
         assert not np.any(np.isinf(stat_unc))
         assert not np.any(np.isinf(sys_err))
-
-        # Should have some NaN values from the problematic inputs
-        # (though maybe not, depending on how the algorithm handles edge cases)
 
     def test_multidimensional_spatial_coords(self):
         """Test that interpolation works with multi-dimensional spatial coordinates."""

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -14,6 +14,7 @@ from imap_processing.ena_maps.utils.corrections import (
     _add_spacecraft_velocity_to_pset,
     _calculate_compton_getting_transform,
     apply_compton_getting_correction,
+    interpolate_map_flux_to_helio_frame,
 )
 from imap_processing.spice import geometry
 
@@ -580,3 +581,424 @@ class TestComptonGettingCorrection:
 
         # Verify all values are boolean
         assert ram_mask.dtype == bool
+
+
+class TestInterpolateMapFluxToHelioFrame:
+    """Test suite for interpolate_map_flux_to_helio_frame function."""
+
+    def create_test_map_dataset(self, n_energy=5, n_spatial=10, power_law_slope=-2.0):
+        """Create a synthetic map dataset for testing interpolation.
+
+        Parameters
+        ----------
+        n_energy : int
+            Number of energy channels
+        n_spatial : int
+            Number of spatial pixels
+        power_law_slope : float
+            Power-law spectral index for test flux
+
+        Returns
+        -------
+        tuple
+            (map_ds, esa_energies, helio_energies)
+        """
+        # Define ESA energy channels (in eV)
+        esa_energies = np.array([500.0, 1000.0, 2000.0, 4000.0, 8000.0])[:n_energy]
+
+        # Create flux with a simple power-law spectrum: flux = E^slope
+        flux_base = esa_energies[:, np.newaxis] ** power_law_slope
+
+        # Add some spatial variation (multiply by factors between 0.5 and 1.5)
+        spatial_factors = np.linspace(0.5, 1.5, n_spatial)
+        flux = flux_base * spatial_factors
+
+        # Create uncertainties (10% statistical, 5% systematic)
+        stat_unc = 0.1 * flux
+        sys_err = 0.05 * flux
+
+        # Create spacecraft energies slightly different from ESA energies
+        # to simulate Compton-Getting shift
+        # Add a small spatial-dependent shift
+        energy_shift_factor = 1.0 + 0.1 * np.linspace(-1, 1, n_spatial)
+        energy_sc = esa_energies[:, np.newaxis] * energy_shift_factor
+
+        # Create xarray Dataset
+        map_ds = xr.Dataset(
+            {
+                "ena_intensity": (["energy", "spatial"], flux),
+                "ena_intensity_stat_uncert": (["energy", "spatial"], stat_unc),
+                "ena_intensity_sys_err": (["energy", "spatial"], sys_err),
+                "energy_sc": (["energy", "spatial"], energy_sc),
+            },
+            coords={
+                "energy": np.arange(n_energy),
+                "spatial": np.arange(n_spatial),
+            },
+        )
+
+        # Helio energies are the same as ESA energies (standard case)
+        helio_energies = xr.DataArray(
+            esa_energies,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+
+        esa_energies_da = xr.DataArray(
+            esa_energies,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+
+        return map_ds, esa_energies_da, helio_energies
+
+    def test_basic_interpolation(self):
+        """Test basic functionality of interpolation."""
+
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset()
+
+        # Apply interpolation
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # Verify output structure
+        assert "ena_intensity" in result_ds
+        assert "ena_intensity_stat_uncert" in result_ds
+        assert "ena_intensity_sys_err" in result_ds
+
+        # Verify shapes are preserved
+        assert result_ds["ena_intensity"].shape == map_ds["ena_intensity"].shape
+        assert (
+            result_ds["ena_intensity_stat_uncert"].shape
+            == map_ds["ena_intensity_stat_uncert"].shape
+        )
+        assert (
+            result_ds["ena_intensity_sys_err"].shape
+            == map_ds["ena_intensity_sys_err"].shape
+        )
+
+    def test_power_law_interpolation_accuracy(self):
+        """Test that power-law interpolation formula is correct."""
+
+        # Create simple test case with known power-law
+        # flux = E^(-2)
+        power_law_slope = -2.0
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset(
+            n_energy=3, n_spatial=1, power_law_slope=power_law_slope
+        )
+
+        # Manually set energy_sc to be between two ESA energies
+        # ESA energies: [500, 1000, 2000]
+        # Set energy_sc for middle channel to 750 eV (between 500 and 1000)
+        map_ds["energy_sc"].values[1, 0] = 750.0
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # For a perfect power-law, interpolation should recover exact values
+        # After interpolation to E_sc=750 and scaling back to E_helio=1000,
+        # we can verify the intermediate calculations
+
+        # The flux should be finite and positive
+        assert np.all(np.isfinite(result_ds["ena_intensity"].values))
+        assert np.all(result_ds["ena_intensity"].values > 0)
+
+    def test_statistical_uncertainty_propagation(self):
+        """Test that statistical uncertainty follows Equation 75."""
+
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset(
+            n_energy=3, n_spatial=1
+        )
+
+        # Set up a specific case where we can verify the formula
+        # Set energy_sc to midpoint between two channels
+        e_sc = 1400.0  # Between left and right
+
+        map_ds["energy_sc"].values[1, 0] = e_sc
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # Statistical uncertainty should be positive and finite
+        stat_unc = result_ds["ena_intensity_stat_uncert"].values
+        assert np.all(stat_unc >= 0)
+        assert np.all(np.isfinite(stat_unc))
+
+        # Statistical uncertainty should scale with flux
+        # (relative uncertainty should be similar to input)
+        flux = result_ds["ena_intensity"].values
+        rel_unc_output = stat_unc / flux
+
+        # Should be on the order of input relative uncertainty (10%)
+        # Allow for propagation effects
+        assert np.all(rel_unc_output > 0)
+        assert np.all(rel_unc_output < 1.0)  # Should be reasonable
+
+    def test_systematic_uncertainty_propagation(self):
+        """Test that systematic uncertainty follows Equation 76."""
+
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset(
+            n_energy=3, n_spatial=1
+        )
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # Systematic uncertainty should be positive and finite
+        sys_err = result_ds["ena_intensity_sys_err"].values
+        assert np.all(sys_err >= 0)
+        assert np.all(np.isfinite(sys_err))
+
+        # Systematic error should scale proportionally with flux
+        flux = result_ds["ena_intensity"].values
+        rel_sys_err = sys_err / flux
+
+        # Relative systematic error should be preserved (5% in input)
+        # within reasonable tolerance for the transformations
+        assert np.all(rel_sys_err > 0)
+        assert np.all(rel_sys_err < 0.5)  # Should be reasonable
+
+    def test_energy_scaling_transformation(self):
+        """Test Liouville theorem: flux_helio = flux_sc * (E_helio / E_sc)."""
+
+        # Create dataset where energy_sc equals ESA energies (no CG shift)
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset(
+            n_energy=3, n_spatial=1
+        )
+
+        # Set energy_sc exactly equal to ESA energies
+        map_ds["energy_sc"].values[:, 0] = esa_energies.values
+
+        # Store original flux for comparison
+        original_flux = map_ds["ena_intensity"].values.copy()
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # When E_sc = E_esa and E_helio = E_esa, then E_helio/E_sc = 1
+        # So flux should be approximately preserved (modulo interpolation effects)
+        result_flux = result_ds["ena_intensity"].values
+
+        # The ratio should be close to 1 for each pixel
+        # (within numerical precision and interpolation effects)
+        ratio = result_flux / original_flux
+
+        # Allow for some numerical error and interpolation effects
+        assert np.all(np.isfinite(ratio))
+        # Most values should be reasonably close to original
+        # (exact match not expected due to interpolation)
+
+    def test_infinite_values_converted_to_nan(self):
+        """Test that infinite values are converted to NaN."""
+
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset(
+            n_energy=3, n_spatial=2
+        )
+
+        # Introduce a zero flux to create divide-by-zero
+        map_ds["ena_intensity"].values[1, 0] = 0.0
+
+        # Set energy_sc to zero to create potential infinities
+        map_ds["energy_sc"].values[1, 1] = 0.0
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # Check that we have NaN values where expected, not infinities
+        flux = result_ds["ena_intensity"].values
+        stat_unc = result_ds["ena_intensity_stat_uncert"].values
+        sys_err = result_ds["ena_intensity_sys_err"].values
+
+        # Should have no infinities
+        assert not np.any(np.isinf(flux))
+        assert not np.any(np.isinf(stat_unc))
+        assert not np.any(np.isinf(sys_err))
+
+        # Should have some NaN values from the problematic inputs
+        # (though maybe not, depending on how the algorithm handles edge cases)
+
+    def test_multidimensional_spatial_coords(self):
+        """Test that interpolation works with multi-dimensional spatial coordinates."""
+
+        n_energy = 4
+        n_lat = 6
+        n_lon = 8
+
+        # Define ESA energies
+        esa_energies_vals = np.array([500.0, 1000.0, 2000.0, 4000.0])
+
+        # Create flux with spatial dimensions (lat, lon)
+        power_law_slope = -2.0
+        flux = np.zeros((n_energy, n_lat, n_lon))
+        stat_unc = np.zeros((n_energy, n_lat, n_lon))
+        sys_err = np.zeros((n_energy, n_lat, n_lon))
+        energy_sc = np.zeros((n_energy, n_lat, n_lon))
+
+        for i in range(n_energy):
+            # Power-law flux with spatial variation
+            spatial_pattern = 1.0 + 0.5 * np.random.random((n_lat, n_lon))
+            flux[i, :, :] = (esa_energies_vals[i] ** power_law_slope) * spatial_pattern
+            stat_unc[i, :, :] = 0.1 * flux[i, :, :]
+            sys_err[i, :, :] = 0.05 * flux[i, :, :]
+
+            # Energy shift varies with position
+            energy_sc[i, :, :] = esa_energies_vals[i] * (
+                1.0 + 0.1 * np.random.random((n_lat, n_lon))
+            )
+
+        # Create dataset with 2D spatial coordinates
+        map_ds = xr.Dataset(
+            {
+                "ena_intensity": (["energy", "latitude", "longitude"], flux),
+                "ena_intensity_stat_uncert": (
+                    ["energy", "latitude", "longitude"],
+                    stat_unc,
+                ),
+                "ena_intensity_sys_err": (["energy", "latitude", "longitude"], sys_err),
+                "energy_sc": (["energy", "latitude", "longitude"], energy_sc),
+            },
+            coords={
+                "energy": np.arange(n_energy),
+                "latitude": np.arange(n_lat),
+                "longitude": np.arange(n_lon),
+            },
+        )
+
+        esa_energies = xr.DataArray(
+            esa_energies_vals,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+        helio_energies = esa_energies.copy()
+
+        # Apply interpolation
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # Verify output shape matches input
+        assert result_ds["ena_intensity"].shape == (n_energy, n_lat, n_lon)
+        assert result_ds["ena_intensity_stat_uncert"].shape == (n_energy, n_lat, n_lon)
+        assert result_ds["ena_intensity_sys_err"].shape == (n_energy, n_lat, n_lon)
+
+        # Verify dimensions are preserved
+        assert list(result_ds["ena_intensity"].dims) == [
+            "energy",
+            "latitude",
+            "longitude",
+        ]
+
+        # Verify values are reasonable
+        assert np.all(result_ds["ena_intensity"].values > 0)
+        assert np.all(np.isfinite(result_ds["ena_intensity"].values))
+
+    def test_boundary_energy_channels(self):
+        """Test interpolation behavior at energy boundaries."""
+
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset(
+            n_energy=5, n_spatial=3
+        )
+
+        # Test when energy_sc is below the lowest ESA energy
+        map_ds["energy_sc"].values[0, 0] = 0.9 * esa_energies.values[0]
+
+        # Test when energy_sc is above the highest ESA energy
+        map_ds["energy_sc"].values[-1, -1] = 1.1 * esa_energies.values[-1]
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # Should handle boundary cases without errors
+        flux = result_ds["ena_intensity"].values
+
+        # Boundary pixels should have values (possibly NaN, but no crashes)
+        # The function clips indices to valid range, so these should interpolate
+        # using the boundary channels
+        assert flux.shape == map_ds["ena_intensity"].shape
+
+    def test_preserves_dataset_structure(self):
+        """Test that the function preserves the dataset structure."""
+
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset()
+
+        # Store original attributes
+        original_dims = list(map_ds["ena_intensity"].dims)
+        original_coords = list(map_ds.coords.keys())
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # Verify dimensions are preserved
+        assert list(result_ds["ena_intensity"].dims) == original_dims
+
+        # Verify coordinates are preserved
+        assert list(result_ds.coords.keys()) == original_coords
+
+        # Verify it's still an xarray Dataset
+        assert isinstance(result_ds, xr.Dataset)
+
+    def test_with_uniform_flux(self):
+        """Test interpolation with uniform flux (no spatial variation)."""
+
+        n_energy = 4
+        n_spatial = 5
+
+        esa_energies_vals = np.array([500.0, 1000.0, 2000.0, 4000.0])
+
+        # Create uniform flux (same for all spatial pixels)
+        power_law_slope = -2.0
+        flux_uniform = (esa_energies_vals**power_law_slope)[:, np.newaxis]
+        flux = np.tile(flux_uniform, (1, n_spatial))
+
+        stat_unc = 0.1 * flux
+        sys_err = 0.05 * flux
+
+        # Energy shift uniform across space
+        energy_sc = np.tile(esa_energies_vals[:, np.newaxis] * 1.05, (1, n_spatial))
+
+        map_ds = xr.Dataset(
+            {
+                "ena_intensity": (["energy", "spatial"], flux),
+                "ena_intensity_stat_uncert": (["energy", "spatial"], stat_unc),
+                "ena_intensity_sys_err": (["energy", "spatial"], sys_err),
+                "energy_sc": (["energy", "spatial"], energy_sc),
+            },
+            coords={
+                "energy": np.arange(n_energy),
+                "spatial": np.arange(n_spatial),
+            },
+        )
+
+        esa_energies = xr.DataArray(
+            esa_energies_vals,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+        helio_energies = esa_energies.copy()
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies
+        )
+
+        # With uniform input, output should also be uniform across spatial dimension
+        result_flux = result_ds["ena_intensity"].values
+
+        # Check that each energy channel has uniform values across spatial pixels
+        for i_energy in range(n_energy):
+            spatial_values = result_flux[i_energy, :]
+            # All spatial pixels at this energy should be similar
+            if np.all(np.isfinite(spatial_values)):
+                std_dev = np.std(spatial_values)
+                mean_val = np.mean(spatial_values)
+                # Relative std should be very small for uniform input
+                if mean_val > 0:
+                    rel_std = std_dev / mean_val
+                    assert rel_std < 1e-10, f"Energy {i_energy}: rel_std = {rel_std}"

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -142,27 +142,34 @@ def sample_map_dataset():
     return test_ds, geometric_factors, esa_energies
 
 
+@pytest.mark.parametrize(
+    "descriptor_str",
+    [
+        "h90-ena-h-sf-nsp-full-hae-4deg-3mo",
+        "h90-ena-h-hf-nsp-ram-gcs-6deg-3mo",
+    ],
+)
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
 def test_hi_l2(
+    descriptor_str,
     hi_l1_test_data_path,
     anc_path_dict,
     imap_ena_sim_metakernel,
 ):
     """Integration type test for hi_l2()"""
     pset_path = hi_l1_test_data_path / "imap_hi_l1c_45sensor-pset_20250415_v999.cdf"
-    descriptor = "h90-ena-h-sf-nsp-full-hae-4deg-3mo"
 
     l2_dataset = hi_l2(
         [pset_path],
         anc_path_dict,
-        "h90-ena-h-sf-nsp-full-hae-4deg-3mo",
+        descriptor_str,
     )[0]
     assert isinstance(l2_dataset, xr.Dataset)
 
     # Check some global attributes
-    assert l2_dataset.attrs["Data_type"].startswith(f"L2_{descriptor}")
-    assert l2_dataset.attrs["Logical_source"] == f"imap_hi_l2_{descriptor}"
+    assert l2_dataset.attrs["Data_type"].startswith(f"L2_{descriptor_str}")
+    assert l2_dataset.attrs["Logical_source"] == f"imap_hi_l2_{descriptor_str}"
     assert "Hi90" in l2_dataset.attrs["Logical_source_description"]
 
     assert len(l2_dataset.data_vars) == 15
@@ -209,8 +216,12 @@ def test_hi_l2_uses_descriptor_to_setup_map(
     ],
 )
 @mock.patch("imap_processing.hi.hi_l2.calculate_ena_intensity", autospec=True)
+@mock.patch(
+    "imap_processing.hi.hi_l2.interpolate_map_flux_to_helio_frame", autospec=True
+)
 @pytest.mark.external_test_data
 def test_genarate_hi_map(
+    mock_interp_flux,
     mock_calc_ena_intensity,
     hi_l1_test_data_path,
     anc_path_dict,
@@ -219,6 +230,7 @@ def test_genarate_hi_map(
 ):
     """Test coverage for genarate_hi_map()"""
     mock_calc_ena_intensity.side_effect = lambda x, y, z: x
+    mock_interp_flux.side_effect = lambda x, y, z: x
 
     kernels = [
         "imap_sclk_0000.tsc",
@@ -252,6 +264,7 @@ def test_genarate_hi_map(
     if "-hf-" in descriptor_str:
         assert "energy_sc" in sky_map.data_1d.data_vars
         assert np.nanmax(sky_map.data_1d["energy_sc"].data) > 0
+        mock_interp_flux.assert_called_once()
 
 
 def test_calculate_ena_signal_rates(empty_rectangular_map_dataset):


### PR DESCRIPTION
# Change Summary

## Overview
Warning: Large PR... sorry
This PR includes the final CG correction code. This piece acts on data that has been projected to a SkyMap. The final step in the CG correction is to interpolate the fluxes that are in the spacecraft frame energies to the desired energy that results in fixed helio frame energies and scale according to Liouville theorem.

Note that the diff shows changes that are in another PR: #2326 
There are no changes in this PR to the ena_maps.py module.

## Updated Files
- imap_processing/ena_maps/utils/corrections.py
   - Add interpolate_map_flux_to_helio_frame
- imap_processing/hi/hi_l2.py
   - Add the interpolate_map_flux_to_helio_frame into the L2 processing flow.
- imap_processing/tests/ena_maps/test_corrections.py
   - Claude assisted addition of tests to fully cover the new interpolate_map_flux_to_helio_frame funciton.
- imap_processing/tests/hi/test_hi_l2.py
   - Test full CG correction in integration type test `test_hi_l2`
   - Mock integration function in lower level test.

Closes: #2251

