### PR TITLE
ULTRA l1c scattering culling

### DIFF
--- a/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_l1c_lookup_utils.py
@@ -3,6 +3,8 @@ import numpy as np
 import pytest
 
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
+    build_energy_bins,
+    calculate_fwhm_spun_scattering,
     get_scattering_thresholds_for_energy,
     get_spacecraft_pointing_lookup_tables,
     get_static_deadtime_ratios,
@@ -111,3 +113,37 @@ def test_get_static_deadtime_ratios(ancillary_files):
     np.testing.assert_array_equal(dt_ratio.shape, (721,))
     # Test the values
     assert np.all((dt_ratio >= 0.0) & (dt_ratio <= 1.0))
+
+
+@pytest.mark.external_test_data
+def test_calculate_fwhm_spun_scattering(ancillary_files):
+    """Test calculate_fwhm_spun_scattering function."""
+    instrument_id = 90
+    (
+        for_indices_by_spin_phase,
+        theta_vals,
+        phi_vals,
+        ra_and_dec,
+        boundary_scale_factors,
+    ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
+
+    (
+        pixels_below_scattering,
+        scattering_theta,
+        scattering_phi,
+        scattering_thresholds,
+    ) = calculate_fwhm_spun_scattering(
+        for_indices_by_spin_phase,
+        theta_vals,
+        phi_vals,
+        ancillary_files,
+        instrument_id,
+        reject_scattering=True,
+    )
+    # Test shapes
+    npix, spin_phase_steps = for_indices_by_spin_phase.shape
+    energy_shape = len(build_energy_bins()[2])
+    assert len(pixels_below_scattering) == spin_phase_steps
+    np.testing.assert_array_equal(scattering_theta.shape, (energy_shape, npix))
+    np.testing.assert_array_equal(scattering_phi.shape, (energy_shape, npix))
+    np.testing.assert_array_equal(scattering_thresholds.shape, (energy_shape,))

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -115,6 +115,7 @@ def calculate_helio_pset(
             phi_vals,
             ancillary_files,
             instrument_id,
+            reject_scattering,
         )
     )
 

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -169,14 +169,12 @@ def calculate_fwhm_spun_scattering(
 
         for energy_idx in range(len(energy_bin_geometric_means)):
             if reject_scattering:
-                # If reject_scattering is True, only keep pixels below the scattering
-                # threshold
-                scattering_valid_pixels = scattering_mask[:, energy_idx]
-                valid_pixels = for_pixel_indices[scattering_valid_pixels]
+                valid_pixels = scattering_mask[:, energy_idx]
+                pixels_below_scattering_for_energy.append(
+                    for_pixel_indices[valid_pixels]
+                )
             else:
-                valid_pixels = for_pixel_indices
-
-            pixels_below_scattering_for_energy.append(valid_pixels)
+                pixels_below_scattering_for_energy.append(for_pixel_indices)
 
         pixels_below_scattering.append(pixels_below_scattering_for_energy)
         # Accumulate FWHM values for averaging

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -72,6 +72,7 @@ def calculate_fwhm_spun_scattering(
     phi_vals: np.ndarray,
     ancillary_files: dict,
     instrument_id: int,
+    reject_scattering: bool = False,
 ) -> tuple[list, NDArray, NDArray, NDArray]:
     """
     Calculate FWHM scattering values for each pixel, energy bin, and spin phase step.
@@ -92,6 +93,8 @@ def calculate_fwhm_spun_scattering(
         Dictionary containing ancillary files.
     instrument_id : int,
         Instrument ID, either 45 or 90.
+    reject_scattering : bool, optional
+        If True, use scattering thresholds to cull pixels. Default is False.
 
     Returns
     -------
@@ -165,8 +168,15 @@ def calculate_fwhm_spun_scattering(
         pixels_below_scattering_for_energy = []
 
         for energy_idx in range(len(energy_bin_geometric_means)):
-            valid_pixels = scattering_mask[:, energy_idx]
-            pixels_below_scattering_for_energy.append(for_pixel_indices[valid_pixels])
+            if reject_scattering:
+                # If reject_scattering is True, only keep pixels below the scattering
+                # threshold
+                scattering_valid_pixels = scattering_mask[:, energy_idx]
+                valid_pixels = for_pixel_indices[scattering_valid_pixels]
+            else:
+                valid_pixels = for_pixel_indices
+
+            pixels_below_scattering_for_energy.append(valid_pixels)
 
         pixels_below_scattering.append(pixels_below_scattering_for_energy)
         # Accumulate FWHM values for averaging

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -165,16 +165,20 @@ def calculate_fwhm_spun_scattering(
         )
         # Extract pixel indices for each energy
         for_pixel_indices = np.where(for_inds)[0]
-        pixels_below_scattering_for_energy = []
 
-        for energy_idx in range(len(energy_bin_geometric_means)):
-            if reject_scattering:
+        if reject_scattering:
+            # Only include pixels below the scattering threshold
+            pixels_below_scattering_for_energy = []
+            for energy_idx in range(len(energy_bin_geometric_means)):
                 valid_pixels = scattering_mask[:, energy_idx]
                 pixels_below_scattering_for_energy.append(
                     for_pixel_indices[valid_pixels]
                 )
-            else:
-                pixels_below_scattering_for_energy.append(for_pixel_indices)
+        else:
+            # All energies get the same pixel list if not rejecting based on scattering
+            pixels_below_scattering_for_energy = [for_pixel_indices] * len(
+                energy_bin_geometric_means
+            )
 
         pixels_below_scattering.append(pixels_below_scattering_for_energy)
         # Accumulate FWHM values for averaging

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -117,6 +117,7 @@ def calculate_spacecraft_pset(
             phi_vals,
             ancillary_files,
             instrument_id,
+            reject_scattering,
         )
     )
     # Determine nside from the lookup table


### PR DESCRIPTION
# Change Summary

## Overview
In ultra l1c we need to explicitly NOT reject pixels based on the FWHM theta and phi values. The ancillary file that controls the FWHM thresholds are currently all set to np.inf so this should not be skipping any pixels but I discovered today that some were still being skipped because the fwhm values were invalid. 

## Updated Files
- imap_processing/ultra/l1c/l1c_lookup_utils.py
   - Do not skip pixels based off of their FWHM value

