### PR TITLE
CoDICE l1b hi and lo aggregated counters

### DIFF
--- a/imap_processing/codice/constants.py
+++ b/imap_processing/codice/constants.py
@@ -797,7 +797,23 @@ LO_SW_SPECIES_VARIABLE_NAMES = [
     "heplus",
     "cnoplus",
 ]
-
+LO_COUNTERS_AGGREGATED_VARIABLE_NAMES = [
+    "tcr",
+    "dcr",
+    "sta",
+    "stb",
+    "sp",
+    "total_position_count",
+]
+HI_COUNTERS_AGGREGATED_VARIABLE_NAMES = [
+    "dcr",
+    "mst",
+    "starts_only",
+    "stops_only",
+    "singles_starts",
+    "singles_stops",
+    "low_tof_cutoff",
+]
 LO_COUNTERS_SINGLES_VARIABLE_NAMES = ["apd_singles"]
 HI_COUNTERS_SINGLES_VARIABLE_NAMES = ["tcr", "ssdo", "stssd"]
 # Various configurations to support L1b processing of individual data products

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -395,6 +395,83 @@ def test_l1b_sw_lo_priorities(mock_get_file_paths, codice_lut_path):
 
 
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_l1b_lo_counters_aggregated(mock_get_file_paths, codice_lut_path):
+    """Tests l1b lo-counters-aggregated."""
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="lo-counters-aggregated", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+
+    l1a_data = process_l1a(dependency=ProcessingInputCollection())[0]
+    l1a_file_path = write_cdf(l1a_data)
+    processed_data = process_codice_l1b(file_path=l1a_file_path)
+    # Validation
+    val_path = (
+        imap_module_directory
+        / "tests/codice/data/l1b_validation/"
+        / (
+            f"imap_codice_l1b_lo-counters-aggregated_{VALIDATION_FILE_DATE}"
+            f"_{VALIDATION_FILE_VERSION}.cdf"
+        )
+    )
+    val_data = load_cdf(val_path)
+    for variable in val_data.data_vars:
+        # TODO ask Joey about these variables. E.g. tof_only
+        if val_data[variable].values.size == 0:
+            continue
+        np.testing.assert_allclose(
+            processed_data[variable].values,
+            val_data[variable].values,
+            rtol=1e-5,
+            err_msg=f"Mismatch in variable '{variable}'",
+        )
+
+    processed_data.attrs["Data_version"] = "001"
+    cdf_file = write_cdf(processed_data, terminate_on_warning=True)
+    assert (
+        cdf_file.name
+        == f"imap_codice_l1b_lo-counters-aggregated_{VALIDATION_FILE_DATE}_v001.cdf"
+    )
+
+
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_l1b_hi_counters_aggregated(mock_get_file_paths, codice_lut_path):
+    """Tests l1b lo-counters-aggregated."""
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="hi-counters-aggregated", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+
+    l1a_data = process_l1a(dependency=ProcessingInputCollection())[0]
+    l1a_file_path = write_cdf(l1a_data)
+    processed_data = process_codice_l1b(file_path=l1a_file_path)
+    # Validation
+    val_path = (
+        imap_module_directory
+        / "tests/codice/data/l1b_validation/"
+        / (
+            f"imap_codice_l1b_hi-counters-aggregated_{VALIDATION_FILE_DATE}"
+            f"_{VALIDATION_FILE_VERSION}.cdf"
+        )
+    )
+    val_data = load_cdf(val_path)
+    for variable in val_data.data_vars:
+        np.testing.assert_allclose(
+            processed_data[variable].values,
+            val_data[variable].values,
+            rtol=1.2e-5,
+            err_msg=f"Mismatch in variable '{variable}'",
+        )
+
+    processed_data.attrs["Data_version"] = "001"
+    cdf_file = write_cdf(processed_data, terminate_on_warning=True)
+    assert (
+        cdf_file.name
+        == f"imap_codice_l1b_hi-counters-aggregated_{VALIDATION_FILE_DATE}_v001.cdf"
+    )
+
+
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
 def test_lo_counters_singles(mock_get_file_paths, codice_lut_path):
     """Tests l1b lo-counters-singles."""
     mock_get_file_paths.side_effect = [


### PR DESCRIPTION
# Change Summary
closes #2166
closes #2148


## Overview
Hi and lo aggregated validation (Tenzin had set up all the processing already)

## Updated Files
- imap_processing/codice/codice_l1b.py
   - Add logic to skip uncertainty calculation for counters products
- imap_processing/codice/constants.py
   - Add aggregate counters variables. 

## Testing
validation test. 