### PR TITLE
CoDICE l2 geometric factor: update mode calculation

### DIFF
--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -318,7 +318,7 @@ def compute_geometric_factors(
     # false (full mode)
     # TODO: The mode calculation will need to be revisited after FW changes in january
     #  2026.
-    # After February 24th 2025 we need to do this step a different way.
+    # After November 24th 2025 we need to do this step a different way.
     date_switch = datetime.datetime(2025, 11, 24, 13, 53, 59)
     start_date = dataset.attrs.get("Logical_file_id", None)
     if start_date is None:

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -42,6 +42,7 @@ from imap_processing.codice.constants import (
     SW_POSITIONS,
 )
 from imap_processing.codice.utils import apply_replacements_to_attrs
+from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
 
 logger = logging.getLogger(__name__)
 
@@ -320,11 +321,10 @@ def compute_geometric_factors(
     #  2026. We also need to fix this on days when the sci Lut changes.
     # After November 24th 2025 we need to do this step a different way.
     date_switch = datetime.datetime(2025, 11, 24)
-    start_date = dataset.attrs.get("Logical_file_id", None)
-    if start_date is None:
-        raise ValueError("Dataset is missing Logical_file_id attribute.")
-    processing_date = datetime.datetime.strptime(start_date.split("_")[4], "%Y%m%d")
-    if processing_date < date_switch:
+    dataset_midpoint_ns = dataset["epoch"].values[dataset["epoch"].size // 2]
+    # Convert to datetime64 for comparison
+    dataset_midpoint = et_to_datetime64(ttj2000ns_to_et(dataset_midpoint_ns))
+    if dataset_midpoint < date_switch:
         modes = (half_spin_per_esa_step > rgfo_half_spin) & (rgfo_half_spin > 0)
     else:
         # After November 24th, 2025, we no longer apply reduced geometric factors;

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -317,9 +317,9 @@ def compute_geometric_factors(
     # Modes will be true (reduced mode) anywhere half_spin > rgfo_half_spin otherwise
     # false (full mode)
     # TODO: The mode calculation will need to be revisited after FW changes in january
-    #  2026.
+    #  2026. We also need to fix this on days when the sci Lut changes.
     # After November 24th 2025 we need to do this step a different way.
-    date_switch = datetime.datetime(2025, 11, 24, 13, 53, 59)
+    date_switch = datetime.datetime(2025, 11, 24)
     start_date = dataset.attrs.get("Logical_file_id", None)
     if start_date is None:
         raise ValueError("Dataset is missing Logical_file_id attribute.")
@@ -327,8 +327,9 @@ def compute_geometric_factors(
     if processing_date < date_switch:
         modes = (half_spin_per_esa_step > rgfo_half_spin) & (rgfo_half_spin > 0)
     else:
-        # After November 24th, 2025, we should be using all half spin values.
-        modes = half_spin_per_esa_step.astype(bool)
+        # After November 24th, 2025, we no longer apply reduced geometric factors;
+        # always use the full geometric factor lookup.
+        modes = np.zeros_like(half_spin_per_esa_step, dtype=bool)
 
     # Get the geometric factors based on the modes
     gf = np.where(

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -9,6 +9,7 @@ from imap_processing.codice.codice_l2 import process_codice_l2
 dataset = process_codice_l2(l1_filename)
 """
 
+import datetime
 import logging
 from pathlib import Path
 
@@ -315,7 +316,18 @@ def compute_geometric_factors(
     # Perform the comparison and calculate modes
     # Modes will be true (reduced mode) anywhere half_spin > rgfo_half_spin otherwise
     # false (full mode)
-    modes = half_spin_per_esa_step > rgfo_half_spin
+    # TODO after the 24th 2025 we need to do this step a different way. This will also
+    #   need to be revisited after FW changes in january 2026.
+    date_switch = datetime.datetime(2025, 11, 24, 13, 53, 59)
+    start_date = dataset.attrs.get("Logical_file_id", None)
+    if start_date is None:
+        raise ValueError("Dataset is missing Logical_file_id attribute.")
+    processing_date = datetime.datetime.strptime(start_date.split("_")[4], "%Y%m%d")
+    if processing_date < date_switch:
+        modes = (half_spin_per_esa_step > rgfo_half_spin) & (rgfo_half_spin > 0)
+    else:
+        # After November 24th, 2025, we should be using all half spin values.
+        modes = half_spin_per_esa_step.astype(bool)
 
     # Get the geometric factors based on the modes
     gf = np.where(

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -316,8 +316,9 @@ def compute_geometric_factors(
     # Perform the comparison and calculate modes
     # Modes will be true (reduced mode) anywhere half_spin > rgfo_half_spin otherwise
     # false (full mode)
-    # TODO after the 24th 2025 we need to do this step a different way. This will also
-    #   need to be revisited after FW changes in january 2026.
+    # TODO: The mode calculation will need to be revisited after FW changes in january
+    #  2026.
+    # After February 24th 2025 we need to do this step a different way.
     date_switch = datetime.datetime(2025, 11, 24, 13, 53, 59)
     start_date = dataset.attrs.get("Logical_file_id", None)
     if start_date is None:

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -91,16 +91,17 @@ def mock_half_spin_per_esa_step():
       ESA steps 0–63 belong to half_spin=1
       ESA steps 64–127 belong to half_spin=2
     """
-    return np.repeat([1, 2], 64)
+    return np.repeat([2, 3], 64)
 
 
 def test_compute_geometric_factors_all_full_mode(mock_half_spin_per_esa_step):
     # rgfo_half_spin = 3 means all half_spin values (1 or 2) are < rgfo_half_spin
     dataset = xr.Dataset(
         {
-            "rgfo_half_spin": (("epoch",), np.array([3, 3])),
+            "rgfo_half_spin": (("epoch",), np.array([4, 4])),
             "half_spin_per_esa_step": (("esa_step",), mock_half_spin_per_esa_step),
         },
+        attrs={"Logical_file_id": "imap_codice_l1b_lo-sw-angular_20250101_v001"},
     )
     geometric_factor_lut = {
         "full": np.zeros((128, 24)),
@@ -117,9 +118,10 @@ def test_compute_geometric_factors_all_reduced_mode(mock_half_spin_per_esa_step)
     # rgfo_half_spin = 0 means all half_spin values (>=1) are >= rgfo_half_spin
     dataset = xr.Dataset(
         {
-            "rgfo_half_spin": (("epoch",), np.array([0])),
+            "rgfo_half_spin": (("epoch",), np.array([1])),
             "half_spin_per_esa_step": (("esa_step",), mock_half_spin_per_esa_step),
         },
+        attrs={"Logical_file_id": "imap_codice_l1b_lo-sw-angular_20250101_v001"},
     )
     geometric_factor_lut = {
         "full": np.zeros((128, 24)),
@@ -136,9 +138,10 @@ def test_compute_geometric_factors_mixed(mock_half_spin_per_esa_step):
     # rgfo_half_spin = 1
     dataset = xr.Dataset(
         {
-            "rgfo_half_spin": (("epoch",), np.array([1])),
+            "rgfo_half_spin": (("epoch",), np.array([2])),
             "half_spin_per_esa_step": (("esa_step",), mock_half_spin_per_esa_step),
         },
+        attrs={"Logical_file_id": "imap_codice_l1b_lo-sw-angular_20250101_v001"},
     )
     geometric_factor_lut = {
         "full": np.zeros((128, 24)),

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -113,6 +113,36 @@ def test_compute_geometric_factors_all_full_mode(mock_half_spin_per_esa_step):
     np.testing.assert_array_equal(result, expected)
 
 
+def test_compute_geometric_factors_past_nov_24th(mock_half_spin_per_esa_step):
+    # rgfo_half_spin = 1 means all half_spin values (>=2) are >= rgfo_half_spin
+    # Although the rgfo_half_spin indicates reduced mode, the date is past Nov 24th,
+    # 2024 so we expect full mode to be used.
+    dataset = xr.Dataset(
+        {
+            "rgfo_half_spin": (("epoch",), np.array([1, 1])),
+            "half_spin_per_esa_step": (
+                (
+                    "epoch",
+                    "esa_step",
+                ),
+                np.tile(mock_half_spin_per_esa_step, (2, 1)),
+            ),
+        },
+    )
+    geometric_factor_lut = {
+        "full": np.zeros((128, 24)),
+        "reduced": np.ones((128, 24)),
+    }
+    # Make sure epoch is past Nov 24th, 2024
+    ns_past_nov_24 = 900000000000000000
+    dataset = dataset.assign_coords({"epoch": np.repeat(ns_past_nov_24, 2)})
+    result = compute_geometric_factors(dataset, geometric_factor_lut)
+
+    # Expect "full" values everywhere
+    expected = np.full((2, 128, 24), 0)
+    np.testing.assert_array_equal(result, expected)
+
+
 def test_compute_geometric_factors_all_reduced_mode(mock_half_spin_per_esa_step):
     # rgfo_half_spin = 1 means all half_spin values (>=2) are >= rgfo_half_spin
     dataset = xr.Dataset(

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -95,7 +95,7 @@ def mock_half_spin_per_esa_step():
 
 
 def test_compute_geometric_factors_all_full_mode(mock_half_spin_per_esa_step):
-    # rgfo_half_spin = 3 means all half_spin values (1 or 2) are < rgfo_half_spin
+    # rgfo_half_spin = 4 means all half_spin values (2 or 3) are < rgfo_half_spin
     dataset = xr.Dataset(
         {
             "rgfo_half_spin": (("epoch",), np.array([4, 4])),
@@ -115,7 +115,7 @@ def test_compute_geometric_factors_all_full_mode(mock_half_spin_per_esa_step):
 
 
 def test_compute_geometric_factors_all_reduced_mode(mock_half_spin_per_esa_step):
-    # rgfo_half_spin = 0 means all half_spin values (>=1) are >= rgfo_half_spin
+    # rgfo_half_spin = 1 means all half_spin values (>=2) are >= rgfo_half_spin
     dataset = xr.Dataset(
         {
             "rgfo_half_spin": (("epoch",), np.array([1])),
@@ -135,7 +135,7 @@ def test_compute_geometric_factors_all_reduced_mode(mock_half_spin_per_esa_step)
 
 
 def test_compute_geometric_factors_mixed(mock_half_spin_per_esa_step):
-    # rgfo_half_spin = 1
+    # rgfo_half_spin = 2
     dataset = xr.Dataset(
         {
             "rgfo_half_spin": (("epoch",), np.array([2])),

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -101,7 +101,6 @@ def test_compute_geometric_factors_all_full_mode(mock_half_spin_per_esa_step):
             "rgfo_half_spin": (("epoch",), np.array([4, 4])),
             "half_spin_per_esa_step": (("esa_step",), mock_half_spin_per_esa_step),
         },
-        attrs={"Logical_file_id": "imap_codice_l1b_lo-sw-angular_20250101_v001"},
     )
     geometric_factor_lut = {
         "full": np.zeros((128, 24)),
@@ -121,7 +120,6 @@ def test_compute_geometric_factors_all_reduced_mode(mock_half_spin_per_esa_step)
             "rgfo_half_spin": (("epoch",), np.array([1])),
             "half_spin_per_esa_step": (("esa_step",), mock_half_spin_per_esa_step),
         },
-        attrs={"Logical_file_id": "imap_codice_l1b_lo-sw-angular_20250101_v001"},
     )
     geometric_factor_lut = {
         "full": np.zeros((128, 24)),
@@ -141,7 +139,6 @@ def test_compute_geometric_factors_mixed(mock_half_spin_per_esa_step):
             "rgfo_half_spin": (("epoch",), np.array([2])),
             "half_spin_per_esa_step": (("esa_step",), mock_half_spin_per_esa_step),
         },
-        attrs={"Logical_file_id": "imap_codice_l1b_lo-sw-angular_20250101_v001"},
     )
     geometric_factor_lut = {
         "full": np.zeros((128, 24)),


### PR DESCRIPTION
# Change Summary

## Overview
Update full / reduce mode calculation when getting the geometric factors at l2.

Summary from Tenzin 

updates:
Old ways:
Looks at rgfo and if value is 3, any value 4 or above should use reduced gain.
New ways:
Now, always triggering rgfo at step 0. Physically, we are not reducing anymore. So we don’t need to use reduced gain. We should use the geometric factor as it is for all of Lo intensity products. So any places that checks rgfo value to determine if we should use reduced gain, we don’t need to do that anymore.
Which data get affected?
Updated in all the data since Nov 24 SCI-LUT version was uploaded.

## Updated Files
- imap_processing/codice/codice_l2.py
   - Update mode calculation

## Testing
Fix tests. 
