### PR TITLE
Logger formatting

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -84,13 +84,6 @@ from imap_processing.ultra.l1b import ultra_l1b
 from imap_processing.ultra.l1c import ultra_l1c
 from imap_processing.ultra.l2 import ultra_l2
 
-# Set the basic logging configuration for all users
-# of the CLI tool.
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s:%(name)s:%(message)s",
-    level=logging.INFO,
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
 logger = logging.getLogger(__name__)
 
 
@@ -204,15 +197,7 @@ def _parse_args() -> argparse.Namespace:
         action="store_const",
         dest="loglevel",
         const=logging.DEBUG,
-        default=logging.WARNING,
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        help="Add verbose output",
-        action="store_const",
-        dest="loglevel",
-        const=logging.INFO,
+        default=logging.INFO,
     )
     parser.add_argument("--instrument", type=str, required=True, help=instrument_help)
     parser.add_argument("--data-level", type=str, required=True, help=level_help)
@@ -265,6 +250,14 @@ def _parse_args() -> argparse.Namespace:
         help="Upload completed output files to the IMAP SDC.",
     )
     args = parser.parse_args()
+
+    # Set the basic logging configuration for all users
+    # of the CLI tool.
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s:%(name)s:%(message)s",
+        level=args.loglevel,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
     # If the dependency argument was passed in as a json file, read it into a string
     if args.dependency.endswith(".json"):

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -84,6 +84,13 @@ from imap_processing.ultra.l1b import ultra_l1b
 from imap_processing.ultra.l1c import ultra_l1c
 from imap_processing.ultra.l2 import ultra_l2
 
+# Set the basic logging configuration for all users
+# of the CLI tool.
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s:%(name)s:%(message)s",
+    level=logging.INFO,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 logger = logging.getLogger(__name__)
 
 

--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -29,7 +29,6 @@ from imap_processing.codice.utils import CODICEAPID, CoDICECompression
 from imap_processing.spice.time import met_to_ttj2000ns
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class CoDICEL1aPipeline:

--- a/imap_processing/codice/codice_l1b.py
+++ b/imap_processing/codice/codice_l1b.py
@@ -20,7 +20,6 @@ from imap_processing.cdf.utils import load_cdf
 from imap_processing.codice import constants
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def convert_to_rates(dataset: xr.Dataset, descriptor: str) -> np.ndarray:

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -41,7 +41,6 @@ from imap_processing.codice.constants import (
 from imap_processing.codice.utils import apply_replacements_to_attrs
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def get_geometric_factor_lut(dependencies: ProcessingInputCollection) -> dict:

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -24,7 +24,6 @@ from imap_processing.spice.time import met_to_ttj2000ns
 from imap_processing.utils import convert_to_binary_string
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 HistPacking = namedtuple(
     "HistPacking",

--- a/imap_processing/lo/l0/lo_star_sensor.py
+++ b/imap_processing/lo/l0/lo_star_sensor.py
@@ -11,7 +11,6 @@ from imap_processing.lo.l0.utils.bit_decompression import (
 )
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def process_star_sensor(ds: xr.Dataset) -> xr.Dataset:

--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -19,7 +19,6 @@ from imap_processing.lo.l0.lo_star_sensor import process_star_sensor
 from imap_processing.utils import packet_file_to_datasets
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def lo_l1a(dependency: Path) -> list[xr.Dataset]:

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -27,7 +27,6 @@ from imap_processing.spice.spin import get_spin_number
 from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_et
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def lo_l1b(sci_dependencies: dict, anc_dependencies: list) -> list[Path]:

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -24,7 +24,6 @@ from imap_processing.tests.codice.conftest import (
 )
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 pytestmark = pytest.mark.external_test_data
 
 

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -34,7 +34,6 @@ from imap_processing.ultra.l0.ultra_utils import (
 )
 from imap_processing.utils import convert_to_binary_string
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -24,7 +24,6 @@ from imap_processing.ultra.l1b.lookup_utils import (
 from imap_processing.ultra.l1b.quality_flag_filters import DE_QUALITY_FLAG_FILTERS
 from imap_processing.ultra.l1c.l1c_lookup_utils import build_energy_bins
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 SPIN_DURATION = 15  # Default spin duration in seconds.


### PR DESCRIPTION
# Change Summary

## Overview

It is useful to see the timestamps of when the log message was written. Right now we have to get this from the cloudwatch logs themselves, but we can also print them out in our normal console output so that they will show up in the version on the website as well.

Right now this looks like:
```
2025-11-19 21:20:10 - INFO:imap_processing.lo.l1a.lo_l1a:
Decommutating packets and converting to dataset
2025-11-19 21:20:10 - INFO:space_packet_parser.generators.utils:Creating packet generator from a filelike object, <_io.BufferedReader name='/Users/grlu5547/code/imap/imap_processing/data/imap/lo/l0/2025/11/imap_lo_l0_raw_20251104-repoint00038_v001.pkts'>. Total length is 37795158 bytes
2025-11-19 21:20:48 - WARNING:imap_processing.utils:Found [4] duplicate packets for APID 676. Dropping duplicate packets and continuing processing.
2025-11-19 21:20:49 - WARNING:imap_processing.utils:Found [14231] duplicate packets for APID 677. Dropping duplicate packets and continuing processing.
```

I'm happy to update the formatting if someone else has preferences/ideas for better versions of this too.