### PR TITLE
ULTRA l1b use energy bin's geometric mean for scattering culling

### DIFF
--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -43,7 +43,7 @@ class ImapDEOutliersUltraFlags(FlagNameMixin):
     NONE = CommonFlags.NONE
     FOV = 2**0  # bit 0
     PHCORR = 2**1  # bit 1
-    COINPH = 2**2  # bit 4 # Event validity
+    COINPH = 2**2  # bit 2 # Event validity
     INVALID_ENERGY = 2**3  # bit 3
 
 

--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -44,6 +44,7 @@ class ImapDEOutliersUltraFlags(FlagNameMixin):
     FOV = 2**0  # bit 0
     PHCORR = 2**1  # bit 1
     COINPH = 2**2  # bit 4 # Event validity
+    INVALID_ENERGY = 2**3  # bit 3
 
 
 class ImapHkUltraFlags(FlagNameMixin):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -267,19 +267,19 @@ def test_get_de_velocity(test_fixture):
 
     np.testing.assert_allclose(
         v_x[test_tof > 0],
-        df_ph["vx"].astype("float").values[test_tof > 0],
+        -df_ph["vx"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
     np.testing.assert_allclose(
         v_y[test_tof > 0],
-        df_ph["vy"].astype("float").values[test_tof > 0],
+        -df_ph["vy"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
     np.testing.assert_allclose(
         v_z[test_tof > 0],
-        df_ph["vz"].astype("float").values[test_tof > 0],
+        -df_ph["vz"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
@@ -354,12 +354,13 @@ def test_get_de_energy_kev(test_fixture):
         test_d,
         test_tof,
     )
-
-    energy = get_de_energy_kev(v, species_bin_ph)
+    quality_flags = np.zeros_like(species_bin_ph)
+    energy = get_de_energy_kev(v, species_bin_ph, quality_flags)
     index_hydrogen = np.where(species_bin_ph == 1)
     actual_energy = energy[index_hydrogen[0]]
     expected_energy = df_ph["energy_revised"].astype("float")
-
+    # All flags should be zero
+    assert np.sum(quality_flags) == 0
     np.testing.assert_allclose(actual_energy, expected_energy, atol=1e-01, rtol=0)
 
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -267,19 +267,19 @@ def test_get_de_velocity(test_fixture):
 
     np.testing.assert_allclose(
         v_x[test_tof > 0],
-        -df_ph["vx"].astype("float").values[test_tof > 0],
+        df_ph["vx"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
     np.testing.assert_allclose(
         v_y[test_tof > 0],
-        -df_ph["vy"].astype("float").values[test_tof > 0],
+        df_ph["vy"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
     np.testing.assert_allclose(
         v_z[test_tof > 0],
-        -df_ph["vz"].astype("float").values[test_tof > 0],
+        df_ph["vz"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -304,7 +304,9 @@ def calculate_de(
     de_dict["direct_event_unit_position"] = r_hat.astype(np.float32)
 
     tof_energy[valid_indices] = get_de_energy_kev(
-        velocities[valid_indices], species_bin[valid_indices]
+        velocities[valid_indices],
+        species_bin[valid_indices],
+        quality_flags[valid_indices],
     )
     de_dict["tof_energy"] = tof_energy
     de_dict["energy"] = energy
@@ -348,8 +350,12 @@ def calculate_de(
     de_dict["velocity_dps_sc"] = sc_dps_velocity
     de_dict["velocity_dps_helio"] = helio_velocity
 
-    de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
-    de_dict["energy_heliosphere"] = get_de_energy_kev(helio_velocity, species_bin)
+    de_dict["energy_spacecraft"] = get_de_energy_kev(
+        sc_dps_velocity, species_bin, quality_flags
+    )
+    de_dict["energy_heliosphere"] = get_de_energy_kev(
+        helio_velocity, species_bin, quality_flags
+    )
 
     de_dict["phi_fwhm"], de_dict["theta_fwhm"] = get_fwhm(
         start_type,
@@ -376,6 +382,7 @@ def calculate_de(
         ancillary_files,
         "l1b-sensor-gf-noblades",
     )
+
     de_dict["quality_outliers"] = quality_flags
     flag_scattering(
         de_dict["tof_energy"],

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -517,6 +517,8 @@ def flag_scattering(
 
     for (e_min, e_max), threshold in scattering_thresholds.items():
         event_mask = (tof_energy >= e_min) & (tof_energy < e_max)
+        # use the geometric mean of the energy bin for the scattering check
+        energy_geom_mean = np.sqrt(e_min * e_max)
         # Input the theta and phi values for the current energy range.
         # Returns a_theta_val, g_theta_val, a_phi_val, g_phi_val
         theta_coeffs, phi_coeffs = get_scattering_coefficients(
@@ -528,8 +530,8 @@ def flag_scattering(
         )
         # FWHM_PHI = A_PHI * E^G_PHI
         # FWHM_THETA = A_THETA * E^G_THETA
-        fwhm_theta = theta_coeffs[:, 0] * tof_energy[event_mask] ** theta_coeffs[:, 1]
-        fwhm_phi = phi_coeffs[:, 0] * tof_energy[event_mask] ** phi_coeffs[:, 1]
+        fwhm_theta = theta_coeffs[:, 0] * energy_geom_mean ** theta_coeffs[:, 1]
+        fwhm_phi = phi_coeffs[:, 0] * energy_geom_mean ** phi_coeffs[:, 1]
         is_nan = np.isnan(fwhm_theta) | np.isnan(fwhm_phi)
         quality_flags[np.where(event_mask)[0][is_nan]] |= (
             ImapDEScatteringUltraFlags.NAN_PHI_OR_THETA.value

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -22,6 +22,7 @@ from imap_processing.ultra.l1b.lookup_utils import (
     get_scattering_thresholds,
 )
 from imap_processing.ultra.l1b.quality_flag_filters import DE_QUALITY_FLAG_FILTERS
+from imap_processing.ultra.l1c.l1c_lookup_utils import build_energy_bins
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -514,11 +515,15 @@ def flag_scattering(
         Quality flags.
     """
     scattering_thresholds = get_scattering_thresholds(ancillary_files)
-
+    _, _, energy_bin_geometric_means = build_energy_bins()
+    energy_bin_inds = np.digitize(tof_energy, UltraConstants.PSET_ENERGY_BIN_EDGES)
+    # Clip indices to valid range (events outside the energy bins get assigned
+    # to the nearest bin. These events have already been flagged and
+    # will be ignored in l1c)
+    energy_bin_inds = np.clip(energy_bin_inds, 1, len(energy_bin_geometric_means))
+    energy_geom_means = energy_bin_geometric_means[energy_bin_inds - 1]
     for (e_min, e_max), threshold in scattering_thresholds.items():
         event_mask = (tof_energy >= e_min) & (tof_energy < e_max)
-        # use the geometric mean of the energy bin for the scattering check
-        energy_geom_mean = np.sqrt(e_min * e_max)
         # Input the theta and phi values for the current energy range.
         # Returns a_theta_val, g_theta_val, a_phi_val, g_phi_val
         theta_coeffs, phi_coeffs = get_scattering_coefficients(
@@ -530,8 +535,11 @@ def flag_scattering(
         )
         # FWHM_PHI = A_PHI * E^G_PHI
         # FWHM_THETA = A_THETA * E^G_THETA
-        fwhm_theta = theta_coeffs[:, 0] * energy_geom_mean ** theta_coeffs[:, 1]
-        fwhm_phi = phi_coeffs[:, 0] * energy_geom_mean ** phi_coeffs[:, 1]
+        # Use the geometric mean of the energy bin for the scattering check
+        fwhm_theta = (
+            theta_coeffs[:, 0] * energy_geom_means[event_mask] ** theta_coeffs[:, 1]
+        )
+        fwhm_phi = phi_coeffs[:, 0] * energy_geom_means[event_mask] ** phi_coeffs[:, 1]
         is_nan = np.isnan(fwhm_theta) | np.isnan(fwhm_phi)
         quality_flags[np.where(event_mask)[0][is_nan]] |= (
             ImapDEScatteringUltraFlags.NAN_PHI_OR_THETA.value

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -541,9 +541,9 @@ def get_de_velocity(
     delta_v[:, 2] = d * 0.1
 
     # Convert from 0.1mm/0.1ns to km/s.
-    v_x = -delta_v[:, 0] / tof * 1e3
-    v_y = -delta_v[:, 1] / tof * 1e3
-    v_z = -delta_v[:, 2] / tof * 1e3
+    v_x = delta_v[:, 0] / tof * 1e3
+    v_y = delta_v[:, 1] / tof * 1e3
+    v_z = delta_v[:, 2] / tof * 1e3
 
     v_x[tof < 0] = FILLVAL_FLOAT32  # used as fillvals
     v_y[tof < 0] = FILLVAL_FLOAT32
@@ -554,7 +554,7 @@ def get_de_velocity(
     v_hat = velocities / np.linalg.norm(velocities, axis=1)[:, None]
     r_hat = -v_hat
 
-    return velocities, v_hat, r_hat
+    return velocities, -v_hat, -r_hat
 
 
 def get_ssd_tof(

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -541,9 +541,9 @@ def get_de_velocity(
     delta_v[:, 2] = d * 0.1
 
     # Convert from 0.1mm/0.1ns to km/s.
-    v_x = delta_v[:, 0] / tof * 1e3
-    v_y = delta_v[:, 1] / tof * 1e3
-    v_z = delta_v[:, 2] / tof * 1e3
+    v_x = -delta_v[:, 0] / tof * 1e3
+    v_y = -delta_v[:, 1] / tof * 1e3
+    v_z = -delta_v[:, 2] / tof * 1e3
 
     v_x[tof < 0] = FILLVAL_FLOAT32  # used as fillvals
     v_y[tof < 0] = FILLVAL_FLOAT32
@@ -554,7 +554,7 @@ def get_de_velocity(
     v_hat = velocities / np.linalg.norm(velocities, axis=1)[:, None]
     r_hat = -v_hat
 
-    return velocities, -v_hat, -r_hat
+    return velocities, v_hat, r_hat
 
 
 def get_ssd_tof(
@@ -616,7 +616,9 @@ def get_ssd_tof(
     return np.asarray(tof, dtype=np.float64)
 
 
-def get_de_energy_kev(v: np.ndarray, species: np.ndarray) -> NDArray:
+def get_de_energy_kev(
+    v: np.ndarray, species: np.ndarray, quality_flags: np.ndarray
+) -> NDArray:
     """
     Calculate the direct event energy.
 
@@ -626,6 +628,8 @@ def get_de_energy_kev(v: np.ndarray, species: np.ndarray) -> NDArray:
         N x 3 array of velocity components (vx, vy, vz) in km/s.
     species : np.ndarray
         Species of the particle.
+    quality_flags : np.ndarray, optional
+        Quality flags to set when there is an outlier.
 
     Returns
     -------
@@ -648,6 +652,11 @@ def get_de_energy_kev(v: np.ndarray, species: np.ndarray) -> NDArray:
     energy[valid_mask] = (
         0.5 * UltraConstants.MASS_H * v2[valid_mask] * UltraConstants.J_KEV
     )
+    # Flag out of range energies
+    energy_out_of_range = (energy < UltraConstants.PSET_ENERGY_BIN_EDGES[0]) | (
+        energy > UltraConstants.PSET_ENERGY_BIN_EDGES[-1]
+    )
+    quality_flags[energy_out_of_range] |= ImapDEOutliersUltraFlags.INVALID_ENERGY.value
 
     return energy
 

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -617,7 +617,7 @@ def get_ssd_tof(
 
 
 def get_de_energy_kev(
-    v: np.ndarray, species: np.ndarray, quality_flags: np.ndarray
+    v: np.ndarray, species: np.ndarray, quality_flags: np.ndarray | None = None
 ) -> NDArray:
     """
     Calculate the direct event energy.
@@ -653,10 +653,13 @@ def get_de_energy_kev(
         0.5 * UltraConstants.MASS_H * v2[valid_mask] * UltraConstants.J_KEV
     )
     # Flag out of range energies
-    energy_out_of_range = (energy < UltraConstants.PSET_ENERGY_BIN_EDGES[0]) | (
-        energy > UltraConstants.PSET_ENERGY_BIN_EDGES[-1]
-    )
-    quality_flags[energy_out_of_range] |= ImapDEOutliersUltraFlags.INVALID_ENERGY.value
+    if quality_flags is not None:
+        energy_out_of_range = (energy < UltraConstants.PSET_ENERGY_BIN_EDGES[0]) | (
+            energy > UltraConstants.PSET_ENERGY_BIN_EDGES[-1]
+        )
+        quality_flags[energy_out_of_range] |= (
+            ImapDEOutliersUltraFlags.INVALID_ENERGY.value
+        )
 
     return energy
 


### PR DESCRIPTION

# Change Summary

## Overview
L1b code was using the "event energy" instead of the geometric mean of the energy bin of that event's energy. Nick was doing this in his code and noticed it was wrong and asked me to check our code. 

## Updated Files
- imap_processing/ultra/l1b/ultra_l1b_culling.py
    - Use the energy bin geometric mean. 

