### PR TITLE
Ultra segmented packet support

### DIFF
--- a/imap_processing/tests/test_utils.py
+++ b/imap_processing/tests/test_utils.py
@@ -262,6 +262,50 @@ def test_packet_file_to_datasets_flat_definition():
         utils.packet_file_to_datasets(packet_files, packet_definition)
 
 
+def test_combine_segmented_packets():
+    """Test combine_segmented_packets function."""
+
+    # unsegmented, first, middle, last, unsegmented
+    sequence_flags = xr.DataArray(np.array([3, 1, 0, 2, 3]), dims=["epoch"])
+
+    binary_data = xr.DataArray(
+        np.array(
+            [
+                b"ABC",
+                b"123",
+                b"456",
+                b"789",
+                b"abc",
+            ],
+            dtype=object,
+        ),
+        dims=["epoch"],
+    )
+
+    ds = xr.Dataset(data_vars={"seq_flgs": sequence_flags, "packetdata": binary_data})
+
+    combined_ds = utils.combine_segmented_packets(ds, "packetdata")
+
+    expected_ds = xr.Dataset(
+        data_vars={
+            "seq_flgs": xr.DataArray(np.array([3, 1, 3]), dims=["epoch"]),
+            "packetdata": xr.DataArray(
+                np.array(
+                    [
+                        b"ABC",
+                        b"123456789",
+                        b"abc",
+                    ],
+                    dtype=object,
+                ),
+                dims=["epoch"],
+            ),
+        }
+    )
+
+    xr.testing.assert_equal(combined_ds, expected_ds)
+
+
 def test_extract_data_dict():
     """Test extract_data_dict function."""
     data_vars = {

--- a/imap_processing/ultra/l0/decom_ultra.py
+++ b/imap_processing/ultra/l0/decom_ultra.py
@@ -32,14 +32,72 @@ from imap_processing.ultra.l0.ultra_utils import (
     ULTRA_RATES,
     PacketProperties,
 )
-from imap_processing.utils import convert_to_binary_string
+from imap_processing.utils import combine_segmented_packets, convert_to_binary_string
 
 logger = logging.getLogger(__name__)
+
+
+def extract_initial_items_from_combined_packets(
+    packets: xr.Dataset,
+) -> xr.Dataset:
+    """
+    Extract metadata fields from the beginning of combined event_data packets.
+
+    Extracts bit fields from the first 20 bytes of each event_data array
+    and adds them as new variables to the dataset.
+
+    Parameters
+    ----------
+    packets : xarray.Dataset
+        Dataset containing combined packets with event_data.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset with extracted metadata fields added.
+    """
+    # Initialize arrays for extracted fields
+    n_packets = len(packets.epoch)
+
+    # Preallocate arrays
+    sid = np.zeros(n_packets, dtype=np.uint8)
+    spin = np.zeros(n_packets, dtype=np.uint8)
+    abortflag = np.zeros(n_packets, dtype=np.uint8)
+    startdelay = np.zeros(n_packets, dtype=np.uint16)
+    p00 = np.zeros(n_packets, dtype=np.uint8)
+
+    # Extract the data array outside of the loop
+    binary_data = packets["packetdata"].data
+    # Extract fields from each packet
+    for pkt_idx in range(n_packets):
+        event_data = binary_data[pkt_idx]
+
+        sid[pkt_idx] = event_data[0]
+        spin[pkt_idx] = event_data[1]
+        abortflag[pkt_idx] = (event_data[2] >> 7) & 0x1
+        startdelay[pkt_idx] = int.from_bytes(event_data[2:4], byteorder="big") & 0x7FFF
+        p00[pkt_idx] = event_data[4]
+
+        # Remove the first 5 bytes after extraction
+        binary_data[pkt_idx] = event_data[5:]
+
+    # Add extracted fields to dataset
+    packets["sid"] = xr.DataArray(sid, dims=["epoch"])
+    packets["spin"] = xr.DataArray(spin, dims=["epoch"])
+    packets["abortflag"] = xr.DataArray(abortflag, dims=["epoch"])
+    packets["startdelay"] = xr.DataArray(startdelay, dims=["epoch"])
+    packets["p00"] = xr.DataArray(p00, dims=["epoch"])
+
+    return packets
 
 
 def process_ultra_tof(ds: xr.Dataset, packet_props: PacketProperties) -> xr.Dataset:
     """
     Unpack and decode Ultra TOF packets.
+
+    The TOF packets contain image data that may be split across multiple segmented
+    packets. This function combines the segmented packets and decompresses the image
+    data.
 
     Parameters
     ----------
@@ -54,6 +112,11 @@ def process_ultra_tof(ds: xr.Dataset, packet_props: PacketProperties) -> xr.Data
     dataset : xarray.Dataset
         Dataset containing the decoded and decompressed data.
     """
+    # Combine segmented packets
+    ds = combine_segmented_packets(ds, binary_field_name="packetdata")
+    # Extract the header keys from each of the combined packetdata fields.
+    ds = extract_initial_items_from_combined_packets(ds)
+
     scalar_keys = [key for key in ds.data_vars if key not in ("packetdata", "sid")]
 
     image_planes = packet_props.image_planes

--- a/imap_processing/ultra/packet_definitions/ULTRA_SCI_COMBINED.xml
+++ b/imap_processing/ultra/packet_definitions/ULTRA_SCI_COMBINED.xml
@@ -4664,27 +4664,12 @@
 			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_ANG.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_ANG.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_ANG.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_ANG.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_ANG.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_ANG.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U45_IMG_ENA_PHXTOF_HI_ANG.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -4692,27 +4677,12 @@
 			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_EGY.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_EGY.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_EGY.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_EGY.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_EGY.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_EGY.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U45_IMG_ENA_PHXTOF_HI_EGY.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -4720,27 +4690,12 @@
 			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_TIME.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_TIME.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_TIME.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_TIME.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_TIME.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_PHXTOF_HI_TIME.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U45_IMG_ENA_PHXTOF_HI_TIME.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -4748,27 +4703,12 @@
 			<xtce:IntegerParameterType name="U45_IMG_ENA_EXTOF_HI_ANG.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_EXTOF_HI_ANG.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_EXTOF_HI_ANG.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_EXTOF_HI_ANG.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_EXTOF_HI_ANG.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ENA_EXTOF_HI_ANG.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U45_IMG_ENA_EXTOF_HI_ANG.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -4776,27 +4716,12 @@
 			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_EGY.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_EGY.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_EGY.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_EGY.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_EGY.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_EGY.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U45_IMG_ION_EXTOF_HI_EGY.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -4804,27 +4729,12 @@
 			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_TIME.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_TIME.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_TIME.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_TIME.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_TIME.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U45_IMG_ION_EXTOF_HI_TIME.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U45_IMG_ION_EXTOF_HI_TIME.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -9662,27 +9572,12 @@
 			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_ANG.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_ANG.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_ANG.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_ANG.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_ANG.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_ANG.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U90_IMG_ENA_PHXTOF_HI_ANG.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -9690,27 +9585,12 @@
 			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_EGY.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_EGY.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_EGY.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_EGY.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_EGY.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_EGY.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U90_IMG_ENA_PHXTOF_HI_EGY.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -9718,27 +9598,12 @@
 			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_TIME.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_TIME.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_TIME.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_TIME.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_TIME.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_PHXTOF_HI_TIME.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U90_IMG_ENA_PHXTOF_HI_TIME.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -9746,27 +9611,12 @@
 			<xtce:IntegerParameterType name="U90_IMG_ENA_EXTOF_HI_ANG.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_EXTOF_HI_ANG.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_EXTOF_HI_ANG.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_EXTOF_HI_ANG.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_EXTOF_HI_ANG.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ENA_EXTOF_HI_ANG.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U90_IMG_ENA_EXTOF_HI_ANG.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -9774,27 +9624,12 @@
 			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_EGY.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_EGY.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_EGY.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_EGY.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_EGY.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_EGY.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U90_IMG_ION_EXTOF_HI_EGY.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -9802,27 +9637,12 @@
 			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_TIME.SHCOARSE" signed="false">
 				<xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
 			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_TIME.SID" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_TIME.SPIN" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_TIME.ABORTFLAG" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="1" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_TIME.STARTDELAY" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="15" encoding="unsigned" />
-			</xtce:IntegerParameterType>
-			<xtce:IntegerParameterType name="U90_IMG_ION_EXTOF_HI_TIME.P00" signed="false">
-				<xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-			</xtce:IntegerParameterType>
 			<xtce:BinaryParameterType name="U90_IMG_ION_EXTOF_HI_TIME.PACKETDATA">
 				<xtce:BinaryDataEncoding bitOrder="mostSignificantBitFirst">
 					<xtce:SizeInBits>
 						<xtce:DynamicValue>
 							<xtce:ParameterInstanceRef parameterRef="PKT_LEN" />
-							<xtce:LinearAdjustment slope="8" intercept="-64" />
+							<xtce:LinearAdjustment slope="8" intercept="-24" />
 						</xtce:DynamicValue>
 					</xtce:SizeInBits>
 				</xtce:BinaryDataEncoding>
@@ -11561,41 +11381,11 @@
 			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_ANG.SHCOARSE" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_ANG.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_ANG.SID" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_ANG.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_ANG.SPIN" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_ANG.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_ANG.ABORTFLAG" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_ANG.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_ANG.STARTDELAY" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_ANG.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_ANG.P00" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_ANG.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
-			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_ANG.PACKETDATA" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_ANG.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_EGY.SHCOARSE" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_EGY.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_EGY.SID" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_EGY.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_EGY.SPIN" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_EGY.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_EGY.ABORTFLAG" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_EGY.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_EGY.STARTDELAY" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_EGY.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_EGY.P00" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_EGY.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_EGY.PACKETDATA" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_EGY.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
@@ -11603,41 +11393,11 @@
 			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_TIME.SHCOARSE" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_TIME.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_TIME.SID" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_TIME.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_TIME.SPIN" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_TIME.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_TIME.ABORTFLAG" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_TIME.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_TIME.STARTDELAY" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_TIME.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_TIME.P00" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_TIME.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
-			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ENA_PHXTOF_HI_TIME.PACKETDATA" parameterTypeRef="U45_IMG_ENA_PHXTOF_HI_TIME.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ENA_EXTOF_HI_ANG.SHCOARSE" parameterTypeRef="U45_IMG_ENA_EXTOF_HI_ANG.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_EXTOF_HI_ANG.SID" parameterTypeRef="U45_IMG_ENA_EXTOF_HI_ANG.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_EXTOF_HI_ANG.SPIN" parameterTypeRef="U45_IMG_ENA_EXTOF_HI_ANG.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_EXTOF_HI_ANG.ABORTFLAG" parameterTypeRef="U45_IMG_ENA_EXTOF_HI_ANG.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_EXTOF_HI_ANG.STARTDELAY" parameterTypeRef="U45_IMG_ENA_EXTOF_HI_ANG.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ENA_EXTOF_HI_ANG.P00" parameterTypeRef="U45_IMG_ENA_EXTOF_HI_ANG.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ENA_EXTOF_HI_ANG.PACKETDATA" parameterTypeRef="U45_IMG_ENA_EXTOF_HI_ANG.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
@@ -11645,41 +11405,11 @@
 			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_EGY.SHCOARSE" parameterTypeRef="U45_IMG_ION_EXTOF_HI_EGY.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_EGY.SID" parameterTypeRef="U45_IMG_ION_EXTOF_HI_EGY.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_EGY.SPIN" parameterTypeRef="U45_IMG_ION_EXTOF_HI_EGY.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_EGY.ABORTFLAG" parameterTypeRef="U45_IMG_ION_EXTOF_HI_EGY.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_EGY.STARTDELAY" parameterTypeRef="U45_IMG_ION_EXTOF_HI_EGY.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_EGY.P00" parameterTypeRef="U45_IMG_ION_EXTOF_HI_EGY.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
-			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_EGY.PACKETDATA" parameterTypeRef="U45_IMG_ION_EXTOF_HI_EGY.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_TIME.SHCOARSE" parameterTypeRef="U45_IMG_ION_EXTOF_HI_TIME.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_TIME.SID" parameterTypeRef="U45_IMG_ION_EXTOF_HI_TIME.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_TIME.SPIN" parameterTypeRef="U45_IMG_ION_EXTOF_HI_TIME.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_TIME.ABORTFLAG" parameterTypeRef="U45_IMG_ION_EXTOF_HI_TIME.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_TIME.STARTDELAY" parameterTypeRef="U45_IMG_ION_EXTOF_HI_TIME.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_TIME.P00" parameterTypeRef="U45_IMG_ION_EXTOF_HI_TIME.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U45_IMG_ION_EXTOF_HI_TIME.PACKETDATA" parameterTypeRef="U45_IMG_ION_EXTOF_HI_TIME.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
@@ -13346,41 +13076,11 @@
 			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_ANG.SHCOARSE" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_ANG.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_ANG.SID" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_ANG.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_ANG.SPIN" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_ANG.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_ANG.ABORTFLAG" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_ANG.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_ANG.STARTDELAY" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_ANG.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_ANG.P00" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_ANG.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
-			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_ANG.PACKETDATA" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_ANG.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_EGY.SHCOARSE" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_EGY.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_EGY.SID" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_EGY.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_EGY.SPIN" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_EGY.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_EGY.ABORTFLAG" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_EGY.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_EGY.STARTDELAY" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_EGY.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_EGY.P00" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_EGY.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_EGY.PACKETDATA" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_EGY.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
@@ -13388,41 +13088,11 @@
 			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_TIME.SHCOARSE" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_TIME.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_TIME.SID" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_TIME.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_TIME.SPIN" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_TIME.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_TIME.ABORTFLAG" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_TIME.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_TIME.STARTDELAY" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_TIME.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_TIME.P00" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_TIME.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
-			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ENA_PHXTOF_HI_TIME.PACKETDATA" parameterTypeRef="U90_IMG_ENA_PHXTOF_HI_TIME.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ENA_EXTOF_HI_ANG.SHCOARSE" parameterTypeRef="U90_IMG_ENA_EXTOF_HI_ANG.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_EXTOF_HI_ANG.SID" parameterTypeRef="U90_IMG_ENA_EXTOF_HI_ANG.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_EXTOF_HI_ANG.SPIN" parameterTypeRef="U90_IMG_ENA_EXTOF_HI_ANG.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_EXTOF_HI_ANG.ABORTFLAG" parameterTypeRef="U90_IMG_ENA_EXTOF_HI_ANG.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_EXTOF_HI_ANG.STARTDELAY" parameterTypeRef="U90_IMG_ENA_EXTOF_HI_ANG.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ENA_EXTOF_HI_ANG.P00" parameterTypeRef="U90_IMG_ENA_EXTOF_HI_ANG.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ENA_EXTOF_HI_ANG.PACKETDATA" parameterTypeRef="U90_IMG_ENA_EXTOF_HI_ANG.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
@@ -13430,41 +13100,11 @@
 			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_EGY.SHCOARSE" parameterTypeRef="U90_IMG_ION_EXTOF_HI_EGY.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
 			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_EGY.SID" parameterTypeRef="U90_IMG_ION_EXTOF_HI_EGY.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_EGY.SPIN" parameterTypeRef="U90_IMG_ION_EXTOF_HI_EGY.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_EGY.ABORTFLAG" parameterTypeRef="U90_IMG_ION_EXTOF_HI_EGY.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_EGY.STARTDELAY" parameterTypeRef="U90_IMG_ION_EXTOF_HI_EGY.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_EGY.P00" parameterTypeRef="U90_IMG_ION_EXTOF_HI_EGY.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
-			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_EGY.PACKETDATA" parameterTypeRef="U90_IMG_ION_EXTOF_HI_EGY.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_TIME.SHCOARSE" parameterTypeRef="U90_IMG_ION_EXTOF_HI_TIME.SHCOARSE" shortDescription="CCSDS Packet  2nd Header Coarse Time">
 				<xtce:LongDescription>CCSDS Packet 2nd Header Coarse Time</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_TIME.SID" parameterTypeRef="U90_IMG_ION_EXTOF_HI_TIME.SID" shortDescription="Science ID">
-				<xtce:LongDescription>Science ID</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_TIME.SPIN" parameterTypeRef="U90_IMG_ION_EXTOF_HI_TIME.SPIN" shortDescription="Spin number at integration start">
-				<xtce:LongDescription>Spin number at integration start</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_TIME.ABORTFLAG" parameterTypeRef="U90_IMG_ION_EXTOF_HI_TIME.ABORTFLAG" shortDescription="Integration aborted">
-				<xtce:LongDescription>Integration aborted</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_TIME.STARTDELAY" parameterTypeRef="U90_IMG_ION_EXTOF_HI_TIME.STARTDELAY" shortDescription="Integration start delay (ms)">
-				<xtce:LongDescription>Integration start delay (ms)</xtce:LongDescription>
-			</xtce:Parameter>
-			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_TIME.P00" parameterTypeRef="U90_IMG_ION_EXTOF_HI_TIME.P00" shortDescription="Starting pixel">
-				<xtce:LongDescription>Starting pixel</xtce:LongDescription>
 			</xtce:Parameter>
 			<xtce:Parameter name="U90_IMG_ION_EXTOF_HI_TIME.PACKETDATA" parameterTypeRef="U90_IMG_ION_EXTOF_HI_TIME.PACKETDATA" shortDescription="Image Packet Data">
 				<xtce:LongDescription>Image Packet Data</xtce:LongDescription>
@@ -14287,11 +13927,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_ANG.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_ANG.SID" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_ANG.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_ANG.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_ANG.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_ANG.P00" />
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_ANG.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -14303,11 +13938,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_EGY.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_EGY.SID" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_EGY.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_EGY.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_EGY.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_EGY.P00" />
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_EGY.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -14319,11 +13949,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_TIME.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_TIME.SID" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_TIME.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_TIME.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_TIME.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_TIME.P00" />
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_PHXTOF_HI_TIME.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -14335,11 +13960,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_EXTOF_HI_ANG.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_EXTOF_HI_ANG.SID" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_EXTOF_HI_ANG.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_EXTOF_HI_ANG.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_EXTOF_HI_ANG.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_EXTOF_HI_ANG.P00" />
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ENA_EXTOF_HI_ANG.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -14351,11 +13971,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_EGY.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_EGY.SID" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_EGY.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_EGY.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_EGY.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_EGY.P00" />
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_EGY.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -14367,11 +13982,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_TIME.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_TIME.SID" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_TIME.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_TIME.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_TIME.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_TIME.P00" />
 					<xtce:ParameterRefEntry parameterRef="U45_IMG_ION_EXTOF_HI_TIME.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -15155,11 +14765,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_ANG.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_ANG.SID" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_ANG.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_ANG.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_ANG.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_ANG.P00" />
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_ANG.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -15171,11 +14776,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_EGY.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_EGY.SID" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_EGY.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_EGY.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_EGY.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_EGY.P00" />
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_EGY.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -15187,11 +14787,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_TIME.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_TIME.SID" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_TIME.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_TIME.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_TIME.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_TIME.P00" />
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_PHXTOF_HI_TIME.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -15203,11 +14798,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_EXTOF_HI_ANG.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_EXTOF_HI_ANG.SID" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_EXTOF_HI_ANG.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_EXTOF_HI_ANG.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_EXTOF_HI_ANG.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_EXTOF_HI_ANG.P00" />
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ENA_EXTOF_HI_ANG.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -15219,11 +14809,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_EGY.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_EGY.SID" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_EGY.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_EGY.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_EGY.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_EGY.P00" />
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_EGY.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>
@@ -15235,11 +14820,6 @@
 				</xtce:BaseContainer>
 				<xtce:EntryList>
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_TIME.SHCOARSE" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_TIME.SID" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_TIME.SPIN" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_TIME.ABORTFLAG" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_TIME.STARTDELAY" />
-					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_TIME.P00" />
 					<xtce:ParameterRefEntry parameterRef="U90_IMG_ION_EXTOF_HI_TIME.PACKETDATA" />
 				</xtce:EntryList>
 			</xtce:SequenceContainer>

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -10,6 +10,7 @@ import pandas as pd
 import space_packet_parser as spp
 import xarray as xr
 from space_packet_parser.exceptions import UnrecognizedPacketTypeError
+from space_packet_parser.generators.ccsds import SequenceFlags
 from space_packet_parser.xtce import definitions, encodings, parameter_types
 
 from imap_processing.spice.time import met_to_ttj2000ns
@@ -347,6 +348,79 @@ def packet_file_to_datasets(
         dataset_by_apid[apid] = ds
 
     return dataset_by_apid
+
+
+def combine_segmented_packets(
+    packets: xr.Dataset, binary_field_name: str = "packetdata"
+) -> xr.Dataset:
+    """
+    Combine segmented packets into unsegmented packets.
+
+    To combine the segmented packets, we only concatenate along the `binary_field_name`
+    and place all values into the first packet of the group. The binary_field_name
+    is the name of the XTCE Parameter that contains the binary data for the packet.
+    The other fields are left as-is from the first packet of the group.
+
+    Parameters
+    ----------
+    packets : xarray.Dataset
+        Dataset containing the packets to combine.
+    binary_field_name : str, default "packetdata"
+        Name of the binary field in the dataset representing the packet data.
+        Defined in the XTCE definition for each instrument.
+
+    Returns
+    -------
+    combined_packets : xarray.Dataset
+        Dataset containing the combined packets.
+    """
+    # Identification of group starts
+    # NOTE: seq_flgs is the same variable name for all instruments on IMAP
+    #       but could be different for other missions depending on the XTCE definition.
+    is_group_start = (packets["seq_flgs"].data == SequenceFlags.UNSEGMENTED) | (
+        packets["seq_flgs"].data == SequenceFlags.FIRST
+    )
+
+    # Assign group IDs using cumulative sum - each group start increments the ID
+    group_ids = np.cumsum(is_group_start)
+
+    # Get indices of packets we'll keep (first packet of each group)
+    group_start_indices = np.where(is_group_start)[0]
+
+    # Concatenate binary data in-place for each group
+    for group_id in np.unique(group_ids):
+        # Find all packets belonging to this group
+        group_mask = group_ids == group_id
+        group_indices = np.where(group_mask)[0]
+
+        # If multiple packets, concatenate into the first packet
+        # [b"abc", b"def", b"ghi"] -> b"abcdefghi"
+        if len(group_indices) > 1:
+            start_index = group_indices[0]
+            # Lets do some quick validation on these packets since we've had
+            # some missing packet groups in the past
+            seq_flags = packets["seq_flgs"].data[group_indices]
+            if (
+                seq_flags[0] != SequenceFlags.FIRST
+                or seq_flags[-1] != SequenceFlags.LAST
+                or (
+                    len(seq_flags) > 2
+                    and not np.all(seq_flags[1:-1] == SequenceFlags.CONTINUATION)
+                )
+            ):
+                logger.warning(
+                    f"Incorrect/incomplete sequence flags in group {group_id}. "
+                    f"Flags: {seq_flags}, "
+                    f"SHCOARSEs: {packets['shcoarse'].data[group_indices]}"
+                )
+            packets[binary_field_name].data[start_index] = np.sum(
+                packets[binary_field_name].data[group_indices]
+            )
+
+    # Select only the first packet of each group (drop the middle/last packets)
+    combined_packets = packets.isel(epoch=group_start_indices)
+
+    return combined_packets
 
 
 def packet_generator(


### PR DESCRIPTION
# Change Summary

This adds a general helper to combine segmented packets together after the XTCE parsing. This required an updated to the XTCE xml so that the header fields aren't read in on the middle/last packets. This means we need to extract those fields manually after the XTCE parsing and combining of segmented packets. That is ultra specific, so I put the extraction function in the Ultra namespace.