### PR TITLE
FIX: Lo l1b_de needs to expand l1a met to each direct event

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -351,9 +351,14 @@ def get_spin_start_times(
     spin_start_time : xr.DataArray
         The start time for the spin that each direct event is in.
     """
-    met = l1a_de["met"].values
-    # Find the closest stop_acq for each shcoarse
-    closest_stop_acq_indices = np.abs(met[:, None] - acq_end.values).argmin(axis=1)
+    # Get the MET times for each individual direct event
+    # l1a_de["met"] has one value per time epoch, but we need one per direct event
+    de_met = np.repeat(l1a_de["met"], l1a_de["de_count"])
+
+    # Find the closest stop_acq for each direct event
+    closest_stop_acq_indices = np.abs(de_met.values[:, None] - acq_end.values).argmin(
+        axis=1
+    )
     # There are 28 spins per epoch (1 aggregated science cycle)
     # Set the spin_cycle_num to the spin number relative to the
     # start of the ASC

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -314,10 +314,10 @@ def test_get_spin_start_times():
     # Arrange
     l1b_de = xr.Dataset(
         {
-            "spin_cycle": ("epoch", [0, 1, 2, 3, 4]),
+            "spin_cycle": ("direct_event", [0, 1, 2, 3, 4]),
         },
         coords={
-            "epoch": [
+            "direct_event": [
                 0,
                 1,
                 2,
@@ -329,7 +329,7 @@ def test_get_spin_start_times():
     l1a_de = xr.Dataset(
         {
             "de_count": ("epoch", [2, 3]),
-            "met": ("direct_event", [0, 1, 2, 3, 4]),
+            "met": ("epoch", [0, 1]),  # MET per time epoch, not per direct event
             "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000]),
         },
         coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4]},
@@ -348,7 +348,7 @@ def test_get_spin_start_times():
     )
 
     end_acq = xr.DataArray([0, 1], dims="epoch")
-    spin_start_times_expected = np.array([20.002, 50.0015, 55.002, 60.003, 65.004])
+    spin_start_times_expected = np.array([20.002, 25.003, 55.002, 60.003, 65.004])
     spin_start_times = get_spin_start_times(l1a_de, l1b_de, spin, end_acq)
 
     np.testing.assert_allclose(


### PR DESCRIPTION
Previously, it was only calculating this per ASC, where there are multiple direct events per ASC. We can repeat the individual MET entries by the number of direct events in that ASC.

The test was assuming MET in l1a was the number of direct events, this turns out not to be the case. I think this is right here, but we could also update the l1a dataset to put MET in terms of direct_events as well.