### PR TITLE
PERF: Improve Lo direct event packet parsing

### DIFF
--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -167,10 +167,14 @@ def parse_events(dataset: xr.Dataset, attr_mgr: ImapCdfAttributes) -> xr.Dataset
     """
     Parse and decompress binary direct event data for Lo.
 
+    This function works directly with raw bytes instead of converting to binary strings,
+    resulting in significant performance improvements.
+
     Parameters
     ----------
     dataset : xr.Dataset
         Lo science direct events from packets_to_dataset function.
+        Should contain raw bytes data in 'data' field.
     attr_mgr : ImapCdfAttributes
         CDF attribute manager for Lo L1A.
 
@@ -184,8 +188,14 @@ def parse_events(dataset: xr.Dataset, attr_mgr: ImapCdfAttributes) -> xr.Dataset
     # parse the count and passes fields. These fields only occur once
     # at the beginning of each packet group and are not part of the
     # compressed direct event data
+
+    # Extract DE counts from raw bytes
+    de_counts = [
+        extract_bits_from_bytes(raw_data, 0, 16) for raw_data in dataset["data"].values
+    ]
+
     dataset["de_count"] = xr.DataArray(
-        [int(pkt[0:16], 2) for pkt in dataset["events"].values],
+        de_counts,
         dims="epoch",
         attrs=attr_mgr.get_variable_attributes("de_count"),
     )
@@ -198,6 +208,7 @@ def parse_events(dataset: xr.Dataset, attr_mgr: ImapCdfAttributes) -> xr.Dataset
         + list(FIXED_FIELD_BITS._asdict().keys())
         + list(VARIABLE_FIELD_BITS._asdict().keys())
     )
+
     # Initialize all Direct Event fields with their fill value
     # L1A Direct event data will not be tied to an epoch
     # data will use a direct event index for the
@@ -210,151 +221,139 @@ def parse_events(dataset: xr.Dataset, attr_mgr: ImapCdfAttributes) -> xr.Dataset
         )
     dataset["passes"] = xr.DataArray(
         np.full(
-            len(dataset["events"].values),
+            len(dataset["data"].values),
             attr_mgr.get_variable_attributes("passes")["FILLVAL"],
         ),
         dims="epoch",
         attrs=attr_mgr.get_variable_attributes("passes"),
     )
 
-    # The DE index for the entire pointing
+    # Pre-extract numpy arrays for all fields to avoid xarray overhead
+    field_arrays = {}
+    for field in de_fields:
+        field_arrays[field] = dataset[field].values
+
+    data_values = dataset["data"].values
+    de_count_values = dataset["de_count"].values
+    passes_values = dataset["passes"].values
+
+    # Process each packet
     pointing_de = 0
-    # for each direct event packet in the pointing
-    for pkt_idx, de_count in enumerate(dataset["de_count"].values):
-        # initialize the bit position for the packet
-        # after the counts field
-        dataset.attrs["bit_pos"] = 16
-        # Parse the passes field for the packet
-        dataset["passes"].values[pkt_idx] = parse_de_bin(dataset, pkt_idx, 32)
-        dataset.attrs["bit_pos"] = dataset.attrs["bit_pos"] + 32
 
-        # for each direct event in the packet
-        for _ in range(de_count):
-            # Parse the fixed fields for the direct event
-            # Coincidence Type, Time, ESA Step, Mode
-            dataset = parse_fixed_fields(dataset, pkt_idx, pointing_de)
-            # Parse the variable fields for the direct event
-            # TOF0, TOF1, TOF2, TOF3, Checksum, Position
-            dataset = parse_variable_fields(dataset, pkt_idx, pointing_de)
+    for pkt_idx, de_count in enumerate(de_count_values):
+        raw_data = data_values[pkt_idx]
 
-            pointing_de += 1
+        # Parse all direct events in this packet using bytewise operations
+        pointing_de, passes_value = parse_packet_events(
+            raw_data, de_count, pointing_de, field_arrays
+        )
+        passes_values[pkt_idx] = passes_value
 
-    del dataset.attrs["bit_pos"]
     logger.info("\n Returning Lo L1A Direct Events Dataset")
     return dataset
 
 
-def parse_fixed_fields(
-    dataset: xr.Dataset, pkt_idx: int, pointing_de: int
-) -> xr.Dataset:
+def parse_packet_events(
+    raw_data: bytes, de_count: int, pointing_de: int, field_arrays: dict
+) -> tuple[int, int]:
     """
-    Parse the fixed fields for a direct event.
-
-    Fixed fields are the fields that are always transmitted for
-    a direct event. These fields are the Coincidence Type,
-    Time, ESA Step, and Mode.
+    Parse all direct events in a single packet using bitwise operations on raw bytes.
 
     Parameters
     ----------
-    dataset : xr.Dataset
-        Lo science direct events from packets_to_dataset function.
-    pkt_idx : int
-        Index of the packet for the pointing.
+    raw_data : bytes
+        Raw packet data as bytes.
+    de_count : int
+        Number of direct events in this packet.
     pointing_de : int
-        Index of the total direct event for the pointing.
+        Starting index for direct events in the pointing.
+    field_arrays : dict
+        Dictionary of field names to pre-extracted numpy arrays.
 
     Returns
     -------
-    dataset : xr.Dataset
-        Updated dataset with the fixed fields parsed.
+    int, int
+        Updated pointing_de index after processing all events in packet.
+        Passes value for this packet.
     """
-    for field, bit_length in FIXED_FIELD_BITS._asdict().items():
-        dataset[field].values[pointing_de] = parse_de_bin(dataset, pkt_idx, bit_length)
-        dataset.attrs["bit_pos"] += bit_length
+    # Parse passes field (bits 16-47)
+    passes_value = extract_bits_from_bytes(raw_data, 16, 32)
 
-    return dataset
+    bit_offset = 48  # Start after count (16 bits) + passes (32 bits)
 
+    # Process all direct events in this packet
+    for de_idx in range(de_count):
+        current_de_idx = pointing_de + de_idx
 
-def parse_variable_fields(
-    dataset: xr.Dataset, pkt_idx: int, pointing_de: int
-) -> xr.Dataset:
-    """
-    Parse the variable fields for a direct event.
-
-    Variable fields are the fields that are not always transmitted.
-    Which fields are transmitted is determined by the Coincidence
-    type and Mode. These fields are TOF0, TOF1, TOF2, TOF3, Checksum,
-    and Position. All of these fields except for Position are bit
-    shifted to the right by 1 when packed into the CCSDS packets.
-
-    Parameters
-    ----------
-    dataset : xr.Dataset
-        Lo science direct events from packets_to_dataset function.
-    pkt_idx : int
-        Index of the packet for the pointing.
-    pointing_de : int
-        Index of the total direct event for the pointing.
-
-    Returns
-    -------
-    dataset : xr.Dataset
-        Updated dataset with the fixed fields parsed.
-    """
-    # The decoder defines which TOF fields are
-    # transmitted for this case and mode
-    case_decoder = CASE_DECODER[
-        (
-            dataset["coincidence_type"].values[pointing_de],
-            dataset["mode"].values[pointing_de],
-        )
-    ]
-
-    for field, field_exists in case_decoder._asdict().items():
-        # Check which TOF fields should have been transmitted for this
-        # case number / mode combination and decompress them.
-        if field_exists:
-            bit_length = VARIABLE_FIELD_BITS._asdict()[field]
-            dataset[field].values[pointing_de] = parse_de_bin(
-                dataset, pkt_idx, bit_length, DE_BIT_SHIFT[field]
+        # Parse fixed fields using bitwise operations
+        for field, bit_length in FIXED_FIELD_BITS._asdict().items():
+            field_arrays[field][current_de_idx] = extract_bits_from_bytes(
+                raw_data, bit_offset, bit_length
             )
-            dataset.attrs["bit_pos"] += bit_length
+            bit_offset += bit_length
 
-    return dataset
+        # Parse variable fields based on coincidence type and mode
+        # Variable fields are the fields that are not always transmitted.
+        # Which fields are transmitted is determined by the Coincidence
+        # type and Mode. These fields are TOF0, TOF1, TOF2, TOF3, Checksum,
+        # and Position. All of these fields except for Position are bit
+        # shifted to the right by 1 when packed into the CCSDS packets.
+        case_decoder = CASE_DECODER[
+            (
+                field_arrays["coincidence_type"][current_de_idx],
+                field_arrays["mode"][current_de_idx],
+            )
+        ]
+
+        for field, field_exists in case_decoder._asdict().items():
+            if field_exists:
+                bit_length = VARIABLE_FIELD_BITS._asdict()[field]
+                bit_shift = DE_BIT_SHIFT.get(field, 0)
+                field_arrays[field][current_de_idx] = extract_bits_from_bytes(
+                    raw_data, bit_offset, bit_length, bit_shift
+                )
+                bit_offset += bit_length
+
+    return pointing_de + de_count, passes_value
 
 
-def parse_de_bin(
-    dataset: xr.Dataset, pkt_idx: int, bit_length: int, bit_shift: int = 0
+def extract_bits_from_bytes(
+    data: bytes, bit_offset: int, bit_length: int, bit_shift: int = 0
 ) -> int:
     """
-    Parse a binary string for a direct event field.
+    Extract bits from raw bytes using bitwise operations.
+
+    This is much faster than converting to binary strings and doing string slicing.
 
     Parameters
     ----------
-    dataset : xr.Dataset
-        Lo science direct events from packets_to_dataset function.
-    pkt_idx : int
-        Index of the packet for the pointing.
+    data : bytes
+        Raw byte data.
+    bit_offset : int
+        Starting bit position (0-based).
     bit_length : int
-        Length of the field in bits.
+        Number of bits to extract.
     bit_shift : int
-        Number of bits to shift the field to the left.
+        Number of bits to shift result left (for unpacking compressed data).
 
     Returns
     -------
     int
-        Parsed integer for the direct event field.
+        Extracted value.
     """
-    bit_pos = dataset.attrs["bit_pos"]
+    # Convert bytes to a big integer for bit manipulation
+    total_bits = len(data) * 8
+    value = int.from_bytes(data, byteorder="big")
 
-    parsed_int = (
-        int(
-            dataset["events"].values[pkt_idx][bit_pos : bit_pos + bit_length],
-            2,
-        )
-        << bit_shift
-    )
-    return parsed_int
+    # Create a mask for the desired bits
+    mask = (1 << bit_length) - 1
+
+    # Shift to align the desired bits to the right, then apply mask
+    shift_amount = total_bits - bit_offset - bit_length
+    extracted = (value >> shift_amount) & mask
+
+    # Apply any additional bit shift for decompression
+    return extracted << bit_shift
 
 
 def combine_segmented_packets(dataset: xr.Dataset) -> xr.Dataset:
@@ -396,19 +395,27 @@ def combine_segmented_packets(dataset: xr.Dataset) -> xr.Dataset:
     # where true means the group is valid
     valid_groups = find_valid_groups(seq_ctrs, seg_starts, seg_ends)
 
-    # Combine the segmented packets into a single binary string
-    dataset["events"] = [
-        "".join(dataset["data"].values[start : end + 1])
-        for start, end in zip(seg_starts, seg_ends, strict=False)
-    ]
+    # Combine the segmented packets into raw bytes directly
+    combined_data_list = []
+    for start, end in zip(seg_starts, seg_ends, strict=False):
+        # Concatenate raw bytes data directly
+        combined_bytes = b"".join(dataset["data"].values[start : end + 1])
+        combined_data_list.append(combined_bytes)
 
-    # drop any group of segmented packets that aren't sequential
-    dataset["events"] = dataset["events"].values[valid_groups]
+    # Drop any group of segmented packets that aren't sequential
+    valid_combined_data = [
+        combined_data_list[i] for i, valid in enumerate(valid_groups) if valid
+    ]
 
     # Update the epoch to the first epoch in the segment
     dataset.coords["epoch"] = dataset["epoch"].values[seg_starts]
-    # drop any group of segmented epochs that aren't sequential
+    # Drop any group of segmented epochs that aren't sequential
     dataset.coords["epoch"] = dataset["epoch"].values[valid_groups]
+
+    # Create the data DataArray with combined raw bytes
+    dataset["data"] = xr.DataArray(
+        valid_combined_data, dims=["epoch"], coords={"epoch": dataset.coords["epoch"]}
+    )
     # Set met to the first segment start times for the valid groups.
     # shcoarse will be retained as a per packet coordinate and met
     # is used as the mission elapsed time for each segment

--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -16,7 +16,7 @@ from imap_processing.lo.l0.lo_science import (
     parse_histogram,
 )
 from imap_processing.lo.l0.lo_star_sensor import process_star_sensor
-from imap_processing.utils import convert_to_binary_string, packet_file_to_datasets
+from imap_processing.utils import packet_file_to_datasets
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -85,14 +85,14 @@ def lo_l1a(dependency: Path) -> list[xr.Dataset]:
         )
         logical_source = "imap_lo_l1a_de"
         ds = datasets_by_apid[LoAPID.ILO_SCI_DE]
-        # Process the "data" array into a string
-        ds["data"] = xr.DataArray(
-            [convert_to_binary_string(data) for data in ds["data"].values],
-            dims=ds["data"].dims,
-            attrs=ds["data"].attrs,
-        )
 
-        ds = combine_segmented_packets(ds)
+        # Check if we need to combine segmented packets first
+        needs_combine = not all(ds.seq_flgs.values == 3)  # 3 = unsegmented
+
+        if needs_combine:
+            # For segmented packets, combine raw bytes directly
+            ds = combine_segmented_packets(ds)
+
         ds = parse_events(ds, attr_mgr)
         ds = add_dataset_attrs(ds, attr_mgr, logical_source)
         datasets_to_return.append(ds)
@@ -328,7 +328,6 @@ def add_dataset_attrs(
                 "src_seq_ctr",
                 "pkt_len",
                 "data",
-                "events",
             ]
         )
         # An empty DEPEND_0 is being added to support_data

--- a/imap_processing/tests/lo/test_lo_science.py
+++ b/imap_processing/tests/lo/test_lo_science.py
@@ -9,12 +9,9 @@ from imap_processing.lo.l0.lo_apid import LoAPID
 from imap_processing.lo.l0.lo_science import (
     combine_segmented_packets,
     organize_spin_data,
-    parse_de_bin,
     parse_events,
-    parse_fixed_fields,
-    parse_variable_fields,
 )
-from imap_processing.utils import convert_to_binary_string, packet_file_to_datasets
+from imap_processing.utils import packet_file_to_datasets
 
 
 @pytest.fixture
@@ -62,10 +59,14 @@ def fake_de_dataset():
         + tof1_2
         + pos_2
     )
+
+    # Convert binary string to actual bytes for the new bytewise parsing
+    byte_data = bytes(int(de_data[i : i + 8], 2) for i in range(0, len(de_data), 8))
+
     dataset = xr.Dataset(
         data_vars=dict(
             count=(["time"], np.array([2])),
-            events=(["time"], np.array([de_data])),
+            data=(["time"], np.array([byte_data], dtype=object)),
         )
     )
 
@@ -88,28 +89,35 @@ def sample_data():
 
 @pytest.fixture
 def segmented_pkts_fake_data():
+    # Convert string binary to bytes for each data entry
+    string_data = [
+        "0000000001",
+        "0000000010",
+        "0000000100",
+        "0000001000",
+        "0000010000",
+        "0000100000",
+        "0001000000",
+        "0010000000",
+        "0100000000",
+        "1000000000",
+    ]
+
+    # Pad strings to be divisible by 8 and convert to bytes
+    byte_data = []
+    for s in string_data:
+        # Pad to nearest multiple of 8
+        padded = s.ljust((len(s) + 7) // 8 * 8, "0")
+        byte_data.append(
+            bytes(int(padded[i : i + 8], 2) for i in range(0, len(padded), 8))
+        )
+
     dataset = xr.Dataset(
         data_vars=dict(
             seq_flgs=(["epoch"], np.array([1, 0, 0, 2, 3, 1, 0, 2, 1, 2])),
             src_seq_ctr=(["epoch"], np.array([0, 1, 2, 3, 4, 5, 7, 8, 9, 10])),
             shcoarse=(["epoch"], np.array([0, 0, 0, 0, 10, 20, 20, 20, 30, 30])),
-            data=(
-                ["epoch"],
-                np.array(
-                    [
-                        "0000000001",
-                        "0000000010",
-                        "0000000100",
-                        "0000001000",
-                        "0000010000",
-                        "0000100000",
-                        "0001000000",
-                        "0010000000",
-                        "0100000000",
-                        "1000000000",
-                    ]
-                ),
-            ),
+            data=(["epoch"], np.array(byte_data, dtype=object)),
         ),
         coords=dict(epoch=(["epoch"], np.array([0, 0, 0, 0, 10, 20, 20, 20, 30, 30]))),
     )
@@ -196,47 +204,6 @@ def test_parse_events(fake_de_dataset, attr_mgr):
     np.testing.assert_array_equal(dataset["pos"].values, np.array([255, 0]))
 
 
-def test_parse_fixed_fields(initialized_dataset):
-    # Arrange
-    initialized_dataset.attrs["bit_pos"] = 48
-
-    # Act
-    dataset = parse_fixed_fields(initialized_dataset, 0, 0)
-
-    # Assert
-    np.testing.assert_array_equal(
-        dataset["coincidence_type"].values, np.array([0, 255])
-    )
-    np.testing.assert_array_equal(dataset["de_time"].values, np.array([100, 65535]))
-    np.testing.assert_array_equal(dataset["esa_step"].values, np.array([2, 255]))
-    np.testing.assert_array_equal(dataset["mode"].values, np.array([1, 255]))
-
-
-def test_parse_variable_fields(initialized_dataset):
-    # Arrange
-    initialized_dataset["coincidence_type"].values = np.array([0, 255])
-    initialized_dataset["mode"].values = np.array([1, 255])
-    initialized_dataset.attrs["bit_pos"] = 68
-
-    # Act
-    dataset = parse_variable_fields(initialized_dataset, 0, 0)
-
-    # Assert
-    np.testing.assert_array_equal(dataset["tof0"].values, np.array([0 << 1, 65535]))
-    np.testing.assert_array_equal(dataset["tof1"].values, np.array([65535, 65535]))
-    np.testing.assert_array_equal(dataset["tof2"].values, np.array([2 << 1, 65535]))
-    np.testing.assert_array_equal(dataset["tof3"].values, np.array([3 << 1, 65535]))
-    np.testing.assert_array_equal(dataset["cksm"].values, np.array([0 << 1, 255]))
-    np.testing.assert_array_equal(dataset["pos"].values, np.array([255, 255]))
-
-
-def test_parse_de_bin(initialized_dataset):
-    # Act
-    parsed_int = parse_de_bin(initialized_dataset, 0, 4, 0)
-    # Assert
-    assert parsed_int == 0
-
-
 def test_combine_segmented_packets(segmented_pkts_fake_data):
     dataset = combine_segmented_packets(segmented_pkts_fake_data)
 
@@ -249,16 +216,13 @@ def test_combine_segmented_packets(segmented_pkts_fake_data):
     np.testing.assert_array_equal(
         dataset["shcoarse"].values, np.array([0, 0, 0, 0, 10, 20, 20, 20, 30, 30])
     )
-    np.testing.assert_array_equal(
-        dataset["events"].values,
-        np.array(
-            [
-                "0000000001000000001000000001000000001000",
-                "0000010000",
-                "01000000001000000000",
-            ]
-        ),
-    )
+
+    # Test that we have the expected number of combined data segments
+    assert len(dataset["data"].values) == 3
+    assert dataset["data"].values[0] == b"\x00@\x00\x80\x01\x00\x02"
+    assert dataset["data"].values[1] == b"\x04"
+    assert dataset["data"].values[2] == b"@\x00\x80"
+
     np.testing.assert_array_equal(dataset["epoch"].values, np.array([0, 10, 30]))
     np.testing.assert_array_equal(dataset["met"].values, np.array([0, 10, 30]))
 
@@ -284,11 +248,6 @@ def test_validate_parse_events(sample_data, attr_mgr):
         "pos",
     ]
 
-    de_data["data"] = xr.DataArray(
-        [convert_to_binary_string(data) for data in de_data["data"].values],
-        dims=de_data["data"].dims,
-        attrs=de_data["data"].attrs,
-    )
     de_data = combine_segmented_packets(de_data)
     dataset = parse_events(de_data, attr_mgr)
 


### PR DESCRIPTION
Use raw bytes instead of going to string representation.

Access the .values numpy arrays outside of the for loops and store the views external to the hot-loops. This was causing a significant slowdown because of all the array creation within the loops.

Currently, this takes ~7 hours to process L0 data and times out on our resources. With this update, it takes a few minutes locally.

**Before**
I killed the process because I wasn't willing to wait 7 hours, but you can see that the parse_events was taking up longer and longer time compared to create_datasets.
<img width="1211" height="324" alt="image" src="https://github.com/user-attachments/assets/0734f495-7ee0-4a4d-a278-931c28f3b1c8" />

**After**
I was able to run the entire processing and the parse_events is less than the create_datasets now.
<img width="1140" height="326" alt="image" src="https://github.com/user-attachments/assets/5030e0cb-3ed7-4565-a223-cb79f1247476" />
