### PR TITLE
CoDICE l2 DE invalid positions

### DIFF
--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -1060,8 +1060,13 @@ def process_lo_direct_events(dependencies: ProcessingInputCollection) -> xr.Data
         l2_dataset["spin_sector"],
     )
     l2_dataset["spin_angle"] = l2_dataset["spin_sector"].astype(np.float32) * 15.0 + 7.5
+
+    # Set spin angle and sector to NaN for invalid positions (>23)
     l2_dataset["spin_angle"] = xr.where(
         (original_spin_sector > 23), np.nan, l2_dataset["spin_angle"]
+    )
+    l2_dataset["spin_sector"] = xr.where(
+        (original_spin_sector > 23), np.nan, l2_dataset["spin_sector"]
     )
     # convert apd energy to physical units
     # Set the gain labels based on gain values

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -551,8 +551,10 @@ def test_codice_l2_lo_de(mock_get_file_paths, codice_lut_path):
     l2_val_data = load_cdf(l2_val_data)
 
     for variable in l2_val_data.data_vars:
-        if variable in ["spin_angle"]:
-            # TODO remove this block when joey fixes spin_angle calculation
+        if variable in ["spin_angle", "spin_sector"]:
+            # TODO remove this block when joey fixes spin_angle and spin_sector
+            #  calculation. Currently they are not setting spin sector and spin angles
+            #  to NaNs for invalid positions.
             continue  # skip spin_angle
         if "label" in variable:
             np.testing.assert_array_equal(


### PR DESCRIPTION
# Change Summary

## Overview
in l2 de, we were setting spin_angles to Nans where positions were invalid. We should also be setting spin_sectors to Nans where positions are invalid. Joey and Michael found this today. They havent updated their code to do this yet so there is still a todo in the tests to revalidate once they provide new CDFs. 

## Updated Files
- imap_processing/tests/codice/test_codice_l2.py
   - Fix spin sector calculation

## Testing
Skip checking spin_sector 
