### PR TITLE
FIX: Ignore points outside of the pointing for Lo l1b

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -862,6 +862,7 @@ def set_pointing_bin(l1b_de: xr.Dataset) -> xr.Dataset:
         np.column_stack((x, y, z)),
         SpiceFrame.IMAP_HAE,
         SpiceFrame.IMAP_DPS,
+        allow_spice_noframeconnect=True,
     )
     # convert the pointing direction to latitudinal coordinates
     direction = cartesian_to_latitudinal(dps_xyz)


### PR DESCRIPTION
These direct events can't be projected because the DPS frame is not defined during repoint maneuvers. For now, we can just ignore the transform during those points, but in the future we should look at defining these as badtimes and then removing them before calling the projection.

Note that the current set_badtimes function is actually called at the very end of the routine, so I think we'd need to move that up higher to be able to ignore the badtimes when using SPICE.