### PR TITLE
ULTRA l1b flag dont filter events in a pointing 

### DIFF
--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -64,6 +64,7 @@ class ImapAttitudeUltraFlags(FlagNameMixin):
     AUXMISMATCH = 2**1  # bit 1 # aux packet does not match Universal Spin Table
     SPINPHASE = 2**2  # bit 2 # spin phase flagged by Universal Spin Table
     SPINPERIOD = 2**3  # bit 3 # spin period flagged by Universal Spin Table
+    DURINGREPOINT = 2**4  # bit 4 # spin during a repointing
 
 
 class ImapRatesUltraFlags(FlagNameMixin):

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -139,6 +139,7 @@ def test_calculate_events_in_pointing(use_fake_repoint_data_for_time):
     in_pointing = calculate_events_in_pointing(
         repoint_id,
         ttj2000ns_to_et(met_to_ttj2000ns(event_times)),
+        valid_events=np.ones(len(event_times), dtype=bool),
     )
     # The first event should be False (not during a pointing), and the rest True.
     assert np.all(not in_pointing[0])

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -136,14 +136,10 @@ def test_calculate_events_in_pointing(use_fake_repoint_data_for_time):
     event_times = np.arange(pointing_start, pointing_start + 10)
     # Edit the first event time to be during a repoint.
     event_times[0] = pointing_start - 1
-    valid_events = np.ones_like(event_times, dtype=bool)
-    quality_flags = np.zeros_like(event_times, dtype=np.uint32)
-    in_poiting = calculate_events_in_pointing(
+    in_pointing = calculate_events_in_pointing(
         repoint_id,
         ttj2000ns_to_et(met_to_ttj2000ns(event_times)),
-        valid_events,
-        quality_flags,
     )
     # The first event should be False (not during a pointing), and the rest True.
-    assert np.all(not in_poiting[0])
-    assert np.all(in_poiting[1:])
+    assert np.all(not in_pointing[0])
+    assert np.all(in_pointing[1:])

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -139,7 +139,6 @@ def test_calculate_events_in_pointing(use_fake_repoint_data_for_time):
     in_pointing = calculate_events_in_pointing(
         repoint_id,
         ttj2000ns_to_et(met_to_ttj2000ns(event_times)),
-        valid_events=np.ones(len(event_times), dtype=bool),
     )
     # The first event should be False (not during a pointing), and the rest True.
     assert np.all(not in_pointing[0])

--- a/imap_processing/tests/ultra/unit/test_de.py
+++ b/imap_processing/tests/ultra/unit/test_de.py
@@ -137,8 +137,12 @@ def test_calculate_events_in_pointing(use_fake_repoint_data_for_time):
     # Edit the first event time to be during a repoint.
     event_times[0] = pointing_start - 1
     valid_events = np.ones_like(event_times, dtype=bool)
+    quality_flags = np.zeros_like(event_times, dtype=np.uint32)
     in_poiting = calculate_events_in_pointing(
-        repoint_id, ttj2000ns_to_et(met_to_ttj2000ns(event_times)), valid_events
+        repoint_id,
+        ttj2000ns_to_et(met_to_ttj2000ns(event_times)),
+        valid_events,
+        quality_flags,
     )
     # The first event should be False (not during a pointing), and the rest True.
     assert np.all(not in_poiting[0])

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -107,13 +107,16 @@ def test_cdf_de(
     de_dataset,
     use_fake_spin_data_for_time,
     ancillary_files,
+    use_fake_repoint_data_for_time,
 ):
     """Tests that CDF file is created and contains same attributes as xarray."""
 
     data_dict = {}
+    de_dataset.attrs["Repointing"] = "repoint00001"
     data_dict[de_dataset.attrs["Logical_source"]] = de_dataset
     # Create a spin table that cover spin 0-141
-    use_fake_spin_data_for_time(0, 141 * 15)
+    use_fake_spin_data_for_time(511000000, 511000000 + 86400 * 5)
+    use_fake_repoint_data_for_time(np.arange(511000000, 511000000 + 86400 * 5, 86400))
 
     # Mock get_annotated_particle_velocity to avoid needing kernels
     def side_effect_func(event_times, position, ultra_frame, dps_frame, sc_frame):
@@ -158,7 +161,6 @@ def test_ultra_l1b_extendedspin(
         TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf"
     )
     l1b_de_dataset = load_cdf(l1b_de_dataset_path)
-
     data_dict = {
         key: l1b_de_dataset
         for key in [

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -423,13 +423,10 @@ def calculate_events_in_pointing(
     pointing_start_met = repoint_row["repoint_end_met"].values[0]
     pointing_end_met = next_repoint_row["repoint_start_met"].values[0]
 
-    # Create a boolean array for events within the pointing
-    in_pointing = np.zeros(len(event_times), dtype=bool)
-
     # Check which events are within the pointing
-    in_pointing[valid_events] = (
-        et_to_met(event_times[valid_events]) >= pointing_start_met
-    ) & (et_to_met(event_times[valid_events]) <= pointing_end_met)
+    in_pointing = (et_to_met(event_times) >= pointing_start_met) & (
+        et_to_met(event_times) <= pointing_end_met
+    )
 
     quality_flags[~in_pointing] |= ImapAttitudeUltraFlags.DURINGREPOINT.value
     return in_pointing

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.quality_flags import (
+    ImapAttitudeUltraFlags,
     ImapDEOutliersUltraFlags,
     ImapDEScatteringUltraFlags,
 )
@@ -321,7 +322,7 @@ def calculate_de(
     # TODO - find a better solution than filtering out data from repointings?
     if repoint_id is not None:
         in_pointing = calculate_events_in_pointing(
-            repoint_id, event_times, valid_events
+            repoint_id, event_times, valid_events, quality_flags
         )
         # Update valid_events to only include times within a pointing
         valid_events &= in_pointing
@@ -383,15 +384,15 @@ def calculate_de(
     de_dict["quality_scattering"] = scattering_quality_flags
 
     dataset = create_dataset(de_dict, name, "l1b")
-    if repoint_id is not None:
-        # filter out the dataset to only include events in pointing
-        dataset = dataset.isel(epoch=in_pointing)
 
     return dataset
 
 
 def calculate_events_in_pointing(
-    repoint_id: int, event_times: np.ndarray, valid_events: np.ndarray
+    repoint_id: int,
+    event_times: np.ndarray,
+    valid_events: np.ndarray,
+    quality_flags: np.ndarray,
 ) -> np.ndarray:
     """
     Calculate boolean array of events within a pointing.
@@ -404,6 +405,8 @@ def calculate_events_in_pointing(
         Array of event times in ET.
     valid_events : np.ndarray
         Boolean array indicating valid events.
+    quality_flags : np.ndarray
+        Array of quality flags to be updated.
 
     Returns
     -------
@@ -428,4 +431,5 @@ def calculate_events_in_pointing(
         et_to_met(event_times[valid_events]) >= pointing_start_met
     ) & (et_to_met(event_times[valid_events]) <= pointing_end_met)
 
+    quality_flags[~in_pointing] |= ImapAttitudeUltraFlags.DURINGREPOINT.value
     return in_pointing

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -407,7 +407,7 @@ def calculate_events_in_pointing(
     event_times : np.ndarray
         Array of event times in ET.
     valid_events : np.ndarray
-        Boolean array indicating valid event_times.
+        Boolean array indicating valid events.
 
     Returns
     -------
@@ -423,9 +423,13 @@ def calculate_events_in_pointing(
     next_repoint_row = repoint_data[repoint_data["repoint_id"] == repoint_id + 1]
     pointing_start_met = repoint_row["repoint_end_met"].values[0]
     pointing_end_met = next_repoint_row["repoint_start_met"].values[0]
+
+    # Create a boolean array for events within the pointing
     in_pointing = np.zeros(len(event_times), dtype=bool)
+
     # Check which events are within the pointing
     in_pointing[valid_events] = (
         et_to_met(event_times[valid_events]) >= pointing_start_met
     ) & (et_to_met(event_times[valid_events]) <= pointing_end_met)
+
     return in_pointing

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -321,9 +321,13 @@ def calculate_de(
     valid_events = event_times != FILLVAL_FLOAT32
     # TODO - find a better solution than filtering out data from repointings?
     if repoint_id is not None:
-        in_pointing = calculate_events_in_pointing(repoint_id, event_times)
-        # Update quality flags for events outside pointing
-        quality_flags[~in_pointing] |= ImapAttitudeUltraFlags.DURINGREPOINT.value
+        in_pointing = calculate_events_in_pointing(
+            repoint_id, event_times, valid_events
+        )
+        # Update quality flags for valid events that are not in the pointing
+        quality_flags[valid_events & ~in_pointing] |= (
+            ImapAttitudeUltraFlags.DURINGREPOINT.value
+        )
         # Update valid_events to only include times within a pointing
         valid_events &= in_pointing
 
@@ -391,6 +395,7 @@ def calculate_de(
 def calculate_events_in_pointing(
     repoint_id: int,
     event_times: np.ndarray,
+    valid_events: np.ndarray,
 ) -> np.ndarray:
     """
     Calculate boolean array of events within a pointing.
@@ -401,6 +406,8 @@ def calculate_events_in_pointing(
         The repointing ID.
     event_times : np.ndarray
         Array of event times in ET.
+    valid_events : np.ndarray
+        Boolean array indicating valid event_times.
 
     Returns
     -------
@@ -416,9 +423,9 @@ def calculate_events_in_pointing(
     next_repoint_row = repoint_data[repoint_data["repoint_id"] == repoint_id + 1]
     pointing_start_met = repoint_row["repoint_end_met"].values[0]
     pointing_end_met = next_repoint_row["repoint_start_met"].values[0]
-
+    in_pointing = np.zeros(len(event_times), dtype=bool)
     # Check which events are within the pointing
-    in_pointing = (et_to_met(event_times) >= pointing_start_met) & (
-        et_to_met(event_times) <= pointing_end_met
-    )
+    in_pointing[valid_events] = (
+        et_to_met(event_times[valid_events]) >= pointing_start_met
+    ) & (et_to_met(event_times[valid_events]) <= pointing_end_met)
     return in_pointing

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -321,9 +321,9 @@ def calculate_de(
     valid_events = event_times != FILLVAL_FLOAT32
     # TODO - find a better solution than filtering out data from repointings?
     if repoint_id is not None:
-        in_pointing = calculate_events_in_pointing(
-            repoint_id, event_times, quality_flags
-        )
+        in_pointing = calculate_events_in_pointing(repoint_id, event_times)
+        # Update quality flags for events outside pointing
+        quality_flags[~in_pointing] |= ImapAttitudeUltraFlags.DURINGREPOINT.value
         # Update valid_events to only include times within a pointing
         valid_events &= in_pointing
 
@@ -391,7 +391,6 @@ def calculate_de(
 def calculate_events_in_pointing(
     repoint_id: int,
     event_times: np.ndarray,
-    quality_flags: np.ndarray,
 ) -> np.ndarray:
     """
     Calculate boolean array of events within a pointing.
@@ -402,8 +401,6 @@ def calculate_events_in_pointing(
         The repointing ID.
     event_times : np.ndarray
         Array of event times in ET.
-    quality_flags : np.ndarray
-        Array of quality flags to be updated.
 
     Returns
     -------
@@ -424,6 +421,4 @@ def calculate_events_in_pointing(
     in_pointing = (et_to_met(event_times) >= pointing_start_met) & (
         et_to_met(event_times) <= pointing_end_met
     )
-
-    quality_flags[~in_pointing] |= ImapAttitudeUltraFlags.DURINGREPOINT.value
     return in_pointing

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -318,18 +318,18 @@ def calculate_de(
     ultra_frame = getattr(SpiceFrame, f"IMAP_ULTRA_{sensor}")
 
     # Account for counts=0 (event times have FILL value)
-    valid_events = event_times != FILLVAL_FLOAT32
+    valid_events = (event_times != FILLVAL_FLOAT32).copy()
     # TODO - find a better solution than filtering out data from repointings?
     if repoint_id is not None:
         in_pointing = calculate_events_in_pointing(
-            repoint_id, event_times, valid_events
+            repoint_id, event_times[valid_events]
         )
         # Update quality flags for valid events that are not in the pointing
-        quality_flags[valid_events & ~in_pointing] |= (
+        quality_flags[valid_events][~in_pointing] |= (
             ImapAttitudeUltraFlags.DURINGREPOINT.value
         )
         # Update valid_events to only include times within a pointing
-        valid_events &= in_pointing
+        valid_events[valid_events] &= in_pointing
 
     if np.any(valid_events):
         (
@@ -395,7 +395,6 @@ def calculate_de(
 def calculate_events_in_pointing(
     repoint_id: int,
     event_times: np.ndarray,
-    valid_events: np.ndarray,
 ) -> np.ndarray:
     """
     Calculate boolean array of events within a pointing.
@@ -406,8 +405,6 @@ def calculate_events_in_pointing(
         The repointing ID.
     event_times : np.ndarray
         Array of event times in ET.
-    valid_events : np.ndarray
-        Boolean array indicating valid events.
 
     Returns
     -------
@@ -424,12 +421,9 @@ def calculate_events_in_pointing(
     pointing_start_met = repoint_row["repoint_end_met"].values[0]
     pointing_end_met = next_repoint_row["repoint_start_met"].values[0]
 
-    # Create a boolean array for events within the pointing
-    in_pointing = np.zeros(len(event_times), dtype=bool)
-
     # Check which events are within the pointing
-    in_pointing[valid_events] = (
-        et_to_met(event_times[valid_events]) >= pointing_start_met
-    ) & (et_to_met(event_times[valid_events]) <= pointing_end_met)
+    in_pointing = (et_to_met(event_times) >= pointing_start_met) & (
+        et_to_met(event_times) <= pointing_end_met
+    )
 
     return in_pointing

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -322,7 +322,7 @@ def calculate_de(
     # TODO - find a better solution than filtering out data from repointings?
     if repoint_id is not None:
         in_pointing = calculate_events_in_pointing(
-            repoint_id, event_times, valid_events, quality_flags
+            repoint_id, event_times, quality_flags
         )
         # Update valid_events to only include times within a pointing
         valid_events &= in_pointing
@@ -391,7 +391,6 @@ def calculate_de(
 def calculate_events_in_pointing(
     repoint_id: int,
     event_times: np.ndarray,
-    valid_events: np.ndarray,
     quality_flags: np.ndarray,
 ) -> np.ndarray:
     """
@@ -403,8 +402,6 @@ def calculate_events_in_pointing(
         The repointing ID.
     event_times : np.ndarray
         Array of event times in ET.
-    valid_events : np.ndarray
-        Boolean array indicating valid events.
     quality_flags : np.ndarray
         Array of quality flags to be updated.
 


### PR DESCRIPTION
# Change Summary

## Overview
Instead of filtering the entire dataset for events within the pointing I should instead, use the fill value and flag those events. 

## Updated Files
- imap_processing/quality_flags.py
   - Add new quality flag
- imap_processing/ultra/l1b/de.py
   - Do not filter the entire dataset!! Just flag the repointing events. 

## Testing
Fix test. 
