### PR TITLE
FIX: Update Lo l2 map statistical uncertainty

### DIFF
--- a/imap_processing/lo/l2/lo_l2.py
+++ b/imap_processing/lo/l2/lo_l2.py
@@ -948,8 +948,7 @@ def calculate_intensities(dataset: xr.Dataset) -> xr.Dataset:
     # the equation is for the variance
     dataset["ena_intensity_stat_uncert"] = np.sqrt(
         dataset["counts_over_eff_squared"]
-        / (dataset["geometric_factor"] * dataset["energy"] * dataset["exposure_factor"])
-    )
+    ) / (dataset["geometric_factor"] * dataset["energy"] * dataset["exposure_factor"])
 
     # Equation 5 from mapping document (systematic uncertainty)
     dataset["ena_intensity_sys_err"] = (

--- a/imap_processing/tests/lo/test_lo_l2.py
+++ b/imap_processing/tests/lo/test_lo_l2.py
@@ -1110,11 +1110,10 @@ class TestCalculateIntensities:
         # Check statistical uncertainty calculation
         expected_stat_uncert = np.sqrt(
             sample_dataset_with_geometric_factors["counts_over_eff_squared"]
-            / (
-                sample_dataset_with_geometric_factors["geometric_factor"]
-                * sample_dataset_with_geometric_factors["energy"]
-                * sample_dataset_with_geometric_factors["exposure_factor"]
-            )
+        ) / (
+            sample_dataset_with_geometric_factors["geometric_factor"]
+            * sample_dataset_with_geometric_factors["energy"]
+            * sample_dataset_with_geometric_factors["exposure_factor"]
         )
         xr.testing.assert_allclose(
             result["ena_intensity_stat_uncert"], expected_stat_uncert


### PR DESCRIPTION
There was an error in the L2 statistical uncertainty equation. The bottom of it should not be under the square root. It is a squared quantity, so doing a square root should just remove the outside square (i.e. we don't need to do a second square root).