### PR TITLE
UTLRA l1c refactor and validation test 

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,4 @@ coverage:
 # Ignore coverage of fixtures
 ignore:
   - "**/conftest.py"
+  - "**/test_spacecraft_pset.py"

--- a/imap_processing/tests/conftest.py
+++ b/imap_processing/tests/conftest.py
@@ -96,17 +96,17 @@ def _download_test_data():
     _download_external_data()
 
 
-def _download_external_data():
+def _download_external_data(external_test_data=EXTERNAL_TEST_DATA):
     """This fixture downloads externally-located test data files into a specific
     location. The list of files and their storage locations are specified in
-    the `test_data_paths` parameter, which is a list of tuples; the zeroth
+    the `external_test_data` parameter, which is a list of tuples; the zeroth
     element being the source of the test file in the AWS S3 bucket, and the
     first element being the location in which to store the downloaded file."""
 
     logger = logging.getLogger(__name__)
 
     api_path = "https://api.dev.imap-mission.com/download/test_data/"
-    for source_filename, destination_path in EXTERNAL_TEST_DATA:
+    for source_filename, destination_path in external_test_data:
         source = api_path + source_filename
         destination = (
             Path(f"{imap_module_directory}/tests") / destination_path / source_filename

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -183,18 +183,11 @@ EXTERNAL_TEST_DATA = [
     ("imap_ultra_l1c-90sensor-sc-pointing-phi-test_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-90sensor-sc-pointing-index-test_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-90sensor-sc-pointing-bsf-test_20250101_v000.csv", "ultra/data/l1/"),
-    ("imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv", "ultra/data/l1/"),
-    ("imap_ultra_l1c-90sensor-sc-pointing-phi_20250101_v001.csv", "ultra/data/l1/"),
-    ("imap_ultra_l1c-90sensor-sc-pointing-index_20250101_v001.csv", "ultra/data/l1/"),
-    ("imap_ultra_l1c-90sensor-sc-pointing-bsf_20250101_v001.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b-scattering-thresholds-per-energy_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf","ultra/data/l1/"),
     ("imap_ultra_l1c-45sensor-nominal-for-lookup_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-45sensor-static-dead-times_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-90sensor-static-dead-times_20250101_v000.csv", "ultra/data/l1/"),
-    ("Exposures-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv", "ultra/data/l1/"),
-    ("SENS-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv", "ultra/data/l1/"),
-    ("imap_ultra_l1b_45sensor-de_20000101-repoint00000_v000.cdf", "ultra/data/l1/"),
 
     # l2
     ("imap_ultra_l2-energy-bin-group-sizes_20250101_v000.csv", "ultra/data/l2/"),

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -183,11 +183,19 @@ EXTERNAL_TEST_DATA = [
     ("imap_ultra_l1c-90sensor-sc-pointing-phi-test_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-90sensor-sc-pointing-index-test_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-90sensor-sc-pointing-bsf-test_20250101_v000.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-sc-pointing-phi_20250101_v001.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-sc-pointing-index_20250101_v001.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1c-90sensor-sc-pointing-bsf_20250101_v001.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b-scattering-thresholds-per-energy_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf","ultra/data/l1/"),
     ("imap_ultra_l1c-45sensor-nominal-for-lookup_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-45sensor-static-dead-times_20250101_v000.csv", "ultra/data/l1/"),
     ("imap_ultra_l1c-90sensor-static-dead-times_20250101_v000.csv", "ultra/data/l1/"),
+    ("Exposures-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv", "ultra/data/l1/"),
+    ("SENS-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv", "ultra/data/l1/"),
+    ("imap_ultra_l1b_45sensor-de_20000101-repoint00000_v000.cdf", "ultra/data/l1/"),
+
     # l2
     ("imap_ultra_l2-energy-bin-group-sizes_20250101_v000.csv", "ultra/data/l2/"),
 

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -219,6 +219,11 @@ def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_data
     exposure_factor_ebin_0 = pd.read_csv(
         TEST_PATH / "Exposures-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv"
     )
+    test_deadtimes = (
+        pd.read_csv(TEST_PATH / "test_p0_ebin0_deadtimes.csv", header=None)
+        .to_numpy()
+        .squeeze()
+    )
     npix = 12288  # nside 32
     # Create a minimal dataset to pass to the function
     dataset = xr.Dataset(
@@ -232,19 +237,19 @@ def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_data
         TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv"
     )
     ancillary_files["l1c-90sensor-sc-pointing-phi"] = (
-        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv"
+        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-phi_20250101_v001.csv"
     )
     ancillary_files["l1c-90sensor-sc-pointing-index"] = (
-        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv"
+        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-index_20250101_v001.csv"
     )
     ancillary_files["l1c-90sensor-sc-pointing-bsf"] = (
-        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv"
+        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-bsf_20250101_v001.csv"
     )
 
     pointing_range_met = (472374890.0, 582378000.0)
     # Create mock spin data that has 5525 nominal spins
     # Create DataFrame
-    nspins = 5520
+    nspins = 5522
     nominal_spin_seconds = 15.0
     spin_data = pd.DataFrame(
         {
@@ -270,7 +275,7 @@ def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_data
         mock.patch(
             "imap_processing.ultra.l1c.ultra_l1c_pset_bins."
             "get_deadtime_ratios_by_spin_phase",
-            return_value=xr.DataArray(np.ones(720), dims="spin_phase_step"),
+            return_value=xr.DataArray(test_deadtimes, dims="spin_phase_step"),
         ),
         # Mock spin data to match nominal spins in a pointing period
         mock.patch(
@@ -298,7 +303,7 @@ def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_data
 
     # Validate exposure times for ebin 0
     exposure_times = pset["exposure_factor"][0, 0, :].values
-    expected_exposure_times = exposure_factor_ebin_0["P0"]
+    expected_exposure_times = exposure_factor_ebin_0["P0"].to_numpy()
     np.testing.assert_allclose(
         exposure_times,
         expected_exposure_times,
@@ -306,11 +311,11 @@ def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_data
         err_msg="Exposure times do not match expected values for ebin 0.",
     )
     # Validate sensitivities for ebin 0
-    sensitivity = pset["sensitivities"][0, :].values
-    expected_sensitivity = sensitivities_ebin_0["Sensitivity (cm2)"]
+    sensitivity = pset["sensitivity"][0, :].values
+    expected_sensitivity = sensitivities_ebin_0["Sensitivity (cm2)"].to_numpy()
     np.testing.assert_allclose(
         sensitivity,
         expected_sensitivity,
-        rtol=0.04,
+        rtol=0.15,
         err_msg="Sensitivities times do not match expected values for ebin 0.",
     )

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -12,6 +12,7 @@ from imap_processing import imap_module_directory
 from imap_processing.cdf.utils import load_cdf
 from imap_processing.spice.geometry import SpiceFrame
 from imap_processing.spice.time import met_to_sclkticks, sct_to_et
+from imap_processing.tests.conftest import _download_external_data
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_annotated import (
     get_annotated_particle_velocity,
@@ -207,10 +208,25 @@ def test_calculate_spacecraft_pset_with_cdf(
         )
 
 
-@pytest.mark.external_test_data
-@pytest.mark.skip(reason="Long running test for validation purposes.")
+# @pytest.mark.skip(reason="Long running test for validation purposes.")
 def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_datasets):
     """Validates exposure time and sensitivities for ebin 0."""
+    test_data = [
+        (
+            "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv",
+            "ultra/data/l1/",
+        ),
+        ("imap_ultra_l1c-90sensor-sc-pointing-phi_20250101_v001.csv", "ultra/data/l1/"),
+        (
+            "imap_ultra_l1c-90sensor-sc-pointing-index_20250101_v001.csv",
+            "ultra/data/l1/",
+        ),
+        ("imap_ultra_l1c-90sensor-sc-pointing-bsf_20250101_v001.csv", "ultra/data/l1/"),
+        ("Exposures-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv", "ultra/data/l1/"),
+        ("SENS-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv", "ultra/data/l1/"),
+        ("imap_ultra_l1b_45sensor-de_20000101-repoint00000_v000.cdf", "ultra/data/l1/"),
+    ]
+    _download_external_data(test_data)
     l1b_de = TEST_PATH / "imap_ultra_l1b_45sensor-de_20000101-repoint00000_v000.cdf"
     l1b_de = load_cdf(l1b_de)
     sensitivities_ebin_0 = pd.read_csv(

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -208,7 +208,7 @@ def test_calculate_spacecraft_pset_with_cdf(
 
 
 @pytest.mark.external_test_data
-# @pytest.mark.skip(reason="Long running test for validation purposes.")
+@pytest.mark.skip(reason="Long running test for validation purposes.")
 def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_datasets):
     """Validates exposure time and sensitivities for ebin 0."""
     l1b_de = TEST_PATH / "imap_ultra_l1b_45sensor-de_20000101-repoint00000_v000.cdf"

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -208,7 +208,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         )
 
 
-# @pytest.mark.skip(reason="Long running test for validation purposes.")
+@pytest.mark.skip(reason="Long running test for validation purposes.")
 def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_datasets):
     """Validates exposure time and sensitivities for ebin 0."""
     test_data = [

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -9,6 +9,7 @@ import spiceypy
 import xarray as xr
 
 from imap_processing import imap_module_directory
+from imap_processing.cdf.utils import load_cdf
 from imap_processing.spice.geometry import SpiceFrame
 from imap_processing.spice.time import met_to_sclkticks, sct_to_et
 from imap_processing.ultra.constants import UltraConstants
@@ -204,3 +205,112 @@ def test_calculate_spacecraft_pset_with_cdf(
             spacecraft_pset.attrs["Logical_source"]
             == "imap_ultra_l1c_45sensor-spacecraftpset"
         )
+
+
+@pytest.mark.external_test_data
+# @pytest.mark.skip(reason="Long running test for validation purposes.")
+def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_datasets):
+    """Validates exposure time and sensitivities for ebin 0."""
+    l1b_de = TEST_PATH / "imap_ultra_l1b_45sensor-de_20000101-repoint00000_v000.cdf"
+    l1b_de = load_cdf(l1b_de)
+    sensitivities_ebin_0 = pd.read_csv(
+        TEST_PATH / "SENS-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv"
+    )
+    exposure_factor_ebin_0 = pd.read_csv(
+        TEST_PATH / "Exposures-IMAP_ULTRA_90-IMAP_DPS-SC-nside32-ebin0.csv"
+    )
+    npix = 12288  # nside 32
+    # Create a minimal dataset to pass to the function
+    dataset = xr.Dataset(
+        {
+            "spin_number": (["epoch"], np.array([1, 2, 3])),
+        }
+    )
+    dataset.attrs["Repointing"] = "repoint00000"
+
+    ancillary_files["l1c-90sensor-sc-pointing-theta"] = (
+        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv"
+    )
+    ancillary_files["l1c-90sensor-sc-pointing-phi"] = (
+        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv"
+    )
+    ancillary_files["l1c-90sensor-sc-pointing-index"] = (
+        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv"
+    )
+    ancillary_files["l1c-90sensor-sc-pointing-bsf"] = (
+        TEST_PATH / "imap_ultra_l1c-90sensor-sc-pointing-theta_20250101_v001.csv"
+    )
+
+    pointing_range_met = (472374890.0, 582378000.0)
+    # Create mock spin data that has 5525 nominal spins
+    # Create DataFrame
+    nspins = 5520
+    nominal_spin_seconds = 15.0
+    spin_data = pd.DataFrame(
+        {
+            "spin_start_met": np.linspace(
+                pointing_range_met[0], pointing_range_met[1], nspins
+            ),
+            "spin_period_sec": np.full(nspins, nominal_spin_seconds),
+            "spin_phase_valid": np.ones(nspins),
+            "spin_period_valid": np.ones(nspins),
+        }
+    )
+    with (
+        # Mock the pointing times
+        mock.patch(
+            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
+            return_value=pointing_range_met,
+        ),
+        mock.patch(
+            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
+            side_effect=lambda x: x,
+        ),
+        # Mock deadtimes to be all ones
+        mock.patch(
+            "imap_processing.ultra.l1c.ultra_l1c_pset_bins."
+            "get_deadtime_ratios_by_spin_phase",
+            return_value=xr.DataArray(np.ones(720), dims="spin_phase_step"),
+        ),
+        # Mock spin data to match nominal spins in a pointing period
+        mock.patch(
+            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_spin_data",
+            return_value=spin_data,
+        ),
+        # Mock background rates to be constant 0.1
+        mock.patch(
+            "imap_processing.ultra.l1c.spacecraft_pset.get_spacecraft_background_rates",
+            return_value=np.ones((46, npix)),
+        ),
+        # Mock culling mask (no culling)
+        mock.patch("imap_processing.ultra.l1c.spacecraft_pset.compute_culling_mask"),
+    ):
+        pset = calculate_spacecraft_pset(
+            l1b_de,
+            dataset,
+            deadtime_datasets["rates"],
+            deadtime_datasets["params"],
+            "imap_ultra_l1c_90sensor-spacecraftpset",
+            ancillary_files,
+            90,
+            UltraConstants.TOFXPH_SPECIES_GROUPS["proton"],
+        )
+
+    # Validate exposure times for ebin 0
+    exposure_times = pset["exposure_factor"][0, 0, :].values
+    expected_exposure_times = exposure_factor_ebin_0["P0"]
+    np.testing.assert_allclose(
+        exposure_times,
+        expected_exposure_times,
+        rtol=1e-8,
+        err_msg="Exposure times do not match expected values for ebin 0.",
+    )
+    # Validate sensitivities for ebin 0
+    sensitivity = pset["sensitivities"][0, :].values
+    expected_sensitivity = sensitivities_ebin_0["Sensitivity (cm2)"]
+    np.testing.assert_allclose(
+        sensitivity,
+        expected_sensitivity,
+        rtol=0.04,
+        err_msg="Sensitivities times do not match expected values for ebin 0.",
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -293,7 +293,7 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
         deadtime_ratios,
         valid_spun_pixels,
         boundary_sf,
-        apply_boundary_scale_factor=True,
+        apply_bsf=True,
     )
     # The adjusted exposure should be of shape (1,npix)
     np.testing.assert_array_equal(exposure_pointing_adjusted.shape, (1, pix))
@@ -309,8 +309,10 @@ def test_apply_deadtime_correction_energy_dep(imap_ena_sim_metakernel, ancillary
     nside = 8
     pix = hp.nside2npix(nside)
     steps = 500  # Reduced for testing
-    mock_theta = np.random.uniform(-60, 60, (pix, steps))
-    mock_phi = np.random.uniform(-60, 60, (pix, steps))
+    theta_vals = np.linspace(-60, 60, pix)
+    phi_vals = np.linspace(-60, 60, steps)
+    mock_theta = np.broadcast_to(theta_vals[:, None], (pix, steps))
+    mock_phi = np.broadcast_to(phi_vals[None, :], (pix, steps))
     spin_phase_steps = np.zeros((pix, steps)).astype(bool)  # Spin phase steps 1-15000,
     # Simulate first 100 pixels are in the FOR for all spin phases
     inside_inds = 100
@@ -332,7 +334,7 @@ def test_apply_deadtime_correction_energy_dep(imap_ena_sim_metakernel, ancillary
         deadtime_ratios,
         valid_spun_pixels,
         boundary_sf,
-        apply_boundary_scale_factor=True,
+        apply_bsf=True,
     )
     # The adjusted exposure should be of shape (1,npix)
     np.testing.assert_array_equal(exposure_pointing_adjusted.shape, (46, pix))
@@ -374,7 +376,7 @@ def test_get_spacecraft_exposure_times(
             spin_phase_steps, mock_theta, mock_phi, ancillary_files, 45
         )
     )
-    boundary_sf = np.ones((pix, steps))
+    boundary_sf = xr.DataArray(np.ones((pix, steps)), dims=("pixel", "spin_phase_step"))
     exposure_pointing, deadtimes = get_spacecraft_exposure_times(
         rates,
         params,

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -276,18 +276,65 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
     # Simulate first 100 pixels are in the FOR for all spin phases
     inside_inds = 100
     spin_phase_steps[:inside_inds, :] = True
-    deadtime_ratios = np.ones(steps)
+    deadtime_ratios = xr.DataArray(np.ones(steps), dims="spin_phase_step")
 
-    pixels_below_threshold, fwhm_theta, fwhm_phi, thresholds = (
+    valid_spun_pixels, fwhm_theta, fwhm_phi, thresholds = (
         calculate_fwhm_spun_scattering(
-            spin_phase_steps, mock_theta, mock_phi, ancillary_files, 45
+            spin_phase_steps,
+            mock_theta,
+            mock_phi,
+            ancillary_files,
+            45,
+            reject_scattering=False,
         )
     )
-    boundary_sf = np.ones((pix, steps))
+    boundary_sf = xr.DataArray(np.ones((pix, steps)), dims=("pixel", "spin_phase_step"))
     exposure_pointing_adjusted = calculate_exposure_time(
-        deadtime_ratios, pixels_below_threshold, boundary_sf, pix
+        deadtime_ratios,
+        valid_spun_pixels,
+        boundary_sf,
+        apply_boundary_scale_factor=True,
     )
-    # The adjusted exposure should now be a function of pixels and energy (46)
+    # The adjusted exposure should be of shape (1,npix)
+    np.testing.assert_array_equal(exposure_pointing_adjusted.shape, (1, pix))
+    # Check that the pixels inside the FOR have adjusted exposure > 0.
+    assert np.all(exposure_pointing_adjusted[:, :inside_inds] > 0)
+    # Assert that pixels outside the FOR remain at 0.
+    assert np.all(exposure_pointing_adjusted[:, inside_inds:] == 0)
+
+
+@pytest.mark.external_kernel
+def test_apply_deadtime_correction_energy_dep(imap_ena_sim_metakernel, ancillary_files):
+    """Tests apply_deadtime_correction function when scattering rejection is on."""
+    nside = 8
+    pix = hp.nside2npix(nside)
+    steps = 500  # Reduced for testing
+    mock_theta = np.random.uniform(-60, 60, (pix, steps))
+    mock_phi = np.random.uniform(-60, 60, (pix, steps))
+    spin_phase_steps = np.zeros((pix, steps)).astype(bool)  # Spin phase steps 1-15000,
+    # Simulate first 100 pixels are in the FOR for all spin phases
+    inside_inds = 100
+    spin_phase_steps[:inside_inds, :] = True
+    deadtime_ratios = xr.DataArray(np.ones(steps), dims="spin_phase_step")
+
+    valid_spun_pixels, fwhm_theta, fwhm_phi, thresholds = (
+        calculate_fwhm_spun_scattering(
+            spin_phase_steps,
+            mock_theta,
+            mock_phi,
+            ancillary_files,
+            45,
+            reject_scattering=True,
+        )
+    )
+    boundary_sf = xr.DataArray(np.ones((pix, steps)), dims=("pixel", "spin_phase_step"))
+    exposure_pointing_adjusted = calculate_exposure_time(
+        deadtime_ratios,
+        valid_spun_pixels,
+        boundary_sf,
+        apply_boundary_scale_factor=True,
+    )
+    # The adjusted exposure should be of shape (1,npix)
     np.testing.assert_array_equal(exposure_pointing_adjusted.shape, (46, pix))
     # Check that the pixels inside the FOR have adjusted exposure > 0.
     # Subset the energy dimension to check values in the last energy bin. These
@@ -337,6 +384,7 @@ def test_get_spacecraft_exposure_times(
             data_start_time,
             data_start_time,
         ),
+        46,  # number of energy bins
         pix,
     )
     np.testing.assert_array_equal(exposure_pointing.shape, (46, pix))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -270,6 +270,7 @@ def test_apply_deadtime_correction(imap_ena_sim_metakernel, ancillary_files):
     nside = 8
     pix = hp.nside2npix(nside)
     steps = 500  # Reduced for testing
+    np.random.seed(42)
     mock_theta = np.random.uniform(-60, 60, (pix, steps))
     mock_phi = np.random.uniform(-60, 60, (pix, steps))
     spin_phase_steps = np.zeros((pix, steps)).astype(bool)  # Spin phase steps 1-15000,
@@ -309,10 +310,9 @@ def test_apply_deadtime_correction_energy_dep(imap_ena_sim_metakernel, ancillary
     nside = 8
     pix = hp.nside2npix(nside)
     steps = 500  # Reduced for testing
-    theta_vals = np.linspace(-60, 60, pix)
-    phi_vals = np.linspace(-60, 60, steps)
-    mock_theta = np.broadcast_to(theta_vals[:, None], (pix, steps))
-    mock_phi = np.broadcast_to(phi_vals[None, :], (pix, steps))
+    np.random.seed(42)
+    mock_theta = np.random.uniform(-60, 60, (pix, steps))
+    mock_phi = np.random.uniform(-60, 60, (pix, steps))
     spin_phase_steps = np.zeros((pix, steps)).astype(bool)  # Spin phase steps 1-15000,
     # Simulate first 100 pixels are in the FOR for all spin phases
     inside_inds = 100
@@ -342,7 +342,7 @@ def test_apply_deadtime_correction_energy_dep(imap_ena_sim_metakernel, ancillary
     # Subset the energy dimension to check values in the last energy bin. These
     # Should have pixels that are below the FWHM scattering threshold and therefore,
     # have the exposure adjusted.
-    last_energy_bin_vals = np.where(build_energy_bins()[2] >= 30)[0]
+    last_energy_bin_vals = np.where(build_energy_bins()[2] >= 40)[0]
     assert np.all(exposure_pointing_adjusted[last_energy_bin_vals, :inside_inds] > 0)
     # Assert that pixels outside the FOR remain at 0.
     assert np.all(exposure_pointing_adjusted[:, inside_inds:] == 0)

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -144,7 +144,7 @@ def calculate_helio_pset(
         pixels_below_scattering,
         boundary_scale_factors,
         pointing_range_met,
-        n_pix=n_pix,
+        n_energy_bins=len(energy_bin_geometric_means),
         sensor_id=sensor_id,
         ancillary_files=ancillary_files,
     )

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -116,6 +116,7 @@ def calculate_helio_pset(
             phi_vals,
             ancillary_files,
             instrument_id,
+            reject_scattering,
         )
     )
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -72,7 +72,8 @@ def calculate_helio_pset(
     """
     # Do not cull events based on scattering thresholds
     reject_scattering = False
-
+    # Do not apply boundary scale factor corrections
+    apply_bsf = False
     sensor_id = int(parse_filename_like(name)["sensor"][0:2])
     pset_dict: dict[str, np.ndarray] = {}
     # Select only the species we are interested in.
@@ -147,6 +148,7 @@ def calculate_helio_pset(
         n_energy_bins=len(energy_bin_geometric_means),
         sensor_id=sensor_id,
         ancillary_files=ancillary_files,
+        apply_bsf=apply_bsf,
     )
     logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
@@ -157,6 +159,7 @@ def calculate_helio_pset(
         phi_vals,
         n_pix,
         ancillary_files,
+        apply_bsf,
     )
 
     logger.info("Calculating background rates.")

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -4,6 +4,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 from numpy._typing import NDArray
 
 from imap_processing.ultra.constants import UltraConstants
@@ -72,7 +73,8 @@ def calculate_fwhm_spun_scattering(
     phi_vals: np.ndarray,
     ancillary_files: dict,
     instrument_id: int,
-) -> tuple[list, NDArray, NDArray, NDArray]:
+    reject_scattering: bool = False,
+) -> tuple[xr.DataArray, NDArray, NDArray, NDArray]:
     """
     Calculate FWHM scattering values for each pixel, energy bin, and spin phase step.
 
@@ -92,14 +94,17 @@ def calculate_fwhm_spun_scattering(
         Dictionary containing ancillary files.
     instrument_id : int,
         Instrument ID, either 45 or 90.
+    reject_scattering : bool
+        Whether to reject pixels based on scattering thresholds.
 
     Returns
     -------
-    pixels_below_scattering : list
-        A Nested list of arrays indicating pixels within the scattering threshold.
-        The outer list indicates spin phase steps, the middle list indicates energy
-        bins, and the inner arrays contain indices indicating pixels that are below
-        the FWHM scattering threshold.
+    valid_spun_pixels : xarray.DataArray
+       Boolean array indicating, for each spin phase step, energy_bin, pixel,
+       the pixel is inside the Field Of Regard (FOR) and whether the pixel is inside the
+       FOR at that spin phase and its computed FWHM at that energy is below the
+       scattering threshold. If reject_scattering is False, this will just reflect
+       the FOR mask (for_indices_by_spin_phase).
     scattering_fwhm_theta : NDArray
         Calculated FWHM scatting values for theta at each energy bin and averaged
         over spin phase.
@@ -111,7 +116,6 @@ def calculate_fwhm_spun_scattering(
     """
     # Load scattering coefficient lookup table
     scattering_luts = load_scattering_lookup_tables(ancillary_files, instrument_id)
-    pixels_below_scattering = []
     # Get energy bin geometric means
     energy_bin_geometric_means = build_energy_bins()[2]
     # Load scattering thresholds for the energy bin geometric means
@@ -127,6 +131,19 @@ def calculate_fwhm_spun_scattering(
 
     steps = for_indices_by_spin_phase.shape[1]
     energies = energy_bin_geometric_means[np.newaxis, :]
+    n_pix = for_indices_by_spin_phase.shape[0]
+    # Initialize DataArray to hold boolean of valid pixels at each spin phase step
+    # If reject_scattering if false, this will just be the FOR mask.
+    spun_dims = ("spin_phase_step", "energy", "pixel")
+    if reject_scattering:
+        valid_pixels = xr.DataArray(
+            np.zeros((steps, len(energy_bin_geometric_means), n_pix), dtype=bool),
+            dims=spun_dims,
+        )
+    else:
+        valid_pixels = xr.DataArray(
+            for_indices_by_spin_phase.T[:, np.newaxis, :], dims=spun_dims
+        )
     # The "for_indices_by_spin_phase" lookup table contains the boolean values of each
     # pixel at each spin phase step, indicating whether the pixel is inside the FOR.
     # It starts at Spin-phase = 0, and increments in fine steps (1 ms), spinning the
@@ -139,12 +156,6 @@ def calculate_fwhm_spun_scattering(
         # Skip if no pixels in FOR
         if not np.any(for_inds):
             logger.info(f"No pixels found in FOR at spin phase step {i}")
-            pixels_below_scattering.append(
-                [
-                    np.array([], dtype=int)
-                    for _ in range(len(energy_bin_geometric_means))
-                ]
-            )
             continue
         # Using the lookup table, get the indices of the pixels inside the FOR at
         # the current spin phase step.
@@ -160,15 +171,11 @@ def calculate_fwhm_spun_scattering(
             energies,
             scattering_thresholds=scattering_thresholds_for_energy_mean,
         )
-        # Extract pixel indices for each energy
-        for_pixel_indices = np.where(for_inds)[0]
-        pixels_below_scattering_for_energy = []
+        # Store results of the scattering mask at the indices corresponding to the
+        # current spin phase step and the pixels inside the FOR.
+        if reject_scattering:
+            valid_pixels[i, :, for_inds] = scattering_mask.T
 
-        for energy_idx in range(len(energy_bin_geometric_means)):
-            valid_pixels = scattering_mask[:, energy_idx]
-            pixels_below_scattering_for_energy.append(for_pixel_indices[valid_pixels])
-
-        pixels_below_scattering.append(pixels_below_scattering_for_energy)
         # Accumulate FWHM values for averaging
         fwhm_theta_sum[:, for_inds] += fwhm_theta.T
         fwhm_phi_sum[:, for_inds] += fwhm_phi.T
@@ -179,7 +186,7 @@ def calculate_fwhm_spun_scattering(
     np.divide(fwhm_phi_sum, sample_count, out=fwhm_phi_avg, where=sample_count != 0)
     np.divide(fwhm_theta_sum, sample_count, out=fwhm_theta_avg, where=sample_count != 0)
     return (
-        pixels_below_scattering,
+        valid_pixels,
         fwhm_theta_avg,
         fwhm_phi_avg,
         scattering_thresholds_for_energy_mean,
@@ -188,7 +195,7 @@ def calculate_fwhm_spun_scattering(
 
 def get_spacecraft_pointing_lookup_tables(
     ancillary_files: dict, instrument_id: int
-) -> tuple[NDArray, NDArray, NDArray, NDArray, NDArray]:
+) -> tuple[NDArray, NDArray, NDArray, NDArray, xr.DataArray]:
     """
     Get indices of pixels in the nominal FOR as a function of spin phase.
 
@@ -215,7 +222,7 @@ def get_spacecraft_pointing_lookup_tables(
          A 2D array of phi values for each HEALPix pixel at each spin phase step.
     ra_and_dec : NDArray
         A 2D array of right ascension and declination values for each HEALPix pixel.
-    boundary_scale_factors : NDArray
+    boundary_scale_factors : xarray.DataArray
         A 2D array of boundary scale factors for each HEALPix pixel at each spin phase
         step.
     """
@@ -243,6 +250,9 @@ def get_spacecraft_pointing_lookup_tables(
     for_indices_by_spin_phase = np.nan_to_num(index_grid[:, 2:], nan=0).astype(
         bool
     )  # Shape (npix, 15000)
+    boundary_scale_factors = xr.DataArray(
+        boundary_scale_factors, dims=("pixel", "spin_phase_step")
+    )
     return (
         for_indices_by_spin_phase,
         theta_vals,

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -110,7 +110,7 @@ def calculate_spacecraft_pset(
     ) = get_spacecraft_pointing_lookup_tables(ancillary_files, instrument_id)
 
     logger.info("calculating spun FWHM scattering values.")
-    pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = (
+    valid_spun_pixels, scattering_theta, scattering_phi, scattering_thresholds = (
         calculate_fwhm_spun_scattering(
             for_indices_by_spin_phase,
             theta_vals,
@@ -140,17 +140,17 @@ def calculate_spacecraft_pset(
     exposure_pointing, deadtime_ratios = get_spacecraft_exposure_times(
         rates_dataset,
         params_dataset,
-        pixels_below_scattering,
+        valid_spun_pixels,
         boundary_scale_factors,
         pointing_range_met,
-        n_pix=n_pix,
+        n_energy_bins=len(energy_bin_geometric_means),
         sensor_id=sensor_id,
         ancillary_files=ancillary_files,
     )
     logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
     geometric_function, efficiencies = get_efficiencies_and_geometric_function(
-        pixels_below_scattering,
+        valid_spun_pixels,
         boundary_scale_factors,
         theta_vals,
         phi_vals,

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -71,7 +71,8 @@ def calculate_spacecraft_pset(
     """
     # Do not cull events based on scattering thresholds
     reject_scattering = False
-
+    # Do not apply boundary scale factor corrections
+    apply_bsf = False
     pset_dict: dict[str, np.ndarray] = {}
 
     sensor_id = int(parse_filename_like(name)["sensor"][0:2])
@@ -146,6 +147,7 @@ def calculate_spacecraft_pset(
         n_energy_bins=len(energy_bin_geometric_means),
         sensor_id=sensor_id,
         ancillary_files=ancillary_files,
+        apply_bsf=apply_bsf,
     )
     logger.info("Calculating spun efficiencies and geometric function.")
     # calculate efficiency and geometric function as a function of energy
@@ -156,10 +158,10 @@ def calculate_spacecraft_pset(
         phi_vals,
         n_pix,
         ancillary_files,
+        apply_bsf,
     )
     sensitivity = efficiencies * geometric_function
 
-    logger.info("Calculating background rates.")
     # Calculate background rates
     background_rates = get_spacecraft_background_rates(
         rates_dataset,

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -370,7 +370,7 @@ def calculate_exposure_time(
     valid_spun_pixels: xr.DataArray,
     boundary_scale_factors: xr.DataArray,
     apply_bsf: bool = True,
-) -> np.ndarray:
+) -> xr.Dataset:
     """
     Adjust the exposure time at each pixel to account for dead time.
 
@@ -392,7 +392,7 @@ def calculate_exposure_time(
 
     Returns
     -------
-    exposure_pointing_adjusted : np.ndarray
+    exposure_pointing_adjusted : xarray.Dataset
         Adjusted exposure times accounting for dead time.
     """
     # nominal spin phase step.
@@ -401,14 +401,13 @@ def calculate_exposure_time(
     # and below the scattering threshold (if scattering rejection is on).
     # Sum over the first dim of valid_spun_pixels is the spin phase step.
     # This is like spinning the spacecraft by nominal 1 ms steps in the despun frame.
+    all_counts = valid_spun_pixels * deadtime_ratios
     if apply_bsf:
-        counts = (valid_spun_pixels * deadtime_ratios * boundary_scale_factors).sum(
-            dim="spin_phase_step"
-        )
-    else:
-        counts = (valid_spun_pixels * deadtime_ratios).sum(dim="spin_phase_step")
+        all_counts *= boundary_scale_factors
+
+    counts = all_counts.sum(dim="spin_phase_step")
     # Multiply by the nominal spin step to get the exposure time in ms
-    exposure_pointing = counts.values * nominal_ms_step
+    exposure_pointing = counts * nominal_ms_step
     return exposure_pointing
 
 
@@ -504,7 +503,7 @@ def get_spacecraft_exposure_times(
     # Ensure exposure factor is broadcast correctly
     if exposure_pointing_adjusted.shape[0] != n_energy_bins:
         exposure_pointing_adjusted = np.repeat(
-            exposure_pointing_adjusted,
+            exposure_pointing_adjusted.values,
             n_energy_bins,
             axis=0,
         )
@@ -613,6 +612,7 @@ def get_efficiencies_and_geometric_function(
             # Determine pixel indices based on energy dependence
             if valid_at_spin.sizes["energy"] == 1:
                 # No scattering rejection. Same pixels for all energies
+                # TODO this may cause performance issues. Revisit later.
                 pixel_inds = np.where(valid_at_spin.isel(energy=0))[0]
             else:
                 # Scattering rejection - different pixels per energy

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -279,7 +279,7 @@ def get_deadtime_ratios_by_spin_phase(
     spin_steps: int,
     sensor_id: int | None = None,
     ancillary_files: dict | None = None,
-) -> np.ndarray:
+) -> xr.DataArray:
     """
     Calculate nominal deadtime ratios at every spin phase step (1ms res).
 
@@ -296,7 +296,7 @@ def get_deadtime_ratios_by_spin_phase(
 
     Returns
     -------
-    numpy.ndarray
+    xarray.DataArray
         Nominal deadtime ratios at every spin phase step.
     """
     if sectored_rates is None or sectored_rates.epoch.size == 0:
@@ -359,72 +359,60 @@ def get_deadtime_ratios_by_spin_phase(
     # Calculate the nominal spin phases at the supplied resolution and query the pchip
     # interpolator to get the deadtime ratios.
     nominal_spin_phases = np.arange(0, 360, 360 / spin_steps)
-    return interpolator(nominal_spin_phases)
+    deadtime_ratios = xr.DataArray(
+        interpolator(nominal_spin_phases), dims="spin_phase_step"
+    )
+    return deadtime_ratios
 
 
 def calculate_exposure_time(
-    deadtime_ratios: np.ndarray,
-    pixels_below_scattering: list,
-    boundary_scale_factors: NDArray,
-    n_pix: int,
+    deadtime_ratios: xr.DataArray,
+    valid_spun_pixels: xr.DataArray,
+    boundary_scale_factors: xr.DataArray,
 ) -> np.ndarray:
     """
     Adjust the exposure time at each pixel to account for dead time.
 
     Parameters
     ----------
-    deadtime_ratios : PchipInterpolator
-        Interpolating function for dead time ratios.
-    pixels_below_scattering : list
-        A Nested list of arrays indicating pixels within the scattering threshold.
-        The outer list indicates spin phase steps, the middle list indicates energy
-        bins, and the inner arrays contain indices indicating pixels that are below
-        the FWHM scattering threshold.
-    boundary_scale_factors : np.ndarray
+    deadtime_ratios : xarray.DataArray
+        Deadtime ratios at each spin phase step.
+    valid_spun_pixels : xarray.DataArray
+        3D Array of pixels valid at each spin phase step. If rejection based on
+        scattering was set, then these are the pixels below the FWHM scattering
+        threshold and in the field of regard at each spin phase step, and energy
+        shape = (spin_phase_steps, energy_bins, n_pix). IF no rejection,
+        then these are simply the pixels in the field of regard at each spin phase step
+        shape = (spin_phase_steps, 1, n_pix).
+    boundary_scale_factors : xr.DataArray
         Boundary scale factors for each pixel at each spin phase.
-    n_pix : int
-        Number of HEALPix pixels.
 
     Returns
     -------
     exposure_pointing_adjusted : np.ndarray
         Adjusted exposure times accounting for dead time.
     """
-    # Get energy bin geometric means
-    energy_bin_geometric_means = build_energy_bins()[2]
-    # Exposure time should now be of shape (energy, npix)
-    counts = np.zeros((len(energy_bin_geometric_means), n_pix))
     # nominal spin phase step.
-    nominal_ms_step = 15 / len(pixels_below_scattering)  # time step
+    nominal_ms_step = 15 / valid_spun_pixels.shape[0]  # time step
     # Query the dead-time ratio and apply the nominal exposure time to pixels in the FOR
-    # and below the scattering threshold
-    # Loop through the spin phase steps. This is spinning the spacecraft by nominal
-    # 1 ms steps in the despun frame.
-    for i, pixels_at_spin in enumerate(pixels_below_scattering):
-        # Loop through energy bins
-        for energy_bin_idx in range(len(energy_bin_geometric_means)):
-            pixels_at_energy_and_spin = pixels_at_spin[energy_bin_idx]
-            if pixels_at_energy_and_spin.size == 0:
-                continue
-            # Apply the nominal exposure time (1 ms) scaled by the deadtime ratio to
-            # every pixel in the FOR, that is below the FWHM scattering threshold,
-            counts[energy_bin_idx, pixels_at_energy_and_spin] += (
-                deadtime_ratios[i]
-                * boundary_scale_factors[pixels_at_energy_and_spin, i]
-            )
-
+    # and below the scattering threshold (if scattering rejection is on).
+    # Sum over the first dim of valid_spun_pixels is the spin phase step.
+    # This is like spinning the spacecraft by nominal 1 ms steps in the despun frame.
+    counts = (valid_spun_pixels * deadtime_ratios * boundary_scale_factors).sum(
+        dim="spin_phase_step"
+    )
     # Multiply by the nominal spin step to get the exposure time in ms
-    exposure_pointing = counts * nominal_ms_step
+    exposure_pointing = counts.values * nominal_ms_step
     return exposure_pointing
 
 
 def get_spacecraft_exposure_times(
     rates_dataset: xr.Dataset,
     params_dataset: xr.Dataset,
-    pixels_below_scattering: list[list],
-    boundary_scale_factors: NDArray,
+    valid_spun_pixels: xr.DataArray,
+    boundary_scale_factors: xr.DataArray,
     pointing_range_met: tuple[float, float],
-    n_pix: int,
+    n_energy_bins: int,
     sensor_id: int | None = None,
     ancillary_files: dict | None = None,
 ) -> tuple[NDArray, NDArray]:
@@ -437,17 +425,19 @@ def get_spacecraft_exposure_times(
         Dataset containing image rates data.
     params_dataset : xarray.Dataset
         Dataset containing image parameters data.
-    pixels_below_scattering : list
-        List of lists indicating pixels within the scattering threshold.
-        The outer list indicates spin phase steps, the middle list indicates energy
-        bins, and the inner list contains pixel indices indicating pixels that are
-        below the FWHM scattering threshold.
-    boundary_scale_factors : np.ndarray
+    valid_spun_pixels : xarray.DataArray
+        3D Array of pixels valid at each spin phase step. If rejection based on
+        scattering was set, then these are the pixels below the FWHM scattering
+        threshold and in the field of regard at each spin phase step, and energy
+        shape = (spin_phase_steps, energy_bins, n_pix). IF no rejection,
+        then these are simply the pixels in the field of regard at each spin phase step
+        shape = (spin_phase_steps, 1, n_pix).
+    boundary_scale_factors : xarray.DataArray
         Boundary scale factors for each pixel at each spin phase.
     pointing_range_met : tuple
         Start and stop time of the pointing period in mission elapsed time.
-    n_pix : int
-        Number of HEALPix pixels.
+    n_energy_bins : int
+        Number of energy bins.
     sensor_id : int, optional
         Sensor ID, either 45 or 90.
     ancillary_files : dict, optional
@@ -470,7 +460,7 @@ def get_spacecraft_exposure_times(
     rates_dataset.isel(epoch=pointing_mask)
     sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
     # Get the number of steps used in the spun pointing lookup tables
-    spin_steps = len(pixels_below_scattering)
+    spin_steps = valid_spun_pixels.shape[0]
     nominal_deadtime_ratios = get_deadtime_ratios_by_spin_phase(
         sectored_rates, spin_steps, sensor_id, ancillary_files
     )
@@ -479,7 +469,7 @@ def get_spacecraft_exposure_times(
     # by the number of spins in the pointing. For more information, see section 3.4.3
     # of the Ultra Algorithm Document.
     exposure_time = calculate_exposure_time(
-        nominal_deadtime_ratios, pixels_below_scattering, boundary_scale_factors, n_pix
+        nominal_deadtime_ratios, valid_spun_pixels, boundary_scale_factors
     )
     # Use the universal spin table to determine the actual number of spins
     nominal_spin_seconds = 15.0
@@ -502,12 +492,19 @@ def get_spacecraft_exposure_times(
     )
     # Adjust exposure time by the actual number of valid spins in the pointing
     exposure_pointing_adjusted = n_spins_in_pointing * exposure_time
-    return exposure_pointing_adjusted, nominal_deadtime_ratios
+    # Ensure exposure factor is broadcast correctly
+    if exposure_pointing_adjusted.shape[0] != n_energy_bins:
+        exposure_pointing_adjusted = np.repeat(
+            exposure_pointing_adjusted,
+            n_energy_bins,
+            axis=0,
+        )
+    return exposure_pointing_adjusted, nominal_deadtime_ratios.values
 
 
 def get_efficiencies_and_geometric_function(
-    pixels_below_scattering: list[list],
-    boundary_scale_factors: np.ndarray,
+    valid_spun_pixels: xr.DataArray,
+    boundary_scale_factors: xr.DataArray,
     theta_vals: np.ndarray,
     phi_vals: np.ndarray,
     npix: int,
@@ -520,12 +517,14 @@ def get_efficiencies_and_geometric_function(
 
     Parameters
     ----------
-    pixels_below_scattering : list
-        List of lists indicating pixels within the scattering threshold.
-        The outer list indicates spin phase steps, the middle list indicates energy
-        bins, and the inner list contains pixel indices indicating pixels that are
-        below the FWHM scattering threshold.
-    boundary_scale_factors : np.ndarray
+    valid_spun_pixels : xarray.DataArray
+        3D Array of pixels valid at each spin phase step. If rejection based on
+        scattering was set, then these are the pixels below the FWHM scattering
+        threshold and in the field of regard at each spin phase step, and energy
+        shape = (spin_phase_steps, energy_bins, n_pix). IF no rejection,
+        then these are simply the pixels in the field of regard at each spin phase step
+        shape = (spin_phase_steps, 1, n_pix).
+    boundary_scale_factors : xarray.DataArray
         Boundary scale factors for each pixel at each spin phase.
     theta_vals : np.ndarray
         A 2D array of theta values for each HEALPix pixel at each spin phase step.
@@ -579,7 +578,8 @@ def get_efficiencies_and_geometric_function(
     eff_summation = np.zeros((energy_bins, npix))
     sample_count = np.zeros((energy_bins, npix))
     # Loop through spin phases
-    for i, pixels_at_spin in enumerate(pixels_below_scattering):
+    spin_steps = valid_spun_pixels.shape[0]
+    for i in range(spin_steps):
         # Loop through energy bins
         # Compute gf and eff for these theta/phi pairs
         theta_at_spin = theta_vals[:, i]
@@ -592,10 +592,25 @@ def get_efficiencies_and_geometric_function(
             quality_flag=np.zeros(len(phi_at_spin)).astype(np.uint16),
             geometric_factor_tables=geometric_lookup_table,
         )
+        # Get valid pixels at this spin phase
+        valid_at_spin = valid_spun_pixels.isel(
+            spin_phase_step=i
+        )  # shape: (energy, pixel)
+
+        # Get pixel indices that are valid at this spin phase and energy bin
+        pixel_inds = None
+        # If the valid_spun_pixels is not dependent on energy
+        # (no scattering rejection), then calculate eff and gf across all energy
+        # bins for the valid pixels.
+        if valid_at_spin.sizes["energy"] == 1:
+            pixel_inds = np.where(valid_at_spin.isel(energy=0))[0]
+
         for energy_bin_idx in range(energy_bins):
-            pixel_inds = pixels_at_spin[energy_bin_idx]
-            if pixel_inds.size == 0:
-                continue
+            # If the valid_spun_pixels is dependent on energy (scattering rejection on),
+            # then get the pixel indices for this energy bin.
+            if pixel_inds is None:
+                pixel_inds = np.where(valid_at_spin.isel(energy=energy_bin_idx))[0]
+
             energy = energy_bin_geometric_means[energy_bin_idx]
             # Clip energy to calibrated range
             energy_clipped = np.clip(energy, 3.0, 80.0)
@@ -607,12 +622,10 @@ def get_efficiencies_and_geometric_function(
                 interpolator=eff_interpolator,
             )
             # Accumulate gf and eff values
-            gf_summation[energy_bin_idx, pixel_inds] += (
-                gf_values[pixel_inds] * boundary_scale_factors[pixel_inds, i]
-            )
-            eff_summation[energy_bin_idx, pixel_inds] += (
-                eff_values * boundary_scale_factors[pixel_inds, i]
-            )
+            bsfs = boundary_scale_factors[pixel_inds, i]
+            gf_summation[energy_bin_idx, pixel_inds] += gf_values[pixel_inds] * bsfs
+            eff_summation[energy_bin_idx, pixel_inds] += eff_values * bsfs
+
             sample_count[energy_bin_idx, pixel_inds] += 1
 
     # return averaged geometric factors and efficiencies across all spin phases

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -369,6 +369,7 @@ def calculate_exposure_time(
     deadtime_ratios: xr.DataArray,
     valid_spun_pixels: xr.DataArray,
     boundary_scale_factors: xr.DataArray,
+    apply_bsf: bool = True,
 ) -> np.ndarray:
     """
     Adjust the exposure time at each pixel to account for dead time.
@@ -386,6 +387,8 @@ def calculate_exposure_time(
         shape = (spin_phase_steps, 1, n_pix).
     boundary_scale_factors : xr.DataArray
         Boundary scale factors for each pixel at each spin phase.
+    apply_bsf : bool, optional
+        Whether to apply boundary scale factors. Default is True.
 
     Returns
     -------
@@ -398,9 +401,12 @@ def calculate_exposure_time(
     # and below the scattering threshold (if scattering rejection is on).
     # Sum over the first dim of valid_spun_pixels is the spin phase step.
     # This is like spinning the spacecraft by nominal 1 ms steps in the despun frame.
-    counts = (valid_spun_pixels * deadtime_ratios * boundary_scale_factors).sum(
-        dim="spin_phase_step"
-    )
+    if apply_bsf:
+        counts = (valid_spun_pixels * deadtime_ratios * boundary_scale_factors).sum(
+            dim="spin_phase_step"
+        )
+    else:
+        counts = (valid_spun_pixels * deadtime_ratios).sum(dim="spin_phase_step")
     # Multiply by the nominal spin step to get the exposure time in ms
     exposure_pointing = counts.values * nominal_ms_step
     return exposure_pointing
@@ -415,6 +421,7 @@ def get_spacecraft_exposure_times(
     n_energy_bins: int,
     sensor_id: int | None = None,
     ancillary_files: dict | None = None,
+    apply_bsf: bool = True,
 ) -> tuple[NDArray, NDArray]:
     """
     Compute exposure times for HEALPix pixels.
@@ -442,6 +449,8 @@ def get_spacecraft_exposure_times(
         Sensor ID, either 45 or 90.
     ancillary_files : dict, optional
         Dictionary containing ancillary files.
+    apply_bsf : bool, optional
+        Whether to apply boundary scale factors. Default is True.
 
     Returns
     -------
@@ -469,7 +478,7 @@ def get_spacecraft_exposure_times(
     # by the number of spins in the pointing. For more information, see section 3.4.3
     # of the Ultra Algorithm Document.
     exposure_time = calculate_exposure_time(
-        nominal_deadtime_ratios, valid_spun_pixels, boundary_scale_factors
+        nominal_deadtime_ratios, valid_spun_pixels, boundary_scale_factors, apply_bsf
     )
     # Use the universal spin table to determine the actual number of spins
     nominal_spin_seconds = 15.0
@@ -509,6 +518,7 @@ def get_efficiencies_and_geometric_function(
     phi_vals: np.ndarray,
     npix: int,
     ancillary_files: dict,
+    apply_bsf: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Compute the geometric factor and efficiency for each pixel and energy bin.
@@ -534,6 +544,8 @@ def get_efficiencies_and_geometric_function(
         Number of HEALPix pixels.
     ancillary_files : dict
         Dictionary containing ancillary files.
+    apply_bsf : bool, optional
+        Whether to apply boundary scale factors. Default is True.
 
     Returns
     -------
@@ -597,35 +609,33 @@ def get_efficiencies_and_geometric_function(
             spin_phase_step=i
         )  # shape: (energy, pixel)
 
-        # Get pixel indices that are valid at this spin phase and energy bin
-        pixel_inds = None
-        # If the valid_spun_pixels is not dependent on energy
-        # (no scattering rejection), then calculate eff and gf across all energy
-        # bins for the valid pixels.
-        if valid_at_spin.sizes["energy"] == 1:
-            pixel_inds = np.where(valid_at_spin.isel(energy=0))[0]
-
         for energy_bin_idx in range(energy_bins):
-            # If the valid_spun_pixels is dependent on energy (scattering rejection on),
-            # then get the pixel indices for this energy bin.
-            if pixel_inds is None:
+            # Determine pixel indices based on energy dependence
+            if valid_at_spin.sizes["energy"] == 1:
+                # No scattering rejection. Same pixels for all energies
+                pixel_inds = np.where(valid_at_spin.isel(energy=0))[0]
+            else:
+                # Scattering rejection - different pixels per energy
                 pixel_inds = np.where(valid_at_spin.isel(energy=energy_bin_idx))[0]
 
+            if pixel_inds.size == 0:
+                continue
+
             energy = energy_bin_geometric_means[energy_bin_idx]
-            # Clip energy to calibrated range
             energy_clipped = np.clip(energy, 3.0, 80.0)
+
             eff_values = get_efficiency(
-                np.full(phi_at_spin[pixel_inds].shape, energy_clipped),
+                np.full(pixel_inds.size, energy_clipped),
                 phi_at_spin_clipped[pixel_inds],
                 theta_at_spin_clipped[pixel_inds],
                 ancillary_files,
                 interpolator=eff_interpolator,
             )
-            # Accumulate gf and eff values
-            bsfs = boundary_scale_factors[pixel_inds, i]
+
+            # Sum
+            bsfs = boundary_scale_factors[pixel_inds, i] if apply_bsf else 1.0
             gf_summation[energy_bin_idx, pixel_inds] += gf_values[pixel_inds] * bsfs
             eff_summation[energy_bin_idx, pixel_inds] += eff_values * bsfs
-
             sample_count[energy_bin_idx, pixel_inds] += 1
 
     # return averaged geometric factors and efficiencies across all spin phases


### PR DESCRIPTION
# Change Summary

## Overview
Slight refactor in regards to the spun valid pixels. I made this into an xarray dataset which simplified other functions. 
Add validation test to make sure we match with ULTRA data. 

## Updated Files
- imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
   - Fix test. 
- imap_processing/ultra/l1c/helio_pset.py
   - DO not apply boundary scale factors
- imap_processing/ultra/l1c/l1c_lookup_utils.py
  - simplify valid pixels if we are not culling pixels by FWHM values 
 - imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
   - simplify exposure factor function and eff and gf calculation

## Testing
Add validation test for checking sensitivity and exposure factor
