### PR TITLE
ULTRA l1b coinph valid and backtof valid flags

### DIFF
--- a/imap_processing/quality_flags.py
+++ b/imap_processing/quality_flags.py
@@ -46,6 +46,7 @@ class ImapDEOutliersUltraFlags(FlagNameMixin):
     COINPH = 2**2  # bit 2 # Event validity
     INVALID_ENERGY = 2**3  # bit 3
     DURINGREPOINT = 2**4  # bit 4 # event during a repointing
+    BACKTOF = 2**5  # bit 5 # Back TOF outlier
 
 
 class ImapHkUltraFlags(FlagNameMixin):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -735,13 +735,14 @@ def test_is_back_tof_valid(test_fixture, ancillary_files):
     df_ph = df_filt[np.isin(df_filt["StopType"], [StopType.PH.value])]
 
     # Get the ph inds
-    ph_indices = np.nonzero(
-        np.isin(de_dataset["stop_type"], [StopType.Top.value, StopType.Bottom.value])
-    )[0]
-    quality_flags = np.zeros(len(ph_indices), dtype=np.uint16)
-    valid = is_back_tof_valid(
-        de_dataset.isel(epoch=ph_indices),
-        df_filt.Xf.astype("float").values[ph_indices],
+    ph_mask = (
+        (de_dataset["stop_type"] == StopType.Top.value)
+        | (de_dataset["stop_type"] == StopType.Bottom.value)
+    ).values
+    quality_flags = np.zeros(len(np.nonzero(ph_mask)[0]), dtype=np.uint16)
+    valid, quality_flags = is_back_tof_valid(
+        de_dataset.isel(epoch=np.nonzero(ph_mask)[0]),
+        df_filt.Xf.astype("float").values[ph_mask],
         "ultra45",
         ancillary_files,
         quality_flags,
@@ -750,6 +751,7 @@ def test_is_back_tof_valid(test_fixture, ancillary_files):
     back_tof_valid_bool = df_ph["BackTOFValid"].astype(int).astype(bool).values
 
     np.testing.assert_equal(back_tof_valid_bool, valid)
+    assert np.any(quality_flags)
 
 
 @pytest.mark.external_test_data
@@ -771,7 +773,7 @@ def test_is_coin_ph_valid(test_fixture, ancillary_files):
         len(ctof), ImapDEOutliersUltraFlags.NONE.value, dtype=np.uint16
     )
 
-    combined_mask = is_coin_ph_valid(
+    combined_mask, quality_flags = is_coin_ph_valid(
         etof,
         xc,
         xb,

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -734,12 +734,19 @@ def test_is_back_tof_valid(test_fixture, ancillary_files):
     df_filt, _, _, de_dataset = test_fixture
     df_ph = df_filt[np.isin(df_filt["StopType"], [StopType.PH.value])]
 
+    # Get the ph inds
+    ph_indices = np.nonzero(
+        np.isin(de_dataset["stop_type"], [StopType.Top.value, StopType.Bottom.value])
+    )[0]
+    quality_flags = np.zeros(len(ph_indices), dtype=np.uint16)
     valid = is_back_tof_valid(
-        de_dataset,
-        df_filt.Xf.astype("float").values,
+        de_dataset.isel(epoch=ph_indices),
+        df_filt.Xf.astype("float").values[ph_indices],
         "ultra45",
         ancillary_files,
+        quality_flags,
     )
+
     back_tof_valid_bool = df_ph["BackTOFValid"].astype(int).astype(bool).values
 
     np.testing.assert_equal(back_tof_valid_bool, valid)

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -209,12 +209,16 @@ def calculate_de(
         f"ultra{sensor}",
         ancillary_files,
     )
+    backtofvalid_quality_flags = np.zeros(len(ph_indices), dtype=quality_flags.dtype)
     backtofvalid = is_back_tof_valid(
-        de_dataset,
-        xf,
+        de_dataset.isel(epoch=ph_indices),
+        xf[ph_indices],
         f"ultra{sensor}",
         ancillary_files,
+        backtofvalid_quality_flags,
     )
+
+    coinphvalid_quality_flags = np.zeros(len(ph_indices), dtype=quality_flags.dtype)
     coinphvalid = is_coin_ph_valid(
         etof[ph_indices],
         xc[ph_indices],
@@ -225,8 +229,11 @@ def calculate_de(
         de_dataset["stop_west_tdc"][ph_indices].values,
         f"ultra{sensor}",
         ancillary_files,
-        quality_flags[ph_indices],
+        coinphvalid_quality_flags,
     )
+    quality_flags[ph_indices] |= coinphvalid_quality_flags
+    quality_flags[ph_indices] |= backtofvalid_quality_flags
+
     e_bin[ph_indices] = determine_ebin_pulse_height(
         energy[ph_indices],
         tof[ph_indices],

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -210,7 +210,7 @@ def calculate_de(
         ancillary_files,
     )
     backtofvalid_quality_flags = np.zeros(len(ph_indices), dtype=quality_flags.dtype)
-    backtofvalid = is_back_tof_valid(
+    backtofvalid, backtofvalid_quality_flags = is_back_tof_valid(
         de_dataset.isel(epoch=ph_indices),
         xf[ph_indices],
         f"ultra{sensor}",
@@ -219,7 +219,7 @@ def calculate_de(
     )
 
     coinphvalid_quality_flags = np.zeros(len(ph_indices), dtype=quality_flags.dtype)
-    coinphvalid = is_coin_ph_valid(
+    coinphvalid, coinphvalid_quality_flags = is_coin_ph_valid(
         etof[ph_indices],
         xc[ph_indices],
         xb[ph_indices],

--- a/imap_processing/ultra/l1b/quality_flag_filters.py
+++ b/imap_processing/ultra/l1b/quality_flag_filters.py
@@ -19,6 +19,8 @@ DE_QUALITY_FLAG_FILTERS: dict[str, list[FlagNameMixin]] = {
     "quality_outliers": [
         ImapDEOutliersUltraFlags.FOV,
         ImapDEOutliersUltraFlags.DURINGREPOINT,
+        ImapDEOutliersUltraFlags.COINPH,
+        ImapDEOutliersUltraFlags.BACKTOF,
     ],
     "quality_scattering": [
         ImapDEScatteringUltraFlags.ABOVE_THRESHOLD,

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -1343,7 +1343,7 @@ def is_back_tof_valid(
     sensor: str,
     ancillary_files: dict,
     quality_flags: NDArray,
-) -> NDArray:
+) -> tuple[NDArray, NDArray]:
     """
     Determine whether back TOF is valid based on stop type.
 
@@ -1365,6 +1365,8 @@ def is_back_tof_valid(
     -------
     valid_mask : NDArray
         Boolean array indicating whether back TOF is valid.
+    quality_flags : NDArray
+        Updated quality flags.
 
     Notes
     -----
@@ -1390,7 +1392,7 @@ def is_back_tof_valid(
         diff[bottom_mask] <= diff_bt_max
     )
     quality_flags[~valid] |= ImapDEOutliersUltraFlags.BACKTOF.value
-    return valid
+    return valid, quality_flags
 
 
 def is_coin_ph_valid(
@@ -1404,7 +1406,7 @@ def is_coin_ph_valid(
     sensor: str,
     ancillary_files: dict,
     quality_flags: NDArray,
-) -> NDArray:
+) -> tuple[NDArray, NDArray]:
     """
     Determine event validity.
 
@@ -1436,6 +1438,8 @@ def is_coin_ph_valid(
     -------
     combined_mask : NDArray
         Boolean array indicating whether back TOF is valid.
+    quality_flags : NDArray
+        Updated quality flags.
 
     Notes
     -----
@@ -1484,4 +1488,4 @@ def is_coin_ph_valid(
 
     quality_flags[~combined_mask] |= ImapDEOutliersUltraFlags.COINPH.value
 
-    return combined_mask
+    return combined_mask, quality_flags

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -1342,6 +1342,7 @@ def is_back_tof_valid(
     xf: NDArray,
     sensor: str,
     ancillary_files: dict,
+    quality_flags: NDArray,
 ) -> NDArray:
     """
     Determine whether back TOF is valid based on stop type.
@@ -1357,6 +1358,8 @@ def is_back_tof_valid(
         Sensor name: "ultra45" or "ultra90".
     ancillary_files : dict
         Ancillary files for lookup.
+    quality_flags : NDArray
+        Quality flag to set when there is an outlier.
 
     Returns
     -------
@@ -1372,15 +1375,10 @@ def is_back_tof_valid(
     )
     diff = tofy - tofx
 
-    indices = np.nonzero(
-        np.isin(de_dataset["stop_type"], [StopType.Top.value, StopType.Bottom.value])
-    )[0]
-    de_ph = de_dataset.isel(epoch=indices)
+    top_mask = de_dataset["stop_type"] == StopType.Top.value
+    bottom_mask = de_dataset["stop_type"] == StopType.Bottom.value
 
-    top_mask = de_ph["stop_type"] == StopType.Top.value
-    bottom_mask = de_ph["stop_type"] == StopType.Bottom.value
-
-    valid = np.zeros_like(diff, dtype=bool)
+    valid = np.zeros(len(top_mask), dtype=bool)
 
     diff_tp_min = get_image_params("TOFDiffTpMin", sensor, ancillary_files)
     diff_tp_max = get_image_params("TOFDiffTpMax", sensor, ancillary_files)
@@ -1391,7 +1389,7 @@ def is_back_tof_valid(
     valid[bottom_mask] = (diff[bottom_mask] >= diff_bt_min) & (
         diff[bottom_mask] <= diff_bt_max
     )
-
+    quality_flags[~valid] |= ImapDEOutliersUltraFlags.BACKTOF.value
     return valid
 
 


### PR DESCRIPTION
# Change Summary

## Overview
Add a quality flag for BACKTOF and make sure to cull events with that flag and COINPH in l1c.

## Updated Files
- imap_processing/ultra/l1b/de.py
   - Make sure to flag both coinphvalid and backtof valid events
- imap_processing/ultra/l1b/quality_flag_filters.py
   - Add quality outlier flags to rejection mask used at l1c
- fix backtof flags to follow pattern and not use numpy fancy indexing!! 
  - imap_processing/ultra/l1b/ultra_l1b_extended.py

## Testing
Fix test
