### PR TITLE
ULTRA l1c and l2 attr updates

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
@@ -49,6 +49,12 @@ latitude:
   LABL_PTR_1: pixel_index_label
 
 # Define Data variables
+ena_count:
+  DEPEND_1: energy
+  DEPEND_2: pixel_index
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: pixel_index_label
+
 ena_intensity:
   DEPEND_1: energy
   DEPEND_2: pixel_index
@@ -96,6 +102,12 @@ positional_uncert_phi:
   DEPEND_2: pixel_index
   LABL_PTR_1: energy_label
   LABL_PTR_2: pixel_index_label
+
+bg_rate:
+    DEPEND_1: energy
+    DEPEND_2: pixel_index
+    LABL_PTR_1: energy_label
+    LABL_PTR_2: pixel_index_label
 # These data variables will have an extra (energy) dimension
 # only if the energy dimension is present in the L1C data.
 # The default is energy-independent.

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -26,6 +26,9 @@ longitude_delta:
   FORMAT: F12.6
   UNITS: degrees
   FIELDNAM: longitude delta
+  LABL_PTR_1: longitude_label
+  VALIDMIN: 0.0
+  VALIDMAX: 180.0
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 latitude_label:
@@ -43,6 +46,9 @@ latitude_delta:
   FORMAT: F12.6
   UNITS: degrees
   FIELDNAM: latitude delta
+  LABL_PTR_1: latitude_label
+  VALIDMIN: 0.0
+  VALIDMAX: 90.0
   DICT_KEY: SPASE>Support>SupportQuantity:Other
 
 # All variables below override the initial attributes defined in the common ENA Map
@@ -110,6 +116,14 @@ ena_count:
   LABL_PTR_3: latitude_label
 
 sensitivity:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+bg_rate:
   DEPEND_1: energy
   DEPEND_2: longitude
   DEPEND_3: latitude

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -1,20 +1,26 @@
+float_32_fillval: &float_32_fillval -1.0e31
+min_int: &min_int -9223372036854775808
+max_int: &max_int 9223372036854775807
+min_float: &min_float -3.4028235e+38
+max_float: &max_float 3.4028235e+38
+
 default_attrs: &default
   # Assumed values for all variable attrs unless overwritten
   DEPEND_0: epoch
   DISPLAY_TYPE: time_series
-  FILLVAL: -9223372036854775808
+  FILLVAL: *min_int
   FORMAT: I12
-  VALIDMIN: -9223372036854775808
-  VALIDMAX: 9223372036854775807
+  VALIDMIN: *min_int
+  VALIDMAX: *max_int
   VAR_TYPE: data
   UNITS: " "
 
 default_float32_attrs: &default_float32
   <<: *default
-  FILLVAL: -1.0e31
+  FILLVAL: *float_32_fillval
   FORMAT: F12.6
-  VALIDMIN: -3.4028235e+38
-  VALIDMAX: 3.4028235e+38
+  VALIDMIN: *min_float
+  VALIDMAX: *max_float
   dtype: float32
 
 default_uint16_attrs: &default_uint16
@@ -211,3 +217,41 @@ energy_delta_plus:
   FIELDNAM: energy_bin_delta_plus
   DISPLAY_TYPE: no_plot
   DEPEND_1: energy_bin_geometric_mean
+
+
+# COORDS
+energy_bin_geometric_mean:
+  FILLVAL: *float_32_fillval
+  CATDESC: Geometric mean energy of each energy bin.
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: energy_bin_geometric_mean
+  FORMAT: F12.6
+  LABLAXIS: Energy
+  UNITS: keV
+  VALIDMIN: *min_float
+  VALIDMAX: *max_float
+  VAR_TYPE: support_data
+
+pixel_index:
+  FILLVAL: *min_int
+  CATDESC: HEALPix pixel index.
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: pixel_index
+  FORMAT: I12
+  LABLAXIS: Pixel Index
+  UNITS: " "
+  VALIDMIN: *min_int
+  VALIDMAX: *max_int
+  VAR_TYPE: support_data
+
+spin_phase_step:
+  FILLVAL: *min_int
+  CATDESC: Spin phase step index (1ms resolution).
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: spin_phase_step
+  FORMAT: I12
+  LABLAXIS: Spin Phase Step
+  UNITS: " "
+  VALIDMIN: *min_int
+  VALIDMAX: *max_int
+  VAR_TYPE: support_data

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -178,9 +178,9 @@ class TestUltraL2:
         )
 
         # Estimate the expected ena_intensity and its uncertainty
-        expected_ena_intensity = (
-            (10 * solid_angle_ratio_map_to_pset / 1) - 1 * solid_angle_ratio_map_to_pset
-        ) / (1 * hp_skymap.solid_angle * 1)
+        expected_ena_intensity = (10 * solid_angle_ratio_map_to_pset / 1) / (
+            1 * hp_skymap.solid_angle * 1
+        )
         expected_ena_intensity_unc = (
             (10 * solid_angle_ratio_map_to_pset) ** 0.5 / 1
         ) / (1 * hp_skymap.solid_angle * 1)
@@ -508,10 +508,12 @@ class TestUltraL2:
 
         # The mean ena_intensity should be close between the healpix / rectangular maps
         # Test they agree to within 1% of one another
+        print(rect_map_dataset["ena_intensity"].mean())
+        print(hp_map_dataset["ena_intensity"].mean())
         np.testing.assert_allclose(
             rect_map_dataset["ena_intensity"].mean(),
             hp_map_dataset["ena_intensity"].mean(),
-            rtol=1e-2,
+            rtol=3e-1,
             atol=1e-12,
         )
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -178,9 +178,9 @@ class TestUltraL2:
         )
 
         # Estimate the expected ena_intensity and its uncertainty
-        expected_ena_intensity = (10 * solid_angle_ratio_map_to_pset / 1) / (
-            1 * hp_skymap.solid_angle * 1
-        )
+        expected_ena_intensity = (
+            10 * solid_angle_ratio_map_to_pset / 1
+        ) - 1 * solid_angle_ratio_map_to_pset / (1 * hp_skymap.solid_angle * 1)
         expected_ena_intensity_unc = (
             (10 * solid_angle_ratio_map_to_pset) ** 0.5 / 1
         ) / (1 * hp_skymap.solid_angle * 1)

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -179,8 +179,8 @@ class TestUltraL2:
 
         # Estimate the expected ena_intensity and its uncertainty
         expected_ena_intensity = (
-            10 * solid_angle_ratio_map_to_pset / 1
-        ) - 1 * solid_angle_ratio_map_to_pset / (1 * hp_skymap.solid_angle * 1)
+            (10 * solid_angle_ratio_map_to_pset / 1) - 1 * solid_angle_ratio_map_to_pset
+        ) / (1 * hp_skymap.solid_angle * 1)
         expected_ena_intensity_unc = (
             (10 * solid_angle_ratio_map_to_pset) ** 0.5 / 1
         ) / (1 * hp_skymap.solid_angle * 1)
@@ -508,12 +508,10 @@ class TestUltraL2:
 
         # The mean ena_intensity should be close between the healpix / rectangular maps
         # Test they agree to within 1% of one another
-        print(rect_map_dataset["ena_intensity"].mean())
-        print(hp_map_dataset["ena_intensity"].mean())
         np.testing.assert_allclose(
             rect_map_dataset["ena_intensity"].mean(),
             hp_map_dataset["ena_intensity"].mean(),
-            rtol=3e-1,
+            rtol=1e-2,
             atol=1e-12,
         )
 

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -381,11 +381,9 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
     # These NaNs are not incorrect, so we temporarily ignore numpy div by 0 warnings.
     with np.errstate(divide="ignore"):
         # Get corrected count rate with background subtraction applied
-        # TODO background rates should not be subtracted until the ULTRA IT team
-        #   decides so.
         skymap.data_1d["corrected_count_rate"] = (
             skymap.data_1d["counts"].astype(float) / skymap.data_1d["exposure_factor"]
-        )  # - skymap.data_1d["background_rates"]
+        ) - skymap.data_1d["background_rates"]
 
         # Calculate ena_intensity = corrected_counts / (
         # sensitivity * solid_angle * delta_energy)

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -668,7 +668,7 @@ def ultra_l2(
             continue
 
         # Support variables do not have epoch as the first dimension
-        # skip schema check for support variables or choords
+        # skip schema check for support variables or coords
         skip_schema_check = not (
             "epoch" not in map_dataset[variable].dims  # Support data
             or variable

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -381,9 +381,11 @@ def generate_ultra_healpix_skymap(  # noqa: PLR0912
     # These NaNs are not incorrect, so we temporarily ignore numpy div by 0 warnings.
     with np.errstate(divide="ignore"):
         # Get corrected count rate with background subtraction applied
+        # TODO background rates should not be subtracted until the ULTRA IT team
+        #   decides so.
         skymap.data_1d["corrected_count_rate"] = (
             skymap.data_1d["counts"].astype(float) / skymap.data_1d["exposure_factor"]
-        ) - skymap.data_1d["background_rates"]
+        )  # - skymap.data_1d["background_rates"]
 
         # Calculate ena_intensity = corrected_counts / (
         # sensitivity * solid_angle * delta_energy)
@@ -566,8 +568,12 @@ def ultra_l2(
         map_dataset = rectangular_skymap.to_dataset()
 
         # Add longitude_delta, latitude_delta to the map dataset
-        map_dataset["longitude_delta"] = rectangular_skymap.spacing_deg / 2
-        map_dataset["latitude_delta"] = rectangular_skymap.spacing_deg / 2
+        map_dataset["longitude_delta"] = np.full(
+            map_dataset["longitude"].shape, rectangular_skymap.spacing_deg / 2
+        )
+        map_dataset["latitude_delta"] = np.full(
+            map_dataset["latitude"].shape, rectangular_skymap.spacing_deg / 2
+        )
 
         map_attrs = {
             "Spacing_degrees": str(output_map_structure.spacing_deg),

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -568,11 +568,13 @@ def ultra_l2(
         map_dataset = rectangular_skymap.to_dataset()
 
         # Add longitude_delta, latitude_delta to the map dataset
-        map_dataset["longitude_delta"] = np.full(
-            map_dataset["longitude"].shape, rectangular_skymap.spacing_deg / 2
+        map_dataset["longitude_delta"] = (
+            "longitude",
+            np.full(map_dataset["longitude"].shape, rectangular_skymap.spacing_deg / 2),
         )
-        map_dataset["latitude_delta"] = np.full(
-            map_dataset["latitude"].shape, rectangular_skymap.spacing_deg / 2
+        map_dataset["latitude_delta"] = (
+            "latitude",
+            np.full(map_dataset["latitude"].shape, rectangular_skymap.spacing_deg / 2),
         )
 
         map_attrs = {

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -93,20 +93,25 @@ def create_dataset(  # noqa: PLR0912
     rates_pulse_keys = {"start_per_spin", "stop_per_spin", "coin_per_spin"}
 
     for key, data in data_dict.items():
-        # Skip keys that are coordinates.
-        if key in [
-            "epoch",
+        if key == "epoch":
+            # epoch coordinate already created with correct attrs
+            continue
+        elif key == "epoch_delta":
+            # Create epoch_delta variable
+            dataset[key] = xr.DataArray(
+                data,
+                dims=["epoch"],
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            )
+        elif key in [
             "spin_number",
             "energy_bin_geometric_mean",
             "pixel_index",
             "spin_phase_step",
         ]:
-            continue
-        elif key == "epoch_delta":
-            dataset[key] = xr.DataArray(
-                data,
-                dims=["epoch"],
-                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            # update attrs
+            dataset[key].attrs = cdf_manager.get_variable_attributes(
+                key, check_schema=False
             )
         elif key in velocity_keys:
             dataset[key] = xr.DataArray(


### PR DESCRIPTION
# Change Summary

## Overview
I noticed some ISTP compliance errors for the l2 maps. Menlo also emailed me with feedback asking to add metadata to pset coordinates. 

## Updated Files
- imap_processing/cdf/config/imap_enamaps_l2-healpix_variable_attrs.yaml
   - Skteditor raised a warning that the DEPENDS and LABL_PTR_1 are missing from bg_rate and counts in my healpix map
- imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
   - skteditor raised a warning that LABL_PTR_1 is missing from bg_rate, longitude_delta, and latitude_delta. 
   - Longitude and latitude delta were also missing min and max. 
- imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
   - Add coord attrs that were missing. 
