### PR TITLE
ULTRA l1c do not reject events due to scattering. 

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -277,6 +277,11 @@ def test_get_de_rejection_mask():
         counted, np.array([False, True, True, True, True, False, True, True, False])
     )
 
+    counts_no_scattering = get_de_rejection_mask(
+        quality_scattering, quality_outliers, reject_scattering=False
+    )
+    np.testing.assert_array_equal(counts_no_scattering, quality_outliers.astype(bool))
+
 
 def test_count_rejected_events_per_spin():
     """Tests count_rejected_events_per_spin function."""

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -555,7 +555,9 @@ def flag_scattering(
 
 
 def get_de_rejection_mask(
-    quality_scattering: NDArray, quality_outliers: NDArray
+    quality_scattering: NDArray,
+    quality_outliers: NDArray,
+    reject_scattering: bool = True,
 ) -> NDArray:
     """
     Create boolean mask where event is rejected due to relevant flags.
@@ -566,6 +568,8 @@ def get_de_rejection_mask(
         Quality scattering flags.
     quality_outliers : NDArray
         Quality outliers flags.
+    reject_scattering : bool
+        Whether to reject based on scattering flags.
 
     Returns
     -------
@@ -579,11 +583,13 @@ def get_de_rejection_mask(
     outliers_mask = sum(
         flag.value for flag in DE_QUALITY_FLAG_FILTERS["quality_outliers"]
     )
-
-    # Boolean mask where event is rejected due to relevant flags
-    rejected = ((quality_scattering & scattering_mask) != 0) | (
-        (quality_outliers & outliers_mask) != 0
-    )
+    if reject_scattering:
+        # Boolean mask where event is rejected due to relevant flags
+        rejected = ((quality_scattering & scattering_mask) != 0) | (
+            (quality_outliers & outliers_mask) != 0
+        )
+    else:
+        rejected = (quality_outliers & outliers_mask) != 0
 
     return rejected
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -70,6 +70,9 @@ def calculate_helio_pset(
     dataset : xarray.Dataset
         Dataset containing the data.
     """
+    # Do not cull events based on scattering thresholds
+    reject_scattering = False
+
     sensor_id = int(parse_filename_like(name)["sensor"][0:2])
     pset_dict: dict[str, np.ndarray] = {}
     # Select only the species we are interested in.
@@ -83,6 +86,7 @@ def calculate_helio_pset(
     rejected = get_de_rejection_mask(
         species_dataset["quality_scattering"].values,
         species_dataset["quality_outliers"].values,
+        reject_scattering,
     )
     species_dataset = species_dataset.isel(epoch=~rejected)
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -69,6 +69,9 @@ def calculate_spacecraft_pset(
     dataset : xarray.Dataset
         Dataset containing the data.
     """
+    # Do not cull events based on scattering thresholds
+    reject_scattering = False
+
     pset_dict: dict[str, np.ndarray] = {}
 
     sensor_id = int(parse_filename_like(name)["sensor"][0:2])
@@ -84,6 +87,7 @@ def calculate_spacecraft_pset(
     rejected = get_de_rejection_mask(
         species_dataset["quality_scattering"].values,
         species_dataset["quality_outliers"].values,
+        reject_scattering,
     )
     species_dataset = species_dataset.isel(epoch=~rejected)
 


### PR DESCRIPTION
# Change Summary

## Overview
Ultra l1c should not have been rejecting due to scattering anyway because the ancillary file scattering thresholds are all inf but I realized that some might be getting rejected still if the FWHM values were nans. This explicitly make sure we do not reject events based on those flags. 


## Updated Files
- imap_processing/ultra/l1b/ultra_l1b_culling.py
   - add bool to not reject based on scattering 
- imap_processing/ultra/l1c/helio_pset.py, imap_processing/ultra/l1c/spacecraft_pset.py
   - descipriton of change 1 in file 2

