### PR TITLE
ULTRA L1c deadtime correction fixes 

### DIFF
--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -547,51 +547,13 @@ def ancillary_files():
 
 
 @pytest.fixture
-def deadtime_datasets():
-    """Fixture to create params and rates datasets needed to calculate the spacecraft
-    exposure time."""
-    # Simulate a test rates dataset.
-    epoch = 200
-    test_l1a_rates_dataset = xr.Dataset(
-        {
-            "fifo_valid_events": (["epoch"], np.random.randint(100, 200, epoch)),
-            "event_active_time": (["epoch"], np.random.uniform(0, 10, epoch)),
-            "start_pos": (["epoch"], np.random.randint(0, 5, epoch)),
-            "start_rf": (["epoch"], np.random.randint(0, 5, epoch)),
-            "start_lf": (["epoch"], np.random.randint(0, 5, epoch)),
-            "coin_tn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "coin_bn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "stop_tn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
-            "shcoarse": (["epoch"], np.arange(epoch)),
-            "spin": (["epoch"], 127 + (np.arange(epoch) % (141 - 127))),
-        }
-    )
-    # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).
-    # each time the mode changes, it is recorded in the params packet.
-    # Create a test params dataset that simulates the mode changing to 3, 3 times.
-    modes = np.tile(np.arange(4), 3)
-    test_l1a_params_dataset = xr.Dataset(
-        {
-            "imageratescadence": (["epoch"], modes),
-        },
-        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
-    )
-    return {"rates": test_l1a_rates_dataset, "params": test_l1a_params_dataset}
-
-
-@pytest.fixture
 def random_spin_data():
     """Fixture for random spin data."""
     with (
         mock.patch(
-            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_spacecraft_spin_phase"
-        ) as mock_spin_phases,
-        mock.patch(
             "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met"
         ) as mock_met,
     ):
-        mock_spin_phases.side_effect = lambda time: np.random.random(time.shape)
         mock_met.side_effect = lambda time: time
         yield
 

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -547,18 +547,6 @@ def ancillary_files():
 
 
 @pytest.fixture
-def random_spin_data():
-    """Fixture for random spin data."""
-    with (
-        mock.patch(
-            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met"
-        ) as mock_met,
-    ):
-        mock_met.side_effect = lambda time: time
-        yield
-
-
-@pytest.fixture
 def mock_spacecraft_pointing_lookups():
     """Test lookup tables fixture."""
     np.random.seed(42)

--- a/imap_processing/tests/ultra/unit/test_helio_pset.py
+++ b/imap_processing/tests/ultra/unit/test_helio_pset.py
@@ -16,7 +16,7 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 
 @pytest.mark.skip(reason="Long running test for validation purposes.")
 def test_validate_exposure_time_and_sensitivities(
-    ancillary_files, deadtime_datasets, imap_ena_sim_metakernel
+    ancillary_files, rates_dataset, imap_ena_sim_metakernel
 ):
     """Validates exposure time and sensitivities for ebin 0."""
     sens_filename = "SENS-IMAP_ULTRA_90-IMAP_DPS-HELIO-nside32-ebin0.csv"
@@ -68,10 +68,6 @@ def test_validate_exposure_time_and_sensitivities(
             "imap_processing.ultra.l1c.helio_pset.get_pointing_times_from_id",
             return_value=pointing_range_met,
         ),
-        mock.patch(
-            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
-            side_effect=lambda x: x,
-        ),
         # Mock deadtimes to be all ones
         mock.patch(
             "imap_processing.ultra.l1c.ultra_l1c_pset_bins."
@@ -94,8 +90,7 @@ def test_validate_exposure_time_and_sensitivities(
         pset = calculate_helio_pset(
             l1b_de,
             dataset,
-            deadtime_datasets["rates"],
-            deadtime_datasets["params"],
+            rates_dataset,
             "imap_ultra_l1c_90sensor-heliopset",
             ancillary_files,
             90,

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -32,7 +32,7 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 @pytest.mark.external_kernel
 def test_calculate_spacecraft_pset(
     random_spin_data,
-    deadtime_datasets,
+    rates_dataset,
     imap_ena_sim_metakernel,
     use_fake_spin_data_for_time,
     ancillary_files,
@@ -41,7 +41,10 @@ def test_calculate_spacecraft_pset(
     """Tests calculate_spacecraft_pset function."""
     # Simulate a spin table from MET = 0 to MET = 141 * 15 seconds
     use_fake_spin_data_for_time(start_met=0, end_met=141 * 15)
-
+    # Ensure rate dataset has correct time range
+    rates_dataset.shcoarse.data = np.linspace(
+        0, 141 * 15, len(rates_dataset.shcoarse.data)
+    )
     # This is just setting up the data so that it is in the format of l1b_de_dataset.
     test_path = TEST_PATH / "ultra-90_raw_event_data_shortened.csv"
     df = pd.read_csv(test_path)
@@ -105,8 +108,7 @@ def test_calculate_spacecraft_pset(
         spacecraft_pset = calculate_spacecraft_pset(
             test_l1b_de_dataset,
             test_l1b_de_dataset,  # placeholder for goodtimes_dataset
-            deadtime_datasets["rates"],
-            deadtime_datasets["params"],
+            rates_dataset,
             "imap_ultra_l1c_45sensor-spacecraftpset",
             ancillary_files,
             45,
@@ -122,7 +124,7 @@ def test_calculate_spacecraft_pset(
 def test_calculate_spacecraft_pset_with_cdf(
     random_spin_data,
     ancillary_files,
-    deadtime_datasets,
+    rates_dataset,
     imap_ena_sim_metakernel,
     use_fake_spin_data_for_time,
     mock_spacecraft_pointing_lookups,
@@ -140,7 +142,10 @@ def test_calculate_spacecraft_pset_with_cdf(
 
         de_dict["epoch"] = df_subset["epoch"].values
         species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
-
+        # Ensure rate dataset has correct time range
+        rates_dataset.shcoarse.data = np.linspace(
+            0, 141 * 15, len(rates_dataset.shcoarse.data)
+        )
         # PosYSlit is True for left (start_type = 1)
         # PosYSlit is False for right (start_type = 2)
         start_type = np.where(df_subset["PosYSlit"].values, 1, 2)
@@ -194,8 +199,7 @@ def test_calculate_spacecraft_pset_with_cdf(
             spacecraft_pset = calculate_spacecraft_pset(
                 dataset,
                 dataset,  # placeholder for goodtimes_dataset
-                deadtime_datasets["rates"],
-                deadtime_datasets["params"],
+                rates_dataset,
                 "imap_ultra_l1c_45sensor-spacecraftpset",
                 ancillary_files,
                 45,
@@ -208,8 +212,10 @@ def test_calculate_spacecraft_pset_with_cdf(
         )
 
 
-@pytest.mark.skip(reason="Long running test for validation purposes.")
-def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_datasets):
+pytest.mark.skip(reason="Long running test for validation purposes.")
+
+
+def test_validate_exposure_time_and_sensitivities(ancillary_files, rates_dataset):
     """Validates exposure time and sensitivities for ebin 0."""
     test_data = [
         (
@@ -309,8 +315,7 @@ def test_validate_exposure_time_and_sensitivities(ancillary_files, deadtime_data
         pset = calculate_spacecraft_pset(
             l1b_de,
             dataset,
-            deadtime_datasets["rates"],
-            deadtime_datasets["params"],
+            rates_dataset,
             "imap_ultra_l1c_90sensor-spacecraftpset",
             ancillary_files,
             90,

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -212,9 +212,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         )
 
 
-pytest.mark.skip(reason="Long running test for validation purposes.")
-
-
+@pytest.mark.skip(reason="Long running test for validation purposes.")
 def test_validate_exposure_time_and_sensitivities(ancillary_files, rates_dataset):
     """Validates exposure time and sensitivities for ebin 0."""
     test_data = [

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -31,7 +31,6 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
 def test_calculate_spacecraft_pset(
-    random_spin_data,
     rates_dataset,
     imap_ena_sim_metakernel,
     use_fake_spin_data_for_time,
@@ -95,15 +94,9 @@ def test_calculate_spacecraft_pset(
         },
         attrs={"Repointing": "repoint00001"},
     )
-    with (
-        mock.patch(
-            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
-            return_value=(482374890.0, 482374000.0),
-        ),
-        mock.patch(
-            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
-            side_effect=lambda x: x,
-        ),
+    with mock.patch(
+        "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
+        return_value=(482374890.0, 482374000.0),
     ):
         spacecraft_pset = calculate_spacecraft_pset(
             test_l1b_de_dataset,
@@ -122,7 +115,6 @@ def test_calculate_spacecraft_pset(
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
 def test_calculate_spacecraft_pset_with_cdf(
-    random_spin_data,
     ancillary_files,
     rates_dataset,
     imap_ena_sim_metakernel,
@@ -186,15 +178,9 @@ def test_calculate_spacecraft_pset_with_cdf(
         name = "imap_ultra_l1b_45sensor-de"
         dataset = create_dataset(de_dict, name, "l1b")
         dataset.attrs["Repointing"] = "repoint00000"
-        with (
-            mock.patch(
-                "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
-                return_value=(472374890.0, 582378000.0),
-            ),
-            mock.patch(
-                "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
-                side_effect=lambda x: x,
-            ),
+        with mock.patch(
+            "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
+            return_value=(472374890.0, 582378000.0),
         ):
             spacecraft_pset = calculate_spacecraft_pset(
                 dataset,
@@ -286,10 +272,6 @@ def test_validate_exposure_time_and_sensitivities(ancillary_files, rates_dataset
         mock.patch(
             "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
             return_value=pointing_range_met,
-        ),
-        mock.patch(
-            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
-            side_effect=lambda x: x,
         ),
         # Mock deadtimes to be all ones
         mock.patch(

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -121,7 +121,6 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
 def test_calculate_spacecraft_pset_with_cdf(
-    random_spin_data,
     ancillary_files,
     rates_dataset,
     imap_ena_sim_metakernel,
@@ -194,10 +193,6 @@ def test_calculate_spacecraft_pset_with_cdf(
             "imap_processing.ultra.l1c.spacecraft_pset.get_pointing_times_from_id",
             return_value=(482374890.0, 482374000.0),
         ),
-        mock.patch(
-            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
-            side_effect=lambda x: x,
-        ),
     ):
         output_datasets = ultra_l1c(
             data_dict, ancillary_files, "45sensor-spacecraftpset"
@@ -217,7 +212,6 @@ def test_calculate_spacecraft_pset_with_cdf(
 @pytest.mark.external_test_data
 @pytest.mark.external_kernel
 def test_calculate_helio_pset_with_cdf(
-    random_spin_data,
     ancillary_files,
     imap_ena_sim_metakernel,
     mock_helio_pointing_lookups,
@@ -295,10 +289,6 @@ def test_calculate_helio_pset_with_cdf(
         mock.patch(
             "imap_processing.ultra.l1c.helio_pset.get_pointing_times_from_id",
             return_value=(482374890.0, 482374000.0),
-        ),
-        mock.patch(
-            "imap_processing.ultra.l1c.ultra_l1c_pset_bins.ttj2000ns_to_met",
-            side_effect=lambda x: x,
         ),
         # Mock efficiencies and geometric function to known values
         mock.patch(

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -123,7 +123,7 @@ def test_ultra_l1c_error(mock_data_l1b_dict):
 def test_calculate_spacecraft_pset_with_cdf(
     random_spin_data,
     ancillary_files,
-    deadtime_datasets,
+    rates_dataset,
     imap_ena_sim_metakernel,
     use_fake_spin_data_for_time,
     mock_spacecraft_pointing_lookups,
@@ -138,7 +138,10 @@ def test_calculate_spacecraft_pset_with_cdf(
     df_subset = df[df["pointing_number"] == pointing].copy()
 
     de_dict = {}
-
+    # Ensure rate dataset has correct time range
+    rates_dataset.shcoarse.data = np.linspace(
+        0, 141 * 15, len(rates_dataset.shcoarse.data)
+    )
     de_dict["epoch"] = df_subset["epoch"].values
     species_bin = np.full(len(df_subset), 1, dtype=np.uint8)
 
@@ -184,8 +187,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         "imap_ultra_l1b_45sensor-de": dataset,
         "imap_ultra_l1b_45sensor-extendedspin": dataset,  # placeholder
         "imap_ultra_l1b_45sensor-goodtimes": dataset,  # placeholder
-        "imap_ultra_l1a_45sensor-rates": deadtime_datasets["rates"],
-        "imap_ultra_l1a_45sensor-params": deadtime_datasets["params"],
+        "imap_ultra_l1a_45sensor-rates": rates_dataset,
     }
     with (
         mock.patch(
@@ -219,7 +221,7 @@ def test_calculate_helio_pset_with_cdf(
     ancillary_files,
     imap_ena_sim_metakernel,
     mock_helio_pointing_lookups,
-    deadtime_datasets,
+    rates_dataset,
     use_fake_spin_data_for_time,
 ):
     """Tests ultra_l1c function with imported test data."""
@@ -230,10 +232,11 @@ def test_calculate_helio_pset_with_cdf(
     )
     df = pd.read_csv(TEST_PATH / "IMAP-Ultra45_r1_L1_V0_shortened.csv")
 
+    # Ensure rate dataset has correct time range
+    rates_dataset.shcoarse.data += 56970124
     # Select a single pointing number
     pointing = 0
     df_subset = df[df["pointing_number"] == pointing].copy()
-
     de_dict = {}
 
     de_dict["epoch"] = df_subset["epoch"].values
@@ -283,8 +286,7 @@ def test_calculate_helio_pset_with_cdf(
                 "spin_number": ("epoch", np.zeros(5)),
             }
         ),  # placeholder
-        "imap_ultra_l1a_45sensor-rates": deadtime_datasets["rates"],
-        "imap_ultra_l1a_45sensor-params": deadtime_datasets["params"],
+        "imap_ultra_l1a_45sensor-rates": rates_dataset,
     }
     n_pix = hp.nside2npix(32)
     mock_eff = np.ones((46, n_pix))

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -170,7 +170,7 @@ def test_get_sectored_rates_manual():
     expected_sectored_rates = xr.concat(
         [
             rates_dataset.isel(epoch=slice(0, 15)),
-            rates_dataset.isel(epoch=slice(17, 33)),
+            rates_dataset.isel(epoch=slice(17, 32)),
         ],
         dim="epoch",
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -195,7 +195,8 @@ def test_get_deadtime_ratios():
         }
     )
     durations = np.full(epoch, 15)
-    deadtime_correction_factors = get_deadtime_ratios(sectored_rates_ds, durations)
+    sectored_rates_ds["spin_durations"] = (["epoch"], durations)
+    deadtime_correction_factors = get_deadtime_ratios(sectored_rates_ds)
     assert deadtime_correction_factors.shape == (sectored_rates_ds.sizes["epoch"],)
     assert np.all(deadtime_correction_factors >= 0)
 

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -148,54 +148,33 @@ def mock_imap_state(time, ref_frame):
     return np.array([0, 0, 0, 0, 0, 0])
 
 
-def test_get_sectored_rates():
+def test_get_sectored_rates(rates_dataset):
     """Tests get_sectored_rates function."""
+    sectored_rates = get_sectored_rates(rates_dataset)
+    expected_sectored_rates = rates_dataset.isel(epoch=slice(14, None))
+    xr.testing.assert_equal(sectored_rates, expected_sectored_rates)
 
-    # Simulate a test rates dataset.
-    epoch = 60
-    test_l1a_rates_dataset = xr.Dataset(
-        {
-            "test_data": (["epoch"], np.arange(epoch)),
-        },
-    )
-    # Sector mode (image rates cadence = 3) happens 3 times a day (per pointing).
-    # each time the mode changes, it is recorded in the params packet.
-    # Create a test params dataset that simulates the mode changing to 3, 3 times.
-    modes = np.tile(np.array([1, 3]), 3)
-    test_l1a_params_dataset = xr.Dataset(
-        {
-            "imageratescadence": (["epoch"], modes),
-        },
-        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
-    )
-    sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
-    np.testing.assert_array_equal(
-        sectored_rates["test_data"].data,
-        np.arange(
-            10, 20
-        ),  # Make sure duplicate epochs with the same mode are filtered out
-    )
-    # Test with one mode shift in the middle of the dataset.
-    modes = np.array([1, 3, 1])
-    test_l1a_params_dataset = xr.Dataset(
-        {
-            "imageratescadence": (["epoch"], modes),
-        },
-        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
-    )
-    sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
-    np.testing.assert_array_equal(sectored_rates["test_data"].data, np.arange(20, 40))
 
-    # Test with one mode shift in the middle of the dataset.
-    modes = np.array([1, 3, 1])
-    test_l1a_params_dataset = xr.Dataset(
+def test_get_sectored_rates_manual():
+    """Tests get_sectored_rates function."""
+    # This dataset has 2 sections where it goes into sectored mode.
+    test_spins = np.concatenate([np.full(15, 0), np.array([10, 11]), np.full(15, 12)])
+    rates_dataset = xr.Dataset(
         {
-            "imageratescadence": (["epoch"], modes),
-        },
-        coords={"epoch": ("epoch", np.arange(0, epoch, epoch / len(modes)))},
+            "epoch": ("epoch", np.arange(32)),
+            "spin": ("epoch", test_spins),
+        }
     )
-    sectored_rates = get_sectored_rates(test_l1a_rates_dataset, test_l1a_params_dataset)
-    np.testing.assert_array_equal(sectored_rates["test_data"].data, np.arange(20, 40))
+    sectored_rates = get_sectored_rates(rates_dataset)
+    # The sectored rates should be the first and last 15 epochs.
+    expected_sectored_rates = xr.concat(
+        [
+            rates_dataset.isel(epoch=slice(0, 15)),
+            rates_dataset.isel(epoch=slice(17, 33)),
+        ],
+        dim="epoch",
+    )
+    xr.testing.assert_equal(sectored_rates, expected_sectored_rates)
 
 
 def test_get_deadtime_ratios():

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -200,7 +200,7 @@ def test_get_deadtime_ratios():
     assert np.all(deadtime_correction_factors >= 0)
 
 
-def test_get_deadtime_interpolator(random_spin_data, use_fake_spin_data_for_time):
+def test_get_deadtime_interpolator(use_fake_spin_data_for_time):
     """Tests get_deadtime_correction_factors function."""
     use_fake_spin_data_for_time(1, 10)
     sector_rate_seconds = 20 * 60  # 20 minutes in seconds
@@ -389,7 +389,6 @@ def test_get_eff_and_gf(imap_ena_sim_metakernel, ancillary_files, spun_index_dat
 @pytest.mark.external_test_data
 def test_get_spacecraft_exposure_times(
     rates_dataset,
-    random_spin_data,
     imap_ena_sim_metakernel,
     ancillary_files,
     use_fake_spin_data_for_time,

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -194,14 +194,15 @@ def test_get_deadtime_ratios():
             "stop_bn": (["epoch"], np.random.randint(0, 5, epoch)),
         }
     )
-    deadtime_correction_factors = get_deadtime_ratios(sectored_rates_ds)
+    durations = np.full(epoch, 15)
+    deadtime_correction_factors = get_deadtime_ratios(sectored_rates_ds, durations)
     assert deadtime_correction_factors.shape == (sectored_rates_ds.sizes["epoch"],)
     assert np.all(deadtime_correction_factors >= 0)
 
 
-def test_get_deadtime_interpolator(random_spin_data):
+def test_get_deadtime_interpolator(random_spin_data, use_fake_spin_data_for_time):
     """Tests get_deadtime_correction_factors function."""
-
+    use_fake_spin_data_for_time(1, 10)
     sector_rate_seconds = 20 * 60  # 20 minutes in seconds
     num_sectors = 3  # Number of sectors per pointing
     num_spins = sector_rate_seconds * num_sectors / 15  # 15 seconds per spin
@@ -212,7 +213,10 @@ def test_get_deadtime_interpolator(random_spin_data):
     deadtime_ratios = xr.DataArray(
         np.random.uniform(0.1, 1.0, num_deadtimes), dims=["epoch"]
     )
-    sectored_rates_ds = xr.Dataset({"epoch": ("epoch", np.ones_like(deadtime_ratios))})
+    sectored_rates_ds = xr.Dataset(
+        {"epoch": ("epoch", np.ones_like(deadtime_ratios))},
+        {"shcoarse": ("epoch", np.ones_like(deadtime_ratios))},
+    )
     with mock.patch(
         "imap_processing.ultra.l1c.ultra_l1c_pset_bins.get_deadtime_ratios",
         return_value=deadtime_ratios,
@@ -384,19 +388,17 @@ def test_get_eff_and_gf(imap_ena_sim_metakernel, ancillary_files, spun_index_dat
 
 @pytest.mark.external_test_data
 def test_get_spacecraft_exposure_times(
-    deadtime_datasets,
+    rates_dataset,
     random_spin_data,
     imap_ena_sim_metakernel,
     ancillary_files,
     use_fake_spin_data_for_time,
 ):
     """Test get_spacecraft_exposure_times function."""
-    data_start_time = 453051293.0
+    data_start_time = 445015665.0
     data_end_time = 453070000.0
     use_fake_spin_data_for_time(data_start_time, data_end_time)
     steps = 500  # reduced for testing
-    rates = deadtime_datasets["rates"]
-    params = deadtime_datasets["params"]
 
     pix = 786
     mock_theta = np.random.uniform(-60, 60, (steps, pix))
@@ -414,8 +416,7 @@ def test_get_spacecraft_exposure_times(
     )
     boundary_sf = xr.DataArray(np.ones((steps, pix)), dims=("spin_phase_step", "pixel"))
     exposure_pointing, deadtimes = get_spacecraft_exposure_times(
-        rates,
-        params,
+        rates_dataset,
         pixels_below_threshold,
         boundary_sf,
         (

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -39,7 +39,6 @@ def calculate_helio_pset(
     de_dataset: xr.Dataset,
     goodtimes_dataset: xr.Dataset,
     rates_dataset: xr.Dataset,
-    params_dataset: xr.Dataset,
     name: str,
     ancillary_files: dict,
     instrument_id: int,
@@ -56,8 +55,6 @@ def calculate_helio_pset(
         Dataset containing goodtimes data.
     rates_dataset : xarray.Dataset
         Dataset containing image rates data.
-    params_dataset : xarray.Dataset
-        Dataset containing image parameters data.
     name : str
         Name of the dataset.
     ancillary_files : dict
@@ -154,7 +151,6 @@ def calculate_helio_pset(
     logger.info("Calculating spacecraft exposure times with deadtime correction.")
     exposure_time, deadtime_ratios = get_spacecraft_exposure_times(
         rates_dataset,
-        params_dataset,
         pixels_below_scattering,
         boundary_scale_factors,
         pointing_range_met,

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -37,7 +37,6 @@ def calculate_spacecraft_pset(
     de_dataset: xr.Dataset,
     goodtimes_dataset: xr.Dataset,
     rates_dataset: xr.Dataset,
-    params_dataset: xr.Dataset,
     name: str,
     ancillary_files: dict,
     instrument_id: int,
@@ -54,8 +53,6 @@ def calculate_spacecraft_pset(
         Dataset containing goodtimes data.
     rates_dataset : xarray.Dataset
         Dataset containing image rates data.
-    params_dataset : xarray.Dataset
-        Dataset containing image parameters data.
     name : str
         Name of the dataset.
     ancillary_files : dict
@@ -142,7 +139,6 @@ def calculate_spacecraft_pset(
     logger.info("Calculating spacecraft exposure times with deadtime correction.")
     exposure_pointing, deadtime_ratios = get_spacecraft_exposure_times(
         rates_dataset,
-        params_dataset,
         valid_spun_pixels,
         boundary_scale_factors,
         pointing_range_met,
@@ -188,7 +184,6 @@ def calculate_spacecraft_pset(
     end = min(end + 1800, ttj2000ns_to_et(pointing_range_ns[1]))
     # Time bins in 30 minute intervals in et
     time_bins = np.arange(start, end, 1800)
-
     # Compute mask for culling the Earth
     compute_culling_mask(
         time_bins,

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -35,14 +35,12 @@ def ultra_l1c(
             f"imap_ultra_l1b_{instrument_id}sensor-goodtimes" in data_dict
             and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
-            and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
             and create_helio_pset
         ):
             helio_pset = calculate_helio_pset(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-goodtimes"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
-                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-params"],
                 f"imap_ultra_l1c_{instrument_id}sensor-heliopset",
                 ancillary_files,
                 instrument_id,
@@ -53,13 +51,11 @@ def ultra_l1c(
             f"imap_ultra_l1b_{instrument_id}sensor-goodtimes" in data_dict
             and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
-            and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
         ):
             spacecraft_pset = calculate_spacecraft_pset(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-goodtimes"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
-                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-params"],
                 f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset",
                 ancillary_files,
                 instrument_id,
@@ -70,7 +66,6 @@ def ultra_l1c(
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-goodtimes"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
-                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-params"],
                 f"imap_ultra_l1c_{instrument_id}sensor-spacecraftpset-nonproton",
                 ancillary_files,
                 instrument_id,

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -324,6 +324,7 @@ def get_deadtime_ratios_by_spin_phase(
         # The center spin phase is the closest / most accurate spin phase.
         # There are 24 spin phases per sector so the nominal middle sector spin phases
         # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.
+        # We can assume each sector 0 starts at spin phase 0
         spin_phases_centered = (sector_indices / num_spin_sectors) * 360.0 + 12.0
 
     # Create a dataset with spin phases and dead time ratios

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -308,18 +308,18 @@ def get_deadtime_ratios_by_spin_phase(
     else:
         num_spin_sectors = 15
         sector_indices = np.arange(len(sectored_rates["epoch"])) % num_spin_sectors
-        # Get timestamps at the START of each spin (sector 0 of each spin)
+        # Get timestamps at the start of each spin (sector 0)
         spin_start_indices = np.where(sector_indices == 0)[0]
         met_time = sectored_rates["shcoarse"].values[spin_start_indices]
         spin_data = get_spin_data()
         spin_numbers = get_spin_number(met_time)
+        # Get spin durations for each spin
         spin_durations = spin_data.loc[spin_numbers, "spin_period_sec"].values
         # Repeat the spin duration for each of the 15 sectors.
-        # Sectors are over a spin so each one has the same spin duration
-        spin_durations = np.repeat(spin_durations, 15)
+        # Sectors are all within a spin so each one corresponds to the same spin
+        # duration
+        spin_durations = np.repeat(spin_durations, num_spin_sectors)
         deadtime_ratios = get_deadtime_ratios(sectored_rates, spin_durations).data
-        # Assume the sectored rate data is evenly spaced in time, and find the middle
-        # spin phase value for each sector.
         # The center spin phase is the closest / most accurate spin phase.
         # There are 24 spin phases per sector so the nominal middle sector spin phases
         # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.
@@ -344,7 +344,6 @@ def get_deadtime_ratios_by_spin_phase(
     deadtime_medians = deadtime_medians.where(
         np.isfinite(deadtime_medians["deadtime_ratio"]), drop=True
     )
-    deadtime_medians.to_netcdf("deadtime_by_spin_phase.nc")
     interpolator = interpolate.PchipInterpolator(
         deadtime_medians["spin_phase"].values, deadtime_medians["deadtime_ratio"].values
     )
@@ -354,7 +353,6 @@ def get_deadtime_ratios_by_spin_phase(
     deadtime_ratios = xr.DataArray(
         interpolator(nominal_spin_phases), dims="spin_phase_step"
     )
-    deadtime_ratios.to_netcdf("deadtime_interp.nc")
     return deadtime_ratios
 
 

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -12,8 +12,6 @@ from imap_processing.spice.geometry import (
     cartesian_to_spherical,
 )
 from imap_processing.spice.spin import (
-    get_spacecraft_spin_phase,
-    get_spin_angle,
     get_spin_data,
     get_spin_number,
 )
@@ -314,23 +312,14 @@ def get_deadtime_ratios_by_spin_phase(
         spin_durations = spin_data.loc[spin_numbers, "spin_period_sec"].values
         print("spin durations:", spin_durations)
         deadtime_ratios = get_deadtime_ratios(sectored_rates, spin_durations).data
-        spin_phases = np.asarray(
-            get_spin_angle(get_spacecraft_spin_phase(met_time), degrees=True)
-        )
-        print("spin phases:", spin_phases)
         # Assume the sectored rate data is evenly spaced in time, and find the middle
         # spin phase value for each sector.
         # The center spin phase is the closest / most accurate spin phase.
         # There are 24 spin phases per sector so the nominal middle sector spin phases
         # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.
-        spin_phases_centered = (spin_phases[:-1] + spin_phases[1:]) / 2
-        # Assume the last sector is nominal because we dont have enough data to
-        # determine the spin phase at the end of the last sector.
-        # TODO: is this assumption valid?
-        # Add the last spin phase value + half of a nominal sector.
-        spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + 12)
-        # Wrap any spin phases > 360 back to [0, 360]
-        spin_phases_centered = np.array(spin_phases_centered % 360)
+        num_spin_sectors = 15
+        sector_indices = np.arange(len(sectored_rates["epoch"])) % num_spin_sectors
+        spin_phases_centered = (sector_indices / num_spin_sectors) * 360.0 + 12.0
     print("spin phases centered:", spin_phases_centered)
     print("deadtime_ratios:", deadtime_ratios)
     # Create a dataset with spin phases and dead time ratios
@@ -338,7 +327,6 @@ def get_deadtime_ratios_by_spin_phase(
         {"deadtime_ratio": (("spin_phase",), deadtime_ratios)},
         coords={"spin_phase": xr.DataArray(spin_phases_centered, dims="spin_phase")},
     )
-
     # Sort the dataset by spin phase (ascending order)
     deadtime_by_spin_phase = deadtime_by_spin_phase.sortby("spin_phase")
     # Group by spin phase and calculate the median dead time ratio for each phase
@@ -353,6 +341,7 @@ def get_deadtime_ratios_by_spin_phase(
     deadtime_medians = deadtime_medians.where(
         np.isfinite(deadtime_medians["deadtime_ratio"]), drop=True
     )
+    deadtime_medians.to_netcdf("deadtime_by_spin_phase.nc")
     interpolator = interpolate.PchipInterpolator(
         deadtime_medians["spin_phase"].values, deadtime_medians["deadtime_ratio"].values
     )
@@ -362,6 +351,7 @@ def get_deadtime_ratios_by_spin_phase(
     deadtime_ratios = xr.DataArray(
         interpolator(nominal_spin_phases), dims="spin_phase_step"
     )
+    deadtime_ratios.to_netcdf("deadtime_interp.nc")
     return deadtime_ratios
 
 

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -306,19 +306,23 @@ def get_deadtime_ratios_by_spin_phase(
             sensor_id, ancillary_files
         )
     else:
-        met_time = sectored_rates["shcoarse"].values
+        num_spin_sectors = 15
+        sector_indices = np.arange(len(sectored_rates["epoch"])) % num_spin_sectors
+        # Get timestamps at the START of each spin (sector 0 of each spin)
+        spin_start_indices = np.where(sector_indices == 0)[0]
+        met_time = sectored_rates["shcoarse"].values[spin_start_indices]
         spin_data = get_spin_data()
         spin_numbers = get_spin_number(met_time)
         spin_durations = spin_data.loc[spin_numbers, "spin_period_sec"].values
-        print("spin durations:", spin_durations)
+        # Repeat the spin duration for each of the 15 sectors.
+        # Sectors are over a spin so each one has the same spin duration
+        spin_durations = np.repeat(spin_durations, 15)
         deadtime_ratios = get_deadtime_ratios(sectored_rates, spin_durations).data
         # Assume the sectored rate data is evenly spaced in time, and find the middle
         # spin phase value for each sector.
         # The center spin phase is the closest / most accurate spin phase.
         # There are 24 spin phases per sector so the nominal middle sector spin phases
         # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.
-        num_spin_sectors = 15
-        sector_indices = np.arange(len(sectored_rates["epoch"])) % num_spin_sectors
         spin_phases_centered = (sector_indices / num_spin_sectors) * 360.0 + 12.0
     print("spin phases centered:", spin_phases_centered)
     print("deadtime_ratios:", deadtime_ratios)

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -251,6 +251,7 @@ def get_sectored_rates(rates_ds: xr.Dataset) -> xr.Dataset | None:
     # Get the length of each spin run
     # e.g. 0,0,0,3,3,3,4,4 -> 3,3,2
     spin_runs = np.diff(spin_change)
+    # Find the indices where the spin run length is exactly 15 (sector mode)
     spin_run_inds = np.where(spin_runs == 15)[0]
 
     if len(spin_run_inds) == 0:

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -15,6 +15,7 @@ from imap_processing.spice.spin import (
     get_spacecraft_spin_phase,
     get_spin_angle,
     get_spin_data,
+    get_spin_number,
 )
 from imap_processing.spice.time import ttj2000ns_to_met
 from imap_processing.ultra.constants import UltraConstants
@@ -178,7 +179,9 @@ def get_spacecraft_count_rate_uncertainty(hist: NDArray, exposure: NDArray) -> N
     return rate_uncertainty
 
 
-def get_deadtime_ratios(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
+def get_deadtime_ratios(
+    sectored_rates_ds: xr.Dataset, spin_durations: np.ndarray
+) -> xr.DataArray:
     """
     Compute the dead time ratio at each sector.
 
@@ -192,38 +195,38 @@ def get_deadtime_ratios(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
     ----------
     sectored_rates_ds : xarray.Dataset
         Dataset containing sector mode image rates data.
+    spin_durations : numpy.ndarray
+        Array of spin durations corresponding to each sector.
 
     Returns
     -------
     dead_time_ratio : xarray.DataArray
         Dead time correction factor for each sector.
     """
-    # Compute the correction factor at each sector
-    a = sectored_rates_ds.fifo_valid_events / (
-        1
-        - (sectored_rates_ds.event_active_time + 2 * sectored_rates_ds.start_pos) * 1e-7
-    )
-
-    start_full = sectored_rates_ds.start_rf + sectored_rates_ds.start_lf
-    b = a * np.exp(start_full * 1e-7 * 5)
-
+    tint = (24 / 360) * spin_durations
+    # (24 / 360) * spin duration
+    # compute the correction factor for each step in each sector
+    start_full_cdf = sectored_rates_ds.start_rf + sectored_rates_ds.start_lf
     coin_stop_nd = (
         sectored_rates_ds.coin_tn
         + sectored_rates_ds.coin_bn
         - sectored_rates_ds.stop_tn
         - sectored_rates_ds.stop_bn
     )
-    corrected_valid_events = b * np.exp(1e-7 * 8 * coin_stop_nd)
+    numerator = np.exp(5e-7 * start_full_cdf) * np.exp(8e-7 * coin_stop_nd) * tint
+    denominator = (
+        tint
+        - (sectored_rates_ds.event_active_time + 2 * sectored_rates_ds.start_pos) * 1e-7
+    )
 
+    correction_factor = numerator / denominator
     # Compute dead time ratio
-    dead_time_ratios = sectored_rates_ds.fifo_valid_events / corrected_valid_events
+    dead_time_ratios = 1 / correction_factor
 
     return dead_time_ratios
 
 
-def get_sectored_rates(
-    rates_ds: xr.Dataset, params_ds: xr.Dataset
-) -> xr.Dataset | None:
+def get_sectored_rates(rates_ds: xr.Dataset) -> xr.Dataset | None:
     """
     Filter rates dataset to only include sector mode data.
 
@@ -231,45 +234,39 @@ def get_sectored_rates(
     ----------
     rates_ds : xarray.Dataset
         Dataset containing image rates data.
-    params_ds : xarray.Dataset
-        Dataset containing image parameters data.
 
     Returns
     -------
     rates : xarray.Dataset or None
         Rates dataset with only the sector mode data.
     """
-    # Find indices in which the parameters dataset, indicates that ULTRA was in
+    # Find indices in which the parameters dataset indicates that ULTRA was in
     # sector mode. At the normal 15-second spin period, each 24° sector takes ~1 second.
+    spins = rates_ds.spin.values
+    # Check if spins are monotonically increasing
+    if not np.all(np.diff(spins) >= 0):
+        logger.warning("Spin values in rates dataset are not monotonically increasing.")
+    # Get the indices where the spin value changes
+    spin_change = np.where(np.diff(spins) != 0)[0] + 1
+    # add the first and last index
+    spin_change = np.concatenate(([0], spin_change, [len(spins)]))
+    # Get the length of each spin run
+    # e.g. 0,0,0,3,3,3,4,4 -> 3,3,2
+    spin_runs = np.diff(spin_change)
+    spin_run_inds = np.where(spin_runs == 15)[0]
 
-    # This means that data was collected as a function of spin allowing for fine grained
-    # rate analysis.
-    # Only get unique combinations of epoch and imageratescadence
-    params = params_ds.groupby(["epoch", "imageratescadence"]).first()
-
-    sector_mode_start_inds = np.where(params["imageratescadence"] == 3)[0]
-    if len(sector_mode_start_inds) == 0:
+    if len(spin_run_inds) == 0:
+        logger.warning("No sector mode data found in the rates dataset.")
         return None
-    # get the sector mode start and stop indices
-    sector_mode_stop_inds = sector_mode_start_inds + 1
-    # get the sector mode start and stop times
-    mode_3_start = params["epoch"].values[sector_mode_start_inds]
-    # if the last mode is a sector mode, we can assume that the sector data goes through
-    # the end of the dataset, so we append np.inf to the end of the last time range.
-    if sector_mode_stop_inds[-1] == len(params["epoch"]):
-        mode_3_end = np.append(
-            params["epoch"].values[sector_mode_stop_inds[:-1]], np.inf
-        )
-    else:
-        mode_3_end = params["epoch"].values[sector_mode_stop_inds]
-    # Build a list of conditions for each sector mode time range
-    conditions = [
-        (rates_ds["epoch"] >= start) & (rates_ds["epoch"] < end)
-        for start, end in zip(mode_3_start, mode_3_end, strict=False)
-    ]
 
-    sector_mode_mask = np.logical_or.reduce(conditions)
-    return rates_ds.isel(epoch=sector_mode_mask)
+    # Get the start indices of each sector mode spin
+    sector_starts = spin_change[spin_run_inds]
+    sectored_mode_mask = np.zeros(len(spins), dtype=bool)
+    for start in sector_starts:
+        # Set the group of 15 to True
+        sectored_mode_mask[start : start + 15] = True
+    # Return the sectored rates dataset
+    return rates_ds.isel(epoch=sectored_mode_mask)
 
 
 def get_deadtime_ratios_by_spin_phase(
@@ -311,12 +308,16 @@ def get_deadtime_ratios_by_spin_phase(
             sensor_id, ancillary_files
         )
     else:
-        deadtime_ratios = get_deadtime_ratios(sectored_rates).data
-        # Get the spin phase at the start of each sector rate measurement
-        met_times = ttj2000ns_to_met(sectored_rates.epoch.data)
+        met_time = sectored_rates["shcoarse"].values
+        spin_data = get_spin_data()
+        spin_numbers = get_spin_number(met_time)
+        spin_durations = spin_data.loc[spin_numbers, "spin_period_sec"].values
+        print("spin durations:", spin_durations)
+        deadtime_ratios = get_deadtime_ratios(sectored_rates, spin_durations).data
         spin_phases = np.asarray(
-            get_spin_angle(get_spacecraft_spin_phase(met_times), degrees=True)
+            get_spin_angle(get_spacecraft_spin_phase(met_time), degrees=True)
         )
+        print("spin phases:", spin_phases)
         # Assume the sectored rate data is evenly spaced in time, and find the middle
         # spin phase value for each sector.
         # The center spin phase is the closest / most accurate spin phase.
@@ -330,7 +331,8 @@ def get_deadtime_ratios_by_spin_phase(
         spin_phases_centered = np.append(spin_phases_centered, spin_phases[-1] + 12)
         # Wrap any spin phases > 360 back to [0, 360]
         spin_phases_centered = np.array(spin_phases_centered % 360)
-
+    print("spin phases centered:", spin_phases_centered)
+    print("deadtime_ratios:", deadtime_ratios)
     # Create a dataset with spin phases and dead time ratios
     deadtime_by_spin_phase = xr.Dataset(
         {"deadtime_ratio": (("spin_phase",), deadtime_ratios)},
@@ -411,7 +413,6 @@ def calculate_exposure_time(
 
 def get_spacecraft_exposure_times(
     rates_dataset: xr.Dataset,
-    params_dataset: xr.Dataset,
     valid_spun_pixels: xr.DataArray,
     boundary_scale_factors: xr.DataArray,
     pointing_range_met: tuple[float, float],
@@ -427,8 +428,6 @@ def get_spacecraft_exposure_times(
     ----------
     rates_dataset : xarray.Dataset
         Dataset containing image rates data.
-    params_dataset : xarray.Dataset
-        Dataset containing image parameters data.
     valid_spun_pixels : xarray.DataArray
         3D Array of pixels valid at each spin phase step. If rejection based on
         scattering was set, then these are the pixels below the FWHM scattering
@@ -464,7 +463,7 @@ def get_spacecraft_exposure_times(
         rates_time <= pointing_range_met[1]
     )
     rates_dataset.isel(epoch=pointing_mask)
-    sectored_rates = get_sectored_rates(rates_dataset, params_dataset)
+    sectored_rates = get_sectored_rates(rates_dataset)
     # Get the number of steps used in the spun pointing lookup tables
     spin_steps = valid_spun_pixels.shape[0]
     nominal_deadtime_ratios = get_deadtime_ratios_by_spin_phase(

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -176,9 +176,7 @@ def get_spacecraft_count_rate_uncertainty(hist: NDArray, exposure: NDArray) -> N
     return rate_uncertainty
 
 
-def get_deadtime_ratios(
-    sectored_rates_ds: xr.Dataset, spin_durations: np.ndarray
-) -> xr.DataArray:
+def get_deadtime_ratios(sectored_rates_ds: xr.Dataset) -> xr.DataArray:
     """
     Compute the dead time ratio at each sector.
 
@@ -192,15 +190,13 @@ def get_deadtime_ratios(
     ----------
     sectored_rates_ds : xarray.Dataset
         Dataset containing sector mode image rates data.
-    spin_durations : numpy.ndarray
-        Array of spin durations corresponding to each sector.
 
     Returns
     -------
     dead_time_ratio : xarray.DataArray
         Dead time correction factor for each sector.
     """
-    tint = (24 / 360) * spin_durations
+    tint = (24 / 360) * sectored_rates_ds.spin_durations
     # compute the correction factor for each step in each sector
     start_full_cdf = sectored_rates_ds.start_rf + sectored_rates_ds.start_lf
     coin_stop_nd = (
@@ -261,9 +257,10 @@ def get_sectored_rates(rates_ds: xr.Dataset) -> xr.Dataset | None:
     # Get the start indices of each sector mode spin
     sector_starts = spin_change[spin_run_inds]
     sectored_mode_mask = np.zeros(len(spins), dtype=bool)
-    for start in sector_starts:
-        # Set the group of 15 to True
-        sectored_mode_mask[start : start + 15] = True
+    starts = np.asarray(sector_starts)
+    # Create offsets 0..14 and broadcast
+    idx = starts[:, None] + np.arange(15)
+    sectored_mode_mask[idx] = True
     # Return the sectored rates dataset
     return rates_ds.isel(epoch=sectored_mode_mask)
 
@@ -319,8 +316,11 @@ def get_deadtime_ratios_by_spin_phase(
         # Repeat the spin duration for each of the 15 sectors.
         # Sectors are all within a spin so each one corresponds to the same spin
         # duration
-        spin_durations = np.repeat(spin_durations, num_spin_sectors)
-        deadtime_ratios = get_deadtime_ratios(sectored_rates, spin_durations).data
+        sectored_rates["spin_durations"] = (
+            "epoch",
+            np.repeat(spin_durations, num_spin_sectors),
+        )
+        deadtime_ratios = get_deadtime_ratios(sectored_rates).data
         # The center spin phase is the closest / most accurate spin phase.
         # There are 24 spin phases per sector so the nominal middle sector spin phases
         # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -324,8 +324,7 @@ def get_deadtime_ratios_by_spin_phase(
         # There are 24 spin phases per sector so the nominal middle sector spin phases
         # would be: array([ 12., 36., ..., 300., 324.]) for 15 sectors.
         spin_phases_centered = (sector_indices / num_spin_sectors) * 360.0 + 12.0
-    print("spin phases centered:", spin_phases_centered)
-    print("deadtime_ratios:", deadtime_ratios)
+
     # Create a dataset with spin phases and dead time ratios
     deadtime_by_spin_phase = xr.Dataset(
         {"deadtime_ratio": (("spin_phase",), deadtime_ratios)},

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -15,7 +15,6 @@ from imap_processing.spice.spin import (
     get_spin_data,
     get_spin_number,
 )
-from imap_processing.spice.time import ttj2000ns_to_met
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.lookup_utils import (
     get_geometric_factor,
@@ -451,12 +450,6 @@ def get_spacecraft_exposure_times(
     nominal_deadtime_ratios : np.ndarray
         Deadtime ratios at each spin phase step (1ms res).
     """
-    # filter rates dataset to only include data during a pointing
-    rates_time = ttj2000ns_to_met(rates_dataset.epoch.data)
-    pointing_mask = (rates_time >= pointing_range_met[0]) & (
-        rates_time <= pointing_range_met[1]
-    )
-    rates_dataset = rates_dataset.isel(epoch=pointing_mask)
     sectored_rates = get_sectored_rates(rates_dataset)
     # Get the number of steps used in the spun pointing lookup tables
     spin_steps = valid_spun_pixels.shape[0]

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -202,7 +202,6 @@ def get_deadtime_ratios(
         Dead time correction factor for each sector.
     """
     tint = (24 / 360) * spin_durations
-    # (24 / 360) * spin duration
     # compute the correction factor for each step in each sector
     start_full_cdf = sectored_rates_ds.start_rf + sectored_rates_ds.start_lf
     coin_stop_nd = (
@@ -228,6 +227,10 @@ def get_sectored_rates(rates_ds: xr.Dataset) -> xr.Dataset | None:
     """
     Filter rates dataset to only include sector mode data.
 
+    Identify intervals where ULTRA was in sector mode by examining contiguous runs
+    of identical spin values. At the normal 15-second spin period, each 24° sector
+    takes ~1 second, so a full spin in sector mode consists of 15 sectors.
+
     Parameters
     ----------
     rates_ds : xarray.Dataset
@@ -238,8 +241,6 @@ def get_sectored_rates(rates_ds: xr.Dataset) -> xr.Dataset | None:
     rates : xarray.Dataset or None
         Rates dataset with only the sector mode data.
     """
-    # Find indices in which the parameters dataset indicates that ULTRA was in
-    # sector mode. At the normal 15-second spin period, each 24° sector takes ~1 second.
     spins = rates_ds.spin.values
     # Check if spins are monotonically increasing
     if not np.all(np.diff(spins) >= 0):
@@ -455,7 +456,7 @@ def get_spacecraft_exposure_times(
     pointing_mask = (rates_time >= pointing_range_met[0]) & (
         rates_time <= pointing_range_met[1]
     )
-    rates_dataset.isel(epoch=pointing_mask)
+    rates_dataset = rates_dataset.isel(epoch=pointing_mask)
     sectored_rates = get_sectored_rates(rates_dataset)
     # Get the number of steps used in the spun pointing lookup tables
     spin_steps = valid_spun_pixels.shape[0]


### PR DESCRIPTION
# Change Summary

## Overview
Determine when the rates dataset was in sectored mode by looking at the spin numbers vs checking the params packet. This is more accurate / simpler/ and what the ULTRA IT does. They will be updating the algorithm document. 

## Updated Files
- imap_processing/tests/ultra/unit/conftest.py
   - Remove fixture - l1c does not need the params dataset anymore. I also discovered there was already a fixture for the rates dataset
- imap_processing/ultra/l1c/helio_pset.py and imap_processing/ultra/l1c/spacecraft_pset.py and imap_processing/ultra/l1c/ultra_l1c.py
   - remove params dataset from parameters
- imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
  - Update deadtime calculation function. Use the algorithm documents version instead of the powerpoint version. 
  - Determine sectored rates data by checking the spins 
  - Determine spin phase logically instead of with SPICE - we can assume each sector 0 starts at spin phase 0 

## Testing
Fix tests, remove params datasets
