### PR TITLE
2388-lo-l2-cg---allow-for-multiple-variables-to-be-interpolated-to-helioframe

### DIFF
--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -680,7 +680,7 @@ def interpolate_map_flux_to_helio_frame(
     helio_energies_ev : xarray.DataArray
         The heliocentric frame energies to interpolate to (in eV).
         In practice, these are the same as esa_energies_ev.
-    vars_to_interpolate : list(str)
+    vars_to_interpolate : list[str]
         List of variables to perform interpolation on. This is just the base
         flux/intensity variable. It is assumed that the associated statistical
         uncertainty and systematic error variables are also present in the input

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -657,6 +657,7 @@ def interpolate_map_flux_to_helio_frame(
     map_ds: xr.Dataset,
     esa_energies_ev: xr.DataArray,
     helio_energies_ev: xr.DataArray,
+    vars_to_interpolate: list[str],
 ) -> xr.Dataset:
     """
     Interpolate flux from spacecraft frame to heliocentric frame energies.
@@ -679,6 +680,13 @@ def interpolate_map_flux_to_helio_frame(
     helio_energies_ev : xarray.DataArray
         The heliocentric frame energies to interpolate to (in eV).
         In practice, these are the same as esa_energies_ev.
+    vars_to_interpolate : list(str)
+        List of variables to perform interpolation on. This is just the base
+        flux/intensity variable. It is assumed that the associated statistical
+        uncertainty and systematic error variables are also present in the input
+        dataset and will be interpolated as well. For example, if ["ena_intensity"]
+        is input, then the variables "ena_intensity", "ena_intensity_stat_uncert",
+        and "ena_intensity_sys_err" will be interpolated.
 
     Returns
     -------
@@ -689,9 +697,6 @@ def interpolate_map_flux_to_helio_frame(
 
     # Work with xarray DataArrays to handle arbitrary spatial dimensions
     energy_sc = map_ds["energy_sc"]
-    intensity = map_ds["ena_intensity"]
-    stat_unc = map_ds["ena_intensity_stat_uncert"]
-    sys_err = map_ds["ena_intensity_sys_err"]
 
     # Step 1: Find bounding ESA energy indices for each position
     # Use np.searchsorted on flattened array, then reshape back
@@ -721,65 +726,70 @@ def interpolate_map_flux_to_helio_frame(
         left_idx, dims=energy_sc.dims, coords=coords_without_energy
     )
 
-    # Step 2: Extract flux values at bounding energy channels
-    # Use xarray's advanced indexing to get fluxes at left and right indices
-    flux_left = intensity.isel({"energy": left_idx_da})
-    flux_right = intensity.isel({"energy": right_idx_da})
-    stat_unc_left = stat_unc.isel({"energy": left_idx_da})
-    stat_unc_right = stat_unc.isel({"energy": right_idx_da})
-    sys_err_left = sys_err.isel({"energy": left_idx_da})
-
     # Get energy values at boundaries - select from esa_energies_ev using indices
     energy_left = esa_energies_ev.isel({"energy": left_idx_da})
     energy_right = esa_energies_ev.isel({"energy": right_idx_da})
 
-    # Step 3: Perform power-law interpolation to spacecraft energy
-    # slope = log(f_right/f_left) / log(e_right/e_left)
-    # flux_sc = f_left * (energy_sc / e_left)^slope
-    with np.errstate(divide="ignore", invalid="ignore"):
-        # Calculate slope for power-law interpolation
-        slope = np.log(flux_right / flux_left) / np.log(energy_right / energy_left)
+    for var_name in vars_to_interpolate:
+        # Step 2: Extract flux values at bounding energy channels
+        # Use xarray's advanced indexing to get fluxes at left and right indices
+        intensity = map_ds[var_name]
+        stat_unc = map_ds[f"{var_name}_stat_uncert"]
+        sys_err = map_ds[f"{var_name}_sys_err"]
+        flux_left = intensity.isel({"energy": left_idx_da})
+        flux_right = intensity.isel({"energy": right_idx_da})
+        stat_unc_left = stat_unc.isel({"energy": left_idx_da})
+        stat_unc_right = stat_unc.isel({"energy": right_idx_da})
+        sys_err_left = sys_err.isel({"energy": left_idx_da})
 
-        # Interpolate flux using power-law
-        flux_sc = flux_left * ((energy_sc / energy_left) ** slope)
+        # Step 3: Perform power-law interpolation to spacecraft energy
+        # slope = log(f_right/f_left) / log(e_right/e_left)
+        # flux_sc = f_left * (energy_sc / e_left)^slope
+        with np.errstate(divide="ignore", invalid="ignore"):
+            # Calculate slope for power-law interpolation
+            slope = np.log(flux_right / flux_left) / np.log(energy_right / energy_left)
 
-        # Interpolation factor for uncertainty propagation (Equations 75 & 76)
-        unc_factor = np.log(energy_sc / energy_left) / np.log(
-            energy_right / energy_left
-        )
+            # Interpolate flux using power-law
+            flux_sc = flux_left * ((energy_sc / energy_left) ** slope)
 
-        # Statistical uncertainty propagation (Equation 75):
-        # δJ = J * sqrt((δJ_left/J_left)^2 * (1 + unc_factor^2)
-        #               + unc_factor^2 * (δJ_right/J_right)^2)
-        stat_unc_sc = flux_sc * np.sqrt(
-            (stat_unc_left / flux_left) ** 2 * (1.0 + unc_factor**2)
-            + unc_factor**2 * (stat_unc_right / flux_right) ** 2
-        )
+            # Interpolation factor for uncertainty propagation (Equations 75 & 76)
+            unc_factor = np.log(energy_sc / energy_left) / np.log(
+                energy_right / energy_left
+            )
 
-        # Systematic uncertainty propagation (Equation 76):
-        # σJ^g = σJ^src_kref * (⟨E^s_kref⟩ / E^ESA_kref)^γ_kref * (E^h / ⟨E^s_kref⟩)
-        # Systematic error scales proportionally with flux during power-law
-        # interpolation
-        sys_err_sc = sys_err_left * ((energy_sc / energy_left) ** slope)
+            # Statistical uncertainty propagation (Equation 75):
+            # δJ = J * sqrt((δJ_left/J_left)^2 * (1 + unc_factor^2)
+            #               + unc_factor^2 * (δJ_right/J_right)^2)
+            stat_unc_sc = flux_sc * np.sqrt(
+                (stat_unc_left / flux_left) ** 2 * (1.0 + unc_factor**2)
+                + unc_factor**2 * (stat_unc_right / flux_right) ** 2
+            )
 
-    # Step 4: Energy scaling transformation (Liouville theorem)
-    # flux_helio = flux_sc * (helio_energy / energy_sc)
-    # Use xarray broadcasting - helio_energies_ev will broadcast along esa_energy_step
-    with np.errstate(divide="ignore", invalid="ignore"):
-        energy_ratio = helio_energies_ev / energy_sc
-        flux_helio = flux_sc * energy_ratio
-        stat_unc_helio = stat_unc_sc * energy_ratio
-        sys_err_helio = sys_err_sc * energy_ratio
+            # Systematic uncertainty propagation (Equation 76):
+            # σJ^g = σJ^src_kref * (⟨E^s_kref⟩ / E^ESA_kref)^γ_kref * (E^h / ⟨E^s_kref⟩)
+            # Systematic error scales proportionally with flux during power-law
+            # interpolation
+            sys_err_sc = sys_err_left * ((energy_sc / energy_left) ** slope)
 
-    # Set any location where the value is not finite to NaN (converts +/-inf to NaN)
-    flux_helio = flux_helio.where(np.isfinite(flux_helio), np.nan)
-    stat_unc_helio = stat_unc_helio.where(np.isfinite(stat_unc_helio), np.nan)
-    sys_err_helio = sys_err_helio.where(np.isfinite(sys_err_helio), np.nan)
+        # Step 4: Energy scaling transformation (Liouville theorem)
+        # flux_helio = flux_sc * (helio_energy / energy_sc)
+        # Using xarray broadcasting, helio_energies_ev will broadcast
+        # along esa_energy_step
+        with np.errstate(divide="ignore", invalid="ignore"):
+            energy_ratio = helio_energies_ev / energy_sc
+            flux_helio = flux_sc * energy_ratio
+            stat_unc_helio = stat_unc_sc * energy_ratio
+            sys_err_helio = sys_err_sc * energy_ratio
 
-    # Update the dataset with interpolated values
-    map_ds["ena_intensity"] = flux_helio
-    map_ds["ena_intensity_stat_uncert"] = stat_unc_helio
-    map_ds["ena_intensity_sys_err"] = sys_err_helio
+        # Set any location where the value is not finite to NaN (converts +/-inf to NaN)
+        flux_helio = flux_helio.where(np.isfinite(flux_helio), np.nan)
+        stat_unc_helio = stat_unc_helio.where(np.isfinite(stat_unc_helio), np.nan)
+        sys_err_helio = sys_err_helio.where(np.isfinite(sys_err_helio), np.nan)
+
+        # Update the dataset with interpolated values
+        map_ds[var_name] = flux_helio
+        map_ds[f"{var_name}_stat_uncert"] = stat_unc_helio
+        map_ds[f"{var_name}_sys_err"] = sys_err_helio
 
     return map_ds
 

--- a/imap_processing/hi/hi_l2.py
+++ b/imap_processing/hi/hi_l2.py
@@ -212,6 +212,7 @@ def generate_hi_map(
             output_map.data_1d,
             output_map.data_1d["energy"] * 1000,  # Convert ESA energies to eV
             esa_energy_ev,  # heliocentric energies (same as ESA energies)
+            ["ena_intensity"],
         )
 
     return output_map

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -862,7 +862,7 @@ class TestInterpolateMapFluxToHelioFrame:
 
         # Apply interpolation
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # Verify output structure
@@ -897,7 +897,7 @@ class TestInterpolateMapFluxToHelioFrame:
         map_ds["energy_sc"].values[1, 0] = 750.0
 
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # For a perfect power-law with flux = E^(-2) * spatial_factor:
@@ -953,7 +953,7 @@ class TestInterpolateMapFluxToHelioFrame:
         map_ds["energy_sc"].values[1, 0] = e_sc
 
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # Statistical uncertainty should be positive and finite
@@ -979,7 +979,7 @@ class TestInterpolateMapFluxToHelioFrame:
         )
 
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # Systematic uncertainty should be positive and finite
@@ -1011,7 +1011,7 @@ class TestInterpolateMapFluxToHelioFrame:
         original_flux = map_ds["ena_intensity"].values.copy()
 
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # When E_sc = E_esa and E_helio = E_esa, then E_helio/E_sc = 1
@@ -1042,7 +1042,7 @@ class TestInterpolateMapFluxToHelioFrame:
         map_ds["energy_sc"].values[1, 1] = 0.0
 
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # Check that we have NaN values where expected, not infinities
@@ -1111,7 +1111,7 @@ class TestInterpolateMapFluxToHelioFrame:
 
         # Apply interpolation
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # Verify output shape matches input
@@ -1144,7 +1144,7 @@ class TestInterpolateMapFluxToHelioFrame:
         map_ds["energy_sc"].values[-1, -1] = 1.1 * esa_energies.values[-1]
 
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # Should handle boundary cases without errors
@@ -1165,7 +1165,7 @@ class TestInterpolateMapFluxToHelioFrame:
         original_coords = list(map_ds.coords.keys())
 
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # Verify dimensions are preserved
@@ -1217,7 +1217,7 @@ class TestInterpolateMapFluxToHelioFrame:
         helio_energies = esa_energies.copy()
 
         result_ds = interpolate_map_flux_to_helio_frame(
-            map_ds, esa_energies, helio_energies
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
         )
 
         # With uniform input, output should also be uniform across spatial dimension
@@ -1234,6 +1234,68 @@ class TestInterpolateMapFluxToHelioFrame:
                 if mean_val > 0:
                     rel_std = std_dev / mean_val
                     assert rel_std < 1e-10, f"Energy {i_energy}: rel_std = {rel_std}"
+
+    def test_multiple_variables_interpolation(self):
+        """Test interpolation with multiple intensity variables."""
+        # Create base dataset with ena_intensity
+        map_ds, esa_energies, helio_energies = self.create_test_map_dataset(
+            n_energy=3, n_spatial=5
+        )
+
+        # Add a second intensity variable (e.g., background) with different values
+        map_ds["background_intensity"] = map_ds["ena_intensity"] * 0.2  # 20% of signal
+        map_ds["background_intensity_stat_uncert"] = (
+            map_ds["ena_intensity_stat_uncert"] * 0.2
+        )
+        map_ds["background_intensity_sys_err"] = map_ds["ena_intensity_sys_err"] * 0.2
+
+        # Interpolate both variables
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds,
+            esa_energies,
+            helio_energies,
+            ["ena_intensity", "background_intensity"],
+        )
+
+        # Verify shapes are preserved for ena_intensity
+        assert result_ds["ena_intensity"].shape == map_ds["ena_intensity"].shape
+        assert (
+            result_ds["ena_intensity_stat_uncert"].shape
+            == map_ds["ena_intensity_stat_uncert"].shape
+        )
+        assert (
+            result_ds["ena_intensity_sys_err"].shape
+            == map_ds["ena_intensity_sys_err"].shape
+        )
+
+        # Verify shapes are preserved for background
+        assert (
+            result_ds["background_intensity"].shape
+            == map_ds["background_intensity"].shape
+        )
+        assert (
+            result_ds["background_intensity_stat_uncert"].shape
+            == map_ds["background_intensity_stat_uncert"].shape
+        )
+        assert (
+            result_ds["background_intensity_sys_err"].shape
+            == map_ds["background_intensity_sys_err"].shape
+        )
+
+        # Verify all values are finite and positive
+        assert np.all(np.isfinite(result_ds["ena_intensity"].values))
+        assert np.all(result_ds["ena_intensity"].values > 0)
+        assert np.all(np.isfinite(result_ds["background_intensity"].values))
+        assert np.all(result_ds["background_intensity"].values > 0)
+
+        # Verify the relative scaling between signal and background is
+        # approximately preserved (background should still be ~20% of signal
+        # after interpolation)
+        signal_values = result_ds["ena_intensity"].values
+        background_values = result_ds["background_intensity"].values
+        ratio = background_values / signal_values
+        # Allow for some numerical variation due to interpolation
+        np.testing.assert_allclose(ratio, 0.2, rtol=0.01)
 
 
 class TestGetPsetDirectionalMask:

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -230,7 +230,7 @@ def test_genarate_hi_map(
 ):
     """Test coverage for genarate_hi_map()"""
     mock_calc_ena_intensity.side_effect = lambda x, y, z: x
-    mock_interp_flux.side_effect = lambda x, y, z: x
+    mock_interp_flux.side_effect = lambda a, b, c, d: a
 
     kernels = [
         "imap_sclk_0000.tsc",


### PR DESCRIPTION
# Change Summary

## Overview
Lo needs to interpolate both ena_intensity and bg_intensity variables in the final CG correction step. This PR adds the ability to specify the base intensity variables to be interpolated to the `interpolate_map_flux_to_helio_frame` function.

## Updated Files
- imap_processing/ena_maps/utils/corrections.py
   - Update `interpolate_map_flux_to_helio_frame` to allow for multiple intensity variable sets to be interpolated.
- imap_processing/tests/ena_maps/test_corrections.py
   - Update and add test coverage checking that multiple variables works
- imap_processing/hi/hi_l2.py
   - Update call to `interpolate_map_flux_to_helio_frame` passing in the single Hi intensity variable to interpolate.
- imap_processing/tests/hi/test_hi_l2.py
   - Allow 4 argument to mock function

Closes: #2388
