### PR TITLE
2555 bug   spin phase calculation reports nan

### DIFF
--- a/imap_processing/spice/spin.py
+++ b/imap_processing/spice/spin.py
@@ -184,7 +184,7 @@ def interpolate_spin_data(query_met_times: float | npt.NDArray) -> pd.DataFrame:
 
     # Make sure input times are within the bounds of spin data
     spin_df_start_time = spin_start_met[0]
-    spin_df_end_time = spin_start_met[-1] + spin_df["spin_period_sec"].values[-1]
+    spin_df_end_time = spin_start_met[-1] + actual_spin_periods[-1]
     input_start_time = query_met_times.min()
     input_end_time = query_met_times.max()
     if input_start_time < spin_df_start_time or input_end_time >= spin_df_end_time:

--- a/imap_processing/spice/spin.py
+++ b/imap_processing/spice/spin.py
@@ -54,7 +54,9 @@ def get_spin_data() -> pd.DataFrame:
             * `spin_start_subsec_sclk`: MET microseconds of spin start time.
             * `spin_start_met`: Floating point MET seconds of spin start.
             * `spin_start_utc`: UTC string of spin start time.
-            * `spin_period_sec`: Floating point spin period in seconds.
+            * `spin_period_sec`: Floating point spin period in seconds (estimated).
+            * `actual_spin_period`: Floating point actual spin period computed from
+              consecutive spin start times. More accurate than spin_period_sec.
             * `spin_period_valid`: Boolean indicating whether spin period is valid.
             * `spin_phase_valid`: Boolean indicating whether spin phase is valid.
             * `spin_period_source`: Source used for determining spin period.
@@ -106,6 +108,7 @@ def _load_spin_data_with_cache(csv_paths: tuple[Path]) -> pd.DataFrame:
                 "spin_start_utc": str,
                 "spin_period_sec": float,
                 "spin_period_valid": bool,
+                "spin_phase_valid": bool,
                 "spin_period_source": int,
                 "thruster_firing": bool,
             },
@@ -124,6 +127,22 @@ def _load_spin_data_with_cache(csv_paths: tuple[Path]) -> pd.DataFrame:
     # time in seconds. The spin start subseconds are in microseconds.
     combined_df["spin_start_met"] = (
         combined_df["spin_start_sec_sclk"] + combined_df["spin_start_subsec_sclk"] / 1e6
+    )
+    # Precompute actual spin periods from consecutive spin start times
+    # Only use actual periods when spin numbers increment by exactly 1
+    # This prevents invalid times from appearing valid when spins are missing
+    spin_numbers = combined_df["spin_number"].values
+    spin_number_diffs = np.diff(spin_numbers)
+    time_diffs = np.diff(combined_df["spin_start_met"].values)
+
+    # Use actual time diff only where spin numbers increment by 1
+    # Otherwise use the estimated spin_period_sec
+    actual_spin_periods = np.where(
+        spin_number_diffs == 1, time_diffs, combined_df["spin_period_sec"].values[:-1]
+    )
+    # For the last spin, use the provided spin_period_sec since there's no next spin
+    combined_df["actual_spin_period"] = np.append(
+        actual_spin_periods, combined_df["spin_period_sec"].values[-1]
     )
     return combined_df
 
@@ -159,11 +178,13 @@ def interpolate_spin_data(query_met_times: float | npt.NDArray) -> pd.DataFrame:
         # convert scalar to array
         query_met_times = np.atleast_1d(query_met_times)
 
+    # Cache frequently accessed arrays to avoid repeated .values calls
+    spin_start_met = spin_df["spin_start_met"].values
+    actual_spin_periods = spin_df["actual_spin_period"].values
+
     # Make sure input times are within the bounds of spin data
-    spin_df_start_time = spin_df["spin_start_met"].values[0]
-    spin_df_end_time = (
-        spin_df["spin_start_met"].values[-1] + spin_df["spin_period_sec"].values[-1]
-    )
+    spin_df_start_time = spin_start_met[0]
+    spin_df_end_time = spin_start_met[-1] + spin_df["spin_period_sec"].values[-1]
     input_start_time = query_met_times.min()
     input_end_time = query_met_times.max()
     if input_start_time < spin_df_start_time or input_end_time >= spin_df_end_time:
@@ -180,15 +201,19 @@ def interpolate_spin_data(query_met_times: float | npt.NDArray) -> pd.DataFrame:
     # >>> np.searchsorted(df['a'], [0, 13, 15, 32, 70], side='right')
     # array([1, 1, 2, 3, 5])
     last_spin_indices = (
-        np.searchsorted(spin_df["spin_start_met"], query_met_times, side="right") - 1
+        np.searchsorted(spin_start_met, query_met_times, side="right") - 1
     )
-    # Generate a dataframe with one row per query time
-    out_df = spin_df.iloc[last_spin_indices]
 
-    # Calculate spin phase
-    spin_phases = (query_met_times - out_df["spin_start_met"].values) / out_df[
-        "spin_period_sec"
-    ].values
+    # Generate a dataframe with one row per query time
+    out_df = spin_df.iloc[last_spin_indices].copy()
+
+    # Get the precomputed actual spin period for each query time
+    spin_periods_for_query = actual_spin_periods[last_spin_indices]
+
+    # Calculate spin phase using actual computed periods
+    spin_phases = (
+        query_met_times - out_df["spin_start_met"].values
+    ) / spin_periods_for_query
 
     # Check for invalid spin phase using below checks:
     # 1. Check that the spin phase is in valid range, [0, 1).

--- a/imap_processing/tests/spice/test_data/fake_spin_data.csv
+++ b/imap_processing/tests/spice/test_data/fake_spin_data.csv
@@ -13,7 +13,9 @@ spin_number,spin_start_sec_sclk,spin_start_subsec_sclk,spin_start_utc,spin_perio
 7,105,0,2024-04-11 00:01:45.000000,15.0,0,1,0,0
 # invalid spin phase
 8,120,0,2024-04-11 00:02:00.000000,15.0,1,0,0,0
-# 1 good spin
-9,135,0,2024-04-11 00:02:15.000000,15.0,1,1,0,0
+# 1 good spin with slightly shorter period estimate
+9,135,0,2024-04-11 00:02:15.000000,14.5,1,1,0,0
+# Spin that starts 0.5s after estimated end of spin 9 (tests gap handling)
+10,150,0,2024-04-11 00:02:30.000000,15.0,1,1,0,0
 # Thruster firing on
-10,150,0,2024-04-11 00:02:30.000000,15.0,1,1,0,1
+11,165,0,2024-04-11 00:02:45.000000,15.0,1,1,0,1

--- a/imap_processing/tests/spice/test_spin.py
+++ b/imap_processing/tests/spice/test_spin.py
@@ -140,6 +140,11 @@ def test_get_spin_number(fake_spin_data, met_time, spin_number_expected):
         # is same as [0, 360) degree angle. At 15 seconds the spacecraft
         # has completed a full spin
         (np.array([0, 15]), np.zeros(2)),
+        # Test gap between estimated spin end and actual next spin start
+        # Spin 9: start=135, spin_period_sec=14.5, estimated_end=149.5
+        # Spin 10: start=150 (actual start is 0.5s after estimated end)
+        # Query at 149.7 should be valid: (149.7-135)/15 = 0.98 < 1
+        (149.7, 14.7 / 15),
     ],
 )
 def test_get_spacecraft_spin_phase(query_met_times, expected, fake_spin_data):
@@ -189,7 +194,7 @@ def test_get_spin_angle(spin_phases, degrees, expected, context):
         np.testing.assert_array_equal(spin_angles, expected)
 
 
-@pytest.mark.parametrize("query_met_times", [-1, 165])
+@pytest.mark.parametrize("query_met_times", [-1, 181])
 def test_get_spacecraft_spin_phase_value_error(query_met_times, fake_spin_data):
     """Test get_spacecraft_spin_phase() for raising ValueError."""
     with pytest.raises(ValueError, match="Query times"):

--- a/imap_processing/tests/spice/test_spin.py
+++ b/imap_processing/tests/spice/test_spin.py
@@ -44,10 +44,11 @@ def test_set_spin_table_paths(monkeypatch):
                     "2024-04-11 00:00:15.000000",
                     15.0,
                     True,
-                    1,
+                    True,
                     0,
                     False,
                     15.0,
+                    15.0,  # actual_spin_period
                     0.0,
                 ]
             ],
@@ -62,10 +63,11 @@ def test_set_spin_table_paths(monkeypatch):
                     "2024-04-11 00:00:15.000000",
                     15.0,
                     True,
-                    1,
+                    True,
                     0,
                     False,
                     15.0,
+                    15.0,  # actual_spin_period
                     0.1 / 15,
                 ],
                 [
@@ -75,10 +77,11 @@ def test_set_spin_table_paths(monkeypatch):
                     "2024-04-11 00:00:30.000000",
                     15.0,
                     True,
-                    1,
+                    True,
                     0,
                     False,
                     30.0,
+                    15.0,  # actual_spin_period
                     0.2 / 15,
                 ],
             ],
@@ -114,6 +117,7 @@ def test_get_spin_number(fake_spin_data, met_time, spin_number_expected):
     [
         (15, 0.0),  # Scalar test
         (np.array([15.1, 30.1]), np.array([0.1 / 15, 0.1 / 15])),  # Array test
+        # Query time 50 is in spin 3 (45-60), uses spin_period_sec=15 (spin 4 missing)
         (np.array([50]), np.array([5 / 15])),  # Single element array test
         # The first spin has thruster firing set, but should return valid value
         (5.0, 5 / 15),
@@ -123,12 +127,13 @@ def test_get_spin_number(fake_spin_data, met_time, spin_number_expected):
         (np.array([121, 122, 123]), np.full(3, np.nan)),
         # Test that invalid spin period causes nans
         (np.array([110, 111]), np.full(2, np.nan)),
-        # Test for time in missing spin
+        # Test for time in gap (spin 4 missing) - invalid because (65-45)/15 > 1
         (65, np.nan),
         (np.array([65.1, 66]), np.full(2, np.nan)),
         # Combined test
         (
             np.array([7.5, 30, 61, 75, 106, 121, 136]),
+            # 61 is in spin 3, uses spin_period_sec=15, (61-45)/15 > 1 → invalid
             np.array([0.5, 0, np.nan, 0, np.nan, np.nan, 1 / 15]),
         ),
         # Test that this spin phase range [0, 1) is valid which
@@ -214,6 +219,7 @@ def test_get_spin_data(use_fake_spin_data_for_time):
         "spin_period_source",
         "thruster_firing",
         "spin_start_met",
+        "actual_spin_period",
     }, "Spin data must have the specified fields."
 
 
@@ -285,6 +291,7 @@ def test_get_instrument_spin_phase(
 ):
     """Test coverage for get_instrument_spin_phase()"""
     met_times = np.array([7.5, 30, 61, 75, 106, 121, 136])
+    # Time 61 is in missing spin gap, should be invalid
     expected_nan_mask = np.array([False, False, True, False, True, True, False])
     with furnish_kernels([spice_test_data_path / "imap_130.tf"]):
         inst_phase = spin.get_instrument_spin_phase(met_times, instrument)


### PR DESCRIPTION
# Change Summary

## Overview
This fixes the bug in computing spin-phase when query time is after spin_start_met + spin_period_sec but before the next spin_start_met time.
Bonus: It also adds some optimization and fixes the settingwithcopywarning that is clogging many logs.

## Updated Files
- imap_processing/spice/spin.py
   - Precomute actual_spin_period in cache function where spin # increments by one. Elsewhere, use spin_period_sec
   - Use copy when interpolating the spin dataframe to query times to avoid getting the SettingWithCopyWarning
   - Compute spin-phase using above computed actual_spin_period
- imap_processing/tests/spice/test_spin.py
   - Add test coverage that specifically tests the bug this ticket fixes
   - Update other tests as needed where spin_period_sec was being relied upon to compute spin-phase.

Closes: #2555 
