### PR TITLE
CoDICE l1b hi omni and sectored revalidation 

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -549,8 +549,8 @@ hi-species-unc-attrs:
 
 hi-energy-attrs:
     CATDESC: Energy Table for {species}
-#    DELTA_MINUS_VAR: energy_{species}_minus
-#    DELTA_PLUS_VAR: energy_{species}_plus
+    DELTA_MINUS_VAR: energy_{species}_minus
+    DELTA_PLUS_VAR: energy_{species}_plus
     DISPLAY_TYPE: no_plot
     FIELDNAM: Energy Table
     FILLVAL: *real_fillval
@@ -564,9 +564,9 @@ hi-energy-attrs:
 hi-energy-delta-attrs:
     CATDESC: Energy Table {operation} value for {species}
     FIELDNAM: Energy Delta {operation}
-#    DEPEND_0: energy_{species}
-#    DELTA_MINUS_VAR: energy_{species}_minus
-#    DELTA_PLUS_VAR: energy_{species}_plus
+    DEPEND_0: energy_{species}
+    DELTA_MINUS_VAR: energy_{species}_minus
+    DELTA_PLUS_VAR: energy_{species}_plus
     DISPLAY_TYPE: no_plot
     FILLVAL: *real_fillval
     FORMAT: F12.9

--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -541,8 +541,8 @@ hi-species-unc-attrs:
 
 hi-energy-attrs:
     CATDESC: Energy Table for {species}
-    DELTA_MINUS_VAR: energy_{species}_minus
-    DELTA_PLUS_VAR: energy_{species}_plus
+#    DELTA_MINUS_VAR: energy_{species}_minus
+#    DELTA_PLUS_VAR: energy_{species}_plus
     DISPLAY_TYPE: no_plot
     FIELDNAM: Energy Table
     FILLVAL: *real_fillval
@@ -556,10 +556,10 @@ hi-energy-attrs:
 hi-energy-delta-attrs:
     CATDESC: Energy Table {operation} value for {species}
     FIELDNAM: Energy Delta {operation}
-    DELTA_MINUS_VAR: energy_{species}_{operation}
-    DELTA_PLUS_VAR: energy_{species}_{operation}
+#    DEPEND_0: energy_{species}
+#    DELTA_MINUS_VAR: energy_{species}_minus
+#    DELTA_PLUS_VAR: energy_{species}_plus
     DISPLAY_TYPE: no_plot
-    FIELDNAM: Energy Delta {operation}
     FILLVAL: *real_fillval
     FORMAT: F12.9
     SCALETYP: log

--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -221,6 +221,14 @@ priority_label:
     FORMAT: A2
     VAR_TYPE: metadata
 
+
+energy_species_label:
+    CATDESC:  Energy Table for {species}
+    DEPEND_1: energy_{species}
+    FIELDNAM: energy_{species}
+    FORMAT: A2
+    VAR_TYPE: metadata
+
 # <=== Dataset Variable Attributes ===>
 # The following are set in multiple data products
 acquisition_time_per_step:
@@ -517,7 +525,7 @@ hi-species-attrs:
     FIELDNAM: Species {species}
     FILLVAL: *uint32_fillval
     FORMAT: I7
-    LABL_PTR_1: energy_{species}
+    LABL_PTR_1: energy_{species}_label
     SCALETYP: linear
     UNITS: counts
     VALIDMAX: *max_uint32
@@ -532,7 +540,7 @@ hi-species-unc-attrs:
     FIELDNAM: Species {species}
     FILLVAL: *uint32_fillval
     FORMAT: I7
-    LABL_PTR_1: energy_{species}
+    LABL_PTR_1: energy_{species}_label
     SCALETYP: linear
     UNITS: counts
     VALIDMAX: *max_uint32

--- a/imap_processing/codice/codice_l1a_hi_omni.py
+++ b/imap_processing/codice/codice_l1a_hi_omni.py
@@ -184,6 +184,17 @@ def l1a_hi_omni(unpacked_dataset: xr.Dataset, lut_file: Path) -> xr.Dataset:
                 )
             }
         )
+        species_label_attrs = cdf_attrs.get_variable_attributes(
+            "energy_species_label", check_schema=False
+        )
+        species_label_attrs = apply_replacements_to_attrs(
+            species_label_attrs, {"species": species_name}
+        )
+        l1a_dataset[f"energy_{species_name}_label"] = xr.DataArray(
+            np.array(centers).astype("str"),
+            dims=(f"energy_{species_name}"),
+            attrs=species_label_attrs,
+        )
         # Add energy minus variables
         delta_attrs = cdf_attrs.get_variable_attributes("hi-energy-delta-attrs")
         delta_attrs = apply_replacements_to_attrs(

--- a/imap_processing/codice/codice_l1a_hi_omni.py
+++ b/imap_processing/codice/codice_l1a_hi_omni.py
@@ -259,7 +259,13 @@ def l1a_hi_omni(unpacked_dataset: xr.Dataset, lut_file: Path) -> xr.Dataset:
         start_idx = end_idx
 
     # ========= Add Additional Variables ===========
-    # Repeat data_quality to match new epoch shape (num_epochs)
+    # Repeat spin_period and data_quality to match new epoch shape (num_epochs)
+    l1a_dataset["spin_period"] = xr.DataArray(
+        np.repeat(unpacked_dataset["spin_period"].values, n_spins)
+        * constants.SPIN_PERIOD_CONVERSION,
+        dims=("epoch",),
+        attrs=cdf_attrs.get_variable_attributes("spin_period"),
+    )
     l1a_dataset["data_quality"] = xr.DataArray(
         np.repeat(unpacked_dataset["suspect"].values, n_spins),
         dims=("epoch",),

--- a/imap_processing/codice/codice_l1a_hi_omni.py
+++ b/imap_processing/codice/codice_l1a_hi_omni.py
@@ -259,13 +259,7 @@ def l1a_hi_omni(unpacked_dataset: xr.Dataset, lut_file: Path) -> xr.Dataset:
         start_idx = end_idx
 
     # ========= Add Additional Variables ===========
-    # Repeat spin_period and data_quality to match new epoch shape (num_epochs)
-    l1a_dataset["spin_period"] = xr.DataArray(
-        np.repeat(unpacked_dataset["spin_period"].values, n_spins)
-        * constants.SPIN_PERIOD_CONVERSION,
-        dims=("epoch",),
-        attrs=cdf_attrs.get_variable_attributes("spin_period"),
-    )
+    # Repeat data_quality to match new epoch shape (num_epochs)
     l1a_dataset["data_quality"] = xr.DataArray(
         np.repeat(unpacked_dataset["suspect"].values, n_spins),
         dims=("epoch",),

--- a/imap_processing/codice/codice_l1a_hi_sectored.py
+++ b/imap_processing/codice/codice_l1a_hi_sectored.py
@@ -204,6 +204,17 @@ def l1a_hi_sectored(unpacked_dataset: xr.Dataset, lut_file: Path) -> xr.Dataset:
                 )
             }
         )
+        species_label_attrs = cdf_attrs.get_variable_attributes(
+            "energy_species_label", check_schema=False
+        )
+        species_label_attrs = apply_replacements_to_attrs(
+            species_label_attrs, {"species": species_name}
+        )
+        l1a_dataset[f"energy_{species_name}_label"] = xr.DataArray(
+            np.array(energy_centers).astype("str"),
+            dims=(f"energy_{species_name}"),
+            attrs=species_label_attrs,
+        )
         # Add energy plus and minus variables
         minus_attrs = cdf_attrs.get_variable_attributes("hi-energy-delta-attrs")
         minus_attrs = apply_replacements_to_attrs(

--- a/imap_processing/codice/codice_l1a_hi_sectored.py
+++ b/imap_processing/codice/codice_l1a_hi_sectored.py
@@ -269,6 +269,11 @@ def l1a_hi_sectored(unpacked_dataset: xr.Dataset, lut_file: Path) -> xr.Dataset:
         )
 
     # ========= Add Additional Variables ===========
+    l1a_dataset["spin_period"] = xr.DataArray(
+        unpacked_dataset["spin_period"].values * constants.SPIN_PERIOD_CONVERSION,
+        dims=("epoch",),
+        attrs=cdf_attrs.get_variable_attributes("spin_period"),
+    )
     l1a_dataset["data_quality"] = xr.DataArray(
         unpacked_dataset["suspect"].values,
         dims=("epoch",),

--- a/imap_processing/codice/codice_l1a_hi_sectored.py
+++ b/imap_processing/codice/codice_l1a_hi_sectored.py
@@ -269,11 +269,6 @@ def l1a_hi_sectored(unpacked_dataset: xr.Dataset, lut_file: Path) -> xr.Dataset:
         )
 
     # ========= Add Additional Variables ===========
-    l1a_dataset["spin_period"] = xr.DataArray(
-        unpacked_dataset["spin_period"].values * constants.SPIN_PERIOD_CONVERSION,
-        dims=("epoch",),
-        attrs=cdf_attrs.get_variable_attributes("spin_period"),
-    )
     l1a_dataset["data_quality"] = xr.DataArray(
         unpacked_dataset["suspect"].values,
         dims=("epoch",),

--- a/imap_processing/codice/codice_l1b.py
+++ b/imap_processing/codice/codice_l1b.py
@@ -147,6 +147,10 @@ def convert_to_rates(dataset: xr.Dataset, descriptor: str) -> np.ndarray:
         )
         dataset[unc_variable].attrs["UNITS"] = "1/s"
 
+    # Drop spin_period
+    if "spin_period" in dataset.variables:
+        dataset = dataset.drop_vars("spin_period")
+
     return dataset
 
 

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -548,7 +548,6 @@ def test_hi_sectored(mock_get_file_paths, codice_lut_path):
             rtol=1e-5,
             err_msg=f"Mismatch in variable '{variable}'",
         )
-
     for variable in val_data.coords:
         # If _label, do string comparison
         if variable.endswith("_label"):

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -503,9 +503,6 @@ def test_hi_omni(mock_get_file_paths, codice_lut_path):
     val_data = load_cdf(val_path)
 
     for variable in val_data.data_vars:
-        # TODO: check with Joey and Michael # TODO remove this
-        if variable.startswith("epoch_delta"):
-            continue
         np.testing.assert_allclose(
             processed_data[variable].values,
             val_data[variable].values,

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -503,7 +503,7 @@ def test_hi_omni(mock_get_file_paths, codice_lut_path):
     val_data = load_cdf(val_path)
 
     for variable in val_data.data_vars:
-        # TODO: check with Joey and Michael
+        # TODO: check with Joey and Michael # TODO remove this
         if variable.startswith("epoch_delta"):
             continue
         np.testing.assert_allclose(

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -259,8 +259,9 @@ def test_l1b_hi_omni(mock_get_file_paths, codice_lut_path):
     val_data = load_cdf(val_path)
     processed_data = process_codice_l1b(file_path=l1a_file_path)
     # hi-omni has species-specific shapes
+    # TODO remove this block when new validation file is available
     for variable in val_data.data_vars:
-        if variable == "epoch_delta_plus":
+        if variable in ["epoch_delta_plus", "epoch_delta_minus"]:
             continue
         assert processed_data[variable].shape == val_data[variable].shape
         np.testing.assert_allclose(

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -8,7 +8,6 @@ from imap_data_access import ProcessingInputCollection
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import load_cdf, write_cdf
-from imap_processing.codice.codice_l1a import process_codice_l1a
 from imap_processing.codice.codice_l1b import process_codice_l1b
 from imap_processing.codice.codice_new_l1a import process_l1a
 from imap_processing.tests.codice.conftest import (
@@ -244,31 +243,28 @@ def test_l1b_lo_nsw_angular(mock_get_file_paths, codice_lut_path):
     )
 
 
-@pytest.mark.skip(reason="Revisit this in l1a refactor work")
 def test_l1b_hi_omni():
-    l0_test_file_path = (
+    # TODO start from l0 file
+    l1a_filepath = (
         imap_module_directory
-        / "tests/codice/data/l1a_input"
-        / "imap_codice_hi-omni_20250814_v001.pkts"
+        / "tests/codice/data/l1a_validation"
+        / "imap_codice_l1a_hi-omni_20250814_v007.cdf"
     )
-    processed_l1a_file = write_cdf(process_codice_l1a(l0_test_file_path)[0])
-
     val_path = (
         imap_module_directory
         / "tests/codice/data/l1b_validation/"
-        / "imap_codice_l1b_hi-omni_20250814211100_v0.0.6.cdf"
+        / "imap_codice_l1b_hi-omni_20250814_v007.cdf"
     )
     val_data = load_cdf(val_path)
-    processed_data = process_codice_l1b(file_path=processed_l1a_file)
+    processed_data = process_codice_l1b(file_path=l1a_filepath)
     # hi-omni has species-specific shapes
     for variable in val_data.data_vars:
-        if variable.startswith("unc_") or variable in TIME_MISMATCHES:
-            continue
         assert processed_data[variable].shape == val_data[variable].shape
         np.testing.assert_allclose(
             processed_data[variable].values,
             val_data[variable].values,
             rtol=1e-5,
+            atol=1e-5,
             err_msg=f"Mismatch in variable '{variable}'",
         )
 
@@ -276,32 +272,27 @@ def test_l1b_hi_omni():
     assert cdf_file.name == f"imap_codice_l1b_hi-omni_{VALIDATION_FILE_DATE}_v999.cdf"
 
 
-@pytest.mark.skip(reason="Revisit this in l1a refactor work")
 def test_l1b_hi_sectored():
-    l0_test_file_path = (
+    # TODO start from l0 file
+    l1a_filepath = (
         imap_module_directory
-        / "tests"
-        / "codice"
-        / "data"
-        / "l1a_input"
-        / "imap_codice_hi-sectored_20250814_v001.pkts"
+        / "tests/codice/data/l1a_validation"
+        / "imap_codice_l1a_hi-sectored_20250814_v007.cdf"
     )
-    processed_l1a_file = write_cdf(process_codice_l1a(l0_test_file_path)[0])
     val_path = (
         imap_module_directory
         / "tests/codice/data/l1b_validation/"
-        / "imap_codice_l1b_hi-sectored_20250814211100_v0.0.6.cdf"
+        / "imap_codice_l1b_hi-sectored_20250814_v007.cdf"
     )
 
     val_data = load_cdf(val_path)
-    processed_data = process_codice_l1b(file_path=processed_l1a_file)
+    processed_data = process_codice_l1b(file_path=l1a_filepath)
     for variable in val_data.data_vars:
-        if variable.startswith("unc_") or variable in TIME_MISMATCHES:
-            continue
         np.testing.assert_allclose(
             processed_data[variable].values,
             val_data[variable].values,
             rtol=1e-5,
+            atol=1.5e-5,
             err_msg=f"Mismatch in variable '{variable}'",
         )
 

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -243,28 +243,30 @@ def test_l1b_lo_nsw_angular(mock_get_file_paths, codice_lut_path):
     )
 
 
-def test_l1b_hi_omni():
-    # TODO start from l0 file
-    l1a_filepath = (
-        imap_module_directory
-        / "tests/codice/data/l1a_validation"
-        / "imap_codice_l1a_hi-omni_20250814_v007.cdf"
-    )
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_l1b_hi_omni(mock_get_file_paths, codice_lut_path):
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="hi-omni", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+
+    l1a_file_path = write_cdf(process_l1a(dependency=ProcessingInputCollection())[0])
     val_path = (
         imap_module_directory
         / "tests/codice/data/l1b_validation/"
         / "imap_codice_l1b_hi-omni_20250814_v007.cdf"
-    )
+    )  # TODO replace with new file.
     val_data = load_cdf(val_path)
-    processed_data = process_codice_l1b(file_path=l1a_filepath)
+    processed_data = process_codice_l1b(file_path=l1a_file_path)
     # hi-omni has species-specific shapes
     for variable in val_data.data_vars:
+        if variable == "epoch_delta_plus":
+            continue
         assert processed_data[variable].shape == val_data[variable].shape
         np.testing.assert_allclose(
             processed_data[variable].values,
             val_data[variable].values,
-            rtol=1e-5,
-            atol=1e-5,
+            rtol=1.5e-5,
             err_msg=f"Mismatch in variable '{variable}'",
         )
 
@@ -272,27 +274,25 @@ def test_l1b_hi_omni():
     assert cdf_file.name == f"imap_codice_l1b_hi-omni_{VALIDATION_FILE_DATE}_v999.cdf"
 
 
-def test_l1b_hi_sectored():
-    # TODO start from l0 file
-    l1a_filepath = (
-        imap_module_directory
-        / "tests/codice/data/l1a_validation"
-        / "imap_codice_l1a_hi-sectored_20250814_v007.cdf"
-    )
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_l1b_hi_sectored(mock_get_file_paths, codice_lut_path):
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="hi-sectored", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
     val_path = (
         imap_module_directory
         / "tests/codice/data/l1b_validation/"
         / "imap_codice_l1b_hi-sectored_20250814_v007.cdf"
     )
-
+    l1a_file_path = write_cdf(process_l1a(dependency=ProcessingInputCollection())[0])
     val_data = load_cdf(val_path)
-    processed_data = process_codice_l1b(file_path=l1a_filepath)
+    processed_data = process_codice_l1b(file_path=l1a_file_path)
     for variable in val_data.data_vars:
         np.testing.assert_allclose(
             processed_data[variable].values,
             val_data[variable].values,
-            rtol=1e-5,
-            atol=1.5e-5,
+            rtol=1.2e-5,
             err_msg=f"Mismatch in variable '{variable}'",
         )
 

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -254,7 +254,8 @@ def test_l1b_hi_omni(mock_get_file_paths, codice_lut_path):
     val_path = (
         imap_module_directory
         / "tests/codice/data/l1b_validation/"
-        / f"imap_codice_l1b_hi-omni_{VALIDATION_FILE_DATE}_v008.cdf"
+        / f"imap_codice_l1b_hi-omni_{VALIDATION_FILE_DATE}"
+        f"_{VALIDATION_FILE_VERSION}.cdf"
     )
     val_data = load_cdf(val_path)
     processed_data = process_codice_l1b(file_path=l1a_file_path)
@@ -281,7 +282,8 @@ def test_l1b_hi_sectored(mock_get_file_paths, codice_lut_path):
     val_path = (
         imap_module_directory
         / "tests/codice/data/l1b_validation/"
-        / f"imap_codice_l1b_hi-sectored_{VALIDATION_FILE_DATE}_v008.cdf"
+        / f"imap_codice_l1b_hi-sectored_{VALIDATION_FILE_DATE}"
+        f"_{VALIDATION_FILE_VERSION}.cdf"
     )
     l1a_file_path = write_cdf(process_l1a(dependency=ProcessingInputCollection())[0])
     val_data = load_cdf(val_path)

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -281,7 +281,7 @@ def test_l1b_hi_sectored(mock_get_file_paths, codice_lut_path):
     val_path = (
         imap_module_directory
         / "tests/codice/data/l1b_validation/"
-        / "imap_codice_l1b_hi-sectored_20250814_v007.cdf"
+        / f"imap_codice_l1b_hi-sectored_{VALIDATION_FILE_DATE}_v008.cdf"
     )
     l1a_file_path = write_cdf(process_l1a(dependency=ProcessingInputCollection())[0])
     val_data = load_cdf(val_path)

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -254,15 +254,12 @@ def test_l1b_hi_omni(mock_get_file_paths, codice_lut_path):
     val_path = (
         imap_module_directory
         / "tests/codice/data/l1b_validation/"
-        / "imap_codice_l1b_hi-omni_20250814_v007.cdf"
-    )  # TODO replace with new file.
+        / f"imap_codice_l1b_hi-omni_{VALIDATION_FILE_DATE}_v008.cdf"
+    )
     val_data = load_cdf(val_path)
     processed_data = process_codice_l1b(file_path=l1a_file_path)
     # hi-omni has species-specific shapes
-    # TODO remove this block when new validation file is available
     for variable in val_data.data_vars:
-        if variable in ["epoch_delta_plus", "epoch_delta_minus"]:
-            continue
         assert processed_data[variable].shape == val_data[variable].shape
         np.testing.assert_allclose(
             processed_data[variable].values,


### PR DESCRIPTION
# Change Summary
closes #2410

## Overview
Revalidation work

## Updated Files
- imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
   - Add energy_<species>_label attrs
- imap_processing/codice/codice_l1a_hi_omni.py
   - create energy_<species>_label arrays
 - imap_processing/tests/codice/test_codice_l1b.py
   - validation tests

## Testing
Do not skip tests. Produce l1bs from l0
