### PR TITLE
2564 bug   hi pset background variable fillval

### DIFF
--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -49,7 +49,7 @@ default_int32_attrs: &default_int32
 
 default_float32_attrs: &default_float32
   <<: *default
-  FILLVAL: .NAN
+  FILLVAL: -1.0e31
   FORMAT: F10.2
   VALIDMIN: -3.4028235e+38
   VALIDMAX: 3.4028235e+38
@@ -57,7 +57,7 @@ default_float32_attrs: &default_float32
 
 default_float64_attrs: &default_float64
   <<: *default
-  FILLVAL: .NAN
+  FILLVAL: -1.0e31
   FORMAT: F10.2
   VALIDMIN: -1.7976931348623157e+308
   VALIDMAX: 1.7976931348623157e+308


### PR DESCRIPTION
# Change Summary

## Overview
A bug in cdflib causes dataset variables with attrs FILLVAL=np.nan to get converted to FILLVAL=0.0 when writing the CDF. This PR changes Hi FILLVAL for all floating point variables to -1e31.

Closes: #2564