### PR TITLE
CoDICE l1b singles counters for lo and hi

### DIFF
--- a/imap_processing/codice/codice_l1b.py
+++ b/imap_processing/codice/codice_l1b.py
@@ -41,6 +41,8 @@ def convert_to_rates(dataset: xr.Dataset, descriptor: str) -> np.ndarray:
     rates_data : np.ndarray
         The converted data array.
     """
+    # No uncertainty calculation for diagnostic counters products
+    calculate_unc = False if "counters" in descriptor else True
     # Variables to convert based on descriptor
     variables_to_convert = getattr(
         constants, f"{descriptor.upper().replace('-', '_')}_VARIABLE_NAMES"
@@ -139,12 +141,13 @@ def convert_to_rates(dataset: xr.Dataset, descriptor: str) -> np.ndarray:
         # Carry over attrs and update as needed
         dataset[variable].attrs["UNITS"] = "counts/s"
 
-        # Uncertainty calculation
-        unc_variable = f"unc_{variable}"
-        dataset[unc_variable].data = (
-            dataset[unc_variable].astype(np.float64) / denominator
-        )
-        dataset[unc_variable].attrs["UNITS"] = "1/s"
+        if calculate_unc:
+            # Uncertainty calculation
+            unc_variable = f"unc_{variable}"
+            dataset[unc_variable].data = (
+                dataset[unc_variable].astype(np.float64) / denominator
+            )
+            dataset[unc_variable].attrs["UNITS"] = "1/s"
 
     # Drop spin_period
     if "spin_period" in dataset.variables:

--- a/imap_processing/codice/constants.py
+++ b/imap_processing/codice/constants.py
@@ -798,6 +798,8 @@ LO_SW_SPECIES_VARIABLE_NAMES = [
     "cnoplus",
 ]
 
+LO_COUNTERS_SINGLES_VARIABLE_NAMES = ["apd_singles"]
+HI_COUNTERS_SINGLES_VARIABLE_NAMES = ["tcr", "ssdo", "stssd"]
 # Various configurations to support L1b processing of individual data products
 # Much of these are described in the algorithm document in chapter 11 ("Data
 # Level 1B")

--- a/imap_processing/tests/codice/test_codice_l1b.py
+++ b/imap_processing/tests/codice/test_codice_l1b.py
@@ -392,3 +392,79 @@ def test_l1b_sw_lo_priorities(mock_get_file_paths, codice_lut_path):
         cdf_file.name
         == f"imap_codice_l1b_lo-sw-priority_{VALIDATION_FILE_DATE}_v999.cdf"
     )
+
+
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_lo_counters_singles(mock_get_file_paths, codice_lut_path):
+    """Tests l1b lo-counters-singles."""
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="lo-counters-singles", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+
+    l1a_data = process_l1a(dependency=ProcessingInputCollection())[0]
+    l1a_file_path = write_cdf(l1a_data)
+    processed_data = process_codice_l1b(file_path=l1a_file_path)
+
+    # Validation
+    val_path = (
+        imap_module_directory
+        / "tests/codice/data/l1b_validation/"
+        / (
+            f"imap_codice_l1b_lo-counters-singles_{VALIDATION_FILE_DATE}"
+            f"_{VALIDATION_FILE_VERSION}.cdf"
+        )
+    )
+    val_data = load_cdf(val_path)
+    for variable in val_data.data_vars:
+        np.testing.assert_allclose(
+            processed_data[variable].values,
+            val_data[variable].values,
+            rtol=1e-5,
+            err_msg=f"Mismatch in variable '{variable}'",
+        )
+
+    processed_data.attrs["Data_version"] = "001"
+    cdf_file = write_cdf(processed_data, terminate_on_warning=True)
+    assert (
+        cdf_file.name
+        == f"imap_codice_l1b_lo-counters-singles_{VALIDATION_FILE_DATE}_v001.cdf"
+    )
+
+
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_hi_counters_singles(mock_get_file_paths, codice_lut_path):
+    """Tests l1b hi-counters-singles."""
+    mock_get_file_paths.side_effect = [
+        codice_lut_path(descriptor="hi-counters-singles", data_type="l0"),
+        codice_lut_path(descriptor="l1a-sci-lut"),
+    ]
+
+    l1a_data = process_l1a(dependency=ProcessingInputCollection())[0]
+    l1a_file_path = write_cdf(l1a_data)
+    processed_data = process_codice_l1b(file_path=l1a_file_path)
+
+    # Validation
+    val_path = (
+        imap_module_directory
+        / "tests/codice/data/l1b_validation/"
+        / (
+            f"imap_codice_l1b_hi-counters-singles_{VALIDATION_FILE_DATE}"
+            f"_{VALIDATION_FILE_VERSION}.cdf"
+        )
+    )
+    val_data = load_cdf(val_path)
+    for variable in val_data.data_vars:
+        np.testing.assert_allclose(
+            processed_data[variable].values,
+            val_data[variable].values,
+            rtol=1.2e-5,
+            err_msg=f"Mismatch in variable '{variable}'",
+        )
+
+    processed_data.attrs["Data_version"] = "001"
+    cdf_file = write_cdf(processed_data, terminate_on_warning=True)
+    assert (
+        cdf_file.name
+        == f"imap_codice_l1b_hi-counters-singles_{VALIDATION_FILE_DATE}_v001.cdf"
+    )


### PR DESCRIPTION
# Change Summary
L1b validation for counters singles. Tenzin already had code in place for counters processing. 

## Overview
closes #2165 
closes #2147


## Updated Files
- imap_processing/codice/codice_l1b.py
   - Do not calculate uncertainties for counters products
- imap_processing/codice/constants.py
   - Add variables to constants

## Testing
Validation test
