### PR TITLE
I-ALiRT - Update realtime packet ingest plots

### DIFF
--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -24,8 +24,13 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
     -------
     packet_times : list
         List of datetime objects when packets were created.
+
+    Notes:
+    ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)
+    2  tlmrelay      001-00:00:00  020-19:57:14    0.0
+    10  Kiel          021-09:57:58  021-08:40:39    2.0
     """
-    {
+    dict = {
         station: {
             "last_data_received": [],
             "rate_kbps": [],
@@ -33,6 +38,7 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
         for station in list(STATIONS) + ["tlmrelay"]
     }
 
+    year = start_file_creation.year
     in_rate_table = False
 
     for line in lines:
@@ -43,9 +49,13 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
             station in line for station in STATIONS
         ):
             rate = float(line.split()[-1])
-            print("hi")
+            data_last_received = line.split()[2]
+            station = line.split()[1]
+            dt = datetime.strptime(f"{year}/{data_last_received}", "%Y/%j-%H:%M:%S", )
+            dict[station]["last_data_received"].append(dt)
+            dict[station]["rate_kbps"].append(rate)
 
-    return packet_times
+    return dict
 
 
 def format_ingest_data(last_filename: str, log_lines: list) -> dict:

--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -25,7 +25,14 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
     packet_times : list
         List of datetime objects when packets were created.
     """
-    packet_times = {}
+    {
+        station: {
+            "last_data_received": [],
+            "rate_kbps": [],
+        }
+        for station in list(STATIONS) + ["tlmrelay"]
+    }
+
     in_rate_table = False
 
     for line in lines:
@@ -36,6 +43,7 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
             station in line for station in STATIONS
         ):
             rate = float(line.split()[-1])
+            print("hi")
 
     return packet_times
 
@@ -75,18 +83,6 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
         "2025-07-31T00:00:00",
         "2025-07-31T02:01:00"
       ],
-      "connection_times": {
-        "Kiel": [
-          {
-            "start": "2025-07-30T23:00:00",
-            "end": "2025-07-31T00:15:00"
-          },
-          {
-            "start": "2025-07-31T02:00:00",
-            "end": "2025-07-31T02:00:00"
-          }
-        ]
-      }
     }
 
     where time_range is the overall time range of the data,
@@ -98,24 +94,20 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
     last_timestamp_str = last_timestamp_str.replace("_", ":")
     end_of_time = datetime.strptime(last_timestamp_str, "%Y-%jT%H:%M:%S")
 
-    # File creation time of last file minus 48 hrs.
+    # File creation time.
     start_of_time = datetime.strptime(last_timestamp_str, "%Y-%jT%H:%M:%S") - timedelta(
-        hours=48
+        minutes=5
     )
 
     realtime_summary: dict[str, Any] = {
         "summary": "I-ALiRT Real-time Ingest Summary",
         "generated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "time_format": "UTC (ISOC)",
-        "stations": list(STATIONS),
         "time_range": [
             start_of_time.isoformat(),
             end_of_time.isoformat(),
         ],  # Overall time range of the data
         "packet_ingest": [],  # Global packet ingest times
-        "connection_times": {
-            station: [] for station in list(STATIONS)
-        },  # Per-station TCP connection windows
     }
 
     # Global packet ingest timestamps

--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -1,4 +1,4 @@
-"""Packet ingest and tcp connection times for each station."""
+"""Packet ingest times and rates for each station."""
 
 import logging
 from datetime import datetime, timedelta, timezone
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 STATIONS = ["Kiel"]
 
 
-def packets_created(start_file_creation: datetime, lines: list) -> list:
+def packets_created(start_file_creation: datetime, lines: list) -> dict:
     """
-    Find timestamps when packets were created based on log lines.
+    Find timestamps and rates when packets were ingested based on log lines.
 
     Parameters
     ----------
@@ -22,35 +22,35 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
 
     Returns
     -------
-    packet_times : list
-        List of datetime objects when packets were created.
-
-    Notes:
-    ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)
-    2  tlmrelay      001-00:00:00  020-19:57:14    0.0
-    10  Kiel          021-09:57:58  021-08:40:39    2.0
+    station_dict : dict
+        Timestamps and rates when packets were ingested.
     """
-    station_dict = {
-        station: {
-            "last_data_received": [],
-            "rate_kbps": [],
-        }
+    station_dict: dict[str, dict[str, list[Any]]] = {
+        station: {"last_data_received": [], "rate_kbps": []}
         for station in list(STATIONS)
     }
 
-    station_year = {station: start_file_creation.year for station in station_dict}
+    station_year: dict[str, int] = {
+        station: start_file_creation.year for station in station_dict
+    }
     prev_doy: dict[str, int | None] = {station: None for station in station_dict}
 
     for line in lines:
-        try :
-            int(line.split()[0])
+        # If line begins with a digit and the station is present.
+        if line.split()[0].isdigit() and line.split()[1] in STATIONS:
+            # Get bps rate.
             rate = float(line.split()[-1])
+            # Get last data received.
             data_last_received = line.split()[2]
+            # Get day of year.
             doy = int(data_last_received[:3])
+            # Get station.
             station = line.split()[1]
 
             # Handle end of year rollover
-            if prev_doy[station] is not None and doy < prev_doy[station]:
+            prev = prev_doy[station]
+
+            if prev is not None and doy < prev:
                 station_year[station] += 1
 
             prev_doy[station] = doy
@@ -66,15 +66,13 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
             )
             station_dict[station]["last_data_received"].append(dt)
             station_dict[station]["rate_kbps"].append(rate)
-        except:
-            pass
 
     return station_dict
 
 
 def format_ingest_data(last_filename: str, log_lines: list) -> dict:
     """
-    Format TCP connection and packet ingest data from multiple log files.
+    Format packet ingest times and rates from log file.
 
     Parameters
     ----------
@@ -86,8 +84,7 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
     Returns
     -------
     realtime_summary : dict
-        Structured output with TCP connection windows per station
-        and global packet ingest timestamps.
+        Structured output with packet receipt info per station.
 
     Notes
     -----
@@ -97,11 +94,11 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
       "generated": "2025-08-07T21:36:09Z",
       "time_format": "UTC (ISOC)",
       "time_range": [
-        "2025-07-30T23:00:00",
-        "2025-07-31T02:00:00"
+        "2025-01-21T09:50:58Z",
+        "2025-01-21T09:55:58Z"
       ],
-      "Kiel": {"last_data_received": ["2025-01-21T09:57:58Z", "2025-01-21T10:27:59Z"],
-      "rate_kbps": [2.0, 2.0]}}
+        "Kiel": {"last_data_received": ["2025-01-21T09:50:58Z", "2025-01-21T09:51:58Z"],
+        "rate_kbps": [2.0, 2.0]}
     }
     """
     # File creation time.
@@ -109,12 +106,12 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
     last_timestamp_str = last_timestamp_str.replace("_", ":")
     end_of_time = datetime.strptime(last_timestamp_str, "%Y-%jT%H:%M:%S")
 
-    # File creation time.
+    # File is created every 5 minutes.
     start_of_time = datetime.strptime(last_timestamp_str, "%Y-%jT%H:%M:%S") - timedelta(
         minutes=5
     )
 
-    # Global packet ingest timestamps
+    # Parse file.
     station_dict = packets_created(start_of_time, log_lines)
 
     realtime_summary: dict[str, Any] = {
@@ -125,7 +122,7 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
             start_of_time.isoformat(),
             end_of_time.isoformat(),
         ],  # Overall time range of the data
-        station_dict
+        **station_dict,
     }
 
     logger.info(f"Created ingest files for {realtime_summary['time_range']}")

--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -4,9 +4,9 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from imap_processing.ialirt.constants import STATIONS
-
 logger = logging.getLogger(__name__)
+
+STATIONS = ["Kiel"]
 
 
 def packets_created(start_file_creation: datetime, lines: list) -> list:
@@ -30,32 +30,46 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
     2  tlmrelay      001-00:00:00  020-19:57:14    0.0
     10  Kiel          021-09:57:58  021-08:40:39    2.0
     """
-    dict = {
+    station_dict = {
         station: {
             "last_data_received": [],
             "rate_kbps": [],
         }
-        for station in list(STATIONS) + ["tlmrelay"]
+        for station in list(STATIONS)
     }
 
-    year = start_file_creation.year
-    in_rate_table = False
+    station_year = {station: start_file_creation.year for station in station_dict}
+    prev_doy: dict[str, int | None] = {station: None for station in station_dict}
 
     for line in lines:
-        if "Rate (kbps)" in line:
-            in_rate_table = True
-            continue
-        if (in_rate_table and "tlmrelay" in line) or any(
-            station in line for station in STATIONS
-        ):
+        try :
+            int(line.split()[0])
             rate = float(line.split()[-1])
             data_last_received = line.split()[2]
+            doy = int(data_last_received[:3])
             station = line.split()[1]
-            dt = datetime.strptime(f"{year}/{data_last_received}", "%Y/%j-%H:%M:%S", )
-            dict[station]["last_data_received"].append(dt)
-            dict[station]["rate_kbps"].append(rate)
 
-    return dict
+            # Handle end of year rollover
+            if prev_doy[station] is not None and doy < prev_doy[station]:
+                station_year[station] += 1
+
+            prev_doy[station] = doy
+
+            dt = (
+                datetime.strptime(
+                    f"{station_year[station]}/{data_last_received}",
+                    "%Y/%j-%H:%M:%S",
+                )
+                .replace(tzinfo=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+            station_dict[station]["last_data_received"].append(dt)
+            station_dict[station]["rate_kbps"].append(rate)
+        except:
+            pass
+
+    return station_dict
 
 
 def format_ingest_data(last_filename: str, log_lines: list) -> dict:
@@ -82,22 +96,13 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
       "summary": "I-ALiRT Real-time Ingest Summary",
       "generated": "2025-08-07T21:36:09Z",
       "time_format": "UTC (ISOC)",
-      "stations": [
-        "Kiel"
-      ],
       "time_range": [
         "2025-07-30T23:00:00",
         "2025-07-31T02:00:00"
       ],
-      "packet_ingest": [
-        "2025-07-31T00:00:00",
-        "2025-07-31T02:01:00"
-      ],
+      "Kiel": {"last_data_received": ["2025-01-21T09:57:58Z", "2025-01-21T10:27:59Z"],
+      "rate_kbps": [2.0, 2.0]}}
     }
-
-    where time_range is the overall time range of the data,
-    packet_ingest contains timestamps when packets were finalized,
-    and tcp contains connection windows for each station.
     """
     # File creation time.
     last_timestamp_str = last_filename.split(".")[2]
@@ -109,6 +114,9 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
         minutes=5
     )
 
+    # Global packet ingest timestamps
+    station_dict = packets_created(start_of_time, log_lines)
+
     realtime_summary: dict[str, Any] = {
         "summary": "I-ALiRT Real-time Ingest Summary",
         "generated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -117,14 +125,8 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
             start_of_time.isoformat(),
             end_of_time.isoformat(),
         ],  # Overall time range of the data
-        "packet_ingest": [],  # Global packet ingest times
+        station_dict
     }
-
-    # Global packet ingest timestamps
-    packet_times = packets_created(start_of_time, log_lines)
-    realtime_summary["packet_ingest"] = [
-        pkt_time.isoformat() for pkt_time in packet_times
-    ]
 
     logger.info(f"Created ingest files for {realtime_summary['time_range']}")
 

--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -9,111 +9,6 @@ from imap_processing.ialirt.constants import STATIONS
 logger = logging.getLogger(__name__)
 
 
-def find_tcp_connections(  # noqa: PLR0912
-    start_file_creation: datetime,
-    end_file_creation: datetime,
-    lines: list,
-    realtime_summary: dict,
-) -> dict:
-    """
-    Find tcp connection time ranges for ground station from log lines.
-
-    Parameters
-    ----------
-    start_file_creation : datetime
-        File creation time of last file minus 48 hrs.
-    end_file_creation : datetime
-        File creation time of last file.
-    lines : list
-        All lines of log files.
-    realtime_summary : dict
-        Input dictionary containing ingest parameters.
-
-    Returns
-    -------
-    realtime_summary : dict
-        Output dictionary with tcp connection info.
-    """
-    current_starts: dict[str, datetime | None] = {}
-    partners_opened = set()
-
-    for line in lines:
-        # Note if this line appears.
-        if "Opened raw record file" in line:
-            station = line.split("Opened raw record file for ")[1].split(
-                " antenna_partner"
-            )[0]
-            partners_opened.add(station)
-
-        if "antenna partner connection is" not in line:
-            continue
-
-        timestamp_str = line.split(" ")[0]
-        msg = " ".join(line.split(" ")[1:])
-        station = msg.split(" antenna")[0]
-
-        if station not in realtime_summary["connection_times"]:
-            realtime_summary["connection_times"][station] = []
-        if station not in realtime_summary["stations"]:
-            realtime_summary["stations"].append(station)
-
-        timestamp = datetime.strptime(timestamp_str, "%Y/%j-%H:%M:%S.%f")
-
-        if f"{station} antenna partner connection is up." in line:
-            current_starts[station] = timestamp
-
-        elif f"{station} antenna partner connection is down!" in line:
-            start = current_starts.get(station)
-            if start is not None:
-                realtime_summary["connection_times"][station].append(
-                    {
-                        "start": datetime.isoformat(start),
-                        "end": datetime.isoformat(timestamp),
-                    }
-                )
-                current_starts[station] = None
-            else:
-                # No matching "up"
-                realtime_summary["connection_times"][station].append(
-                    {
-                        "start": datetime.isoformat(start_file_creation),
-                        "end": datetime.isoformat(timestamp),
-                    }
-                )
-                current_starts[station] = None
-
-    # Handle hanging "up" at the end of file
-    for station, start in current_starts.items():
-        if start is not None:
-            realtime_summary["connection_times"][station].append(
-                {
-                    "start": datetime.isoformat(start),
-                    "end": datetime.isoformat(end_file_creation),
-                }
-            )
-
-    # Handle stations with only "Opened raw record file" (no up/down)
-    for station in partners_opened:
-        if not realtime_summary["connection_times"][station]:
-            realtime_summary["connection_times"][station].append(
-                {
-                    "start": datetime.isoformat(start_file_creation),
-                    "end": datetime.isoformat(end_file_creation),
-                }
-            )
-
-    # Filter out connection windows that are completely outside the time window
-    for station in realtime_summary["connection_times"]:
-        realtime_summary["connection_times"][station] = [
-            window
-            for window in realtime_summary["connection_times"][station]
-            if datetime.fromisoformat(window["end"]) >= start_file_creation
-            and datetime.fromisoformat(window["start"]) <= end_file_creation
-        ]
-
-    return realtime_summary
-
-
 def packets_created(start_file_creation: datetime, lines: list) -> list:
     """
     Find timestamps when packets were created based on log lines.
@@ -130,15 +25,17 @@ def packets_created(start_file_creation: datetime, lines: list) -> list:
     packet_times : list
         List of datetime objects when packets were created.
     """
-    packet_times = []
+    packet_times = {}
+    in_rate_table = False
 
     for line in lines:
-        if "Renamed iois_1_packets" in line:
-            timestamp_str = line.split(" ")[0]
-            timestamp = datetime.strptime(timestamp_str, "%Y/%j-%H:%M:%S.%f")
-            # Possible that data extends further than 48 hrs in the past.
-            if timestamp >= start_file_creation:
-                packet_times.append(timestamp)
+        if "Rate (kbps)" in line:
+            in_rate_table = True
+            continue
+        if (in_rate_table and "tlmrelay" in line) or any(
+            station in line for station in STATIONS
+        ):
+            rate = float(line.split()[-1])
 
     return packet_times
 
@@ -220,11 +117,6 @@ def format_ingest_data(last_filename: str, log_lines: list) -> dict:
             station: [] for station in list(STATIONS)
         },  # Per-station TCP connection windows
     }
-
-    # TCP connection data for each station
-    realtime_summary = find_tcp_connections(
-        start_of_time, end_of_time, log_lines, realtime_summary
-    )
 
     # Global packet ingest timestamps
     packet_times = packets_created(start_of_time, log_lines)

--- a/imap_processing/tests/ialirt/data/l0/flight_iois_1.log.2026-021T10-58-00.171087
+++ b/imap_processing/tests/ialirt/data/l0/flight_iois_1.log.2026-021T10-58-00.171087
@@ -1,0 +1,363 @@
+ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)
+ 2  tlmrelay      001-00:00:00  020-19:57:14    0.0
+10  Kiel          021-09:57:58  021-08:40:39    2.0
+2026/021-09:58:26.231 Closed packets file for SDC: iois_1_packets_2026_021_09_57_25.partial
+2026/021-09:58:26.231 Renamed iois_1_packets_2026_021_09_57_25.partial to iois_1_packets_2026_021_09_57_25.
+2026/021-09:58:26.231 Spawning: mv
+2026/021-09:58:26.231 Opened packets file for SDC: iois_1_packets_2026_021_09_58_26.partial
+2026/021-09:58:27.126 Spawned command succeeded: mv
+2026/021-09:59:27.455 Closed packets file for SDC: iois_1_packets_2026_021_09_58_26.partial
+2026/021-09:59:27.455 Renamed iois_1_packets_2026_021_09_58_26.partial to iois_1_packets_2026_021_09_58_26.
+2026/021-09:59:27.455 Spawning: mv
+2026/021-09:59:27.455 Opened packets file for SDC: iois_1_packets_2026_021_09_59_27.partial
+2026/021-09:59:28.274 Spawned command succeeded: mv
+2026/021-10:00:28.556 Closed packets file for SDC: iois_1_packets_2026_021_09_59_27.partial
+2026/021-10:00:28.556 Renamed iois_1_packets_2026_021_09_59_27.partial to iois_1_packets_2026_021_09_59_27.
+2026/021-10:00:28.556 Spawning: mv
+2026/021-10:00:28.556 Opened packets file for SDC: iois_1_packets_2026_021_10_00_28.partial
+2026/021-10:00:29.411 Spawned command succeeded: mv
+2026/021-10:01:00.009 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_09_56_00.partial
+2026/021-10:01:00.009 Renamed IOIS_1_raw_record_20_2026_021_09_56_00.partial to IOIS_1_raw_record_20_2026_021_09_56_00.
+2026/021-10:01:00.009 Spawning: rsync
+2026/021-10:01:00.010 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_01_00.partial
+2026/021-10:01:02.628 Spawned command succeeded: rsync
+2026/021-10:01:29.698 Closed packets file for SDC: iois_1_packets_2026_021_10_00_28.partial
+2026/021-10:01:29.698 Renamed iois_1_packets_2026_021_10_00_28.partial to iois_1_packets_2026_021_10_00_28.
+2026/021-10:01:29.698 Spawning: mv
+2026/021-10:01:29.698 Opened packets file for SDC: iois_1_packets_2026_021_10_01_29.partial
+2026/021-10:01:30.630 Spawned command succeeded: mv
+2026/021-10:02:30.851 Closed packets file for SDC: iois_1_packets_2026_021_10_01_29.partial
+2026/021-10:02:30.851 Renamed iois_1_packets_2026_021_10_01_29.partial to iois_1_packets_2026_021_10_01_29.
+2026/021-10:02:30.851 Spawning: mv
+2026/021-10:02:30.851 Opened packets file for SDC: iois_1_packets_2026_021_10_02_30.partial
+2026/021-10:02:31.740 Spawned command succeeded: mv
+2026/021-10:03:31.133 Closed packets file for SDC: iois_1_packets_2026_021_10_02_30.partial
+2026/021-10:03:31.133 Renamed iois_1_packets_2026_021_10_02_30.partial to iois_1_packets_2026_021_10_02_30.
+2026/021-10:03:31.133 Spawning: mv
+2026/021-10:03:31.133 Opened packets file for SDC: iois_1_packets_2026_021_10_03_31.partial
+2026/021-10:03:32.023 Spawned command succeeded: mv
+2026/021-10:04:32.269 Closed packets file for SDC: iois_1_packets_2026_021_10_03_31.partial
+2026/021-10:04:32.270 Renamed iois_1_packets_2026_021_10_03_31.partial to iois_1_packets_2026_021_10_03_31.
+2026/021-10:04:32.270 Spawning: mv
+2026/021-10:04:32.270 Opened packets file for SDC: iois_1_packets_2026_021_10_04_32.partial
+2026/021-10:04:33.206 Spawned command succeeded: mv
+2026/021-10:05:33.458 Closed packets file for SDC: iois_1_packets_2026_021_10_04_32.partial
+2026/021-10:05:33.459 Renamed iois_1_packets_2026_021_10_04_32.partial to iois_1_packets_2026_021_10_04_32.
+2026/021-10:05:33.459 Spawning: mv
+2026/021-10:05:33.459 Opened packets file for SDC: iois_1_packets_2026_021_10_05_33.partial
+2026/021-10:05:34.315 Spawned command succeeded: mv
+2026/021-10:06:00.505 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_01_00.partial
+2026/021-10:06:00.505 Renamed IOIS_1_raw_record_20_2026_021_10_01_00.partial to IOIS_1_raw_record_20_2026_021_10_01_00.
+2026/021-10:06:00.505 Spawning: rsync
+2026/021-10:06:00.505 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_06_00.partial
+2026/021-10:06:03.149 Spawned command succeeded: rsync
+2026/021-10:06:34.629 Closed packets file for SDC: iois_1_packets_2026_021_10_05_33.partial
+2026/021-10:06:34.629 Renamed iois_1_packets_2026_021_10_05_33.partial to iois_1_packets_2026_021_10_05_33.
+2026/021-10:06:34.629 Spawning: mv
+2026/021-10:06:34.629 Opened packets file for SDC: iois_1_packets_2026_021_10_06_34.partial
+2026/021-10:06:35.453 Spawned command succeeded: mv
+2026/021-10:07:35.734 Closed packets file for SDC: iois_1_packets_2026_021_10_06_34.partial
+2026/021-10:07:35.734 Renamed iois_1_packets_2026_021_10_06_34.partial to iois_1_packets_2026_021_10_06_34.
+2026/021-10:07:35.734 Spawning: mv
+2026/021-10:07:35.735 Opened packets file for SDC: iois_1_packets_2026_021_10_07_35.partial
+2026/021-10:07:36.631 Spawned command succeeded: mv
+2026/021-10:08:36.029 Closed packets file for SDC: iois_1_packets_2026_021_10_07_35.partial
+2026/021-10:08:36.029 Renamed iois_1_packets_2026_021_10_07_35.partial to iois_1_packets_2026_021_10_07_35.
+2026/021-10:08:36.029 Spawning: mv
+2026/021-10:08:36.029 Opened packets file for SDC: iois_1_packets_2026_021_10_08_36.partial
+2026/021-10:08:36.892 Spawned command succeeded: mv
+2026/021-10:09:37.170 Closed packets file for SDC: iois_1_packets_2026_021_10_08_36.partial
+2026/021-10:09:37.170 Renamed iois_1_packets_2026_021_10_08_36.partial to iois_1_packets_2026_021_10_08_36.
+2026/021-10:09:37.170 Spawning: mv
+2026/021-10:09:37.170 Opened packets file for SDC: iois_1_packets_2026_021_10_09_37.partial
+2026/021-10:09:38.067 Spawned command succeeded: mv
+2026/021-10:10:38.311 Closed packets file for SDC: iois_1_packets_2026_021_10_09_37.partial
+2026/021-10:10:38.311 Renamed iois_1_packets_2026_021_10_09_37.partial to iois_1_packets_2026_021_10_09_37.
+2026/021-10:10:38.311 Spawning: mv
+2026/021-10:10:38.311 Opened packets file for SDC: iois_1_packets_2026_021_10_10_38.partial
+2026/021-10:10:39.207 Spawned command succeeded: mv
+2026/021-10:11:00.152 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_06_00.partial
+2026/021-10:11:00.152 Renamed IOIS_1_raw_record_20_2026_021_10_06_00.partial to IOIS_1_raw_record_20_2026_021_10_06_00.
+2026/021-10:11:00.152 Spawning: rsync
+2026/021-10:11:00.152 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_11_00.partial
+2026/021-10:11:03.650 Spawned command succeeded: rsync
+2026/021-10:11:39.489 Closed packets file for SDC: iois_1_packets_2026_021_10_10_38.partial
+2026/021-10:11:39.489 Renamed iois_1_packets_2026_021_10_10_38.partial to iois_1_packets_2026_021_10_10_38.
+2026/021-10:11:39.489 Spawning: mv
+2026/021-10:11:39.490 Opened packets file for SDC: iois_1_packets_2026_021_10_11_39.partial
+2026/021-10:11:40.360 Spawned command succeeded: mv
+2026/021-10:12:40.673 Closed packets file for SDC: iois_1_packets_2026_021_10_11_39.partial
+2026/021-10:12:40.673 Renamed iois_1_packets_2026_021_10_11_39.partial to iois_1_packets_2026_021_10_11_39.
+2026/021-10:12:40.673 Spawning: mv
+2026/021-10:12:40.673 Opened packets file for SDC: iois_1_packets_2026_021_10_12_40.partial
+2026/021-10:12:41.493 Spawned command succeeded: mv
+2026/021-10:13:41.777 Closed packets file for SDC: iois_1_packets_2026_021_10_12_40.partial
+2026/021-10:13:41.777 Renamed iois_1_packets_2026_021_10_12_40.partial to iois_1_packets_2026_021_10_12_40.
+2026/021-10:13:41.777 Spawning: mv
+2026/021-10:13:41.778 Opened packets file for SDC: iois_1_packets_2026_021_10_13_41.partial
+2026/021-10:13:42.669 Spawned command succeeded: mv
+2026/021-10:14:42.067 Closed packets file for SDC: iois_1_packets_2026_021_10_13_41.partial
+2026/021-10:14:42.067 Renamed iois_1_packets_2026_021_10_13_41.partial to iois_1_packets_2026_021_10_13_41.
+2026/021-10:14:42.067 Spawning: mv
+2026/021-10:14:42.068 Opened packets file for SDC: iois_1_packets_2026_021_10_14_42.partial
+2026/021-10:14:42.922 Spawned command succeeded: mv
+2026/021-10:15:43.210 Closed packets file for SDC: iois_1_packets_2026_021_10_14_42.partial
+2026/021-10:15:43.210 Renamed iois_1_packets_2026_021_10_14_42.partial to iois_1_packets_2026_021_10_14_42.
+2026/021-10:15:43.210 Spawning: mv
+2026/021-10:15:43.210 Opened packets file for SDC: iois_1_packets_2026_021_10_15_43.partial
+2026/021-10:15:44.147 Spawned command succeeded: mv
+2026/021-10:16:00.708 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_11_00.partial
+2026/021-10:16:00.708 Renamed IOIS_1_raw_record_20_2026_021_10_11_00.partial to IOIS_1_raw_record_20_2026_021_10_11_00.
+2026/021-10:16:00.708 Spawning: rsync
+2026/021-10:16:00.708 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_16_00.partial
+2026/021-10:16:04.207 Spawned command succeeded: rsync
+2026/021-10:16:44.357 Closed packets file for SDC: iois_1_packets_2026_021_10_15_43.partial
+2026/021-10:16:44.357 Renamed iois_1_packets_2026_021_10_15_43.partial to iois_1_packets_2026_021_10_15_43.
+2026/021-10:16:44.358 Spawning: mv
+2026/021-10:16:44.358 Opened packets file for SDC: iois_1_packets_2026_021_10_16_44.partial
+2026/021-10:16:45.249 Spawned command succeeded: mv
+2026/021-10:17:45.530 Closed packets file for SDC: iois_1_packets_2026_021_10_16_44.partial
+2026/021-10:17:45.530 Renamed iois_1_packets_2026_021_10_16_44.partial to iois_1_packets_2026_021_10_16_44.
+2026/021-10:17:45.530 Spawning: mv
+2026/021-10:17:45.530 Opened packets file for SDC: iois_1_packets_2026_021_10_17_45.partial
+2026/021-10:17:46.389 Spawned command succeeded: mv
+2026/021-10:18:46.694 Closed packets file for SDC: iois_1_packets_2026_021_10_17_45.partial
+2026/021-10:18:46.694 Renamed iois_1_packets_2026_021_10_17_45.partial to iois_1_packets_2026_021_10_17_45.
+2026/021-10:18:46.694 Spawning: mv
+2026/021-10:18:46.694 Opened packets file for SDC: iois_1_packets_2026_021_10_18_46.partial
+2026/021-10:18:47.530 Spawned command succeeded: mv
+2026/021-10:19:47.822 Closed packets file for SDC: iois_1_packets_2026_021_10_18_46.partial
+2026/021-10:19:47.822 Renamed iois_1_packets_2026_021_10_18_46.partial to iois_1_packets_2026_021_10_18_46.
+2026/021-10:19:47.822 Spawning: mv
+2026/021-10:19:47.822 Opened packets file for SDC: iois_1_packets_2026_021_10_19_47.partial
+2026/021-10:19:48.704 Spawned command succeeded: mv
+2026/021-10:20:48.133 Closed packets file for SDC: iois_1_packets_2026_021_10_19_47.partial
+2026/021-10:20:48.134 Renamed iois_1_packets_2026_021_10_19_47.partial to iois_1_packets_2026_021_10_19_47.
+2026/021-10:20:48.134 Spawning: mv
+2026/021-10:20:48.134 Opened packets file for SDC: iois_1_packets_2026_021_10_20_48.partial
+2026/021-10:20:48.965 Spawned command succeeded: mv
+2026/021-10:21:00.360 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_16_00.partial
+2026/021-10:21:00.360 Renamed IOIS_1_raw_record_20_2026_021_10_16_00.partial to IOIS_1_raw_record_20_2026_021_10_16_00.
+2026/021-10:21:00.360 Spawning: rsync
+2026/021-10:21:00.360 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_21_00.partial
+2026/021-10:21:02.945 Spawned command succeeded: rsync
+2026/021-10:21:49.252 Closed packets file for SDC: iois_1_packets_2026_021_10_20_48.partial
+2026/021-10:21:49.252 Renamed iois_1_packets_2026_021_10_20_48.partial to iois_1_packets_2026_021_10_20_48.
+2026/021-10:21:49.252 Spawning: mv
+2026/021-10:21:49.252 Opened packets file for SDC: iois_1_packets_2026_021_10_21_49.partial
+2026/021-10:21:50.138 Spawned command succeeded: mv
+2026/021-10:22:50.384 Closed packets file for SDC: iois_1_packets_2026_021_10_21_49.partial
+2026/021-10:22:50.384 Renamed iois_1_packets_2026_021_10_21_49.partial to iois_1_packets_2026_021_10_21_49.
+2026/021-10:22:50.384 Spawning: mv
+2026/021-10:22:50.384 Opened packets file for SDC: iois_1_packets_2026_021_10_22_50.partial
+2026/021-10:22:51.285 Spawned command succeeded: mv
+2026/021-10:23:51.571 Closed packets file for SDC: iois_1_packets_2026_021_10_22_50.partial
+2026/021-10:23:51.571 Renamed iois_1_packets_2026_021_10_22_50.partial to iois_1_packets_2026_021_10_22_50.
+2026/021-10:23:51.571 Spawning: mv
+2026/021-10:23:51.571 Opened packets file for SDC: iois_1_packets_2026_021_10_23_51.partial
+2026/021-10:23:52.417 Spawned command succeeded: mv
+2026/021-10:24:52.709 Closed packets file for SDC: iois_1_packets_2026_021_10_23_51.partial
+2026/021-10:24:52.709 Renamed iois_1_packets_2026_021_10_23_51.partial to iois_1_packets_2026_021_10_23_51.
+2026/021-10:24:52.709 Spawning: mv
+2026/021-10:24:52.709 Opened packets file for SDC: iois_1_packets_2026_021_10_24_52.partial
+2026/021-10:24:53.574 Spawned command succeeded: mv
+2026/021-10:25:53.855 Closed packets file for SDC: iois_1_packets_2026_021_10_24_52.partial
+2026/021-10:25:53.855 Renamed iois_1_packets_2026_021_10_24_52.partial to iois_1_packets_2026_021_10_24_52.
+2026/021-10:25:53.855 Spawning: mv
+2026/021-10:25:53.855 Opened packets file for SDC: iois_1_packets_2026_021_10_25_53.partial
+2026/021-10:25:54.748 Spawned command succeeded: mv
+2026/021-10:26:00.859 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_21_00.partial
+2026/021-10:26:00.859 Renamed IOIS_1_raw_record_20_2026_021_10_21_00.partial to IOIS_1_raw_record_20_2026_021_10_21_00.
+2026/021-10:26:00.859 Spawning: rsync
+2026/021-10:26:00.859 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_26_00.partial
+2026/021-10:26:03.449 Spawned command succeeded: rsync
+2026/021-10:26:54.146 Closed packets file for SDC: iois_1_packets_2026_021_10_25_53.partial
+2026/021-10:26:54.147 Renamed iois_1_packets_2026_021_10_25_53.partial to iois_1_packets_2026_021_10_25_53.
+2026/021-10:26:54.147 Spawning: mv
+2026/021-10:26:54.147 Opened packets file for SDC: iois_1_packets_2026_021_10_26_54.partial
+2026/021-10:26:54.995 Spawned command succeeded: mv
+2026/021-10:27:55.287 Closed packets file for SDC: iois_1_packets_2026_021_10_26_54.partial
+2026/021-10:27:55.287 Renamed iois_1_packets_2026_021_10_26_54.partial to iois_1_packets_2026_021_10_26_54.
+2026/021-10:27:55.287 Spawning: mv
+2026/021-10:27:55.287 Opened packets file for SDC: iois_1_packets_2026_021_10_27_55.partial
+2026/021-10:27:56.172 Spawned command succeeded: mv
+2026/021-10:27:59.674 Periodic status report:
+ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)
+ 2  tlmrelay      001-00:00:00  020-19:57:14    0.0
+10  Kiel          021-10:27:59  021-08:40:39    2.0
+2026/021-10:28:56.419 Closed packets file for SDC: iois_1_packets_2026_021_10_27_55.partial
+2026/021-10:28:56.419 Renamed iois_1_packets_2026_021_10_27_55.partial to iois_1_packets_2026_021_10_27_55.
+2026/021-10:28:56.419 Spawning: mv
+2026/021-10:28:56.419 Opened packets file for SDC: iois_1_packets_2026_021_10_28_56.partial
+2026/021-10:28:57.328 Spawned command succeeded: mv
+2026/021-10:29:57.641 Closed packets file for SDC: iois_1_packets_2026_021_10_28_56.partial
+2026/021-10:29:57.641 Renamed iois_1_packets_2026_021_10_28_56.partial to iois_1_packets_2026_021_10_28_56.
+2026/021-10:29:57.641 Spawning: mv
+2026/021-10:29:57.641 Opened packets file for SDC: iois_1_packets_2026_021_10_29_57.partial
+2026/021-10:29:58.464 Spawned command succeeded: mv
+2026/021-10:30:58.750 Closed packets file for SDC: iois_1_packets_2026_021_10_29_57.partial
+2026/021-10:30:58.750 Renamed iois_1_packets_2026_021_10_29_57.partial to iois_1_packets_2026_021_10_29_57.
+2026/021-10:30:58.750 Spawning: mv
+2026/021-10:30:58.751 Opened packets file for SDC: iois_1_packets_2026_021_10_30_58.partial
+2026/021-10:30:59.625 Spawned command succeeded: mv
+2026/021-10:31:00.502 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_26_00.partial
+2026/021-10:31:00.502 Renamed IOIS_1_raw_record_20_2026_021_10_26_00.partial to IOIS_1_raw_record_20_2026_021_10_26_00.
+2026/021-10:31:00.502 Spawning: rsync
+2026/021-10:31:00.502 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_31_00.partial
+2026/021-10:31:03.137 Spawned command succeeded: rsync
+2026/021-10:31:59.052 Closed packets file for SDC: iois_1_packets_2026_021_10_30_58.partial
+2026/021-10:31:59.052 Renamed iois_1_packets_2026_021_10_30_58.partial to iois_1_packets_2026_021_10_30_58.
+2026/021-10:31:59.052 Spawning: mv
+2026/021-10:31:59.052 Opened packets file for SDC: iois_1_packets_2026_021_10_31_59.partial
+2026/021-10:31:59.892 Spawned command succeeded: mv
+2026/021-10:33:00.178 Closed packets file for SDC: iois_1_packets_2026_021_10_31_59.partial
+2026/021-10:33:00.179 Renamed iois_1_packets_2026_021_10_31_59.partial to iois_1_packets_2026_021_10_31_59.
+2026/021-10:33:00.179 Spawning: mv
+2026/021-10:33:00.179 Opened packets file for SDC: iois_1_packets_2026_021_10_33_00.partial
+2026/021-10:33:01.035 Spawned command succeeded: mv
+2026/021-10:34:01.354 Closed packets file for SDC: iois_1_packets_2026_021_10_33_00.partial
+2026/021-10:34:01.355 Renamed iois_1_packets_2026_021_10_33_00.partial to iois_1_packets_2026_021_10_33_00.
+2026/021-10:34:01.355 Spawning: mv
+2026/021-10:34:01.355 Opened packets file for SDC: iois_1_packets_2026_021_10_34_01.partial
+2026/021-10:34:02.208 Spawned command succeeded: mv
+2026/021-10:35:02.464 Closed packets file for SDC: iois_1_packets_2026_021_10_34_01.partial
+2026/021-10:35:02.464 Renamed iois_1_packets_2026_021_10_34_01.partial to iois_1_packets_2026_021_10_34_01.
+2026/021-10:35:02.464 Spawning: mv
+2026/021-10:35:02.464 Opened packets file for SDC: iois_1_packets_2026_021_10_35_02.partial
+2026/021-10:35:03.351 Spawned command succeeded: mv
+2026/021-10:36:00.177 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_31_00.partial
+2026/021-10:36:00.178 Renamed IOIS_1_raw_record_20_2026_021_10_31_00.partial to IOIS_1_raw_record_20_2026_021_10_31_00.
+2026/021-10:36:00.178 Spawning: rsync
+2026/021-10:36:00.178 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_36_00.partial
+2026/021-10:36:02.744 Spawned command succeeded: rsync
+2026/021-10:36:03.637 Closed packets file for SDC: iois_1_packets_2026_021_10_35_02.partial
+2026/021-10:36:03.637 Renamed iois_1_packets_2026_021_10_35_02.partial to iois_1_packets_2026_021_10_35_02.
+2026/021-10:36:03.637 Spawning: mv
+2026/021-10:36:03.637 Opened packets file for SDC: iois_1_packets_2026_021_10_36_03.partial
+2026/021-10:36:04.497 Spawned command succeeded: mv
+2026/021-10:37:04.782 Closed packets file for SDC: iois_1_packets_2026_021_10_36_03.partial
+2026/021-10:37:04.782 Renamed iois_1_packets_2026_021_10_36_03.partial to iois_1_packets_2026_021_10_36_03.
+2026/021-10:37:04.782 Spawning: mv
+2026/021-10:37:04.782 Opened packets file for SDC: iois_1_packets_2026_021_10_37_04.partial
+2026/021-10:37:05.647 Spawned command succeeded: mv
+2026/021-10:38:05.068 Closed packets file for SDC: iois_1_packets_2026_021_10_37_04.partial
+2026/021-10:38:05.068 Renamed iois_1_packets_2026_021_10_37_04.partial to iois_1_packets_2026_021_10_37_04.
+2026/021-10:38:05.068 Spawning: mv
+2026/021-10:38:05.068 Opened packets file for SDC: iois_1_packets_2026_021_10_38_05.partial
+2026/021-10:38:05.931 Spawned command succeeded: mv
+2026/021-10:39:06.213 Closed packets file for SDC: iois_1_packets_2026_021_10_38_05.partial
+2026/021-10:39:06.213 Renamed iois_1_packets_2026_021_10_38_05.partial to iois_1_packets_2026_021_10_38_05.
+2026/021-10:39:06.213 Spawning: mv
+2026/021-10:39:06.213 Opened packets file for SDC: iois_1_packets_2026_021_10_39_06.partial
+2026/021-10:39:07.068 Spawned command succeeded: mv
+2026/021-10:40:07.357 Closed packets file for SDC: iois_1_packets_2026_021_10_39_06.partial
+2026/021-10:40:07.357 Renamed iois_1_packets_2026_021_10_39_06.partial to iois_1_packets_2026_021_10_39_06.
+2026/021-10:40:07.357 Spawning: mv
+2026/021-10:40:07.357 Opened packets file for SDC: iois_1_packets_2026_021_10_40_07.partial
+2026/021-10:40:08.250 Spawned command succeeded: mv
+2026/021-10:41:00.642 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_36_00.partial
+2026/021-10:41:00.643 Renamed IOIS_1_raw_record_20_2026_021_10_36_00.partial to IOIS_1_raw_record_20_2026_021_10_36_00.
+2026/021-10:41:00.643 Spawning: rsync
+2026/021-10:41:00.643 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_41_00.partial
+2026/021-10:41:03.289 Spawned command succeeded: rsync
+2026/021-10:41:08.494 Closed packets file for SDC: iois_1_packets_2026_021_10_40_07.partial
+2026/021-10:41:08.495 Renamed iois_1_packets_2026_021_10_40_07.partial to iois_1_packets_2026_021_10_40_07.
+2026/021-10:41:08.495 Spawning: mv
+2026/021-10:41:08.495 Opened packets file for SDC: iois_1_packets_2026_021_10_41_08.partial
+2026/021-10:41:09.390 Spawned command succeeded: mv
+2026/021-10:42:09.682 Closed packets file for SDC: iois_1_packets_2026_021_10_41_08.partial
+2026/021-10:42:09.682 Renamed iois_1_packets_2026_021_10_41_08.partial to iois_1_packets_2026_021_10_41_08.
+2026/021-10:42:09.682 Spawning: mv
+2026/021-10:42:09.683 Opened packets file for SDC: iois_1_packets_2026_021_10_42_09.partial
+2026/021-10:42:10.531 Spawned command succeeded: mv
+2026/021-10:43:10.822 Closed packets file for SDC: iois_1_packets_2026_021_10_42_09.partial
+2026/021-10:43:10.822 Renamed iois_1_packets_2026_021_10_42_09.partial to iois_1_packets_2026_021_10_42_09.
+2026/021-10:43:10.822 Spawning: mv
+2026/021-10:43:10.822 Opened packets file for SDC: iois_1_packets_2026_021_10_43_10.partial
+2026/021-10:43:11.679 Spawned command succeeded: mv
+2026/021-10:44:11.145 Closed packets file for SDC: iois_1_packets_2026_021_10_43_10.partial
+2026/021-10:44:11.145 Renamed iois_1_packets_2026_021_10_43_10.partial to iois_1_packets_2026_021_10_43_10.
+2026/021-10:44:11.145 Spawning: mv
+2026/021-10:44:11.145 Opened packets file for SDC: iois_1_packets_2026_021_10_44_11.partial
+2026/021-10:44:11.961 Spawned command succeeded: mv
+2026/021-10:45:12.254 Closed packets file for SDC: iois_1_packets_2026_021_10_44_11.partial
+2026/021-10:45:12.254 Renamed iois_1_packets_2026_021_10_44_11.partial to iois_1_packets_2026_021_10_44_11.
+2026/021-10:45:12.254 Spawning: mv
+2026/021-10:45:12.254 Opened packets file for SDC: iois_1_packets_2026_021_10_45_12.partial
+2026/021-10:45:13.146 Spawned command succeeded: mv
+2026/021-10:46:00.296 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_41_00.partial
+2026/021-10:46:00.296 Renamed IOIS_1_raw_record_20_2026_021_10_41_00.partial to IOIS_1_raw_record_20_2026_021_10_41_00.
+2026/021-10:46:00.296 Spawning: rsync
+2026/021-10:46:00.296 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_46_00.partial
+2026/021-10:46:02.936 Spawned command succeeded: rsync
+2026/021-10:46:13.390 Closed packets file for SDC: iois_1_packets_2026_021_10_45_12.partial
+2026/021-10:46:13.390 Renamed iois_1_packets_2026_021_10_45_12.partial to iois_1_packets_2026_021_10_45_12.
+2026/021-10:46:13.390 Spawning: mv
+2026/021-10:46:13.390 Opened packets file for SDC: iois_1_packets_2026_021_10_46_13.partial
+2026/021-10:46:14.283 Spawned command succeeded: mv
+2026/021-10:47:14.541 Closed packets file for SDC: iois_1_packets_2026_021_10_46_13.partial
+2026/021-10:47:14.541 Renamed iois_1_packets_2026_021_10_46_13.partial to iois_1_packets_2026_021_10_46_13.
+2026/021-10:47:14.541 Spawning: mv
+2026/021-10:47:14.541 Opened packets file for SDC: iois_1_packets_2026_021_10_47_14.partial
+2026/021-10:47:15.426 Spawned command succeeded: mv
+2026/021-10:48:15.727 Closed packets file for SDC: iois_1_packets_2026_021_10_47_14.partial
+2026/021-10:48:15.727 Renamed iois_1_packets_2026_021_10_47_14.partial to iois_1_packets_2026_021_10_47_14.
+2026/021-10:48:15.727 Spawning: mv
+2026/021-10:48:15.727 Opened packets file for SDC: iois_1_packets_2026_021_10_48_15.partial
+2026/021-10:48:16.567 Spawned command succeeded: mv
+2026/021-10:49:16.007 Closed packets file for SDC: iois_1_packets_2026_021_10_48_15.partial
+2026/021-10:49:16.007 Renamed iois_1_packets_2026_021_10_48_15.partial to iois_1_packets_2026_021_10_48_15.
+2026/021-10:49:16.007 Spawning: mv
+2026/021-10:49:16.007 Opened packets file for SDC: iois_1_packets_2026_021_10_49_16.partial
+2026/021-10:49:16.872 Spawned command succeeded: mv
+2026/021-10:50:17.141 Closed packets file for SDC: iois_1_packets_2026_021_10_49_16.partial
+2026/021-10:50:17.141 Renamed iois_1_packets_2026_021_10_49_16.partial to iois_1_packets_2026_021_10_49_16.
+2026/021-10:50:17.141 Spawning: mv
+2026/021-10:50:17.141 Opened packets file for SDC: iois_1_packets_2026_021_10_50_17.partial
+2026/021-10:50:18.008 Spawned command succeeded: mv
+2026/021-10:51:00.836 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_46_00.partial
+2026/021-10:51:00.836 Renamed IOIS_1_raw_record_20_2026_021_10_46_00.partial to IOIS_1_raw_record_20_2026_021_10_46_00.
+2026/021-10:51:00.836 Spawning: rsync
+2026/021-10:51:00.836 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_51_00.partial
+2026/021-10:51:03.438 Spawned command succeeded: rsync
+2026/021-10:51:18.293 Closed packets file for SDC: iois_1_packets_2026_021_10_50_17.partial
+2026/021-10:51:18.293 Renamed iois_1_packets_2026_021_10_50_17.partial to iois_1_packets_2026_021_10_50_17.
+2026/021-10:51:18.293 Spawning: mv
+2026/021-10:51:18.293 Opened packets file for SDC: iois_1_packets_2026_021_10_51_18.partial
+2026/021-10:51:19.139 Spawned command succeeded: mv
+2026/021-10:52:19.435 Closed packets file for SDC: iois_1_packets_2026_021_10_51_18.partial
+2026/021-10:52:19.435 Renamed iois_1_packets_2026_021_10_51_18.partial to iois_1_packets_2026_021_10_51_18.
+2026/021-10:52:19.435 Spawning: mv
+2026/021-10:52:19.436 Opened packets file for SDC: iois_1_packets_2026_021_10_52_19.partial
+2026/021-10:52:20.322 Spawned command succeeded: mv
+2026/021-10:53:20.627 Closed packets file for SDC: iois_1_packets_2026_021_10_52_19.partial
+2026/021-10:53:20.627 Renamed iois_1_packets_2026_021_10_52_19.partial to iois_1_packets_2026_021_10_52_19.
+2026/021-10:53:20.627 Spawning: mv
+2026/021-10:53:20.627 Opened packets file for SDC: iois_1_packets_2026_021_10_53_20.partial
+2026/021-10:53:21.468 Spawned command succeeded: mv
+2026/021-10:54:21.751 Closed packets file for SDC: iois_1_packets_2026_021_10_53_20.partial
+2026/021-10:54:21.751 Renamed iois_1_packets_2026_021_10_53_20.partial to iois_1_packets_2026_021_10_53_20.
+2026/021-10:54:21.751 Spawning: mv
+2026/021-10:54:21.752 Opened packets file for SDC: iois_1_packets_2026_021_10_54_21.partial
+2026/021-10:54:22.637 Spawned command succeeded: mv
+2026/021-10:55:22.047 Closed packets file for SDC: iois_1_packets_2026_021_10_54_21.partial
+2026/021-10:55:22.047 Renamed iois_1_packets_2026_021_10_54_21.partial to iois_1_packets_2026_021_10_54_21.
+2026/021-10:55:22.047 Spawning: mv
+2026/021-10:55:22.047 Opened packets file for SDC: iois_1_packets_2026_021_10_55_22.partial
+2026/021-10:55:22.900 Spawned command succeeded: mv
+2026/021-10:56:00.448 Closed raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_51_00.partial
+2026/021-10:56:00.448 Renamed IOIS_1_raw_record_20_2026_021_10_51_00.partial to IOIS_1_raw_record_20_2026_021_10_51_00.
+2026/021-10:56:00.448 Spawning: rsync
+2026/021-10:56:00.448 Opened raw record file for Kiel antenna_partner: IOIS_1_raw_record_20_2026_021_10_56_00.partial
+2026/021-10:56:03.084 Spawned command succeeded: rsync
+2026/021-10:56:23.201 Closed packets file for SDC: iois_1_packets_2026_021_10_55_22.partial
+2026/021-10:56:23.201 Renamed iois_1_packets_2026_021_10_55_22.partial to iois_1_packets_2026_021_10_55_22.
+2026/021-10:56:23.201 Spawning: mv
+2026/021-10:56:23.201 Opened packets file for SDC: iois_1_packets_2026_021_10_56_23.partial
+2026/021-10:56:24.049 Spawned command succeeded: mv
+2026/021-10:57:24.323 Closed packets file for SDC: iois_1_packets_2026_021_10_56_23.partial
+2026/021-10:57:24.323 Renamed iois_1_packets_2026_021_10_56_23.partial to iois_1_packets_2026_021_10_56_23.
+2026/021-10:57:24.323 Spawning: mv
+2026/021-10:57:24.323 Opened packets file for SDC: iois_1_packets_2026_021_10_57_24.partial
+2026/021-10:57:25.231 Spawned command succeeded: mv
+2026/021-10:58:00.171 Periodic status report:

--- a/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
+++ b/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
@@ -20,13 +20,17 @@ def test_packets_created():
 
     actual_output = packets_created(datetime(2025, 7, 31, 16, 33, 39, 0), lines)
 
-    # 2025/212-16:33:39.186
-    time_0 = datetime(2025, 7, 31, 16, 33, 39, 186000)
-    # 2025/212-16:34:40.199
-    time_1 = datetime(2025, 7, 31, 16, 34, 40, 199000)
+    expected = {
+        "Kiel": {
+            "last_data_received": [
+                "2025-01-21T09:57:58Z",
+                "2025-01-21T10:27:59Z",
+            ],
+            "rate_kbps": [2.0, 2.0],
+        }
+    }
 
-    assert actual_output[0] == time_0
-    assert actual_output[1] == time_1
+    assert actual_output == expected
 
 
 def test_format_ingest_data():
@@ -68,67 +72,24 @@ def test_format_ingest_data():
                 f"iois_1_packets_{pkt_time}.\n"
             )
 
+        if current_time == base_date + timedelta(hours=8):
+            log_lines.append(
+                "ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)\n"
+            )
+            log_lines.append("10  Kiel          365-08:00:00  365-08:00:00    2.0\n")
+
+        if current_time == base_date + timedelta(hours=15):
+            log_lines.append(
+                "ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)\n"
+            )
+            log_lines.append("10  Kiel          001-15:00:00  001-08:00:00    2.0\n")
+
         current_time += timedelta(seconds=1)
 
     filenames = sorted(filenames)
 
     data = format_ingest_data(filenames[-1], log_lines)
 
-    assert data["packet_ingest"][0] == "2025-07-31T08:00:00"
-    assert data["packet_ingest"][-1] == "2025-07-31T15:00:00"
-    assert data["connection_times"]["Kiel"][0]["start"] == "2025-07-31T08:00:00"
-    assert data["connection_times"]["Kiel"][0]["end"] == "2025-07-31T16:00:00"
-
-
-def test_format_ingest_data_edge_cases():
-    """Test the edge cases of the format_ingest_data function."""
-
-    # File names for a short 3 hour test window
-    filenames = [
-        "flight_iois_1.log.2025-212T00_00_00.000000",
-        "flight_iois_1.log.2025-212T01_00_00.000000",
-        "flight_iois_1.log.2025-212T02_00_00.000000",
-    ]
-
-    base_date = datetime(2025, 7, 31, 0, 0, 0)
-    log_lines = []
-
-    # Simulate case: log starts with a "down!" at 00:15 (no prior "up.")
-    timestamp_down = (base_date + timedelta(minutes=15)).strftime("%Y/%j-%H:%M:%S.%f")[
-        :-3
-    ]
-    log_lines.append(f"{timestamp_down} Kiel antenna partner connection is down!\n")
-
-    # Add packet event at 00:00
-    timestamp_pkt = base_date.strftime("%Y/%j-%H:%M:%S.%f")[:-3]
-    pkt_time = base_date.strftime("%Y_%j_%H_%M_%S")
-    log_lines.append(
-        f"{timestamp_pkt} Renamed iois_1_packets_{pkt_time}.partial to "
-        f"iois_1_packets_{pkt_time}.\n"
-    )
-
-    # Simulate case: "up." at 02:00 (no matching "down!" before end of file)
-    timestamp_up = (base_date + timedelta(hours=2)).strftime("%Y/%j-%H:%M:%S.%f")[:-3]
-    log_lines.append(f"{timestamp_up} Kiel antenna partner connection is up.\n")
-
-    # Add packet event at 02:01
-    timestamp_pkt = (base_date + timedelta(hours=2, minutes=1)).strftime(
-        "%Y/%j-%H:%M:%S.%f"
-    )[:-3]
-    pkt_time = (base_date + timedelta(hours=2, minutes=1)).strftime("%Y_%j_%H_%M_%S")
-    log_lines.append(
-        f"{timestamp_pkt} Renamed iois_1_packets_{pkt_time}.partial to "
-        f"iois_1_packets_{pkt_time}.\n"
-    )
-    filenames = sorted(filenames)
-
-    data = format_ingest_data(filenames[-1], log_lines)
-
-    assert data["connection_times"]["Kiel"][0]["start"] == "2025-07-29T02:00:00"
-    assert data["connection_times"]["Kiel"][0]["end"] == "2025-07-31T00:15:00"
-
-    assert data["connection_times"]["Kiel"][1]["start"] == "2025-07-31T02:00:00"
-    assert data["connection_times"]["Kiel"][1]["end"] == "2025-07-31T02:00:00"
-
-    assert data["packet_ingest"][0] == "2025-07-31T00:00:00"
-    assert data["packet_ingest"][1] == "2025-07-31T02:01:00"
+    assert data["Kiel"]["last_data_received"][0] == "2025-12-31T08:00:00Z"
+    assert data["Kiel"]["last_data_received"][-1] == "2026-01-01T15:00:00Z"
+    assert data["Kiel"]["rate_kbps"][0] == 2.0

--- a/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
+++ b/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
@@ -18,13 +18,13 @@ def test_packets_created():
     ) as f:
         lines = f.readlines()
 
-    actual_output = packets_created(datetime(2025, 7, 31, 16, 33, 39, 0), lines)
+    actual_output = packets_created(datetime(2026, 7, 31, 16, 33, 39, 0), lines)
 
     expected = {
         "Kiel": {
             "last_data_received": [
-                "2025-01-21T09:57:58Z",
-                "2025-01-21T10:27:59Z",
+                "2026-01-21T09:57:58Z",
+                "2026-01-21T10:27:59Z",
             ],
             "rate_kbps": [2.0, 2.0],
         }

--- a/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
+++ b/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
@@ -1,97 +1,20 @@
 """Test calculate_ingest functions."""
 
-from datetime import datetime, timedelta, timezone
-from typing import Any
+from datetime import datetime, timedelta
 
 from imap_processing import imap_module_directory
 from imap_processing.ialirt.calculate_ingest import (
-    find_tcp_connections,
     format_ingest_data,
     packets_created,
 )
-from imap_processing.ialirt.constants import STATIONS
 
 TEST_PATH = imap_module_directory / "tests" / "ialirt" / "data" / "l0"
-
-
-def test_find_tcp_connections():
-    """Test the find_tcp_connections function."""
-    filename = "flight_iois_1.log.2025-212T16_55_27.531613"
-    # File creation time minus 1 hr.
-    timestamp_str = filename.split(".")[2]
-    timestamp_str = timestamp_str.replace("_", ":")
-    start_of_time = datetime.strptime(timestamp_str, "%Y-%jT%H:%M:%S") - timedelta(
-        hours=1
-    )
-    end_of_time = start_of_time + timedelta(hours=48)
-
-    with open(TEST_PATH / filename, encoding="utf-8") as f:
-        lines = f.readlines()
-
-    formatted: dict[str, Any] = {
-        "summary": "I-ALiRT Real-time Ingest Summary",
-        "generated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "time_format": "UTC (ISOC)",
-        "stations": list(STATIONS),
-        "time_range": [
-            start_of_time.isoformat(),
-            end_of_time.isoformat(),
-        ],  # Overall time range of the data
-        "packet_ingest": [],  # Global packet ingest times
-        "connection_times": {
-            station: [] for station in list(STATIONS)
-        },  # Per-station TCP connection windows
-    }
-
-    test = find_tcp_connections(start_of_time, end_of_time, lines, formatted)
-
-    # 2025/212-16:33:03.247
-    time_0 = datetime(2025, 7, 31, 16, 33, 3, 247000)
-    # 2025/212-16:33:40.189
-    time_1 = datetime(2025, 7, 31, 16, 33, 40, 189000)
-
-    assert test["connection_times"]["Kiel"][0]["start"] == datetime.isoformat(time_0)
-    assert test["connection_times"]["Kiel"][0]["end"] == datetime.isoformat(time_1)
-
-
-def test_find_tcp_connections_no_info():
-    """Test the find_tcp_connections function if tcp connection up not present."""
-    filename = "flight_iois_1.log.2025-295T17-28-05.937369"
-    # File creation time minus 1 hr.
-    timestamp_str = filename.split(".")[2]
-    start_of_time = datetime.strptime(timestamp_str, "%Y-%jT%H-%M-%S") - timedelta(
-        hours=1
-    )
-    end_of_time = start_of_time + timedelta(hours=48)
-
-    with open(TEST_PATH / filename, encoding="utf-8") as f:
-        lines = f.readlines()
-
-    formatted: dict[str, Any] = {
-        "summary": "I-ALiRT Real-time Ingest Summary",
-        "generated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "time_format": "UTC (ISOC)",
-        "stations": list(STATIONS),
-        "time_range": [
-            start_of_time.isoformat(),
-            end_of_time.isoformat(),
-        ],  # Overall time range of the data
-        "packet_ingest": [],  # Global packet ingest times
-        "connection_times": {
-            station: [] for station in list(STATIONS)
-        },  # Per-station TCP connection windows
-    }
-
-    test = find_tcp_connections(start_of_time, end_of_time, lines, formatted)
-
-    assert test["connection_times"]["Kiel"][0]["start"] == start_of_time.isoformat()
-    assert test["connection_times"]["Kiel"][0]["end"] == end_of_time.isoformat()
 
 
 def test_packets_created():
     """Test the packets_created function."""
     with open(
-        TEST_PATH / "flight_iois_1.log.2025-212T16_55_27.531613", encoding="utf-8"
+        TEST_PATH / "flight_iois_1.log.2026-021T10-58-00.171087", encoding="utf-8"
     ) as f:
         lines = f.readlines()
 


### PR DESCRIPTION
# Change Summary

## Overview
The Kiel team has requested confirmation of packet ingest within 5 minutes. The POC updated the cadence of their logs to 5 minutes to accomodate this request. This statement appears within the log every minute:

ID  Description   LastDataRcvd  ConnectionTime  Rate (kbps)
 2  tlmrelay      001-00:00:00  020-19:57:14    0.0     
10  Kiel          021-09:57:58  021-08:40:39    2.0   

We are using the LastDataRcvd timestamp for each station (right now only Kiel) to be able to know when each packet has been received as a function of station.

## Updated Files
- calculate_ingest.py
   - parses logs

## Testing
- test_calculate_ingest.py
- flight_iois_1.log.2026-021T10-58-00.171087