### PR TITLE
fix: MAG Offsets should be added

### DIFF
--- a/imap_processing/mag/l1d/mag_l1d_data.py
+++ b/imap_processing/mag/l1d/mag_l1d_data.py
@@ -403,7 +403,7 @@ class MagL1d(MagL2L1dBase):  # type: ignore[misc]
         updated_vector = input_vector.copy()
         rng = int(input_vector[3])
         x_y_z = input_vector[:3]
-        updated_vector[:3] = x_y_z - offsets[int(is_magi), rng, :]
+        updated_vector[:3] = x_y_z + offsets[int(is_magi), rng, :]
         return updated_vector
 
     def calculate_spin_offsets(self) -> xr.Dataset:

--- a/imap_processing/tests/mag/test_mag_l1d.py
+++ b/imap_processing/tests/mag/test_mag_l1d.py
@@ -113,7 +113,7 @@ def test_offset_vector():
     )
     test_vector = np.array([1, 2, 3, 3])
 
-    expected_vector = [-3, -2, -1, 3]
+    expected_vector = [5, 6, 7, 3]
     output_vector = MagL1d.apply_calibration_offset_single_vector(
         test_vector, offsets, False
     )
@@ -121,7 +121,7 @@ def test_offset_vector():
     assert np.array_equal(expected_vector, output_vector)
 
     test_vector = np.array([1, 2, 3, 0])
-    expected_vector = [2, 3, 4, 0]
+    expected_vector = [0, 1, 2, 0]
     output_vector = MagL1d.apply_calibration_offset_single_vector(
         test_vector, offsets, True
     )


### PR DESCRIPTION
# Change Summary

## Overview
The MAG algorithm states offsets should be added to the science data, not subtracted. Currently the logic will make the science worse, not better! This is currently making the I-ALiRT and L1D data wrong.

<img width="915" height="672" alt="image" src="https://github.com/user-attachments/assets/84c619bc-d608-497f-9c2f-8547232e40f2" />

Tagging @mhairifin (who found this) and @laspsandoval @maxinelasp who need this fix.

Thank you!



