### PR TITLE
2374 lo l2 part3  integrate cg correction for hf maps

### DIFF
--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -731,6 +731,10 @@ def interpolate_map_flux_to_helio_frame(
     energy_right = esa_energies_ev.isel({"energy": right_idx_da})
 
     for var_name in vars_to_interpolate:
+        logger.debug(
+            f"Interpolating {var_name}, {var_name}_stat_uncert, and"
+            f"{var_name}_sys_err to heliocentric frame energies"
+        )
         # Step 2: Extract flux values at bounding energy channels
         # Use xarray's advanced indexing to get fluxes at left and right indices
         intensity = map_ds[var_name]

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -749,7 +749,7 @@ def interpolate_map_flux_to_helio_frame(
 
     for var_name in vars_to_interpolate:
         logger.debug(
-            f"Interpolating {var_name}, {var_name}_stat_uncert, and"
+            f"Interpolating {var_name}, {var_name}_stat_uncert, and "
             f"{var_name}_sys_err to heliocentric frame energies"
         )
         # Step 2: Extract flux values at bounding energy channels

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -273,7 +273,8 @@ class PowerLawFluxCorrector:
             source_uncertainties = observed_uncertainties / eta_final
 
             # Check convergence
-            ratios_sq = (source_fluxes_n / source_fluxes_prev) ** 2
+            with np.errstate(divide="ignore", invalid="ignore"):
+                ratios_sq = (source_fluxes_n / source_fluxes_prev) ** 2
             chi_n = np.sqrt(np.mean(ratios_sq)) - 1
 
             if chi_n < convergence_threshold:
@@ -344,10 +345,26 @@ def add_spacecraft_velocity_to_pset(
     - "sc_velocity": Spacecraft velocity vector (km/s) with dims ["x_y_z"]
     - "sc_direction_vector": Spacecraft velocity unit vector with dims ["x_y_z"]
     """
-    # Compute ephemeris time (J2000 seconds) of PSET midpoint
-    # epoch contains Pointing start time, and epoch_delta indicates the total
-    # duration of the Pointing
-    et = ttj2000ns_to_et(pset["epoch"].values[0] + pset["epoch_delta"].values[0] / 2)
+    # Hi and Lo need to use different methods for computing the Pointing
+    # midpoint time.
+    if pset.attrs["Logical_source"].startswith("imap_hi"):
+        # Compute ephemeris time (J2000 seconds) of PSET midpoint
+        # epoch contains Pointing start time, and epoch_delta indicates the total
+        # duration of the Pointing
+        # For Hi, epoch_delta is the duration of the Pointing in nanoseconds
+        pointing_duration_ns = pset["epoch_delta"].values[0]
+    elif pset.attrs["Logical_source"].startswith("imap_lo"):
+        # For Lo, compute the pointing duration using pointing start/end MET times
+        pointing_duration_ns = (
+            pset["pointing_end_met"].values[0] - pset["pointing_start_met"].values[0]
+        ) * 1e9
+    else:
+        raise NotImplementedError(
+            f"add_spacecraft_velocity_to_pset does not support PSETs with "
+            f"Logical_source: {pset.attrs['Logical_source']}"
+        )
+    et = ttj2000ns_to_et(pset["epoch"].values[0] + pointing_duration_ns / 2)
+
     # Get spacecraft state in HAE frame
     sc_state = geometry.imap_state(et, ref_frame=geometry.SpiceFrame.IMAP_HAE)
     sc_velocity_vector = sc_state[3:6]
@@ -492,7 +509,7 @@ def _calculate_compton_getting_transform(
     # x_k = (êₛ · û_sc) + sqrt(y² + (êₛ · û_sc)² - 1)
     x = dot_product + np.sqrt(y**2 + dot_product**2 - 1)
     # Get the dimensions in the right order so that spatial is last
-    x = x.transpose(dot_product.dims[0], y.dims[0], dot_product.dims[1])
+    x = x.transpose(dot_product.dims[0], y.dims[0], *dot_product.dims[1:])
 
     # Calculate ENA speed in the spacecraft frame
     # |v⃗_sc| = x_k * U_sc
@@ -551,9 +568,9 @@ def calculate_ram_mask(pset: xr.Dataset) -> xr.Dataset:
         Pointing set dataset with ram_mask variable added.
     """
     logger.debug(
-        f"Calculating the RAM mask using input spacecraft direction"
-        f"vector: {pset['sc_direction_vector']} and hae coordinates in the"
-        f"dataset hae_longitude and hae_latitude variables."
+        f"Calculating the RAM mask using input spacecraft direction "
+        f"vector: {pset['sc_direction_vector'].values} and hae coordinates in "
+        f"the dataset hae_longitude and hae_latitude variables."
     )
     longitude = pset["hae_longitude"]
     latitude = pset["hae_latitude"]

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -97,7 +97,6 @@ def lo_l2(
     dataset = add_geometric_factors(dataset, map_descriptor.species)
 
     logger.info("Step 4: Calculating rates and intensities")
-
     dataset = calculate_all_rates_and_intensities(
         dataset,
         sputtering_correction=sputtering_correction,
@@ -685,10 +684,9 @@ def reduce_geometric_factor_dataset(species: str, esa_mode: int) -> xr.Dataset:
     # Convert to xarray Dataset indexed by energy step for vectorized selection
     gf_ds = gf_data.set_index("Observed_E-Step").to_xarray()
 
-    # TODO: The ancillary data has repeated Observed_E-Step values with different
-    #    incident_E-Step values. Figure out how we get the correct row. For now,
-    #    just remove duplicate Observed_E-Step values.
-    gf_ds = gf_ds.drop_duplicates(dim="Observed_E-Step")
+    # Lo Instrument team: Use only geometric factors where
+    # incident_E-Step == Observed_E-Step
+    gf_ds = gf_ds.where(gf_ds["incident_E-Step"] == gf_ds["Observed_E-Step"], drop=True)
 
     # Select energy steps 1-7 and return
     return gf_ds.sel({"Observed_E-Step": range(1, 8)})
@@ -847,10 +845,12 @@ def calculate_all_rates_and_intensities(
 
     # Optional Step 4: Calculate sputtering corrections
     if sputtering_correction:
+        logger.info("Calculating sputtering corrections")
         dataset = calculate_sputtering_corrections(dataset, o_map_dataset)
 
     # Optional Step 5: Calculate bootstrap corrections
     if bootstrap_correction:
+        logger.info("Calculating bootstrap corrections")
         dataset = calculate_bootstrap_corrections(dataset)
 
     # Optional Step 6: Calculate flux corrections

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -310,6 +310,8 @@ def create_sky_map_from_psets(
     # Initialize the output map
     output_map = map_descriptor.to_empty_map()
 
+    cg_correct = True if map_descriptor.frame_descriptor == "hf" else False
+
     if not isinstance(output_map, RectangularSkyMap):
         raise NotImplementedError("HEALPix map output not supported for Lo")
 
@@ -321,10 +323,12 @@ def create_sky_map_from_psets(
             pset,
             efficiency_data,
             map_descriptor.species,
-            map_descriptor.frame_descriptor,
+            cg_correct,
         )
-        directional_mask = get_pset_directional_mask(pset, map_descriptor.spin_phase)
-        project_pset_to_map(processed_pset, output_map, directional_mask)
+        directional_mask = get_pset_directional_mask(
+            processed_pset, map_descriptor.spin_phase
+        )
+        project_pset_to_map(processed_pset, output_map, directional_mask, cg_correct)
 
     return output_map
 
@@ -333,7 +337,7 @@ def process_single_pset(
     pset: xr.Dataset,
     efficiency_data: pd.DataFrame,
     species: str,
-    frame: str,
+    cg_correct: bool = False,
 ) -> xr.Dataset:
     """
     Process a single pointing set for projection to the sky map.
@@ -346,10 +350,10 @@ def process_single_pset(
         Efficiency factor data for correcting counts.
     species : str
         The species to process (e.g., "h", "o").
-    frame : str
-        The output reference frame (e.g., "sc", "hf"). A frame of "hf"
-        (heliocentric frame) will cause the pre-projection Compton Getting
-        Correction to be applied to the PSET data.
+    cg_correct : bool
+        Whether to apply the CG correction to each PSET. A value of True will
+        cause the pre-projection Compton Getting Correction to be applied to
+        the PSET data.
 
     Returns
     -------
@@ -366,10 +370,21 @@ def process_single_pset(
     pset_processed = calculate_efficiency_corrected_quantities(pset_processed)
 
     # Step 4: CG correction and compute ram mask
-    if frame == "hf":
+    if cg_correct:
+        # NOTE: Heliospheric frame energy selection for CG correction
+        # The heliospheric (HF) energies passed to the CG correction algorithm
+        # could in principle be completely different from the ESA central energies.
+        # However, for Lo, the instrument team has chosen to use the same HF
+        # energies as the ESA central energies (from the geometric factor files).
+        # This decision aligns the energy grid between the spacecraft frame and
+        # heliospheric frame representations.
+
+        # Convert energy coordinate from keV to eV for CG correction
+        # (energy coordinate was set in normalize_pset_coordinates in keV)
+        energy_values_ev: xr.DataArray = pset_processed["energy"] * 1000.0
         # ram_mask variable is added as part of apply_compton_getting_correction
         pset_processed = apply_compton_getting_correction(
-            pset_processed, pset_processed["energy"]
+            pset_processed, energy_values_ev
         )
     else:
         pset_processed = add_spacecraft_velocity_to_pset(pset_processed)
@@ -394,16 +409,23 @@ def normalize_pset_coordinates(pset: xr.Dataset, species: str) -> xr.Dataset:
     xr.Dataset
         Pointing set with normalized energy coordinates and dimension names.
     """
+    # Load true energy values for this species (in keV, matching map convention)
+    esa_modes = np.unique(pset["esa_mode"].values)
+    if len(esa_modes) > 1:
+        raise ValueError(
+            f"Multiple ESA modes found in pointing set: {esa_modes}. "
+            "Only one ESA mode is supported for Lo."
+        )
+    gf_datset = get_geometric_factor_dataset(species, esa_mode=esa_modes[0])
+
     # Ensure consistent energy coordinates (maps want energy not esa_energy_step)
     pset_renamed = pset.rename_dims({"esa_energy_step": "energy"})
 
     # Drop the esa_energy_step coordinate first to avoid conflicts
     pset_renamed = pset_renamed.drop_vars("esa_energy_step")
 
-    # Ensure the pset energy coordinates match the output map
-    # TODO: Do we even need this if we are assigning the true
-    #       energy levels later?
-    pset_renamed = pset_renamed.assign_coords(energy=range(7))
+    # Assign TRUE energy values as coordinates (in keV, matching map convention)
+    pset_renamed = pset_renamed.assign_coords(energy=gf_datset["Cntr_E"].values)
 
     # Rename the variables in the pset for projection to the map
     # L2 wants different variable names than l1c
@@ -511,6 +533,7 @@ def project_pset_to_map(
     pset: xr.Dataset,
     output_map: AbstractSkyMap,
     directional_mask: xr.DataArray,
+    cg_correct: bool = False,
 ) -> None:
     """
     Project pointing set data to the output map.
@@ -524,6 +547,9 @@ def project_pset_to_map(
     directional_mask : xr.DataArray
         Boolean mask indicating which PSET bins to use for projection. This is
         how ram/anti-ram bins are removed depending on the descriptor spin phase.
+    cg_correct : bool
+        Whether the CG correction is being applied. If set to True, "energy_sc"
+        is added to the list of variables to be projected.
 
     Returns
     -------
@@ -541,6 +567,8 @@ def project_pset_to_map(
         "bg_rates_exposure_factor",
         "bg_rates_stat_uncert_exposure_factor2",
     ]
+    if cg_correct:
+        value_keys.append("energy_sc")
 
     # Create LoPointingSet and project to map
     lo_pset = ena_maps.LoPointingSet(pset)
@@ -625,6 +653,45 @@ def load_geometric_factor_data(species: str) -> pd.DataFrame:
         gf_file = anc_path / "imap_lo_oxygen-geometric-factor_v001.csv"
 
     return lo_ancillary.read_ancillary_file(gf_file)
+
+
+def get_geometric_factor_dataset(species: str, esa_mode: int) -> xr.Dataset:
+    """
+    Get geometric factor data as xarray Dataset for a specific species and ESA mode.
+
+    This helper function loads geometric factor data, filters by ESA mode, converts
+    to xarray, and selects all 7 energy steps for vectorized operations.
+
+    Parameters
+    ----------
+    species : str
+        The species to load geometric factors for ("h" or "o").
+    esa_mode : int
+        ESA mode (0 for HiRes, 1 for HiThr).
+
+    Returns
+    -------
+    xarray.Dataset
+        Geometric factor data indexed by Observed_E-Step (1-7), containing all
+        columns from the geometric factor CSV file.
+    """
+    # Load geometric factor data for this species
+    gf_data = load_geometric_factor_data(species)
+
+    # Filter for the specific ESA mode
+    if "esa_mode" in gf_data.columns:
+        gf_data = gf_data[gf_data["esa_mode"] == esa_mode].copy()
+
+    # Convert to xarray Dataset indexed by energy step for vectorized selection
+    gf_ds = gf_data.set_index("Observed_E-Step").to_xarray()
+
+    # TODO: The ancillary data has repeated Observed_E-Step values with different
+    #    incident_E-Step values. Figure out how we get the correct row. For now,
+    #    just remove duplicate Observed_E-Step values.
+    gf_ds = gf_ds.drop_duplicates(dim="Observed_E-Step")
+
+    # Select energy steps 1-7 and return
+    return gf_ds.sel({"Observed_E-Step": range(1, 8)})
 
 
 def initialize_geometric_factor_variables(
@@ -715,16 +782,15 @@ def populate_geometric_factors(
         # Default to mode 0 if not available (HiRes mode)
         esa_mode = 0
 
-    # Populate the geometric factors for each energy step
-    for i in range(7):
-        # Get geometric factor data for this energy step and ESA mode
-        gf_row = gf_data[
-            (gf_data["esa_mode"] == esa_mode) & (gf_data["Observed_E-Step"] == i + 1)
-        ].iloc[0]
+    # Filter for the specific ESA mode
+    gf_dataset = get_geometric_factor_dataset(species, esa_mode)
 
-        # Fill energy step with the geometric factor values
-        for var, col in gf_vars.items():
-            dataset[var].values[i] = gf_row[col]
+    # Populate all geometric factors at once using xarray operations
+    for var, col in gf_vars.items():
+        if var == "energy":
+            dataset = dataset.assign_coords(energy=gf_dataset[col].values)
+        else:
+            dataset[var].values = gf_dataset[col].values
 
     # Update delta_minus and delta_plus based on ESA mode
     if esa_mode == 0:  # HiRes

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -410,13 +410,13 @@ def normalize_pset_coordinates(pset: xr.Dataset, species: str) -> xr.Dataset:
         Pointing set with normalized energy coordinates and dimension names.
     """
     # Load true energy values for this species (in keV, matching map convention)
-    esa_modes = np.unique(pset["esa_mode"].values)
-    if len(esa_modes) > 1:
-        raise ValueError(
-            f"Multiple ESA modes found in pointing set: {esa_modes}. "
-            "Only one ESA mode is supported for Lo."
-        )
-    gf_datset = get_geometric_factor_dataset(species, esa_mode=esa_modes[0])
+    # TODO: Figure out how to handle esa_mode properly
+    if "esa_mode" in pset:
+        esa_mode = pset["esa_mode"].values[0]
+    else:
+        # Default to mode 0 if not available (HiRes mode)
+        esa_mode = 0
+    gf_datset = get_geometric_factor_dataset(species, esa_mode=esa_mode)
 
     # Ensure consistent energy coordinates (maps want energy not esa_energy_step)
     pset_renamed = pset.rename_dims({"esa_energy_step": "energy"})
@@ -609,14 +609,11 @@ def add_geometric_factors(dataset: xr.Dataset, species: str) -> xr.Dataset:
 
     logger.info(f"Loading and applying geometric factors for species: {species}")
 
-    # Load geometric factor data for the specific species
-    gf_data = load_geometric_factor_data(species)
-
     # Initialize geometric factor variables
     dataset = initialize_geometric_factor_variables(dataset)
 
     # Populate geometric factors for each energy step
-    dataset = populate_geometric_factors(dataset, gf_data, species)
+    dataset = populate_geometric_factors(dataset, species)
 
     return dataset
 
@@ -730,7 +727,6 @@ def initialize_geometric_factor_variables(
 
 def populate_geometric_factors(
     dataset: xr.Dataset,
-    gf_data: pd.DataFrame,
     species: str,
 ) -> xr.Dataset:
     """
@@ -740,8 +736,6 @@ def populate_geometric_factors(
     ----------
     dataset : xr.Dataset
         Dataset with initialized geometric factor variables.
-    gf_data : pd.DataFrame
-        Geometric factor data for the specified species.
     species : str
         The species to process (only "h" and "o" have geometric factors).
 

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -10,7 +10,14 @@ import xarray as xr
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.ena_maps import ena_maps
 from imap_processing.ena_maps.ena_maps import AbstractSkyMap, RectangularSkyMap
-from imap_processing.ena_maps.utils.corrections import PowerLawFluxCorrector
+from imap_processing.ena_maps.utils.corrections import (
+    PowerLawFluxCorrector,
+    add_spacecraft_velocity_to_pset,
+    apply_compton_getting_correction,
+    calculate_ram_mask,
+    get_pset_directional_mask,
+    interpolate_map_flux_to_helio_frame,
+)
 from imap_processing.ena_maps.utils.naming import MapDescriptor
 from imap_processing.lo import lo_ancillary
 from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
@@ -84,6 +91,7 @@ def lo_l2(
         flux_correction,
         o_map_dataset,
         flux_factors,
+        cg_correction,
     ) = _prepare_corrections(
         map_descriptor, descriptor, sci_dependencies, anc_dependencies
     )
@@ -95,6 +103,7 @@ def lo_l2(
         flux_correction=flux_correction,
         o_map_dataset=o_map_dataset,
         flux_factors=flux_factors,
+        cg_correction=cg_correction,
     )
 
     logger.info("Step 5: Finalizing dataset with attributes")
@@ -111,7 +120,7 @@ def _prepare_corrections(
     descriptor: str,
     sci_dependencies: dict,
     anc_dependencies: list,
-) -> tuple[bool, bool, bool, xr.Dataset | None, Path | None]:
+) -> tuple[bool, bool, bool, xr.Dataset | None, Path | None, bool]:
     """
     Determine what corrections are needed and prepare oxygen dataset if required.
 
@@ -136,7 +145,11 @@ def _prepare_corrections(
         A tuple containing:
         - sputtering_correction: Whether to apply sputtering corrections
         - bootstrap_correction: Whether to apply bootstrap corrections
+        - flux_correction: Whether to apply flux corrections
         - o_map_dataset: Oxygen dataset if needed, None otherwise
+        - flux_factors: Path to flux factors ancillary file if needed,
+         None otherwise
+        - cg_correction: Whether to apply CG correction to the dataset.
     """
     # Default values - no corrections needed
     sputtering_correction = False
@@ -169,12 +182,15 @@ def _prepare_corrections(
                 "No flux correction factor file found in ancillary dependencies"
             ) from None
 
+    cg_correction = True if map_descriptor.frame_descriptor == "hf" else False
+
     return (
         sputtering_correction,
         bootstrap_correction,
         flux_correction,
         o_map_dataset,
         flux_factors,
+        cg_correction,
     )
 
 
@@ -302,9 +318,13 @@ def create_sky_map_from_psets(
     for i, pset in enumerate(psets):
         logger.debug(f"Processing pointing set {i + 1}/{len(psets)}")
         processed_pset = process_single_pset(
-            pset, efficiency_data, map_descriptor.species
+            pset,
+            efficiency_data,
+            map_descriptor.species,
+            map_descriptor.frame_descriptor,
         )
-        project_pset_to_map(processed_pset, output_map)
+        directional_mask = get_pset_directional_mask(pset, map_descriptor.spin_phase)
+        project_pset_to_map(processed_pset, output_map, directional_mask)
 
     return output_map
 
@@ -313,6 +333,7 @@ def process_single_pset(
     pset: xr.Dataset,
     efficiency_data: pd.DataFrame,
     species: str,
+    frame: str,
 ) -> xr.Dataset:
     """
     Process a single pointing set for projection to the sky map.
@@ -325,6 +346,10 @@ def process_single_pset(
         Efficiency factor data for correcting counts.
     species : str
         The species to process (e.g., "h", "o").
+    frame : str
+        The output reference frame (e.g., "sc", "hf"). A frame of "hf"
+        (heliocentric frame) will cause the pre-projection Compton Getting
+        Correction to be applied to the PSET data.
 
     Returns
     -------
@@ -339,6 +364,16 @@ def process_single_pset(
 
     # Step 3: Calculate efficiency-corrected quantities
     pset_processed = calculate_efficiency_corrected_quantities(pset_processed)
+
+    # Step 4: CG correction and compute ram mask
+    if frame == "hf":
+        # ram_mask variable is added as part of apply_compton_getting_correction
+        pset_processed = apply_compton_getting_correction(
+            pset_processed, pset_processed["energy"]
+        )
+    else:
+        pset_processed = add_spacecraft_velocity_to_pset(pset_processed)
+        pset_processed = calculate_ram_mask(pset_processed)
 
     return pset_processed
 
@@ -475,6 +510,7 @@ def calculate_efficiency_corrected_quantities(
 def project_pset_to_map(
     pset: xr.Dataset,
     output_map: AbstractSkyMap,
+    directional_mask: xr.DataArray,
 ) -> None:
     """
     Project pointing set data to the output map.
@@ -485,6 +521,9 @@ def project_pset_to_map(
         Processed pointing set ready for projection.
     output_map : AbstractSkyMap
         Target sky map to receive the projected data.
+    directional_mask : xr.DataArray
+        Boolean mask indicating which PSET bins to use for projection. This is
+        how ram/anti-ram bins are removed depending on the descriptor spin phase.
 
     Returns
     -------
@@ -509,6 +548,7 @@ def project_pset_to_map(
         pointing_set=lo_pset,
         value_keys=value_keys,
         index_match_method=ena_maps.IndexMatchMethod.PUSH,
+        pset_valid_mask=directional_mask,
     )
     logger.debug(f"Projected {len(value_keys)} quantities to sky map")
 
@@ -709,6 +749,7 @@ def calculate_all_rates_and_intensities(
     flux_correction: bool = False,
     o_map_dataset: xr.Dataset | None = None,
     flux_factors: Path | None = None,
+    cg_correction: bool = False,
 ) -> xr.Dataset:
     """
     Calculate rates and intensities with proper error propagation.
@@ -730,6 +771,8 @@ def calculate_all_rates_and_intensities(
         Dataset specifically for oxygen, needed for sputtering corrections.
     flux_factors : Path, optional
         Path to flux factor file for flux corrections.
+    cg_correction : bool, optional
+        Whether to apply CG correction to intensities.
 
     Returns
     -------
@@ -759,6 +802,16 @@ def calculate_all_rates_and_intensities(
         if flux_factors is None:
             raise ValueError("Flux factors file must be provided for flux corrections")
         dataset = calculate_flux_corrections(dataset, flux_factors)
+
+    # Optional Step 7: Finish CG correction
+    if cg_correction:
+        logger.info("Interpolating map intensities to helio-frame energies")
+        dataset = interpolate_map_flux_to_helio_frame(
+            dataset,
+            dataset["energy"],
+            dataset["energy"],
+            ["ena_intensity", "bg_intensity"],
+        )
 
     # Step 7: Clean up intermediate variables
     dataset = cleanup_intermediate_variables(dataset)

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -384,7 +384,9 @@ def process_single_pset(
         # Convert energy coordinate from keV to eV for CG correction
         # (energy coordinate was set in normalize_pset_coordinates in keV)
         energy_values_ev: xr.DataArray = pset_processed["energy"] * 1000.0
-        # ram_mask variable is added as part of apply_compton_getting_correction
+        # TODO: Pull add_spacecraft_velocity_to_pset and calculate_ram_mask out
+        #    of apply_compton_getting_correction for visibility. Issue:
+        # https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/2434
         pset_processed = apply_compton_getting_correction(
             pset_processed, energy_values_ev
         )

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -72,18 +72,6 @@ def lo_l2(
     map_descriptor = MapDescriptor.from_string(descriptor)
     logger.info(f"Processing map for species: {map_descriptor.species}")
 
-    logger.info("Step 1: Loading ancillary data")
-    efficiency_data = load_efficiency_data(anc_dependencies)
-
-    logger.info(f"Step 2: Creating sky map from {len(psets)} pointing sets")
-    sky_map = create_sky_map_from_psets(psets, map_descriptor, efficiency_data)
-
-    logger.info("Step 3: Converting to dataset and adding geometric factors")
-    dataset = sky_map.to_dataset()
-    dataset = add_geometric_factors(dataset, map_descriptor.species)
-
-    logger.info("Step 4: Calculating rates and intensities")
-
     # Determine if corrections are needed and prepare oxygen data if required
     (
         sputtering_correction,
@@ -95,6 +83,20 @@ def lo_l2(
     ) = _prepare_corrections(
         map_descriptor, descriptor, sci_dependencies, anc_dependencies
     )
+
+    logger.info("Step 1: Loading ancillary data")
+    efficiency_data = load_efficiency_data(anc_dependencies)
+
+    logger.info(f"Step 2: Creating sky map from {len(psets)} pointing sets")
+    sky_map = create_sky_map_from_psets(
+        psets, map_descriptor, efficiency_data, cg_correction
+    )
+
+    logger.info("Step 3: Converting to dataset and adding geometric factors")
+    dataset = sky_map.to_dataset()
+    dataset = add_geometric_factors(dataset, map_descriptor.species)
+
+    logger.info("Step 4: Calculating rates and intensities")
 
     dataset = calculate_all_rates_and_intensities(
         dataset,
@@ -284,6 +286,7 @@ def create_sky_map_from_psets(
     psets: list[xr.Dataset],
     map_descriptor: MapDescriptor,
     efficiency_data: pd.DataFrame,
+    cg_correct: bool,
 ) -> AbstractSkyMap:
     """
     Create a sky map by processing all pointing sets.
@@ -296,6 +299,8 @@ def create_sky_map_from_psets(
         Map descriptor object defining the projection and binning.
     efficiency_data : pd.DataFrame
         Efficiency factor data for correcting counts.
+    cg_correct : bool
+        Whether to apply the CG correction to each PSET.
 
     Returns
     -------
@@ -309,8 +314,6 @@ def create_sky_map_from_psets(
     """
     # Initialize the output map
     output_map = map_descriptor.to_empty_map()
-
-    cg_correct = True if map_descriptor.frame_descriptor == "hf" else False
 
     if not isinstance(output_map, RectangularSkyMap):
         raise NotImplementedError("HEALPix map output not supported for Lo")
@@ -750,21 +753,16 @@ def populate_geometric_factors(
         return dataset
 
     # Mapping of dataset variables to dataframe columns for this species
+    gf_coords = {"energy": "Cntr_E"}
+    gf_vars = {
+        "geometric_factor": f"GF_Trpl_{species.upper()}",
+        "geometric_factor_stat_uncert": f"GF_Trpl_{species.upper()}_unc",
+    }
     if species == "h":
-        gf_vars = {
-            "energy": "Cntr_E",
-            "geometric_factor": "GF_Trpl_H",
-            "geometric_factor_stat_uncert": "GF_Trpl_H_unc",
-        }
         # NOTE: From an e-mail from Nathan on 2025-09-11
         energy_delta_hires_values = [5.43, 10.02, 18.61, 33.31, 64.98, 131.64, 262.35]
         energy_delta_hithr_values = [8.81, 16.04, 28.50, 53.13, 105.60, 219.67, 413.60]
     else:  # species == "o"
-        gf_vars = {
-            "energy": "Cntr_E",
-            "geometric_factor": "GF_Trpl_O",
-            "geometric_factor_stat_uncert": "GF_Trpl_O_unc",
-        }
         energy_delta_hires_values = [5.82, 11.10, 21.78, 41.47, 85.61, 180.67, 361.93]
         energy_delta_hithr_values = [9.45, 17.84, 33.51, 66.61, 139.95, 302.24, 569.48]
 
@@ -779,12 +777,10 @@ def populate_geometric_factors(
     # Filter for the specific ESA mode
     gf_dataset = reduce_geometric_factor_dataset(species, esa_mode)
 
-    # Populate all geometric factors at once using xarray operations
+    # Populate geometric factors in dataset
+    dataset = dataset.assign_coords(energy=gf_dataset[gf_coords["energy"]].values)
     for var, col in gf_vars.items():
-        if var == "energy":
-            dataset = dataset.assign_coords(energy=gf_dataset[col].values)
-        else:
-            dataset[var].values = gf_dataset[col].values
+        dataset[var].values = gf_dataset[col].values
 
     # Update delta_minus and delta_plus based on ESA mode
     if esa_mode == 0:  # HiRes

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -143,7 +143,7 @@ def _prepare_corrections(
 
     Returns
     -------
-    tuple[bool, bool, xr.Dataset | None]
+    tuple[bool, bool, bool, xr.Dataset | None, Path | None, bool]
         A tuple containing:
         - sputtering_correction: Whether to apply sputtering corrections
         - bootstrap_correction: Whether to apply bootstrap corrections
@@ -419,7 +419,7 @@ def normalize_pset_coordinates(pset: xr.Dataset, species: str) -> xr.Dataset:
     else:
         # Default to mode 0 if not available (HiRes mode)
         esa_mode = 0
-    gf_datset = reduce_geometric_factor_dataset(species, esa_mode=esa_mode)
+    gf_dataset = reduce_geometric_factor_dataset(species, esa_mode=esa_mode)
 
     # Ensure consistent energy coordinates (maps want energy not esa_energy_step)
     pset_renamed = pset.rename_dims({"esa_energy_step": "energy"})
@@ -428,7 +428,7 @@ def normalize_pset_coordinates(pset: xr.Dataset, species: str) -> xr.Dataset:
     pset_renamed = pset_renamed.drop_vars("esa_energy_step")
 
     # Assign TRUE energy values as coordinates (in keV, matching map convention)
-    pset_renamed = pset_renamed.assign_coords(energy=gf_datset["Cntr_E"].values)
+    pset_renamed = pset_renamed.assign_coords(energy=gf_dataset["Cntr_E"].values)
 
     # Rename the variables in the pset for projection to the map
     # L2 wants different variable names than l1c

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -416,7 +416,7 @@ def normalize_pset_coordinates(pset: xr.Dataset, species: str) -> xr.Dataset:
     else:
         # Default to mode 0 if not available (HiRes mode)
         esa_mode = 0
-    gf_datset = get_geometric_factor_dataset(species, esa_mode=esa_mode)
+    gf_datset = reduce_geometric_factor_dataset(species, esa_mode=esa_mode)
 
     # Ensure consistent energy coordinates (maps want energy not esa_energy_step)
     pset_renamed = pset.rename_dims({"esa_energy_step": "energy"})
@@ -652,7 +652,7 @@ def load_geometric_factor_data(species: str) -> pd.DataFrame:
     return lo_ancillary.read_ancillary_file(gf_file)
 
 
-def get_geometric_factor_dataset(species: str, esa_mode: int) -> xr.Dataset:
+def reduce_geometric_factor_dataset(species: str, esa_mode: int) -> xr.Dataset:
     """
     Get geometric factor data as xarray Dataset for a specific species and ESA mode.
 
@@ -777,7 +777,7 @@ def populate_geometric_factors(
         esa_mode = 0
 
     # Filter for the specific ESA mode
-    gf_dataset = get_geometric_factor_dataset(species, esa_mode)
+    gf_dataset = reduce_geometric_factor_dataset(species, esa_mode)
 
     # Populate all geometric factors at once using xarray operations
     for var, col in gf_vars.items():

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -269,7 +269,38 @@ def mock_hi_pset():
                 np.linspace(-90, 90, n_spin).reshape(n_epoch, n_spin),
             ),
             "spin_angle_bin": (["spin_angle_bin"], np.arange(n_spin)),
-        }
+        },
+        attrs={"Logical_source": "imap_hi_l1c_45sensor-pset"},
+    )
+
+    return data
+
+
+@pytest.fixture
+def mock_lo_pset():
+    """Create a minimal mock Lo pointing set dataset for testing."""
+    # Create a simple dataset with necessary fields for Lo
+    n_epoch = 1
+    n_spin = 50
+    n_off = 20
+
+    data = xr.Dataset(
+        {
+            "epoch": (["epoch"], np.array([797949131184000000])),
+            "pointing_start_met": (["epoch"], np.array([100.0])),
+            "pointing_end_met": (["epoch"], np.array([200.0])),
+            "hae_longitude": (
+                ["epoch", "spin_angle_bin", "off_angle_bin"],
+                np.linspace(0, 360, n_spin * n_off, endpoint=False).reshape(
+                    n_epoch, n_spin, n_off
+                ),
+            ),
+            "hae_latitude": (
+                ["epoch", "spin_angle_bin", "off_angle_bin"],
+                np.linspace(-90, 90, n_spin * n_off).reshape(n_epoch, n_spin, n_off),
+            ),
+        },
+        attrs={"Logical_source": "imap_lo_l1c_pset"},
     )
 
     return data
@@ -312,6 +343,62 @@ class TestComptonGettingCorrection:
         np.testing.assert_allclose(
             mock_hi_pset["sc_direction_vector"].values, expected_direction
         )
+
+    @mock.patch("imap_processing.ena_maps.utils.corrections.ttj2000ns_to_et")
+    @mock.patch("imap_processing.ena_maps.utils.corrections.geometry.imap_state")
+    def test_add_spacecraft_velocity_to_pset_lo(
+        self, mock_imap_state, mock_ttj2000_to_et, mock_lo_pset
+    ):
+        """Test that spacecraft velocity is correctly added to Lo pointing set."""
+        # Mock conversion from TTJ2000ns to ET
+        et = 1000.0
+        mock_ttj2000_to_et.return_value = et
+        # Mock spacecraft state vector (position + velocity in HAE frame)
+        mock_sc_state = np.array([1e8, 2e8, 3e8, 15.0, 25.0, 35.0])  # km and km/s
+        mock_imap_state.return_value = mock_sc_state
+
+        # For Lo, pointing duration is calculated from MET times
+        # pointing_end_met - pointing_start_met = 200.0 - 100.0 = 100.0 seconds
+        # In nanoseconds: 100.0 * 1e9 = 1e11 ns
+        # Midpoint: epoch + pointing_duration_ns / 2
+        expected_midpoint_time_ns = mock_lo_pset["epoch"].values[0] + 1e11 / 2
+
+        mock_lo_pset = add_spacecraft_velocity_to_pset(mock_lo_pset)
+
+        # Verify SPICE was called correctly
+        mock_ttj2000_to_et.assert_called_once_with(expected_midpoint_time_ns)
+        mock_imap_state.assert_called_once_with(
+            et, ref_frame=geometry.SpiceFrame.IMAP_HAE
+        )
+
+        # Verify sc_velocity was added
+        assert "sc_velocity" in mock_lo_pset
+        assert isinstance(mock_lo_pset["sc_velocity"], xr.DataArray)
+        np.testing.assert_array_equal(
+            mock_lo_pset["sc_velocity"].values, np.array([15.0, 25.0, 35.0])
+        )
+
+        # Verify sc_direction_vector was added
+        assert "sc_direction_vector" in mock_lo_pset
+        expected_speed = np.sqrt(15**2 + 25**2 + 35**2)
+        expected_direction = np.array([15.0, 25.0, 35.0]) / expected_speed
+        np.testing.assert_allclose(
+            mock_lo_pset["sc_direction_vector"].values, expected_direction
+        )
+
+    def test_add_spacecraft_velocity_unsupported_instrument(self):
+        """Test that unsupported instrument raises NotImplementedError."""
+        # Create a dataset with unsupported Logical_source
+        unsupported_pset = xr.Dataset(
+            {
+                "epoch": (["epoch"], np.array([797949131184000000])),
+                "epoch_delta": (["epoch"], np.array([1e12])),
+            },
+            attrs={"Logical_source": "imap_unsupported_instrument_pset"},
+        )
+
+        with pytest.raises(NotImplementedError, match="does not support PSETs"):
+            add_spacecraft_velocity_to_pset(unsupported_pset)
 
     def test_add_cartesian_look_direction(self, mock_hi_pset):
         """Test that look directions are correctly calculated and added."""

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -101,6 +101,9 @@ EXTERNAL_TEST_DATA = [
     ("imap_idex_l2a-calibration-curve-yield-params_20250101_v001.csv", "idex/test_data/"),
     ("imap_idex_l2a-calibration-curve-t-rise_20250101_v001.csv", "idex/test_data/"),
 
+    # Lo
+    ("imap_lo_l1c_pset_20260101-repoint01261_v001.cdf", "lo/test_cdfs"),
+
     # Ultra
     ("FM90_Startup_20230711T081655.CCSDS", "ultra/data/l0/"),
     ("IMAP-Ultra45_r1_L1_V0_shortened.csv", "ultra/data/l1/"),

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from imap_processing.cdf.utils import load_cdf
 from imap_processing.ena_maps.ena_maps import RectangularSkyMap
 from imap_processing.ena_maps.utils.naming import MapDescriptor
 from imap_processing.lo.l1c.lo_l1c import (
@@ -687,7 +688,13 @@ class TestNormalizePsetCoordinates:
 
         # Check that energy coordinate is present
         assert "energy" in result.coords
-        np.testing.assert_array_equal(result.coords["energy"], list(range(7)))
+        expected_energies = (
+            np.array([0.015, 0.029, 0.055, 0.11, 0.209, 0.439, 0.872])
+            if species == "h"
+            else np.array([0.016, 0.032, 0.065, 0.135, 0.279, 0.601, 1.206])
+        )
+        assert np.array_equal(result.coords["energy"].values, expected_energies)
+        np.testing.assert_array_equal(result.coords["energy"], expected_energies)
 
         # Check that old coordinate variable was dropped
         assert "esa_energy_step" not in result.variables
@@ -720,8 +727,8 @@ class TestNormalizePsetCoordinates:
         )
 
         # For species without background rates, the function should fail
-        # because it tries to access background variables that don't exist
-        with pytest.raises(ValueError, match="cannot rename"):
+        # because geometric factors can only be retrieved for "h" and "o"
+        with pytest.raises(ValueError, match="Geometric factors only available"):
             normalize_pset_coordinates(pset, species)
 
     def test_normalize_coordinates_removes_old_coordinate(self):
@@ -1572,16 +1579,20 @@ class TestPopulateGeometricFactors:
     """Tests for the populate_geometric_factors function."""
 
     @pytest.mark.parametrize("species", ["h", "o"])
-    def test_populate_geometric_factors(self, species, sample_geometric_factor_data):
+    @patch("imap_processing.lo.l2.lo_l2.get_geometric_factor_dataset")
+    def test_populate_geometric_factors(
+        self, mock_get_geometric_factor_dataset, species, sample_geometric_factor_data
+    ):
         """Test population of geometric factor values for a specific species."""
         h_gf_data, o_gf_data = sample_geometric_factor_data
         gf_data = h_gf_data if species == "h" else o_gf_data
+        mock_get_geometric_factor_dataset.return_value = gf_data.to_xarray()
 
         # Create initialized dataset
         dataset = xr.Dataset(coords={"energy": range(7)})
         dataset = initialize_geometric_factor_variables(dataset)
 
-        result = populate_geometric_factors(dataset, gf_data, species)
+        result = populate_geometric_factors(dataset, species)
 
         # Check that values were populated correctly
         for i in range(7):
@@ -1605,10 +1616,8 @@ class TestPopulateGeometricFactors:
         dataset = xr.Dataset(coords={"energy": range(7)})
         dataset = initialize_geometric_factor_variables(dataset)
 
-        gf_data = pd.DataFrame()  # Empty dataframe
-
         # Test with doubles (no geometric factors)
-        result = populate_geometric_factors(dataset, gf_data, "doubles")
+        result = populate_geometric_factors(dataset, "doubles")
 
         # Should return dataset unchanged (all zeros)
         assert np.all(result["geometric_factor"].values == 0)
@@ -2263,6 +2272,37 @@ class TestIntegrationWithMocks:
             assert isinstance(result[0], xr.Dataset)
 
 
+@pytest.fixture
+def ibex_pset_file():
+    """Path to the LO flux factors test file."""
+    # Use the actual test data file from the ena_maps test data
+    test_data_path = Path(__file__).parent / "test_cdfs"
+    return test_data_path / "imap_lo_l1c_pset_20260101-repoint01261_v001.cdf"
+
+
+@pytest.mark.external_test_data
+@pytest.mark.external_kernel
+class TestIntegration:
+    """Integration tests using IBEX data and simulated kernels."""
+
+    def test_lo_l2_integration_full(
+        self, ibex_pset_file, imap_ena_sim_metakernel, lo_flux_factors_file
+    ):
+        """Test the main lo_l2 function with no mocking."""
+        # Test with hydrogen data
+        sci_dependencies = {"imap_lo_l1c_pset": [load_cdf(ibex_pset_file)]}
+        anc_dependencies = [lo_flux_factors_file]  # Include flux factors file
+        descriptor = "l090-ena-o-hf-nsp-ram-hae-6deg-3mo"
+
+        # Run the function - should not crash
+        result = lo_l2(sci_dependencies, anc_dependencies, descriptor)
+
+        # Basic validation
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], xr.Dataset)
+
+
 # =============================================================================
 # ERROR HANDLING TESTS
 # =============================================================================
@@ -2484,7 +2524,7 @@ class TestProcessSinglePset:
             mock_cg.return_value = pset
 
             # Process with hf frame
-            _ = process_single_pset(pset, sample_efficiency_data, "h", "hf")
+            _ = process_single_pset(pset, sample_efficiency_data, "h", cg_correct=True)
 
             # Check that CG correction was called
             mock_cg.assert_called_once()
@@ -2521,7 +2561,7 @@ class TestProcessSinglePset:
             mock_cg.return_value = pset
 
             # Process with sc frame
-            _ = process_single_pset(pset, sample_efficiency_data, "h", "sc")
+            _ = process_single_pset(pset, sample_efficiency_data, "h", cg_correct=False)
 
             # Check that CG correction was NOT called
             mock_cg.assert_not_called()

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from imap_processing.ena_maps.ena_maps import RectangularSkyMap
 from imap_processing.ena_maps.utils.naming import MapDescriptor
 from imap_processing.lo.l1c.lo_l1c import (
     ESA_ENERGY_STEPS,
@@ -19,6 +20,7 @@ from imap_processing.lo.l1c.lo_l1c import (
     SPIN_ANGLE_BIN_CENTERS,
 )
 from imap_processing.lo.l2.lo_l2 import (
+    _prepare_corrections,
     add_efficiency_factors_to_pset,
     calculate_all_rates_and_intensities,
     calculate_backgrounds,
@@ -35,6 +37,8 @@ from imap_processing.lo.l2.lo_l2 import (
     load_efficiency_data,
     normalize_pset_coordinates,
     populate_geometric_factors,
+    process_single_pset,
+    project_pset_to_map,
 )
 
 # =============================================================================
@@ -2123,6 +2127,87 @@ class TestCalculateAllRatesAndIntensities:
         assert "bg_rates_exposure_factor" not in result.data_vars
         assert "bg_rates_stat_uncert_exposure_factor2" not in result.data_vars
 
+    def test_calculate_all_rates_with_cg_correction(
+        self, sample_dataset_with_intensities
+    ):
+        """Test that CG correction is applied when cg_correction=True."""
+        # Add necessary variables for the calculation
+        dataset = sample_dataset_with_intensities.copy(deep=True)
+        dataset["counts"] = (("epoch", "energy"), np.ones((1, 7)) * 10)
+        dataset["counts_over_eff"] = (("epoch", "energy"), np.ones((1, 7)) * 12)
+        dataset["counts_over_eff_squared"] = (("epoch", "energy"), np.ones((1, 7)) * 12)
+        dataset["exposure_factor"] = (("epoch", "energy"), np.ones((1, 7)) * 1.0)
+        dataset["geometric_factor"] = (("energy",), np.ones(7) * 1e-4)
+        dataset["geometric_factor_stat_uncert"] = (("energy",), np.ones(7) * 1e-5)
+        dataset["bg_rates_exposure_factor"] = (
+            ("epoch", "energy"),
+            np.ones((1, 7)) * 0.3,
+        )
+        dataset["bg_rates_stat_uncert_exposure_factor2"] = (
+            ("epoch", "energy"),
+            np.ones((1, 7)) * 0.009,
+        )
+
+        # Mock the interpolation function
+        with patch(
+            "imap_processing.lo.l2.lo_l2.interpolate_map_flux_to_helio_frame"
+        ) as mock_interp:
+            # Make the mock return the input dataset
+            mock_interp.side_effect = lambda ds, *args, **kwargs: ds
+
+            # Call with CG correction enabled
+            _ = calculate_all_rates_and_intensities(dataset, cg_correction=True)
+
+            # Verify that interpolation was called
+            mock_interp.assert_called_once()
+
+            # Check the call arguments
+            call_args = mock_interp.call_args
+            assert call_args[0][1].equals(
+                dataset["energy"]
+            )  # spacecraft frame energies
+            assert call_args[0][2].equals(dataset["energy"])  # helio frame energies
+            assert "ena_intensity" in call_args[0][3]  # variables to interpolate
+            assert "bg_intensity" in call_args[0][3]
+
+    def test_calculate_all_rates_cg_with_other_corrections(
+        self, sample_dataset_with_intensities, lo_flux_factors_file
+    ):
+        """Test CG correction works alongside other corrections."""
+        # Add necessary variables
+        dataset = sample_dataset_with_intensities.copy(deep=True)
+        dataset["counts"] = (("epoch", "energy"), np.ones((1, 7)) * 10)
+        dataset["counts_over_eff"] = (("epoch", "energy"), np.ones((1, 7)) * 12)
+        dataset["counts_over_eff_squared"] = (("epoch", "energy"), np.ones((1, 7)) * 12)
+        dataset["exposure_factor"] = (("epoch", "energy"), np.ones((1, 7)) * 1.0)
+        dataset["geometric_factor"] = (("energy",), np.ones(7) * 1e-4)
+        dataset["geometric_factor_stat_uncert"] = (("energy",), np.ones(7) * 1e-5)
+        dataset["bg_rates_exposure_factor"] = (
+            ("epoch", "energy"),
+            np.ones((1, 7)) * 0.3,
+        )
+        dataset["bg_rates_stat_uncert_exposure_factor2"] = (
+            ("epoch", "energy"),
+            np.ones((1, 7)) * 0.009,
+        )
+
+        with patch(
+            "imap_processing.lo.l2.lo_l2.interpolate_map_flux_to_helio_frame"
+        ) as mock_interp:
+            mock_interp.side_effect = lambda ds, *args, **kwargs: ds
+
+            # Call with both flux correction and CG correction
+            result = calculate_all_rates_and_intensities(
+                dataset,
+                flux_correction=True,
+                flux_factors=lo_flux_factors_file,
+                cg_correction=True,
+            )
+
+            # Both corrections should be applied
+            assert "ena_intensity" in result.data_vars
+            mock_interp.assert_called_once()
+
 
 @pytest.mark.external_kernel
 class TestIntegrationWithMocks:
@@ -2263,3 +2348,237 @@ class TestEdgeCases:
         # Uncertainty calculation should handle negative counts
         # (sqrt of negative gives NaN, which is expected behavior)
         assert np.isnan(result["ena_count_rate_stat_uncert"].values[0])
+
+
+# =============================================================================
+# TESTS FOR CG CORRECTION FUNCTIONALITY
+# =============================================================================
+
+
+class TestPrepareCorrections:
+    """Tests for the _prepare_corrections function."""
+
+    def test_prepare_corrections_hf_frame(self, lo_flux_factors_file):
+        """Test that CG correction is enabled for heliocentric frame (hf)."""
+        # Create a map descriptor with heliocentric frame
+        descriptor = "ilo90-ena-h-hf-nsp-full-hae-6deg-3mo"
+        map_descriptor = MapDescriptor.from_string(descriptor)
+
+        sci_dependencies = {"imap_lo_l1c_pset": []}
+        anc_dependencies = [lo_flux_factors_file]
+
+        with patch("imap_processing.lo.l2.lo_l2.lo_l2") as mock_lo_l2:
+            mock_o_dataset = xr.Dataset()
+            mock_lo_l2.return_value = [mock_o_dataset]
+            result = _prepare_corrections(
+                map_descriptor, descriptor, sci_dependencies, anc_dependencies
+            )
+
+        # Unpack the tuple
+        (
+            sputtering_correction,
+            bootstrap_correction,
+            flux_correction,
+            o_map_dataset,
+            flux_factors,
+            cg_correction,
+        ) = result
+
+        # Check that CG correction is enabled for hf frame
+        assert cg_correction is True, "CG correction should be enabled for 'hf' frame"
+
+        # Check other correction flags
+        assert flux_correction is True  # ENA data should have flux correction
+        assert sputtering_correction is True  # h-ena product, apply sputtering
+        assert bootstrap_correction is True  # h-ena product, apply bootstrap
+        assert o_map_dataset is not None  # oxygen dataset produced
+        assert flux_factors is not None  # Flux factors should be found
+
+    def test_prepare_corrections_sc_frame(self, lo_flux_factors_file):
+        """Test that CG correction is disabled for spacecraft frame (sc)."""
+        # Create a map descriptor with spacecraft frame
+        descriptor = "ilo90-ena-o-sf-nsp-full-hae-6deg-3mo"
+        map_descriptor = MapDescriptor.from_string(descriptor)
+
+        sci_dependencies = {"imap_lo_l1c_pset": []}
+        anc_dependencies = [lo_flux_factors_file]
+
+        result = _prepare_corrections(
+            map_descriptor, descriptor, sci_dependencies, anc_dependencies
+        )
+
+        # Unpack the tuple
+        (
+            sputtering_correction,
+            bootstrap_correction,
+            flux_correction,
+            o_map_dataset,
+            flux_factors,
+            cg_correction,
+        ) = result
+
+        # Check that CG correction is disabled for sc frame
+        assert cg_correction is False, (
+            "CG correction should be disabled for non-'hf' frame"
+        )
+
+    def test_prepare_corrections_with_hydrogen_ena(self, lo_flux_factors_file):
+        """Test corrections for hydrogen ENA data."""
+        descriptor = "ilo90-ena-h-sf-nsp-full-hae-6deg-3mo"
+        map_descriptor = MapDescriptor.from_string(descriptor)
+
+        # Mock the recursive call to lo_l2 for oxygen
+        with patch("imap_processing.lo.l2.lo_l2.lo_l2") as mock_lo_l2:
+            mock_o_dataset = xr.Dataset({"test": (("energy",), np.ones(7))})
+            mock_lo_l2.return_value = [mock_o_dataset]
+
+            sci_dependencies = {"imap_lo_l1c_pset": []}
+            anc_dependencies = [lo_flux_factors_file]
+
+            result = _prepare_corrections(
+                map_descriptor, descriptor, sci_dependencies, anc_dependencies
+            )
+
+            (
+                sputtering_correction,
+                bootstrap_correction,
+                flux_correction,
+                o_map_dataset,
+                flux_factors,
+                cg_correction,
+            ) = result
+
+            # Check that all corrections are enabled for hydrogen ENA
+            assert sputtering_correction is True
+            assert bootstrap_correction is True
+            assert flux_correction is True
+            assert o_map_dataset is not None
+            assert cg_correction is False  # hae frame, not hf
+
+
+class TestProcessSinglePset:
+    """Tests for the process_single_pset function with CG correction."""
+
+    def test_process_single_pset_hf_frame(self, minimal_pset, sample_efficiency_data):
+        """Test that CG correction is applied for heliocentric frame."""
+        pset = minimal_pset.copy()
+        pset = pset.rename({"esa_energy_step": "energy"})
+
+        with (
+            patch(
+                "imap_processing.lo.l2.lo_l2.normalize_pset_coordinates"
+            ) as mock_norm,
+            patch(
+                "imap_processing.lo.l2.lo_l2.add_efficiency_factors_to_pset"
+            ) as mock_add_ef,
+            patch(
+                "imap_processing.lo.l2.lo_l2.calculate_efficiency_corrected_quantities"
+            ) as mock_calc_ef,
+            patch(
+                "imap_processing.lo.l2.lo_l2.apply_compton_getting_correction"
+            ) as mock_cg,
+        ):
+            mock_norm.return_value = pset
+            mock_add_ef.return_value = pset
+            mock_calc_ef.return_value = pset
+            mock_cg.return_value = pset
+
+            # Process with hf frame
+            _ = process_single_pset(pset, sample_efficiency_data, "h", "hf")
+
+            # Check that CG correction was called
+            mock_cg.assert_called_once()
+            assert mock_cg.call_args[0][0] is pset
+            # Energy should be passed as second argument
+            assert "energy" in mock_cg.call_args[0][1].dims
+
+    def test_process_single_pset_sc_frame(self, minimal_pset, sample_efficiency_data):
+        """Test that CG correction is not applied for spacecraft frame."""
+        pset = minimal_pset.copy()
+        pset = pset.rename({"esa_energy_step": "energy"})
+
+        with (
+            patch(
+                "imap_processing.lo.l2.lo_l2.normalize_pset_coordinates"
+            ) as mock_norm,
+            patch(
+                "imap_processing.lo.l2.lo_l2.add_efficiency_factors_to_pset"
+            ) as mock_add_ef,
+            patch(
+                "imap_processing.lo.l2.lo_l2.calculate_efficiency_corrected_quantities"
+            ) as mock_calc_ef,
+            patch(
+                "imap_processing.lo.l2.lo_l2.apply_compton_getting_correction"
+            ) as mock_cg,
+            patch(
+                "imap_processing.lo.l2.lo_l2.add_spacecraft_velocity_to_pset"
+            ) as mock_sc_vel,
+            patch("imap_processing.lo.l2.lo_l2.calculate_ram_mask") as mock_ram_mask,
+        ):
+            mock_norm.return_value = pset
+            mock_add_ef.return_value = pset
+            mock_calc_ef.return_value = pset
+            mock_cg.return_value = pset
+
+            # Process with sc frame
+            _ = process_single_pset(pset, sample_efficiency_data, "h", "sc")
+
+            # Check that CG correction was NOT called
+            mock_cg.assert_not_called()
+
+            # Check that spacecraft velocity and ram mask were called instead
+            mock_sc_vel.assert_called_once()
+            mock_ram_mask.assert_called_once()
+
+
+class TestProjectPsetToMap:
+    """Tests for the project_pset_to_map function with directional mask."""
+
+    def test_project_pset_to_map_with_mask(self, minimal_pset_for_species):
+        """Test that directional mask is passed to projection."""
+        # Create a mock sky map
+        mock_map = Mock(spec=RectangularSkyMap)
+
+        # Create a directional mask
+        directional_mask = xr.DataArray(
+            np.ones(7, dtype=bool),
+            dims=["energy"],
+            coords={"energy": list(range(7))},
+        )
+
+        # Call project_pset_to_map
+        project_pset_to_map(minimal_pset_for_species, mock_map, directional_mask)
+
+        # Verify that project_pset_values_to_map was called with the mask
+        mock_map.project_pset_values_to_map.assert_called_once()
+        call_kwargs = mock_map.project_pset_values_to_map.call_args[1]
+        assert "pset_valid_mask" in call_kwargs
+        assert call_kwargs["pset_valid_mask"] is directional_mask
+
+    def test_project_pset_to_map_value_keys(self, minimal_pset_for_species):
+        """Test that correct value keys are projected."""
+        mock_map = Mock(spec=RectangularSkyMap)
+        directional_mask = xr.DataArray(
+            np.ones(7, dtype=bool),
+            dims=["energy"],
+        )
+
+        project_pset_to_map(minimal_pset_for_species, mock_map, directional_mask)
+
+        # Check that the expected value keys are in the call
+        call_kwargs = mock_map.project_pset_values_to_map.call_args[1]
+        value_keys = call_kwargs["value_keys"]
+
+        expected_keys = [
+            "exposure_factor",
+            "counts",
+            "counts_over_eff",
+            "counts_over_eff_squared",
+            "bg_rates",
+            "bg_rates_stat_uncert",
+            "bg_rates_exposure_factor",
+            "bg_rates_stat_uncert_exposure_factor2",
+        ]
+
+        for key in expected_keys:
+            assert key in value_keys, f"Expected key '{key}' not in value_keys"

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -1734,7 +1734,7 @@ class TestPopulateGeometricFactors:
     """Tests for the populate_geometric_factors function."""
 
     @pytest.mark.parametrize("species", ["h", "o"])
-    @patch("imap_processing.lo.l2.lo_l2.get_geometric_factor_dataset")
+    @patch("imap_processing.lo.l2.lo_l2.reduce_geometric_factor_dataset")
     def test_populate_geometric_factors(
         self, mock_get_geometric_factor_dataset, species, sample_geometric_factor_data
     ):
@@ -2488,7 +2488,7 @@ class TestErrorHandling:
                 NotImplementedError, match="HEALPix map output not supported"
             ):
                 create_sky_map_from_psets(
-                    [minimal_pset_for_species], mock_map_desc, pd.DataFrame()
+                    [minimal_pset_for_species], mock_map_desc, pd.DataFrame(), False
                 )
 
 

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -40,6 +40,7 @@ from imap_processing.lo.l2.lo_l2 import (
     populate_geometric_factors,
     process_single_pset,
     project_pset_to_map,
+    reduce_geometric_factor_dataset,
 )
 
 # =============================================================================
@@ -653,6 +654,160 @@ class TestLoadEfficiencyData:
 
         assert isinstance(result, pd.DataFrame)
         assert result.empty
+
+
+class TestReduceGeometricFactor:
+    """Tests for the reduce_geometric_factor_dataset function."""
+
+    @pytest.mark.parametrize("species", ["h", "o"])
+    @pytest.mark.parametrize("esa_mode", [0, 1])
+    def test_reduce_geometric_factor_dataset(
+        self,
+        species,
+        esa_mode,
+    ):
+        """Test functionality of reduce_geometric_factor_dataset with real gf data."""
+
+        result = reduce_geometric_factor_dataset(species, esa_mode)
+
+        # Verify it returns an xarray Dataset
+        assert isinstance(result, xr.Dataset)
+
+        # Verify it has 7 energy steps
+        assert len(result["Observed_E-Step"]) == 7
+
+        # Verify the index is 1-7
+        expected_indices = list(range(1, 8))
+        np.testing.assert_array_equal(
+            result["Observed_E-Step"].values, expected_indices
+        )
+
+    @patch("imap_processing.lo.l2.lo_l2.load_geometric_factor_data")
+    def test_reduce_geometric_factor_dataset_hydrogen(
+        self, mock_load_gf, sample_geometric_factor_data
+    ):
+        """Test that hydrogen geometric factors are correctly loaded and processed."""
+        h_gf_data, _ = sample_geometric_factor_data
+        mock_load_gf.return_value = h_gf_data
+
+        result = reduce_geometric_factor_dataset("h", esa_mode=0)
+
+        # Check that hydrogen-specific columns are present
+        assert "Cntr_E" in result.data_vars
+        assert "GF_Trpl_H" in result.data_vars
+        assert "GF_Trpl_H_unc" in result.data_vars
+
+        # Verify energy values match expected for hydrogen
+        expected_energies = [0.01 * (i + 1) for i in range(7)]
+        np.testing.assert_array_almost_equal(result["Cntr_E"].values, expected_energies)
+
+    @patch("imap_processing.lo.l2.lo_l2.load_geometric_factor_data")
+    def test_reduce_geometric_factor_dataset_oxygen(
+        self, mock_load_gf, sample_geometric_factor_data
+    ):
+        """Test that oxygen geometric factors are correctly loaded and processed."""
+        _, o_gf_data = sample_geometric_factor_data
+        mock_load_gf.return_value = o_gf_data
+
+        result = reduce_geometric_factor_dataset("o", esa_mode=0)
+
+        # Check that oxygen-specific columns are present
+        assert "Cntr_E" in result.data_vars
+        assert "GF_Trpl_O" in result.data_vars
+        assert "GF_Trpl_O_unc" in result.data_vars
+
+        # Verify energy values match expected for oxygen
+        expected_energies = [0.015 * (i + 1) for i in range(7)]
+        np.testing.assert_array_almost_equal(result["Cntr_E"].values, expected_energies)
+
+    @patch("imap_processing.lo.l2.lo_l2.load_geometric_factor_data")
+    def test_reduce_geometric_factor_dataset_esa_mode_filtering(
+        self, mock_load_gf, sample_geometric_factor_data
+    ):
+        """Test that ESA mode filtering works correctly."""
+        h_gf_data, _ = sample_geometric_factor_data
+
+        # Create data with two ESA modes
+        h_gf_mode_0 = h_gf_data.copy()
+        h_gf_mode_1 = h_gf_data.copy()
+
+        # Modify mode 1 data to have different GF values
+        for col in ["GF_Trpl_H", "GF_Dbl_all", "GF_Trpl_all"]:
+            h_gf_mode_1[col] = h_gf_mode_1[col] * 1.5
+        h_gf_mode_1["esa_mode"] = 1
+
+        combined_data = pd.concat([h_gf_mode_0, h_gf_mode_1], ignore_index=True)
+        mock_load_gf.return_value = combined_data
+
+        # Get data for mode 0
+        result_mode_0 = reduce_geometric_factor_dataset("h", esa_mode=0)
+
+        # Get data for mode 1
+        result_mode_1 = reduce_geometric_factor_dataset("h", esa_mode=1)
+
+        # Verify that mode 1 has different (larger) GF values
+        assert np.all(
+            result_mode_1["GF_Trpl_H"].values > result_mode_0["GF_Trpl_H"].values
+        )
+
+        # Verify the ratio is approximately 1.5
+        ratio = result_mode_1["GF_Trpl_H"].values / result_mode_0["GF_Trpl_H"].values
+        np.testing.assert_array_almost_equal(ratio, np.ones(7) * 1.5)
+
+    @patch("imap_processing.lo.l2.lo_l2.load_geometric_factor_data")
+    def test_reduce_geometric_factor_dataset_duplicate_removal(
+        self, mock_load_gf, sample_geometric_factor_data
+    ):
+        """Test that duplicate Observed_E-Step values are handled correctly."""
+        h_gf_data, _ = sample_geometric_factor_data
+
+        # Add duplicate rows with same Observed_E-Step but different incident_E-Step
+        duplicates = h_gf_data.copy()
+        duplicates["incident_E-Step"] = [
+            i + 8 for i in range(7)
+        ]  # Different incident steps
+
+        combined_data = pd.concat([h_gf_data, duplicates], ignore_index=True)
+        mock_load_gf.return_value = combined_data
+
+        result = reduce_geometric_factor_dataset("h", esa_mode=0)
+
+        # Should still have exactly 7 energy steps (duplicates removed)
+        assert len(result["Observed_E-Step"]) == 7
+
+        # Verify no duplicate indices
+        assert len(np.unique(result["Observed_E-Step"].values)) == 7
+
+    @patch("imap_processing.lo.l2.lo_l2.load_geometric_factor_data")
+    def test_reduce_geometric_factor_dataset_invalid_species(self, mock_load_gf):
+        """Test that invalid species raises appropriate error."""
+        # Mock should raise ValueError for invalid species
+        mock_load_gf.side_effect = ValueError(
+            "Geometric factors only available for 'h' and 'o', got 'invalid'"
+        )
+
+        with pytest.raises(ValueError, match="Geometric factors only available"):
+            reduce_geometric_factor_dataset("invalid", esa_mode=0)
+
+    @patch("imap_processing.lo.l2.lo_l2.load_geometric_factor_data")
+    def test_reduce_geometric_factor_dataset_no_esa_mode_column(
+        self, mock_load_gf, sample_geometric_factor_data
+    ):
+        """Test handling when esa_mode column is missing from data."""
+        h_gf_data, _ = sample_geometric_factor_data
+
+        # Remove esa_mode column if it exists
+        if "esa_mode" in h_gf_data.columns:
+            h_gf_data = h_gf_data.drop(columns=["esa_mode"])
+
+        mock_load_gf.return_value = h_gf_data
+
+        # Should still work, just won't filter by esa_mode
+        result = reduce_geometric_factor_dataset("h", esa_mode=0)
+
+        # Should return 7 energy steps
+        assert len(result["Observed_E-Step"]) == 7
+        assert isinstance(result, xr.Dataset)
 
 
 class TestNormalizePsetCoordinates:

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -271,6 +271,7 @@ def sample_geometric_factor_data():
             {
                 "esa_mode": 0,
                 "Observed_E-Step": i + 1,
+                "incident_E-Step": i + 1,
                 "Cntr_E": 0.01 * (i + 1),  # Simple energy values
                 "Cntr_E_unc": 0.001 * (i + 1),
                 "GF_Trpl_H": 1e-4 * (i + 1),
@@ -286,6 +287,7 @@ def sample_geometric_factor_data():
             {
                 "esa_mode": 0,
                 "Observed_E-Step": i + 1,
+                "incident_E-Step": i + 1,
                 "Cntr_E": 0.015 * (i + 1),  # Slightly different for oxygen
                 "Cntr_E_unc": 0.0015 * (i + 1),
                 "GF_Trpl_O": 1.5e-4 * (i + 1),
@@ -680,6 +682,11 @@ class TestReduceGeometricFactor:
         expected_indices = list(range(1, 8))
         np.testing.assert_array_equal(
             result["Observed_E-Step"].values, expected_indices
+        )
+
+        # Verify that incident_E-Step == Observed_E-Step
+        np.testing.assert_array_equal(
+            result["incident_E-Step"].values, result["Observed_E-Step"].values
         )
 
     @patch("imap_processing.lo.l2.lo_l2.load_geometric_factor_data")

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -848,7 +848,6 @@ class TestNormalizePsetCoordinates:
             if species == "h"
             else np.array([0.016, 0.032, 0.065, 0.135, 0.279, 0.601, 1.206])
         )
-        assert np.array_equal(result.coords["energy"].values, expected_energies)
         np.testing.assert_array_equal(result.coords["energy"], expected_energies)
 
         # Check that old coordinate variable was dropped
@@ -2429,7 +2428,7 @@ class TestIntegrationWithMocks:
 
 @pytest.fixture
 def ibex_pset_file():
-    """Path to the LO flux factors test file."""
+    """Path to the LO/IBEX pset test file."""
     # Use the actual test data file from the ena_maps test data
     test_data_path = Path(__file__).parent / "test_cdfs"
     return test_data_path / "imap_lo_l1c_pset_20260101-repoint01261_v001.cdf"
@@ -2444,7 +2443,7 @@ class TestIntegration:
         self, ibex_pset_file, imap_ena_sim_metakernel, lo_flux_factors_file
     ):
         """Test the main lo_l2 function with no mocking."""
-        # Test with hydrogen data
+        # Test with oxygen data to reduce test run-time
         sci_dependencies = {"imap_lo_l1c_pset": [load_cdf(ibex_pset_file)]}
         anc_dependencies = [lo_flux_factors_file]  # Include flux factors file
         descriptor = "l090-ena-o-hf-nsp-ram-hae-6deg-3mo"
@@ -2648,7 +2647,7 @@ class TestPrepareCorrections:
             assert bootstrap_correction is True
             assert flux_correction is True
             assert o_map_dataset is not None
-            assert cg_correction is False  # hae frame, not hf
+            assert cg_correction is False  # sf frame, not hf
 
 
 class TestProcessSinglePset:


### PR DESCRIPTION
# Change Summary

## Overview
Sorry for another rather large PR. I would have liked to break this up but am trying to get the Lo L2 stuff out the door.

This adds ram/anti filtering and CG correction to the Lo L2 pipeline. See the Updated Files section for more details.

## Updated Files
- imap_processing/ena_maps/utils/corrections.py
   - Unrelated - add `with np.errstate():` to remove invalid divide in logs.
   - Add code to correctly calculate the Pointing midpoint time for Lo.
   - Update `interpolate_map_flux_to_helio_frame` method to be able to interpolate multiple sets of intensity/uncertainty variables independently. Lo needs the ability to interpolate both "ena_intensity" and "bg_intensity".
- imap_processing/hi/hi_l2.py
   - Update call to `interpolate_map_flux_to_helio_frame`.
- imap_processing/lo/l2/lo_l2.py
   - Move `_prepare_corrections` earlier in order to reduce duplicate identification of `cg_correction` bool.
   - Add CG correction to`process_single_pset`
   - Add direction_mask to `project_pset_to_map` for ram/anti filtering
   - Set correct energy values to energy coordinate in `normalize_pset_coordinates` (needed for CG correction).
   - Add `reduce_geometric_factor_dataset` method that returns a dataset of reduced geometric factor data for only the species and esa_mode.
   - Add interpolation to helio-frame energies to `calculate_all_rates_and_intensities`
- imap_processing/tests/ena_maps/test_corrections.py
   - Add Lo specific testing
   - Add coverage for interpolating multiple intensity variables in `interpolate_map_flux_to_helio_frame`.
- imap_processing/tests/hi/test_hi_l2.py
   - Minimal update to mock function due to signature change of `interpolate_map_flux_to_helio_frame`
- imap_processing/tests/lo/test_lo_l2.py
   - Add test coverage for new and updated lo_l2.py functions

Closes: #2374 
