### PR TITLE
FIX: Add additional packet sequence checking

### DIFF
--- a/imap_processing/codice/codice_l1a_de.py
+++ b/imap_processing/codice/codice_l1a_de.py
@@ -96,6 +96,11 @@ def extract_initial_items_from_combined_packets(
 
         # Remove the first 20 bytes from event_data (header fields from above)
         # Then trim to the number of bytes indicated by byte_count
+        if byte_count[pkt_idx] > len(event_data) - 20:
+            raise ValueError(
+                f"Byte count {byte_count[pkt_idx]} exceeds available "
+                f"data length {len(event_data) - 20} for packet index {pkt_idx}."
+            )
         packets.event_data.data[pkt_idx] = event_data[20 : 20 + byte_count[pkt_idx]]
 
         if compressed[pkt_idx]:

--- a/imap_processing/tests/test_utils.py
+++ b/imap_processing/tests/test_utils.py
@@ -306,6 +306,58 @@ def test_combine_segmented_packets():
     xr.testing.assert_equal(combined_ds, expected_ds)
 
 
+def test_combine_single_segmented_packets(caplog):
+    """Test combine_segmented_packets function when there are missing segments."""
+
+    # Create a dataset with the MIDDLE and LAST segments missing.
+    # unsegmented, first, unsegmented
+    sequence_flags = xr.DataArray(np.array([3, 1, 3]), dims=["epoch"])
+
+    binary_data = xr.DataArray(
+        np.array(
+            [
+                b"ABC",
+                b"123",
+                b"abc",
+            ],
+            dtype=object,
+        ),
+        dims=["epoch"],
+    )
+    shcoarse = xr.DataArray(np.array([0, 1, 2]), dims=["epoch"])
+
+    ds = xr.Dataset(
+        data_vars={
+            "seq_flgs": sequence_flags,
+            "packetdata": binary_data,
+            "shcoarse": shcoarse,
+        }
+    )
+
+    combined_ds = utils.combine_segmented_packets(ds, "packetdata")
+
+    # The combined dataset should only have the unsegmented packets
+    # and a warning should be logged about the missing segments.
+    expected_ds = xr.Dataset(
+        data_vars={
+            "seq_flgs": xr.DataArray(np.array([3, 3]), dims=["epoch"]),
+            "packetdata": xr.DataArray(
+                np.array(
+                    [b"ABC", b"abc"],
+                    dtype=object,
+                ),
+                dims=["epoch"],
+            ),
+            "shcoarse": xr.DataArray(np.array([0, 2]), dims=["epoch"]),
+        }
+    )
+
+    xr.testing.assert_equal(combined_ds, expected_ds)
+
+    # check that a warning was logged
+    assert "Incorrect/incomplete sequence flags in group 2." in caplog.text
+
+
 def test_check_source_sequence_counter(caplog):
     """Test _check_source_sequence_counter function."""
     data_vars = {

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -400,7 +400,10 @@ def combine_segmented_packets(
 
         # If multiple packets, concatenate into the first packet
         # [b"abc", b"def", b"ghi"] -> b"abcdefghi"
-        if len(group_indices) > 1:
+        if (
+            len(group_indices) > 1
+            or packets["seq_flgs"].data[group_indices[0]] != SequenceFlags.UNSEGMENTED
+        ):
             start_index = group_indices[0]
             # Lets do some quick validation on these packets since we've had
             # some missing packet groups in the past


### PR DESCRIPTION
We can get a single FIRST / LAST / MIDDLE packet, which isn't the full segment, so we need to add a check for singular packets that are not UNSEGMENTED.