### PR TITLE
ULTRA l1b correct particle direction velocity 

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -267,19 +267,19 @@ def test_get_de_velocity(test_fixture):
 
     np.testing.assert_allclose(
         v_x[test_tof > 0],
-        df_ph["vx"].astype("float").values[test_tof > 0],
+        -df_ph["vx"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
     np.testing.assert_allclose(
         v_y[test_tof > 0],
-        df_ph["vy"].astype("float").values[test_tof > 0],
+        -df_ph["vy"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )
     np.testing.assert_allclose(
         v_z[test_tof > 0],
-        df_ph["vz"].astype("float").values[test_tof > 0],
+        -df_ph["vz"].astype("float").values[test_tof > 0],
         atol=1e-01,
         rtol=0,
     )

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -541,9 +541,9 @@ def get_de_velocity(
     delta_v[:, 2] = d * 0.1
 
     # Convert from 0.1mm/0.1ns to km/s.
-    v_x = delta_v[:, 0] / tof * 1e3
-    v_y = delta_v[:, 1] / tof * 1e3
-    v_z = delta_v[:, 2] / tof * 1e3
+    v_x = -delta_v[:, 0] / tof * 1e3
+    v_y = -delta_v[:, 1] / tof * 1e3
+    v_z = -delta_v[:, 2] / tof * 1e3
 
     v_x[tof < 0] = FILLVAL_FLOAT32  # used as fillvals
     v_y[tof < 0] = FILLVAL_FLOAT32
@@ -554,7 +554,7 @@ def get_de_velocity(
     v_hat = velocities / np.linalg.norm(velocities, axis=1)[:, None]
     r_hat = -v_hat
 
-    return velocities, -v_hat, -r_hat
+    return velocities, v_hat, r_hat
 
 
 def get_ssd_tof(


### PR DESCRIPTION
# Change Summary

## Overview
The psets created on Friday have counts where there was no exposure factor (they were on the opposite side of the map). This led the instrument team to believe there was a sign flip somewhere when calculation velocities in the instrument frame. Sure enough there was. Apparently at one point Larry was calculating it this way as well so the code was validating but it needs to be corrected now. The issue is in equation 3. That R factor should be negated and our code was not doing that. 

<img width="565" height="145" alt="Screenshot 2025-11-03 at 12 28 09 PM" src="https://github.com/user-attachments/assets/ad4fd622-3920-46fb-83c8-b9aac3536cc9" />


## Updated Files
- imap_processing/ultra/l1b/ultra_l1b_extended.py
   - fix velocity valculations

## Testing
Fix tests