### PR TITLE
Update to latest IMAP frame kernel v1.3.0

### DIFF
--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -65,6 +65,8 @@ class SpiceFrame(IntEnum):
     IMAP_GLOWS = -43750
 
     # IMAP Science Frames (new additions from imap_science_xxx.tf)
+    # IMAP_OMD appears to have a bad definition in imap_science_100.tf
+    # Commenting it out for now.
     # IMAP_OMD = -43900
     IMAP_EARTHFIXED = -43910
     IMAP_ECLIPDATE = -43911

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -47,15 +47,16 @@ class SpiceFrame(IntEnum):
     # IMAP specific as defined in imap_###.tf
     IMAP_SPACECRAFT = -43000
     IMAP_LO_BASE = -43100
-    IMAP_LO_STAR_SENSOR = -43103
-    IMAP_LO = -43105
+    IMAP_LO = -43101
+    IMAP_LO_STAR_SENSOR = -43102
     IMAP_HI_45 = -43150
-    IMAP_HI_90 = -43160
+    IMAP_HI_90 = -43151
     IMAP_ULTRA_45 = -43200
-    IMAP_ULTRA_90 = -43210
+    IMAP_ULTRA_90 = -43201
     IMAP_MAG_BOOM = -43250
     IMAP_MAG_I = -43251
     IMAP_MAG_O = -43252
+    IMAP_MAG_BASE = -43253
     IMAP_SWE = -43300
     IMAP_SWAPI = -43350
     IMAP_CODICE = -43400
@@ -64,7 +65,7 @@ class SpiceFrame(IntEnum):
     IMAP_GLOWS = -43750
 
     # IMAP Science Frames (new additions from imap_science_xxx.tf)
-    IMAP_OMD = -43900
+    # IMAP_OMD = -43900
     IMAP_EARTHFIXED = -43910
     IMAP_ECLIPDATE = -43911
     IMAP_MDI = -43912
@@ -217,14 +218,14 @@ def get_spacecraft_to_instrument_spin_phase_offset(instrument: SpiceFrame) -> fl
         The spin phase offset from the spacecraft to the instrument.
     """
     phase_offset_lookup = {
-        # Phase offset values based on imap_100.tf frame kernel
+        # Phase offset values based on imap_130.tf frame kernel
         # See docstring notes for details on how these values were determined.
         SpiceFrame.IMAP_LO: 60 / 360,  # (330 + 90) % 360 = 60
         SpiceFrame.IMAP_HI_45: 344.8264 / 360,  # 255 + 90 = 345
         SpiceFrame.IMAP_HI_90: 15.1649 / 360,  # (285 + 90) % 360 = 15
         SpiceFrame.IMAP_ULTRA_45: 122.8642 / 360,  # 33 + 90 = 123
         SpiceFrame.IMAP_ULTRA_90: 299.9511 / 360,  # 210 + 90 = 300
-        SpiceFrame.IMAP_SWAPI: 258 / 360,  # 168 + 90 = 258
+        SpiceFrame.IMAP_SWAPI: 258.0135 / 360,  # 168 + 90 = 258
         SpiceFrame.IMAP_IDEX: 179.9229 / 360,  # 90 + 90 = 180
         SpiceFrame.IMAP_CODICE: 225.9086 / 360,  # 136 + 90 = 226
         SpiceFrame.IMAP_HIT: 119.6452 / 360,  # 30 + 90 = 120

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -474,7 +474,7 @@ def imap_ena_sim_metakernel(furnish_kernels, _download_kernels):
         "naif0012.tls",
         "imap_spk_demo.bsp",
         "sim_1yr_imap_attitude.bc",
-        "imap_100.tf",
+        "imap_130.tf",
         "de440s.bsp",
         "imap_science_100.tf",
         "sim_1yr_imap_pointing_frame.bc",
@@ -485,7 +485,7 @@ def imap_ena_sim_metakernel(furnish_kernels, _download_kernels):
 
 @pytest.fixture
 def imap_ialirt_sim_metakernel(furnish_kernels):
-    kernels = ["imap_100.tf"]
+    kernels = ["imap_130.tf"]
     with furnish_kernels(kernels) as k:
         yield k
 

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -514,7 +514,7 @@ def test_hist_spice_output(
         "naif0012.tls",
         "de440s.bsp",
         "imap_sclk_0000.tsc",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",
         "sim_1yr_imap_pointing_frame.bc",

--- a/imap_processing/tests/ialirt/unit/test_parse_mag.py
+++ b/imap_processing/tests/ialirt/unit/test_parse_mag.py
@@ -458,7 +458,7 @@ def test_transform_to_frames(furnish_kernels, spice_test_data_path):
 
     kernels = [
         "imap_science_100.tf",
-        "imap_100.tf",
+        "imap_130.tf",
         "naif0012.tls",
         "de440s.bsp",
         "imap_spk_demo.bsp",
@@ -534,7 +534,7 @@ def test_process_packet(
 
     kernels = [
         "imap_science_100.tf",
-        "imap_100.tf",
+        "imap_130.tf",
         "naif0012.tls",
         "de440s.bsp",
         "imap_spk_demo.bsp",

--- a/imap_processing/tests/mag/test_mag_l1d.py
+++ b/imap_processing/tests/mag/test_mag_l1d.py
@@ -142,7 +142,7 @@ def test_calculate_spin_offsets(
     kernels = [
         "naif0012.tls",
         "imap_sclk_0000.tsc",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",
         "sim_1yr_imap_pointing_frame.bc",

--- a/imap_processing/tests/spice/test_data/imap_130.tf
+++ b/imap_processing/tests/spice/test_data/imap_130.tf
@@ -35,9 +35,22 @@ Version and Date
 
    \begindata
 
-   TEXT_KERNEL_ID += 'IMAP_FRAMES V1.0.0 2025-SEPT-19 FK'
+   TEXT_KERNEL_ID += 'IMAP_FRAMES V1.3.0 2025-NOV-13 FK'
    
    \begintext
+   
+
+   Version 1.3.0 -- Nov 13, 2025 -- Lillian Nguyen
+   
+      Inserted a nominal base frame for MAG.
+      Corrected frame name to ID mapping for HI-90, ULTRA-90, MAG-O.
+	  (Note: Release version number 1.1.0 was inadvertently skipped.)
+
+   Version 1.2.0 -- Oct 21, 2025 -- Lillian Nguyen
+   
+      Updated SWAPI frame with launch site alignments.
+      Added instrument coordinate system diagrams for SWAPI, CoDICE, and GLOWS.
+      Removed unimplemented SWAPI and CODICE aperture frame IDs.
 
    Version 1.0.0 -- Sept 19, 2025 -- Douglas Rodgers
                                      Lillian Nguyen
@@ -278,13 +291,13 @@ IMAP NAIF ID Codes -- Definitions
       NAIF_BODY_CODE   += ( -43150       )
       
       NAIF_BODY_NAME   += ( 'IMAP_HI_90' )
-      NAIF_BODY_CODE   += ( -43175       )
+      NAIF_BODY_CODE   += ( -43151       )
 
       NAIF_BODY_NAME   += ( 'IMAP_ULTRA_45' )
       NAIF_BODY_CODE   += ( -43200          )
       
       NAIF_BODY_NAME   += ( 'IMAP_ULTRA_90' )
-      NAIF_BODY_CODE   += ( -43225          )
+      NAIF_BODY_CODE   += ( -43201          )
 
       NAIF_BODY_NAME   += ( 'IMAP_MAG_BOOM' )
       NAIF_BODY_CODE   += ( -43250          )
@@ -293,7 +306,10 @@ IMAP NAIF ID Codes -- Definitions
       NAIF_BODY_CODE   += ( -43251       )
 
       NAIF_BODY_NAME   += ( 'IMAP_MAG_O' )
-      NAIF_BODY_CODE   += ( -43251       )
+      NAIF_BODY_CODE   += ( -43252       )
+
+      NAIF_BODY_NAME   += ( 'IMAP_MAG_BASE' )
+      NAIF_BODY_CODE   += ( -43253          )
       
       NAIF_BODY_NAME   += ( 'IMAP_SWE' )
       NAIF_BODY_CODE   += ( -43300     )
@@ -322,125 +338,8 @@ IMAP NAIF ID Codes -- Definitions
       NAIF_BODY_NAME   += ( 'IMAP_SWAPI' )
       NAIF_BODY_CODE   += ( -43350      )
       
-      NAIF_BODY_NAME   += ( 'IMAP_SWAPI_APERTURE_L' )
-      NAIF_BODY_CODE   += ( -43351                  )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_SWAPI_APERTURE_R' )
-      NAIF_BODY_CODE   += ( -43352                  )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_SWAPI_SUNGLASSES' )
-      NAIF_BODY_CODE   += ( -43353                  )
-
       NAIF_BODY_NAME   += ( 'IMAP_CODICE' )
       NAIF_BODY_CODE   += ( -43400        )
-
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_01' )
-      NAIF_BODY_CODE   += ( -43401                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_02' )
-      NAIF_BODY_CODE   += ( -43402                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_03' )
-      NAIF_BODY_CODE   += ( -43403                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_04' )
-      NAIF_BODY_CODE   += ( -43404                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_05' )
-      NAIF_BODY_CODE   += ( -43405                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_06' )
-      NAIF_BODY_CODE   += ( -43406                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_07' )
-      NAIF_BODY_CODE   += ( -43407                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_08' )
-      NAIF_BODY_CODE   += ( -43408                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_09' )
-      NAIF_BODY_CODE   += ( -43409                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_10' )
-      NAIF_BODY_CODE   += ( -43410                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_11' )
-      NAIF_BODY_CODE   += ( -43411                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_12' )
-      NAIF_BODY_CODE   += ( -43412                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_13' )
-      NAIF_BODY_CODE   += ( -43413                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_14' )
-      NAIF_BODY_CODE   += ( -43414                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_15' )
-      NAIF_BODY_CODE   += ( -43415                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_16' )
-      NAIF_BODY_CODE   += ( -43416                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_17' )
-      NAIF_BODY_CODE   += ( -43417                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_18' )
-      NAIF_BODY_CODE   += ( -43418                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_19' )
-      NAIF_BODY_CODE   += ( -43419                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_20' )
-      NAIF_BODY_CODE   += ( -43420                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_21' )
-      NAIF_BODY_CODE   += ( -43421                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_22' )
-      NAIF_BODY_CODE   += ( -43422                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_23' )
-      NAIF_BODY_CODE   += ( -43423                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_LO_APERTURE_24' )
-      NAIF_BODY_CODE   += ( -43424                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_01' )
-      NAIF_BODY_CODE   += ( -43425                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_02' )
-      NAIF_BODY_CODE   += ( -43426                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_03' )
-      NAIF_BODY_CODE   += ( -43427                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_04' )
-      NAIF_BODY_CODE   += ( -43428                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_05' )
-      NAIF_BODY_CODE   += ( -43429                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_06' )
-      NAIF_BODY_CODE   += ( -43430                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_07' )
-      NAIF_BODY_CODE   += ( -43431                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_08' )
-      NAIF_BODY_CODE   += ( -43432                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_09' )
-      NAIF_BODY_CODE   += ( -43433                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_10' )
-      NAIF_BODY_CODE   += ( -43434                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_11' )
-      NAIF_BODY_CODE   += ( -43435                       )
-      
-      NAIF_BODY_NAME   += ( 'IMAP_CODICE_HI_APERTURE_12' )
-      NAIF_BODY_CODE   += ( -43436                       )
             
       NAIF_BODY_NAME   += ( 'IMAP_HIT' )
       NAIF_BODY_CODE   += ( -43500     )
@@ -542,8 +441,9 @@ IMAP NAIF ID Codes -- Definitions
       MAG (250-299)
       --------------------------
       IMAP_MAG_BOOM                 IMAP_SPACECRAFT    FIXED     -43250
-      IMAP_MAG_I                    IMAP_SPACECRAFT    FIXED     -43251
-      IMAP_MAG_O                    IMAP_SPACECRAFT    FIXED     -43252
+      IMAP_MAG_BASE                 IMAP_SPACECRAFT    FIXED     -43253
+      IMAP_MAG_I                    IMAP_MAG_BASE      FIXED     -43251
+      IMAP_MAG_O                    IMAP_MAG_BASE      FIXED     -43252
 
       SWE (300-349)
       --------------------------
@@ -559,49 +459,10 @@ IMAP NAIF ID Codes -- Definitions
       SWAPI (350-399)
       --------------------------
       IMAP_SWAPI                    IMAP_SPACECRAFT    FIXED     -43350
-      IMAP_SWAPI_APERTURE_L         IMAP_SWAPI         FIXED     -43351
-      IMAP_SWAPI_APERTURE_R         IMAP_SWAPI         FIXED     -43352
-      IMAP_SWAPI_SUNGLASSES         IMAP_SWAPI         FIXED     -43353
 
       CODICE (400-499)
       --------------------------
       IMAP_CODICE                   IMAP_SPACECRAFT    FIXED     -43400
-      IMAP_CODICE_LO_APERTURE_01    IMAP_CODICE        FIXED     -43401
-      IMAP_CODICE_LO_APERTURE_02    IMAP_CODICE        FIXED     -43402
-      IMAP_CODICE_LO_APERTURE_03    IMAP_CODICE        FIXED     -43403
-      IMAP_CODICE_LO_APERTURE_04    IMAP_CODICE        FIXED     -43404
-      IMAP_CODICE_LO_APERTURE_05    IMAP_CODICE        FIXED     -43405
-      IMAP_CODICE_LO_APERTURE_06    IMAP_CODICE        FIXED     -43406
-      IMAP_CODICE_LO_APERTURE_07    IMAP_CODICE        FIXED     -43407
-      IMAP_CODICE_LO_APERTURE_08    IMAP_CODICE        FIXED     -43408
-      IMAP_CODICE_LO_APERTURE_09    IMAP_CODICE        FIXED     -43409
-      IMAP_CODICE_LO_APERTURE_10    IMAP_CODICE        FIXED     -43410
-      IMAP_CODICE_LO_APERTURE_11    IMAP_CODICE        FIXED     -43411
-      IMAP_CODICE_LO_APERTURE_12    IMAP_CODICE        FIXED     -43412
-      IMAP_CODICE_LO_APERTURE_13    IMAP_CODICE        FIXED     -43413
-      IMAP_CODICE_LO_APERTURE_14    IMAP_CODICE        FIXED     -43414
-      IMAP_CODICE_LO_APERTURE_15    IMAP_CODICE        FIXED     -43415
-      IMAP_CODICE_LO_APERTURE_16    IMAP_CODICE        FIXED     -43416
-      IMAP_CODICE_LO_APERTURE_17    IMAP_CODICE        FIXED     -43417
-      IMAP_CODICE_LO_APERTURE_18    IMAP_CODICE        FIXED     -43418
-      IMAP_CODICE_LO_APERTURE_19    IMAP_CODICE        FIXED     -43419
-      IMAP_CODICE_LO_APERTURE_20    IMAP_CODICE        FIXED     -43420
-      IMAP_CODICE_LO_APERTURE_21    IMAP_CODICE        FIXED     -43421
-      IMAP_CODICE_LO_APERTURE_22    IMAP_CODICE        FIXED     -43422
-      IMAP_CODICE_LO_APERTURE_23    IMAP_CODICE        FIXED     -43423
-      IMAP_CODICE_LO_APERTURE_24    IMAP_CODICE        FIXED     -43424
-      IMAP_CODICE_HI_APERTURE_01    IMAP_CODICE        FIXED     -43425
-      IMAP_CODICE_HI_APERTURE_02    IMAP_CODICE        FIXED     -43426
-      IMAP_CODICE_HI_APERTURE_03    IMAP_CODICE        FIXED     -43427
-      IMAP_CODICE_HI_APERTURE_04    IMAP_CODICE        FIXED     -43428
-      IMAP_CODICE_HI_APERTURE_05    IMAP_CODICE        FIXED     -43429
-      IMAP_CODICE_HI_APERTURE_06    IMAP_CODICE        FIXED     -43430
-      IMAP_CODICE_HI_APERTURE_07    IMAP_CODICE        FIXED     -43431
-      IMAP_CODICE_HI_APERTURE_08    IMAP_CODICE        FIXED     -43432
-      IMAP_CODICE_HI_APERTURE_09    IMAP_CODICE        FIXED     -43433
-      IMAP_CODICE_HI_APERTURE_10    IMAP_CODICE        FIXED     -43434
-      IMAP_CODICE_HI_APERTURE_11    IMAP_CODICE        FIXED     -43435
-      IMAP_CODICE_HI_APERTURE_12    IMAP_CODICE        FIXED     -43436
 
       HIT (500-699)
       --------------------------
@@ -681,9 +542,11 @@ IMAP Frame Tree
            |
            IMAP_MAG_BOOM
            |    
-           IMAP_MAP_I
-           |    
-           IMAP_MAP_O
+           IMAP_MAG_BASE
+           |    |
+           |    IMAP_MAG_I
+           |    |
+           |    IMAP_MAG_O
            |
            IMAP_SWE
            |    |
@@ -702,26 +565,8 @@ IMAP Frame Tree
            |    IMAP_SWE_DETECTOR_M63
            |
            IMAP_SWAPI
-           |    |
-           |    IMAP_SWAPI_APERTURE_L
-           |    |
-           |    IMAP_SWAPI_APERTURE_R
-           |    |
-           |    IMAP_SWAPI_SUNGLASSES
            |
            IMAP_CODICE
-           |    |
-           |    IMAP_CODICE_LO_APERTURE_01
-           |    |
-           |    |...
-           |    |
-           |    IMAP_CODICE_LO_APERTURE_24
-           |    |
-           |    IMAP_CODICE_HI_APERTURE_01
-           |    |
-           |    |...
-           |    |
-           |    IMAP_CODICE_HI_APERTURE_12
            |
            IMAP_HIT
            |    |
@@ -2319,9 +2164,9 @@ IMAP-Hi Frames
    ports aligned with the +Z' axis, and X' = Y' x Z'.
    
    The local coordinate system is shown below, looking into the sensor.
-   The vent ports are aligned as shown with the Z axis.
+   The vent ports are aligned as shown with the Z' axis.
    
-                                +Z
+                                +Z'
                                  ^
                                  |
                                  |
@@ -2332,7 +2177,7 @@ IMAP-Hi Frames
                     /    .'    |'|'|    '.    \  
                    /    /      | | |      \    \ 
                   |    /       |_|_|       \    |
-        +X  /_____|__ |__________|          |   |
+        +X' /_____|__ |__________|          |   |
             \     |   |                     |   |
                   |    \       |'''|       /    |
                    \    \      |   |      /    / 
@@ -2484,6 +2329,12 @@ IMAP-Hi Frames
    rotation matrix generated from these Euler angles is consistent with
    the rotation matrix using the azimuth/elevation look direction. 
 
+   Applying the method described above to the measured alignment vector
+   in [17], 
+   
+   D = +Y' = [ 0.965176886, 0.261597765, 0.000434036 ],
+   
+   we arrive at the definition below.
  
    \begindata
      
@@ -2595,14 +2446,14 @@ IMAP-Ultra Frames
    #-----------||-|-,      @                          /~,".' ;'.'          #
    #===        ||---|@  @     @                 @ @  ,\ '  ,.^`            #
    #___________||_/-~_ _   @     @           _,  _,-' ,.-'`                #
-   #   @| | |  ||       `- , @      @        \,\'  ,'`     S/C +Z'         # 
+   #   @| | |  ||       `- , @      @        \,\'  ,'`     +Z'             # 
    #----' | |  ||           `~,@       @  ,~`' _,'`         ^              #
    #      | |  ||              ',@ .^\_,'` ,.'`             |              #
    #______'-'__||-@--~-~,        \ .;`  .'`                 |              #
    #___________||/ ~  #  ~        | {.'`                    |              #
-   #        |* ||*|   +  <------------  Collector plate     o----> S/C +Y' #
-   #____     --||\ ~     ~       |      axis of symmetry   S/C +X'         #
-   #_  *|      ||-@-^~-~^-------|                        out of page       #
+   #        |* ||*|   +  <------------ Collector plate      o------> +Y'   #
+   #____     --||\ ~     ~       |     axis of symmetry     Instrument     #
+   #_  *|      ||-@-^~-~^-------|                           Coordinates    #
    #*| |       ||_______________|                                          #
    #___*|_______|_|_|__|__|_|_| |                                          #
    #########################################################################
@@ -2612,9 +2463,7 @@ IMAP-Ultra Frames
    defined with the collector-plate-fan axes of symmetry aligned with
    the +X' axis, the cylindrical axes offset in the +Y' axis, and the
    Z' axis perpendicular to both and outward as in the diagram below.
-   
-   TODO: add diagram of instrument axes
-   
+      
    
    IMAP ULTRA 45
    --------------
@@ -2847,8 +2696,11 @@ IMAP Magnetometer (MAG) Frames
       [Y]    = [  -1   0   0  ] [Y']
       [Z]S/C   [   0   0  +1  ] [Z']MAG undeployed   
    
-   The definitions are offset from the nominal values described above to
-   include launch sight alignment measurements.            
+   The MAG local coordinate system is shown in the diagram above. The 
+   matrix taking vectors from the MAG coordinate system to the spacecraft
+   coordinate system is provided below in the IMAP_MAG_BASE frame definition.
+   It represents a nominal, or idealized, orientation. The measured 
+   alignments [17] are given in frames IMAP_MAG_I and IMAP_MAG_O.      
 
    \begindata
 
@@ -2867,49 +2719,64 @@ IMAP Magnetometer (MAG) Frames
                                    -0.000000000000000,
                                     0.004211767995864,
                                    -0.000058106512157,
-                                    0.999991128777642 )
+                                    0.999991128777642 )									
+
+   FRAME_IMAP_MAG_BASE         = -43253
+   FRAME_-43253_NAME           = 'IMAP_MAG_BASE'
+   FRAME_-43253_CLASS          = 4
+   FRAME_-43253_CLASS_ID       = -43253
+   FRAME_-43253_CENTER         = -43
+   TKFRAME_-43253_RELATIVE     = 'IMAP_SPACECRAFT'
+   TKFRAME_-43253_SPEC         = 'MATRIX'
+   TKFRAME_-43253_MATRIX       = (  0.0,
+                                   -1.0,
+                                    0.0,
+                                   -1.0,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                   -1.0 )
 
    FRAME_IMAP_MAG_I            = -43251
    FRAME_-43251_NAME           = 'IMAP_MAG_I'
    FRAME_-43251_CLASS          = 4
    FRAME_-43251_CLASS_ID       = -43251
    FRAME_-43251_CENTER         = -43
-   TKFRAME_-43251_RELATIVE     = 'IMAP_SPACECRAFT'
+   TKFRAME_-43251_RELATIVE     = 'IMAP_MAG_BASE'
    TKFRAME_-43251_SPEC         = 'MATRIX'
-   TKFRAME_-43251_MATRIX       = ( -0.000507384835577,
-                                   -0.999999871280306,
-                                   -0.000000000000000,
-                                   -0.999928705504181,
-                                    0.000507348727136,
-                                    0.011930067309210,
-                                   -0.011930065773575,
-                                    0.000006053135240,
-                                   -0.999928834214714 )
+   TKFRAME_-43251_MATRIX       = ( 0.999999871280306
+                                   0.000507384835577
+                                   0.0
+                                  -0.000507348727136
+                                   0.999928705504181
+                                  -0.011930067309210
+                                  -0.000006053135240
+                                   0.011930065773575
+                                   0.999928834214714 )
 
    FRAME_IMAP_MAG_O            = -43252
    FRAME_-43252_NAME           = 'IMAP_MAG_O'
    FRAME_-43252_CLASS          = 4
    FRAME_-43252_CLASS_ID       = -43252
    FRAME_-43252_CENTER         = -43
-   TKFRAME_-43252_RELATIVE     = 'IMAP_SPACECRAFT'
+   TKFRAME_-43252_RELATIVE     = 'IMAP_MAG_BASE'
    TKFRAME_-43252_SPEC         = 'MATRIX'
-   TKFRAME_-43252_MATRIX       = ( -0.010338102964849,
-                                   -0.999946560385648,
-                                   -0.000000000000000,
-                                   -0.999926946999490,
-                                    0.010337900188807,
-                                    0.006263264641177,
-                                   -0.006262929934730,
-                                    0.000064750274757,
-                                   -0.999980385565654 )
+   TKFRAME_-43252_MATRIX       = ( 0.999946560385648
+                                   0.010338102964849
+                                   0.0
+                                  -0.010337900188807
+                                   0.999926946999490
+                                  -0.006263264641177
+                                  -0.000064750274757
+                                   0.006262929934730
+                                   0.999980385565654 )
 
    \begintext
 
 
 IMAP Solar Wind Electron (SWE) Frames
 ========================================================================
-     
-   TODO: Add diagram of SWE location on S/C
      
    The SWE instrument frame is defined in [18] as
    
@@ -2918,18 +2785,18 @@ IMAP Solar Wind Electron (SWE) Frames
       *  +Z is nominally aligned with S/C +Z
       *  +Y complements the right-handed frame
       
-   A view of the instrument looking down the Y axis is illustrated below.
+   A view of the instrument looking down the Y' axis is illustrated below. 
    
                                                 
              .                                       ^   S/C +Z 
-          P63 .      ^ +Z                            | (spin axis)
+          P63 .      ^ +Z'                           | (spin axis)
           .    .     |                               |
       P43  `.   .    |_________ SWE Sensor           |
          .    `.  .  ||         |                    |
      P21   `.   `. . ||         |
         `   . `.  `..||         |
-    000   -X <--------x         |
-        .   ' .'  .'.| +Y (into page )
+    000  -X' <--------x         |
+        .   ' .'  .'.| +Y' (into page )
      M21   .'   .' . |          |
          '    .'  .  |__________|______________
        M43  .'   .     |                       |  Mounting Plate
@@ -3072,41 +2939,64 @@ IMAP Solar Wind Electron (SWE) Frames
 
 IMAP Solar Wind and Pickup Ion (SWAPI) Frames
 ========================================================================
-
-   TODO: add diagrams
+   
+   SWAPI has the following nominal alignment to the spacecraft frame,
+   reference Table 1 of [6]. The azimuth and elevation angles are 
+   illustrated in the 'IMAP I&T Component Placement' section near the 
+   top of this document.
+   
+        azimuth  | elevation 
+         (deg)   |  (deg)
+        ---------+---------
+           168   |    0
    
    The SWAPI base frame is defined in the instrument MICD [8] as follows:
    
       *  -Z axis is the axis of symmetry of the instrument, pointing 
             away from the spacecraft body.
       *  +Y axis is along the aperture center, in the anti-sunward direction.
-    
+      
+   Two views of the instrument are illustrated below. The diagram on the left 
+   is looking down the top of the instrument towards the spacecraft body. The 
+   diagram on the right is a side view of the instrument assembly. In both 
+   diagrams the sunglasses aperture vanes point to the right (+Y direction).
+   The labeled coordinate axes are in the instrument reference frame.   
+   
+                                                 -Z'
+            +X'                                   ^
+             ^                             _______|________
+             |                            |       |        |---- 
+        . ***|*** .                       |       o---------------> +Y'
+       *     |     *    .-'               |________________|----  (towards
+      *      |      *.-'                  . '            ' .        Sun)
+     *       |       *                  '--------------------'
+     *       o----------> +Y'                 /        \   
+     *               *                        |        |
+      *             *'-.                      |\      /|          |
+       *.         .*    `-.                  _|_|____|_|_         |
+          *******                           |            |        |
+                                            |            |        v
+      spacecraft body                       |            |   spacecraft
+        behind page                         |____________|      body
+        
+       
    The nominal azimuth and elevation give the outward axis of symmetry, -Z in the
    instrument frame:
     
       -Z      = -[ -sin(az) * cos(el), cos(az) * cos(el), sin(el) ]
         instr    
       
-   The instrument +Y axis is in the sunward direction, towards the
-   spacecraft +Z axis:
-
-       Y      = [ 0 0 1 ]    
-        instr    
-           
-   Taking the cross product and normalizing, we arrive at the instrumet +X
-   axis:
-                  Y x Z
-       X      = ---------
-        instr   | Y x Z |
-    
-   And adjusting Y:
-    
-                  Z x X
-       Y      = ---------
-        instr   | Z x X |
-    
-    This definition is captured in the keywords below.    
-     
+   [17] provides measured values of the above nominal instrument alignment. The
+   following measured vectors are parallel to the spacecraft axes listed:
+   
+      -Y = Tophat Topplate Rib                    = [ -0.00142, -0.01019, -0.99995 ]
+      
+      -Z = Top of Aperture Grid Frame             = [ -0.20761, -0.97821, 0.001128 ]
+      -Z = Top of Lower Outer ESA Mounting Flange = [ -0.20775, -0.97818, 0.00003  ]
+      
+   Since two measurements were taken for instrument -Z, we use their average.
+   The X axis completes the right-handed coordinate system.
+      
    \begindata
 
    FRAME_IMAP_SWAPI            = -43350
@@ -3116,23 +3006,21 @@ IMAP Solar Wind and Pickup Ion (SWAPI) Frames
    FRAME_-43350_CENTER         = -43
    TKFRAME_-43350_RELATIVE     = 'IMAP_SPACECRAFT'
    TKFRAME_-43350_SPEC         = 'MATRIX'
-   TKFRAME_-43350_MATRIX       = ( -0.97814760073381,
-                                    0.20791169081776,
-                                    0.00000000000000,
-                                    0.00000000000000,
-                                    0.00000000000000,
-                                    1.00000000000000,
-                                    0.20791169081776,
-                                    0.97814760073381,
-                                    0.00000000000000 )
+   TKFRAME_-43350_MATRIX       = ( -0.978196569749791
+   0.207679902805407
+  -0.000727255443315
+  -0.000591151927685
+   0.000717413380944
+   0.999999567928626
+   0.207680334815652
+   0.978196577017512
+  -0.000579000933447 )
 
-\begintext
+   \begintext
 
 
 IMAP Compact Dual Ion Composition Experiment (CoDICE) Frames
 ========================================================================
-
-   TODO: add text and diagram. Add detector frames
 
    CoDICE has the following nominal alignment to the spacecraft frame,
    reference Table 1 of [6]. The azimuth and elevation angles are 
@@ -3151,7 +3039,28 @@ IMAP Compact Dual Ion Composition Experiment (CoDICE) Frames
             away from the spacecraft body.
       *  +Z is aligned with the spacecraft +Z axis
       
-   The alignment measurements [17] give the three axes of the 
+   A diagram of the CoDICE local coordinate system is shown below.
+   
+                         -X'
+                          ^
+                  ________|_______
+                 |________|_______| 
+                    \     |    /
+                    /     |    \   
+                   |      o----------> +Z'
+                    \          /   (towards Sun) 
+                    \ \ \  / / /          
+                   |''''''''''''|         
+                   |            |      |  
+                   |            |      |  
+                   |            |      |  
+                   |            |      |   
+                   |            |      v  
+                   |            |  spacecraft     
+                   |            |     body       
+                   |____________|  
+                   
+   The alignment measurements in [17] give the three axes of the 
    instrument coordinate system and are captured below.
      
    \begindata
@@ -3212,7 +3121,7 @@ IMAP High-energy Ion Telescope (HIT) Frames
                      HIT local coordinate system
                      ----------------------------
                                          
-     S/C +Z axis                         +Z 
+     S/C +Z axis                         +Z' 
     (facing Sun)                         ^
           ^                              `
           |                             .
@@ -3228,9 +3137,9 @@ IMAP High-energy Ion Telescope (HIT) Frames
      groups A1-A5 ||||.            `          .       ___
       and A6-A10 |||||            .           |---''''
             ___....---|           o ....      ||||||| 50 deg space
-                      '       +Y(out)    ```` '|||||
+                      '        +Y'out)   ```` '|||||
                 A10    \                     /|||||``` --- 
-                     .-''.                 .''-.||        ````--> -X
+                     .-''.                 .''-.||        ````--> -X'
                   .-'     '.             .'     '-.
                .-'          / ''--+--'' \          '-.
                      A9    /      |      \   A6
@@ -3532,9 +3441,7 @@ IMAP Interstellar Dust Experiment (IDEX) Frames
 
 IMAP GLObal solar Wind Structure (GLOWS) Frames
 ========================================================================
-
-   TODO: add diagrams
-     
+    
    GLOWS has the following nominal alignment to the spacecraft frame,
    reference Table 1 of [6]. The azimuth and elevation angles are 
    illustrated in the 'IMAP I&T Component Placement' section near the top 
@@ -3549,14 +3456,28 @@ IMAP GLObal solar Wind Structure (GLOWS) Frames
    
       *  +Z axis points in the anti-boresight direction
       *  +Y axis points in the anti-sunward direction (towards S/C -Z)
+         
+   A diagram of the GLOWS local coordinate system is shown below.
+                 ______________________                 
+                |                      |              .-'|       __ -Z'
+     S/C +Z     |                      |           .-'   |    _.-*/    
+    (sunward)   |                      |        .-'      |.-*'
+        ^       |                      |    _.-*'\  _.-*'|
+        |       |                      '.-*'   _.-*'     |
+        |       |                      \    o*'    \ _.-'
+        |       |                       \    \_.-*' '
+                |                        \.-*'\         
+                |________________________|     \
+                                                \
+                                                 v  +Y'                                    
       
-   The azimuth and elevation give the outward axis of symmetry, -Z in the
-   instrument frame:
+   The azimuth and elevation give the nominal outward axis of symmetry, 
+   -Z in the instrument frame:
     
        Z      = -[ -sin(az) * cos(el), cos(az) * cos(el), sin(el) ]
         instr  
     
-   The alignment measurements in [17] give the outward axis of symmetry, 
+   The alignment report [17] gives the measured outward axis of symmetry, 
    -Z in the instrument frame:
     
       -Z      = [ -0.7699232700, -0.5831000067, 0.2592538148 ]
@@ -3580,7 +3501,7 @@ IMAP GLObal solar Wind Structure (GLOWS) Frames
        Y      = ---------
         instr   | Z x X |
     
-    This definition is captured in the keywords below.
+   This definition is captured in the keywords below.
      
    \begindata
 

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -24,6 +24,13 @@ from imap_processing.spice.geometry import (
 )
 
 
+def test_spice_frame_enum(furnish_kernels):
+    """Test that the SpiceFrame enum values match imap frames kernel."""
+    with furnish_kernels(["imap_130.tf", "imap_science_100.tf"]):
+        for frame in SpiceFrame:
+            assert frame.value == spiceypy.namfrm(frame.name)
+
+
 @pytest.mark.parametrize(
     "et",
     [
@@ -72,7 +79,7 @@ def test_get_instrument_mounting_az_el(
     furnish_kernels, spice_test_data_path, instrument, expected_az_el
 ):
     """Test coverage for get_instrument_mounting_az_el()"""
-    with furnish_kernels([spice_test_data_path / "imap_100.tf"]):
+    with furnish_kernels([spice_test_data_path / "imap_130.tf"]):
         result = get_instrument_mounting_az_el(instrument)
         # Testing as built angles against nominal. Allow for 0.75 degrees of
         # mounting error.
@@ -103,7 +110,7 @@ def test_get_spacecraft_to_instrument_spin_phase_offset(
 ):
     """Test coverage for get_spacecraft_to_instrument_spin_phase_offset()"""
     # Test that the offset is close to SPICE derived mounting azimuth
-    with furnish_kernels([spice_test_data_path / "imap_100.tf"]):
+    with furnish_kernels([spice_test_data_path / "imap_130.tf"]):
         # Lo requires an additional kernel to use the below function. So here,
         # we use the IMAP_LO_BASE frame to verify
         verify_inst = (
@@ -160,7 +167,7 @@ def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_ker
     kernels = [
         "naif0012.tls",
         "imap_sclk_0000.tsc",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",
         "sim_1yr_imap_pointing_frame.bc",
@@ -331,7 +338,7 @@ def test_get_rotation_matrix(furnish_kernels):
     """Test coverage for get_rotation_matrix()."""
     kernels = [
         "naif0012.tls",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_sclk_0000.tsc",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",
@@ -366,7 +373,7 @@ def test_get_rotation_matrix_no_transformation_defined_for_et_allowed(furnish_ke
     transformation when allow_spice_noframeconnect is True in get_rotation_matrix()."""
     kernels = [
         "naif0012.tls",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_sclk_0000.tsc",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",
@@ -405,7 +412,7 @@ def test_get_rotation_matrix_no_transformation_defined_for_et_not_allowed(
     allow_spice_noframeconnect is False (default) in get_rotation_matrix()."""
     kernels = [
         "naif0012.tls",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_sclk_0000.tsc",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",
@@ -425,7 +432,7 @@ def test_get_rotation_matrix_no_transformation_defined_for_et_not_allowed(
 def test_instrument_pointing(furnish_kernels):
     kernels = [
         "naif0012.tls",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_sclk_0000.tsc",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",
@@ -473,7 +480,7 @@ def test_instrument_pointing_all_instruments(frame, furnish_kernels):
     """Test the ability to compute instrument pointing for all but Lo."""
     kernels = [
         "naif0012.tls",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_sclk_0000.tsc",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",
@@ -497,7 +504,7 @@ def test_instrument_pointing_lo_ck(frame, furnish_kernels):
     """Test calculating Lo pointing."""
     kernels = [
         "naif0012.tls",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_sclk_0000.tsc",
         "imap_science_100.tf",
         "sim_1yr_imap_attitude.bc",

--- a/imap_processing/tests/spice/test_pointing_frame.py
+++ b/imap_processing/tests/spice/test_pointing_frame.py
@@ -28,7 +28,7 @@ def furnish_pointing_frame_kernels(furnish_kernels, spice_test_data_path):
     required_kernels = [
         "naif0012.tls",
         "imap_sclk_0000.tsc",
-        "imap_100.tf",
+        "imap_130.tf",
         "imap_science_100.tf",
         "imap_sim_ck_2hr_2secsampling_with_nutation.bc",
     ]

--- a/imap_processing/tests/spice/test_spin.py
+++ b/imap_processing/tests/spice/test_spin.py
@@ -286,7 +286,7 @@ def test_get_instrument_spin_phase(
     """Test coverage for get_instrument_spin_phase()"""
     met_times = np.array([7.5, 30, 61, 75, 106, 121, 136])
     expected_nan_mask = np.array([False, False, True, False, True, True, False])
-    with furnish_kernels([spice_test_data_path / "imap_100.tf"]):
+    with furnish_kernels([spice_test_data_path / "imap_130.tf"]):
         inst_phase = spin.get_instrument_spin_phase(met_times, instrument)
     assert inst_phase.shape == met_times.shape
     np.testing.assert_array_equal(np.isnan(inst_phase), expected_nan_mask)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_annotated.py
@@ -17,7 +17,7 @@ def furnish_kernels(spice_test_data_path, furnish_kernels):
         "imap_science_100.tf",
         "imap_sclk_0000.tsc",
         "sim_1yr_imap_attitude.bc",
-        "imap_100.tf",
+        "imap_130.tf",
         "naif0012.tls",
         "sim_1yr_imap_pointing_frame.bc",
         "de440s.bsp",


### PR DESCRIPTION
# Change Summary

## Overview
Updates to use the latest frames kernel
Add/update frame id numbers
Add test that checks that all SpiceFrame enums match frames kernel definitions

When github gets back online, I will push the commit with the new frames kernel.

Changes in this frames kernel compared to v1.0.0

>    Version 1.2.0 -- Oct 21, 2025 -- Lillian Nguyen
>   
>       Updated SWAPI frame with launch site alignments.
>       Added instrument coordinate system diagrams for SWAPI, CoDICE, and GLOWS.
>       Removed unimplemented SWAPI and CODICE aperture frame IDs.

>    Version 1.3.0 -- Nov 13, 2025 -- Lillian Nguyen
>   
>       Inserted a nominal base frame for MAG.
>       Corrected frame name to ID mapping for HI-90, ULTRA-90, MAG-O.

## New Files
- imap_processing/tests/spice/test_data/imap_130.tf
   - Latest imap frames kernel
   - See above for detailed changes

## Deleted Files
- imap_processing/tests/spice/test_data/imap_100.tf
   - remove previous imap frames kernel

## Updated Files
Many search and replace changes from imap_100.tf -> imap_130.tf
- imap_processing/spice/geometry.py
   - Update SPICE frame IDs to match latest frames kernel
   - Update SWAPI spin-phase offset
- imap_processing/tests/spice/test_geometry.py
   - Added test to specifically check ID numbers defined in SpiceFrame enum

Closes: #2443 
