### PR TITLE
CoDICE remove old l0 direct event file

### DIFF
--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -22,7 +22,6 @@ EXTERNAL_TEST_DATA = [
     ("imap_codice_l0_lo-ialirt_20250814_v001.pkts", "codice/data/l1a_input/"),
     ("imap_codice_l0_lo-direct-events_20250814_v001.pkts", "codice/data/l1a_input/"),
     ("imap_codice_l0_hi-ialirt_20250814_v001.pkts", "codice/data/l1a_input/"),
-    ("imap_codice_l0_hi-pha_20250814_v001.pkts", "codice/data/l1a_input/"),
     ("imap_codice_l0_hi-counters-aggregated_20250814_v001.pkts", "codice/data/l1a_input/"),
     ("imap_codice_l0_hi-counters-singles_20250814_v001.pkts", "codice/data/l1a_input/"),
     ("imap_codice_l0_hi-omni_20250814_v001.pkts", "codice/data/l1a_input/"),


### PR DESCRIPTION
# Change Summary

## Overview
There are duplicate l0 files for direct event test data. 

This is the correct test file:` imap_codice_l0_lo-direct-events_20250814_v001.pkts`

## Updated Files
- imap_processing/tests/external_test_data_config.py
   - Remove outdated direct event l0 test file. 
