### PR TITLE
MNT: Handle negative counts in SWAPI

### DIFF
--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -25,7 +25,7 @@ counts_default: &counts_default
   DEPEND_1: esa_step
   DISPLAY_TYPE: spectrogram
   LABL_PTR_1: esa_step_label
-  FILLVAL: 65535
+  FILLVAL: -1.0000000E+31
   FORMAT: I5
   UNITS: counts
   VALIDMIN: 0

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -259,6 +259,11 @@ def swapi_l2(
     l2_dataset["swp_pcem_rate"] = l1_dataset["swp_pcem_counts"] / SWAPI_LIVETIME
     l2_dataset["swp_scem_rate"] = l1_dataset["swp_scem_counts"] / SWAPI_LIVETIME
     l2_dataset["swp_coin_rate"] = l1_dataset["swp_coin_counts"] / SWAPI_LIVETIME
+
+    # NOTE: The counts can be negative from FILLVAL in l1a data. We want to ignore those
+    #       and propagate nans
+    for var in ["swp_pcem_rate", "swp_scem_rate", "swp_coin_rate"]:
+        l2_dataset[var] = l2_dataset[var].where(l2_dataset[var] >= 0, np.nan)
     # update attrs
     l2_dataset["swp_pcem_rate"].attrs = cdf_manager.get_variable_attributes("pcem_rate")
     l2_dataset["swp_scem_rate"].attrs = cdf_manager.get_variable_attributes("scem_rate")


### PR DESCRIPTION
# Change Summary

The counts variable had a FILLVAL of 65535, but the datatype was float. The L1 files were getting produced with -1E31 values in them, but then when they were getting loaded they weren't matching with the FILLVAL expected so weren't getting replaced upon loading them.

This does two things. Updates the FILLVAL in the counts variable and also updates the code to handle negative counts and just replace those with nans since they are nonsensical.