### PR TITLE
MNT: Change Lo logging in loop from info to debug

### DIFF
--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -240,7 +240,7 @@ def parse_events(dataset: xr.Dataset, attr_mgr: ImapCdfAttributes) -> xr.Dataset
     pointing_de = 0
 
     for pkt_idx, de_count in enumerate(de_count_values):
-        logger.info(
+        logger.debug(
             f"Parsing packet {pkt_idx} of {len(de_count_values)} "
             f"with {de_count} direct events"
         )


### PR DESCRIPTION
There are a lot of packets, so this adds a lot of logs to the command line. We can add the log statements for debugging purposes, but don't need them all the time.

Noticed this while running `imap_cli` locally and it added a lot of extra prints. @sdhoyt are you OK with switching to debug if we need it?