### PR TITLE
MNT/FIX: Load CDF files with NaN replacement for FILLVAL by default

### DIFF
--- a/imap_processing/cdf/utils.py
+++ b/imap_processing/cdf/utils.py
@@ -50,6 +50,9 @@ def load_cdf(
     # round-trip of writing and then loading a cdf keeps the dataset the same.
     if "to_datetime" not in kwargs:
         kwargs["to_datetime"] = False  # type: ignore
+    # By default, load fillvalues as nan
+    if "fillval_to_nan" not in kwargs:
+        kwargs["fillval_to_nan"] = True  # type: ignore
     dataset = cdf_to_xarray(file_path, **kwargs)
 
     # cdf_to_xarray converts single-value attributes to lists

--- a/imap_processing/tests/cdf/test_utils.py
+++ b/imap_processing/tests/cdf/test_utils.py
@@ -35,7 +35,8 @@ def test_dataset():
             "epoch": (
                 "epoch",
                 met_to_ttj2000ns([1, 2, 3]),
-            )
+            ),
+            "nan_data": ("epoch", np.array([1.0, 2.0, np.nan]), {"FILLVAL": -1.0e31}),
         },
         attrs=swe_attrs.get_global_attributes("imap_swe_l1a_sci")
         | {
@@ -66,6 +67,8 @@ def test_load_cdf(test_dataset):
     for _, data_array in dataset.variables.items():
         for attr in xarray_attrs:
             assert attr not in data_array.attrs
+
+    assert np.isnan(dataset["nan_data"].data[2])
 
 
 def test_load_cdf_extra_kwargs(test_dataset):

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -343,6 +343,8 @@ def test_codice_l2_sw_species_intensity(mock_get_file_paths, codice_lut_path):
     l2_val_data = load_cdf(l2_val_data)
     for variable in l2_val_data.data_vars:
         processed_val = processed_2_ds[variable].values
+        # NOTE: Replace nan with 0 for comparison as the validation data uses 0
+        processed_val[np.isnan(processed_val)] = 0.0
         np.testing.assert_allclose(
             processed_val,
             l2_val_data[variable].values,
@@ -382,8 +384,11 @@ def test_codice_l2_nsw_species_intensity(mock_get_file_paths, codice_lut_path):
     )
     l2_val_data = load_cdf(l2_val_data)
     for variable in l2_val_data.data_vars:
+        # NOTE: Replace nan with 0 for comparison as the validation data uses 0
+        processed_val = processed_2_ds[variable].values
+        processed_val[np.isnan(processed_val)] = 0.0
         np.testing.assert_allclose(
-            processed_2_ds[variable].values,
+            processed_val,
             l2_val_data[variable].values,
             rtol=1e-5,
             err_msg=f"Mismatch in variable '{variable}'",


### PR DESCRIPTION
We want to propagate NaNs in data products rather than propagating the fill value itself.

related to #2470