### PR TITLE
FIX: The I-ALiRT sc declination is an unsigned integer

### DIFF
--- a/imap_processing/ialirt/l0/parse_mag.py
+++ b/imap_processing/ialirt/l0/parse_mag.py
@@ -572,11 +572,11 @@ def process_packet(
         2 * np.pi / 65535.0
     )
     sc_inertial_right = accumulated_data["sc_inertial_right"].astype(float) * (
-        2 * np.pi / 65535.0
+        0.0055 * np.pi / 180
     )
-    sc_inertial_decline = (
-        accumulated_data["sc_inertial_decline"].astype(float) / 65535.0
-    ) * np.pi - (np.pi / 2)
+    sc_inertial_decline = accumulated_data["sc_inertial_decline"].astype(float) * (
+        0.0027 * np.pi / 180
+    )
 
     attitude_time = met_to_ttj2000ns(accumulated_data["met"])
 

--- a/imap_processing/ialirt/packet_definitions/ialirt.xml
+++ b/imap_processing/ialirt/packet_definitions/ialirt.xml
@@ -142,6 +142,9 @@
 				<xtce:IntegerDataEncoding sizeInBits="48" encoding="unsigned" />
 				<xtce:UnitSet />
 			</xtce:IntegerParameterType>
+			<xtce:IntegerParameterType name="int16" signed="true">
+				<xtce:IntegerDataEncoding sizeInBits="16" encoding="signed" />
+			</xtce:IntegerParameterType>
 						<!-- Enumerated Data Types -->
 			<xtce:EnumeratedParameterType name="status" signed="false">
                 <xtce:UnitSet/>
@@ -296,7 +299,7 @@
 			<xtce:Parameter name="SC_INERTIAL_RIGHT" parameterTypeRef="uint16">
 				<xtce:LongDescription>Inertial Right Ascension of system angular momentum vector</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="SC_INERTIAL_DECLINE" parameterTypeRef="uint16">
+			<xtce:Parameter name="SC_INERTIAL_DECLINE" parameterTypeRef="int16">
 				<xtce:LongDescription>Inertial Declination of system angular momentum vector</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="SC_SPINPERIODVALID" parameterTypeRef="validity_enum">


### PR DESCRIPTION
Also, use the spacecraft conversion values directly so we are aligned with what the s/c is measuring onboard.

This is from an e-mail from the MOC on 11/13/2025.