### PR TITLE
MNT: Suppress log messages and filter SPP warnings during tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,9 @@ jobs:
             # Download external data before we run our tests so that
             # we don't try to download them in parallel
             poetry run python imap_processing/tests/conftest.py
-            poetry run pytest -vvv -n auto --color=yes --cov --cov-report=xml
+            poetry run pytest -vvv -n auto --color=yes --cov --cov-report=xml --log-disable=root
           else
-            poetry run pytest -vvv -n auto --color=yes --cov --cov-report=xml -m "not external_kernel and not external_test_data"
+            poetry run pytest -vvv -n auto --color=yes --cov --cov-report=xml  --log-disable=root -m "not external_kernel and not external_test_data"
           fi
 
       - name: Upload coverage reports to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ filterwarnings = [
     "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:cdflib",
     # Ignore Data_version warnings during tests because we default to v001
     "ignore:No Data_version attribute found:UserWarning:imap_processing",
+    # Some test packet data is of the incorrect length and causes many warnings
+    # that can be ignored for testing purposes
+    "ignore:Number of bits:UserWarning:space_packet_parser",
 ]
 markers = [
     "external_kernel: marks tests as requiring external SPICE kernels (deselect with '-m \"not external_kernel\"')",


### PR DESCRIPTION
Quality of life improvement here. If you go to even a succeeding test, we get flooded with logs and warnings. I think it would be helpful to filter these out. For example, in this succeeding test there are many of these Number of bits warnings that we just ignore anyways, so we might as well filter them.
https://github.com/IMAP-Science-Operations-Center/imap_processing/actions/runs/19574991215/job/56057805699?pr=2452#step:7:2395

There are many CDF schema logger.warnings filling the tests that are not relevant. We can use the command line option to filter these warnings.

There are also space packet parser warnings that are emitted for many of our packets that are the wrong size, but that is all we have so we can ignore them during tests.