### PR TITLE
MNT: Turn down cdflib log messages while writing L1 CDFs

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import imap_data_access
 import numpy as np
 import xarray as xr
+from cdflib.logging import logger as cdflib_logger
 from cdflib.xarray import cdf_to_xarray, xarray_to_cdf
 from cdflib.xarray.cdf_to_xarray import ISTP_TO_XARRAY_ATTRS
 
@@ -166,7 +167,17 @@ def write_cdf(
     if "compression" not in extra_cdf_kwargs:
         extra_cdf_kwargs["compression"] = 6  # type: ignore
 
-    xarray_to_cdf(dataset, str(file_path), **extra_cdf_kwargs)
+    prev_cdflib_level = cdflib_logger.level
+    try:
+        if not extra_cdf_kwargs.get("istp", False):
+            # Suppress cdflib logging messages for data levels that don't need
+            # strict ISTP compliance
+            logger.info("Disabling cdflib ISTP logging for level 1 data products")
+            cdflib_logger.setLevel(logging.ERROR)
+        xarray_to_cdf(dataset, str(file_path), **extra_cdf_kwargs)
+    finally:
+        # Set back to the previous logging level
+        cdflib_logger.setLevel(prev_cdflib_level)
     return file_path
 
 


### PR DESCRIPTION
There are a lot of messages in the stream about ISTP compliance that aren't relevant if the L1 files don't need to be ISTP compliant. This can hide useful information, so lets suppress the log messages for L1 files by default.

closes #2408