### PR TITLE
I-ALiRT - single packet error

### DIFF
--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -212,13 +212,12 @@ def get_time(
 
     primary_time = TimeTuple(int(pri_coarsetm.item()), int(pri_fintm.item()))
     secondary_time = TimeTuple(int(sec_coarsetm.item()), int(sec_fintm.item()))
-    time_data_pri_met = primary_time.to_seconds()
-    time_data_primary_ttj2000ns = met_to_ttj2000ns(time_data_pri_met)
+
+    time_data_primary_ttj2000ns = primary_time.to_j2000ns()
     time_data["primary_epoch"] = shift_time(
         time_data_primary_ttj2000ns, time_shift_mago
     )
-    time_data_sec_met = secondary_time.to_seconds()
-    time_data_secondary_ttj2000ns = met_to_ttj2000ns(time_data_sec_met)
+    time_data_secondary_ttj2000ns = secondary_time.to_j2000ns()
     time_data["secondary_epoch"] = shift_time(
         time_data_secondary_ttj2000ns, time_shift_magi
     )

--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -212,12 +212,13 @@ def get_time(
 
     primary_time = TimeTuple(int(pri_coarsetm.item()), int(pri_fintm.item()))
     secondary_time = TimeTuple(int(sec_coarsetm.item()), int(sec_fintm.item()))
-
-    time_data_primary_ttj2000ns = primary_time.to_j2000ns()
+    time_data_pri_met = primary_time.to_seconds()
+    time_data_primary_ttj2000ns = met_to_ttj2000ns(time_data_pri_met)
     time_data["primary_epoch"] = shift_time(
         time_data_primary_ttj2000ns, time_shift_mago
     )
-    time_data_secondary_ttj2000ns = secondary_time.to_j2000ns()
+    time_data_sec_met = secondary_time.to_seconds()
+    time_data_secondary_ttj2000ns = met_to_ttj2000ns(time_data_sec_met)
     time_data["secondary_epoch"] = shift_time(
         time_data_secondary_ttj2000ns, time_shift_magi
     )
@@ -691,10 +692,14 @@ def process_packet(
     )
 
     spherical = cartesian_to_spherical(gsm_vector)
+    if spherical.ndim == 1:
+        spherical = spherical[np.newaxis, :]
     phi_gsm = spherical[:, 1]
     theta_gsm = spherical[:, 2]
 
     spherical = cartesian_to_spherical(gse_vector)
+    if spherical.ndim == 1:
+        spherical = spherical[np.newaxis, :]
     phi_gse = spherical[:, 1]
     theta_gse = spherical[:, 2]
 


### PR DESCRIPTION
# Change Summary

## Overview
Most times we have many packets in the MAG packets file; however at the end or beginning of a connection with a ground station we might end of only having a single packet, which was causing an error in processing:

[ERROR] IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
Traceback (most recent call last):
  File "/var/task/ialirt_ingest.py", line 613, in lambda_handler
    process_algorithms(combined, algorithm_table, algorithm_table_name)
  File "/var/task/ialirt_ingest.py", line 309, in process_algorithms
    result = process_func(
  File "/var/lang/lib/python3.12/site-packages/imap_processing/ialirt/l0/parse_mag.py", line 694, in process_packet
    phi_gsm = spherical[:, 1]

This change resolves this issue.

## Updated Files
- parse_mag.py
   - Created newaxis.

## Testing
Tested with packet:
iois_1_packets_2025_315_14_06_39
