### PR TITLE
MNT/FIX: Update SWAPI L2 to handle generalized fine sweeps

### DIFF
--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -65,9 +65,16 @@ def solve_full_sweep_energy(
         dtype="datetime64[ns]"
     )
 
-    first_63_energies = []
+    # Initialize the output energy array
+    # Each sweep will have different energies for each step.
+    # The first 63 energies are coarse steps, then followed by 9 fine steps.
+    # The 9 fine steps may be defined in the main table (fixed steps), or "solve"
+    # which requires a separate lookup in the lut-notes table.
+    energy_data = np.empty((len(sweep_table), NUM_ENERGY_STEPS), dtype=float)
 
-    for time, sweep_id in zip(data_time, sweep_table, strict=False):
+    for i_sweep, (time, sweep_id, esa_lvl5_val) in enumerate(
+        zip(data_time, sweep_table, esa_lvl5_data, strict=True)
+    ):
         # Find the sweep's ESA data for the given time and sweep_id
         subset = esa_table_df[
             (esa_table_df["timestamp"] <= time) & (esa_table_df["Sweep #"] == sweep_id)
@@ -89,83 +96,56 @@ def solve_full_sweep_energy(
                 )
             subset = earliest_subset
 
-        # Subset data can contain multiple 72 energy values with last 9 fine energies
-        # with 'Solve' value. We need to sort by time and ESA step to maintain correct
-        # order. Then take the last group of 72 steps values and select first 63
-        # values only.
-        subset = subset.sort_values(["timestamp", "ESA Step #"])
-        grouped = subset["Energy"].values.reshape(-1, NUM_ENERGY_STEPS)
-        first_63 = grouped[-1, :63]
-        first_63_energies.append(first_63)
-
-    # Find last 9 fine energy values of all sweeps data
-    # -------------------------------------------------
-    # First, verify that all values in the LUT-notes table's 'ESA DAC (Hex)' column
-    # exactly matches a value in the esa_lvl5_data.
-    has_exact_match = np.isin(esa_lvl5_data, lut_notes_df["ESA DAC (Hex)"].values)
-    if not np.all(has_exact_match):
-        raise ValueError(
-            "These ESA_LVL5 values not found in lut-notes table: "
-            f"{esa_lvl5_data[np.where(~has_exact_match)[0]]} "
-        )
-
-    # Find index of 71st energy step for all sweeps data in lut-notes table.
-    # Tried using np.where(np.isin(...)) or df.index[np.isin(...)] to find the index
-    # of each value in esa_lvl5_data within the LUT table. However, these methods
-    # return only the unique matching indices — not one index per input value.
-    # For example, given the input:
-    #   ['12F1', '12F1', '12F1', '12F1']
-    # np.where(np.isin(...)) would return:
-    #   [336]
-    # because it finds that '12F1' exists in the LUT and only returns its position once.
-    # What we actually need is:
-    #   [336, 336, 336, 336]
-    # — one index for *each* occurrence in the input, preserving its shape and order.
-    # Therefore, instead of relying on np.isin or similar, we explicitly use
-    # np.where in a loop to find the index of each value in esa_lvl5_data individually,
-    # ensuring the output array has the same shape as the input.
-
-    # Page 31 of algorithm document
-    last_energy_step_indices = np.array(
-        [
-            np.where(lut_notes_df["ESA DAC (Hex)"].values == val)[0][0]
-            for val in esa_lvl5_data
+        # Subset data can contain multiple sweeps of 72 energy values.
+        # We need to sort by time and ESA step to maintain correct
+        # order. Then take the last sweep (72 values).
+        subset = subset.sort_values(["timestamp", "ESA Step #"]).iloc[
+            -NUM_ENERGY_STEPS:
         ]
-    )
-    # Use back tracking steps to find all 9 fine energy value indices
-    # Eg. [-32, -28, ... -8, -4, 0]
-    steps = np.arange(9)[::-1] * -4
+        sweep_esa_energies = subset["Energy"].values
 
-    # Find indices of last 9 fine energy values of all sweeps data
-    fine_energy_indices = last_energy_step_indices[:, None] + steps
+        # Solve steps are the fine sweep steps. This can be variable numbers and is
+        # not always the final 9 steps. They are negative values when reading in the df
+        solve_steps = sweep_esa_energies < 0
+        energy_data[i_sweep, ~solve_steps] = sweep_esa_energies[~solve_steps]
+        if not np.any(solve_steps):
+            # No solve steps, we've already filled all energies continue to next sweep
+            continue
 
-    # NOTE: This back tracking method was updated with sweep id 3. So
-    # we need to change the step values based on sweep id.
-    # The final 3 steps are background and will be set to 0 energy later.
-    sweep_id_3_mask = np.asarray(sweep_table) == 3
-    steps = np.array([-80, -64, -48, -32, -16, 0, 0, 0, 0])
-    fine_energy_indices[sweep_id_3_mask, :] = (
-        last_energy_step_indices[sweep_id_3_mask, None] + steps
-    )
+        # Page 31 of algorithm document
+        # Get the last energy step index for use in looking up the fine sweep values
+        # Find the index of the matching ESA DAC value
+        matching_indices = np.nonzero(
+            lut_notes_df["ESA DAC (Hex)"].values == esa_lvl5_val
+        )[0]
+        if len(matching_indices) == 0:
+            raise ValueError(
+                f"ESA DAC value '{esa_lvl5_val}' not found in LUT notes table "
+                f"for sweep {i_sweep} at time {time}"
+            )
+        last_energy_step_index = matching_indices[0]
 
-    # NOTE: Per SWAPI instruction, set every index that result in negative
-    # indices during back tracking to zero index. SWAPI calls this
-    # "flooring" the index. For example, if the 71st energy step index results
-    # in less than 32, then it would result in some negative indices. Eg.
-    #    71st index = 31
-    #    nine fine energy indices = [31, 27, 23, 19, 15, 11, 7, 3, -1]
-    #    flooring = [31, 27, 23, 19, 15, 11, 7, 3, 0]
-    fine_energy_indices[fine_energy_indices < 0] = 0
+        # The ESA Index Number contains the offset indices for the fine energy values
+        fine_offsets = subset["ESA Index Number"].values[solve_steps]
+        # Since we are backtracking from the final index, we need to subtract that
+        # offset from all of the other indices.
+        fine_offsets -= fine_offsets[-1]
+        fine_lut_indices = last_energy_step_index + fine_offsets
 
-    energy_values = lut_notes_df["Energy"].values[fine_energy_indices]
+        # NOTE: Per SWAPI instruction, set every index that result in negative
+        # indices during back tracking to zero index. SWAPI calls this
+        # "flooring" the index. For example, if the 71st energy step index results
+        # in less than 32, then it would result in some negative indices. Eg.
+        #    71st index = 31
+        #    nine fine energy indices = [31, 27, 23, 19, 15, 11, 7, 3, -1]
+        #    flooring = [31, 27, 23, 19, 15, 11, 7, 3, 0]
+        fine_lut_indices[fine_lut_indices < 0] = 0  # Ensure no negative indices
 
-    # Set last 3 fine energies to 0 for sweep id 3
-    energy_values[sweep_id_3_mask, -3:] = 0.0
+        energy_data[i_sweep, solve_steps] = lut_notes_df["Energy"].values[
+            fine_lut_indices
+        ]
 
-    # Append the first_63_values in front of energy_values
-    sweeps_energy_value = np.hstack([first_63_energies, energy_values])
-
-    return sweeps_energy_value
+    return energy_data
 
 
 def swapi_l2(

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -226,14 +226,14 @@ def test_solve_full_sweep_energy(esa_unit_conversion_table, lut_notes_table):
             107,
         ]
     )
-    assert np.all(sweeps_energy_value[:, :63] == fixed_energy_values)
+    np.testing.assert_array_equal(sweeps_energy_value[0, :63], fixed_energy_values)
 
     # Now, test that the last 9 fine energy values are as expected for first sweep.
     # I manually picked those values from LUT table.
     expected_fine_energies = np.array(
         [3220.0, 3151.0, 3083.0, 3017.0, 2953.0, 2889.0, 2827.0, 2767.0, 2707.0]
     )
-    assert np.all(sweeps_energy_value[0, -9:] == expected_fine_energies)
+    np.testing.assert_array_equal(sweeps_energy_value[0, -9:], expected_fine_energies)
 
     # Test that we get different values for date later than 2025-05-19
     data_time = [np.datetime64("2025-05-20T00:00:00", "ns")]
@@ -307,12 +307,12 @@ def test_solve_full_sweep_energy(esa_unit_conversion_table, lut_notes_table):
             100,
         ]
     )
-    assert np.all(sweeps_energy_value[:, :63] == new_fixed_energy_values)
+    np.testing.assert_array_equal(sweeps_energy_value[0, :63], new_fixed_energy_values)
 
     # Test mismatch values for 9 fine steps x 4 steps.
     mismatch_value = [1]
     with pytest.raises(
-        ValueError, match="These ESA_LVL5 values not found in lut-notes table"
+        ValueError, match="ESA DAC value '1' not found in LUT notes table"
     ):
         solve_full_sweep_energy(
             np.array(mismatch_value),
@@ -330,6 +330,19 @@ def test_solve_full_sweep_energy_id3(esa_unit_conversion_table, lut_notes_table)
     esa_unit_conversion_table.loc[
         esa_unit_conversion_table["Sweep #"] == 2, "Sweep #"
     ] = 3
+    # Update the first 3 fine energies to be 0 rather than "solve" / negative
+    # This makes 6 fine energy steps for sweep id 3
+    # Get sweep 3 rows and set Energy values at indices 63-66 (inclusive) to 0
+    sweep_3_mask = esa_unit_conversion_table["Sweep #"] == 3
+    sweep_3_indices = esa_unit_conversion_table[sweep_3_mask].index
+    esa_unit_conversion_table.loc[sweep_3_indices[63:66], "Energy"] = 0
+
+    # Update the ESA Index Number in lut_notes_table for sweep id 3
+    # to match the 6 fine energy steps
+    esa_unit_conversion_table.loc[sweep_3_indices[66:], "ESA Index Number"] = np.array(
+        [-40, -24, -8, 8, 24, 40]
+    )
+
     esa_lvl5_arr = [4663]
     sweep_table = [3]
     data_time = [np.datetime64("2025-12-24T00:00:00", "ns")]
@@ -339,10 +352,11 @@ def test_solve_full_sweep_energy_id3(esa_unit_conversion_table, lut_notes_table)
     )
     assert sweeps_energy_value.shape == (1, 72)
 
-    # The last 3 values should be 0 for sweep id 3
+    # The first 3 fine step values should be 0 for sweep id 3
     np.testing.assert_array_equal(
-        sweeps_energy_value[0, -3:], np.array([0.0, 0.0, 0.0])
+        sweeps_energy_value[0, 63:66], np.array([0.0, 0.0, 0.0])
     )
-    # The -9th value (first fine step) should be the same as the last index-80
+    # The -6th value (first fine step) should be the same as the last index-80
     # 4663 corresponds to 383rd index in lut_notes_table
-    assert sweeps_energy_value[0, -9] == lut_notes_table["Energy"].values[383 - 80]
+    assert sweeps_energy_value[0, -6] == lut_notes_table["Energy"].values[383 - 80]
+    assert sweeps_energy_value[0, -1] == lut_notes_table["Energy"].values[383]


### PR DESCRIPTION
We are not guaranteed to get 9 fine sweep values in the LUT, so we need to only look up values when "solve" is declared. There have been quite a few updates with different changes, so this should address things in a general way so that we only need to upload new ancillary files now and don't need to update the code anytime new fine stepping sizes change with sweep number.

For now, everything is in a loop per-sweep, I'm not sure off the top of my head if there is a way to do this more efficiently with numpy vectorization with all the potential changing of sizes and wanted to get this in and we can tackle that later if we have more time. It is not that slow as-is.

closes #2500 