### PR TITLE
ENH: Add codice housekeeping l1a and l1b processing

### DIFF
--- a/imap_processing/codice/codice_l1a.py
+++ b/imap_processing/codice/codice_l1a.py
@@ -6,6 +6,7 @@ import xarray as xr
 from imap_data_access import ProcessingInputCollection
 
 from imap_processing import imap_module_directory
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.codice.codice_l1a_de import l1a_direct_event
 from imap_processing.codice.codice_l1a_hi_counters_aggregated import (
     l1a_hi_counters_aggregated,
@@ -116,5 +117,25 @@ def process_l1a(  # noqa: PLR0912
         elif apid == CODICEAPID.COD_LO_INST_COUNTS_SINGLES:
             logger.info("Processing Lo Counters singles")
             datasets.append(l1a_lo_counters_singles(datasets_by_apid[apid], lut_file))
+        elif apid == CODICEAPID.COD_NHK:
+            logger.info("Processing l1a housekeeping data")
+            cdf_attrs = ImapCdfAttributes()
+            cdf_attrs.add_instrument_global_attrs("codice")
+            l1a_ds = datasets_by_apid[apid]
+            l1a_ds.attrs.update(cdf_attrs.get_global_attributes("imap_codice_l1a_hskp"))
+            datasets.append(l1a_ds)
+
+            # l1b processing need to re-run packet file to datasets to do the
+            # housekeeping engineering unit conversions based on the packet definitions
+            # We only do this if there are any housekeeping packets that need it so we
+            # don't process unnecessarily here.
+            logger.info("Processing l1b housekeeping data")
+            l1b_ds = packet_file_to_datasets(
+                science_file,
+                xtce_file,
+                use_derived_value=True,
+            )[apid]
+            l1b_ds.attrs.update(cdf_attrs.get_global_attributes("imap_codice_l1b_hskp"))
+            datasets.append(l1b_ds)
 
     return datasets

--- a/imap_processing/tests/codice/conftest.py
+++ b/imap_processing/tests/codice/conftest.py
@@ -163,6 +163,15 @@ def codice_lut_path():
                 / "l1a_input"
                 / "imap_codice_l0_lo-counters-aggregated_20250814_v001.pkts"
             ]
+        elif descriptor == "hskp" and data_type == "l0":
+            return [
+                imap_module_directory
+                / "tests"
+                / "codice"
+                / "data"
+                / "l1a_input"
+                / "imap_codice_hskp_20250814_v001.pkts"
+            ]
         if descriptor == "lo-nsw-species" and data_type == "l1b":
             return [
                 imap_module_directory

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -27,24 +27,24 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.external_test_data
 
 
-@pytest.mark.skip(reason="test_hskp - KeyError: 'optics_hv_cmd_err_cnt'")
-def test_hskp():
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_hskp(mock_get_file_paths, codice_lut_path):
     """Tests the housekeeping."""
-    test_file_path = (
-        imap_module_directory
-        / "tests/codice/data/l1a_input"
-        / "imap_codice_hskp_20250814_v001.pkts"
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="hskp", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+    processed_datasets = process_l1a(dependency=ProcessingInputCollection())
+
+    assert len(processed_datasets) == 2
+    processed_l1a = processed_datasets[0]
+    processed_l1b = processed_datasets[1]
+
+    # spot check the l1a value is an integer and the l1b is a float after conversion
+    np.testing.assert_almost_equal(processed_l1a["fee_ssd_eb_temp_1_t"].values[0], 2199)
+    np.testing.assert_almost_equal(
+        processed_l1b["fee_ssd_eb_temp_1_t"].values[0], 18.71, decimal=2
     )
-
-    processed_data = process_l1a(file_path=test_file_path)[0]
-
-    # Instead of checking all variables, just check that time-related variables
-    # have the expected shape and that the processing completes
-    if "time" in processed_data:
-        assert len(processed_data.time.shape) == 1, "Time should be a 1D array"
-
-    cdf_file = write_cdf(processed_data)
-    assert cdf_file.name == f"imap_codice_l1a_hskp_{VALIDATION_FILE_DATE}_v999.cdf"
 
 
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -33,6 +33,7 @@ EXTERNAL_TEST_DATA = [
     ("imap_codice_l0_hi-sectored_20250814_v001.pkts", "codice/data/l1a_input/"),
     ("imap_codice_l0_hi-priority_20250814_v001.pkts", "codice/data/l1a_input/"),
     ("imap_codice_l0_hi-direct-events_20250814_v001.pkts", "codice/data/l1a_input/"),
+    ("imap_codice_hskp_20250814_v001.pkts", "codice/data/l1a_input/"),
 
     # L1A LUT
     ("imap_codice_l1a-sci-lut_20251007_v004.json", "codice/data/l1a_lut/"),


### PR DESCRIPTION
# Change Summary

Create housekeeping CDFs for l1a and l1b. Following other instruments, we aren't doing any metadata or extra work with housekeeping datasets, just turning the packets into l1a/l1b CDFs.

closes #2146
