### PR TITLE
I-ALiRT - add tcp modifications

### DIFF
--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -9,7 +9,7 @@ from imap_processing.ialirt.constants import STATIONS
 logger = logging.getLogger(__name__)
 
 
-def find_tcp_connections(
+def find_tcp_connections(  # noqa: PLR0912
     start_file_creation: datetime,
     end_file_creation: datetime,
     lines: list,
@@ -35,8 +35,16 @@ def find_tcp_connections(
         Output dictionary with tcp connection info.
     """
     current_starts: dict[str, datetime | None] = {}
+    partners_opened = set()
 
     for line in lines:
+        # Note if this line appears.
+        if "Opened raw record file" in line:
+            station = line.split("Opened raw record file for ")[1].split(
+                " antenna_partner"
+            )[0]
+            partners_opened.add(station)
+
         if "antenna partner connection is" not in line:
             continue
 
@@ -80,6 +88,16 @@ def find_tcp_connections(
             realtime_summary["connection_times"][station].append(
                 {
                     "start": datetime.isoformat(start),
+                    "end": datetime.isoformat(end_file_creation),
+                }
+            )
+
+    # Handle stations with only "Opened raw record file" (no up/down)
+    for station in partners_opened:
+        if not realtime_summary["connection_times"][station]:
+            realtime_summary["connection_times"][station].append(
+                {
+                    "start": datetime.isoformat(start_file_creation),
                     "end": datetime.isoformat(end_file_creation),
                 }
             )

--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -72,4 +72,10 @@ STATIONS = {
         altitude=0.1,  # approx 100 meters
         min_elevation_deg=5,  # 5 degrees is the requirement
     ),
+    "SANSA": StationProperties(
+        longitude=27.714,  # degrees East (negative = West)
+        latitude=-25.888,  # degrees North (negative = South)
+        altitude=1.542,  # approx 1542 meters
+        min_elevation_deg=2,  # 5 degrees is the requirement
+    ),
 }

--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -53,16 +53,16 @@ class StationProperties(NamedTuple):
 # Verified by Kiel and KSWC Observatory staff.
 # Notes: the KSWC station is not yet operational,
 # but will have the following properties:
-# "KSWC": StationProperties(
-#     longitude=126.2958,  # degrees East
-#     latitude=33.4273,  # degrees North
-#     altitude=0.1,  # approx 100 meters
-#     min_elevation_deg=5,  # 5 degrees is the requirement
-# ),
 STATIONS = {
     "Kiel": StationProperties(
         longitude=10.1808,  # degrees East
         latitude=54.2632,  # degrees North
+        altitude=0.1,  # approx 100 meters
+        min_elevation_deg=5,  # 5 degrees is the requirement
+    ),
+    "Korea": StationProperties(
+        longitude=126.2958,  # degrees East
+        latitude=33.4273,  # degrees North
         altitude=0.1,  # approx 100 meters
         min_elevation_deg=5,  # 5 degrees is the requirement
     ),

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -57,6 +57,9 @@ def generate_coverage(
 
     stations = {
         "Kiel": STATIONS["Kiel"],
+        "Korea": STATIONS["Korea"],
+        "Manaus": STATIONS["Manaus"],
+        "SANSA": STATIONS["SANSA"],
     }
     coverage_dict = {}
     outage_dict = {}

--- a/imap_processing/tests/ialirt/data/l0/flight_iois_1.log.2025-295T17-28-05.937369
+++ b/imap_processing/tests/ialirt/data/l0/flight_iois_1.log.2025-295T17-28-05.937369
@@ -1,0 +1,202 @@
+ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)
+ 2  tlmrelay      295-16:28:03  277-08:58:24    1.5
+10  Kiel          295-13:54:00  295-05:19:13    0.0
+2025/295-16:28:40.308 Closed packets file for SDC: iois_1_packets_2025_295_16_27_39.partial
+2025/295-16:28:40.308 Renamed iois_1_packets_2025_295_16_27_39.partial to iois_1_packets_2025_295_16_27_39.
+2025/295-16:28:40.308 Spawning: mv
+2025/295-16:28:40.308 Opened packets file for SDC: iois_1_packets_2025_295_16_28_40.partial
+2025/295-16:28:41.310 Spawned command succeeded: mv
+2025/295-16:29:41.956 Closed packets file for SDC: iois_1_packets_2025_295_16_28_40.partial
+2025/295-16:29:41.956 Renamed iois_1_packets_2025_295_16_28_40.partial to iois_1_packets_2025_295_16_28_40.
+2025/295-16:29:41.956 Spawning: mv
+2025/295-16:29:41.956 Opened packets file for SDC: iois_1_packets_2025_295_16_29_41.partial
+2025/295-16:29:42.960 Spawned command succeeded: mv
+2025/295-16:30:42.104 Closed packets file for SDC: iois_1_packets_2025_295_16_29_41.partial
+2025/295-16:30:42.104 Renamed iois_1_packets_2025_295_16_29_41.partial to iois_1_packets_2025_295_16_29_41.
+2025/295-16:30:42.104 Spawning: mv
+2025/295-16:30:42.104 Opened packets file for SDC: iois_1_packets_2025_295_16_30_42.partial
+2025/295-16:30:43.093 Spawned command succeeded: mv
+2025/295-16:31:00.161 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_16_26_00.partial
+2025/295-16:31:00.162 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_16_31_00.partial
+2025/295-16:31:43.225 Closed packets file for SDC: iois_1_packets_2025_295_16_30_42.partial
+2025/295-16:31:43.225 Renamed iois_1_packets_2025_295_16_30_42.partial to iois_1_packets_2025_295_16_30_42.
+2025/295-16:31:43.225 Spawning: mv
+2025/295-16:31:43.225 Opened packets file for SDC: iois_1_packets_2025_295_16_31_43.partial
+2025/295-16:31:44.226 Spawned command succeeded: mv
+2025/295-16:32:44.388 Closed packets file for SDC: iois_1_packets_2025_295_16_31_43.partial
+2025/295-16:32:44.389 Renamed iois_1_packets_2025_295_16_31_43.partial to iois_1_packets_2025_295_16_31_43.
+2025/295-16:32:44.389 Spawning: mv
+2025/295-16:32:44.389 Opened packets file for SDC: iois_1_packets_2025_295_16_32_44.partial
+2025/295-16:32:45.392 Spawned command succeeded: mv
+2025/295-16:33:45.043 Closed packets file for SDC: iois_1_packets_2025_295_16_32_44.partial
+2025/295-16:33:45.043 Renamed iois_1_packets_2025_295_16_32_44.partial to iois_1_packets_2025_295_16_32_44.
+2025/295-16:33:45.043 Spawning: mv
+2025/295-16:33:45.043 Opened packets file for SDC: iois_1_packets_2025_295_16_33_45.partial
+2025/295-16:33:46.046 Spawned command succeeded: mv
+2025/295-16:34:46.204 Closed packets file for SDC: iois_1_packets_2025_295_16_33_45.partial
+2025/295-16:34:46.204 Renamed iois_1_packets_2025_295_16_33_45.partial to iois_1_packets_2025_295_16_33_45.
+2025/295-16:34:46.204 Spawning: mv
+2025/295-16:34:46.204 Opened packets file for SDC: iois_1_packets_2025_295_16_34_46.partial
+2025/295-16:34:47.205 Spawned command succeeded: mv
+2025/295-16:35:47.860 Closed packets file for SDC: iois_1_packets_2025_295_16_34_46.partial
+2025/295-16:35:47.860 Renamed iois_1_packets_2025_295_16_34_46.partial to iois_1_packets_2025_295_16_34_46.
+2025/295-16:35:47.860 Spawning: mv
+2025/295-16:35:47.860 Opened packets file for SDC: iois_1_packets_2025_295_16_35_47.partial
+2025/295-16:35:48.862 Spawned command succeeded: mv
+2025/295-16:36:00.891 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_16_31_00.partial
+2025/295-16:36:00.891 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_16_36_00.partial
+2025/295-16:36:48.001 Closed packets file for SDC: iois_1_packets_2025_295_16_35_47.partial
+2025/295-16:36:48.001 Renamed iois_1_packets_2025_295_16_35_47.partial to iois_1_packets_2025_295_16_35_47.
+2025/295-16:36:48.001 Spawning: mv
+2025/295-16:36:48.001 Opened packets file for SDC: iois_1_packets_2025_295_16_36_48.partial
+2025/295-16:36:49.002 Spawned command succeeded: mv
+2025/295-16:37:49.657 Closed packets file for SDC: iois_1_packets_2025_295_16_36_48.partial
+2025/295-16:37:49.657 Renamed iois_1_packets_2025_295_16_36_48.partial to iois_1_packets_2025_295_16_36_48.
+2025/295-16:37:49.657 Spawning: mv
+2025/295-16:37:49.658 Opened packets file for SDC: iois_1_packets_2025_295_16_37_49.partial
+2025/295-16:37:51.645 Spawned command succeeded: mv
+2025/295-16:38:50.308 Closed packets file for SDC: iois_1_packets_2025_295_16_37_49.partial
+2025/295-16:38:50.308 Renamed iois_1_packets_2025_295_16_37_49.partial to iois_1_packets_2025_295_16_37_49.
+2025/295-16:38:50.308 Spawning: mv
+2025/295-16:38:50.308 Opened packets file for SDC: iois_1_packets_2025_295_16_38_50.partial
+2025/295-16:38:51.309 Spawned command succeeded: mv
+2025/295-16:39:51.448 Closed packets file for SDC: iois_1_packets_2025_295_16_38_50.partial
+2025/295-16:39:51.448 Renamed iois_1_packets_2025_295_16_38_50.partial to iois_1_packets_2025_295_16_38_50.
+2025/295-16:39:51.448 Spawning: mv
+2025/295-16:39:51.448 Opened packets file for SDC: iois_1_packets_2025_295_16_39_51.partial
+2025/295-16:39:52.449 Spawned command succeeded: mv
+2025/295-16:40:52.099 Closed packets file for SDC: iois_1_packets_2025_295_16_39_51.partial
+2025/295-16:40:52.099 Renamed iois_1_packets_2025_295_16_39_51.partial to iois_1_packets_2025_295_16_39_51.
+2025/295-16:40:52.099 Spawning: mv
+2025/295-16:40:52.099 Opened packets file for SDC: iois_1_packets_2025_295_16_40_52.partial
+2025/295-16:40:53.101 Spawned command succeeded: mv
+2025/295-16:41:00.120 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_16_36_00.partial
+2025/295-16:41:00.120 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_16_41_00.partial
+2025/295-16:41:53.769 Closed packets file for SDC: iois_1_packets_2025_295_16_40_52.partial
+2025/295-16:41:53.769 Renamed iois_1_packets_2025_295_16_40_52.partial to iois_1_packets_2025_295_16_40_52.
+2025/295-16:41:53.769 Spawning: mv
+2025/295-16:41:53.769 Opened packets file for SDC: iois_1_packets_2025_295_16_41_53.partial
+2025/295-16:41:54.836 Spawned command succeeded: mv
+2025/295-16:42:54.940 Closed packets file for SDC: iois_1_packets_2025_295_16_41_53.partial
+2025/295-16:42:54.940 Renamed iois_1_packets_2025_295_16_41_53.partial to iois_1_packets_2025_295_16_41_53.
+2025/295-16:42:54.940 Spawning: mv
+2025/295-16:42:54.940 Opened packets file for SDC: iois_1_packets_2025_295_16_42_54.partial
+2025/295-16:42:55.940 Spawned command succeeded: mv
+2025/295-16:43:55.098 Closed packets file for SDC: iois_1_packets_2025_295_16_42_54.partial
+2025/295-16:43:55.098 Renamed iois_1_packets_2025_295_16_42_54.partial to iois_1_packets_2025_295_16_42_54.
+2025/295-16:43:55.098 Spawning: mv
+2025/295-16:43:55.098 Opened packets file for SDC: iois_1_packets_2025_295_16_43_55.partial
+2025/295-16:43:56.098 Spawned command succeeded: mv
+2025/295-16:44:56.250 Closed packets file for SDC: iois_1_packets_2025_295_16_43_55.partial
+2025/295-16:44:56.250 Renamed iois_1_packets_2025_295_16_43_55.partial to iois_1_packets_2025_295_16_43_55.
+2025/295-16:44:56.250 Spawning: mv
+2025/295-16:44:56.250 Opened packets file for SDC: iois_1_packets_2025_295_16_44_56.partial
+2025/295-16:44:57.252 Spawned command succeeded: mv
+2025/295-16:45:57.320 Closed packets file for SDC: iois_1_packets_2025_295_16_44_56.partial
+2025/295-16:45:57.320 Renamed iois_1_packets_2025_295_16_44_56.partial to iois_1_packets_2025_295_16_44_56.
+2025/295-16:45:57.320 Spawning: mv
+2025/295-16:45:57.320 Opened packets file for SDC: iois_1_packets_2025_295_16_45_57.partial
+2025/295-16:45:59.323 Spawned command succeeded: mv
+2025/295-16:46:01.325 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_16_41_00.partial
+2025/295-16:46:01.325 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_16_46_01.partial
+2025/295-16:46:59.386 Deleting zero-length file: iois_1_packets_2025_295_16_45_57.partial
+2025/295-16:46:59.386 Opened packets file for SDC: iois_1_packets_2025_295_16_46_59.partial
+2025/295-16:48:01.450 Deleting zero-length file: iois_1_packets_2025_295_16_46_59.partial
+2025/295-16:48:01.450 Opened packets file for SDC: iois_1_packets_2025_295_16_48_01.partial
+2025/295-16:49:03.514 Deleting zero-length file: iois_1_packets_2025_295_16_48_01.partial
+2025/295-16:49:03.514 Opened packets file for SDC: iois_1_packets_2025_295_16_49_03.partial
+2025/295-16:50:05.580 Deleting zero-length file: iois_1_packets_2025_295_16_49_03.partial
+2025/295-16:50:05.580 Opened packets file for SDC: iois_1_packets_2025_295_16_50_05.partial
+2025/295-16:51:01.640 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_16_46_01.partial
+2025/295-16:51:01.640 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_16_51_01.partial
+2025/295-16:51:07.646 Deleting zero-length file: iois_1_packets_2025_295_16_50_05.partial
+2025/295-16:51:07.646 Opened packets file for SDC: iois_1_packets_2025_295_16_51_07.partial
+2025/295-16:52:09.712 Deleting zero-length file: iois_1_packets_2025_295_16_51_07.partial
+2025/295-16:52:09.712 Opened packets file for SDC: iois_1_packets_2025_295_16_52_09.partial
+2025/295-16:53:11.777 Deleting zero-length file: iois_1_packets_2025_295_16_52_09.partial
+2025/295-16:53:11.777 Opened packets file for SDC: iois_1_packets_2025_295_16_53_11.partial
+2025/295-16:54:13.842 Deleting zero-length file: iois_1_packets_2025_295_16_53_11.partial
+2025/295-16:54:13.843 Opened packets file for SDC: iois_1_packets_2025_295_16_54_13.partial
+2025/295-16:55:15.901 Deleting zero-length file: iois_1_packets_2025_295_16_54_13.partial
+2025/295-16:55:15.901 Opened packets file for SDC: iois_1_packets_2025_295_16_55_15.partial
+2025/295-16:56:01.948 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_16_51_01.partial
+2025/295-16:56:01.948 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_16_56_01.partial
+2025/295-16:56:17.965 Deleting zero-length file: iois_1_packets_2025_295_16_55_15.partial
+2025/295-16:56:17.965 Opened packets file for SDC: iois_1_packets_2025_295_16_56_17.partial
+2025/295-16:57:18.027 Deleting zero-length file: iois_1_packets_2025_295_16_56_17.partial
+2025/295-16:57:18.027 Opened packets file for SDC: iois_1_packets_2025_295_16_57_18.partial
+2025/295-16:58:04.075 Periodic status report:
+ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)
+ 2  tlmrelay      295-16:45:03  277-08:58:24    0.0
+10  Kiel          295-13:54:00  295-05:19:13    0.0
+2025/295-16:58:20.092 Deleting zero-length file: iois_1_packets_2025_295_16_57_18.partial
+2025/295-16:58:20.093 Opened packets file for SDC: iois_1_packets_2025_295_16_58_20.partial
+2025/295-16:59:22.156 Deleting zero-length file: iois_1_packets_2025_295_16_58_20.partial
+2025/295-16:59:22.156 Opened packets file for SDC: iois_1_packets_2025_295_16_59_22.partial
+2025/295-17:00:24.221 Deleting zero-length file: iois_1_packets_2025_295_16_59_22.partial
+2025/295-17:00:24.221 Opened packets file for SDC: iois_1_packets_2025_295_17_00_24.partial
+2025/295-17:01:00.258 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_16_56_01.partial
+2025/295-17:01:00.258 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_17_01_00.partial
+2025/295-17:01:26.285 Deleting zero-length file: iois_1_packets_2025_295_17_00_24.partial
+2025/295-17:01:26.285 Opened packets file for SDC: iois_1_packets_2025_295_17_01_26.partial
+2025/295-17:02:28.350 Deleting zero-length file: iois_1_packets_2025_295_17_01_26.partial
+2025/295-17:02:28.350 Opened packets file for SDC: iois_1_packets_2025_295_17_02_28.partial
+2025/295-17:03:30.412 Deleting zero-length file: iois_1_packets_2025_295_17_02_28.partial
+2025/295-17:03:30.412 Opened packets file for SDC: iois_1_packets_2025_295_17_03_30.partial
+2025/295-17:04:32.477 Deleting zero-length file: iois_1_packets_2025_295_17_03_30.partial
+2025/295-17:04:32.477 Opened packets file for SDC: iois_1_packets_2025_295_17_04_32.partial
+2025/295-17:05:34.540 Deleting zero-length file: iois_1_packets_2025_295_17_04_32.partial
+2025/295-17:05:34.540 Opened packets file for SDC: iois_1_packets_2025_295_17_05_34.partial
+2025/295-17:06:00.568 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_17_01_00.partial
+2025/295-17:06:00.568 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_17_06_00.partial
+2025/295-17:06:36.604 Deleting zero-length file: iois_1_packets_2025_295_17_05_34.partial
+2025/295-17:06:36.605 Opened packets file for SDC: iois_1_packets_2025_295_17_06_36.partial
+2025/295-17:07:38.669 Deleting zero-length file: iois_1_packets_2025_295_17_06_36.partial
+2025/295-17:07:38.669 Opened packets file for SDC: iois_1_packets_2025_295_17_07_38.partial
+2025/295-17:08:40.734 Deleting zero-length file: iois_1_packets_2025_295_17_07_38.partial
+2025/295-17:08:40.734 Opened packets file for SDC: iois_1_packets_2025_295_17_08_40.partial
+2025/295-17:09:42.799 Deleting zero-length file: iois_1_packets_2025_295_17_08_40.partial
+2025/295-17:09:42.799 Opened packets file for SDC: iois_1_packets_2025_295_17_09_42.partial
+2025/295-17:10:44.864 Deleting zero-length file: iois_1_packets_2025_295_17_09_42.partial
+2025/295-17:10:44.864 Opened packets file for SDC: iois_1_packets_2025_295_17_10_44.partial
+2025/295-17:11:00.881 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_17_06_00.partial
+2025/295-17:11:00.881 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_17_11_00.partial
+2025/295-17:11:46.930 Deleting zero-length file: iois_1_packets_2025_295_17_10_44.partial
+2025/295-17:11:46.930 Opened packets file for SDC: iois_1_packets_2025_295_17_11_46.partial
+2025/295-17:12:48.994 Deleting zero-length file: iois_1_packets_2025_295_17_11_46.partial
+2025/295-17:12:48.994 Opened packets file for SDC: iois_1_packets_2025_295_17_12_48.partial
+2025/295-17:13:49.056 Deleting zero-length file: iois_1_packets_2025_295_17_12_48.partial
+2025/295-17:13:49.056 Opened packets file for SDC: iois_1_packets_2025_295_17_13_49.partial
+2025/295-17:14:51.122 Deleting zero-length file: iois_1_packets_2025_295_17_13_49.partial
+2025/295-17:14:51.122 Opened packets file for SDC: iois_1_packets_2025_295_17_14_51.partial
+2025/295-17:15:53.186 Deleting zero-length file: iois_1_packets_2025_295_17_14_51.partial
+2025/295-17:15:53.186 Opened packets file for SDC: iois_1_packets_2025_295_17_15_53.partial
+2025/295-17:16:01.195 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_17_11_00.partial
+2025/295-17:16:01.195 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_17_16_01.partial
+2025/295-17:16:55.251 Deleting zero-length file: iois_1_packets_2025_295_17_15_53.partial
+2025/295-17:16:55.251 Opened packets file for SDC: iois_1_packets_2025_295_17_16_55.partial
+2025/295-17:17:57.317 Deleting zero-length file: iois_1_packets_2025_295_17_16_55.partial
+2025/295-17:17:57.317 Opened packets file for SDC: iois_1_packets_2025_295_17_17_57.partial
+2025/295-17:18:59.377 Deleting zero-length file: iois_1_packets_2025_295_17_17_57.partial
+2025/295-17:18:59.377 Opened packets file for SDC: iois_1_packets_2025_295_17_18_59.partial
+2025/295-17:20:01.442 Deleting zero-length file: iois_1_packets_2025_295_17_18_59.partial
+2025/295-17:20:01.442 Opened packets file for SDC: iois_1_packets_2025_295_17_20_01.partial
+2025/295-17:21:01.500 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_17_16_01.partial
+2025/295-17:21:01.500 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_17_21_01.partial
+2025/295-17:21:03.502 Deleting zero-length file: iois_1_packets_2025_295_17_20_01.partial
+2025/295-17:21:03.502 Opened packets file for SDC: iois_1_packets_2025_295_17_21_03.partial
+2025/295-17:22:05.566 Deleting zero-length file: iois_1_packets_2025_295_17_21_03.partial
+2025/295-17:22:05.566 Opened packets file for SDC: iois_1_packets_2025_295_17_22_05.partial
+2025/295-17:23:07.629 Deleting zero-length file: iois_1_packets_2025_295_17_22_05.partial
+2025/295-17:23:07.630 Opened packets file for SDC: iois_1_packets_2025_295_17_23_07.partial
+2025/295-17:24:09.694 Deleting zero-length file: iois_1_packets_2025_295_17_23_07.partial
+2025/295-17:24:09.694 Opened packets file for SDC: iois_1_packets_2025_295_17_24_09.partial
+2025/295-17:25:11.753 Deleting zero-length file: iois_1_packets_2025_295_17_24_09.partial
+2025/295-17:25:11.754 Opened packets file for SDC: iois_1_packets_2025_295_17_25_11.partial
+2025/295-17:26:01.807 Deleting zero-length file: IOIS_1_raw_record_20_2025_295_17_21_01.partial
+2025/295-17:26:01.807 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2025_295_17_26_01.partial
+2025/295-17:26:13.820 Deleting zero-length file: iois_1_packets_2025_295_17_25_11.partial
+2025/295-17:26:13.820 Opened packets file for SDC: iois_1_packets_2025_295_17_26_13.partial
+2025/295-17:27:15.884 Deleting zero-length file: iois_1_packets_2025_295_17_26_13.partial
+2025/295-17:27:15.884 Opened packets file for SDC: iois_1_packets_2025_295_17_27_15.partial
+2025/295-17:28:05.937 Periodic status report:

--- a/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
+++ b/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
@@ -54,6 +54,40 @@ def test_find_tcp_connections():
     assert test["connection_times"]["Kiel"][0]["end"] == datetime.isoformat(time_1)
 
 
+def test_find_tcp_connections_no_info():
+    """Test the find_tcp_connections function if tcp connection up not present."""
+    filename = "flight_iois_1.log.2025-295T17-28-05.937369"
+    # File creation time minus 1 hr.
+    timestamp_str = filename.split(".")[2]
+    start_of_time = datetime.strptime(timestamp_str, "%Y-%jT%H-%M-%S") - timedelta(
+        hours=1
+    )
+    end_of_time = start_of_time + timedelta(hours=48)
+
+    with open(TEST_PATH / filename, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    formatted: dict[str, Any] = {
+        "summary": "I-ALiRT Real-time Ingest Summary",
+        "generated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "time_format": "UTC (ISOC)",
+        "stations": list(STATIONS),
+        "time_range": [
+            start_of_time.isoformat(),
+            end_of_time.isoformat(),
+        ],  # Overall time range of the data
+        "packet_ingest": [],  # Global packet ingest times
+        "connection_times": {
+            station: [] for station in list(STATIONS)
+        },  # Per-station TCP connection windows
+    }
+
+    test = find_tcp_connections(start_of_time, end_of_time, lines, formatted)
+
+    assert test["connection_times"]["Kiel"][0]["start"] == start_of_time.isoformat()
+    assert test["connection_times"]["Kiel"][0]["end"] == end_of_time.isoformat()
+
+
 def test_packets_created():
     """Test the packets_created function."""
     with open(

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -122,4 +122,4 @@ def test_dsn(furnish_kernels):
         )
 
         assert "I-ALiRT Coverage Summary" in output["summary"]
-        assert 37.5 == output["total_coverage_percent"]
+        assert 91.7 == output["total_coverage_percent"]


### PR DESCRIPTION
# Change Summary

## Overview
We had made the assumption that the tcp connection would go down (and then up again) after a DSN contact, but it seems that Kiel's tcp connection is perpetually stable, which is great! The issue is that our code was created to search for those messages "tcp up/down" in the logs. So the plots shown on the imap website show that there is no tcp connection, when indeed it is actually stable:
https://imap-mission.com/ialirt/packets

This PR searches for another message and if the tcp up/down message is not in the logs, we populate the tcp connection so that it is from the start/end time of the logs' timestamps if the secondary message appears ("Opened raw record file for {partner}")

I also added the coordinates for Korea.

## Updated Files
- calculate_ingest.py
   - Add alternative message in case "tcp up/down" is not present in the logs.

## Testing
- test_calculate_ingest.py
