### PR TITLE
ULTRA l1c add static dead time ratios

### DIFF
--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -160,6 +160,8 @@ EXTERNAL_TEST_DATA = [
     ("imap_ultra_l1b-scattering-thresholds-per-energy_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf","ultra/data/l1/"),
     ("imap_ultra_l1c-45sensor-nominal-for-lookup_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-45sensor-static-dead-times_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-static-dead-times_20250101_v000.csv", "ultra/data/l1/"),
 
     # MAG
     ("mag-l1b-l1c-t013-magi-burst-in.csv",

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -539,6 +539,10 @@ def ancillary_files():
         / "imap_ultra_l1c-90sensor-sc-pointing-bsf-test_20250101_v000.csv",
         "l1b-scattering-thresholds-per-energy": path
         / "imap_ultra_l1b-scattering-thresholds-per-energy_20250101_v000.csv",
+        "l1c-45sensor-static-dead-times": path
+        / "imap_ultra_l1c-45sensor-static-dead-times_20250101_v000.csv",
+        "l1c-90sensor-static-dead-times": path
+        / "imap_ultra_l1c-90sensor-static-dead-times_20250101_v000.csv",
     }
 
 

--- a/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
@@ -5,6 +5,7 @@ import pytest
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     get_scattering_thresholds_for_energy,
     get_spacecraft_pointing_lookup_tables,
+    get_static_deadtime_ratios,
     mask_below_fwhm_scattering_threshold,
 )
 
@@ -92,3 +93,21 @@ def test_get_mask_below_fwhm_scattering_threshold_zero(ancillary_files):
     )
     np.testing.assert_array_equal(pixel_mask.shape, (3, 1))
     np.testing.assert_array_equal(pixel_mask, expected_pixel_mask)
+
+
+@pytest.mark.external_test_data
+def test_get_static_deadtime_ratios(ancillary_files):
+    """Test get_static_deadtime_ratios function."""
+    # test 45
+    spin_phase, dt_ratio = get_static_deadtime_ratios(45, ancillary_files)
+    # Test shape
+    # TODO confirm if the duplicate row in the 45 LUT is a mistake
+    np.testing.assert_array_equal(dt_ratio.shape, (720,))
+    # Test values
+    assert np.all((dt_ratio >= 0.0) & (dt_ratio <= 1.0))
+    # test 90
+    spin_phase, dt_ratio = get_static_deadtime_ratios(90, ancillary_files)
+    # Test shape
+    np.testing.assert_array_equal(dt_ratio.shape, (721,))
+    # Test values
+    assert np.all((dt_ratio >= 0.0) & (dt_ratio <= 1.0))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from scipy import interpolate
 
 from imap_processing import imap_module_directory
 from imap_processing.ultra.l1c import ultra_l1c_pset_bins
@@ -218,8 +219,10 @@ def test_get_deadtime_interpolator(random_spin_data):
         "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_deadtime_ratios",
         return_value=deadtime_ratios,
     ):
-        deadtime_ratios = get_deadtime_ratios_by_spin_phase(sectored_rates_ds)
-    np.testing.assert_array_equal(deadtime_ratios.shape, (15000))
+        deadtime_ratios = get_deadtime_ratios_by_spin_phase(
+            sectored_rates_ds, spin_steps=num_deadtimes
+        )
+    np.testing.assert_array_equal(deadtime_ratios.shape, (num_deadtimes))
 
     with mock.patch(
         "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_deadtime_ratios",
@@ -230,7 +233,35 @@ def test_get_deadtime_interpolator(random_spin_data):
             ValueError,
             match="All dead time ratios are NaN, cannot interpolate",
         ):
-            get_deadtime_ratios_by_spin_phase(sectored_rates_ds)
+            get_deadtime_ratios_by_spin_phase(
+                sectored_rates_ds, spin_steps=num_deadtimes
+            )
+
+
+@pytest.mark.external_test_data
+def test_get_deadtime_interpolator_no_sectored_rates(ancillary_files):
+    """Tests get_deadtime_correction_factors function."""
+
+    num_deadtimes = 15000  # Standard number of spin phases
+    sensor = 45
+    # If the sectored rates dataset is None, the function should use the
+    # static deadtime ratios lookup.
+    dt_ratios = get_deadtime_ratios_by_spin_phase(
+        sectored_rates=None,
+        spin_steps=num_deadtimes,
+        sensor_id=sensor,
+        ancillary_files=ancillary_files,
+    )
+    spin_phase, dts = ultra_l1c_pset_bins.get_static_deadtime_ratios(
+        sensor, ancillary_files
+    )
+    # Calculate the nominal spin phases at the supplied resolution and query the pchip
+    # interpolator to get the deadtime ratios.
+    nominal_spin_phases = np.arange(0, 360, 360 / num_deadtimes)
+    expected_dt_ratios = interpolate.PchipInterpolator(spin_phase, dts)(
+        nominal_spin_phases
+    )
+    np.testing.assert_array_equal(dt_ratios, expected_dt_ratios)
 
 
 @pytest.mark.external_kernel
@@ -309,7 +340,7 @@ def test_get_spacecraft_exposure_times(
         pix,
     )
     np.testing.assert_array_equal(exposure_pointing.shape, (24, pix))
-    np.testing.assert_array_equal(deadtimes.shape, (15000,))
+    np.testing.assert_array_equal(deadtimes.shape, (steps,))
 
 
 @pytest.mark.external_kernel

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -16,12 +16,12 @@ from imap_processing.spice.time import (
 )
 from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
+    build_energy_bins,
     calculate_fwhm_spun_scattering,
     get_spacecraft_pointing_lookup_tables,
 )
 from imap_processing.ultra.l1c.ultra_l1c_culling import compute_culling_mask
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
-    build_energy_bins,
     get_efficiencies_and_geometric_function,
     get_energy_delta_minus_plus,
     get_helio_adjusted_data,
@@ -71,7 +71,7 @@ def calculate_helio_pset(
     dataset : xarray.Dataset
         Dataset containing the data.
     """
-    sensor = parse_filename_like(name)["sensor"][0:2]
+    sensor_id = int(parse_filename_like(name)["sensor"][0:2])
     pset_dict: dict[str, np.ndarray] = {}
     # Select only the species we are interested in.
     indices = np.where(np.isin(de_dataset["ebin"].values, species_id))[0]
@@ -139,6 +139,8 @@ def calculate_helio_pset(
         boundary_scale_factors,
         pointing_range_met,
         n_pix=n_pix,
+        sensor_id=sensor_id,
+        ancillary_files=ancillary_files,
     )
     logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
@@ -156,7 +158,7 @@ def calculate_helio_pset(
     # Calculate background rates
     background_rates = get_spacecraft_background_rates(
         rates_dataset,
-        sensor,
+        sensor_id,
         ancillary_files,
         intervals,
         goodtimes_dataset["spin_number"].values,

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -6,12 +6,12 @@ import numpy as np
 import pandas as pd
 from numpy._typing import NDArray
 
+from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.lookup_utils import (
     get_scattering_coefficients,
     get_scattering_thresholds,
     load_scattering_lookup_tables,
 )
-from imap_processing.ultra.l1c.ultra_l1c_pset_bins import build_energy_bins
 
 logger = logging.getLogger(__name__)
 
@@ -289,3 +289,60 @@ def get_scattering_thresholds_for_energy(
             threshold = 0
         thresholds.append(threshold)
     return np.array(thresholds)
+
+
+def get_static_deadtime_ratios(
+    sensor_id: int, ancillary_files: dict
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Get static deadtime ratios.
+
+    These should only be used when the instrument is operating in a mode that does not
+    produce sectored rates data.
+
+    Parameters
+    ----------
+    sensor_id : int
+        Sensor ID, either 45 or 90.
+    ancillary_files : dict
+        Dictionary containing ancillary files.
+
+    Returns
+    -------
+    np.ndarray
+        Array of static deadtime ratios for each energy bin.
+    """
+    descriptor = f"l1c-{sensor_id}sensor-static-dead-times"
+    df = pd.read_csv(ancillary_files[descriptor])
+    # Drop any rows that are duplicates. We only want unique spin phase and dead time
+    # ratio pairs.
+    df = df.drop_duplicates()
+    return df["Spin Phase (deg)"].to_numpy(dtype=float), df["Dead Time Ratio"].to_numpy(
+        dtype=float
+    )
+
+
+def build_energy_bins() -> tuple[list[tuple[float, float]], np.ndarray, np.ndarray]:
+    """
+    Build energy bin boundaries.
+
+    Returns
+    -------
+    intervals : list[tuple[float, float]]
+        Energy bins.
+    energy_midpoints : np.ndarray
+        Array of energy bin midpoints.
+    energy_bin_geometric_means : np.ndarray
+        Array of geometric means of energy bins.
+    """
+    # Create energy bins.
+    energy_bin_edges = np.array(UltraConstants.PSET_ENERGY_BIN_EDGES)
+    energy_midpoints = (energy_bin_edges[:-1] + energy_bin_edges[1:]) / 2
+
+    intervals = [
+        (float(energy_bin_edges[i]), float(energy_bin_edges[i + 1]))
+        for i in range(len(energy_bin_edges) - 1)
+    ]
+    energy_bin_geometric_means = np.sqrt(energy_bin_edges[:-1] * energy_bin_edges[1:])
+
+    return intervals, energy_midpoints, energy_bin_geometric_means

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -15,12 +15,12 @@ from imap_processing.spice.time import (
 )
 from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
+    build_energy_bins,
     calculate_fwhm_spun_scattering,
     get_spacecraft_pointing_lookup_tables,
 )
 from imap_processing.ultra.l1c.ultra_l1c_culling import compute_culling_mask
 from imap_processing.ultra.l1c.ultra_l1c_pset_bins import (
-    build_energy_bins,
     get_efficiencies_and_geometric_function,
     get_energy_delta_minus_plus,
     get_spacecraft_background_rates,
@@ -71,7 +71,7 @@ def calculate_spacecraft_pset(
     """
     pset_dict: dict[str, np.ndarray] = {}
 
-    sensor = parse_filename_like(name)["sensor"][0:2]
+    sensor_id = int(parse_filename_like(name)["sensor"][0:2])
     indices = np.where(np.isin(de_dataset["ebin"].values, species_id))[0]
     species_dataset = de_dataset.isel(epoch=indices)
 
@@ -124,7 +124,23 @@ def calculate_spacecraft_pset(
         nside=nside,
     )
     healpix = np.arange(n_pix)
+    # Get the start and stop times of the pointing period
+    pointing_range_met = get_pointing_times(
+        float(et_to_met(species_dataset["event_times"].mean()))
+    )
 
+    # Calculate exposure times
+    logger.info("Calculating spacecraft exposure times with deadtime correction.")
+    exposure_pointing, deadtime_ratios = get_spacecraft_exposure_times(
+        rates_dataset,
+        params_dataset,
+        pixels_below_scattering,
+        boundary_scale_factors,
+        pointing_range_met,
+        n_pix=n_pix,
+        sensor_id=sensor_id,
+        ancillary_files=ancillary_files,
+    )
     logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
     geometric_function, efficiencies = get_efficiencies_and_geometric_function(
@@ -137,25 +153,11 @@ def calculate_spacecraft_pset(
     )
     sensitivity = efficiencies * geometric_function
 
-    # Get the start and stop times of the pointing period
-    pointing_range_met = get_pointing_times(
-        float(et_to_met(species_dataset["event_times"].mean()))
-    )
-    # Calculate exposure times
-    logger.info("Calculating spacecraft exposure times with deadtime correction.")
-    exposure_pointing, deadtime_ratios = get_spacecraft_exposure_times(
-        rates_dataset,
-        params_dataset,
-        pixels_below_scattering,
-        boundary_scale_factors,
-        pointing_range_met,
-        n_pix=n_pix,
-    )
     logger.info("Calculating background rates.")
     # Calculate background rates
     background_rates = get_spacecraft_background_rates(
         rates_dataset,
-        sensor,
+        sensor_id,
         ancillary_files,
         intervals,
         goodtimes_dataset["spin_number"].values,

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -33,37 +33,15 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
     get_efficiency,
     get_efficiency_interpolator,
 )
+from imap_processing.ultra.l1c.l1c_lookup_utils import (
+    build_energy_bins,
+    get_static_deadtime_ratios,
+)
 
 # TODO: add species binning.
 FILLVAL_FLOAT32 = -1.0e31
 
 logger = logging.getLogger(__name__)
-
-
-def build_energy_bins() -> tuple[list[tuple[float, float]], np.ndarray, np.ndarray]:
-    """
-    Build energy bin boundaries.
-
-    Returns
-    -------
-    intervals : list[tuple[float, float]]
-        Energy bins.
-    energy_midpoints : np.ndarray
-        Array of energy bin midpoints.
-    energy_bin_geometric_means : np.ndarray
-        Array of geometric means of energy bins.
-    """
-    # Create energy bins.
-    energy_bin_edges = np.array(UltraConstants.PSET_ENERGY_BIN_EDGES)
-    energy_midpoints = (energy_bin_edges[:-1] + energy_bin_edges[1:]) / 2
-
-    intervals = [
-        (float(energy_bin_edges[i]), float(energy_bin_edges[i + 1]))
-        for i in range(len(energy_bin_edges) - 1)
-    ]
-    energy_bin_geometric_means = np.sqrt(energy_bin_edges[:-1] * energy_bin_edges[1:])
-
-    return intervals, energy_midpoints, energy_bin_geometric_means
 
 
 def get_energy_delta_minus_plus() -> tuple[NDArray, NDArray]:
@@ -238,7 +216,9 @@ def get_deadtime_ratios(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
     return dead_time_ratios
 
 
-def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Dataset:
+def get_sectored_rates(
+    rates_ds: xr.Dataset, params_ds: xr.Dataset
+) -> xr.Dataset | None:
     """
     Filter rates dataset to only include sector mode data.
 
@@ -251,7 +231,7 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
 
     Returns
     -------
-    rates : xarray.Dataset
+    rates : xarray.Dataset or None
         Rates dataset with only the sector mode data.
     """
     # Find indices in which the parameters dataset, indicates that ULTRA was in
@@ -264,7 +244,7 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
 
     sector_mode_start_inds = np.where(params["imageratescadence"] == 3)[0]
     if len(sector_mode_start_inds) == 0:
-        raise ValueError("No sector mode data found in the parameters dataset.")
+        return None
     # get the sector mode start and stop indices
     sector_mode_stop_inds = sector_mode_start_inds + 1
     # get the sector mode start and stop times
@@ -288,46 +268,68 @@ def get_sectored_rates(rates_ds: xr.Dataset, params_ds: xr.Dataset) -> xr.Datase
 
 
 def get_deadtime_ratios_by_spin_phase(
-    sectored_rates: xr.Dataset,
+    sectored_rates: xr.Dataset | None,
+    spin_steps: int,
+    sensor_id: int | None = None,
+    ancillary_files: dict | None = None,
 ) -> np.ndarray:
     """
     Calculate nominal deadtime ratios at every spin phase step (1ms res).
 
     Parameters
     ----------
-    sectored_rates : xarray.Dataset
+    sectored_rates : xarray.Dataset, optional
         Dataset containing sector mode image rates data.
+    spin_steps : int
+        Number of spin phase steps (e.g. 15000 for 1ms resolution).
+    sensor_id : int, optional
+        Sensor ID, either 45 or 90.
+    ancillary_files : dict, optional
+        Dictionary containing ancillary files.
 
     Returns
     -------
     numpy.ndarray
-        Nominal deadtime ratios at every spin phase step (1ms res).
+        Nominal deadtime ratios at every spin phase step.
     """
-    deadtime_ratios = get_deadtime_ratios(sectored_rates)
-    # Get the spin phase at the start of each sector rate measurement
-    met_times = ttj2000ns_to_met(sectored_rates.epoch.data)
-    spin_phases = np.asarray(
-        get_spin_angle(get_spacecraft_spin_phase(met_times), degrees=True)
-    )
-    # Assume the sectored rate data is evenly spaced in time, and find the middle spin
-    # phase value for each sector.
-    # The center spin phase is the closest / most accurate spin phase.
-    # There are 24 spin phases per sector so the nominal middle sector spin phases
-    # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.
-    spin_phases_centered = (spin_phases[:-1] + spin_phases[1:]) / 2
-    # Assume the last sector is nominal because we dont have enough data to determine
-    # the spin phase at the end of the last sector.
-    # TODO: is this assumption valid?
-    # Add the last spin phase value + half of a nominal sector.
-    spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + 12)
-    # Wrap any spin phases > 360 back to [0, 360]
-    spin_phases_centered = spin_phases_centered % 360
+    if sectored_rates is None:
+        logger.warning(
+            "No sector mode data found in the parameters dataset. Using "
+            "static dead time ratios from an ancillary file."
+        )
+        if sensor_id is None or ancillary_files is None:
+            raise ValueError(
+                "sensor_id and ancillary_files must be provided to "
+                "get static deadtime ratios."
+            )
+        spin_phases_centered, deadtime_ratios = get_static_deadtime_ratios(
+            sensor_id, ancillary_files
+        )
+    else:
+        deadtime_ratios = get_deadtime_ratios(sectored_rates).data
+        # Get the spin phase at the start of each sector rate measurement
+        met_times = ttj2000ns_to_met(sectored_rates.epoch.data)
+        spin_phases = np.asarray(
+            get_spin_angle(get_spacecraft_spin_phase(met_times), degrees=True)
+        )
+        # Assume the sectored rate data is evenly spaced in time, and find the middle
+        # spin phase value for each sector.
+        # The center spin phase is the closest / most accurate spin phase.
+        # There are 24 spin phases per sector so the nominal middle sector spin phases
+        # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.
+        spin_phases_centered = (spin_phases[:-1] + spin_phases[1:]) / 2
+        # Assume the last sector is nominal because we dont have enough data to
+        # determine the spin phase at the end of the last sector.
+        # TODO: is this assumption valid?
+        # Add the last spin phase value + half of a nominal sector.
+        spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + 12)
+        # Wrap any spin phases > 360 back to [0, 360]
+        spin_phases_centered = np.array(spin_phases_centered % 360)
+
     # Create a dataset with spin phases and dead time ratios
     deadtime_by_spin_phase = xr.Dataset(
-        {"deadtime_ratio": deadtime_ratios},
-        coords={
-            "spin_phase": xr.DataArray(np.array(spin_phases_centered), dims="epoch")
-        },
+        {"deadtime_ratio": (("spin_phase",), deadtime_ratios)},
+        coords={"spin_phase": xr.DataArray(spin_phases_centered, dims="spin_phase")},
     )
 
     # Sort the dataset by spin phase (ascending order)
@@ -347,11 +349,10 @@ def get_deadtime_ratios_by_spin_phase(
     interpolator = interpolate.PchipInterpolator(
         deadtime_medians["spin_phase"].values, deadtime_medians["deadtime_ratio"].values
     )
-    # Calculate the nominal spin phases at 1 ms resolution and query the pchip
+    # Calculate the nominal spin phases at the supplied resolution and query the pchip
     # interpolator to get the deadtime ratios.
-    steps = 15 * 1000  # 15 seconds at 1 ms resolution
-    nominal_spin_phases_1ms_res = np.arange(0, 360, 360 / steps)
-    return interpolator(nominal_spin_phases_1ms_res)
+    nominal_spin_phases = np.arange(0, 360, 360 / spin_steps)
+    return interpolator(nominal_spin_phases)
 
 
 def calculate_exposure_time(
@@ -417,6 +418,8 @@ def get_spacecraft_exposure_times(
     boundary_scale_factors: NDArray,
     pointing_range_met: tuple[float, float],
     n_pix: int,
+    sensor_id: int | None = None,
+    ancillary_files: dict | None = None,
 ) -> tuple[NDArray, NDArray]:
     """
     Compute exposure times for HEALPix pixels.
@@ -438,6 +441,10 @@ def get_spacecraft_exposure_times(
         Start and stop time of the pointing period in mission elapsed time.
     n_pix : int
         Number of HEALPix pixels.
+    sensor_id : int, optional
+        Sensor ID, either 45 or 90.
+    ancillary_files : dict, optional
+        Dictionary containing ancillary files.
 
     Returns
     -------
@@ -449,7 +456,11 @@ def get_spacecraft_exposure_times(
         Deadtime ratios at each spin phase step (1ms res).
     """
     sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
-    nominal_deadtime_ratios = get_deadtime_ratios_by_spin_phase(sectored_rates)
+    # Get the number of steps used in the spun pointing lookup tables
+    spin_steps = len(pixels_below_scattering)
+    nominal_deadtime_ratios = get_deadtime_ratios_by_spin_phase(
+        sectored_rates, spin_steps, sensor_id, ancillary_files
+    )
     # The exposure time will be approximately the same per spin, so to save
     # computation time, calculate the exposure time for a single spin and then scale it
     # by the number of spins in the pointing. For more information, see section 3.4.3
@@ -720,7 +731,7 @@ def get_helio_adjusted_data(
 
 def get_spacecraft_background_rates(
     rates_dataset: xr.Dataset,
-    sensor: str,
+    sensor_id: int,
     ancillary_files: dict,
     energy_bin_edges: list[tuple[float, float]],
     goodtimes_spin_number: NDArray,
@@ -733,8 +744,8 @@ def get_spacecraft_background_rates(
     ----------
     rates_dataset : xr.Dataset
         Rates dataset.
-    sensor : str
-        Sensor name: "ultra45" or "ultra90".
+    sensor_id : int
+        Sensor ID: either 45 or 90.
     ancillary_files : dict[Path]
         Ancillary files containing the lookup tables.
     energy_bin_edges : list[tuple[float, float]]
@@ -757,8 +768,8 @@ def get_spacecraft_background_rates(
     """
     pulses = get_pulses_per_spin(rates_dataset)
     # Pulses for the pointing.
-    etof_min = get_image_params("eTOFMin", f"ultra{sensor}", ancillary_files)
-    etof_max = get_image_params("eTOFMax", f"ultra{sensor}", ancillary_files)
+    etof_min = get_image_params("eTOFMin", f"ultra{sensor_id}", ancillary_files)
+    etof_max = get_image_params("eTOFMax", f"ultra{sensor_id}", ancillary_files)
     spin_number, _ = get_spin_and_duration(
         rates_dataset["shcoarse"], rates_dataset["spin"]
     )


### PR DESCRIPTION
# Change Summary

## Overview
Add static dead time ratio lookup tables for when sectored rates data is not available. 

ULTRA is currently not operating in a mode that produces sectored rates data. The sectored rates are needed for calculating the exposure time in l1c. They will not be produced during commissioning so the ultra team asked me to use these static dead time ratios temporarily so they can start producing psets.

## Updated Files
- imap_processing/ultra/l1c/helio_pset.py, imap_processing/ultra/l1c/spacecraft_pset.py
   - Pass in sensor id (45 or 90) to exposure time calculation in case static dead times are needed. 
- imap_processing/ultra/l1c/l1c_lookup_utils.py
   - Add function to get static dead times 
   - Move build_pset_bins to the utils file to avoid circular import. 
- imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
   - Instead of raising an error if there are no sectored rates, get the static deadtimes from the LUTS. 
   - While I was adding this code I also noticed that the spin_phase_step should be the same dim size as the scattering lookup table. 

## Testing
Test the dead time calculation when there is no sectored rates data 
