### PR TITLE
task: Add more SPICE frames for MAG L2 processing and fix issue with SPICE epochs missing

### DIFF
--- a/imap_processing/cdf/config/imap_mag_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_global_cdf_attrs.yaml
@@ -189,6 +189,13 @@ imap_mag_l2_norm-gse:
     Logical_source_description: IMAP Mission Normal Rate Instrument Level-2 Data in
         Geocentric Solar Ecliptic Reference Frame.
 
+imap_mag_l2_burst-gse:
+    <<: *default
+    Data_type: L2_burst-gse>Level 2 burst rate data in GSE
+    Logical_source: imap_mag_l2_burst-gse
+    Logical_source_description: IMAP Mission Burst Rate Instrument Level-2 Data in
+        Geocentric Solar Ecliptic Reference Frame.
+
 imap_mag_l2_norm-gsm:
     <<: *default
     Data_type: L2_norm-gsm>Level 2 normal rate data in GSM
@@ -196,9 +203,9 @@ imap_mag_l2_norm-gsm:
     Logical_source_description: IMAP Mission Normal Rate Instrument Level-2 Data in
         Geocentric Solar Magnetospheric Reference Frame.
 
-imap_mag_l2_burst-gse:
+imap_mag_l2_burst-gsm:
     <<: *default
-    Data_type: L2_burst-gse>Level 2 burst rate data in GSE
-    Logical_source: imap_mag_l2_burst-gse
+    Data_type: L2_burst-gsm>Level 2 burst rate data in GSM
+    Logical_source: imap_mag_l2_burst-gsm
     Logical_source_description: IMAP Mission Burst Rate Instrument Level-2 Data in
-        Geocentric Solar Ecliptic Reference Frame.
+        Geocentric Solar Magnetospheric Reference Frame.

--- a/imap_processing/cdf/config/imap_mag_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_global_cdf_attrs.yaml
@@ -189,6 +189,13 @@ imap_mag_l2_norm-gse:
     Logical_source_description: IMAP Mission Normal Rate Instrument Level-2 Data in
         Geocentric Solar Ecliptic Reference Frame.
 
+imap_mag_l2_norm-gsm:
+    <<: *default
+    Data_type: L2_norm-gsm>Level 2 normal rate data in GSM
+    Logical_source: imap_mag_l2_norm-gsm
+    Logical_source_description: IMAP Mission Normal Rate Instrument Level-2 Data in
+        Geocentric Solar Magnetospheric Reference Frame.
+
 imap_mag_l2_burst-gse:
     <<: *default
     Data_type: L2_burst-gse>Level 2 burst rate data in GSE

--- a/imap_processing/mag/l1d/mag_l1d_data.py
+++ b/imap_processing/mag/l1d/mag_l1d_data.py
@@ -298,6 +298,7 @@ class MagL1d(MagL2L1dBase):  # type: ignore[misc]
             self.vectors,
             from_frame=start_frame.value,
             to_frame=end_frame.value,
+            allow_spice_noframeconnect=True,
         )
 
         # If we were in MAGO frame, we need to rotate MAGI vectors from MAGI to
@@ -310,6 +311,7 @@ class MagL1d(MagL2L1dBase):  # type: ignore[misc]
             self.magi_vectors,
             from_frame=start_frame.value,
             to_frame=end_frame.value,
+            allow_spice_noframeconnect=True,
         )
 
         self.frame = end_frame

--- a/imap_processing/mag/l2/mag_l2.py
+++ b/imap_processing/mag/l2/mag_l2.py
@@ -1,5 +1,7 @@
 """Module to run MAG L2 processing."""
 
+import logging
+
 import numpy as np
 import xarray as xr
 
@@ -7,6 +9,8 @@ from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.mag import imap_mag_sdc_configuration_v001 as configuration
 from imap_processing.mag.constants import DataMode
 from imap_processing.mag.l2.mag_l2_data import MagL2, ValidFrames
+
+logger = logging.getLogger(__name__)
 
 
 def mag_l2(
@@ -105,17 +109,31 @@ def mag_l2(
         frame=instrument_frame,
     )
 
+    # L2 data should not include the extra 30 min padding either side
+    # Note: this must be done after applying offsets and timedeltas
+    l2_data.truncate_to_24h(day)
+
     attributes = ImapCdfAttributes()
     attributes.add_instrument_global_attrs("mag")
     attributes.add_instrument_variable_attrs("mag", "l2")
 
     # Rotate from the MAG frame into the SRF frame
-    l2_data.rotate_frame(ValidFrames.SRF)
-    imap_srf = l2_data.generate_dataset(attributes, day)
-    l2_data.rotate_frame(ValidFrames.DSRF)
-    imap_dsrf = l2_data.generate_dataset(attributes, day)
+    frames: list[xr.Dataset] = []
 
-    return [imap_dsrf, imap_srf]
+    for frame in [
+        ValidFrames.SRF,
+        ValidFrames.GSE,
+        ValidFrames.GSM,
+        ValidFrames.RTN,
+        ValidFrames.DSRF,  # should be last as some vectors may become NaN
+    ]:
+        try:
+            l2_data.rotate_frame(frame)
+            frames.append(l2_data.generate_dataset(attributes, day))
+        except Exception:
+            logger.exception(f"Error rotating to frame {frame.name}")
+
+    return frames
 
 
 def retrieve_matrix_from_l2_calibration(

--- a/imap_processing/mag/l2/mag_l2.py
+++ b/imap_processing/mag/l2/mag_l2.py
@@ -127,11 +127,8 @@ def mag_l2(
         ValidFrames.RTN,
         ValidFrames.DSRF,  # should be last as some vectors may become NaN
     ]:
-        try:
-            l2_data.rotate_frame(frame)
-            frames.append(l2_data.generate_dataset(attributes, day))
-        except Exception:
-            logger.exception(f"Error rotating to frame {frame.name}")
+        l2_data.rotate_frame(frame)
+        frames.append(l2_data.generate_dataset(attributes, day))
 
     return frames
 

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -319,6 +319,7 @@ class MagL2L1dBase:
             self.vectors,
             from_frame=self.frame.value,
             to_frame=end_frame.value,
+            allow_spice_noframeconnect=True,
         )
         self.frame = end_frame
 

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -25,6 +25,7 @@ class ValidFrames(Enum):
     DSRF = SpiceFrame.IMAP_DPS
     SRF = SpiceFrame.IMAP_SPACECRAFT
     GSE = SpiceFrame.IMAP_GSE
+    GSM = SpiceFrame.IMAP_GSM
     RTN = SpiceFrame.IMAP_RTN
 
 

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -215,6 +215,9 @@ class MagL2L1dBase:
         self.quality_flags = self.quality_flags[day_start_index:day_end_index]
         self.quality_bitmask = self.quality_bitmask[day_start_index:day_end_index]
 
+        if self.epoch_et is not None:
+            self.epoch_et = self.epoch_et[day_start_index:day_end_index]
+
     @staticmethod
     def calculate_magnitude(
         vectors: np.ndarray,

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -9,6 +9,7 @@ Paradigms for developing this module:
 * Always return numpy arrays for vectorized calls.
 """
 
+import logging
 import typing
 from enum import IntEnum
 
@@ -16,6 +17,8 @@ import numpy as np
 import numpy.typing as npt
 import spiceypy
 from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
 
 
 class SpiceBody(IntEnum):
@@ -367,6 +370,8 @@ def get_rotation_matrix(
     """
     Get the rotation matrix/matrices that can be used to transform between frames.
 
+    If no transformation is defined for a specific time, a matrix of NaNs is returned.
+
     This is a vectorized wrapper around `spiceypy.pxform`
     "Return the matrix that transforms position vectors from one specified frame
     to another at a specified epoch."
@@ -388,8 +393,21 @@ def get_rotation_matrix(
         `et` is a np.ndarray, the returned rotation matrix is of shape `(n, 3, 3)`
         where `n` matches the number of elements in et.
     """
+
+    def pxform_error_handler(  # type: ignore[no-untyped-def]
+        *arg, **kwargs
+    ):  # numpydoc ignore=GL08
+        try:
+            return spiceypy.pxform(*arg, **kwargs)
+        except spiceypy.utils.exceptions.SpiceNOFRAMECONNECT:
+            logger.exception(
+                f"Error getting rotation matrix from {from_frame} to {to_frame}"
+                f" at et={et}. Returning NaNs."
+            )
+            return np.full((3, 3), np.nan)
+
     vec_pxform = np.vectorize(
-        spiceypy.pxform,
+        pxform_error_handler,
         excluded=["fromstr", "tostr"],
         signature="(),(),()->(3,3)",
         otypes=[np.float64],

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -241,6 +241,7 @@ def frame_transform(
     position: npt.NDArray,
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
+    allow_spice_noframeconnect: bool = False,
 ) -> npt.NDArray:
     """
     Transform an <x, y, z> vector between reference frames (rotation only).
@@ -267,6 +268,11 @@ def frame_transform(
         Reference frame of input vector(s).
     to_frame : SpiceFrame
         Reference frame of output vector(s).
+    allow_spice_noframeconnect : bool
+        If True, does not throw SPICE NOFRAMECONNECT error and returns a NaN vector
+        for those `et`s where there is insufficient information available to transform
+        from `from_frame` to `to_frame`.
+        Defaults to False.
 
     Returns
     -------
@@ -299,7 +305,7 @@ def frame_transform(
 
     # rotate will have shape = (3, 3) or (n, 3, 3)
     # position will have shape = (3,) or (n, 3)
-    rotate = get_rotation_matrix(et, from_frame, to_frame)
+    rotate = get_rotation_matrix(et, from_frame, to_frame, allow_spice_noframeconnect)
     # adding a dimension to position results in the following input and output
     # shapes from matrix multiplication
     # Single et/position:      (3, 3),(3, 1) -> (3, 1)
@@ -366,6 +372,7 @@ def get_rotation_matrix(
     et: float | npt.NDArray,
     from_frame: SpiceFrame,
     to_frame: SpiceFrame,
+    allow_spice_noframeconnect: bool = False,
 ) -> npt.NDArray:
     """
     Get the rotation matrix/matrices that can be used to transform between frames.
@@ -385,6 +392,11 @@ def get_rotation_matrix(
         Reference frame to transform from.
     to_frame : SpiceFrame
         Reference frame to transform to.
+    allow_spice_noframeconnect : bool
+        If True, does not throw SPICE NOFRAMECONNECT error and returns a NaN matrix
+        for those `et`s where there is insufficient information available to transform
+        from `from_frame` to `to_frame`.
+        Defaults to False.
 
     Returns
     -------
@@ -392,6 +404,8 @@ def get_rotation_matrix(
         If `et` is a float, the returned rotation matrix is of shape `(3, 3)`. If
         `et` is a np.ndarray, the returned rotation matrix is of shape `(n, 3, 3)`
         where `n` matches the number of elements in et.
+        Some of the matrices in the output may be NaN if no transformation was
+        available for the corresponding `et` and `allow_spice_noframeconnect` is True.
     """
 
     def pxform_error_handler(  # type: ignore[no-untyped-def]
@@ -399,10 +413,13 @@ def get_rotation_matrix(
     ):  # numpydoc ignore=GL08
         try:
             return spiceypy.pxform(*arg, **kwargs)
-        except spiceypy.utils.exceptions.SpiceNOFRAMECONNECT:
-            logger.exception(
-                f"Error getting rotation matrix from {from_frame} to {to_frame}"
-                f" at et={et}. Returning NaNs."
+        except spiceypy.utils.exceptions.SpiceNOFRAMECONNECT as e:
+            if not allow_spice_noframeconnect:
+                raise e
+            logger.debug(
+                "Returning NaN matrix due to spiceypy error in rotation from"
+                f" {from_frame} to {to_frame} at et={et}",
+                exc_info=True,
             )
             return np.full((3, 3), np.nan)
 

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -419,7 +419,7 @@ def get_rotation_matrix(
             logger.debug(
                 "Returning NaN matrix due to spiceypy error in rotation from"
                 f" {from_frame} to {to_frame} at et={et}",
-                exc_info=True,
+                exc_info=e,
             )
             return np.full((3, 3), np.nan)
 

--- a/imap_processing/tests/mag/test_mag_l1d.py
+++ b/imap_processing/tests/mag/test_mag_l1d.py
@@ -461,7 +461,9 @@ def test_rotate_frames(mag_l1d_test_class):
     initial_magi_vectors = mag_l1d_test_class.magi_vectors.copy()
 
     # Mock frame_transform to return identifiable transformed vectors
-    def mock_frame_transform(epoch_et, vectors, from_frame, to_frame):
+    def mock_frame_transform(
+        epoch_et, vectors, from_frame, to_frame, allow_spice_noframeconnect
+    ):
         if from_frame == ValidFrames.MAGO.value:
             return vectors + 100
         elif from_frame == ValidFrames.MAGI.value:

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -86,6 +86,33 @@ def test_mag_l2_some_epochs_not_in_spice(norm_dataset, mag_test_l2_data):
         assert np.isnan(dsrf_vectors[i]).all(), f"Vectors at index {i} should be NaN"
 
 
+def test_mag_l2_frame_transform_fails(norm_dataset, mag_test_l2_data, caplog):
+    calibration_dataset = mag_test_l2_data[0]
+
+    offset_dataset = mag_test_l2_data[1]
+    with patch(
+        "imap_processing.mag.l2.mag_l2_data.frame_transform",
+        side_effect=Exception("Simulated frame transform failure"),
+    ):
+        mag_l2(
+            calibration_dataset,
+            offset_dataset,
+            norm_dataset,
+            np.datetime64("2025-10-17"),
+        )
+
+    expected_frames = [
+        ValidFrames.SRF,
+        ValidFrames.GSE,
+        ValidFrames.GSM,
+        ValidFrames.RTN,
+        ValidFrames.DSRF,
+    ]
+
+    for frame in expected_frames:
+        assert f"Error rotating to frame {frame.name}" in caplog.text
+
+
 def test_offset_application(norm_dataset, mag_test_l2_data):
     # Test against zeros
     offsets = mag_test_l2_data[1]

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -51,7 +51,9 @@ def test_mag_l2(norm_dataset, mag_test_l2_data):
 
 
 def test_mag_l2_some_epochs_not_in_spice(norm_dataset, mag_test_l2_data):
-    def return_some_nan_matrices_for_dsrf(et, from_frame, to_frame):
+    def return_some_nan_matrices_for_dsrf(
+        et, from_frame, to_frame, allow_spice_noframeconnect
+    ):
         matrices = np.tile(np.eye(3), (len(et), 1, 1))
         if to_frame == ValidFrames.DSRF.value:
             for i in range(10, matrices.shape[0], 10):  # every 10th matrix is NaN
@@ -84,33 +86,6 @@ def test_mag_l2_some_epochs_not_in_spice(norm_dataset, mag_test_l2_data):
     dsrf_vectors = l2[-1]["vectors"].data
     for i in range(10, len(dsrf_vectors), 10):
         assert np.isnan(dsrf_vectors[i]).all(), f"Vectors at index {i} should be NaN"
-
-
-def test_mag_l2_frame_transform_fails(norm_dataset, mag_test_l2_data, caplog):
-    calibration_dataset = mag_test_l2_data[0]
-
-    offset_dataset = mag_test_l2_data[1]
-    with patch(
-        "imap_processing.mag.l2.mag_l2_data.frame_transform",
-        side_effect=Exception("Simulated frame transform failure"),
-    ):
-        mag_l2(
-            calibration_dataset,
-            offset_dataset,
-            norm_dataset,
-            np.datetime64("2025-10-17"),
-        )
-
-    expected_frames = [
-        ValidFrames.SRF,
-        ValidFrames.GSE,
-        ValidFrames.GSM,
-        ValidFrames.RTN,
-        ValidFrames.DSRF,
-    ]
-
-    for frame in expected_frames:
-        assert f"Error rotating to frame {frame.name}" in caplog.text
 
 
 def test_offset_application(norm_dataset, mag_test_l2_data):

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -32,7 +32,58 @@ def test_mag_l2(norm_dataset, mag_test_l2_data):
             norm_dataset,
             np.datetime64("2025-10-17"),
         )
-    assert "vectors" in l2[0].data_vars
+
+    expected_frames = [
+        ValidFrames.SRF,
+        ValidFrames.GSE,
+        ValidFrames.GSM,
+        ValidFrames.RTN,
+        ValidFrames.DSRF,
+    ]
+
+    assert len(l2) == len(expected_frames), (
+        f"L2 should produce {len(expected_frames)} frames"
+    )
+
+    for i, dataset in enumerate(l2):
+        assert "vectors" in dataset.data_vars
+        assert expected_frames[i].name in dataset.attrs["Data_type"]
+
+
+def test_mag_l2_some_epochs_not_in_spice(norm_dataset, mag_test_l2_data):
+    def return_some_nan_matrices_for_dsrf(et, from_frame, to_frame):
+        matrices = np.tile(np.eye(3), (len(et), 1, 1))
+        if to_frame == ValidFrames.DSRF.value:
+            for i in range(10, matrices.shape[0], 10):  # every 10th matrix is NaN
+                matrices[i] = np.full((3, 3), np.nan)
+        return matrices
+
+    calibration_dataset = mag_test_l2_data[0]
+    offset_dataset = mag_test_l2_data[1]
+
+    with patch(
+        "imap_processing.spice.geometry.get_rotation_matrix",
+        side_effect=return_some_nan_matrices_for_dsrf,
+    ):
+        l2 = mag_l2(
+            calibration_dataset,
+            offset_dataset,
+            norm_dataset,
+            np.datetime64("2025-10-17"),
+        )
+
+    assert len(l2) == 5, "L2 should produce 5 frames"
+
+    for dataset in l2:
+        assert "vectors" in dataset.data_vars
+
+    assert (
+        l2[-1].attrs["Data_type"] == "L2_norm-dsrf>Level 2 normal rate data in DSRF"
+    ), "Last frame should be DSRF"
+
+    dsrf_vectors = l2[-1]["vectors"].data
+    for i in range(10, len(dsrf_vectors), 10):
+        assert np.isnan(dsrf_vectors[i]).all(), f"Vectors at index {i} should be NaN"
 
 
 def test_offset_application(norm_dataset, mag_test_l2_data):

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -357,8 +357,9 @@ def test_get_rotation_matrix(furnish_kernels):
 
 
 @pytest.mark.external_kernel
-def test_get_rotation_matrix_no_transformation_defined_for_et(furnish_kernels):
-    """Test error handling in get_rotation_matrix()."""
+def test_get_rotation_matrix_no_transformation_defined_for_et_allowed(furnish_kernels):
+    """Test error is swallowed and NaN matrix is returned for undefined SPICE
+    transformation when allow_spice_noframeconnect is True in get_rotation_matrix()."""
     kernels = [
         "naif0012.tls",
         "imap_100.tf",
@@ -370,9 +371,51 @@ def test_get_rotation_matrix_no_transformation_defined_for_et(furnish_kernels):
     ]
     with furnish_kernels(kernels):
         # Midnight is not defined in pointing frame
-        et = spiceypy.utc2et("2029-01-01T00:00:00.000")
-        rotation = get_rotation_matrix(et, SpiceFrame.IMAP_MAG_O, SpiceFrame.IMAP_DPS)
+        et = spiceypy.utc2et("2026-01-01T00:00:00.000")
+        rotation = get_rotation_matrix(
+            et,
+            SpiceFrame.IMAP_MAG_O,
+            SpiceFrame.IMAP_DPS,
+            allow_spice_noframeconnect=True,
+        )
         assert np.isnan(rotation).all()
+
+        # one hour after midnight should have coverage
+        ets = np.array([et, et + 3600])
+        rotations = get_rotation_matrix(
+            ets,
+            SpiceFrame.IMAP_MAG_O,
+            SpiceFrame.IMAP_DPS,
+            allow_spice_noframeconnect=True,
+        )
+        assert rotations.shape == (2, 3, 3)
+        assert np.isnan(rotations[0]).all()
+        assert np.isfinite(rotations[1]).all()
+
+
+@pytest.mark.external_kernel
+def test_get_rotation_matrix_no_transformation_defined_for_et_not_allowed(
+    furnish_kernels,
+):
+    """Test error is thrown for undefined SPICE transformation when
+    allow_spice_noframeconnect is False (default) in get_rotation_matrix()."""
+    kernels = [
+        "naif0012.tls",
+        "imap_100.tf",
+        "imap_sclk_0000.tsc",
+        "imap_science_100.tf",
+        "sim_1yr_imap_attitude.bc",
+        "sim_1yr_imap_pointing_frame.bc",
+        "de440s.bsp",
+    ]
+    with furnish_kernels(kernels):
+        # Midnight is not defined in pointing frame
+        et = spiceypy.utc2et("2026-01-01T00:00:00.000")
+        with pytest.raises(
+            spiceypy.utils.exceptions.SpiceNOFRAMECONNECT,
+            match=r"SPICE\(NOFRAMECONNECT\)",
+        ):
+            get_rotation_matrix(et, SpiceFrame.IMAP_MAG_O, SpiceFrame.IMAP_DPS)
 
 
 def test_instrument_pointing(furnish_kernels):

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -345,15 +345,19 @@ def test_get_rotation_matrix(furnish_kernels):
             et, SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT
         )
         assert rotation.shape == (3, 3)
+        assert np.isfinite(rotation).all()
         # test array of et input
         rotation = get_rotation_matrix(
             np.arange(10) + et, SpiceFrame.IMAP_IDEX, SpiceFrame.IMAP_SPACECRAFT
         )
         assert rotation.shape == (10, 3, 3)
+        for i in range(10):
+            assert np.isfinite(rotation[i]).all()
         rotation = get_rotation_matrix(
             et, SpiceFrame.IMAP_SPACECRAFT, SpiceFrame.IMAP_GSE
         )
         assert rotation.shape == (3, 3)
+        assert np.isfinite(rotation).all()
 
 
 @pytest.mark.external_kernel

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -356,6 +356,25 @@ def test_get_rotation_matrix(furnish_kernels):
         assert rotation.shape == (3, 3)
 
 
+@pytest.mark.external_kernel
+def test_get_rotation_matrix_no_transformation_defined_for_et(furnish_kernels):
+    """Test error handling in get_rotation_matrix()."""
+    kernels = [
+        "naif0012.tls",
+        "imap_100.tf",
+        "imap_sclk_0000.tsc",
+        "imap_science_100.tf",
+        "sim_1yr_imap_attitude.bc",
+        "sim_1yr_imap_pointing_frame.bc",
+        "de440s.bsp",
+    ]
+    with furnish_kernels(kernels):
+        # Midnight is not defined in pointing frame
+        et = spiceypy.utc2et("2029-01-01T00:00:00.000")
+        rotation = get_rotation_matrix(et, SpiceFrame.IMAP_MAG_O, SpiceFrame.IMAP_DPS)
+        assert np.isnan(rotation).all()
+
+
 def test_instrument_pointing(furnish_kernels):
     kernels = [
         "naif0012.tls",


### PR DESCRIPTION
# Change Summary

## Overview
This change:
1. Adds transformation of MAG L2 data to 3 new frames (GSE, GSM, RTN)
2. Fixes a few issues with processing MAG L2 data due to:
  a. DSRF transformation not being defined during periods of thruster firing (transformation matrix is now all `NaN`s)
  b. Truncates L2 data to the specified day at the beginning of L2 processing
  c. Truncation also crops `epoch_et` 

> [!NOTE]
> The current implementation will require a lot of memory for processing Burst mode in 128 cadence (as the data for 1 entire day will be held in memory for 5 different frames).

## New Dependencies
N/A

## New Files
N/A

## Deleted Files
N/A

## Updated Files
* `imap_mag_global_cdf_attrs.yaml`
  - Adds definition for GSM reference frame
* `mag_l2.py`:
  - Adds conversion to all supported reference frames
* `mag_l2_data.py`:
  - Adds enum for GSM reference frame
  - Also crops `epoch_et` when truncating
* `geometry.py`:
  - If SPICE tranformation fails becuase of `SpiceNOFRAMECONNECT`, i.e., no SPICE data is available for a specific timestamp (this happens every day between 10 and 10:30 AM for the despun reference frame, due to thruster firing), a `NaN` matrix is returned, instead of an error being thrown
* `test_mag_l2.py`:
  - Modifies existing test to expect 5 datasets for each frame
  - Adds a test to make sure `NaN` matrices are supported
* `test_geometry.py`:
  - Adds a test to make sure `get_rotation_matrix` returns `NaN` matrix when despun frame not defined for input `et`

## Testing
Testing was added to cover all cases.