### PR TITLE
ULTRA l1b carry through event_id 

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -159,6 +159,8 @@ def test_cdf_de(
         test_data_path.name
         == "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf"
     )
+    # check that event_id exists in the dataset
+    assert "event_id" in l1b_de_dataset[0].variables
 
 
 @pytest.mark.external_test_data

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -89,6 +89,7 @@ def calculate_de(
         "event_type",
         "de_event_met",
         "phase_angle",
+        "event_id",
     ]
     dataset_keys = [
         "coin_type",
@@ -96,6 +97,7 @@ def calculate_de(
         "stop_type",
         "shcoarse",
         "phase_angle",
+        "event_id",
     ]
 
     de_dict.update(

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -99,7 +99,7 @@ def calculate_de(
         "phase_angle",
         "event_id",
     ]
-
+    # Populate de_dict with existing fields from de_dataset
     de_dict.update(
         {
             key: de_dataset[dataset_key]


### PR DESCRIPTION
# Change Summary

## Overview
Simple PR to carry through the event_id to ultra l1b. 

## Updated Files
- imap_processing/ultra/l1b/de.py
   - Copy event_id from l1a to l1b with the same name. 

## Testing
Simple test to ensure l1b cdf has the event_id var
