### PR TITLE
MNT: Rename SWAPI variable swp_esa_energy to just esa_energy

### DIFF
--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -235,7 +235,7 @@ def swapi_l2(
         data_time=sci_start_time,
     )
 
-    l2_dataset["swp_esa_energy"] = xr.DataArray(
+    l2_dataset["esa_energy"] = xr.DataArray(
         esa_energy,
         name="esa_energy",
         dims=["epoch", "esa_step"],

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -143,7 +143,7 @@ def test_swapi_l2_cdf(
         3687.0,
         3608.0,
     ]
-    assert np.all(l2_dataset["swp_esa_energy"].values[0, -9:] == fine_energies)
+    assert np.all(l2_dataset["esa_energy"].values[0, -9:] == fine_energies)
 
 
 def test_solve_full_sweep_energy(esa_unit_conversion_table, lut_notes_table):


### PR DESCRIPTION
# Change Summary

This changes `swp_esa_energy` to be `esa_energy` (drop the swp_ prefix).

@bishwassth and @hafarooki I'm not sure what the first bullet in #2421 means. Could you let me know if this is the only change you need or if I'm missing something else here that was supposed to be done?

> update L2 esa_step to be esa_energy

`esa_step` is a dimension that is of shape 72. I don't think it can/should be `esa_energy` because it will be variable and change with time. So I think what we have is currently correct where the `esa_step` is the dimension (length 72), and then esa_energy is the variable with shape (nepochs, esa_step). 

closes #2421
