### PR TITLE
FIX: Lo DE handle partial ASCs

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -80,16 +80,14 @@ def lo_l1b(sci_dependencies: dict, anc_dependencies: list) -> list[Path]:
         pointing_start_met, pointing_end_met = get_pointing_times(
             l1a_de["met"].values[0].item()
         )
-        # Get the start and end times for each spin epoch
-        acq_start, acq_end = convert_start_end_acq_times(spin_data)
+
         # Get the average spin durations for each epoch
-        avg_spin_durations_per_cycle = get_avg_spin_durations_per_cycle(
-            acq_start, acq_end
-        )
+        avg_spin_durations_per_cycle = get_avg_spin_durations_per_cycle(spin_data)
         # set the spin cycle for each direct event
         l1b_de = set_spin_cycle(pointing_start_met, l1a_de, l1b_de)
         # get spin start times for each event
-        spin_start_time = get_spin_start_times(l1a_de, l1b_de, spin_data, acq_end)
+        spin_start_time = get_spin_start_times(l1a_de, l1b_de, spin_data)
+
         # get the absolute met for each event
         l1b_de = set_event_met(
             l1a_de, l1b_de, spin_start_time, avg_spin_durations_per_cycle
@@ -153,9 +151,7 @@ def lo_l1b(sci_dependencies: dict, anc_dependencies: list) -> list[Path]:
         # Get the start and end times for each spin epoch
         acq_start, acq_end = convert_start_end_acq_times(spin_data)
         # Get the average spin durations for each epoch
-        avg_spin_durations_per_cycle = get_avg_spin_durations_per_cycle(
-            acq_start, acq_end
-        )
+        avg_spin_durations_per_cycle = get_avg_spin_durations_per_cycle(spin_data)
         l1b_histrates = calculate_histogram_rates(
             l1b_histrates,
             acq_start,
@@ -309,26 +305,27 @@ def convert_start_end_acq_times(
 
 
 def get_avg_spin_durations_per_cycle(
-    acq_start: xr.DataArray, acq_end: xr.DataArray
+    spin_data: xr.Dataset,
 ) -> xr.DataArray:
     """
-    Get the average spin duration for each spin epoch.
+    Get the average spin duration for each aggregated science cycle.
 
     Parameters
     ----------
-    acq_start : xarray.DataArray
-        The start acquisition times for each spin epoch.
-    acq_end : xarray.DataArray
-        The end acquisition times for each spin epoch.
+    spin_data : xarray.Dataset
+        The L1A Spin dataset.
 
     Returns
     -------
     avg_spin_durations : xarray.DataArray
-        The average spin duration for each spin epoch.
+        The average spin duration for each ASC.
     """
+    acq_start = spin_data["acq_start_sec"] + spin_data["acq_start_subsec"] * 1e-6
+    acq_end = spin_data["acq_end_sec"] + spin_data["acq_end_subsec"] * 1e-6
     # Get the avg spin duration for each spin epoch
-    # There are 28 spins per epoch (1 aggregated science cycle)
-    avg_spin_durations_per_cycle = (acq_end - acq_start) / 28
+    # We need to use the number of spins that were actually in the ASC
+    # because there may be partial ASCs where only some of the spins were completed
+    avg_spin_durations_per_cycle = (acq_end - acq_start) / spin_data["num_completed"]
     return avg_spin_durations_per_cycle
 
 
@@ -584,7 +581,7 @@ def _check_sufficient_spins(spin_data: xr.Dataset) -> np.ndarray:
 
 
 def get_spin_start_times(
-    l1a_de: xr.Dataset, l1b_de: xr.Dataset, spin_data: xr.Dataset, acq_end: xr.DataArray
+    l1a_de: xr.Dataset, l1b_de: xr.Dataset, spin_data: xr.Dataset
 ) -> xr.DataArray:
     """
     Get the start time for the spin that each direct event is in.
@@ -601,40 +598,40 @@ def get_spin_start_times(
         The L1B DE dataset.
     spin_data : xr.Dataset
         The L1A Spin dataset.
-    acq_end : xr.DataArray
-        The end acquisition times for each spin ASC.
 
     Returns
     -------
     spin_start_time : xr.DataArray
         The start time for the spin that each direct event is in.
     """
-    # Get the MET times for each individual direct event
-    # l1a_de["met"] has one value per time epoch, but we need one per direct event
-    de_met = np.repeat(l1a_de["met"], l1a_de["de_count"])
-
-    # Find the closest stop_acq for each direct event
-    closest_stop_acq_indices = np.abs(de_met.values[:, None] - acq_end.values).argmin(
-        axis=1
+    # align l1a_de packets with spin_data packets
+    de_to_spin_indices = match_science_to_spin_asc(
+        l1a_de["epoch"].values, spin_data["epoch"].values
     )
+    # Repeat this for each direct event based on the de_count
+    de_to_spin_indices = np.repeat(de_to_spin_indices, l1a_de["de_count"])
+
     # There are 28 spins per epoch (1 aggregated science cycle)
     # Set the spin_cycle_num to the spin number relative to the
     # start of the ASC
     spin_cycle_num = l1b_de["spin_cycle"] % 28
-    # Get the seconds portion of the start time for each spin
-    start_sec_spins = spin_data["start_sec_spin"].values[
-        closest_stop_acq_indices, spin_cycle_num
-    ]
-    # Get the subseconds portion of the spin start time and convert from
-    # microseconds to seconds
-    start_subsec_spins = (
-        spin_data["start_subsec_spin"].values[closest_stop_acq_indices, spin_cycle_num]
-        * 1e-6
-    )
+    asc_starts = spin_data["acq_start_sec"] + spin_data["acq_start_subsec"] * 1e-6
+    avg_spin_durations = get_avg_spin_durations_per_cycle(spin_data)
 
-    # Combine the seconds and subseconds to get the start time for each spin
-    spin_start_time = start_sec_spins + start_subsec_spins
-    return xr.DataArray(spin_start_time)
+    # Calculate the time based off of the start of the acquisition period
+    # then using an average spin duration to calculate the offset within the ASC
+    # NOTE: We don't want to use the spin start times directly from the ASC spin packet
+    #       because we are using an average spin_cycle for the ASC and there are
+    #       times when only half the spins were completed in an ASC. This allows us
+    #       to still get a valid spin_cycle start time for each direct event, even
+    #       if the average spin_cycle was after the end of the acquisition period.
+    # TODO: Can we do even better by knowing how many esa_steps and spins were complete?
+    #       i.e. change the spin_cycle calculation
+    spin_start_time = (
+        asc_starts[de_to_spin_indices]
+        + spin_cycle_num * avg_spin_durations[de_to_spin_indices]
+    )
+    return spin_start_time
 
 
 def set_event_met(

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -164,6 +164,11 @@ def test_lo_l1b_de(
     data = {}
     for file in [de_file, spin_file]:
         dataset = load_cdf(file)
+        if file == spin_file:
+            # We have 0 for num_completed which causes issues downstream
+            # when calculating the average spin durations and cascading
+            # failures. Set to 28 for testing.
+            dataset["num_completed"] = 28
         data[dataset.attrs["Logical_source"]] = dataset
 
     expected_logical_source_de = "imap_lo_l1b_de"
@@ -364,13 +369,22 @@ def test_convert_start_end_acq_times():
 
 def test_get_avg_spin_durations():
     # Arrange
-    acq_start = xr.DataArray([0, 423, 846.2], dims="epoch")
-    acq_end = xr.DataArray([422.8, 846, 1269.7], dims="epoch")
-    expected_avg_spin_durations = np.array([422.8, 423, 423.5]) / 28
+    spin_ds = xr.Dataset(
+        {
+            "acq_start_sec": ("epoch", [1, 2, 3]),
+            "acq_start_subsec": ("epoch", [1e6, 2e6, 3e6]),
+            "acq_end_sec": ("epoch", [100, 200, 300]),
+            "acq_end_subsec": ("epoch", [1e6, 2e6, 3e6]),
+            "num_completed": ("epoch", [28, 14, 28]),
+        },
+        coords={"epoch": [0, 1, 2]},
+    )
+    expected_avg_spin_durations = np.array(
+        [(101 - 2) / 28, (202 - 4) / 14, (303 - 6) / 28]
+    )
 
     # Act
-    avg_spin_durations = get_avg_spin_durations_per_cycle(acq_start, acq_end)
-
+    avg_spin_durations = get_avg_spin_durations_per_cycle(spin_ds)
     # Assert
     np.testing.assert_array_equal(avg_spin_durations, expected_avg_spin_durations)
 
@@ -406,10 +420,10 @@ def test_get_spin_start_times():
     # Arrange
     l1b_de = xr.Dataset(
         {
-            "spin_cycle": ("direct_event", [0, 1, 2, 3, 4]),
+            "spin_cycle": ("epoch", [0, 1, 2, 3, 4]),
         },
         coords={
-            "direct_event": [
+            "epoch": [
                 0,
                 1,
                 2,
@@ -420,6 +434,7 @@ def test_get_spin_start_times():
     )
     l1a_de = xr.Dataset(
         {
+            "shcoarse": ("epoch", [0, 1]),
             "de_count": ("epoch", [2, 3]),
             "met": ("epoch", [0, 1]),  # MET per time epoch, not per direct event
             "de_time": ("direct_event", [0000, 1000, 2000, 3000, 4000]),
@@ -428,20 +443,34 @@ def test_get_spin_start_times():
     )
     spin = xr.Dataset(
         {
-            "start_sec_spin": (
-                ["epoch", "spin"],
-                [[20, 25, 30, 35, 40], [45, 50, 55, 60, 65]],
+            "shcoarse": ("epoch", [0, 1]),
+            "acq_start_sec": (
+                "epoch",
+                [20, 25],
             ),
-            "start_subsec_spin": (
-                ["epoch", "spin"],
-                [[2000, 3000, 4000, 5000, 6000], [1000, 1500, 2000, 3000, 4000]],
+            "acq_start_subsec": (
+                "epoch",
+                [0, 0],
+            ),
+            "acq_end_sec": (
+                "epoch",
+                [25, 30],
+            ),
+            "acq_end_subsec": (
+                "epoch",
+                [0, 0],
+            ),
+            "num_completed": (
+                "epoch",
+                [28, 14],
             ),
         }
     )
 
-    end_acq = xr.DataArray([0, 1], dims="epoch")
-    spin_start_times_expected = np.array([20.002, 25.003, 55.002, 60.003, 65.004])
-    spin_start_times = get_spin_start_times(l1a_de, l1b_de, spin, end_acq)
+    spin_start_times_expected = np.array(
+        [20, 20 + 5 / 28, 25 + 5 * 2 / 14, 25 + 5 * 3 / 14, 25 + 5 * 4 / 14]
+    )
+    spin_start_times = get_spin_start_times(l1a_de, l1b_de, spin)
 
     np.testing.assert_allclose(
         spin_start_times,


### PR DESCRIPTION
The spin_cycle variable is an average value over an ASC (28 spins). This means that when we have a partial ASC, the spin_cycle value could be in a "bad" spin which was reported as 0 in the ASC for spin_start_sec. To avoid this, we can use the average spin duration of the ASC and calculate the spin_start based on the start of the acquisition period of the ASC. This means we will always have a valid spin_start rather than 0 which caused SPICE lookup issues.

This gets l1b-de products being produced again and looks like it worked for a few quick old processing failures I tried locally.