### PR TITLE
Ultra ena rates l1b

### DIFF
--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -72,8 +72,7 @@ def get_energy_histogram(
     spin_df = get_spin_data()
 
     unique_spin_number = np.unique(spin_number)
-    spin_edges = unique_spin_number.astype(np.uint32)
-    spin_edges = np.append(spin_edges, spin_edges.max() + 1)
+    spin_edges = np.append(unique_spin_number, unique_spin_number.max() + 1)
 
     # Counts per spin at each energy bin.
     hist, _ = np.histogramdd(

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -72,7 +72,7 @@ def get_energy_histogram(
     spin_df = get_spin_data()
 
     unique_spin_number = np.unique(spin_number)
-    spin_edges = unique_spin_number.astype(np.uint16)
+    spin_edges = unique_spin_number.astype(np.uint32)
     spin_edges = np.append(spin_edges, spin_edges.max() + 1)
 
     # Counts per spin at each energy bin.


### PR DESCRIPTION
# Change Summary

## Overview
The spin edges were getting converted to uint16. This was causing the spins to roll over when it reached the max uint16 val. This was causing ena_rates to be an array of zeros because none of the spins were within the spin_edges. 

`unconverted spins [140309 140310 140311 ... 146033 146034 146035]
converted spins [ 9237  9238  9239 ... 14961 14962 14963]`

This was a remanent of when the spin_number was uint8. @laspsandoval helped me confirm this was the correct way to fix this issue. 

## Updated Files
- imap_processing/ultra/l1b/ultra_l1b_culling.py
   - Dont convert spin numbers to uint16. 

