### PR TITLE
Convert energy_sc to keV for interpolation

### DIFF
--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -878,8 +878,9 @@ def calculate_all_rates_and_intensities(
     if cg_correction:
         logger.info("Interpolating map intensities to helio-frame energies")
         # Finish calculation of the exposure factor weighted projection of energy_sc
+        # and convert to units of keV
         dataset["energy_sc"] = (
-            dataset["energy_sc_exposure_factor"] / dataset["exposure_factor"]
+            dataset["energy_sc_exposure_factor"] / dataset["exposure_factor"] / 1e3
         )
         dataset = interpolate_map_flux_to_helio_frame(
             dataset,

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -2341,6 +2341,13 @@ class TestCalculateAllRatesAndIntensities:
                 dataset["energy"]
             )  # spacecraft frame energies
             assert call_args[0][2].equals(dataset["energy"])  # helio frame energies
+            # Check that s/c energies get computed in keV units
+            expected_sc_energies = (
+                dataset["energy_sc_exposure_factor"] / dataset["exposure_factor"] / 1e3
+            )
+            xr.testing.assert_allclose(
+                call_args[0][0]["energy_sc"], expected_sc_energies
+            )
             assert "ena_intensity" in call_args[0][3]  # variables to interpolate
             assert "bg_intensity" in call_args[0][3]
 


### PR DESCRIPTION
# Change Summary

## Overview
This just fixes a bug in the Lo L2 CG code. I needed to convert spacecraft energies to keV to match the other energies passed in to the interpolation function.

Closes: #2592 