### PR TITLE
CoDICE l2 lo attributes 

### DIFF
--- a/imap_processing/cdf/config/imap_codice_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_global_cdf_attrs.yaml
@@ -249,13 +249,13 @@ imap_codice_l2_lo-nsw-species:
 
 imap_codice_l2_lo-sw-angular:
   <<: *instrument_base
-  Data_type: L2_lo-sw-species>Level-2 Lo Sunward Angular Intensities Data
+  Data_type: L2_lo-sw-angular>Level-2 Lo Sunward Angular Intensities Data
   Logical_source: imap_codice_l2_lo-sw-angular
   Logical_source_description: IMAP Mission CoDICE Lo Level-2 Sunward Angular Intensity Data.
 
 imap_codice_l2_lo-nsw-angular:
   <<: *instrument_base
-  Data_type: L2_lo-nsw-species>Level-2 Lo Non-Sunward Angular Intensities Data
+  Data_type: L2_lo-nsw-angular>Level-2 Lo Non-Sunward Angular Intensities Data
   Logical_source: imap_codice_l2_lo-nsw-angular
   Logical_source_description: IMAP Mission CoDICE Lo Level-2 Non-Sunward Angular Intensity Data.
 

--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -289,7 +289,7 @@ voltage_table:
     LABLAXIS: V
     SCALETYP: log
     UNITS: V
-    VALIDMIN: 1.0
+    VALIDMIN: 0.5
     VALIDMAX: 14100.0
     VAR_TYPE: support_data
 

--- a/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
@@ -405,7 +405,7 @@ energy_he3he4_plus:
   DEPEND_1: energy_he3he4
 
 # spin angles:
-spin_angles:
+spin_angle:
   VAR_TYPE: support_data
   CATDESC: Spin Angle
   FIELDNAM: Spin Angle

--- a/imap_processing/cdf/config/imap_codice_l2-lo-angular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-angular_variable_attrs.yaml
@@ -26,8 +26,8 @@ spin_sector:
   VALIDMAX: 24
   VAR_TYPE: support_data
 
-# spin angles:
-spin_angles:
+# spin angle:
+spin_angle:
   VAR_TYPE: support_data
   CATDESC: Spin Angle
   FIELDNAM: Spin Angle
@@ -63,10 +63,11 @@ lo-angular-attrs:
     LABL_PTR_1: esa_step_label
     LABL_PTR_2: spin_sector_label
     LABL_PTR_3: elevation_angle_label
-    UNITS: intensities
+    UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMIN: 0.0
     VALIDMAX: 16777216.0
     VAR_TYPE: data
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 lo-angular-unc-attrs:
     CATDESC: "{species} {direction} species uncertainty"
@@ -81,7 +82,8 @@ lo-angular-unc-attrs:
     LABL_PTR_1: esa_step_label
     LABL_PTR_2: spin_sector_label
     LABL_PTR_3: elevation_angle_label
-    UNITS: intensities
+    UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMIN: 0.0
     VALIDMAX: 16777216.0
     VAR_TYPE: data
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Uncertainty

--- a/imap_processing/cdf/config/imap_codice_l2-lo-angular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-angular_variable_attrs.yaml
@@ -1,0 +1,87 @@
+# ----------------------------- Useful variables -----------------------------
+real_fillval: &real_fillval -1.0e+31
+max_float: &max_float 3.4028235e+38
+
+# ------------------------------- Coordinates -------------------------------
+elevation_angle:
+  CATDESC: Elevation Angle
+  FIELDNAM: Elevation Angle
+  FORMAT: I8
+  LABLAXIS: Elevation Angle
+  SCALETYP: linear
+  UNITS: degrees
+  VALIDMAX: 180.0
+  VALIDMIN: 0.0
+  VAR_TYPE: support_data
+
+spin_sector:
+  CATDESC: Spin Sector Index
+  FIELDNAM: Spin Sector Index
+  FILLVAL: -1
+  FORMAT: I2
+  LABLAXIS: " "
+  SCALETYP: linear
+  UNITS: " "
+  VALIDMIN: 0
+  VALIDMAX: 24
+  VAR_TYPE: support_data
+
+# spin angles:
+spin_angles:
+  VAR_TYPE: support_data
+  CATDESC: Spin Angle
+  FIELDNAM: Spin Angle
+  SCALETYP: linear
+  UNITS: degrees
+  FILLVAL: *real_fillval
+  VALIDMAX: 360.0
+  VALIDMIN: 0.0
+  FORMAT: '%f'
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:ArrivalDirection,Qualifier:DirectionAngle.AzimuthAngle
+  DEPEND_1: spin_sector
+  LABL_PTR_1: spin_sector_label
+
+# ------------------------------- labels -------------------------------
+elevation_angle_label:
+  CATDESC: Elevation Angle
+  FIELDNAM: Elevation Angle
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+# ------------------------------- species -------------------------------
+# lo-angular attribute templates (combined versions of the previous entries)
+lo-angular-attrs:
+    CATDESC: "{species} {direction} species"
+    DEPEND_0: epoch
+    DEPEND_1: esa_step
+    DEPEND_2: spin_sector
+    DEPEND_3: elevation_angle
+    DISPLAY_TYPE: time_series
+    FIELDNAM: "{direction} - {species}"
+    FILLVAL: *real_fillval
+    FORMAT: F13.4
+    LABL_PTR_1: esa_step_label
+    LABL_PTR_2: spin_sector_label
+    LABL_PTR_3: elevation_angle_label
+    UNITS: intensities
+    VALIDMIN: 0.0
+    VALIDMAX: 16777216.0
+    VAR_TYPE: data
+
+lo-angular-unc-attrs:
+    CATDESC: "{species} {direction} species uncertainty"
+    DEPEND_0: epoch
+    DEPEND_1: esa_step
+    DEPEND_2: spin_sector
+    DEPEND_3: elevation_angle
+    DISPLAY_TYPE: time_series
+    FIELDNAM: "{direction} - {species}"
+    FILLVAL: *real_fillval
+    FORMAT: F13.4
+    LABL_PTR_1: esa_step_label
+    LABL_PTR_2: spin_sector_label
+    LABL_PTR_3: elevation_angle_label
+    UNITS: intensities
+    VALIDMIN: 0.0
+    VALIDMAX: 16777216.0
+    VAR_TYPE: data

--- a/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
@@ -46,10 +46,11 @@ lo-species-attrs:
     FORMAT: F13.4
     LABL_PTR_1: esa_step_label
     LABL_PTR_2: spin_sector_label
-    UNITS: counts
+    UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMIN: 0.0
     VALIDMAX: 16777216.0
     VAR_TYPE: data
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 lo-pui-species-attrs:
     CATDESC: "{species} Pickup Ion Sunward Species"
@@ -62,10 +63,11 @@ lo-pui-species-attrs:
     FORMAT: F13.4
     LABL_PTR_1: esa_step_label
     LABL_PTR_2: spin_sector_label
-    UNITS: counts
+    UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMIN: 0.0
     VALIDMAX: 16777216.0
     VAR_TYPE: data
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 lo-sw-species-attrs:
   CATDESC: "{species} Solar Wind Sunward Species"
@@ -78,10 +80,11 @@ lo-sw-species-attrs:
   FORMAT: F13.4
   LABL_PTR_1: esa_step_label
   LABL_PTR_2: spin_sector_label
-  UNITS: counts
+  UNITS: "#/(cm^2-s-sr-keV/q)"
   VALIDMIN: 0.0
   VALIDMAX: 16777216.0
   VAR_TYPE: data
+  DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
 
 lo-species-unc-attrs:
     CATDESC: "{species} Non-sunward Species uncertainty"
@@ -94,10 +97,11 @@ lo-species-unc-attrs:
     FORMAT: F20.9
     LABL_PTR_1: esa_step_label
     LABL_PTR_2: spin_sector_label
-    UNITS: counts
+    UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMIN: 0.0
     VALIDMAX: 16777216.0
     VAR_TYPE: data
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Uncertainty
 
 lo-pui-species-unc-attrs:
     CATDESC: "{species} Pickup Ion Sunward Species uncertainty"
@@ -110,10 +114,11 @@ lo-pui-species-unc-attrs:
     FORMAT: F20.9
     LABL_PTR_1: esa_step_label
     LABL_PTR_2: spin_sector_label
-    UNITS: counts
+    UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMIN: 0.0
     VALIDMAX: 16777216.0
     VAR_TYPE: data
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Uncertainty
 
 lo-sw-species-unc-attrs:
     CATDESC: "{species} Solar Wind Sunward Species uncertainty"
@@ -126,7 +131,8 @@ lo-sw-species-unc-attrs:
     FORMAT: F20.9
     LABL_PTR_1: esa_step_label
     LABL_PTR_2: spin_sector_label
-    UNITS: counts
+    UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMIN: 0.0
     VALIDMAX: 16777216.0
     VAR_TYPE: data
+    DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Uncertainty

--- a/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
@@ -1,0 +1,132 @@
+# ----------------------------- Useful variables -----------------------------
+real_fillval: &real_fillval -1.0e+31
+max_float: &max_float 3.4028235e+38
+
+# ------------------------------- Coordinates -------------------------------
+elevation_angle:
+  CATDESC: Elevation Angle
+  FIELDNAM: Elevation Angle
+  FORMAT: I8
+  LABLAXIS: Elevation Angle
+  SCALETYP: linear
+  UNITS: degrees
+  VALIDMAX: 180.0
+  VALIDMIN: 0.0
+  VAR_TYPE: support_data
+
+spin_sector:
+  CATDESC: Spin Sector Index
+  FIELDNAM: Spin Sector Index
+  FILLVAL: -1
+  FORMAT: I2
+  LABLAXIS: " "
+  SCALETYP: linear
+  UNITS: " "
+  VALIDMIN: 0
+  VALIDMAX: 24
+  VAR_TYPE: support_data
+
+# ------------------------------- labels -------------------------------
+elevation_angle_label:
+  CATDESC: Elevation Angle
+  FIELDNAM: Elevation Angle
+  FORMAT: A6
+  VAR_TYPE: metadata
+
+# ------------------------------- species -------------------------------
+# lo species attrs
+lo-species-attrs:
+    CATDESC: "{species} Non-sunward Species"
+    DEPEND_0: epoch
+    DEPEND_1: esa_step
+    DEPEND_2: spin_sector
+    DISPLAY_TYPE: time_series
+    FIELDNAM: "Non-sunward - {species}"
+    FILLVAL: *real_fillval
+    FORMAT: F13.4
+    LABL_PTR_1: esa_step_label
+    LABL_PTR_2: spin_sector_label
+    UNITS: counts
+    VALIDMIN: 0.0
+    VALIDMAX: 16777216.0
+    VAR_TYPE: data
+
+lo-pui-species-attrs:
+    CATDESC: "{species} Pickup Ion Sunward Species"
+    DEPEND_0: epoch
+    DEPEND_1: esa_step
+    DEPEND_2: spin_sector
+    DISPLAY_TYPE: time_series
+    FIELDNAM: "Sunward - {species}"
+    FILLVAL: *real_fillval
+    FORMAT: F13.4
+    LABL_PTR_1: esa_step_label
+    LABL_PTR_2: spin_sector_label
+    UNITS: counts
+    VALIDMIN: 0.0
+    VALIDMAX: 16777216.0
+    VAR_TYPE: data
+
+lo-sw-species-attrs:
+  CATDESC: "{species} Solar Wind Sunward Species"
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
+  DEPEND_2: spin_sector
+  DISPLAY_TYPE: time_series
+  FIELDNAM: "Sunward - {species}"
+  FILLVAL: *real_fillval
+  FORMAT: F13.4
+  LABL_PTR_1: esa_step_label
+  LABL_PTR_2: spin_sector_label
+  UNITS: counts
+  VALIDMIN: 0.0
+  VALIDMAX: 16777216.0
+  VAR_TYPE: data
+
+lo-species-unc-attrs:
+    CATDESC: "{species} Non-sunward Species uncertainty"
+    DEPEND_0: epoch
+    DEPEND_1: esa_step
+    DEPEND_2: spin_sector
+    DISPLAY_TYPE: time_series
+    FIELDNAM: "Non-sunward - {species}"
+    FILLVAL: *real_fillval
+    FORMAT: F20.9
+    LABL_PTR_1: esa_step_label
+    LABL_PTR_2: spin_sector_label
+    UNITS: counts
+    VALIDMIN: 0.0
+    VALIDMAX: 16777216.0
+    VAR_TYPE: data
+
+lo-pui-species-unc-attrs:
+    CATDESC: "{species} Pickup Ion Sunward Species uncertainty"
+    DEPEND_0: epoch
+    DEPEND_1: esa_step
+    DEPEND_2: spin_sector
+    DISPLAY_TYPE: time_series
+    FIELDNAM: "Sunward - {species}"
+    FILLVAL: *real_fillval
+    FORMAT: F20.9
+    LABL_PTR_1: esa_step_label
+    LABL_PTR_2: spin_sector_label
+    UNITS: counts
+    VALIDMIN: 0.0
+    VALIDMAX: 16777216.0
+    VAR_TYPE: data
+
+lo-sw-species-unc-attrs:
+    CATDESC: "{species} Solar Wind Sunward Species uncertainty"
+    DEPEND_0: epoch
+    DEPEND_1: esa_step
+    DEPEND_2: spin_sector
+    DISPLAY_TYPE: time_series
+    FIELDNAM: "Sunward - {species}"
+    FILLVAL: *real_fillval
+    FORMAT: F20.9
+    LABL_PTR_1: esa_step_label
+    LABL_PTR_2: spin_sector_label
+    UNITS: counts
+    VALIDMIN: 0.0
+    VALIDMAX: 16777216.0
+    VAR_TYPE: data

--- a/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2_variable_attrs.yaml
@@ -128,7 +128,7 @@ energy_delta_attrs: &energy_delta_default
   <<: *energy_default
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge,Qualifier:Uncertainty
 
-spin_angles_attrs: &spin_angles_default
+spin_angle_attrs: &spin_angle_default
   VAR_TYPE: support_data
   CATDESC: Spin Angle
   FIELDNAM: Spin Angle
@@ -207,7 +207,7 @@ elevation_angle:
   VAR_TYPE: support_data
 
 spin_angle:
-  <<: *spin_angles_default
+  <<: *spin_angle_default
   LABLAXIS: Spin Angle
 
 energy_table:
@@ -1603,8 +1603,8 @@ hi-ialirt-h:
   VALIDMAX: 16777216
   VALIDMIN: 0
 
-hi-ialirt-spin_angles:
-  <<: *spin_angles_default
+hi-ialirt-spin_angle:
+  <<: *spin_angle_default
   DEPEND_1: spin_sector_index
   DEPEND_2: elevation_angle
   LABL_PTR_1: spin_sector_index_label
@@ -1860,8 +1860,8 @@ hi-sectored-energy_he3he4_plus:
   FIELDNAM: energy delta plus
   DEPEND_1: energy_he3he4
 
-hi-sectored-spin_angles:
-  <<: *spin_angles_default
+hi-sectored-spin_angle:
+  <<: *spin_angle_default
   DEPEND_1: spin_sector_index
   DEPEND_2: elevation_angle
   LABL_PTR_1: spin_sector_index_label

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -123,10 +123,10 @@ def get_species_efficiency(species: str, efficiency: pd.DataFrame) -> xr.DataArr
         [col for col in species_efficiency if col.startswith("position")],
         key=lambda x: int(x.split("_")[-1]),
     )
-    # Shape: (energy_table, inst_az)
+    # Shape: (esa_step, inst_az)
     return xr.DataArray(
         species_efficiency[position_names_sorted].to_numpy(),
-        dims=("energy_table", "inst_az"),
+        dims=("esa_step", "inst_az"),
     )
 
 
@@ -178,14 +178,12 @@ def compute_geometric_factors(
 
     # Get the geometric factors based on the modes
     gf = np.where(
-        modes[:, :, np.newaxis],  # Shape (epoch, energy_table, 1)
-        geometric_factor_lookup[
-            "reduced"
-        ],  # Shape (1, energy_table, 24) - reduced mode
-        geometric_factor_lookup["full"],  # Shape (1, energy_table, 24) - full mode
-    )  # Shape: (epoch, energy_table, inst_az)
+        modes[:, :, np.newaxis],  # Shape (epoch, esa_step, 1)
+        geometric_factor_lookup["reduced"],  # Shape (1, esa_step, 24) - reduced mode
+        geometric_factor_lookup["full"],  # Shape (1, esa_step, 24) - full mode
+    )  # Shape: (epoch, esa_step, inst_az)
 
-    return xr.DataArray(gf, dims=("epoch", "energy_table", "inst_az"))
+    return xr.DataArray(gf, dims=("epoch", "esa_step", "inst_az"))
 
 
 def calculate_intensity(
@@ -234,7 +232,7 @@ def calculate_intensity(
     # intensity = species_rate / (gm * eff * esa_step) for position and spin angle
     for species in species_list:
         # Select the relevant positions for the species from the efficiency LUT
-        # Shape: (epoch, energy_table, inst_az)
+        # Shape: (epoch, esa_step, inst_az)
         species_eff = get_species_efficiency(species, efficiency).isel(
             inst_az=positions
         )
@@ -246,16 +244,17 @@ def calculate_intensity(
             # Take the mean efficiency across positions
             species_eff = species_eff.mean(dim="inst_az")
 
-        # Shape: (epoch, energy_table, inst_az) or
-        # (epoch, energy_table) if averaged
+        # Shape: (epoch, esa_step, inst_az) or
+        # (epoch, esa_step) if averaged
         denominator = scalar * geometric_factors * species_eff * dataset["energy_table"]
         if species not in dataset:
             logger.warning(
                 f"Species {species} not found in dataset. Filling with NaNS."
             )
-            dataset[species] = np.full(dataset["energy_table"].data.shape, np.nan)
+            dataset[species].data = np.full(dataset["esa_step"].data.shape, np.nan)
         else:
-            dataset[species] = dataset[species] / denominator
+            # Only replace the data with calculated intensity to keep the attributes
+            dataset[species].data = (dataset[species] / denominator).data
 
         # Also calculate uncertainty if available
         species_uncertainty = f"unc_{species}"
@@ -264,11 +263,13 @@ def calculate_intensity(
                 f"Uncertainty {species_uncertainty} not found in dataset."
                 f" Filling with NaNS."
             )
-            dataset[species_uncertainty] = np.full(
-                dataset["energy_table"].data.shape, np.nan
+            dataset[species_uncertainty].data = np.full(
+                dataset["esa_step"].data.shape, np.nan
             )
         else:
-            dataset[species_uncertainty] = dataset[species_uncertainty] / denominator
+            dataset[species_uncertainty].data = (
+                dataset[species_uncertainty] / denominator
+            ).data
 
     return dataset
 
@@ -312,6 +313,28 @@ def process_lo_species_intensity(
         positions,
         average_across_positions=True,
     )
+    cdf_attrs = ImapCdfAttributes()
+    cdf_attrs.add_instrument_variable_attrs("codice", "l2-lo-species")
+    if positions == SOLAR_WIND_POSITIONS:
+        species_attrs = cdf_attrs.get_variable_attributes("lo-sw-species-attrs")
+        unc_attrs = cdf_attrs.get_variable_attributes("lo-sw-species-unc-attrs")
+    elif positions == PUI_POSITIONS:
+        species_attrs = cdf_attrs.get_variable_attributes("lo-pui-species-attrs")
+        unc_attrs = cdf_attrs.get_variable_attributes("lo-pui-species-unc-attrs")
+    else:
+        species_attrs = cdf_attrs.get_variable_attributes("lo-species-attrs")
+        unc_attrs = cdf_attrs.get_variable_attributes("lo-species-unc-attrs")
+
+    # update species attrs
+    for species in species_list:
+        if "unc_" in species:
+            attrs = unc_attrs
+        else:
+            attrs = species_attrs
+        # Replace {species} and {direction} in attrs
+        attrs["CATDESC"] = attrs["CATDESC"].format(species=species)
+        attrs["FIELDNAM"] = attrs["FIELDNAM"].format(species=species)
+        dataset[species].attrs.update(attrs)
 
     return dataset
 
@@ -360,9 +383,11 @@ def process_lo_angular_intensity(
     if positions == SW_POSITIONS:
         pos_to_el = LO_POSITION_TO_ELEVATION_ANGLE["sw"]
         position_index_to_adjust = 0
+        direction = "Sunward"
     elif positions == NSW_POSITIONS:
         pos_to_el = LO_POSITION_TO_ELEVATION_ANGLE["nsw"]
         position_index_to_adjust = 9
+        direction = "Non-Sunward"
     else:
         raise ValueError("Unknown positions for elevation angle mapping.")
 
@@ -382,12 +407,12 @@ def process_lo_angular_intensity(
         .sum(keep_attrs=True)  # One position should always contain zeros so sum is safe
         # Restore original dimension order because groupby moves the grouped
         # dimension to the front
-        .transpose("epoch", "energy_table", "spin_sector", "elevation_angle", ...)
+        .transpose("epoch", "esa_step", "spin_sector", "elevation_angle", ...)
     )
     # Create a new coordinate for spin angle based on spin_sector
     # Use equation from section 11.2.2 of algorithm document
     dataset = dataset.assign_coords(
-        spin_angle=("spin_sector", dataset["spin_sector"].data * 15.0 + 7.5)
+        spin_angles=("spin_sector", dataset["spin_sector"].data * 15.0 + 7.5)
     )
     dataset = dataset.drop_vars(species_list).merge(dataset_converted)
     # Positions 0 and 10 only observe half of the 24 spins for each esa step.
@@ -424,6 +449,43 @@ def process_lo_angular_intensity(
             :, b_inds[:, np.newaxis], spin_inds_1, position_index
         ]
 
+    cdf_attrs = ImapCdfAttributes()
+    cdf_attrs.add_instrument_variable_attrs("codice", "l2-lo-angular")
+    species_attrs = cdf_attrs.get_variable_attributes("lo-angular-attrs")
+    unc_attrs = cdf_attrs.get_variable_attributes("lo-angular-unc-attrs")
+
+    # update species attrs
+    for species in species_list:
+        if "unc_" in species:
+            attrs = unc_attrs
+        else:
+            attrs = species_attrs
+        # Replace {species} and {direction} in attrs
+        attrs["CATDESC"] = attrs["CATDESC"].format(species=species, direction=direction)
+        attrs["FIELDNAM"] = attrs["FIELDNAM"].format(
+            species=species, direction=direction
+        )
+        dataset[species].attrs.update(attrs)
+
+    # make sure elevation_angle is a coordinate and has the right attrs
+    dataset["elevation_angle"].attrs.update(
+        cdf_attrs.get_variable_attributes("elevation_angle", check_schema=False)
+    )
+    dataset["elevation_angle_label"] = xr.DataArray(
+        dataset["elevation_angle"].data.astype(str),
+        dims=("elevation_angle",),
+        attrs=cdf_attrs.get_variable_attributes(
+            "elevation_angle_label", check_schema=False
+        ),
+    )
+    # update spin angle attributes
+    dataset["spin_angles"].attrs = cdf_attrs.get_variable_attributes(
+        "spin_angles", check_schema=False
+    )
+    # update spin sector attributes
+    dataset["spin_sector"].attrs = cdf_attrs.get_variable_attributes(
+        "spin_sector", check_schema=False
+    )
     return dataset
 
 

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -38,6 +38,7 @@ from imap_processing.codice.constants import (
     SOLAR_WIND_POSITIONS,
     SW_POSITIONS,
 )
+from imap_processing.codice.utils import apply_replacements_to_attrs
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -327,13 +328,9 @@ def process_lo_species_intensity(
 
     # update species attrs
     for species in species_list:
-        if "unc_" in species:
-            attrs = unc_attrs
-        else:
-            attrs = species_attrs
+        attrs = unc_attrs if "unc" in unc_attrs else species_attrs
         # Replace {species} and {direction} in attrs
-        attrs["CATDESC"] = attrs["CATDESC"].format(species=species)
-        attrs["FIELDNAM"] = attrs["FIELDNAM"].format(species=species)
+        attrs = apply_replacements_to_attrs(attrs, {"species": species})
         dataset[species].attrs.update(attrs)
 
     return dataset
@@ -456,14 +453,10 @@ def process_lo_angular_intensity(
 
     # update species attrs
     for species in species_list:
-        if "unc_" in species:
-            attrs = unc_attrs
-        else:
-            attrs = species_attrs
+        attrs = unc_attrs if "unc" in unc_attrs else species_attrs
         # Replace {species} and {direction} in attrs
-        attrs["CATDESC"] = attrs["CATDESC"].format(species=species, direction=direction)
-        attrs["FIELDNAM"] = attrs["FIELDNAM"].format(
-            species=species, direction=direction
+        attrs = apply_replacements_to_attrs(
+            attrs, {"species": species, "direction": direction}
         )
         dataset[species].attrs.update(attrs)
 

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -412,7 +412,7 @@ def process_lo_angular_intensity(
     # Create a new coordinate for spin angle based on spin_sector
     # Use equation from section 11.2.2 of algorithm document
     dataset = dataset.assign_coords(
-        spin_angles=("spin_sector", dataset["spin_sector"].data * 15.0 + 7.5)
+        spin_angle=("spin_sector", dataset["spin_sector"].data * 15.0 + 7.5)
     )
     dataset = dataset.drop_vars(species_list).merge(dataset_converted)
     # Positions 0 and 10 only observe half of the 24 spins for each esa step.
@@ -479,8 +479,8 @@ def process_lo_angular_intensity(
         ),
     )
     # update spin angle attributes
-    dataset["spin_angles"].attrs = cdf_attrs.get_variable_attributes(
-        "spin_angles", check_schema=False
+    dataset["spin_angle"].attrs = cdf_attrs.get_variable_attributes(
+        "spin_angle", check_schema=False
     )
     # update spin sector attributes
     dataset["spin_sector"].attrs = cdf_attrs.get_variable_attributes(
@@ -811,12 +811,12 @@ def process_hi_sectored(dependencies: ProcessingInputCollection) -> xr.Dataset:
     # for each SSD index and then adding multiple of 30 degrees for each elevation.
     # Then mod by 360 to keep it within 0-360 range.
     elevation_angles = np.arange(len(l2_dataset["elevation_angle"].values)) * 30.0
-    spin_angles = (L2_HI_SECTORED_ANGLE[:, np.newaxis] + elevation_angles) % 360.0
+    spin_angle = (L2_HI_SECTORED_ANGLE[:, np.newaxis] + elevation_angles) % 360.0
 
     # Add spin angle variable using the new elevation_angle dimension
-    l2_dataset["spin_angles"] = (("spin_sector", "elevation_angle"), spin_angles)
-    l2_dataset["spin_angles"].attrs = cdf_attrs.get_variable_attributes(
-        "spin_angles", check_schema=False
+    l2_dataset["spin_angle"] = (("spin_sector", "elevation_angle"), spin_angle)
+    l2_dataset["spin_angle"].attrs = cdf_attrs.get_variable_attributes(
+        "spin_angle", check_schema=False
     )
 
     # Now carry over other variables from L1B to L2 dataset

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -172,9 +172,9 @@ def compute_geometric_factors(
     # all half_spin_values
     rgfo_half_spin = dataset.rgfo_half_spin.data[:, np.newaxis]  # Shape: (epoch, 1)
     # Perform the comparison and calculate modes
-    # Modes will be true (reduced mode) anywhere half_spin >= rgfo_half_spin otherwise
+    # Modes will be true (reduced mode) anywhere half_spin > rgfo_half_spin otherwise
     # false (full mode)
-    modes = half_spin_values >= rgfo_half_spin
+    modes = half_spin_values > rgfo_half_spin
 
     # Get the geometric factors based on the modes
     gf = np.where(

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -251,7 +251,7 @@ def calculate_intensity(
             logger.warning(
                 f"Species {species} not found in dataset. Filling with NaNS."
             )
-            dataset[species].data = np.full(dataset["esa_step"].data.shape, np.nan)
+            dataset[species] = np.full(dataset["esa_step"].data.shape, np.nan)
         else:
             # Only replace the data with calculated intensity to keep the attributes
             dataset[species].data = (dataset[species] / denominator).data
@@ -263,7 +263,7 @@ def calculate_intensity(
                 f"Uncertainty {species_uncertainty} not found in dataset."
                 f" Filling with NaNS."
             )
-            dataset[species_uncertainty].data = np.full(
+            dataset[species_uncertainty] = np.full(
                 dataset["esa_step"].data.shape, np.nan
             )
         else:

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -36,7 +36,7 @@ from imap_processing.spice.geometry import (
     solar_longitude,
 )
 from imap_processing.spice.spin import get_spacecraft_spin_phase, get_spin_angle
-from imap_processing.spice.time import ttj2000ns_to_et
+from imap_processing.spice.time import et_to_utc, ttj2000ns_to_et
 from imap_processing.utils import convert_raw_to_eu
 
 logger = logging.getLogger(__name__)
@@ -346,13 +346,14 @@ def get_spice_data(
     """
     # convert 'epoch' from nanoseconds to seconds since j2000
     et = ttj2000ns_to_et(l1a_dataset["epoch"].data)
+    print(et_to_utc(et))
     # Get 'shcoarse' (Mission Elapsed Time)
     met = l1a_dataset["shcoarse"].data
     # Get spacecraft spin phase in degrees
     spin_phase = get_spacecraft_spin_phase(query_met_times=met)
     imap_spin_phase = get_spin_angle(spin_phase, degrees=True)
     # Get the position and velocity of IMAP in ecliptic frame
-    ephemeris = imap_state(et, observer=SpiceBody.SUN)
+    ephemeris = imap_state(et[-1], observer=SpiceBody.SUN)
     # Get Idex pointing in the defined frame
     idex_pointing = instrument_pointing(
         et, SpiceFrame.IMAP_IDEX, IDEX_EVENT_REFERENCE_FRAME, cartesian=True

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -36,7 +36,7 @@ from imap_processing.spice.geometry import (
     solar_longitude,
 )
 from imap_processing.spice.spin import get_spacecraft_spin_phase, get_spin_angle
-from imap_processing.spice.time import et_to_utc, ttj2000ns_to_et
+from imap_processing.spice.time import ttj2000ns_to_et
 from imap_processing.utils import convert_raw_to_eu
 
 logger = logging.getLogger(__name__)
@@ -346,7 +346,6 @@ def get_spice_data(
     """
     # convert 'epoch' from nanoseconds to seconds since j2000
     et = ttj2000ns_to_et(l1a_dataset["epoch"].data)
-    print(et_to_utc(et))
     # Get 'shcoarse' (Mission Elapsed Time)
     met = l1a_dataset["shcoarse"].data
     # Get spacecraft spin phase in degrees

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -352,7 +352,7 @@ def get_spice_data(
     spin_phase = get_spacecraft_spin_phase(query_met_times=met)
     imap_spin_phase = get_spin_angle(spin_phase, degrees=True)
     # Get the position and velocity of IMAP in ecliptic frame
-    ephemeris = imap_state(et[-1], observer=SpiceBody.SUN)
+    ephemeris = imap_state(et, observer=SpiceBody.SUN)
     # Get Idex pointing in the defined frame
     idex_pointing = instrument_pointing(
         et, SpiceFrame.IMAP_IDEX, IDEX_EVENT_REFERENCE_FRAME, cartesian=True

--- a/imap_processing/tests/codice/test_codice_hi_l2.py
+++ b/imap_processing/tests/codice/test_codice_hi_l2.py
@@ -89,7 +89,8 @@ def test_l2_hi_sectored(mock_get_file_paths):
     )
 
     val_data = load_cdf(val_data)
-
+    # TODO fix validation data to have correct array name. Spin_angles -> spin_angle
+    val_data = val_data.rename({"spin_angles": "spin_angle"})
     # Check data variables
     for variable in val_data.data_vars:
         if variable.startswith("unc_"):

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -119,16 +119,16 @@ def test_compute_geometric_factors_all_reduced_mode(mock_half_spin_lut):
 
 
 def test_compute_geometric_factors_mixed(mock_half_spin_lut):
-    # rgfo_half_spin = 2
-    dataset = xr.Dataset({"rgfo_half_spin": (("epoch",), np.array([2]))})
+    # rgfo_half_spin = 1
+    dataset = xr.Dataset({"rgfo_half_spin": (("epoch",), np.array([1]))})
     geometric_factor_lut = {
         "full": np.zeros((128, 24)),
         "reduced": np.ones((128, 24)),
     }
     result = compute_geometric_factors(dataset, geometric_factor_lut)
 
-    # ESA steps 0-63 (half_spin=1) -> 1 < 2 → mode=full → 1
-    # ESA steps 64-127 (half_spin=2) -> 2 !< 2 → mode=reduced → 0
+    # ESA steps 0-63 (half_spin=1) -> 2 > 1 → mode=full → 1
+    # ESA steps 64-127 (half_spin=2) -> 1 !>1 → mode=reduced → 0
     expected = np.repeat(np.array([[[0]] * 64 + [[1]] * 64]), 24, -1)
     np.testing.assert_array_equal(result, expected)
 

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -168,26 +168,21 @@ def test_get_efficiency_lut(processing_dependencies, mock_get_file_paths):
         assert col in efficiency_lut.columns, f"Missing column {col} in efficiency LUT"
 
 
-def test_process_lo_species_intensity():
-    l1b_val_data = (
-        imap_module_directory
-        / "tests"
-        / "codice"
-        / "data"
-        / "l1b_validation"
-        / "imap_codice_l1b_lo-sw-species_20250814_v007.cdf"
-    )
-    l1b_val_data = load_cdf(l1b_val_data)
-    l1b_val_data_processed = l1b_val_data.copy()
+def test_process_lo_species_intensity(mock_get_file_paths, codice_lut_path):
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="lo-sw-species", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+    processed_l1a_file = write_cdf(process_l1a(ProcessingInputCollection())[0])
+    l1b_data = process_codice_l1b(processed_l1a_file)
+    l1b_val_data_processed = l1b_data.copy()
     gf = xr.DataArray(
-        np.ones((len(l1b_val_data.epoch), 128, 24)) * 2,
-        dims=("epoch", "energy_table", "inst_az"),
+        np.ones((len(l1b_data.epoch), 128, 24)) * 2,
+        dims=("epoch", "esa_step", "inst_az"),
     )
     with mock.patch(
         "imap_processing.codice.codice_l2.get_species_efficiency",
-        return_value=xr.DataArray(
-            np.ones((128, 24)) * 2, dims=("energy_table", "inst_az")
-        ),
+        return_value=xr.DataArray(np.ones((128, 24)) * 2, dims=("esa_step", "inst_az")),
     ):
         len_pos = 5
         process_lo_species_intensity(
@@ -206,10 +201,8 @@ def test_process_lo_species_intensity():
         )
         # Check that values match expected calculation
         expected_intensity = (
-            l1b_val_data[var]
-            / (len_pos * 4 * l1b_val_data["energy_table"].data)[
-                np.newaxis, :, np.newaxis
-            ]
+            l1b_data[var]
+            / (len_pos * 4 * l1b_data["energy_table"].data)[np.newaxis, :, np.newaxis]
         )
         np.testing.assert_allclose(
             l1b_val_data_processed[var].values, expected_intensity.values, rtol=1e-5
@@ -252,26 +245,21 @@ def test_process_lo_missing_species_intensity():
         )
 
 
-def test_process_lo_angular_intensity():
-    l1b_val_data = (
-        imap_module_directory
-        / "tests"
-        / "codice"
-        / "data"
-        / "l1b_validation"
-        / "imap_codice_l1b_lo-sw-angular_20250814_v007.cdf"
-    )
-    l1b_val_data = load_cdf(l1b_val_data)
-    l1b_val_data_processed = l1b_val_data.copy()
+def test_process_lo_angular_intensity(mock_get_file_paths, codice_lut_path):
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="lo-sw-angular", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+    processed_l1a_file = write_cdf(process_l1a(ProcessingInputCollection())[0])
+    l1b_data = process_codice_l1b(processed_l1a_file)
+    l1b_val_data_processed = l1b_data.copy()
     gf = xr.DataArray(
-        np.ones((len(l1b_val_data.epoch), 128, 24)) * 2,
-        dims=("epoch", "energy_table", "inst_az"),
+        np.ones((len(l1b_data.epoch), 128, 24)) * 2,
+        dims=("epoch", "esa_step", "inst_az"),
     )
     with mock.patch(
         "imap_processing.codice.codice_l2.get_species_efficiency",
-        return_value=xr.DataArray(
-            np.ones((128, 24)) * 2, dims=("energy_table", "inst_az")
-        ),
+        return_value=xr.DataArray(np.ones((128, 24)) * 2, dims=("esa_step", "inst_az")),
     ):
         l1b_val_data_processed = process_lo_angular_intensity(
             l1b_val_data_processed,
@@ -289,9 +277,9 @@ def test_process_lo_angular_intensity():
         )
         # Check shape
         expected_shape = (
-            len(l1b_val_data.epoch),
-            len(l1b_val_data.energy_table),
-            len(l1b_val_data.spin_sector),
+            len(l1b_data.epoch),
+            len(l1b_data.energy_table),
+            len(l1b_data.spin_sector),
             3,  # 3 elevation angles map to 5 positions
         )
         np.testing.assert_allclose(
@@ -299,10 +287,8 @@ def test_process_lo_angular_intensity():
         )
         # Check that values match expected calculation
         expected_intensity = (
-            l1b_val_data[var]
-            / (4 * l1b_val_data["energy_table"].data)[
-                np.newaxis, :, np.newaxis, np.newaxis
-            ]
+            l1b_data[var]
+            / (4 * l1b_data["energy_table"].data)[np.newaxis, :, np.newaxis, np.newaxis]
         )
         # convert pos to el
         expected_intensity = (
@@ -320,7 +306,7 @@ def test_process_lo_angular_intensity():
     # Check coords
     np.testing.assert_allclose(l1b_val_data_processed["elevation_angle"], [0, 15, 30])
     np.testing.assert_allclose(
-        l1b_val_data_processed["spin_angle"], np.arange(24) * 15 + 7.5
+        l1b_val_data_processed["spin_angles"], np.arange(24) * 15 + 7.5
     )
 
 

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -306,7 +306,7 @@ def test_process_lo_angular_intensity(mock_get_file_paths, codice_lut_path):
     # Check coords
     np.testing.assert_allclose(l1b_val_data_processed["elevation_angle"], [0, 15, 30])
     np.testing.assert_allclose(
-        l1b_val_data_processed["spin_angles"], np.arange(24) * 15 + 7.5
+        l1b_val_data_processed["spin_angle"], np.arange(24) * 15 + 7.5
     )
 
 

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -7,11 +7,12 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from imap_data_access import AncillaryInput, ProcessingInputCollection, ScienceInput
+from imap_data_access import AncillaryInput, ProcessingInputCollection
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import load_cdf, write_cdf
+from imap_processing.codice.codice_l1b import process_codice_l1b
 from imap_processing.codice.codice_l2 import (
     compute_geometric_factors,
     get_efficiency_lut,
@@ -20,6 +21,7 @@ from imap_processing.codice.codice_l2 import (
     process_lo_angular_intensity,
     process_lo_species_intensity,
 )
+from imap_processing.codice.codice_new_l1a import process_l1a
 from imap_processing.codice.constants import (
     LO_NSW_ANGULAR_VARIABLE_NAMES,
     LO_SW_ANGULAR_VARIABLE_NAMES,
@@ -322,10 +324,21 @@ def test_process_lo_angular_intensity():
     )
 
 
-def test_codice_l2_sw_species_intensity(processing_dependencies, mock_get_file_paths):
-    sci_input = ScienceInput("imap_codice_l1b_lo-sw-species_20250814_v007.cdf")
-    processing_dependencies.add(sci_input)
-
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_codice_l2_sw_species_intensity(mock_get_file_paths, codice_lut_path):
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="lo-sw-species", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+    processed_l1a_file = write_cdf(process_l1a(ProcessingInputCollection())[0])
+    processed_l1b_file = write_cdf(process_codice_l1b(processed_l1a_file))
+    # Mock get_files for l2
+    mock_get_file_paths.side_effect = [
+        [processed_l1b_file.as_posix()],
+        codice_lut_path(descriptor="l2-lo-gfactor"),
+        codice_lut_path(descriptor="l2-lo-efficiency"),
+    ]
+    processed_2_ds = process_codice_l2("lo-sw-species", ProcessingInputCollection())
     l2_val_data = (
         imap_module_directory
         / "tests"
@@ -335,22 +348,34 @@ def test_codice_l2_sw_species_intensity(processing_dependencies, mock_get_file_p
         / "imap_codice_l2_lo-sw-species_20250814_v007.cdf"
     )
     l2_val_data = load_cdf(l2_val_data)
-    ds = process_codice_l2("lo-sw-species", processing_dependencies)
     for variable in l2_val_data.data_vars:
-        processed_val = ds[variable].values
+        processed_val = processed_2_ds[variable].values
         np.testing.assert_allclose(
             processed_val,
             l2_val_data[variable].values,
             rtol=1e-5,
             err_msg=f"Mismatch in variable '{variable}'",
         )
-    ds.attrs["Data_version"] = "001"
-    write_cdf(ds, istp=False)
+    processed_2_ds.attrs["Data_version"] = "001"
+    assert processed_2_ds.attrs["Logical_source"] == "imap_codice_l2_lo-sw-species"
+    write_cdf(processed_2_ds)
 
 
-def test_codice_l2_nsw_species_intensity(processing_dependencies, mock_get_file_paths):
-    sci_input = ScienceInput("imap_codice_l1b_lo-nsw-species_20250814_v007.cdf")
-    processing_dependencies.add(sci_input)
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_codice_l2_nsw_species_intensity(mock_get_file_paths, codice_lut_path):
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="lo-nsw-species", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+    processed_l1a_file = write_cdf(process_l1a(ProcessingInputCollection())[0])
+    processed_l1b_file = write_cdf(process_codice_l1b(processed_l1a_file))
+    # Mock get_files for l2
+    mock_get_file_paths.side_effect = [
+        [processed_l1b_file.as_posix()],
+        codice_lut_path(descriptor="l2-lo-gfactor"),
+        codice_lut_path(descriptor="l2-lo-efficiency"),
+    ]
+    processed_2_ds = process_codice_l2("lo-nsw-angular", ProcessingInputCollection())
     l2_val_data = (
         imap_module_directory
         / "tests"
@@ -360,21 +385,33 @@ def test_codice_l2_nsw_species_intensity(processing_dependencies, mock_get_file_
         / "imap_codice_l2_lo-nsw-species_20250814_v007.cdf"
     )
     l2_val_data = load_cdf(l2_val_data)
-    ds = process_codice_l2("lo-nsw-species", processing_dependencies)
     for variable in l2_val_data.data_vars:
         np.testing.assert_allclose(
-            ds[variable].values,
+            processed_2_ds[variable].values,
             l2_val_data[variable].values,
             rtol=1e-5,
             err_msg=f"Mismatch in variable '{variable}'",
         )
-    ds.attrs["Data_version"] = "001"
-    write_cdf(ds, istp=False)
+    processed_2_ds.attrs["Data_version"] = "001"
+    assert processed_2_ds.attrs["Logical_source"] == "imap_codice_l2_lo-nsw-species"
+    write_cdf(processed_2_ds)
 
 
-def test_codice_l2_nsw_angular_intensity(processing_dependencies, mock_get_file_paths):
-    sci_input = ScienceInput("imap_codice_l1b_lo-nsw-angular_20250814_v007.cdf")
-    processing_dependencies.add(sci_input)
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_codice_l2_nsw_angular_intensity(mock_get_file_paths, codice_lut_path):
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="lo-nsw-angular", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+    processed_l1a_file = write_cdf(process_l1a(ProcessingInputCollection())[0])
+    processed_l1b_file = write_cdf(process_codice_l1b(processed_l1a_file))
+    # Mock get_files for l2
+    mock_get_file_paths.side_effect = [
+        [processed_l1b_file.as_posix()],
+        codice_lut_path(descriptor="l2-lo-gfactor"),
+        codice_lut_path(descriptor="l2-lo-efficiency"),
+    ]
+    processed_2_ds = process_codice_l2("lo-nsw-species", ProcessingInputCollection())
     l2_val_data = (
         imap_module_directory
         / "tests"
@@ -384,22 +421,33 @@ def test_codice_l2_nsw_angular_intensity(processing_dependencies, mock_get_file_
         / "imap_codice_l2_lo-nsw-angular_20250814_v007.cdf"
     )
     l2_val_data = load_cdf(l2_val_data)
-    ds = process_codice_l2("lo-nsw-angular", processing_dependencies)
     for variable in LO_NSW_ANGULAR_VARIABLE_NAMES:
         np.testing.assert_allclose(
-            ds[variable].values,
+            processed_2_ds[variable].values,
             l2_val_data[variable].values,
             rtol=1e-5,
             err_msg=f"Mismatch in variable '{variable}'",
         )
-    ds.attrs["Data_version"] = "001"
-    # TODO fix attrs
-    write_cdf(ds, istp=False)
+    processed_2_ds.attrs["Data_version"] = "001"
+    assert processed_2_ds.attrs["Logical_source"] == "imap_codice_l2_lo-nsw-angular"
+    write_cdf(processed_2_ds)
 
 
-def test_codice_l2_sw_angular_intensity(processing_dependencies, mock_get_file_paths):
-    sci_input = ScienceInput("imap_codice_l1b_lo-sw-angular_20250814_v007.cdf")
-    processing_dependencies.add(sci_input)
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_codice_l2_sw_angular_intensity(mock_get_file_paths, codice_lut_path):
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="lo-sw-angular", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+    processed_l1a_file = write_cdf(process_l1a(ProcessingInputCollection())[0])
+    processed_l1b_file = write_cdf(process_codice_l1b(processed_l1a_file))
+    # Mock get_files for l2
+    mock_get_file_paths.side_effect = [
+        [processed_l1b_file.as_posix()],
+        codice_lut_path(descriptor="l2-lo-gfactor"),
+        codice_lut_path(descriptor="l2-lo-efficiency"),
+    ]
+    processed_2_ds = process_codice_l2("lo-sw-angular", ProcessingInputCollection())
     l2_val_data = (
         imap_module_directory
         / "tests"
@@ -409,16 +457,15 @@ def test_codice_l2_sw_angular_intensity(processing_dependencies, mock_get_file_p
         / "imap_codice_l2_lo-sw-angular_20250814_v007.cdf"
     )
     l2_val_data = load_cdf(l2_val_data)
-    ds = process_codice_l2("lo-sw-angular", processing_dependencies)
     for variable in LO_SW_ANGULAR_VARIABLE_NAMES:
         np.testing.assert_allclose(
-            ds[variable].values,
+            processed_2_ds[variable].values,
             l2_val_data[variable].values,
             # TODO is 1e-4 ok?
             rtol=1e-4,
             err_msg=f"Mismatch in variable '{variable}'",
         )
 
-    ds.attrs["Data_version"] = "001"
-    # TODO fix attrs
-    write_cdf(ds, istp=False)
+    processed_2_ds.attrs["Data_version"] = "001"
+    assert processed_2_ds.attrs["Logical_source"] == "imap_codice_l2_lo-sw-angular"
+    write_cdf(processed_2_ds)


### PR DESCRIPTION
# Change Summary

## Overview
CoDICE lo l2 attrs. These have been validated by ISTP. There is a warning in the species cdfs that a dim is < 2 (spin sectors) I will have to let the CoDICE team know and see what they think. 

## Updated Files
- imap_processing/cdf/config/imap_codice_global_cdf_attrs.yaml
   - fix global attrs 
- imap_processing/cdf/config/imap_codice_l2-lo-angular_variable_attrs.yaml
   - Add attrs
- imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml  
   - Add attrs
 - imap_processing/codice/codice_l2.py
   - energy_Table dim -> esa_step

