### PR TITLE
2350 - BUG - ena_maps pixel masking broken for push projection

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -845,6 +845,7 @@ class AbstractSkyMap(ABC):
             raise KeyError(f"Value keys not found in pointing set: {missing_keys}")
 
         if pset_valid_mask is None:
+            logger.debug("No pset_valid_mask provided, using all pixels as valid.")
             pset_valid_mask = np.ones(pointing_set.num_points, dtype=bool)
 
         if index_match_method is IndexMatchMethod.PUSH:
@@ -906,8 +907,14 @@ class AbstractSkyMap(ABC):
                     stacked_valid_mask = pset_valid_mask.stack(
                         {CoordNames.GENERIC_PIXEL.value: pointing_set.spatial_coords}
                     )
-                    pset_valid_mask_bc, _ = xr.broadcast(data_bc, stacked_valid_mask)
+                    _, pset_valid_mask_bc = xr.broadcast(data_bc, stacked_valid_mask)
                     pset_valid_mask_values = pset_valid_mask_bc.values
+                    logger.debug(
+                        f"pset_valid_mask with shape: {pset_valid_mask.shape}"
+                        f"has been broadcasted to shape: {pset_valid_mask_values.shape}"
+                        f"with {np.prod(pset_valid_mask_values.shape)} elements,"
+                        f"{np.sum(pset_valid_mask_values)} of which are true."
+                    )
                 else:
                     pset_valid_mask_values = pset_valid_mask
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -909,12 +909,6 @@ class AbstractSkyMap(ABC):
                     )
                     _, pset_valid_mask_bc = xr.broadcast(data_bc, stacked_valid_mask)
                     pset_valid_mask_values = pset_valid_mask_bc.values
-                    logger.debug(
-                        f"pset_valid_mask with shape: {pset_valid_mask.shape}"
-                        f"has been broadcasted to shape: {pset_valid_mask_values.shape}"
-                        f"with {np.prod(pset_valid_mask_values.shape)} elements,"
-                        f"{np.sum(pset_valid_mask_values)} of which are true."
-                    )
                 else:
                     pset_valid_mask_values = pset_valid_mask
 

--- a/imap_processing/ena_maps/utils/map_utils.py
+++ b/imap_processing/ena_maps/utils/map_utils.py
@@ -191,10 +191,6 @@ def bin_single_array_at_indices(
     values = value_array[..., input_indices]
 
     # Apply mask: set invalid values to 0
-    logger.debug(
-        f"input_valid_mask keeps {np.sum(input_valid_mask_bc)} elements"
-        f"of {np.prod(values.shape)} possible values to bin."
-    )
     values_masked = np.where(input_valid_mask_bc, values, 0)
 
     num_projection_indices = int(np.prod(projection_grid_shape))

--- a/imap_processing/ena_maps/utils/map_utils.py
+++ b/imap_processing/ena_maps/utils/map_utils.py
@@ -191,6 +191,10 @@ def bin_single_array_at_indices(
     values = value_array[..., input_indices]
 
     # Apply mask: set invalid values to 0
+    logger.debug(
+        f"input_valid_mask keeps {np.sum(input_valid_mask_bc)} elements"
+        f"of {np.prod(values.shape)} possible values to bin."
+    )
     values_masked = np.where(input_valid_mask_bc, values, 0)
 
     num_projection_indices = int(np.prod(projection_grid_shape))

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -156,8 +156,18 @@ def generate_hi_map(
         pset_valid_mask = None  # Default to no mask (full spin)
         if descriptor.spin_phase == "ram":
             pset_valid_mask = pset.data["ram_mask"]
+            logger.debug(
+                f"Using ram mask with shape: {pset_valid_mask.shape} "
+                f"containing {np.prod(pset_valid_mask.shape)} pixels,"
+                f"{np.sum(pset_valid_mask)} of which are True."
+            )
         elif descriptor.spin_phase == "anti":
             pset_valid_mask = ~pset.data["ram_mask"]
+            logger.debug(
+                f"Using anti-ram mask with shape: {pset_valid_mask.shape} "
+                f"containing {np.prod(pset_valid_mask.shape)} pixels,"
+                f"{np.sum(pset_valid_mask)} of which are True."
+            )
 
         # Project (bin) the PSET variables into the map pixels
         output_map.project_pset_values_to_map(

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -159,14 +159,14 @@ def generate_hi_map(
             logger.debug(
                 f"Using ram mask with shape: {pset_valid_mask.shape} "
                 f"containing {np.prod(pset_valid_mask.shape)} pixels,"
-                f"{np.sum(pset_valid_mask)} of which are True."
+                f"{np.sum(pset_valid_mask.values)} of which are True."
             )
         elif descriptor.spin_phase == "anti":
             pset_valid_mask = ~pset.data["ram_mask"]
             logger.debug(
                 f"Using anti-ram mask with shape: {pset_valid_mask.shape} "
                 f"containing {np.prod(pset_valid_mask.shape)} pixels,"
-                f"{np.sum(pset_valid_mask)} of which are True."
+                f"{np.sum(pset_valid_mask.values)} of which are True."
             )
 
         # Project (bin) the PSET variables into the map pixels

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -704,6 +704,11 @@ class TestRectangularSkyMap:
 
         rect_pset = self.rectangular_psets[0]
 
+        # Set all counts to a uniform non-zero value
+        rect_pset.data["counts"] = xr.full_like(
+            rect_pset.data["counts"], fill_value=10.0
+        )
+
         # Create a DataArray mask matching the pset spatial dimensions
         valid_mask = xr.DataArray(
             np.ones(rect_pset.data["counts"].shape[2:], dtype=bool),
@@ -713,7 +718,8 @@ class TestRectangularSkyMap:
             },
         )
         # Mask out one quadrant
-        valid_mask[:90, :90] = False
+        valid_mask_shape = valid_mask.shape
+        valid_mask[: valid_mask_shape[0] // 2, : valid_mask_shape[1] // 2] = False
 
         # Project with DataArray mask
         rectangular_map.project_pset_values_to_map(
@@ -726,6 +732,17 @@ class TestRectangularSkyMap:
         # Map should have data
         assert "counts" in rectangular_map.data_1d
         assert rectangular_map.data_1d["counts"].sum() > 0
+
+        # Check that pixel mask reduces total map counts to ~3/4 of pset counts
+        total_pset_counts = rect_pset.data["counts"].sum()
+        expected_map_counts = total_pset_counts * 3 / 4  # Only half should be included
+        actual_map_counts = rectangular_map.data_1d["counts"].sum()
+        np.testing.assert_allclose(
+            actual_map_counts,
+            expected_map_counts,
+            rtol=0.1,
+            err_msg=("Mask filtering failed"),
+        )
 
     @pytest.mark.usefixtures("_setup_rectangular_l1c_pset_products")
     @mock.patch("imap_processing.spice.geometry.frame_transform_az_el")


### PR DESCRIPTION
# Change Summary

## Overview
From Hi Helio-frame validation, I found a bug in how the pixel mask was being applied. This PR fixes that bug.

## Updated Files
- imap_processing/ena_maps/ena_maps.py
   - Add debugging statements to help find the pixel mask bug
   - Fix bug causing `valid_pixel_mask` to get swapped with pixel values
- imap_processing/ena_maps/utils/map_utils.py
   - Add debugging statements to help find the pixel mask bug
- imap_processing/hi/hi_l2.py
   - Add debug messages about pixels being masked as ram/anti-ram
- imap_processing/tests/ena_maps/test_ena_maps.py
   - Update test to explicitly check that masking is being applied correctly

Closes: #2350 