### PR TITLE
Optimize MAG L1D functions to reduce SPICE tranform overhead

### DIFF
--- a/imap_processing/mag/l1d/mag_l1d.py
+++ b/imap_processing/mag/l1d/mag_l1d.py
@@ -1,5 +1,8 @@
 """Module for generating Level 1d magnetic field data."""
 
+from copy import deepcopy
+from itertools import product
+
 import numpy as np
 import xarray as xr
 
@@ -99,19 +102,15 @@ def mag_l1d(  # noqa: PLR0912
 
     # Nominally, this is expected to create MAGO data. However, if the configuration
     # setting for always_output_mago is set to False, it will create MAGI data.
+    l1d_norm.rotate_frame(ValidFrames.J2000)
 
-    l1d_norm.rotate_frame(ValidFrames.SRF)
-    norm_srf_dataset = l1d_norm.generate_dataset(attributes, day_to_process)
-    l1d_norm.rotate_frame(ValidFrames.DSRF)
-    norm_dsrf_dataset = l1d_norm.generate_dataset(attributes, day_to_process)
-    l1d_norm.rotate_frame(ValidFrames.GSE)
-    norm_gse_dataset = l1d_norm.generate_dataset(attributes, day_to_process)
-    l1d_norm.rotate_frame(ValidFrames.RTN)
-    norm_rtn_dataset = l1d_norm.generate_dataset(attributes, day_to_process)
-    output_datasets.append(norm_srf_dataset)
-    output_datasets.append(norm_dsrf_dataset)
-    output_datasets.append(norm_gse_dataset)
-    output_datasets.append(norm_rtn_dataset)
+    output_frames = [
+        ValidFrames.SRF,
+        ValidFrames.DSRF,
+        ValidFrames.GSE,
+        ValidFrames.RTN,
+    ]
+    input_datasets = [l1d_norm]
 
     if input_mago_burst is not None and input_magi_burst is not None:
         # If burst data is provided, use it to create the burst L1d dataset
@@ -134,19 +133,13 @@ def mag_l1d(  # noqa: PLR0912
             day=day,
         )
 
-        # TODO: frame specific attributes may be required
-        l1d_burst.rotate_frame(ValidFrames.SRF)
-        burst_srf_dataset = l1d_burst.generate_dataset(attributes, day_to_process)
-        l1d_burst.rotate_frame(ValidFrames.DSRF)
-        burst_dsrf_dataset = l1d_burst.generate_dataset(attributes, day_to_process)
-        l1d_burst.rotate_frame(ValidFrames.GSE)
-        burst_gse_dataset = l1d_burst.generate_dataset(attributes, day_to_process)
-        l1d_burst.rotate_frame(ValidFrames.RTN)
-        burst_rtn_dataset = l1d_burst.generate_dataset(attributes, day_to_process)
-        output_datasets.append(burst_srf_dataset)
-        output_datasets.append(burst_dsrf_dataset)
-        output_datasets.append(burst_gse_dataset)
-        output_datasets.append(burst_rtn_dataset)
+        l1d_burst.rotate_frame(ValidFrames.J2000)
+        input_datasets.append(l1d_burst)
+
+    for l1d, frame in product(input_datasets, output_frames):
+        output_datasets.append(
+            rotate_copy_to_frame_and_output(l1d, frame, attributes, day_to_process)
+        )
 
     # Output ancillary files
     # Add spin offsets dataset from normal mode processing
@@ -173,3 +166,39 @@ def mag_l1d(  # noqa: PLR0912
                 output_datasets.append(burst_gradiometry_dataset)
 
     return output_datasets
+
+
+def rotate_copy_to_frame_and_output(
+    l1d_input: MagL1d,
+    target_frame: ValidFrames,
+    attributes: ImapCdfAttributes,
+    day_to_process: np.datetime64,
+) -> xr.Dataset:
+    """
+    Given an input, create a copy, rotate to target_frame, and output dataset.
+
+    For efficiency, the best input should be in the J2000 frame.
+
+    Parameters
+    ----------
+    l1d_input : MagL1d
+        Input L1D class instance, which for best efficiency should be in the J2000
+        frame.
+    target_frame : ValidFrames
+        Output frame.
+    attributes : ImapCdfAttributes
+        Attributes instance with the correct MAG L1D from ImapCdfAttributes.
+    day_to_process : np.datetime64
+        The day to process - this will crop the data to the exact 24 hours provided.
+
+    Returns
+    -------
+    xr.Dataset
+        The resulting dataset.
+    """
+    l1d_copy = deepcopy(l1d_input)
+    # Rotate to target frame (this is expensive)
+    l1d_copy.rotate_frame(target_frame)
+    dataset = l1d_copy.generate_dataset(attributes, day_to_process)
+
+    return dataset

--- a/imap_processing/mag/l1d/mag_l1d_data.py
+++ b/imap_processing/mag/l1d/mag_l1d_data.py
@@ -289,14 +289,25 @@ class MagL1d(MagL2L1dBase):  # type: ignore[misc]
                 "data is in the instrument frame, use MAGO."
             )
 
-        start_frame = self.frame
-
         if self.epoch_et is None:
             self.epoch_et: np.ndarray = ttj2000ns_to_et(self.epoch)
             self.magi_epoch_et: np.ndarray = ttj2000ns_to_et(self.magi_epoch)
 
+        start_frame = self.frame
+
+        single_mago_epoch = None
+        single_magi_epoch = None
+        if (
+            start_frame in (ValidFrames.MAGO, ValidFrames.MAGI)
+            and end_frame == ValidFrames.SRF
+        ):
+            # Since Instrument -> spacecraft rotations are static, we can optimize
+            # by only passing one time into frame_transform.
+            single_mago_epoch = self.epoch_et[0]
+            single_magi_epoch = self.magi_epoch_et[0]
+
         self.vectors = frame_transform(
-            self.epoch_et,
+            self.epoch_et if single_mago_epoch is None else single_mago_epoch,
             self.vectors,
             from_frame=start_frame.spice_frame,
             to_frame=end_frame.spice_frame,
@@ -309,7 +320,7 @@ class MagL1d(MagL2L1dBase):  # type: ignore[misc]
             start_frame = ValidFrames.MAGI
 
         self.magi_vectors = frame_transform(
-            self.magi_epoch_et,
+            self.magi_epoch_et if single_magi_epoch is None else single_magi_epoch,
             self.magi_vectors,
             from_frame=start_frame.spice_frame,
             to_frame=end_frame.spice_frame,
@@ -359,21 +370,14 @@ class MagL1d(MagL2L1dBase):  # type: ignore[misc]
             vectors_plus_range_magi, magi_calibration
         )
 
-        mago_vectors = np.apply_along_axis(
-            func1d=self.apply_calibration_offset_single_vector,
-            axis=1,
-            arr=mago_vectors,
-            offsets=offsets,
-            is_magi=False,
-        )
+        # Extract range values and convert to int for indexing
+        mago_range_indices = mago_vectors[:, 3].astype(int)
+        magi_range_indices = magi_vectors[:, 3].astype(int)
 
-        magi_vectors = np.apply_along_axis(
-            func1d=self.apply_calibration_offset_single_vector,
-            axis=1,
-            arr=magi_vectors,
-            offsets=offsets,
-            is_magi=True,
-        )
+        # offsets[sensor, range, axis]
+        # For MAGO: sensor=0, for MAGI: sensor=1
+        mago_vectors[:, :3] = mago_vectors[:, :3] + offsets[0, mago_range_indices, :]
+        magi_vectors[:, :3] = magi_vectors[:, :3] + offsets[1, magi_range_indices, :]
 
         return mago_vectors[:, :3], magi_vectors[:, :3]
 
@@ -754,11 +758,8 @@ class MagL1d(MagL2L1dBase):  # type: ignore[misc]
             The output vectors with gradiometry offsets applied, shape (N, 3).
         """
         offset_value = gradiometry_offsets["gradiometer_offsets"].data
-        offset_value = np.apply_along_axis(
-            np.dot,
-            1,
-            offset_value,
-            gradiometer_factor,
-        )
+        # np.dot(row, matrix) = row @ matrix
+        gradiometer_factor = np.asarray(gradiometer_factor)
+        offset_value = offset_value @ gradiometer_factor
 
         return vectors - offset_value

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -51,6 +51,10 @@ class ValidFrames(Enum):
     GSM = ("GSM", SpiceFrame.IMAP_GSM, "vector_attrs_gsm", "b_gsm")
     RTN = ("RTN", SpiceFrame.IMAP_RTN, "vector_attrs_rtn", "b_rtn")
 
+    # J2000 is used as an intermediate step for rotations, and generally should not be
+    # used as an output.
+    J2000 = ("J2000", SpiceFrame.J2000, "vector_attrs_j2000", "b_j2000")
+
     _spice_frame_: SpiceFrame
     _vector_attrs_name_: str
     _var_name_: str


### PR DESCRIPTION
# Change Summary
This addresses #2518 and includes some fixes described in that ticket. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
1. Since the SPICE transform calls take so much time, the code now transforms to J2000 as a hub for data and then goes from there to each frame to reduce the number of dynamic rotations
2. Switching out apply_along_axis for more efficient numpy calls

This showed about a 20% improvement.
