### PR TITLE
I-ALiRT - update from swapi team

### DIFF
--- a/imap_processing/ialirt/l0/process_swapi.py
+++ b/imap_processing/ialirt/l0/process_swapi.py
@@ -193,6 +193,8 @@ def process_swapi_ialirt(
         )
 
     raw_coin_count = process_sweep_data(grouped_dataset, "swapi_coin_cnt")
+    # I-ALiRT packets are 16 times less than the regular science packets.
+    raw_coin_count = raw_coin_count * 16
     # Subset to only the relevant I-ALiRT energy steps
     raw_coin_count = raw_coin_count[:, :NUM_IALIRT_ENERGY_STEPS]
     raw_coin_rate = raw_coin_count / SWAPI_LIVETIME


### PR DESCRIPTION
# Change Summary

## Overview
Request from SWAPI team to multiply the coin counts.

## Updated Files
- process_swapi.py
   - Multiplications of coin counts.

## Email
Counts on the SWAPI I-ALiRT packet and the SWAPI science CDF, and it appears that the counts on the I-ALiRT packets are 16 times less. This is due to compression of the counts in the I-ALiRT packets. I ran this with Jamie, and she agrees that we need to multiply the current I-ALiRT counts (raw_coin_count) by 16 to get the correct counts. Other calculations should follow automatically from there.
