### PR TITLE
Adjust pyproject.toml so it can be built by `uv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ test = ["openpyxl", "pytest", "pytest-cov", "pytest-xdist", "requests", "netcdf4
 tools = ["openpyxl", "pandas"]
 map_visualization = ["healpy"]
 
+[project]
+name = "imap-processing"
+
 [project.urls]
 homepage = "https://github.com/IMAP-Science-Operations-Center"
 repository = "https://github.com/IMAP-Science-Operations-Center/imap_processing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ map_visualization = ["healpy"]
 
 [project]
 name = "imap-processing"
+dynamic = ["version"]
 
 [project.urls]
 homepage = "https://github.com/IMAP-Science-Operations-Center"


### PR DESCRIPTION
Downstream consumers `imap_L3_processing` and the IMAP `mapping_tool` use `uv` for managing dependencies. When building a package from source, `uv` requires the `project.name` and `project.version` fields to be populated if the `project` table is present at all in the `pyproject.toml` file.  

Because the project version is determined dynamically by poetry, we have marked it as dynamic in the project table rather than setting a specific version.