### PR TITLE
Ignore fill values when converting healpix to rectangular

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1633,13 +1633,6 @@ class HealpixSkyMap(AbstractSkyMap):
             + subpix_spacing / 2
         )
 
-        # We must weight by solid angle, which is not exactly equal for all subpixels
-        # Calculate the solid angle of the full rectangular pixel (sterad)
-        full_rect_pixel_solid_angle = np.deg2rad(rect_pix_spacing_deg) * (
-            np.sin(np.deg2rad(bottom_edge_lat + rect_pix_spacing_deg))
-            - np.sin(np.deg2rad(bottom_edge_lat))
-        )
-
         # Calculate solid angle of each subpix from the rect_subpix_lat_ctrs (sterad)
         all_edges_lat = bottom_edge_lat + np.arange(n_subpix_side + 1) * subpix_spacing
         sine_all_edges_lat = np.sin(np.deg2rad(all_edges_lat))
@@ -1669,13 +1662,16 @@ class HealpixSkyMap(AbstractSkyMap):
         # Get the healpix values at the rectangular subpixel centers
         hp_vals_at_rect_pix_ctrs = value_array.values[..., hp_pix_at_rect_subpix_ctrs]
 
+        mask = np.isfinite(hp_vals_at_rect_pix_ctrs)
+
         # Weighted mean (weighted by solid angle) of these values over the pixel axis,
         # which is the last axis of this array
+        non_nan_weights = np.where(mask, rect_subpix_solid_angle_by_lat, 0)
         weighted_hp_vals_at_rect_pix_ctrs = (
-            hp_vals_at_rect_pix_ctrs * rect_subpix_solid_angle_by_lat
+            np.where(mask, hp_vals_at_rect_pix_ctrs, 0) * non_nan_weights
         )
-        mean_pixel_value = (
-            weighted_hp_vals_at_rect_pix_ctrs.sum(axis=-1) / full_rect_pixel_solid_angle
+        mean_pixel_value = weighted_hp_vals_at_rect_pix_ctrs.sum(axis=-1) / np.sum(
+            non_nan_weights, axis=-1
         )
         # Log the mean pixel value and the number of subdivisions for debugging
         logger.debug(

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1662,17 +1662,22 @@ class HealpixSkyMap(AbstractSkyMap):
         # Get the healpix values at the rectangular subpixel centers
         hp_vals_at_rect_pix_ctrs = value_array.values[..., hp_pix_at_rect_subpix_ctrs]
 
-        mask = np.isfinite(hp_vals_at_rect_pix_ctrs)
+        valid_pixel_mask = np.isfinite(hp_vals_at_rect_pix_ctrs)
 
         # Weighted mean (weighted by solid angle) of these values over the pixel axis,
         # which is the last axis of this array
-        non_nan_weights = np.where(mask, rect_subpix_solid_angle_by_lat, 0)
+        valid_pixel_weights = np.where(
+            valid_pixel_mask, rect_subpix_solid_angle_by_lat, 0
+        )
         weighted_hp_vals_at_rect_pix_ctrs = (
-            np.where(mask, hp_vals_at_rect_pix_ctrs, 0) * non_nan_weights
+            np.where(valid_pixel_mask, hp_vals_at_rect_pix_ctrs, 0)
+            * valid_pixel_weights
         )
-        mean_pixel_value = weighted_hp_vals_at_rect_pix_ctrs.sum(axis=-1) / np.sum(
-            non_nan_weights, axis=-1
-        )
+
+        with np.errstate(invalid="ignore"):
+            mean_pixel_value = weighted_hp_vals_at_rect_pix_ctrs.sum(axis=-1) / np.sum(
+                valid_pixel_weights, axis=-1
+            )
         # Log the mean pixel value and the number of subdivisions for debugging
         logger.debug(
             f"    Mean pixel value at Number of subdivisions: {num_subdivisions}: "

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -1327,18 +1327,18 @@ class TestHealpixSkyMap:
             (179.5, -0.5): 10,
             (179.5, 0.5): 11,
             (179.5, 1.5): 12,
-            (180.5, -1.5): 12,
+            (180.5, -1.5): 13,
             (180.5, -0.5): 14,
             (180.5, 0.5): 15,
             (180.5, 1.5): 16,
             (181.5, -1.5): 17,
             (181.5, -0.5): 18,
             (181.5, 0.5): 19,
-            (181.5, 1.5): 20,
+            (181.5, 1.5): 999,
         }
         expected_mean_0_subdivisions = 0
         expected_mean_1_subdivisions = 2.5
-        expected_mean_2_subdivisions = 12.5
+        expected_mean_2_subdivisions = 12
 
         def mock_ang2pix_fn(nside, theta, phi, nest=True, lonlat=False):
             vals = []
@@ -1354,10 +1354,11 @@ class TestHealpixSkyMap:
         )
         hp_map.data_1d["counts"] = xr.DataArray(
             data=[
-                np.arange(hp_map.num_points),
+                np.arange(hp_map.num_points, dtype=float),
             ],
             dims=["epoch", "pixel"],
         )
+        hp_map.data_1d["counts"][0, 999] = np.nan
 
         for num_subdiv, (expected_value, atol) in enumerate(
             [
@@ -1365,7 +1366,7 @@ class TestHealpixSkyMap:
                 (expected_mean_0_subdivisions, 1e-9),
                 (expected_mean_1_subdivisions, 1e-9),
                 # Slight difference from not taking into account asym solid angle
-                (expected_mean_2_subdivisions, 0.1),
+                (expected_mean_2_subdivisions, 1e-4),
             ]
         ):
             mock_ang2pix.reset_mock()

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+import warnings
 from copy import deepcopy
 from pathlib import Path
 from unittest import mock
@@ -1390,6 +1391,64 @@ class TestHealpixSkyMap:
             rect_pix_spacing_deg=2,
             value_array=hp_map.data_1d["counts"],
             num_subdivisions=0,
+        )
+
+    @mock.patch("astropy_healpix.healpy.ang2pix")
+    def test_calculate_rect_pixel_value_outputs_fill_for_pixels_with_zero_non_fill_vals(
+        self,
+        mock_ang2pix,
+    ):
+        """Test getting rectangular pixel values from HealpixSkyMap via subdivision."""
+
+        # Mock ang2pix to return fixed values based on a dict
+        pixel_dict = {
+            # 0 subdiv - just 1 pixel
+            (180, 0): 0,
+            # 1 subdiv - all subpix have same solid angle because centered on equator
+            (179, -1): 999,
+            (179, 1): 999,
+            (181, -1): 999,
+            (181, 1): 999,
+        }
+
+        def mock_ang2pix_fn(nside, theta, phi, nest=True, lonlat=False):
+            vals = []
+            for pix_num in range(len(theta)):
+                key = (theta[pix_num], phi[pix_num])
+                vals.append(pixel_dict.get(key, 0))
+            return np.array(vals)
+
+        mock_ang2pix.side_effect = mock_ang2pix_fn
+
+        hp_map = ena_maps.HealpixSkyMap(
+            nside=16,
+            spice_frame=geometry.SpiceFrame.ECLIPJ2000,
+            nested=True,
+        )
+        hp_map.data_1d["counts"] = xr.DataArray(
+            data=[
+                np.arange(hp_map.num_points, dtype=float),
+            ],
+            dims=["epoch", "pixel"],
+        )
+        hp_map.data_1d["counts"][0, 999] = np.nan
+
+        with warnings.catch_warnings(record=True) as w:
+            mean_value = (
+                hp_map.calculate_rect_pixel_value_from_healpix_map_n_subdivisions(
+                    rect_pix_center_lon_lat=(180, 0),
+                    rect_pix_spacing_deg=4,
+                    value_array=hp_map.data_1d["counts"],
+                    num_subdivisions=1,
+                )
+            )
+
+        assert len(w) == 0, "Should not raise RuntimeWarning for dividing by zero"
+
+        np.testing.assert_allclose(
+            mean_value,
+            np.nan,
+            err_msg=f"Failed for num_subdivisions: {1}",
         )
 
     @mock.patch(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -1335,6 +1335,7 @@ class TestHealpixSkyMap:
             (181.5, -1.5): 17,
             (181.5, -0.5): 18,
             (181.5, 0.5): 19,
+            # Set the final entry to 999 to identify a pixel that will be set to NaN
             (181.5, 1.5): 999,
         }
         expected_mean_0_subdivisions = 0


### PR DESCRIPTION
# Change Summary

## Overview
Addressing issue #2489 to ignore fill values when calculating the weighted averages of subpixels.

## Updated Files
- ena_maps.py
  - No longer weighting by the full rectangular pixel, we are taking a mask of the finite values and applying those to the numerator and denominator in the weighted averaging.

## Testing
- Modified `test_calculate_rect_pixel_value_from_healpix_map_n_subdivisions` to include nan value that should be ignored when performing subdivision averaging.