### PR TITLE
MNT/FIX: Update Lo ancillary file naming from strt to start

### DIFF
--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -561,19 +561,19 @@ def set_background_rates(
 
     # find to the rows for the current pointing
     pointing_bg_df = background_df[
-        (background_df["GoodTime_strt"] >= pointing_start_met)
+        (background_df["GoodTime_start"] >= pointing_start_met)
         & (background_df["GoodTime_end"] <= pointing_end_met)
     ]
 
     # convert the bin start and end resolution from 6 degrees to .1 degrees
-    pointing_bg_df["bin_strt"] = pointing_bg_df["bin_strt"] * 60
+    pointing_bg_df["bin_start"] = pointing_bg_df["bin_start"] * 60
     # The last bin end in the file is 0, which means 60 degrees. This is
     # converted to 0.1 degree resolution of 3600
     pointing_bg_df["bin_end"] = pointing_bg_df["bin_end"] * 60
     pointing_bg_df.loc[pointing_bg_df["bin_end"] == 0, "bin_end"] = 3600
     # for each row in the bg ancillary file for this pointing
     for _, row in pointing_bg_df.iterrows():
-        bin_start = int(row["bin_strt"])
+        bin_start = int(row["bin_start"])
         bin_end = int(row["bin_end"])
         # for each energy step, set the background rate and uncertainty
         for esa_step in range(0, 7):

--- a/imap_processing/tests/lo/test_anc/imap_lo_hydrogen-background-small_20250101_20270101_v001.csv
+++ b/imap_processing/tests/lo/test_anc/imap_lo_hydrogen-background-small_20250101_20270101_v001.csv
@@ -1,4 +1,4 @@
-YYYYDDD,GoodTime_strt,GoodTime_end,bin_strt,bin_end,Lo,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,type
+YYYYDDD,GoodTime_start,GoodTime_end,bin_start,bin_end,Lo,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,type
 2025001,473389200.0,473472000.0,0,1,Lo,0.0098,0.0089,0.0118,0.0113,0.0056,0.0008,0.0000,rate
 2025001,473389200.0,473472000.0,0,1,Lo,0.0025,0.0020,0.0015,0.0015,0.0010,0.0008,0.0000,sigma
 2025001,473389200.0,473472000.0,1,2,Lo,0.0098,0.0089,0.0118,0.0113,0.0056,0.0008,0.0000,rate

--- a/imap_processing/tests/lo/test_anc/imap_lo_oxygen-background-small_20250101_20270101_v001.csv
+++ b/imap_processing/tests/lo/test_anc/imap_lo_oxygen-background-small_20250101_20270101_v001.csv
@@ -1,4 +1,4 @@
-YYYYDDD,GoodTime_strt,GoodTime_end,bin_strt,bin_end,Lo,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,type
+YYYYDDD,GoodTime_start,GoodTime_end,bin_start,bin_end,Lo,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,type
 2025001,473389200.0,473472000.0,0,1,Lo,0.0098,0.0089,0.0118,0.0113,0.0056,0.0008,0.0000,rate
 2025001,473389200.0,473472000.0,0,1,Lo,0.0025,0.0020,0.0015,0.0015,0.0010,0.0008,0.0000,sigma
 2025001,473389200.0,473472000.0,1,2,Lo,0.0098,0.0089,0.0118,0.0113,0.0056,0.0008,0.0000,rate


### PR DESCRIPTION
# Change Summary

## Overview

Processing L1c failed because of the naming for the background ancillary file columns. It is unclear to me what we are expecting going forward, so just putting this up here for awareness right now.

What would you think about adding a condition into the code to allow for both cases @sdhoyt? I am not sure how I feel about that, but it would make our lives easier potentially too.