### PR TITLE
Add Lo l2 map metadata

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -155,7 +155,7 @@ ena_intensity_sys_err:
   DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
-ena_rate:
+ena_count_rate:
   <<: *default_float32
   CATDESC: Mono-energetic ENA Rate.
   FIELDNAM: Rate
@@ -165,6 +165,17 @@ ena_rate:
   LABLAXIS: Rate
   DISPLAY_TYPE: map_image
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+
+ena_count_rate_stat_uncert:
+  <<: *default_float32
+  CATDESC: ENA Rate statistical uncertainty.
+  FIELDNAM: Rate Uncertainty
+  UNITS: counts/s
+  DEPEND_0: epoch
+  VAR_TYPE: support_data
+  LABLAXIS: Rate Uncertainty
+  DISPLAY_TYPE: map_image
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 bg_rate:
   <<: *default_float32
@@ -177,6 +188,54 @@ bg_rate:
   DISPLAY_TYPE: map_image
   FORMAT: F6.3
   DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+
+bg_rate_uncert:
+  <<: *default_float32
+  CATDESC: Uncertainty in the background count rate from non-ENA (non-heliospheric) sources.
+  FIELDNAM: Background Rate Uncertainty
+  UNITS: count s-1
+  DEPEND_0: epoch
+  VAR_TYPE: support_data
+  LABLAXIS: Rate Uncertainty
+  DISPLAY_TYPE: map_image
+  FORMAT: F6.3
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+
+bg_intensity:
+  <<: *default_float32
+  CATDESC: Total background intensity from non-ENA (non-heliospheric) sources
+  FIELDNAM: Background Intensity
+  UNITS: cm -2 s -1 sr -1 keV -1
+  DEPEND_0: epoch
+  VAR_TYPE: data
+  LABLAXIS: Intensity
+  DISPLAY_TYPE: map_image
+  FORMAT: F8.3
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Incident,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+
+bg_intensity_stat_uncert:
+  <<: *default_float32
+  CATDESC: Uncertainty in the background intensity from non-ENA (non-heliospheric) sources.
+  FIELDNAM: Background Intensity Statistical Uncertainty
+  UNITS: cm -2 s -1 sr -1 keV -1
+  DEPEND_0: epoch
+  VAR_TYPE: support_data
+  LABLAXIS: Intensity Uncertainty
+  DISPLAY_TYPE: map_image
+  FORMAT: F8.3
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+
+bg_intensity_sys_err:
+  <<: *default_float32
+  CATDESC: Non-statistical error in the background intensity from non-ENA (non-heliospheric) sources.
+  FIELDNAM: Background Intensity Non-statistical Error
+  UNITS: cm -2 s -1 sr -1 keV -1
+  DEPEND_0: epoch
+  VAR_TYPE: support_data
+  LABLAXIS: Intensity Non-statistical Error
+  DISPLAY_TYPE: map_image
+  FORMAT: F8.3
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
 
 ena_count:
   <<: *default_float32

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -99,7 +99,15 @@ ena_intensity_sys_err:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
-ena_rate:
+ena_count_rate:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+ena_count_rate_stat_uncert:
   DEPEND_1: energy
   DEPEND_2: longitude
   DEPEND_3: latitude
@@ -124,6 +132,38 @@ sensitivity:
   LABL_PTR_3: latitude_label
 
 bg_rate:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+bg_rate_uncert:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+bg_intensity:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+bg_intensity_stat_uncert:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+bg_intensity_sys_err:
   DEPEND_1: energy
   DEPEND_2: longitude
   DEPEND_3: latitude

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1273,6 +1273,7 @@ class RectangularSkyMap(AbstractSkyMap):
         descriptor: str,
         sensor: str | None = None,
         drop_vars_with_no_attributes: bool = True,
+        external_map_dataset: xr.Dataset | None = None,
     ) -> xr.Dataset:
         """
         Format the data into a xarray.Dataset and add required CDF variables.
@@ -1293,6 +1294,12 @@ class RectangularSkyMap(AbstractSkyMap):
             the output CDF doesn't have any of the intermedeiate variables left
             over from computations. Sometimes, it is useful to output the
             intermedeiate variables. To do so, set this to False.
+        external_map_dataset : xarray.Dataset, optional
+            If provided, this dataset will be used as the base dataset to
+            build the CDF dataset from, instead of using the internal map data.
+            This is useful if additional processing has been done to the map data
+            after projection, and those results need to be included in the CDF.
+            Default is None.
 
         Returns
         -------
@@ -1308,7 +1315,10 @@ class RectangularSkyMap(AbstractSkyMap):
 
         logger.info("Building CDF ready dataset from RectangularSkyMap data.")
 
-        cdf_ds = self.to_dataset()
+        if external_map_dataset is not None:
+            cdf_ds = external_map_dataset
+        else:
+            cdf_ds = self.to_dataset()
 
         # Set the value of the epoch coord
         cdf_ds = cdf_ds.assign_coords(**{CoordNames.TIME.value: [self.min_epoch]})

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -98,7 +98,9 @@ def lo_l2(
     )
 
     logger.info("Step 5: Finalizing dataset with attributes")
-    dataset = finalize_dataset(dataset, descriptor)
+    dataset = sky_map.build_cdf_dataset(  # type: ignore[attr-defined]
+        instrument="lo", level="l2", descriptor=descriptor, external_map_dataset=dataset
+    )
 
     logger.info("IMAP-Lo L2 processing pipeline completed successfully")
     return [dataset]
@@ -603,7 +605,8 @@ def initialize_geometric_factor_variables(
     """
     gf_vars = [
         "energy",
-        "energy_stat_uncert",
+        "energy_delta_minus",
+        "energy_delta_plus",
         "geometric_factor",
         "geometric_factor_stat_uncert",
     ]
@@ -649,17 +652,20 @@ def populate_geometric_factors(
     if species == "h":
         gf_vars = {
             "energy": "Cntr_E",
-            "energy_stat_uncert": "Cntr_E_unc",
             "geometric_factor": "GF_Trpl_H",
             "geometric_factor_stat_uncert": "GF_Trpl_H_unc",
         }
+        # NOTE: From an e-mail from Nathan on 2025-09-11
+        energy_delta_hires_values = [5.43, 10.02, 18.61, 33.31, 64.98, 131.64, 262.35]
+        energy_delta_hithr_values = [8.81, 16.04, 28.50, 53.13, 105.60, 219.67, 413.60]
     else:  # species == "o"
         gf_vars = {
             "energy": "Cntr_E",
-            "energy_stat_uncert": "Cntr_E_unc",
             "geometric_factor": "GF_Trpl_O",
             "geometric_factor_stat_uncert": "GF_Trpl_O_unc",
         }
+        energy_delta_hires_values = [5.82, 11.10, 21.78, 41.47, 85.61, 180.67, 361.93]
+        energy_delta_hithr_values = [9.45, 17.84, 33.51, 66.61, 139.95, 302.24, 569.48]
 
     # Get ESA mode from the map (assuming it's constant or we take the first)
     # TODO: Figure out how to handle esa_mode properly
@@ -679,6 +685,14 @@ def populate_geometric_factors(
         # Fill energy step with the geometric factor values
         for var, col in gf_vars.items():
             dataset[var].values[i] = gf_row[col]
+
+    # Update delta_minus and delta_plus based on ESA mode
+    if esa_mode == 0:  # HiRes
+        dataset["energy_delta_minus"].values = energy_delta_hires_values
+        dataset["energy_delta_plus"].values = energy_delta_hires_values
+    else:  # HiThr
+        dataset["energy_delta_minus"].values = energy_delta_hithr_values
+        dataset["energy_delta_plus"].values = energy_delta_hithr_values
 
     return dataset
 
@@ -850,6 +864,19 @@ def calculate_backgrounds(dataset: xr.Dataset) -> xr.Dataset:
         / dataset["geometric_factor"]
     )
 
+    # Background intensity
+    dataset["bg_intensity"] = dataset["bg_rates"] / (
+        dataset["geometric_factor"] * dataset["energy"]
+    )
+    dataset["bg_intensity_stat_uncert"] = dataset["bg_rates_stat_uncert"] / (
+        dataset["geometric_factor"] * dataset["energy"]
+    )
+    dataset["bg_intensity_sys_err"] = (
+        dataset["bg_intensity"]
+        * dataset["geometric_factor_stat_uncert"]
+        / dataset["geometric_factor"]
+    )
+
     return dataset
 
 
@@ -885,14 +912,6 @@ def calculate_sputtering_corrections(
     energy_indices = [4, 5]
     small_dataset = dataset.isel(epoch=0, energy=energy_indices)
     o_small_dataset = o_dataset.isel(epoch=0, energy=energy_indices)
-
-    # NOTE: We only have background rates, so turn them into intensities
-    o_small_dataset["bg_intensity"] = o_small_dataset["bg_rates"] / (
-        o_small_dataset["geometric_factor"] * o_small_dataset["energy"]
-    )
-    o_small_dataset["bg_intensity_stat_uncert"] = o_small_dataset[
-        "bg_rates_stat_uncert"
-    ] / (o_small_dataset["geometric_factor"] * o_small_dataset["energy"])
 
     # We need to align the energy dimensions from the oxygen dataset to the
     # Hydrogen dataset so the calculations below get aligned by xarray correctly.
@@ -987,10 +1006,7 @@ def calculate_bootstrap_corrections(dataset: xr.Dataset) -> xr.Dataset:
     )
 
     # Equation 14
-    bg_intensity = dataset["bg_rates"] / (
-        dataset["geometric_factor"] * dataset["energy"]
-    )
-    j_c_prime = dataset["ena_intensity"] - bg_intensity
+    j_c_prime = dataset["ena_intensity"] - dataset["bg_intensity"]
     j_c_prime.values[j_c_prime.values < 0] = 0
 
     # Equation 15
@@ -1196,6 +1212,8 @@ def cleanup_intermediate_variables(dataset: xr.Dataset) -> xr.Dataset:
 
     # Only remove variables that exist in the dataset for the specific species
     potential_vars = [
+        "geometric_factor",
+        "geometric_factor_stat_uncert",
         "counts_over_eff",
         "counts_over_eff_squared",
         "bg_rates_exposure_factor",

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -982,6 +982,30 @@ class TestRectangularSkyMap:
                 )
 
     @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
+    def test_build_cdf_dataset_external_dataset(
+        self, mock_to_dataset, mock_data_for_build_cdf_dataset
+    ):
+        """Test coverage for the RectangularSkyMap.build_cdf_dataset method."""
+        # Set up the mock
+        mock_to_dataset.return_value = mock_data_for_build_cdf_dataset
+
+        skymap = ena_maps.RectangularSkyMap(6, geometry.SpiceFrame.ECLIPJ2000)
+        skymap.min_epoch = 10
+        skymap.max_epoch = 15
+        cdf_dataset_standard = skymap.build_cdf_dataset(
+            "hi", "l2", "foo_descriptor", sensor="45", drop_vars_with_no_attributes=True
+        )
+        cdf_dataset_external = skymap.build_cdf_dataset(
+            "hi",
+            "l2",
+            "foo_descriptor",
+            sensor="45",
+            drop_vars_with_no_attributes=True,
+            external_map_dataset=mock_data_for_build_cdf_dataset,
+        )
+        assert cdf_dataset_standard.equals(cdf_dataset_external)
+
+    @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
     def test_build_cdf_dataset_key_error(
         self, mock_to_dataset, mock_data_for_build_cdf_dataset
     ):
@@ -995,7 +1019,7 @@ class TestRectangularSkyMap:
 
         # Test that missing energy delta variable raise KeyError
         # Test for missing energy_delta_plus
-        mock_dataset = mock_dataset.drop(["energy_delta_plus"])
+        mock_dataset = mock_dataset.drop_vars(["energy_delta_plus"])
         mock_to_dataset.return_value = mock_dataset
         with pytest.raises(
             KeyError,
@@ -1003,7 +1027,7 @@ class TestRectangularSkyMap:
         ):
             _ = skymap.build_cdf_dataset("hi", "l2", "foo_descriptor", sensor="45")
         # Test for missing energy_delta_minus
-        mock_dataset = mock_dataset.drop(["energy_delta_minus"])
+        mock_dataset = mock_dataset.drop_vars(["energy_delta_minus"])
         mock_to_dataset.return_value = mock_dataset
         with pytest.raises(
             KeyError,

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -1564,7 +1564,8 @@ class TestInitializeGeometricFactorVariables:
 
         # Check that all geometric factor variables were initialized
         expected_vars = [
-            "energy_stat_uncert",
+            "energy_delta_minus",
+            "energy_delta_plus",
             "geometric_factor",
             "geometric_factor_stat_uncert",
         ]
@@ -2169,6 +2170,7 @@ class TestIntegrationWithMocks:
             mock_sky_map = Mock()
             mock_dataset = xr.Dataset({"test_var": (("energy",), np.ones(7))})
             mock_sky_map.to_dataset.return_value = mock_dataset
+            mock_sky_map.build_cdf_dataset.return_value = mock_dataset
             mock_create_map.return_value = mock_sky_map
             mock_add_gf.return_value = mock_dataset
             mock_calc_rates.return_value = mock_dataset

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -411,30 +411,21 @@ def sample_dataset_with_sputtering_data():
         ("epoch", "energy", "longitude", "latitude"),
         h_intensity_values,
     )
-
-    # Add hydrogen background rates (lower values)
-    h_bg_rates_values = np.ones((1, n_energy, n_lon, n_lat)) * 0.1e6  # 10% of intensity
-    h_dataset["bg_rates"] = (
-        ("epoch", "energy", "longitude", "latitude"),
-        h_bg_rates_values,
-    )
+    h_dataset["bg_intensity"] = h_dataset["ena_intensity"] * 0.1  # 10% background
 
     # Add statistical uncertainties
     h_dataset["ena_intensity_stat_uncert"] = (
         ("epoch", "energy", "longitude", "latitude"),
         np.sqrt(h_intensity_values) * 0.1,
     )
-
-    h_dataset["bg_rates_stat_uncert"] = (
-        ("epoch", "energy", "longitude", "latitude"),
-        np.sqrt(h_bg_rates_values) * 0.1,
-    )
+    h_dataset["bg_intensity_stat_uncert"] = np.sqrt(h_dataset["bg_intensity"]) * 0.1
 
     # Add systematic error
     h_dataset["ena_intensity_sys_err"] = (
         ("epoch", "energy", "longitude", "latitude"),
         h_intensity_values * 0.05,
     )
+    h_dataset["bg_intensity_sys_err"] = h_dataset["bg_intensity"] * 0.05
 
     # Create oxygen dataset
     o_intensity_values = np.ones((1, n_energy, n_lon, n_lat)) * 1e6  # Base intensity
@@ -446,23 +437,16 @@ def sample_dataset_with_sputtering_data():
         ("epoch", "energy", "longitude", "latitude"),
         o_intensity_values,
     )
-
-    # Add oxygen background rates (lower values)
-    o_bg_rates_values = np.ones((1, n_energy, n_lon, n_lat)) * 0.1e6  # 10% of intensity
-    o_dataset["bg_rates"] = (
-        ("epoch", "energy", "longitude", "latitude"),
-        o_bg_rates_values,
-    )
+    o_dataset["bg_intensity"] = o_dataset["ena_intensity"] * 0.1  # 10% background
+    o_dataset["bg_intensity_stat_uncert"] = np.sqrt(o_dataset["bg_intensity"]) * 0.1
 
     # Add statistical uncertainties
     o_dataset["ena_intensity_stat_uncert"] = (
         ("epoch", "energy", "longitude", "latitude"),
         np.sqrt(o_intensity_values) * 0.1,
     )
-
-    o_dataset["bg_rates_stat_uncert"] = (
-        ("epoch", "energy", "longitude", "latitude"),
-        np.sqrt(o_bg_rates_values) * 0.1,
+    o_dataset["bg_intensity_stat_uncert"] = (
+        np.sqrt(o_dataset["bg_intensity_stat_uncert"]) * 0.1
     )
 
     # Add systematic error
@@ -470,6 +454,7 @@ def sample_dataset_with_sputtering_data():
         ("epoch", "energy", "longitude", "latitude"),
         o_intensity_values * 0.05,
     )
+    o_dataset["bg_intensity_sys_err"] = o_dataset["bg_intensity"] * 0.05
 
     # Add geometric factors for intensity calculations
     o_dataset["geometric_factor"] = (("energy",), np.ones(n_energy))
@@ -513,10 +498,10 @@ def sample_dataset_with_bootstrap_data():
     dataset["geometric_factor"] = (("energy",), np.ones(n_energy))
 
     # Add background rates (much lower values)
-    bg_rates_values = intensity_values * 0.1  # 10% of intensity as background
-    dataset["bg_rates"] = (
-        ("epoch", "energy", "longitude", "latitude"),
-        bg_rates_values,
+    dataset["bg_intensity"] = (
+        dataset["ena_intensity"]
+        * 0.1
+        / (dataset["geometric_factor"] * dataset["energy"])
     )
 
     # Add statistical uncertainties (Poisson-like)
@@ -1264,9 +1249,9 @@ class TestCalculateSputteringCorrections:
         o_small_dataset = o_dataset.isel(epoch=0, energy=[4, 5])
 
         # Calculate expected j_o_prime (Equation 9)
-        expected_j_o_prime = o_small_dataset["ena_intensity"] - o_small_dataset[
-            "bg_rates"
-        ] / (o_small_dataset["geometric_factor"] * o_small_dataset["energy"])
+        expected_j_o_prime = (
+            o_small_dataset["ena_intensity"] - o_small_dataset["bg_intensity"]
+        )
         expected_j_o_prime = expected_j_o_prime.where(expected_j_o_prime >= 0, 0)
 
         # Expected correction factors from the mapping document table 2
@@ -1306,19 +1291,11 @@ class TestCalculateSputteringCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 5, 3)) * 1e6,
         )
-        h_dataset["bg_rates"] = (
-            ("epoch", "energy", "longitude", "latitude"),
-            np.ones((1, 7, 5, 3)) * 0.5e6,
-        )
 
         # Add required uncertainty variables for hydrogen
         h_dataset["ena_intensity_stat_uncert"] = (
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 5, 3)) * 0.1e6,
-        )
-        h_dataset["bg_rates_stat_uncert"] = (
-            ("epoch", "energy", "longitude", "latitude"),
-            np.ones((1, 7, 5, 3)) * 0.05e6,
         )
         h_dataset["ena_intensity_sys_err"] = (
             ("epoch", "energy", "longitude", "latitude"),
@@ -1331,7 +1308,7 @@ class TestCalculateSputteringCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 5, 3)) * 1e6,
         )
-        o_dataset["bg_rates"] = (
+        o_dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 5, 3)) * 2e6,  # Higher than signal
         )
@@ -1341,7 +1318,7 @@ class TestCalculateSputteringCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 5, 3)) * 0.1e6,
         )
-        o_dataset["bg_rates_stat_uncert"] = (
+        o_dataset["bg_intensity_stat_uncert"] = (
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 5, 3)) * 0.1e6,
         )
@@ -1418,16 +1395,12 @@ class TestCalculateSputteringCorrections:
         h_small_dataset = h_dataset.isel(epoch=0, energy=[4, 5])
 
         # Manual calculation following equations 10, 12
-        j_o_prime = o_small_dataset["ena_intensity"] - o_small_dataset["bg_rates"]
+        j_o_prime = o_small_dataset["ena_intensity"] - o_small_dataset["bg_intensity"]
         j_o_prime = j_o_prime.where(j_o_prime >= 0, 0)
 
         j_o_prime_var = (
             o_small_dataset["ena_intensity_stat_uncert"] ** 2
-            + (
-                o_small_dataset["bg_rates_stat_uncert"]
-                / (o_small_dataset["energy"] * o_small_dataset["geometric_factor"])
-            )
-            ** 2
+            + (o_small_dataset["bg_intensity_stat_uncert"]) ** 2
         )
 
         sputter_correction_factor = np.array([0.15, 0.01])[:, np.newaxis, np.newaxis]
@@ -1472,7 +1445,7 @@ class TestCalculateSputteringCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             h_intensity_data,
         )
-        h_dataset["bg_rates"] = (
+        h_dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             h_bg_rates_data,
         )
@@ -1480,7 +1453,7 @@ class TestCalculateSputteringCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 4, 3)) * 100_000,
         )
-        h_dataset["bg_rates_stat_uncert"] = (
+        h_dataset["bg_intensity_stat_uncert"] = (
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 4, 3)) * 10_000,
         )
@@ -1504,7 +1477,7 @@ class TestCalculateSputteringCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             o_intensity_data,
         )
-        o_dataset["bg_rates"] = (
+        o_dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             o_bg_rates_data,
         )
@@ -1512,7 +1485,7 @@ class TestCalculateSputteringCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 4, 3)) * 100_000,
         )
-        o_dataset["bg_rates_stat_uncert"] = (
+        o_dataset["bg_intensity_stat_uncert"] = (
             ("epoch", "energy", "longitude", "latitude"),
             np.ones((1, 7, 4, 3)) * 10_000,
         )
@@ -1731,7 +1704,7 @@ class TestCalculateBootstrapCorrections:
         dataset = sample_dataset_with_bootstrap_data.copy()
 
         # Calculate expected j_c_prime (equation 14)
-        j_c_prime_expected = dataset["ena_intensity"] - dataset["bg_rates"]
+        j_c_prime_expected = dataset["ena_intensity"] - dataset["bg_intensity"]
         j_c_prime_expected = j_c_prime_expected.where(j_c_prime_expected >= 0, 0)
 
         # Apply bootstrap corrections and check the calculation was done correctly
@@ -1762,15 +1735,15 @@ class TestCalculateBootstrapCorrections:
 
         # Create intensities where some background > intensity (negative j_c_prime)
         intensity_values = np.ones((1, 7, 2, 2)) * 1e6
-        bg_rates_values = np.ones((1, 7, 2, 2)) * 1.5e6  # Higher than intensity
+        bg_intensity_values = np.ones((1, 7, 2, 2)) * 1.5e6  # Higher than intensity
 
         dataset["ena_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             intensity_values,
         )
-        dataset["bg_rates"] = (
+        dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
-            bg_rates_values,
+            bg_intensity_values,
         )
         dataset["ena_intensity_stat_uncert"] = (
             ("epoch", "energy", "longitude", "latitude"),
@@ -1817,7 +1790,7 @@ class TestCalculateBootstrapCorrections:
         )
 
         # Low background
-        dataset["bg_rates"] = (
+        dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             intensity_values * 0.01,  # 1% background
         )
@@ -1895,7 +1868,7 @@ class TestCalculateBootstrapCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             intensity_values,
         )
-        dataset["bg_rates"] = (
+        dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             intensity_values * 0.1,  # 10% background
         )
@@ -1957,7 +1930,7 @@ class TestCalculateBootstrapCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             intensity_values,
         )
-        dataset["bg_rates"] = (
+        dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             intensity_values * 0.05,  # 5% background
         )
@@ -1971,7 +1944,7 @@ class TestCalculateBootstrapCorrections:
         )
 
         # Calculate expected E8 and gamma manually
-        j_c_prime = dataset["ena_intensity"] - dataset["bg_rates"]
+        j_c_prime = dataset["ena_intensity"] - dataset["bg_intensity"]
         j_c_prime = j_c_prime.where(j_c_prime >= 0, 0)
 
         result = calculate_bootstrap_corrections(dataset)
@@ -2008,7 +1981,7 @@ class TestCalculateBootstrapCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             intensity_values,
         )
-        dataset["bg_rates"] = (
+        dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             np.zeros((1, 7, 1, 1)),  # No background
         )
@@ -2063,7 +2036,7 @@ class TestCalculateBootstrapCorrections:
             ("epoch", "energy", "longitude", "latitude"),
             intensity_values,
         )
-        dataset["bg_rates"] = (
+        dataset["bg_intensity"] = (
             ("epoch", "energy", "longitude", "latitude"),
             np.zeros((1, 7, 1, 1)),
         )


### PR DESCRIPTION
Take advantage of the build_cdf_dataset function to automatically handle the adding of metadata and variables. However, the Lo code has already switched to a 2d map dataset, so we don't want to transform the 1d dataset anymore, but rather allow for our own processed map dataset to be used as the base.

The second commit is largely renaming things to add background uncertainty to the dataset itself rather than having to calculate it as an intermediate product.

closes #2182