### PR TITLE
Get pointing start and stop from repoint id

### DIFF
--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -260,7 +260,7 @@ def get_pointing_times_from_id(repoint_id: int | str) -> tuple[float, float]:
     next_repoint_row = repoint_df[repoint_df["repoint_id"] == repoint_id + 1]
     if next_repoint_row.empty:
         raise ValueError(
-            "Pointing end time not found. Either current "
+            f"Pointing end time not found for repoint ID {repoint_id}. Either current "
             "pointing is ongoing or the repoint table is outdated."
         )
 

--- a/imap_processing/spice/repoint.py
+++ b/imap_processing/spice/repoint.py
@@ -2,6 +2,7 @@
 
 import functools
 import logging
+import re
 from pathlib import Path
 
 import numpy as np
@@ -222,6 +223,49 @@ def get_pointing_times(met_time: float) -> tuple[float, float]:
         repoint_df["repoint_end_met"] == pointing_start_met
     ][0]
     pointing_end_met = repoint_df["repoint_start_met"].iloc[pointing_idx + 1].item()
+    return pointing_start_met, pointing_end_met
+
+
+def get_pointing_times_from_id(repoint_id: int | str) -> tuple[float, float]:
+    """
+    Get the start and end MET times for the pointing given a repoint ID.
+
+    Parameters
+    ----------
+    repoint_id : int
+        The repoint ID corresponding to the pointing.
+
+    Returns
+    -------
+    pointing_start_time : float
+        The MET time of the repoint maneuver that ends before the query MET time.
+    pointing_end_time : float
+        The MET time of the repoint maneuver that starts after the query MET time.
+    """
+    if isinstance(repoint_id, str):
+        if not bool(re.fullmatch(r"repoint\d{5}", str(repoint_id))):
+            raise ValueError(
+                f"Invalid repoint ID string format: {repoint_id}. "
+                f"Expected format is 'repointXXXXX'"
+            )
+
+        repoint_id = int(repoint_id.replace("repoint", ""))
+
+    repoint_df = get_repoint_data()
+    # To find the pointing start and stop, get the end of the current repointing
+    # and the start of the next repointing
+    repoint_row = repoint_df[repoint_df["repoint_id"] == repoint_id]
+    if repoint_row.empty:
+        raise ValueError(f"Repoint ID {repoint_id} not found in repoint table.")
+    next_repoint_row = repoint_df[repoint_df["repoint_id"] == repoint_id + 1]
+    if next_repoint_row.empty:
+        raise ValueError(
+            "Pointing end time not found. Either current "
+            "pointing is ongoing or the repoint table is outdated."
+        )
+
+    pointing_start_met = repoint_row["repoint_end_met"].values[0]
+    pointing_end_met = next_repoint_row["repoint_start_met"].values[0]
     return pointing_start_met, pointing_end_met
 
 

--- a/imap_processing/tests/spice/test_repoint.py
+++ b/imap_processing/tests/spice/test_repoint.py
@@ -82,6 +82,38 @@ def test_get_pointing_times(fake_repoint_data):
     assert pointing_end_time == expected_times[1]
 
 
+def test_get_pointing_times_from_id(fake_repoint_data):
+    """Test coverage for get_pointing_times_from_id function."""
+    id = 0
+    expected_times = (5.1, 15.2)
+
+    pointing_start_time, pointing_end_time = repoint.get_pointing_times_from_id(id)
+
+    assert pointing_start_time == expected_times[0]
+    assert pointing_end_time == expected_times[1]
+
+    # Test with string id
+    str_id = "repoint00000"
+    pointing_start_time, pointing_end_time = repoint.get_pointing_times_from_id(str_id)
+
+    assert pointing_start_time == expected_times[0]
+    assert pointing_end_time == expected_times[1]
+
+
+def test_get_pointing_times_from_id_no_end_time(fake_repoint_data):
+    """Test coverage for get_pointing_times_from_id function."""
+    id = 2
+    with pytest.raises(ValueError, match="Pointing end time not found"):
+        repoint.get_pointing_times_from_id(id)
+
+
+def test_get_pointing_times_from_no_id(fake_repoint_data):
+    """Test coverage for get_pointing_times_from_id function."""
+    id = 3
+    with pytest.raises(ValueError, match="Repoint ID 3 not found in repoint table."):
+        repoint.get_pointing_times_from_id(id)
+
+
 def test_get_pointing_mid_time(fake_repoint_data, monkeypatch):
     """Test coverage for get_pointing_mid_time function."""
     times = 6

--- a/imap_processing/tests/spice/test_repoint.py
+++ b/imap_processing/tests/spice/test_repoint.py
@@ -85,6 +85,11 @@ def test_get_pointing_times(fake_repoint_data):
 def test_get_pointing_times_from_id(fake_repoint_data):
     """Test coverage for get_pointing_times_from_id function."""
     id = 0
+    # These are the expected start and end times for the pointing that
+    # corresponds to repoint 0 in the fake data.
+    # The first repoint has start time 0.1 and end time 5.1 and the
+    # second repoint has start time 15.2 and end time 20.2
+    # So the pointing period is from 5.1 to 15.2
     expected_times = (5.1, 15.2)
 
     pointing_start_time, pointing_end_time = repoint.get_pointing_times_from_id(id)

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -88,10 +88,11 @@ def test_calculate_spacecraft_pset(
             "epoch": ("epoch", epoch),
             "component": ("component", ["vx", "vy", "vz"]),
         },
+        attrs={"Repointing": "repoint00001"},
     )
     with (
         mock.patch(
-            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times",
+            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
             return_value=(482374890.0, 482374000.0),
         ),
         mock.patch(
@@ -177,10 +178,11 @@ def test_calculate_spacecraft_pset_with_cdf(
 
         name = "imap_ultra_l1b_45sensor-de"
         dataset = create_dataset(de_dict, name, "l1b")
+        dataset.attrs["Repointing"] = "repoint00000"
         with (
             mock.patch(
-                "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times",
-                return_value=(482374890.0, 482374000.0),
+                "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
+                return_value=(472374890.0, 582378000.0),
             ),
             mock.patch(
                 "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -178,7 +178,7 @@ def test_calculate_spacecraft_pset_with_cdf(
 
     name = "imap_ultra_l1b_45sensor-de"
     dataset = create_dataset(de_dict, name, "l1b")
-
+    dataset.attrs["Repointing"] = "repoint00001"
     data_dict = {
         "imap_ultra_l1b_45sensor-de": dataset,
         "imap_ultra_l1b_45sensor-extendedspin": dataset,  # placeholder
@@ -188,7 +188,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     }
     with (
         mock.patch(
-            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times",
+            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
             return_value=(482374890.0, 482374000.0),
         ),
         mock.patch(
@@ -271,10 +271,9 @@ def test_calculate_helio_pset_with_cdf(
     de_dict["quality_outliers"] = np.zeros(len(helio_dps_velocity), dtype=np.uint16)
     de_dict["species"] = np.ones(len(helio_dps_velocity), dtype=np.uint8)
     de_dict["event_times"] = df_subset["tdb"].values
-
     name = "imap_ultra_l1b_45sensor-de"
     dataset = create_dataset(de_dict, name, "l1b")
-
+    dataset.attrs["Repointing"] = "repoint00001"
     data_dict = {
         "imap_ultra_l1b_45sensor-de": dataset,
         "imap_ultra_l1b_45sensor-extendedspin": xr.Dataset(),  # placeholder
@@ -289,7 +288,7 @@ def test_calculate_helio_pset_with_cdf(
 
     with (
         mock.patch(
-            "imap_processing.ultra.l1c.helio_pset.get_pointing_times",
+            "imap_processing.ultra.l1c.helio_pset.get_pointing_times_from_id",
             return_value=(482374890.0, 482374000.0),
         ),
         mock.patch(

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -9,7 +9,7 @@ from imap_processing.quality_flags import (
     ImapDEScatteringUltraFlags,
 )
 from imap_processing.spice.geometry import SpiceFrame
-from imap_processing.spice.repoint import get_repoint_data
+from imap_processing.spice.repoint import get_pointing_times_from_id
 from imap_processing.spice.time import et_to_met
 from imap_processing.ultra.l1b.lookup_utils import get_geometric_factor
 from imap_processing.ultra.l1b.ultra_l1b_annotated import (
@@ -418,15 +418,7 @@ def calculate_events_in_pointing(
         Boolean array indicating whether each event is within the pointing period
         combined with the valid_events mask.
     """
-    # TODO add this as a helper function in repoint.py
-    repoint_data = get_repoint_data()
-    # To find the pointing start and stop, get the end of the current repointing
-    # and the start of the next repointing
-    repoint_row = repoint_data[repoint_data["repoint_id"] == repoint_id]
-    next_repoint_row = repoint_data[repoint_data["repoint_id"] == repoint_id + 1]
-    pointing_start_met = repoint_row["repoint_end_met"].values[0]
-    pointing_end_met = next_repoint_row["repoint_start_met"].values[0]
-
+    pointing_start_met, pointing_end_met = get_pointing_times_from_id(repoint_id)
     # Check which events are within the pointing
     in_pointing = (et_to_met(event_times) >= pointing_start_met) & (
         et_to_met(event_times) <= pointing_end_met

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -320,7 +320,6 @@ def calculate_de(
 
     # Account for counts=0 (event times have FILL value)
     valid_events = (event_times != FILLVAL_FLOAT32).copy()
-    # TODO - find a better solution than filtering out data from repointings?
     if repoint_id is not None:
         in_pointing = calculate_events_in_pointing(
             repoint_id, event_times[valid_events]

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -8,9 +8,8 @@ import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.quality_flags import ImapPSETUltraFlags
-from imap_processing.spice.repoint import get_pointing_times
+from imap_processing.spice.repoint import get_pointing_times_from_id
 from imap_processing.spice.time import (
-    et_to_met,
     met_to_ttj2000ns,
     ttj2000ns_to_et,
 )
@@ -127,10 +126,13 @@ def calculate_helio_pset(
     )
     healpix = np.arange(n_pix)
 
-    # Get midpoint timestamp for pointing.
-    pointing_range_met = get_pointing_times(
-        et_to_met(species_dataset["event_times"].mean())
-    )
+    # Get the start and stop times of the pointing period
+    repoint_id = species_dataset.attrs.get("Repointing", None)
+    if repoint_id is None:
+        raise ValueError("Repointing ID attribute is missing from the dataset.")
+
+    pointing_range_met = get_pointing_times_from_id(repoint_id)
+
     logger.info("Calculating spacecraft exposure times with deadtime correction.")
     exposure_time, deadtime_ratios = get_spacecraft_exposure_times(
         rates_dataset,

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -184,8 +184,13 @@ def calculate_helio_pset(
     start: float = np.min(species_dataset["event_times"].values)
     end: float = np.max(species_dataset["event_times"].values)
 
+    # Convert pointing start and end time to ttj2000ns
+    pointing_range_ns = met_to_ttj2000ns(pointing_range_met)
+    # use either the pointing end time + 30 mins or the max event time,
+    # whichever is smaller.
+    end = min(end + 1800, ttj2000ns_to_et(pointing_range_ns[1]))
     # Time bins in 30 minute intervals
-    time_bins = np.arange(start, end + 1800, 1800)
+    time_bins = np.arange(start, end, 1800)
 
     # Compute mask for culling the Earth
     compute_culling_mask(
@@ -194,8 +199,6 @@ def calculate_helio_pset(
         helio_pset_quality_flags,
         nside=nside,
     )
-    # Convert pointing start and end time to ttj2000ns
-    pointing_range_ns = met_to_ttj2000ns(pointing_range_met)
     # Epoch should be the start of the pointing
     pset_dict["epoch"] = np.atleast_1d(pointing_range_ns[0]).astype(np.int64)
     pset_dict["epoch_delta"] = np.atleast_1d(np.diff(pointing_range_ns)).astype(

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -11,6 +11,7 @@ from imap_processing.quality_flags import ImapPSETUltraFlags
 from imap_processing.spice.repoint import get_pointing_times_from_id
 from imap_processing.spice.time import (
     met_to_ttj2000ns,
+    ttj2000ns_to_et,
 )
 from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
@@ -168,11 +169,17 @@ def calculate_spacecraft_pset(
         n_pix, ImapPSETUltraFlags.NONE.value, dtype=np.uint16
     )
 
+    # Convert pointing start and end time to ttj2000ns
+    pointing_range_ns = met_to_ttj2000ns(pointing_range_met)
+
     start: float = np.min(species_dataset["event_times"].values)
     end: float = np.max(species_dataset["event_times"].values)
 
+    # use either the pointing end time + 30 mins or the max event time,
+    # whichever is smaller.
+    end = min(end + 1800, ttj2000ns_to_et(pointing_range_ns[1]))
     # Time bins in 30 minute intervals
-    time_bins = np.arange(start, end + 1800, 1800)
+    time_bins = np.arange(start, end, 1800)
 
     # Compute mask for culling the Earth
     compute_culling_mask(
@@ -181,8 +188,6 @@ def calculate_spacecraft_pset(
         spacecraft_pset_quality_flags,
         nside=nside,
     )
-    # Convert pointing start and end time to ttj2000ns
-    pointing_range_ns = met_to_ttj2000ns(pointing_range_met)
     # Epoch should be the start of the pointing
     pset_dict["epoch"] = np.atleast_1d(pointing_range_ns[0]).astype(np.int64)
     pset_dict["epoch_delta"] = np.atleast_1d(np.diff(pointing_range_ns)).astype(

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -8,9 +8,8 @@ import xarray as xr
 
 from imap_processing.cdf.utils import parse_filename_like
 from imap_processing.quality_flags import ImapPSETUltraFlags
-from imap_processing.spice.repoint import get_pointing_times
+from imap_processing.spice.repoint import get_pointing_times_from_id
 from imap_processing.spice.time import (
-    et_to_met,
     met_to_ttj2000ns,
 )
 from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
@@ -125,9 +124,11 @@ def calculate_spacecraft_pset(
     )
     healpix = np.arange(n_pix)
     # Get the start and stop times of the pointing period
-    pointing_range_met = get_pointing_times(
-        float(et_to_met(species_dataset["event_times"].mean()))
-    )
+    repoint_id = species_dataset.attrs.get("Repointing", None)
+    if repoint_id is None:
+        raise ValueError("Repointing ID attribute is missing from the dataset.")
+
+    pointing_range_met = get_pointing_times_from_id(repoint_id)
 
     # Calculate exposure times
     logger.info("Calculating spacecraft exposure times with deadtime correction.")


### PR DESCRIPTION
# Change Summary
closes #2353 
closes #2327 
## Overview
Get pointing times using repoint id. This is probably more reliable for ultra than using met times in case an event falls within a repoint. 


## Updated Files
- imap_processing/spice/repoint.py
   - Get pointing times from id. I made a new function for this instead of adding it to get_pointing_times because I felt that there was enough of a difference
- imap_processing/ultra/l1b/de.py
   - use new helper function
- 
