### PR TITLE
Lo L1B DE - Binning fixes

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -19,6 +19,7 @@ from imap_processing.lo.l1b.tof_conversions import (
 from imap_processing.spice.geometry import (
     SpiceFrame,
     cartesian_to_latitudinal,
+    frame_transform,
     instrument_pointing,
 )
 from imap_processing.spice.repoint import get_pointing_times
@@ -761,7 +762,7 @@ def set_bad_or_goodtimes(
     # 0.1 degree bins to align with the spin_bins, so multiply by 60
     time_mask = (epochs[:, None] >= times_start) & (epochs[:, None] <= times_end)
     bin_mask = (spin_bins[:, None] >= times_df["bin_start"].values * 60) & (
-        spin_bins[:, None] <= times_df["bin_end"].values * 60
+        spin_bins[:, None] < (times_df["bin_end"].values + 1) * 60
     )
 
     # Combined mask for epochs that fall within the time and bin ranges
@@ -853,8 +854,15 @@ def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
     x = l1b_de["hae_x"]
     y = l1b_de["hae_y"]
     z = l1b_de["hae_z"]
+    # Convert from HAE to DPS coordinates
+    dps_xyz = frame_transform(
+        ttj2000ns_to_et(l1b_de["epoch"]),
+        np.column_stack((x, y, z)),
+        SpiceFrame.IMAP_HAE,
+        SpiceFrame.IMAP_DPS,
+    )
     # convert the pointing direction to latitudinal coordinates
-    direction = cartesian_to_latitudinal(np.column_stack((x, y, z)))
+    direction = cartesian_to_latitudinal(dps_xyz)
     # first column: radius (Not needed)
     # second column: longitude
     lons = direction[:, 1]

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -761,6 +761,8 @@ def set_bad_or_goodtimes(
     # the bin_start and bin_end are 6 degree bins and need to be converted to
     # 0.1 degree bins to align with the spin_bins, so multiply by 60
     time_mask = (epochs[:, None] >= times_start) & (epochs[:, None] <= times_end)
+    # The ancillary file binning uses 0-59 for the 6 degree bins, so add 1 to bin_end
+    # so the upper bound is inclusive of the full bin range.
     bin_mask = (spin_bins[:, None] >= times_df["bin_start"].values * 60) & (
         spin_bins[:, None] < (times_df["bin_end"].values + 1) * 60
     )

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -295,8 +295,8 @@ def create_pset_counts(
     data = np.column_stack(
         (
             de_filtered["esa_step"],
-            de_filtered["pointing_bin_lon"],
-            de_filtered["pointing_bin_lat"],
+            de_filtered["spin_bin"],
+            de_filtered["off_angle_bin"],
         )
     )
     # Create the histogram with 3600 longitude bins, 40 latitude bins, and 7 energy bins
@@ -341,7 +341,7 @@ def calculate_exposure_times(counts: xr.DataArray, l1b_de: xr.Dataset) -> xr.Dat
         The exposure times for the L1B Direct Event dataset.
     """
     data = np.column_stack(
-        (l1b_de["esa_step"], l1b_de["pointing_bin_lon"], l1b_de["pointing_bin_lat"])
+        (l1b_de["esa_step"], l1b_de["spin_bin"], l1b_de["off_angle_bin"])
     )
 
     result = binned_statistic_dd(
@@ -628,7 +628,7 @@ def set_pointing_directions(epoch: float) -> tuple[xr.DataArray, xr.DataArray]:
     hae_latitude : xr.DataArray
         The HAE latitude for each spin and off angle bin.
     """
-    et = ttj2000ns_to_et(epoch)
+    et = ttj2000ns_to_et(epoch) + 1
     # create a meshgrid of spin and off angles using the bin centers
     spin, off = np.meshgrid(
         SPIN_ANGLE_BIN_CENTERS, OFF_ANGLE_BIN_CENTERS, indexing="ij"

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -302,7 +302,7 @@ def create_pset_counts(
     # Create the histogram with 3600 longitude bins, 40 latitude bins, and 7 energy bins
     lon_edges = np.arange(3601)
     lat_edges = np.arange(41)
-    energy_edges = np.arange(8)
+    energy_edges = np.arange(1, 9)
 
     hist, edges = np.histogramdd(
         data,

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -628,7 +628,7 @@ def set_pointing_directions(epoch: float) -> tuple[xr.DataArray, xr.DataArray]:
     hae_latitude : xr.DataArray
         The HAE latitude for each spin and off angle bin.
     """
-    et = ttj2000ns_to_et(epoch) + 1
+    et = ttj2000ns_to_et(epoch)
     # create a meshgrid of spin and off angles using the bin centers
     spin, off = np.meshgrid(
         SPIN_ANGLE_BIN_CENTERS, OFF_ANGLE_BIN_CENTERS, indexing="ij"

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -78,6 +78,10 @@ def attr_mgr_l1a():
 
 
 @patch(
+    "imap_processing.lo.l1b.lo_l1b.frame_transform",
+    return_value=np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]),
+)
+@patch(
     "imap_processing.lo.l1b.lo_l1b.instrument_pointing",
     return_value=np.zeros((2000, 3)),
 )
@@ -91,6 +95,7 @@ def attr_mgr_l1a():
     return_value=np.zeros((2000, 3)),
 )
 def test_lo_l1b(
+    mock_frame_transform,
     mock_instrument_pointing,
     mocked_get_pointing_times,
     mock_spin_number,
@@ -631,10 +636,14 @@ def test_set_direction(imap_ena_sim_metakernel):
 
 
 @patch(
+    "imap_processing.lo.l1b.lo_l1b.frame_transform",
+    return_value=np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]),
+)
+@patch(
     "imap_processing.lo.l1b.lo_l1b.cartesian_to_latitudinal",
     return_value=np.array([[0, -180, -2], [0, 0, 0], [0, 90, 1], [0, 180, 2]]),
 )
-def test_pointing_bins(imap_ena_sim_metakernel):
+def test_pointing_bins(mock_cartesian_to_latitudinal, mock_frame_transform):
     # Arrange
     l1b_de = xr.Dataset(
         {

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -23,8 +23,8 @@ from imap_processing.spice.time import met_to_ttj2000ns
 def l1b_de():
     l1b_de = xr.Dataset(
         {
-            "pointing_bin_lon": ("epoch", [20, 0, 20, 2000, 3500]),
-            "pointing_bin_lat": ("epoch", [20, 20, 20, 20, 20]),
+            "spin_bin": ("epoch", [20, 0, 20, 2000, 3500]),
+            "off_angle_bin": ("epoch", [20, 20, 20, 20, 20]),
             "esa_step": ("epoch", [1, 2, 1, 4, 5]),
             "coincidence_type": (
                 "epoch",
@@ -39,7 +39,6 @@ def l1b_de():
             "species": ("epoch", ["H", "O", "H", "H", "O"]),
             "spin_cycle": ("epoch", [1, 2, 3, 4, 5]),
             "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9]),
-            "spin_bin": ("epoch", [1900, 2000, 3000, 3000, 3000]),
         },
         coords={
             "epoch": [
@@ -64,8 +63,8 @@ def repoint_met():
 def l1b_de_spin():
     l1b_de = xr.Dataset(
         {
-            "pointing_bin_lon": ("epoch", [20, 0, 20, 2000, 3500]),
-            "pointing_bin_lat": ("epoch", [20, 20, 20, 20, 20]),
+            "spin_bin": ("epoch", [20, 0, 20, 2000, 3500]),
+            "off_angle_bin": ("epoch", [20, 20, 20, 20, 20]),
             "esa_step": ("epoch", [1, 2, 1, 4, 5]),
             "coincidence_type": (
                 "epoch",
@@ -80,7 +79,6 @@ def l1b_de_spin():
             "species": ("epoch", ["H", "O", "H", "H", "O"]),
             "spin_cycle": ("epoch", [1, 2, 3, 4, 5]),
             "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9]),
-            "spin_bin": ("epoch", [1900, 2000, 3000, 3000, 3000]),
         },
         coords={
             "epoch": met_to_ttj2000ns(np.arange(511000000, 511000000 + 200, 40) + 902),


### PR DESCRIPTION
# Change Summary

## Overview
This PR makes some fixes to the L1B DE binning:

- Convert to DPS frame for binning
- Fix goodtimes/badtimes bin window checks
- Update naming in pset code to align with updated DE code

These fixes are unrelated to the PSET validation currently happening with Lo. The DE CDF being used for that validation is prior to these bugs being introduced. I re-ran my checks of DE counts vs PSET counts and, like the previous DE CDF that Lo is working with, the DE/PSET comparisons are matching with the new set of DE/PSET with this update.

Thank you @subagonsouth for your help with the transform!