### PR TITLE
Change CDF types of L2/L1D variables for MAG

### DIFF
--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -50,6 +50,7 @@ vector_attrs: &vectors_default
     LABL_PTR_1: direction_label
     FILLVAL: 9223372036854775807
     FORMAT: F12.5
+    CDF_DATA_TYPE: CDF_FLOAT
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:DSRF,CoordinateRepresentation:Cartesian"
 
 # Frame-specific vector attributes
@@ -99,6 +100,7 @@ magnitude:
   UNITS: nT
   VALIDMIN: 0
   VALIDMAX: 1.0e+5
+  CDF_DATA_TYPE: CDF_FLOAT
   DICT_KEY: SPASE>Field>FieldQuantity:Magnetic,Qualifier:Scalar
 
 range:
@@ -111,6 +113,7 @@ range:
   UNITS: ' '
   VALIDMAX: 3
   VALIDMIN: 0
+  CDF_DATA_TYPE: CDF_UINT1
   DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
 
 pri_sens:

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -147,7 +147,7 @@ class MagL2L1dBase:
         )
 
         vectors = xr.DataArray(
-            self.vectors,
+            self.vectors.astype(np.float32),
             name="vectors",
             dims=["epoch", "direction"],
             attrs=attribute_manager.get_variable_attributes(vector_attrs_name),
@@ -168,14 +168,14 @@ class MagL2L1dBase:
         )
 
         rng = xr.DataArray(
-            self.range,
+            self.range.astype(np.uint8),
             name="range",
             dims=["epoch"],
             attrs=attribute_manager.get_variable_attributes("range"),
         )
 
         magnitude = xr.DataArray(
-            self.magnitude,
+            self.magnitude.astype(np.float32),
             name="magnitude",
             dims=["epoch"],
             attrs=attribute_manager.get_variable_attributes("magnitude"),

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -147,10 +147,12 @@ class MagL2L1dBase:
         )
 
         vectors = xr.DataArray(
-            self.vectors.astype(np.float32),
+            self.vectors,
             name="vectors",
             dims=["epoch", "direction"],
-            attrs=attribute_manager.get_variable_attributes(vector_attrs_name),
+            attrs=attribute_manager.get_variable_attributes(
+                vector_attrs_name, check_schema=False
+            ),
         )
 
         quality_flags = xr.DataArray(
@@ -168,17 +170,21 @@ class MagL2L1dBase:
         )
 
         rng = xr.DataArray(
-            self.range.astype(np.uint8),
+            self.range,
             name="range",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("range"),
+            attrs=attribute_manager.get_variable_attributes(
+                "range", check_schema=False
+            ),
         )
 
         magnitude = xr.DataArray(
-            self.magnitude.astype(np.float32),
+            self.magnitude,
             name="magnitude",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("magnitude"),
+            attrs=attribute_manager.get_variable_attributes(
+                "magnitude", check_schema=False
+            ),
         )
 
         global_attributes = (

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -75,6 +75,7 @@ def test_mag_l2_attributes(norm_dataset, mag_test_l2_data, data_mode):
         assert dataset["range"].attrs["DICT_KEY"] == (
             "SPASE>Support>SupportQuantity:InstrumentMode"
         )
+        assert dataset["vectors"].attrs["CDF_DATA_TYPE"] == "CDF_FLOAT"
 
 
 def test_mag_l2(norm_dataset, mag_test_l2_data):

--- a/imap_processing/tests/mag/test_mag_validation.py
+++ b/imap_processing/tests/mag/test_mag_validation.py
@@ -382,6 +382,9 @@ def test_mag_l2_validation(test_number, mode):
     # leapseconds.
     # Subtract 5 seconds from epoch to account for leap seconds
     expected_output["epoch"] = expected_output["epoch"] - pd.Timedelta(seconds=5)
+    expected_output["x"] = expected_output["x"].astype(np.float32)
+    expected_output["y"] = expected_output["y"].astype(np.float32)
+    expected_output["z"] = expected_output["z"].astype(np.float32)
 
     # Truncate expected output to only include time after 2025-05-06T00:00:00
     expected_output = expected_output[

--- a/imap_processing/tests/mag/test_mag_validation.py
+++ b/imap_processing/tests/mag/test_mag_validation.py
@@ -382,9 +382,6 @@ def test_mag_l2_validation(test_number, mode):
     # leapseconds.
     # Subtract 5 seconds from epoch to account for leap seconds
     expected_output["epoch"] = expected_output["epoch"] - pd.Timedelta(seconds=5)
-    expected_output["x"] = expected_output["x"].astype(np.float32)
-    expected_output["y"] = expected_output["y"].astype(np.float32)
-    expected_output["z"] = expected_output["z"].astype(np.float32)
 
     # Truncate expected output to only include time after 2025-05-06T00:00:00
     expected_output = expected_output[


### PR DESCRIPTION
# Change Summary

## Overview

Some of the MAG variable types are unnecessarily large for the precision of the underlying data. This forces the types of those variables to be more appropriate to the underlying data. Specifically, the magnetic field vectors and magnitude variables will now be CDF_FLOAT rather than CDF_DOUBLE, and the range (which can only be 0,1,2,3) is CDF_UINT1.

## New Dependencies
N/A

## New Files
N/A

## Deleted Files
N/A

## Updated Files

- imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
   - Set CDF_DATA_TYPE for range, magnitude, and all vectors to CDF_UINT1, and CDF_FLOAT respectively
- imap_processing/mag/l2/mag_l2_data.py
   - Don't check schema for attributes so the CDF_DATA_TYPE attribute is carried through

## Testing
Updated tests to test the CDF_DATA_TYPE is set for the vectors
