### PR TITLE
FIX: SWAPI datetimes were not offset from epoch and ESA tables 0 padded

### DIFF
--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -220,13 +220,19 @@ def swapi_l2(
     # -----------------------------------
     # Convert unpacked ESA_LVL5 values to hex to match the LUT table
     # value
-    esa_lvl5_hex = np.vectorize(lambda x: format(x, "X"))(l1_dataset["esa_lvl5"].values)
+    esa_lvl5_hex = np.vectorize(lambda x: format(x, "04X"))(
+        l1_dataset["esa_lvl5"].values
+    )
+
+    # Turn the string start times into numpy datetime64
+    sci_start_time = l1_dataset["sci_start_time"].values.astype("datetime64[ns]")
+
     esa_energy = solve_full_sweep_energy(
         esa_lvl5_hex,
         l1_dataset["sweep_table"].data,
         esa_table_df=esa_table_df,
         lut_notes_df=lut_notes_df,
-        data_time=np.array(l1_dataset["epoch"].data, dtype="datetime64[ns]"),
+        data_time=sci_start_time,
     )
 
     l2_dataset["swp_esa_energy"] = xr.DataArray(


### PR DESCRIPTION
The ESA tables provided have 0 padding for the ESA levels. i.e. 0A12 rather than just A12, so we need to specify that as 04X in the format string to get the 0 padding from the hex conversion.

We were converting l1 epoch values directly to datetime64, but the datetime64 epoch is different than the CDF epoch. We need to convert to timedelta64ns and then offset from the 2000-01-01 epoch CDF uses. I think we should use the spice time routines, but when I did that quickly I got missing clock kernels, so we'll need to add those to the datamanager still. That can be a follow-up or updated later. Putting this up for a hotfix reference point right now.