### PR TITLE
ENH: Add Lo L1b badtimes data product

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -1051,10 +1051,15 @@ def create_badtimes_dataset() -> xr.Dataset:
             data=np.array([], dtype=np.uint8), dims=["epoch"]
         )
 
-        for i in range(1, 8):
-            empty_ds[f"E-Step{i}"] = xr.DataArray(
-                data=np.array([], dtype=np.uint8), dims=["epoch"]
-            )
+        empty_ds["esa_step"] = xr.DataArray(
+            data=np.arange(1, 8, dtype=np.uint8),
+            name="esa_step",
+            dims=["esa_step"],
+        )
+        empty_ds["badtime_flag"] = xr.DataArray(
+            data=np.empty((0, len(empty_ds["esa_step"])), dtype=np.uint8),
+            dims=["epoch", "esa_step"],
+        )
 
         empty_ds["Comment"] = xr.DataArray(
             data=np.array([], dtype=object), dims=["epoch"]
@@ -1096,11 +1101,17 @@ def create_badtimes_dataset() -> xr.Dataset:
         data=np.full(len(thruster_ds["epoch"]), 59, dtype=np.uint8),
         dims=["epoch"],
     )
-    for i in range(1, 8):
-        thruster_ds[f"E-Step{i}"] = xr.DataArray(
-            data=np.ones(len(thruster_ds["epoch"]), dtype=np.uint8),
-            dims=["epoch"],
-        )
+    thruster_ds["esa_step"] = xr.DataArray(
+        data=np.arange(1, 8, dtype=np.uint8),
+        name="esa_step",
+        dims=["esa_step"],
+    )
+    thruster_ds["badtime_flag"] = xr.DataArray(
+        data=np.ones(
+            (len(thruster_ds["epoch"]), len(thruster_ds["esa_step"])), dtype=np.uint8
+        ),
+        dims=["epoch", "esa_step"],
+    )
     thruster_ds["Comment"] = xr.DataArray(
         data=np.full(len(thruster_ds["epoch"]), "Thruster Firing", dtype=object),
         dims=["epoch"],

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -23,7 +23,7 @@ from imap_processing.spice.geometry import (
     instrument_pointing,
 )
 from imap_processing.spice.repoint import get_pointing_times
-from imap_processing.spice.spin import get_spin_number
+from imap_processing.spice.spin import get_spin_data, get_spin_number
 from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_et
 
 logger = logging.getLogger(__name__)
@@ -53,6 +53,15 @@ def lo_l1b(sci_dependencies: dict, anc_dependencies: list) -> list[Path]:
     attr_mgr_l1a = ImapCdfAttributes()
     attr_mgr_l1a.add_instrument_variable_attrs(instrument="lo", level="l1a")
     logger.info(f"\n Dependencies: {list(sci_dependencies.keys())}\n")
+
+    datasets_to_return = []
+
+    badtimes_ds = create_badtimes_dataset()
+    if badtimes_ds.data_vars:
+        # If it was an empty dataset, then we don't want to
+        badtimes_ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_badtimes")
+        datasets_to_return.append(badtimes_ds)
+
     # if the dependencies are used to create Annotated Direct Events
     if "imap_lo_l1a_de" in sci_dependencies and "imap_lo_l1a_spin" in sci_dependencies:
         logger.info("\nProcessing IMAP-Lo L1B Direct Events...")
@@ -106,8 +115,9 @@ def lo_l1b(sci_dependencies: dict, anc_dependencies: list) -> list[Path]:
         l1b_de = set_pointing_bin(l1b_de)
         # set the badtimes
         l1b_de = set_bad_times(l1b_de, anc_dependencies)
+        datasets_to_return.append(l1b_de)
 
-    return [l1b_de]
+    return datasets_to_return
 
 
 def initialize_l1b_de(
@@ -1003,3 +1013,98 @@ def create_datasets(
             )
 
     return dataset
+
+
+def create_badtimes_dataset() -> xr.Dataset:
+    """
+    Create a badtimes dataset using the spin products.
+
+    Returns
+    -------
+    dataset : xarray.Dataset
+        Dataset with all badtimes data product fields in xr.DataArray.
+    """
+    logger.info("Creating badtimes dataset")
+    try:
+        spin_df = get_spin_data()
+    except ValueError:
+        logger.warning("No spin data found. Skipping badtimes dataset creation.")
+        # Return an empty dataset with the expected badtimes fields (zero-length)
+        empty_epoch = xr.DataArray(
+            data=np.array([], dtype=np.int64), name="epoch", dims=["epoch"]
+        )
+        empty_ds = xr.Dataset(coords={"epoch": empty_epoch})
+
+        empty_ds["yyyymmdd"] = xr.DataArray(
+            data=np.array([], dtype=np.int32), dims=["epoch"]
+        )
+        empty_ds["BadTime_start"] = xr.DataArray(
+            data=np.array([], dtype=np.int64), dims=["epoch"]
+        )
+        empty_ds["BadTime_end"] = xr.DataArray(
+            data=np.array([], dtype=np.int64), dims=["epoch"]
+        )
+        empty_ds["bin_start"] = xr.DataArray(
+            data=np.array([], dtype=np.uint8), dims=["epoch"]
+        )
+        empty_ds["bin_end"] = xr.DataArray(
+            data=np.array([], dtype=np.uint8), dims=["epoch"]
+        )
+
+        for i in range(1, 8):
+            empty_ds[f"E-Step{i}"] = xr.DataArray(
+                data=np.array([], dtype=np.uint8), dims=["epoch"]
+            )
+
+        empty_ds["Comment"] = xr.DataArray(
+            data=np.array([], dtype=object), dims=["epoch"]
+        )
+
+        return empty_ds
+
+    # All spins with thruster firings are bad times
+    thruster_data = spin_df[spin_df["thruster_firing"]]
+    logger.info("Number of thruster firings found: %d", len(thruster_data))
+    thruster_ds = xr.Dataset(
+        coords={
+            "epoch": xr.DataArray(
+                data=met_to_ttj2000ns(thruster_data["spin_start_met"]),
+                name="epoch",
+                dims=["epoch"],
+            )
+        },
+    )
+    thruster_ds["yyyymmdd"] = xr.DataArray(
+        data=thruster_data["spin_start_utc"]
+        .str.replace("-", "")
+        .str.slice(0, 8)
+        .values.astype(int),
+        dims=["epoch"],
+    )
+    thruster_ds["BadTime_start"] = xr.DataArray(
+        data=thruster_data["spin_start_sec_sclk"].values,
+        dims=["epoch"],
+    )
+    thruster_ds["BadTime_end"] = thruster_ds["BadTime_start"] + thruster_data[
+        "spin_period_sec"
+    ].values.astype(int)
+    thruster_ds["bin_start"] = xr.DataArray(
+        data=np.zeros(len(thruster_ds["epoch"]), dtype=np.uint8),
+        dims=["epoch"],
+    )
+    thruster_ds["bin_end"] = xr.DataArray(
+        data=np.full(len(thruster_ds["epoch"]), 59, dtype=np.uint8),
+        dims=["epoch"],
+    )
+    for i in range(1, 8):
+        thruster_ds[f"E-Step{i}"] = xr.DataArray(
+            data=np.ones(len(thruster_ds["epoch"]), dtype=np.uint8),
+            dims=["epoch"],
+        )
+    thruster_ds["Comment"] = xr.DataArray(
+        data=np.full(len(thruster_ds["epoch"]), "Thruster Firing", dtype=object),
+        dims=["epoch"],
+    )
+
+    # TODO: Merge with other datasets if/when those are created
+    return thruster_ds

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -702,3 +702,4 @@ def test_badtimes_with_spin(spice_test_data_path, use_test_spin_data_csv):
     np.testing.assert_array_equal(
         badtimes_ds["BadTime_start"], thruster_df["spin_start_sec_sclk"]
     )
+    np.testing.assert_array_equal(badtimes_ds["badtime_flag"], 1)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -12,6 +12,7 @@ from imap_processing.lo.l1b.lo_l1b import (
     calculate_tof1_for_golden_triples,
     convert_start_end_acq_times,
     convert_tofs_to_eu,
+    create_badtimes_dataset,
     create_datasets,
     get_avg_spin_durations_per_cycle,
     get_spin_start_times,
@@ -30,6 +31,7 @@ from imap_processing.lo.l1b.lo_l1b import (
     set_spin_cycle,
 )
 from imap_processing.lo.lo_ancillary import read_ancillary_file
+from imap_processing.spice.spin import get_spin_data
 from imap_processing.spice.time import met_to_ttj2000ns
 
 
@@ -117,10 +119,10 @@ def test_lo_l1b(
     expected_logical_source = "imap_lo_l1b_de"
 
     # Act
-    output_file = lo_l1b(data, anc_dependencies)
+    output_files = lo_l1b(data, anc_dependencies)
 
     # Assert
-    assert expected_logical_source == output_file[0].attrs["Logical_source"]
+    assert expected_logical_source == output_files[-1].attrs["Logical_source"]
 
 
 # @pytest.mark.external_kernel
@@ -670,3 +672,33 @@ def test_pointing_bins(mock_cartesian_to_latitudinal, mock_frame_transform):
     # Assert
     np.testing.assert_array_equal(l1b_de["off_angle_bin"], expected_pointing_lats)
     np.testing.assert_array_equal(l1b_de["spin_bin"], expected_pointing_lons)
+
+
+def test_badtimes_no_spin():
+    """An empty dataset should still be returned when no spin data is found."""
+    badtimes_ds = create_badtimes_dataset()
+
+    assert len(badtimes_ds["epoch"]) == 0
+    # We should have put empty variables into the dataset
+    assert "BadTime_start" in badtimes_ds.data_vars
+
+
+def test_badtimes_with_spin(spice_test_data_path, use_test_spin_data_csv):
+    """Verify some actual badtimes are created from thruster firings."""
+    # Initialize the spin data
+    fake_spin_path = spice_test_data_path / "fake_spin_data.csv"
+    use_test_spin_data_csv([fake_spin_path])
+
+    badtimes_ds = create_badtimes_dataset()
+    spin_df = get_spin_data()
+
+    thruster_df = spin_df[spin_df["thruster_firing"]]
+    n_thruster_firings = len(thruster_df)
+    # We should have some thruster firings
+    assert n_thruster_firings > 0
+
+    # Check the thruster firings we created match those in the spin data
+    assert len(badtimes_ds["epoch"]) == n_thruster_firings
+    np.testing.assert_array_equal(
+        badtimes_ds["BadTime_start"], thruster_df["spin_start_sec_sclk"]
+    )


### PR DESCRIPTION
# Change Summary

## Overview

This adds the Lo L1b badtimes data product as output during L1b processing. This is the start of the product, removing any times with thruster firings. It is formatted as a data product like our normal science products, so we will make one of these files for each l1b science product now, it is not an ever growing list of times like the ancillary products.

Future work:
* Make use of this in processing? For now it is considered a diagnostic product and we are going to use it as output only. A separate ticket would be to incorporate this into the processing pipeline.
* Incorporate other badtime algorithms.

closes #1873