### PR TITLE
Codice continuation packets

### DIFF
--- a/imap_processing/codice/codice_l1a_de.py
+++ b/imap_processing/codice/codice_l1a_de.py
@@ -9,112 +9,107 @@ from imap_processing.codice.decompress import decompress
 from imap_processing.codice.utils import (
     CODICEAPID,
     CoDICECompression,
-    SegmentedPacketOrder,
     ViewTabInfo,
     apply_replacements_to_attrs,
     get_codice_epoch_time,
 )
 from imap_processing.spice.time import met_to_ttj2000ns
+from imap_processing.utils import combine_segmented_packets
 
 
-def get_de_metadata(packets: xr.Dataset, packet_index: int) -> bytes:
+def extract_initial_items_from_combined_packets(
+    packets: xr.Dataset,
+) -> xr.Dataset:
     """
-    Gather and return packet metadata (From packet_version through byte_count).
+    Extract metadata fields from the beginning of combined event_data packets.
 
-    Extract the metadata in the packet_indexed direct event packet, which is then
-    used to construct the full data of the group of packet_indexs.
+    Extracts bit fields from the first 20 bytes of each event_data array
+    and adds them as new variables to the dataset.
 
     Parameters
     ----------
-    packets : xarray.Dataset
-        The packet_indexed direct event packet data.
-    packet_index : int
-        The index of the packet_index of interest.
+    packets : xr.Dataset
+        Dataset containing combined packets with event_data.
 
     Returns
     -------
-    metadata : bytes
-        The compressed metadata for the packet_indexed packet.
+    xr.Dataset
+        Dataset with extracted metadata fields added.
     """
-    # String together the metadata fields and convert the data to a bytes obj
-    metadata_str = ""
-    for field, num_bits in constants.DE_METADATA_FIELDS.items():
-        metadata_str += f"{packets[field].data[packet_index]:0{num_bits}b}"
-    metadata_chunks = [metadata_str[i : i + 8] for i in range(0, len(metadata_str), 8)]
-    metadata_ints = [int(item, 2) for item in metadata_chunks]
-    metadata = bytes(metadata_ints)
+    # Initialize arrays for extracted fields
+    n_packets = len(packets.epoch)
 
-    return metadata
+    # Preallocate arrays
+    packet_version = np.zeros(n_packets, dtype=np.uint16)
+    spin_period = np.zeros(n_packets, dtype=np.uint16)
+    acq_start_seconds = np.zeros(n_packets, dtype=np.uint32)
+    acq_start_subseconds = np.zeros(n_packets, dtype=np.uint32)
+    spare_1 = np.zeros(n_packets, dtype=np.uint8)
+    st_bias_gain_mode = np.zeros(n_packets, dtype=np.uint8)
+    sw_bias_gain_mode = np.zeros(n_packets, dtype=np.uint8)
+    priority = np.zeros(n_packets, dtype=np.uint8)
+    suspect = np.zeros(n_packets, dtype=np.uint8)
+    compressed = np.zeros(n_packets, dtype=np.uint8)
+    num_events = np.zeros(n_packets, dtype=np.uint32)
+    byte_count = np.zeros(n_packets, dtype=np.uint32)
 
+    # Extract fields from each packet
+    for pkt_idx in range(n_packets):
+        event_data = packets.event_data.data[pkt_idx]
 
-def group_data(packets: xr.Dataset) -> list[bytes]:
-    """
-    Organize continuation packets into appropriate groups.
+        # Byte-aligned fields using int.from_bytes
+        packet_version[pkt_idx] = int.from_bytes(event_data[0:2], byteorder="big")
+        spin_period[pkt_idx] = int.from_bytes(event_data[2:4], byteorder="big")
+        acq_start_seconds[pkt_idx] = int.from_bytes(event_data[4:8], byteorder="big")
 
-    Some packets are continuation packets, as in, they are packets that are
-    part of a group of packets. These packets are marked by the `seq_flgs` field
-    in the CCSDS header of the packet. For CoDICE, the values are defined as
-    follows:
+        # Non-byte-aligned fields (bytes 8-12 contain mixed bit fields)
+        # Extract 4 bytes and unpack bit fields
+        mixed_bytes = int.from_bytes(event_data[8:12], byteorder="big")
 
-    3 = Packet is not part of a group
-    1 = Packet is the first packet of the group
-    0 = Packet is in the middle of the group
-    2 = Packet is the last packet of the group
+        # acq_start_subseconds: 20 bits (MSB)
+        acq_start_subseconds[pkt_idx] = (mixed_bytes >> 12) & 0xFFFFF
+        # spare_1: 2 bits
+        spare_1[pkt_idx] = (mixed_bytes >> 10) & 0x3
+        # st_bias_gain_mode: 2 bits
+        st_bias_gain_mode[pkt_idx] = (mixed_bytes >> 8) & 0x3
+        # sw_bias_gain_mode: 2 bits
+        sw_bias_gain_mode[pkt_idx] = (mixed_bytes >> 6) & 0x3
+        # priority: 4 bits
+        priority[pkt_idx] = (mixed_bytes >> 2) & 0xF
+        # suspect: 1 bit
+        suspect[pkt_idx] = (mixed_bytes >> 1) & 0x1
+        # compressed: 1 bit (LSB)
+        compressed[pkt_idx] = mixed_bytes & 0x1
 
-    For packets that are part of a group, the byte count associated with the
-    first packet of the group signifies the byte count for the entire group.
+        # Remaining byte-aligned fields
+        num_events[pkt_idx] = int.from_bytes(event_data[12:16], byteorder="big")
+        byte_count[pkt_idx] = int.from_bytes(event_data[16:20], byteorder="big")
 
-    Parameters
-    ----------
-    packets : xarray.Dataset
-        Dataset containing the packets to group.
+        # Remove the first 20 bytes from event_data (header fields from above)
+        # Then trim to the number of bytes indicated by byte_count
+        packets.event_data.data[pkt_idx] = event_data[20 : 20 + byte_count[pkt_idx]]
 
-    Returns
-    -------
-    grouped_data : list[bytes]
-        The packet data, converted to bytes and grouped appropriately.
-    """
-    grouped_data = []  # Holds the properly grouped data to be decompressed
-    current_group = bytearray()  # Temporary storage for current group
-    group_byte_count = None  # Temporary storage for current group byte count
+        if compressed[pkt_idx]:
+            packets.event_data.data[pkt_idx] = decompress(
+                packets.event_data.data[pkt_idx],
+                CoDICECompression.LOSSLESS,
+            )
 
-    for packet_index in range(len(packets.event_data.data)):
-        packet_data = packets.event_data.data[packet_index]
-        group_code = packets.seq_flgs.data[packet_index]
-        byte_count = packets.byte_count.data[packet_index]
+    # Add extracted fields to dataset
+    packets["packet_version"] = xr.DataArray(packet_version, dims=["epoch"])
+    packets["spin_period"] = xr.DataArray(spin_period, dims=["epoch"])
+    packets["acq_start_seconds"] = xr.DataArray(acq_start_seconds, dims=["epoch"])
+    packets["acq_start_subseconds"] = xr.DataArray(acq_start_subseconds, dims=["epoch"])
+    packets["spare_1"] = xr.DataArray(spare_1, dims=["epoch"])
+    packets["st_bias_gain_mode"] = xr.DataArray(st_bias_gain_mode, dims=["epoch"])
+    packets["sw_bias_gain_mode"] = xr.DataArray(sw_bias_gain_mode, dims=["epoch"])
+    packets["priority"] = xr.DataArray(priority, dims=["epoch"])
+    packets["suspect"] = xr.DataArray(suspect, dims=["epoch"])
+    packets["compressed"] = xr.DataArray(compressed, dims=["epoch"])
+    packets["num_events"] = xr.DataArray(num_events, dims=["epoch"])
+    packets["byte_count"] = xr.DataArray(byte_count, dims=["epoch"])
 
-        # If the group code is 3, this means the data is unsegmented
-        # and can be decompressed as-is
-        if group_code == SegmentedPacketOrder.UNSEGMENTED:
-            grouped_data.append(packet_data[:byte_count])
-
-        # If the group code is 1, this means the data is the first data in a
-        # group. Also, set the byte count for the group
-        elif group_code == SegmentedPacketOrder.FIRST_SEGMENT:
-            group_byte_count = byte_count
-            current_group += packet_data
-
-        # If the group code is 0, this means the data is part of the middle of
-        # the group.
-        elif group_code == SegmentedPacketOrder.CONTINUATION_SEGMENT:
-            current_group += get_de_metadata(packets, packet_index)
-            current_group += packet_data
-
-        # If the group code is 2, this means the data is the last data in the
-        # group
-        elif group_code == SegmentedPacketOrder.LAST_SEGMENT:
-            current_group += get_de_metadata(packets, packet_index)
-            current_group += packet_data
-
-            # The grouped data is now ready to be decompressed
-            values_to_decompress = current_group[:group_byte_count]
-            grouped_data.append(values_to_decompress)
-
-            # Reset the current group
-            current_group = bytearray()
-            group_byte_count = None
-
-    return grouped_data
+    return packets
 
 
 def unpack_bits(bit_structure: dict, de_data: np.ndarray) -> dict:
@@ -160,162 +155,293 @@ def unpack_bits(bit_structure: dict, de_data: np.ndarray) -> dict:
     return unpacked
 
 
+def _create_dataset_coords(
+    packets: xr.Dataset,
+    apid: int,
+    num_priorities: int,
+    cdf_attrs: ImapCdfAttributes,
+) -> xr.Dataset:
+    """
+    Create the output dataset with coordinates.
+
+    Parameters
+    ----------
+    packets : xr.Dataset
+        Combined packets with extracted header fields.
+    apid : int
+        APID for sensor type.
+    num_priorities : int
+        Number of priorities for this APID.
+    cdf_attrs : ImapCdfAttributes
+        CDF attributes manager.
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset with coordinates defined.
+    """
+    # Get timing info from the first packet of each epoch
+    epoch_slice = slice(None, None, num_priorities)
+
+    view_tab_info = ViewTabInfo(
+        apid=apid,
+        sensor=1 if apid == CODICEAPID.COD_HI_PHA else 0,
+        collapse_table=0,
+        three_d_collapsed=0,
+        view_id=0,
+    )
+    epochs, epochs_delta = get_codice_epoch_time(
+        packets["acq_start_seconds"].isel(epoch=epoch_slice),
+        packets["acq_start_subseconds"].isel(epoch=epoch_slice),
+        packets["spin_period"].isel(epoch=epoch_slice),
+        view_tab_info,
+    )
+
+    # Convert to numpy arrays
+    epochs_data = np.asarray(epochs)
+    epochs_delta_data = np.asarray(epochs_delta)
+    epoch_values = met_to_ttj2000ns(epochs_data)
+
+    dataset = xr.Dataset(
+        coords={
+            "epoch": (
+                "epoch",
+                epoch_values,
+                cdf_attrs.get_variable_attributes("epoch", check_schema=False),
+            ),
+            "epoch_delta_minus": (
+                "epoch",
+                epochs_delta_data,
+                cdf_attrs.get_variable_attributes(
+                    "epoch_delta_minus", check_schema=False
+                ),
+            ),
+            "epoch_delta_plus": (
+                "epoch",
+                epochs_delta_data,
+                cdf_attrs.get_variable_attributes(
+                    "epoch_delta_plus", check_schema=False
+                ),
+            ),
+            "event_num": (
+                "event_num",
+                np.arange(constants.MAX_DE_EVENTS_PER_PACKET),
+                cdf_attrs.get_variable_attributes("event_num", check_schema=False),
+            ),
+            "event_num_label": (
+                "event_num",
+                np.arange(constants.MAX_DE_EVENTS_PER_PACKET).astype(str),
+                cdf_attrs.get_variable_attributes(
+                    "event_num_label", check_schema=False
+                ),
+            ),
+            "priority": (
+                "priority",
+                np.arange(num_priorities),
+                cdf_attrs.get_variable_attributes("priority", check_schema=False),
+            ),
+            "priority_label": (
+                "priority",
+                np.arange(num_priorities).astype(str),
+                cdf_attrs.get_variable_attributes("priority_label", check_schema=False),
+            ),
+        }
+    )
+
+    return dataset
+
+
+def _unpack_and_store_events(
+    de_data: xr.Dataset,
+    packets: xr.Dataset,
+    num_priorities: int,
+    bit_structure: dict,
+    event_fields: list[str],
+) -> xr.Dataset:
+    """
+    Unpack all event data and store directly into the dataset arrays.
+
+    Parameters
+    ----------
+    de_data : xr.Dataset
+        Dataset to store unpacked events into (modified in place).
+    packets : xr.Dataset
+        Combined packets with extracted header fields.
+    num_priorities : int
+        Number of priorities per epoch.
+    bit_structure : dict
+        Bit structure defining how to unpack 64-bit event values.
+    event_fields : list[str]
+        List of field names to unpack (excludes priority/spare).
+
+    Returns
+    -------
+    xr.Dataset
+        The dataset with unpacked events stored.
+    """
+    # Extract arrays from packets dataset
+    num_events_arr = packets.num_events.values
+    priorities_arr = packets.priority.values
+    event_data_arr = packets.event_data.values
+
+    total_events = int(np.sum(num_events_arr))
+    if total_events == 0:
+        return de_data
+
+    num_packets = len(num_events_arr)
+
+    # Preallocate arrays for concatenated events and their destination indices
+    all_event_bytes = np.zeros((total_events, 8), dtype=np.uint8)
+    event_epoch_idx = np.zeros(total_events, dtype=np.int32)
+    event_priority_idx = np.zeros(total_events, dtype=np.int32)
+    event_position_idx = np.zeros(total_events, dtype=np.int32)
+
+    # Build concatenated event array and index mappings
+    offset = 0
+    for pkt_idx in range(num_packets):
+        n_events = int(num_events_arr[pkt_idx])
+        if n_events == 0:
+            continue
+
+        # Extract and byte-reverse events for LSB unpacking
+        pkt_bytes = np.asarray(event_data_arr[pkt_idx], dtype=np.uint8)
+        pkt_bytes = pkt_bytes.reshape(n_events, 8)[:, ::-1]
+        all_event_bytes[offset : offset + n_events] = pkt_bytes
+
+        # Record destination indices for scattering
+        event_epoch_idx[offset : offset + n_events] = pkt_idx // num_priorities
+        event_priority_idx[offset : offset + n_events] = priorities_arr[pkt_idx]
+        event_position_idx[offset : offset + n_events] = np.arange(n_events)
+
+        offset += n_events
+
+    # Convert bytes to 64-bit values and unpack all fields at once
+    all_64bits = all_event_bytes.view(np.uint64).ravel()
+    unpacked = unpack_bits(bit_structure, all_64bits)
+
+    # Scatter unpacked values directly into the dataset arrays
+    for field in event_fields:
+        de_data[field].values[
+            event_epoch_idx, event_priority_idx, event_position_idx
+        ] = unpacked[field]
+
+    return de_data
+
+
 def process_de_data(
     packets: xr.Dataset,
-    decompressed_data: list[list[int]],
     apid: int,
     cdf_attrs: ImapCdfAttributes,
 ) -> xr.Dataset:
     """
-    Reshape the decompressed direct event data into CDF-ready arrays.
-
-    Unpacking DE needs below for-loops because of many reasons, including:
-        - Need of preserve fillval per field of various bit lengths
-        - inability to use nan for 64-bits unpacking
-        - num_events being variable length per epoch
-        - binning priorities into its bins
-        - unpacking 64-bits into fields and indexing correctly
+    Process direct event data into a complete CDF-ready dataset.
 
     Parameters
     ----------
     packets : xarray.Dataset
-        Dataset containing the packets, needed to determine priority order
-        and data quality.
-    decompressed_data : list[list[int]]
-        The decompressed data to reshape, in the format <epoch>[<priority>[<event>]].
+        Dataset containing the combined packets with extracted header fields.
     apid : int
-        The sensor type, used primarily to determine if the data are from
-        CoDICE-Lo or CoDICE-Hi.
+        The APID identifying CoDICE-Lo or CoDICE-Hi.
     cdf_attrs : ImapCdfAttributes
-        The CDF attributes to be added to the dataset.
+        The CDF attributes manager.
 
     Returns
     -------
-    data : xarray.Dataset
-        Processed Direct Event data.
+    xarray.Dataset
+        Complete processed Direct Event dataset with coordinates and attributes.
     """
-    # xr.Dataset to hold all the (soon to be restructured) direct event data
-    de_data = xr.Dataset()
+    # Get configuration for this APID
+    config = constants.DE_DATA_PRODUCT_CONFIGURATIONS[apid]
+    num_priorities = config["num_priorities"]
+    bit_structure = config["bit_structure"]
 
-    # Extract some useful variables
-    num_priorities = constants.DE_DATA_PRODUCT_CONFIGURATIONS[apid]["num_priorities"]
-    bit_structure = constants.DE_DATA_PRODUCT_CONFIGURATIONS[apid]["bit_structure"]
+    # Truncate to complete priority groups only
+    num_packets = len(packets["epoch"])
+    num_epochs = num_packets // num_priorities
+    num_complete_packets = num_epochs * num_priorities
+    if num_complete_packets < num_packets:
+        packets = packets.isel(epoch=slice(None, num_complete_packets))
 
-    # Determine the number of epochs to help with data array initialization
-    # There is one epoch per set of priorities
-    num_epochs = len(decompressed_data) // num_priorities
+    # Create dataset with coordinates
+    de_data = _create_dataset_coords(packets, apid, num_priorities, cdf_attrs)
 
-    # Initialize data arrays for unpacked 64-bits fields
-    for field in bit_structure:
-        if field not in ["Priority", "Spare"]:
-            # Update attrs based on fillval per field
-            fillval = bit_structure[field]["fillval"]
-            dtype = bit_structure[field]["dtype"]
-            attrs = cdf_attrs.get_variable_attributes("de_3d_attrs")
-            attrs = apply_replacements_to_attrs(
-                attrs, {"num_digits": len(str(fillval)), "valid_max": fillval}
-            )
-            de_data[field] = xr.DataArray(
-                np.full(
-                    (num_epochs, num_priorities, 10000),
-                    fillval,
-                    dtype=dtype,
-                ),
-                name=field,
-                dims=["epoch", "priority", "event_num"],
-                attrs=attrs,
-            )
-
-    # Get num_events, data quality, and priorities data for beginning of packet_indexs
-    packet_index_starts = np.where(
-        (packets.seq_flgs.data == SegmentedPacketOrder.UNSEGMENTED)
-        | (packets.seq_flgs.data == SegmentedPacketOrder.FIRST_SEGMENT)
-    )[0]
-    num_events_arr = packets.num_events.data[packet_index_starts]
-    data_quality_arr = packets.suspect.data[packet_index_starts]
-    priorities_arr = packets.priority.data[packet_index_starts]
-
-    # Initialize other fields of l1a that we want to
-    # carry in L1A CDF file
-    de_data["num_events"] = xr.DataArray(
-        np.full((num_epochs, num_priorities), 65535, dtype=np.uint16),
-        name="num_events",
-        dims=["epoch", "priority"],
-        attrs=cdf_attrs.get_variable_attributes("de_2d_attrs"),
-    )
-
-    de_data["data_quality"] = xr.DataArray(
-        np.full((num_epochs, num_priorities), 65535, dtype=np.uint16),
-        name="data_quality",
-        dims=["epoch", "priority"],
-        attrs=cdf_attrs.get_variable_attributes("de_2d_attrs"),
-    )
-
-    # As mentioned above, epoch data is of this shape:
-    #   (epoch, (num_events * <number of priorities>)).
-    # num_events is a variable number per priority.
-    for epoch_index in range(num_epochs):
-        # current epoch's grouped data are:
-        #   current group's start index * 8 to next group's start indices * 8
-        epoch_start = packet_index_starts[epoch_index] * num_priorities
-        epoch_end = packet_index_starts[epoch_index + 1] * num_priorities
-        # Extract the decompressed data for current epoch.
-        # epoch_data should be of shape ((num_priorities * num_events),)
-        epoch_data = decompressed_data[epoch_start:epoch_end]
-
-        # Extract these other data
-        unordered_priority = priorities_arr[epoch_start:epoch_end]
-        unordered_data_quality = data_quality_arr[epoch_start:epoch_end]
-        unordered_num_events = num_events_arr[epoch_start:epoch_end]
-
-        # If priority array unique size is not same size as
-        # num_priorities, then throw error. They should match.
-        if len(np.unique(unordered_priority)) != num_priorities:
-            raise ValueError(
-                f"Priority array for epoch {epoch_index} contains "
-                f"non-unique values: {unordered_priority}"
-            )
-
-        # Until here, we have the out of order priority data. Data could have been
-        # collected in any priority order. Eg.
-        #   priority - [0, 4, 5, 1, 3, 2, 6, 7]
-        # Now, we need to put data into their respective priority indexes
-        # in final arrays for the current epoch. Eg. put data into
-        #   priority - [0, 1, 2, 3, 4, 5, 6, 7]
-        de_data["num_events"][epoch_index, unordered_priority] = unordered_num_events
-        de_data["data_quality"][epoch_index, unordered_priority] = (
-            unordered_data_quality
+    # Set global attributes based on APID
+    if apid == CODICEAPID.COD_LO_PHA:
+        de_data.attrs = cdf_attrs.get_global_attributes(
+            "imap_codice_l1a_lo-direct-events"
+        )
+        de_data["k_factor"] = xr.DataArray(
+            np.array([constants.K_FACTOR]),
+            dims=["k_factor"],
+            attrs=cdf_attrs.get_variable_attributes("k_factor", check_schema=False),
+        )
+    else:
+        de_data.attrs = cdf_attrs.get_global_attributes(
+            "imap_codice_l1a_hi-direct-events"
         )
 
-        # Fill the event data into it's bin in same logic as above. But
-        # since the epoch has different num_events per priority,
-        # we need to loop and index accordingly. Otherwise, numpy throws
-        # 'The detected shape was (n,) + inhomogeneous part' error.
-        for priority_index in range(len(unordered_priority)):
-            # Get num_events
-            priority_num_events = int(unordered_num_events[priority_index])
-            # Reshape epoch data into (num_events, 8). That 8 is 8-bytes that
-            # make up 64-bits. Therefore, combine last 8 dimension into one to
-            # get 64-bits event data that we need to unpack later. First,
-            # combine last 8 dimension into one 64-bits value
-            #   we need to make a copy and reverse the byte order
-            #   to match LSB order before we use .view.
-            events_in_bytes = (
-                np.array(epoch_data[priority_index], dtype=np.uint8)
-                .reshape(priority_num_events, 8)[:, ::-1]
-                .copy()
-            )
-            combined_64bits = events_in_bytes.view(np.uint64)[:, 0]
-            # Unpack 64-bits into fields
-            unpacked_fields = unpack_bits(bit_structure, combined_64bits)
-            # Put unpacked event data into their respective variable and priority
-            # number bins
-            priority_num = int(unordered_priority[priority_index])
-            for field_name, field_data in unpacked_fields.items():
-                if field_name not in ["Priority", "Spare"]:
-                    de_data[field_name][
-                        epoch_index, priority_num, :priority_num_events
-                    ] = field_data
+    # Add per-epoch metadata from first packet of each epoch
+    epoch_slice = slice(None, None, num_priorities)
+    for var in ["sw_bias_gain_mode", "st_bias_gain_mode"]:
+        de_data[var] = xr.DataArray(
+            packets[var].isel(epoch=epoch_slice).values,
+            dims=["epoch"],
+            attrs=cdf_attrs.get_variable_attributes(var),
+        )
+
+    # Initialize 3D event data arrays with fill values
+    event_fields = [f for f in bit_structure if f not in ["priority"]]
+    for field in event_fields:
+        info = bit_structure[field]
+        attrs = apply_replacements_to_attrs(
+            cdf_attrs.get_variable_attributes("de_3d_attrs"),
+            {"num_digits": len(str(info["fillval"])), "valid_max": info["fillval"]},
+        )
+        de_data[field] = xr.DataArray(
+            np.full(
+                (num_epochs, num_priorities, constants.MAX_DE_EVENTS_PER_PACKET),
+                info["fillval"],
+                dtype=info["dtype"],
+            ),
+            dims=["epoch", "priority", "event_num"],
+            attrs=attrs,
+        )
+
+    # Initialize 2D per-priority metadata arrays
+    for var in ["num_events", "data_quality"]:
+        de_data[var] = xr.DataArray(
+            np.full((num_epochs, num_priorities), 65535, dtype=np.uint16),
+            dims=["epoch", "priority"],
+            attrs=cdf_attrs.get_variable_attributes("de_2d_attrs"),
+        )
+
+    # Reshape packet arrays for validation and assignment
+    priorities_2d = packets.priority.values.reshape(num_epochs, num_priorities)
+    num_events_2d = packets.num_events.values.reshape(num_epochs, num_priorities)
+    data_quality_2d = packets.suspect.values.reshape(num_epochs, num_priorities)
+
+    # Validate each epoch has all unique priorities
+    unique_counts = np.array([len(np.unique(row)) for row in priorities_2d])
+    if np.any(unique_counts != num_priorities):
+        bad_epoch = np.argmax(unique_counts != num_priorities)
+        raise ValueError(
+            f"Priority array for epoch {bad_epoch} contains "
+            f"non-unique values: {priorities_2d[bad_epoch]}"
+        )
+
+    # Assign num_events and data_quality using priorities as column indices
+    epoch_idx = np.arange(num_epochs)[:, np.newaxis]
+    de_data["num_events"].values[epoch_idx, priorities_2d] = num_events_2d
+    de_data["data_quality"].values[epoch_idx, priorities_2d] = data_quality_2d
+
+    # Unpack all events and store directly into dataset arrays
+    de_data = _unpack_and_store_events(
+        de_data,
+        packets,
+        num_priorities,
+        bit_structure,
+        event_fields,
+    )
 
     return de_data
 
@@ -336,142 +462,16 @@ def l1a_direct_event(unpacked_dataset: xr.Dataset, apid: int) -> xr.Dataset:
     xarray.Dataset
         Processed L1A Direct Event dataset.
     """
-    # Group segmented data.
-    # TODO: this may get replaced with space_packet_parser's functionality
-    grouped_data = group_data(unpacked_dataset)
-
-    # Decompress data shape is (epoch, priority * num_events)
-    decompressed_data = [
-        decompress(
-            group,
-            CoDICECompression.LOSSLESS,
-        )
-        for group in grouped_data
-    ]
+    # Combine segmented packets and extract header fields
+    packets = combine_segmented_packets(
+        unpacked_dataset, binary_field_name="event_data"
+    )
+    packets = extract_initial_items_from_combined_packets(packets)
 
     # Gather the CDF attributes
     cdf_attrs = ImapCdfAttributes()
     cdf_attrs.add_instrument_global_attrs("codice")
     cdf_attrs.add_instrument_variable_attrs("codice", "l1a")
 
-    # Unpack DE packet data into CDF-ready variables
-    de_dataset = process_de_data(unpacked_dataset, decompressed_data, apid, cdf_attrs)
-
-    # Determine the epochs to use in the dataset, which are the epochs whenever
-    # there is a start of a segment and the priority is 0
-    epoch_indices = np.where(
-        (
-            (unpacked_dataset.seq_flgs.data == SegmentedPacketOrder.UNSEGMENTED)
-            | (unpacked_dataset.seq_flgs.data == SegmentedPacketOrder.FIRST_SEGMENT)
-        )
-        & (unpacked_dataset.priority.data == 0)
-    )[0]
-    acq_start_seconds = unpacked_dataset.acq_start_seconds[epoch_indices]
-    acq_start_subseconds = unpacked_dataset.acq_start_subseconds[epoch_indices]
-    spin_periods = unpacked_dataset.spin_period[epoch_indices]
-
-    # Calculate epoch variables using sensor id and apid
-    # Provide 0 as default input for other inputs but they
-    # are not used in epoch calculation
-    view_tab_info = ViewTabInfo(
-        apid=apid,
-        sensor=1 if apid == CODICEAPID.COD_HI_PHA else 0,
-        collapse_table=0,
-        three_d_collapsed=0,
-        view_id=0,
-    )
-    epochs, epochs_delta = get_codice_epoch_time(
-        acq_start_seconds, acq_start_subseconds, spin_periods, view_tab_info
-    )
-
-    # Define coordinates
-    epoch = xr.DataArray(
-        met_to_ttj2000ns(epochs),
-        name="epoch",
-        dims=["epoch"],
-        attrs=cdf_attrs.get_variable_attributes("epoch", check_schema=False),
-    )
-    epoch_delta_minus = xr.DataArray(
-        epochs_delta,
-        name="epoch_delta_minus",
-        dims=["epoch"],
-        attrs=cdf_attrs.get_variable_attributes(
-            "epoch_delta_minus", check_schema=False
-        ),
-    )
-    epoch_delta_plus = xr.DataArray(
-        epochs_delta,
-        name="epoch_delta_plus",
-        dims=["epoch"],
-        attrs=cdf_attrs.get_variable_attributes("epoch_delta_plus", check_schema=False),
-    )
-    event_num = xr.DataArray(
-        np.arange(constants.MAX_DE_EVENTS_PER_PACKET),
-        name="event_num",
-        dims=["event_num"],
-        attrs=cdf_attrs.get_variable_attributes("event_num", check_schema=False),
-    )
-    event_num_label = xr.DataArray(
-        np.arange(constants.MAX_DE_EVENTS_PER_PACKET).astype(str),
-        name="event_num_label",
-        dims=["event_num"],
-        attrs=cdf_attrs.get_variable_attributes("event_num_label", check_schema=False),
-    )
-    priority = xr.DataArray(
-        np.arange(constants.DE_DATA_PRODUCT_CONFIGURATIONS[apid]["num_priorities"]),
-        name="priority",
-        dims=["priority"],
-        attrs=cdf_attrs.get_variable_attributes("priority", check_schema=False),
-    )
-    priority_label = xr.DataArray(
-        np.arange(
-            constants.DE_DATA_PRODUCT_CONFIGURATIONS[apid]["num_priorities"]
-        ).astype(str),
-        name="priority_label",
-        dims=["priority"],
-        attrs=cdf_attrs.get_variable_attributes("priority_label", check_schema=False),
-    )
-
-    # Logical source id to lookup global attributes
-    if apid == CODICEAPID.COD_LO_PHA:
-        attrs = cdf_attrs.get_global_attributes("imap_codice_l1a_lo-direct-events")
-    elif apid == CODICEAPID.COD_HI_PHA:
-        attrs = cdf_attrs.get_global_attributes("imap_codice_l1a_hi-direct-events")
-
-    # Add coordinates and global attributes to dataset
-    de_dataset = de_dataset.assign_coords(
-        epoch=epoch,
-        epoch_delta_minus=epoch_delta_minus,
-        epoch_delta_plus=epoch_delta_plus,
-        event_num=event_num,
-        event_num_label=event_num_label,
-        priority=priority,
-        priority_label=priority_label,
-    )
-    de_dataset.attrs = attrs
-
-    # Carry over these variables from unpacked dataset
-    if apid == CODICEAPID.COD_LO_PHA:
-        # Add k_factor
-        de_dataset["k_factor"] = xr.DataArray(
-            np.array([constants.K_FACTOR]),
-            name="k_factor",
-            dims=["k_factor"],
-            attrs=cdf_attrs.get_variable_attributes("k_factor", check_schema=False),
-        )
-
-    de_dataset["sw_bias_gain_mode"] = xr.DataArray(
-        unpacked_dataset["sw_bias_gain_mode"].data[epoch_indices],
-        name="sw_bias_gain_mode",
-        dims=["epoch"],
-        attrs=cdf_attrs.get_variable_attributes("sw_bias_gain_mode"),
-    )
-
-    de_dataset["st_bias_gain_mode"] = xr.DataArray(
-        unpacked_dataset["st_bias_gain_mode"].data[epoch_indices],
-        name="st_bias_gain_mode",
-        dims=["epoch"],
-        attrs=cdf_attrs.get_variable_attributes("st_bias_gain_mode"),
-    )
-
-    return de_dataset
+    # Process packets into complete CDF-ready dataset
+    return process_de_data(packets, apid, cdf_attrs)

--- a/imap_processing/codice/codice_l1a_de.py
+++ b/imap_processing/codice/codice_l1a_de.py
@@ -1,5 +1,7 @@
 """Processing functions for CoDICE L1A Direct Event data."""
 
+import logging
+
 import numpy as np
 import xarray as xr
 
@@ -15,6 +17,8 @@ from imap_processing.codice.utils import (
 )
 from imap_processing.spice.time import met_to_ttj2000ns
 from imap_processing.utils import combine_segmented_packets
+
+logger = logging.getLogger(__name__)
 
 
 def extract_initial_items_from_combined_packets(
@@ -355,12 +359,31 @@ def process_de_data(
     num_priorities = config["num_priorities"]
     bit_structure = config["bit_structure"]
 
-    # Truncate to complete priority groups only
-    num_packets = len(packets["epoch"])
-    num_epochs = num_packets // num_priorities
-    num_complete_packets = num_epochs * num_priorities
-    if num_complete_packets < num_packets:
-        packets = packets.isel(epoch=slice(None, num_complete_packets))
+    # Identify complete priority groups by acq_start_seconds
+    # Each priority group should have exactly num_priorities packets
+    # with the same acq_start_seconds value
+    acq_start_seconds = packets["acq_start_seconds"].values
+    unique_times, counts = np.unique(acq_start_seconds, return_counts=True)
+
+    # Find incomplete groups (not exactly num_priorities packets)
+    incomplete_mask = counts != num_priorities
+    if np.any(incomplete_mask):
+        incomplete_times = unique_times[incomplete_mask]
+        incomplete_counts = counts[incomplete_mask]
+        logger.warning(
+            f"Found {len(incomplete_times)} incomplete priority group(s) "
+            f"for APID {apid}. Expected {num_priorities} packets per group. "
+            f"Incomplete groups at acq_start_seconds {incomplete_times.tolist()} "
+            f"with counts {incomplete_counts.tolist()}. Dropping these packets."
+        )
+
+    # Keep only complete groups
+    complete_times = unique_times[~incomplete_mask]
+    keep_mask = np.isin(acq_start_seconds, complete_times)
+    packets = packets.isel(epoch=keep_mask)
+
+    # Calculate number of epochs from complete groups
+    num_epochs = len(complete_times)
 
     # Create dataset with coordinates
     de_data = _create_dataset_coords(packets, apid, num_priorities, cdf_attrs)

--- a/imap_processing/codice/codice_l1a_de.py
+++ b/imap_processing/codice/codice_l1a_de.py
@@ -25,19 +25,24 @@ def extract_initial_items_from_combined_packets(
     packets: xr.Dataset,
 ) -> xr.Dataset:
     """
-    Extract metadata fields from the beginning of combined event_data packets.
+    Extract fields from the beginning of combined event_data packets.
 
     Extracts bit fields from the first 20 bytes of each event_data array
-    and adds them as new variables to the dataset.
+    and add them as new variables to the dataset.
+
+    This was previously done in XTCE, but we can't do that because of
+    segmented packets that need to be combined. Each segmented packet
+    has its own (SHCOARSE, EVENTDATA, CHKSUM) fields, so we need to
+    only combine along the EVENTDATA field and extract data that way.
 
     Parameters
     ----------
-    packets : xr.Dataset
+    packets : xarray.Dataset
         Dataset containing combined packets with event_data.
 
     Returns
     -------
-    xr.Dataset
+    xarray.Dataset
         Dataset with extracted metadata fields added.
     """
     # Initialize arrays for extracted fields
@@ -170,7 +175,7 @@ def _create_dataset_coords(
 
     Parameters
     ----------
-    packets : xr.Dataset
+    packets : xarray.Dataset
         Combined packets with extracted header fields.
     apid : int
         APID for sensor type.
@@ -181,7 +186,7 @@ def _create_dataset_coords(
 
     Returns
     -------
-    xr.Dataset
+    xarray.Dataset
         Dataset with coordinates defined.
     """
     # Get timing info from the first packet of each epoch
@@ -267,9 +272,9 @@ def _unpack_and_store_events(
 
     Parameters
     ----------
-    de_data : xr.Dataset
+    de_data : xarray.Dataset
         Dataset to store unpacked events into (modified in place).
-    packets : xr.Dataset
+    packets : xarray.Dataset
         Combined packets with extracted header fields.
     num_priorities : int
         Number of priorities per epoch.
@@ -280,7 +285,7 @@ def _unpack_and_store_events(
 
     Returns
     -------
-    xr.Dataset
+    xarray.Dataset
         The dataset with unpacked events stored.
     """
     # Extract arrays from packets dataset
@@ -312,7 +317,7 @@ def _unpack_and_store_events(
         pkt_bytes = pkt_bytes.reshape(n_events, 8)[:, ::-1]
         all_event_bytes[offset : offset + n_events] = pkt_bytes
 
-        # Record destination indices for scattering
+        # Record destination indices for later array-based assignments
         event_epoch_idx[offset : offset + n_events] = pkt_idx // num_priorities
         event_priority_idx[offset : offset + n_events] = priorities_arr[pkt_idx]
         event_position_idx[offset : offset + n_events] = np.arange(n_events)
@@ -323,7 +328,7 @@ def _unpack_and_store_events(
     all_64bits = all_event_bytes.view(np.uint64).ravel()
     unpacked = unpack_bits(bit_structure, all_64bits)
 
-    # Scatter unpacked values directly into the dataset arrays
+    # Place unpacked values directly into the dataset arrays
     for field in event_fields:
         de_data[field].values[
             event_epoch_idx, event_priority_idx, event_position_idx

--- a/imap_processing/codice/packet_definitions/codice_packet_definition.xml
+++ b/imap_processing/codice/packet_definitions/codice_packet_definition.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="COD">
-	<xtce:Header date="19/04/2024" version="1" author="IMAP SDC" />
+	<xtce:Header date="04/12/2025" version="1" author="IMAP SDC" source_file="TLM_COD.xlsx" />
 	<xtce:TelemetryMetaData>
 		<xtce:ParameterTypeSet>
 			<xtce:IntegerParameterType name="VERSION" signed="false">
@@ -45,7 +45,7 @@
 			<xtce:EnumeratedParameterType name="COD_NHK.LAST_OPCODE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
 				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="ERROR" />
+					<xtce:Enumeration value="0" label="NONE" />
 					<xtce:Enumeration value="4096" label="COD_NOOP" />
 					<xtce:Enumeration value="4097" label="COD_RESET" />
 					<xtce:Enumeration value="4098" label="COD_SHUTDOWN" />
@@ -297,8 +297,17 @@
 					<xtce:Enumeration value="1" label="EN" />
 				</xtce:EnumerationList>
 			</xtce:EnumeratedParameterType>
+			<xtce:EnumeratedParameterType name="COD_NHK.LO_ESA_OP_ST" signed="false">
+				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="NORMAL" />
+					<xtce:Enumeration value="1" label="RGFO" />
+					<xtce:Enumeration value="2" label="NSO" />
+					<xtce:Enumeration value="3" label="INVALID" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.SPARE_4" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="3" encoding="unsigned" />
+				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.ESAA_DAC" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
@@ -358,7 +367,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="0.1587301587301587" exponent="1" />
+							<xtce:Term coefficient="0.1465201465201465" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -439,7 +448,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="-4.731379731379731" exponent="1" />
+							<xtce:Term coefficient="4.319650655022997" exponent="0" />
+							<xtce:Term coefficient="-5.067248908296944" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -567,46 +577,28 @@
 				</xtce:IntegerDataEncoding>
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.MDM25P_14_T" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
-					<xtce:DefaultCalibrator>
-						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
-						</xtce:PolynomialCalibrator>
-					</xtce:DefaultCalibrator>
-				</xtce:IntegerDataEncoding>
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.MDM25P_15_T" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
-					<xtce:DefaultCalibrator>
-						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
-						</xtce:PolynomialCalibrator>
-					</xtce:DefaultCalibrator>
-				</xtce:IntegerDataEncoding>
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.MDM25P_16_T" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
-					<xtce:DefaultCalibrator>
-						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
-						</xtce:PolynomialCalibrator>
-					</xtce:DefaultCalibrator>
-				</xtce:IntegerDataEncoding>
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.MDM51P_27_T" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
-					<xtce:DefaultCalibrator>
-						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
-						</xtce:PolynomialCalibrator>
-					</xtce:DefaultCalibrator>
-				</xtce:IntegerDataEncoding>
+				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.IO_HVPS_T" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-221.1818252275" exponent="0" />
+							<xtce:Term coefficient="0.8267522147985" exponent="1" />
+							<xtce:Term coefficient="-0.001244271145701" exponent="2" />
+							<xtce:Term coefficient="1.042036140147e-06" exponent="3" />
+							<xtce:Term coefficient="-4.838134493789e-10" exponent="4" />
+							<xtce:Term coefficient="1.170514336388e-13" exponent="5" />
+							<xtce:Term coefficient="-1.149646218581e-17" exponent="6" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -615,7 +607,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-273.2" exponent="0" />
+							<xtce:Term coefficient="0.1444619083" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -624,7 +617,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-273.2" exponent="0" />
+							<xtce:Term coefficient="0.1444619083" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -633,7 +627,8 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-273.2" exponent="0" />
+							<xtce:Term coefficient="0.1444619083" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -688,7 +683,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="0.0009156844968268358" exponent="1" />
+							<xtce:Term coefficient="0.0009132947976878612" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -697,8 +692,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.110223024625157e-16" exponent="0" />
-							<xtce:Term coefficient="0.0004921562596124269" exponent="1" />
+							<xtce:Term coefficient="0.0004919831223628692" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -707,8 +701,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.110223024625157e-16" exponent="0" />
-							<xtce:Term coefficient="0.0004921562596124269" exponent="1" />
+							<xtce:Term coefficient="0.0004923547400611621" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -717,7 +710,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="0.0007037943696450428" exponent="1" />
+							<xtce:Term coefficient="0.0007031578947368422" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -726,7 +719,7 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="0.0007037943696450428" exponent="1" />
+							<xtce:Term coefficient="0.0001407528641571195" exponent="1" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -796,19 +789,19 @@
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_NHK.TBD_HVPS_1_IF_ERR_CNT" signed="false">
+			<xtce:IntegerParameterType name="COD_NHK.HVPS_1_IF_ERR_CNT" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_NHK.TBD_HVPS_2_IF_ERR_CNT" signed="false">
+			<xtce:IntegerParameterType name="COD_NHK.HVPS_2_IF_ERR_CNT" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_NHK.TBD_FEE_1_IF_ERR_CNT" signed="false">
+			<xtce:IntegerParameterType name="COD_NHK.FEE_1_IF_ERR_CNT" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_NHK.TBD_FEE_2_IF_ERR_CNT" signed="false">
+			<xtce:IntegerParameterType name="COD_NHK.FEE_2_IF_ERR_CNT" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_NHK.TBD_MACRO_STATUS" signed="false">
+			<xtce:IntegerParameterType name="COD_NHK.MACRO_STATUS" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="28" encoding="unsigned" />
 			</xtce:IntegerParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.FDC_TRIGGER_CNT_FSW" signed="false">
@@ -835,15 +828,55 @@
 			<xtce:IntegerParameterType name="COD_NHK.FDC_TRIGGER_CNT_SPARE4" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_NHK.FDC_LAST_TRIGGER_MINMAX" signed="false">
+			<xtce:EnumeratedParameterType name="COD_NHK.FDC_LAST_TRIGGER_MINMAX" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="MIN" />
+					<xtce:Enumeration value="1" label="MAX" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
 			<xtce:IntegerParameterType name="COD_NHK.FDC_LAST_TRIGGER_ID" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_NHK.FDC_LAST_TRIGGER_ACTION" signed="false">
+			<xtce:EnumeratedParameterType name="COD_NHK.FDC_LAST_TRIGGER_ACTION" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
+				<xtce:EnumerationList>
+					<xtce:Enumeration value="0" label="REPORT_ONLY" />
+					<xtce:Enumeration value="1" label="SOFT_SAFE" />
+					<xtce:Enumeration value="128" label="MACRO_0" />
+					<xtce:Enumeration value="129" label="MACRO_1" />
+					<xtce:Enumeration value="130" label="MACRO_2" />
+					<xtce:Enumeration value="131" label="MACRO_3" />
+					<xtce:Enumeration value="132" label="MACRO_4" />
+					<xtce:Enumeration value="133" label="MACRO_5" />
+					<xtce:Enumeration value="134" label="MACRO_6" />
+					<xtce:Enumeration value="135" label="MACRO_7" />
+					<xtce:Enumeration value="136" label="MACRO_8" />
+					<xtce:Enumeration value="137" label="MACRO_9" />
+					<xtce:Enumeration value="138" label="MACRO_10" />
+					<xtce:Enumeration value="139" label="MACRO_11" />
+					<xtce:Enumeration value="140" label="MACRO_12" />
+					<xtce:Enumeration value="141" label="MACRO_13" />
+					<xtce:Enumeration value="142" label="MACRO_14" />
+					<xtce:Enumeration value="143" label="MACRO_15" />
+					<xtce:Enumeration value="144" label="MACRO_16" />
+					<xtce:Enumeration value="145" label="MACRO_17" />
+					<xtce:Enumeration value="146" label="MACRO_18" />
+					<xtce:Enumeration value="147" label="MACRO_19" />
+					<xtce:Enumeration value="148" label="MACRO_20" />
+					<xtce:Enumeration value="149" label="MACRO_21" />
+					<xtce:Enumeration value="150" label="MACRO_22" />
+					<xtce:Enumeration value="151" label="MACRO_23" />
+					<xtce:Enumeration value="152" label="MACRO_24" />
+					<xtce:Enumeration value="153" label="MACRO_25" />
+					<xtce:Enumeration value="154" label="MACRO_26" />
+					<xtce:Enumeration value="155" label="MACRO_27" />
+					<xtce:Enumeration value="156" label="MACRO_28" />
+					<xtce:Enumeration value="157" label="MACRO_29" />
+					<xtce:Enumeration value="158" label="MACRO_30" />
+					<xtce:Enumeration value="159" label="MACRO_31" />
+				</xtce:EnumerationList>
+			</xtce:EnumeratedParameterType>
 			<xtce:EnumeratedParameterType name="COD_NHK.ROUND_ROBIN_INDEX" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
 				<xtce:EnumerationList>
@@ -1115,7 +1148,7 @@
 					<xtce:Enumeration value="1" label="EN" />
 				</xtce:EnumerationList>
 			</xtce:EnumeratedParameterType>
-			<xtce:EnumeratedParameterType name="COD_NHK.HEATER_OUTPUT_STATE" signed="false">
+			<xtce:EnumeratedParameterType name="COD_NHK.HEATER_OUTPUT_STATE_1" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
 				<xtce:EnumerationList>
 					<xtce:Enumeration value="0" label="DS" />
@@ -1145,7 +1178,13 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-221.1818252275" exponent="0" />
+							<xtce:Term coefficient="0.8267522147985" exponent="1" />
+							<xtce:Term coefficient="-0.001244271145701" exponent="2" />
+							<xtce:Term coefficient="1.042036140147e-06" exponent="3" />
+							<xtce:Term coefficient="-4.838134493789e-10" exponent="4" />
+							<xtce:Term coefficient="1.170514336388e-13" exponent="5" />
+							<xtce:Term coefficient="-1.149646218581e-17" exponent="6" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -1154,7 +1193,13 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-221.1818252275" exponent="0" />
+							<xtce:Term coefficient="0.8267522147985" exponent="1" />
+							<xtce:Term coefficient="-0.001244271145701" exponent="2" />
+							<xtce:Term coefficient="1.042036140147e-06" exponent="3" />
+							<xtce:Term coefficient="-4.838134493789e-10" exponent="4" />
+							<xtce:Term coefficient="1.170514336388e-13" exponent="5" />
+							<xtce:Term coefficient="-1.149646218581e-17" exponent="6" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -1163,7 +1208,13 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-221.1818252275" exponent="0" />
+							<xtce:Term coefficient="0.8267522147985" exponent="1" />
+							<xtce:Term coefficient="-0.001244271145701" exponent="2" />
+							<xtce:Term coefficient="1.042036140147e-06" exponent="3" />
+							<xtce:Term coefficient="-4.838134493789e-10" exponent="4" />
+							<xtce:Term coefficient="1.170514336388e-13" exponent="5" />
+							<xtce:Term coefficient="-1.149646218581e-17" exponent="6" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -1172,7 +1223,13 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-221.1818252275" exponent="0" />
+							<xtce:Term coefficient="0.8267522147985" exponent="1" />
+							<xtce:Term coefficient="-0.001244271145701" exponent="2" />
+							<xtce:Term coefficient="1.042036140147e-06" exponent="3" />
+							<xtce:Term coefficient="-4.838134493789e-10" exponent="4" />
+							<xtce:Term coefficient="1.170514336388e-13" exponent="5" />
+							<xtce:Term coefficient="-1.149646218581e-17" exponent="6" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -1181,7 +1238,13 @@
 				<xtce:IntegerDataEncoding sizeInBits="12" encoding="unsigned">
 					<xtce:DefaultCalibrator>
 						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="1.0" exponent="1" />
+							<xtce:Term coefficient="-221.1818252275" exponent="0" />
+							<xtce:Term coefficient="0.8267522147985" exponent="1" />
+							<xtce:Term coefficient="-0.001244271145701" exponent="2" />
+							<xtce:Term coefficient="1.042036140147e-06" exponent="3" />
+							<xtce:Term coefficient="-4.838134493789e-10" exponent="4" />
+							<xtce:Term coefficient="1.170514336388e-13" exponent="5" />
+							<xtce:Term coefficient="-1.149646218581e-17" exponent="6" />
 						</xtce:PolynomialCalibrator>
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
@@ -1474,74 +1537,12 @@
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_LO_PHA.PACKET_VERSION" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_LO_PHA.SPIN_PERIOD" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
-					<xtce:DefaultCalibrator>
-						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="0.00032" exponent="1" />
-						</xtce:PolynomialCalibrator>
-					</xtce:DefaultCalibrator>
-				</xtce:IntegerDataEncoding>
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_LO_PHA.ACQ_START_SECONDS" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_LO_PHA.ACQ_START_SUBSECONDS" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="20" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_LO_PHA.SPARE_1" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:EnumeratedParameterType name="COD_LO_PHA.ST_BIAS_GAIN_MODE" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
-				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="LV" />
-					<xtce:Enumeration value="1" label="MV" />
-					<xtce:Enumeration value="2" label="HV" />
-					<xtce:Enumeration value="3" label="nan" />
-				</xtce:EnumerationList>
-			</xtce:EnumeratedParameterType>
-			<xtce:EnumeratedParameterType name="COD_LO_PHA.SW_BIAS_GAIN_MODE" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
-				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="LV" />
-					<xtce:Enumeration value="1" label="MV" />
-					<xtce:Enumeration value="2" label="HV" />
-					<xtce:Enumeration value="3" label="nan" />
-				</xtce:EnumerationList>
-			</xtce:EnumeratedParameterType>
-			<xtce:IntegerParameterType name="COD_LO_PHA.PRIORITY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:EnumeratedParameterType name="COD_LO_PHA.SUSPECT" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="NO" />
-					<xtce:Enumeration value="1" label="YES" />
-				</xtce:EnumerationList>
-			</xtce:EnumeratedParameterType>
-			<xtce:EnumeratedParameterType name="COD_LO_PHA.COMPRESSED" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="NO" />
-					<xtce:Enumeration value="1" label="YES" />
-				</xtce:EnumerationList>
-			</xtce:EnumeratedParameterType>
-			<xtce:IntegerParameterType name="COD_LO_PHA.NUM_EVENTS" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_LO_PHA.BYTE_COUNT" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="COD_LO_PHA.EVENT_DATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-200" />
+							<xtce:LinearAdjustment slope="8" intercept="-40" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -1737,7 +1738,6 @@
 					<xtce:Enumeration value="3" label="LOSSLESS_ONLY" />
 					<xtce:Enumeration value="4" label="LOSSY_A_LOSSLESS" />
 					<xtce:Enumeration value="5" label="LOSSY_B_LOSSLESS" />
-					<xtce:Enumeration value="6" label="24_BIT_PACKED" />
 				</xtce:EnumerationList>
 			</xtce:EnumeratedParameterType>
 			<xtce:IntegerParameterType name="COD_LO_SW_SPECIES_COUNTS.BYTE_COUNT" signed="false">
@@ -2422,74 +2422,12 @@
 					</xtce:DefaultCalibrator>
 				</xtce:IntegerDataEncoding>
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_HI_PHA.PACKET_VERSION" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_HI_PHA.SPIN_PERIOD" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned">
-					<xtce:DefaultCalibrator>
-						<xtce:PolynomialCalibrator>
-							<xtce:Term coefficient="0.00032" exponent="1" />
-						</xtce:PolynomialCalibrator>
-					</xtce:DefaultCalibrator>
-				</xtce:IntegerDataEncoding>
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_HI_PHA.ACQ_START_SECONDS" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_HI_PHA.ACQ_START_SUBSECONDS" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="20" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_HI_PHA.SPARE_1" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:EnumeratedParameterType name="COD_HI_PHA.ST_BIAS_GAIN_MODE" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
-				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="LV" />
-					<xtce:Enumeration value="1" label="MV" />
-					<xtce:Enumeration value="2" label="HV" />
-					<xtce:Enumeration value="3" label="nan" />
-				</xtce:EnumerationList>
-			</xtce:EnumeratedParameterType>
-			<xtce:EnumeratedParameterType name="COD_HI_PHA.SW_BIAS_GAIN_MODE" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned" />
-				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="LV" />
-					<xtce:Enumeration value="1" label="MV" />
-					<xtce:Enumeration value="2" label="HV" />
-					<xtce:Enumeration value="3" label="nan" />
-				</xtce:EnumerationList>
-			</xtce:EnumeratedParameterType>
-			<xtce:IntegerParameterType name="COD_HI_PHA.PRIORITY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="4" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:EnumeratedParameterType name="COD_HI_PHA.SUSPECT" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="NO" />
-					<xtce:Enumeration value="1" label="YES" />
-				</xtce:EnumerationList>
-			</xtce:EnumeratedParameterType>
-			<xtce:EnumeratedParameterType name="COD_HI_PHA.COMPRESSED" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-				<xtce:EnumerationList>
-					<xtce:Enumeration value="0" label="NO" />
-					<xtce:Enumeration value="1" label="YES" />
-				</xtce:EnumerationList>
-			</xtce:EnumeratedParameterType>
-			<xtce:IntegerParameterType name="COD_HI_PHA.NUM_EVENTS" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="COD_HI_PHA.BYTE_COUNT" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="COD_HI_PHA.EVENT_DATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-200" />
+							<xtce:LinearAdjustment slope="8" intercept="-40" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -3104,6 +3042,12 @@
 			<xtce:Parameter name="COD_NHK.SBULK_EN" parameterTypeRef="COD_NHK.SBULK_EN" shortDescription="SENSOR HV - P6KV ENABLE" />
 			<xtce:Parameter name="COD_NHK.STPMCP_EN" parameterTypeRef="COD_NHK.STPMCP_EN" shortDescription="SENSOR HV - STOP MCP ENABLE" />
 			<xtce:Parameter name="COD_NHK.STRMCP_EN" parameterTypeRef="COD_NHK.STRMCP_EN" shortDescription="SENSOR HV - START MCP ENABLE" />
+			<xtce:Parameter name="COD_NHK.LO_ESA_OP_ST" parameterTypeRef="COD_NHK.LO_ESA_OP_ST" shortDescription="ESA RGFO/NSO STATUS">
+				<xtce:LongDescription>INDICATES THE CURRENT OPERATIONAL STATE OF THE LO ESA SWEEP:
+- NORMAL - BOTH ESAS ARE TRACKING TOGETHER
+- RGFO - REDUCED GAIN FACTOR OPERATION; ESA-A IS REDUCED IN ORDER TO REDUCE THE GAIN FACTOR AND ALLOW FEWER IONS INTO THE DETECTOR
+- NSO - NO SCAN OPERATION; BOTH ESAS ARE RETURNED TO A HIGH-ENERGY SETTING AND NO SCANNING IS DONE FOR THE REMAINDER OF THE ESA SWEEP</xtce:LongDescription>
+			</xtce:Parameter>
 			<xtce:Parameter name="COD_NHK.SPARE_4" parameterTypeRef="COD_NHK.SPARE_4" shortDescription="SPARE FOR ALIGNMENT" />
 			<xtce:Parameter name="COD_NHK.ESAA_DAC" parameterTypeRef="COD_NHK.ESAA_DAC" shortDescription="OPTICS HV - ESA A DAC" />
 			<xtce:Parameter name="COD_NHK.ESAB_DAC" parameterTypeRef="COD_NHK.ESAB_DAC" shortDescription="OPTICS HV -  ESA B DAC" />
@@ -3127,17 +3071,27 @@
 			<xtce:Parameter name="COD_NHK.STPMCP_VMON" parameterTypeRef="COD_NHK.STPMCP_VMON" shortDescription="HVPS – V10: STOP MCP VOLTAGE MONITOR" />
 			<xtce:Parameter name="COD_NHK.STPOG_VMON" parameterTypeRef="COD_NHK.STPOG_VMON" shortDescription="HVPS – V11: STOP OPTICS GRID VOLTAGE MONITOR" />
 			<xtce:Parameter name="COD_NHK.APDB1_IMON" parameterTypeRef="COD_NHK.APDB1_IMON" shortDescription="HVPS – V12: APD1 BIAS CURRENT MONITOR" />
-			<xtce:Parameter name="COD_NHK.ESAB_HI_VMON" parameterTypeRef="COD_NHK.ESAB_HI_VMON" shortDescription="HVPS – V13: ESA A HIGH RANGE VOLTAGE MONITOR" />
+			<xtce:Parameter name="COD_NHK.ESAB_HI_VMON" parameterTypeRef="COD_NHK.ESAB_HI_VMON" shortDescription="HVPS – V13: ESA B HIGH RANGE VOLTAGE MONITOR" />
 			<xtce:Parameter name="COD_NHK.SPARE_68" parameterTypeRef="COD_NHK.SPARE_68" shortDescription="SPARE (WAS ESAB_LO_VMON)" />
-			<xtce:Parameter name="COD_NHK.APDB2_IMON" parameterTypeRef="COD_NHK.APDB2_IMON" shortDescription="HVPS – V15: APD2 BIAS CURRENT MONITOR" />
-			<xtce:Parameter name="COD_NHK.SSDB_IMON" parameterTypeRef="COD_NHK.SSDB_IMON" shortDescription="HVPS – V16: SSD BIAS CURRENT MONIOTR" />
-			<xtce:Parameter name="COD_NHK.STPMCP_IMON" parameterTypeRef="COD_NHK.STPMCP_IMON" shortDescription="HVPS – I1: STOP MCP CURRENT MONITOR" />
-			<xtce:Parameter name="COD_NHK.IOBULK_IMON" parameterTypeRef="COD_NHK.IOBULK_IMON" shortDescription="HVPS – I2: IO BULK CURRENTMONITOR" />
-			<xtce:Parameter name="COD_NHK.STRMCP_IMON" parameterTypeRef="COD_NHK.STRMCP_IMON" shortDescription="HVPS – I3: START MCP CURRENT MONITOR" />
-			<xtce:Parameter name="COD_NHK.MDM25P_14_T" parameterTypeRef="COD_NHK.MDM25P_14_T" shortDescription="SYSTEM TEMPERATURE 1: MDM25P – 14 TEMPERATURE" />
-			<xtce:Parameter name="COD_NHK.MDM25P_15_T" parameterTypeRef="COD_NHK.MDM25P_15_T" shortDescription="SYSTEM TEMPERATURE 2: MDM25P – 15 TEMPERATURE" />
-			<xtce:Parameter name="COD_NHK.MDM25P_16_T" parameterTypeRef="COD_NHK.MDM25P_16_T" shortDescription="SYSTEM TEMPERATURE 3: MDM25P – 16 TEMPERATURE" />
-			<xtce:Parameter name="COD_NHK.MDM51P_27_T" parameterTypeRef="COD_NHK.MDM51P_27_T" shortDescription="LO TEMPERATURE: MDM51P – 27 TEMPERATURE" />
+			<xtce:Parameter name="COD_NHK.APDB2_IMON" parameterTypeRef="COD_NHK.APDB2_IMON" shortDescription="HVPS – V15: APD2 BIAS CURRENT MONITOR">
+				<xtce:LongDescription>ALARM PERSISTENCE = 3 IN OASIS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COD_NHK.SSDB_IMON" parameterTypeRef="COD_NHK.SSDB_IMON" shortDescription="HVPS – V16: SSD BIAS CURRENT MONIOTR">
+				<xtce:LongDescription>ALARM PERSISTENCE = 3 IN OASIS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COD_NHK.STPMCP_IMON" parameterTypeRef="COD_NHK.STPMCP_IMON" shortDescription="HVPS – I1: STOP MCP CURRENT MONITOR">
+				<xtce:LongDescription>ALARM PERSISTENCE = 3 IN OASIS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COD_NHK.IOBULK_IMON" parameterTypeRef="COD_NHK.IOBULK_IMON" shortDescription="HVPS – I2: IO BULK CURRENTMONITOR">
+				<xtce:LongDescription>ALARM PERSISTENCE = 3 IN OASIS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COD_NHK.STRMCP_IMON" parameterTypeRef="COD_NHK.STRMCP_IMON" shortDescription="HVPS – I3: START MCP CURRENT MONITOR">
+				<xtce:LongDescription>ALARM PERSISTENCE = 3 IN OASIS</xtce:LongDescription>
+			</xtce:Parameter>
+			<xtce:Parameter name="COD_NHK.MDM25P_14_T" parameterTypeRef="COD_NHK.MDM25P_14_T" shortDescription="TEMP SENSOR (NOT POPULATED)" />
+			<xtce:Parameter name="COD_NHK.MDM25P_15_T" parameterTypeRef="COD_NHK.MDM25P_15_T" shortDescription="TEMP SENSOR (NOT POPULATED)" />
+			<xtce:Parameter name="COD_NHK.MDM25P_16_T" parameterTypeRef="COD_NHK.MDM25P_16_T" shortDescription="TEMP SENSOR (NOT POPULATED)" />
+			<xtce:Parameter name="COD_NHK.MDM51P_27_T" parameterTypeRef="COD_NHK.MDM51P_27_T" shortDescription="TEMP SENSOR (NOT POPULATED)" />
 			<xtce:Parameter name="COD_NHK.IO_HVPS_T" parameterTypeRef="COD_NHK.IO_HVPS_T" shortDescription="HVPS TEMPERATURE: IO-HVPS TEMPERATURE" />
 			<xtce:Parameter name="COD_NHK.LVPS_12V_T" parameterTypeRef="COD_NHK.LVPS_12V_T" shortDescription="LVPS TEMPERATURE 1: LVPS – 12V TEMPERATURE" />
 			<xtce:Parameter name="COD_NHK.LVPS_5V_T" parameterTypeRef="COD_NHK.LVPS_5V_T" shortDescription="LVPS TEMPERATURE 2: LVPS – 5V TEMPERATURE" />
@@ -3159,11 +3113,13 @@
 			<xtce:Parameter name="COD_NHK.CDH_N12V" parameterTypeRef="COD_NHK.CDH_N12V" shortDescription="CDH – -12V" />
 			<xtce:Parameter name="COD_NHK.CDH_5V" parameterTypeRef="COD_NHK.CDH_5V" shortDescription="CDH – +5V" />
 			<xtce:Parameter name="COD_NHK.CDH_5V_ADC" parameterTypeRef="COD_NHK.CDH_5V_ADC" shortDescription="CDH – ANALOG REF: CDH – +5V ADC" />
-			<xtce:Parameter name="COD_NHK.TBD_HVPS_1_IF_ERR_CNT" parameterTypeRef="COD_NHK.TBD_HVPS_1_IF_ERR_CNT" shortDescription="TBD - PLACEHOLDER FOR HVPS 1 INTERFACE ERROR COUNTS" />
-			<xtce:Parameter name="COD_NHK.TBD_HVPS_2_IF_ERR_CNT" parameterTypeRef="COD_NHK.TBD_HVPS_2_IF_ERR_CNT" shortDescription="TBD - PLACEHOLDER FOR HVPS 2 INTERFACE ERROR COUNTS" />
-			<xtce:Parameter name="COD_NHK.TBD_FEE_1_IF_ERR_CNT" parameterTypeRef="COD_NHK.TBD_FEE_1_IF_ERR_CNT" shortDescription="TBD - PLACEHOLDER FOR FEE 1 INTERFACE ERROR COUNTS" />
-			<xtce:Parameter name="COD_NHK.TBD_FEE_2_IF_ERR_CNT" parameterTypeRef="COD_NHK.TBD_FEE_2_IF_ERR_CNT" shortDescription="TBD - PLACEHOLDER FOR FEE 2 INTERFACE ERROR COUNTS" />
-			<xtce:Parameter name="COD_NHK.TBD_MACRO_STATUS" parameterTypeRef="COD_NHK.TBD_MACRO_STATUS" shortDescription="TBD - PLACEHOLDER FOR MACRO STATUS" />
+			<xtce:Parameter name="COD_NHK.HVPS_1_IF_ERR_CNT" parameterTypeRef="COD_NHK.HVPS_1_IF_ERR_CNT" shortDescription="HVPS 1 INTERFACE ERROR COUNTS" />
+			<xtce:Parameter name="COD_NHK.HVPS_2_IF_ERR_CNT" parameterTypeRef="COD_NHK.HVPS_2_IF_ERR_CNT" shortDescription="HVPS 2 INTERFACE ERROR COUNTS" />
+			<xtce:Parameter name="COD_NHK.FEE_1_IF_ERR_CNT" parameterTypeRef="COD_NHK.FEE_1_IF_ERR_CNT" shortDescription="FEE 1 INTERFACE ERROR COUNTS" />
+			<xtce:Parameter name="COD_NHK.FEE_2_IF_ERR_CNT" parameterTypeRef="COD_NHK.FEE_2_IF_ERR_CNT" shortDescription="FEE 2 INTERFACE ERROR COUNTS" />
+			<xtce:Parameter name="COD_NHK.MACRO_STATUS" parameterTypeRef="COD_NHK.MACRO_STATUS" shortDescription="MACRO STATUS">
+				<xtce:LongDescription>EACH BIT INDICATES WHETHER THE CORRESPONDING MACRO IS CURRENTLY RUNNING (E.G. BIT 1 WILL BE SET IF MACRO 1 IS RUNNING)</xtce:LongDescription>
+			</xtce:Parameter>
 			<xtce:Parameter name="COD_NHK.FDC_TRIGGER_CNT_FSW" parameterTypeRef="COD_NHK.FDC_TRIGGER_CNT_FSW" shortDescription="INDICATES WHETHER ANY CATEGORY 1 LIMITS HAVE TRIGGERED">
 				<xtce:LongDescription>INDICATES WHETHER ANY CATEGORY 1 LIMITS HAVE TRIGGERED.
 
@@ -3194,7 +3150,7 @@
 				<xtce:LongDescription>INDICATES WHETHER THE MOST RECENT TRIGGER WAS A MINIMUM OR MAXIMUM LIMIT</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="COD_NHK.FDC_LAST_TRIGGER_ID" parameterTypeRef="COD_NHK.FDC_LAST_TRIGGER_ID" shortDescription="INDICATES THE ID OF THE MOST RECENT FDC TRIGGER">
-				<xtce:LongDescription>INDICATES THE ID OF THE MOST RECENT FDC TRIGGER</xtce:LongDescription>
+				<xtce:LongDescription>INDICATES THE TABLE INDEX OF THE MOST RECENT FDC TRIGGER</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="COD_NHK.FDC_LAST_TRIGGER_ACTION" parameterTypeRef="COD_NHK.FDC_LAST_TRIGGER_ACTION" shortDescription="INDICATES THE ACTION THAT WAS TAKEN FOR THE MOST RECENT FDC TRIGGER">
 				<xtce:LongDescription>INDICATES THE ACTION THAT WAS TAKEN FOR THE MOST RECENT FDC TRIGGER</xtce:LongDescription>
@@ -3208,7 +3164,7 @@
 			<xtce:Parameter name="COD_NHK.HEATER_CONTROL_STATE" parameterTypeRef="COD_NHK.HEATER_CONTROL_STATE" shortDescription="STATE OF THE HEATER CONTROLLER">
 				<xtce:LongDescription>INDICATES WHETHER FSW CONTROL OF THE OPERATIONAL HEATER IS ENABLED</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="COD_NHK.HEATER_OUTPUT_STATE" parameterTypeRef="COD_NHK.HEATER_OUTPUT_STATE" shortDescription="STATE OF THE HEATER OUTPUT">
+			<xtce:Parameter name="COD_NHK.HEATER_OUTPUT_STATE_1" parameterTypeRef="COD_NHK.HEATER_OUTPUT_STATE_1" shortDescription="STATE OF THE HEATER OUTPUT">
 				<xtce:LongDescription>INDICATES THE CURRENT STATE OF THE PHYSICAL HEATER OUTPUT</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="COD_NHK.HEATER_OUTPUT_STATE_2" parameterTypeRef="COD_NHK.HEATER_OUTPUT_STATE_2" shortDescription="STATE OF THE HEATER OUTPUT 2">
@@ -3312,40 +3268,6 @@
 			</xtce:Parameter>
 			<xtce:Parameter name="COD_LO_PHA.SHCOARSE" parameterTypeRef="COD_LO_PHA.SHCOARSE" shortDescription="S/C TIME - SECONDS">
 				<xtce:LongDescription>SECONDARY HEADER - WHOLE-SECONDS PART OF SCLK</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.PACKET_VERSION" parameterTypeRef="COD_LO_PHA.PACKET_VERSION" shortDescription="PACKET VERSION">
-				<xtce:LongDescription>PACKET VERSION - THIS WILL BE INCREMENTED EACH TIME THE FORMAT OF THE PACKET CHANGESCOD_LO_PHA.</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.SPIN_PERIOD" parameterTypeRef="COD_LO_PHA.SPIN_PERIOD" shortDescription="SPIN PERIOD REPORTED BY THE SPACECRAFT">
-				<xtce:LongDescription>SPIN PERIOD REPORTED BY THE SPACECRAFT IN THE TIME AND STATUS MESSAGE.  REPORTED PERIOD IS THE PERIOD THAT WAS ACTIVE WHEN THE 16-SPIN ACQUISITION CYCLE STARTED.</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.ACQ_START_SECONDS" parameterTypeRef="COD_LO_PHA.ACQ_START_SECONDS" shortDescription="ACQUISITION START TIME (SECONDS)">
-				<xtce:LongDescription>FULL-SECONDS PORTION OF THE TIME AT WHICH THE 16-SPIN CYCLE STARTED</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.ACQ_START_SUBSECONDS" parameterTypeRef="COD_LO_PHA.ACQ_START_SUBSECONDS" shortDescription="ACQUISITION START TIME (SUBSECONDS)">
-				<xtce:LongDescription>SUB-SECONDS PORTION OF THE TIME AT WHICH THE 16-SPIN CYCLE STARTED</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.SPARE_1" parameterTypeRef="COD_LO_PHA.SPARE_1" shortDescription="SPARE FOR ALIGNMENT">
-				<xtce:LongDescription>SPARE FOR ALIGNMENT</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.ST_BIAS_GAIN_MODE" parameterTypeRef="COD_LO_PHA.ST_BIAS_GAIN_MODE" shortDescription="BIAS GAIN MODE (SUPRATHERMAL)">
-				<xtce:LongDescription>BIAS GAIN MODE FOR THE SUPRATHERMAL SECTOR</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.SW_BIAS_GAIN_MODE" parameterTypeRef="COD_LO_PHA.SW_BIAS_GAIN_MODE" shortDescription="BIAS GAIN MODE (SOLARWIND)">
-				<xtce:LongDescription>BIAS GAIN MODE FOR THE SOLARWIND SECTOR</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.PRIORITY" parameterTypeRef="COD_LO_PHA.PRIORITY" shortDescription="PRIORITY INCLUDED IN THIS PACKET" />
-			<xtce:Parameter name="COD_LO_PHA.SUSPECT" parameterTypeRef="COD_LO_PHA.SUSPECT" shortDescription="INDICATES A DATA QUALITY ISSUE">
-				<xtce:LongDescription>INDICATES THAT THERE WAS SOME ERROR DETECTED DURING ACQUISITION OR PROCESSING OF THE DATA.  ERRORS COULD INCLUDE CORRUPTED ACQUISITION MEMORY (I.E. EDAC ERRORS), TIMING VIOLATIONS, OR OTHER EVENTS THAT INTERRUPTED OR OTHERWISE AFFECTED DATA COLLECTION.</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.COMPRESSED" parameterTypeRef="COD_LO_PHA.COMPRESSED" shortDescription="WHETHER THE EVENT DATA IS COMPRESSED">
-				<xtce:LongDescription>WHETHER THE EVENT DATA IS COMPRESSED.  IF 1/YES, EVENT_DATA ARRAY IS COMPRESSED USING THE LZMA COMPRESSION ALGORITHM.</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.NUM_EVENTS" parameterTypeRef="COD_LO_PHA.NUM_EVENTS" shortDescription="NUMBER OF EVENTS INCLUDED IN THIS PACKET">
-				<xtce:LongDescription>NUMBER OF EVENTS SELECTED FOR DOWNLINK (I.E. NUMBER OF EVENTS IN THE EVENT_DATA ARRAY)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_LO_PHA.BYTE_COUNT" parameterTypeRef="COD_LO_PHA.BYTE_COUNT" shortDescription="NUMBER OF BYTES IN THE EVENT DATA ARRAY">
-				<xtce:LongDescription>NUMBER OF BYTES IN THE EVENT_DATA ARRAY.  IF COMPRESSED, THIS VALUE REPRESENTS THE LENGTH OF THE COMPRESSED DATA.</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="COD_LO_PHA.EVENT_DATA" parameterTypeRef="COD_LO_PHA.EVENT_DATA" shortDescription="EVENT DATA">
 				<xtce:LongDescription>OPTIONALLY COMPRESSED ARRAY OF EVENT DATA
@@ -3999,40 +3921,6 @@ WHEN THIS ARRAY IS TOO LARGE FOR A SINGLE CCSDS PACKET, CODICE WILL UTILIZE THE 
 			<xtce:Parameter name="COD_HI_PHA.SHCOARSE" parameterTypeRef="COD_HI_PHA.SHCOARSE" shortDescription="S/C TIME - SECONDS">
 				<xtce:LongDescription>SECONDARY HEADER - WHOLE-SECONDS PART OF SCLK</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.PACKET_VERSION" parameterTypeRef="COD_HI_PHA.PACKET_VERSION" shortDescription="PACKET VERSION">
-				<xtce:LongDescription>PACKET VERSION - THIS WILL BE INCREMENTED EACH TIME THE FORMAT OF THE PACKET CHANGESCOD_LO_PHA.</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.SPIN_PERIOD" parameterTypeRef="COD_HI_PHA.SPIN_PERIOD" shortDescription="SPIN PERIOD REPORTED BY THE SPACECRAFT">
-				<xtce:LongDescription>SPIN PERIOD REPORTED BY THE SPACECRAFT IN THE TIME AND STATUS MESSAGE.  REPORTED PERIOD IS THE PERIOD THAT WAS ACTIVE WHEN THE 16-SPIN ACQUISITION CYCLE STARTED.</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.ACQ_START_SECONDS" parameterTypeRef="COD_HI_PHA.ACQ_START_SECONDS" shortDescription="ACQUISITION START TIME (SECONDS)">
-				<xtce:LongDescription>FULL-SECONDS PORTION OF THE TIME AT WHICH THE 16-SPIN CYCLE STARTED</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.ACQ_START_SUBSECONDS" parameterTypeRef="COD_HI_PHA.ACQ_START_SUBSECONDS" shortDescription="ACQUISITION START TIME (SUBSECONDS)">
-				<xtce:LongDescription>SUB-SECONDS PORTION OF THE TIME AT WHICH THE 16-SPIN CYCLE STARTED</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.SPARE_1" parameterTypeRef="COD_HI_PHA.SPARE_1" shortDescription="SPARE FOR ALIGNMENT">
-				<xtce:LongDescription>SPARE FOR ALIGNMENT</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.ST_BIAS_GAIN_MODE" parameterTypeRef="COD_HI_PHA.ST_BIAS_GAIN_MODE" shortDescription="BIAS GAIN MODE (SUPRATHERMAL)">
-				<xtce:LongDescription>BIAS GAIN MODE FOR THE SUPRATHERMAL SECTOR</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.SW_BIAS_GAIN_MODE" parameterTypeRef="COD_HI_PHA.SW_BIAS_GAIN_MODE" shortDescription="BIAS GAIN MODE (SOLARWIND)">
-				<xtce:LongDescription>BIAS GAIN MODE FOR THE SOLARWIND SECTOR</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.PRIORITY" parameterTypeRef="COD_HI_PHA.PRIORITY" shortDescription="PRIORITY INCLUDED IN THIS PACKET" />
-			<xtce:Parameter name="COD_HI_PHA.SUSPECT" parameterTypeRef="COD_HI_PHA.SUSPECT" shortDescription="INDICATES A DATA QUALITY ISSUE">
-				<xtce:LongDescription>INDICATES THAT THERE WAS SOME ERROR DETECTED DURING ACQUISITION OR PROCESSING OF THE DATA.  ERRORS COULD INCLUDE CORRUPTED ACQUISITION MEMORY (I.E. EDAC ERRORS), TIMING VIOLATIONS, OR OTHER EVENTS THAT INTERRUPTED OR OTHERWISE AFFECTED DATA COLLECTION.</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.COMPRESSED" parameterTypeRef="COD_HI_PHA.COMPRESSED" shortDescription="WHETHER THE EVENT DATA IS COMPRESSED">
-				<xtce:LongDescription>WHETHER THE EVENT DATA IS COMPRESSED.  IF 1/YES, EVENT_DATA ARRAY IS COMPRESSED USING THE RICE COMPRESSION ALGORITHM.</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.NUM_EVENTS" parameterTypeRef="COD_HI_PHA.NUM_EVENTS" shortDescription="NUMBER OF EVENTS INCLUDED IN THIS PACKET">
-				<xtce:LongDescription>NUMBER OF EVENTS SELECTED FOR DOWNLINK (I.E. NUMBER OF EVENTS IN THE EVENT_DATA ARRAY)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="COD_HI_PHA.BYTE_COUNT" parameterTypeRef="COD_HI_PHA.BYTE_COUNT" shortDescription="NUMBER OF BYTES IN THE EVENT DATA ARRAY">
-				<xtce:LongDescription>NUMBER OF BYTES IN THE EVENT_DATA ARRAY.  IF COMPRESSED, THIS VALUE REPRESENTS THE LENGTH OF THE COMPRESSED DATA.</xtce:LongDescription>
-			</xtce:Parameter>
 			<xtce:Parameter name="COD_HI_PHA.EVENT_DATA" parameterTypeRef="COD_HI_PHA.EVENT_DATA" shortDescription="EVENT DATA">
 				<xtce:LongDescription>OPTIONALLY COMPRESSED ARRAY OF EVENT DATA
 
@@ -4491,6 +4379,7 @@ WHEN THIS ARRAY IS TOO LARGE FOR A SINGLE CCSDS PACKET, CODICE WILL UTILIZE THE 
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.SBULK_EN" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.STPMCP_EN" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.STRMCP_EN" />
+					<xtce:ParameterRefEntry parameterRef="COD_NHK.LO_ESA_OP_ST" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.SPARE_4" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.ESAA_DAC" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.ESAB_DAC" />
@@ -4546,11 +4435,11 @@ WHEN THIS ARRAY IS TOO LARGE FOR A SINGLE CCSDS PACKET, CODICE WILL UTILIZE THE 
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.CDH_N12V" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.CDH_5V" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.CDH_5V_ADC" />
-					<xtce:ParameterRefEntry parameterRef="COD_NHK.TBD_HVPS_1_IF_ERR_CNT" />
-					<xtce:ParameterRefEntry parameterRef="COD_NHK.TBD_HVPS_2_IF_ERR_CNT" />
-					<xtce:ParameterRefEntry parameterRef="COD_NHK.TBD_FEE_1_IF_ERR_CNT" />
-					<xtce:ParameterRefEntry parameterRef="COD_NHK.TBD_FEE_2_IF_ERR_CNT" />
-					<xtce:ParameterRefEntry parameterRef="COD_NHK.TBD_MACRO_STATUS" />
+					<xtce:ParameterRefEntry parameterRef="COD_NHK.HVPS_1_IF_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="COD_NHK.HVPS_2_IF_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="COD_NHK.FEE_1_IF_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="COD_NHK.FEE_2_IF_ERR_CNT" />
+					<xtce:ParameterRefEntry parameterRef="COD_NHK.MACRO_STATUS" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.FDC_TRIGGER_CNT_FSW" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.FDC_TRIGGER_CNT_HVPS" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.FDC_TRIGGER_CNT_CDH" />
@@ -4565,7 +4454,7 @@ WHEN THIS ARRAY IS TOO LARGE FOR A SINGLE CCSDS PACKET, CODICE WILL UTILIZE THE 
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.ROUND_ROBIN_INDEX" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.ROUND_ROBIN_VALUE" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.HEATER_CONTROL_STATE" />
-					<xtce:ParameterRefEntry parameterRef="COD_NHK.HEATER_OUTPUT_STATE" />
+					<xtce:ParameterRefEntry parameterRef="COD_NHK.HEATER_OUTPUT_STATE_1" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.HEATER_OUTPUT_STATE_2" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.SPARE_5" />
 					<xtce:ParameterRefEntry parameterRef="COD_NHK.CPU_IDLE" />
@@ -4632,18 +4521,6 @@ WHEN THIS ARRAY IS TOO LARGE FOR A SINGLE CCSDS PACKET, CODICE WILL UTILIZE THE 
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.PACKET_VERSION" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.SPIN_PERIOD" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.ACQ_START_SECONDS" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.ACQ_START_SUBSECONDS" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.SPARE_1" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.ST_BIAS_GAIN_MODE" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.SW_BIAS_GAIN_MODE" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.PRIORITY" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.SUSPECT" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.COMPRESSED" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.NUM_EVENTS" />
-					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.BYTE_COUNT" />
 					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.EVENT_DATA" />
 					<xtce:ParameterRefEntry parameterRef="COD_LO_PHA.CHKSUM" />
 				</xtce:EntryList>
@@ -4908,18 +4785,6 @@ WHEN THIS ARRAY IS TOO LARGE FOR A SINGLE CCSDS PACKET, CODICE WILL UTILIZE THE 
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.PACKET_VERSION" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.SPIN_PERIOD" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.ACQ_START_SECONDS" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.ACQ_START_SUBSECONDS" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.SPARE_1" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.ST_BIAS_GAIN_MODE" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.SW_BIAS_GAIN_MODE" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.PRIORITY" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.SUSPECT" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.COMPRESSED" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.NUM_EVENTS" />
-					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.BYTE_COUNT" />
 					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.EVENT_DATA" />
 					<xtce:ParameterRefEntry parameterRef="COD_HI_PHA.CHKSUM" />
 				</xtce:EntryList>

--- a/imap_processing/tests/test_utils.py
+++ b/imap_processing/tests/test_utils.py
@@ -306,6 +306,18 @@ def test_combine_segmented_packets():
     xr.testing.assert_equal(combined_ds, expected_ds)
 
 
+def test_check_source_sequence_counter(caplog):
+    """Test _check_source_sequence_counter function."""
+    data_vars = {
+        "src_seq_ctr": (["epoch"], np.array([0, 1, 3, 4, 6])),
+    }
+    ds = xr.Dataset(data_vars=data_vars)
+
+    utils._check_source_sequence_counter(ds, apid=1234)
+
+    assert "Found [2] gap(s) in source sequence counter for APID 1234" in caplog.text
+
+
 def test_extract_data_dict():
     """Test extract_data_dict function."""
     data_vars = {

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -389,6 +389,8 @@ def combine_segmented_packets(
 
     # Get indices of packets we'll keep (first packet of each group)
     group_start_indices = np.where(is_group_start)[0]
+    # Keep track of the groups that don't have the expected sequences
+    bad_groups = []
 
     # Concatenate binary data in-place for each group
     for group_id in np.unique(group_ids):
@@ -411,15 +413,19 @@ def combine_segmented_packets(
                     and not np.all(seq_flags[1:-1] == SequenceFlags.CONTINUATION)
                 )
             ):
+                bad_groups.append(start_index)
                 logger.warning(
                     f"Incorrect/incomplete sequence flags in group {group_id}. "
                     f"Flags: {seq_flags}, "
                     f"SHCOARSEs: {packets['shcoarse'].data[group_indices]}"
                 )
+
             packets[binary_field_name].data[start_index] = np.sum(
                 packets[binary_field_name].data[group_indices]
             )
 
+    # Remove any bad groups from the start indices we are keeping
+    group_start_indices = np.setdiff1d(group_start_indices, bad_groups)
     # Select only the first packet of each group (drop the middle/last packets)
     combined_packets = packets.isel(epoch=group_start_indices)
 

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -333,6 +333,9 @@ def packet_file_to_datasets(
             )
             ds = ds.isel(epoch=unique_indices)
 
+        # Log a warning if there are gaps in the source sequence counter
+        _check_source_sequence_counter(ds, apid)
+
         # Strip any leading characters before "." from the field names which was due
         # to the packet_name being a part of the variable name in the XTCE definition
         ds = ds.rename(
@@ -421,6 +424,51 @@ def combine_segmented_packets(
     combined_packets = packets.isel(epoch=group_start_indices)
 
     return combined_packets
+
+
+def _check_source_sequence_counter(ds: xr.Dataset, apid: int) -> None:
+    """
+    Check for gaps in the source sequence counter.
+
+    Log a warning if gaps are found, but don't do anything else.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing the packets to check.
+    apid : int
+        APID of the packets.
+    """
+    # Check for sequential source sequence counters
+    # CCSDS source sequence counter is a 14-bit field (0-16383)
+    counter_max = 16384
+    src_seq_ctr = ds["src_seq_ctr"].data
+
+    if len(src_seq_ctr) <= 1:
+        return
+
+    # Check if each counter equals (previous + 1) % counter_max
+    # This handles both normal increments and rollover (16383 -> 0)
+    expected = (src_seq_ctr[:-1] + 1) % counter_max
+    actual = src_seq_ctr[1:]
+    non_sequential = expected != actual
+
+    if np.any(non_sequential):
+        gap_indices = np.where(non_sequential)[0]
+        # Calculate total missing packets across all gaps
+        total_missing = sum(
+            (src_seq_ctr[idx + 1] - src_seq_ctr[idx] - 1) % counter_max
+            for idx in gap_indices
+        )
+        # Show the counter values before and after each gap
+        gap_starts = src_seq_ctr[gap_indices].tolist()
+        gap_ends = src_seq_ctr[gap_indices + 1].tolist()
+        gap_pairs = list(zip(gap_starts, gap_ends, strict=True))
+        logger.warning(
+            f"Found [{len(gap_indices)}] gap(s) in source sequence counter "
+            f"for APID {apid} at {gap_pairs} "
+            f"({total_missing} total missing packets)"
+        )
 
 
 def packet_generator(


### PR DESCRIPTION
# Change Summary

## Overview

This changes the CoDICE packet definition for direct events. Previously, we were reading in many fields for each packet, but this is incorrect, the fields are only in the _first_ packet. This meant that we were extracting things with XTCE, then recombining those fields back into binary and then extracting again. The issue came about when the second packet's binary payload was not long enough to unpack all the individual fields.

This is a significant refactor as well. Rather than working with binary strings, we are working with bytes directly and doing bitshifts on numpy arrays. Thanks to good unit tests, this was able to be refactored with the help of AI.

closes #2568