### PR TITLE
MNT: Handle GLOWS empty hist and/or DE packets

### DIFF
--- a/imap_processing/glows/l1a/glows_l1a.py
+++ b/imap_processing/glows/l1a/glows_l1a.py
@@ -57,18 +57,17 @@ def glows_l1a(packet_filepath: Path) -> list[xr.Dataset]:
     # Decompose packet file into histogram, and direct event data.
     hist_l0, de_l0 = decom_packets(packet_filepath)
 
-    l1a_de = process_de_l0(de_l0)
-    l1a_hists = []
-    for hist in hist_l0:
-        l1a_hists.append(HistogramL1A(hist))
-
     # Generate CDF files for each day
     output_datasets = []
-    dataset = generate_histogram_dataset(l1a_hists, glows_attrs)
-    output_datasets.append(dataset)
+    if hist_l0:
+        l1a_hists = [HistogramL1A(hist) for hist in hist_l0]
+        dataset = generate_histogram_dataset(l1a_hists, glows_attrs)
+        output_datasets.append(dataset)
 
-    dataset = generate_de_dataset(l1a_de, glows_attrs)
-    output_datasets.append(dataset)
+    if de_l0:
+        l1a_de = process_de_l0(de_l0)
+        dataset = generate_de_dataset(l1a_de, glows_attrs)
+        output_datasets.append(dataset)
 
     return output_datasets
 

--- a/imap_processing/tests/glows/test_glows_l1a_data.py
+++ b/imap_processing/tests/glows/test_glows_l1a_data.py
@@ -2,6 +2,7 @@ import ast
 import dataclasses
 import json
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -559,3 +560,11 @@ def test_expected_hist_results(l1a_dataset):
 
         for field in compare_fields:
             assert np.array_equal(data[field], datapoint[field].data)
+
+
+@mock.patch("imap_processing.glows.l1a.glows_l1a.decom_packets")
+def test_glows_l1a_no_packet_data(decom_packets_mock):
+    # Should return empty list when no packet data is present
+    decom_packets_mock.return_value = ([], [])
+    output = glows_l1a("fake/filepath/packets.bin")
+    assert output == []


### PR DESCRIPTION
There may be no DE and/or hist packets returned after decomming the data, so we should gate the subsequent function calls to make sure that we are only processing when necessary.

Related to, but does not fully finish #2427 I think there is another issue still to resolve with the binary data unpacking.