### PR TITLE
Lo: CG Map Normalizing 'energy_sc'

### DIFF
--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -875,8 +875,8 @@ def calculate_all_rates_and_intensities(
         logger.info("Interpolating map intensities to helio-frame energies")
         dataset = interpolate_map_flux_to_helio_frame(
             dataset,
-            dataset["energy"],
-            dataset["energy"],
+            dataset["energy"] * 1000,
+            dataset["energy"] * 1000,
             ["ena_intensity", "bg_intensity"],
         )
 

--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -94,6 +94,10 @@ def lo_l2(
 
     logger.info("Step 3: Converting to dataset and adding geometric factors")
     dataset = sky_map.to_dataset()
+
+    if cg_correction:
+        dataset["energy_sc"] /= dataset["exposure_factor"]
+
     dataset = add_geometric_factors(dataset, map_descriptor.species)
 
     logger.info("Step 4: Calculating rates and intensities")
@@ -393,6 +397,8 @@ def process_single_pset(
         pset_processed = apply_compton_getting_correction(
             pset_processed, energy_values_ev
         )
+
+        pset_processed["energy_sc"] *= pset_processed["exposure_factor"]
 
     # Always calculate ram-mask to identify ram/anti-ram bins
     pset_processed = calculate_ram_mask(pset_processed)


### PR DESCRIPTION
# Change Summary
We found an issue when trying to generate L3 HF maps from Lo HF maps. We found that the energy_sc values being computed were far larger than we would expect. All energy_sc values were being summed together and then not normalized after being projected into the map. We chose to do this with an exposure weighting to match Hi, but we are not sure if this is what the Lo team actually wants. It did yield a map that has reasonable looking values. 

You'll notice that there is no test coverage for this fix, as we don't intend for this PR to be merged as is but we didn't want it to get lost over the holiday break.

## Overview
In lo_l2.py, before projecting pset values to a map, multiply the energy_sc by exposure_factor. After projection, divide the exposure_factor back out.