### PR TITLE
MNT: Add pivot_angle to Lo direct event l1b and pass-through more

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -122,9 +122,14 @@ def l1b_de(
     # get the dependency dataset for l1b direct events
     l1a_de = sci_dependencies["imap_lo_l1a_de"]
     spin_data = sci_dependencies["imap_lo_l1a_spin"]
+    l1b_nhk = sci_dependencies["imap_lo_l1b_nhk"]
 
     # Initialize the L1B DE dataset
     l1b_de = initialize_l1b_de(l1a_de, attr_mgr_l1b, logical_source)
+    # Get the pivot angle from the housekeeping dataset
+    pivot_angle = _get_nearest_pivot_angle(l1b_de["epoch"].values[0], l1b_nhk)
+    l1b_de["pivot_angle"] = xr.DataArray([pivot_angle], dims=["pivot_angle"])
+
     pointing_start_met, pointing_end_met = get_pointing_times(
         l1a_de["met"].values[0].item()
     )
@@ -1650,7 +1655,6 @@ def calculate_de_rates(
     """
     l1b_de = sci_dependencies["imap_lo_l1b_de"]
     l1a_spin = sci_dependencies["imap_lo_l1a_spin"]
-    l1b_nhk = sci_dependencies["imap_lo_l1b_nhk"]
     # Set the asc_start for each DE by removing the average spin cycle
     # which is a function of esa_step (see set_spin_cycle function)
     # spin_cycle is an average over esa steps and spins per asc, so finding
@@ -1776,8 +1780,7 @@ def calculate_de_rates(
     # TODO: Add badtimes
     ds["badtime"] = xr.zeros_like(ds["epoch"], dtype=int)
 
-    pivot_angle = _get_nearest_pivot_angle(ds["epoch"].values[0], l1b_nhk)
-    ds["pivot_angle"] = xr.DataArray([pivot_angle], dims=["pivot_angle"])
+    ds["pivot_angle"] = l1b_de["pivot_angle"]
 
     pointing_start_met, pointing_end_met = get_pointing_times(
         ttj2000ns_to_met(ds["epoch"].values[0].item())

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -85,6 +85,9 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
             attrs=attr_mgr.get_global_attributes(logical_source),
         )
 
+        # pass-through of the pivot_angle from L1B DE
+        pset["pivot_angle"] = l1b_de["pivot_angle"]
+
         # ESA mode needs to be added to L1B DE. Adding try statement
         # to avoid error until it's available in the dataset
         if "esa_mode" not in l1b_de:

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -172,6 +172,13 @@ def test_lo_l1b_de(
             dataset["num_completed"] = 28
         data[dataset.attrs["Logical_source"]] = dataset
 
+    # Add l1b_nhk dependency with pivot angle information
+    l1b_nhk = xr.Dataset(
+        {"pcc_cumulative_cnt_pri": ("epoch", [45.0])},
+        coords={"epoch": [met_to_ttj2000ns(473389200)]},
+    )
+    data["imap_lo_l1b_nhk"] = l1b_nhk
+
     expected_logical_source_de = "imap_lo_l1b_de"
 
     # Act
@@ -179,6 +186,9 @@ def test_lo_l1b_de(
 
     # Assert
     assert expected_logical_source_de == output_files[-1].attrs["Logical_source"]
+    # Verify that pivot_angle is present in the output
+    assert "pivot_angle" in output_files[-1]
+    assert output_files[-1]["pivot_angle"].values[0] == 45.0
 
 
 @patch("imap_processing.lo.l1b.lo_l1b.get_spin_number", return_value=0)
@@ -1339,6 +1349,9 @@ def test_calculate_de_rates(
         {"pcc_cumulative_cnt_pri": ("epoch", [45.0])},
         coords={"epoch": epoch_time[:1]},
     )
+
+    # Add pivot_angle to l1b_de (normally set from l1b_nhk in l1b_de function)
+    l1b_de["pivot_angle"] = xr.DataArray([45.0], dims=["pivot_angle"])
 
     sci_dependencies = {
         "imap_lo_l1b_de": l1b_de,

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -79,6 +79,7 @@ def l1b_de_spin():
             "species": ("epoch", ["H", "O", "H", "H", "O"]),
             "spin_cycle": ("epoch", [1, 2, 3, 4, 5]),
             "avg_spin_durations": ("epoch", [15.2, 15.2, 14.9, 15, 14.9]),
+            "pivot_angle": ([45.0]),
         },
         coords={
             "epoch": met_to_ttj2000ns(np.arange(511000000, 511000000 + 200, 40) + 902),
@@ -223,6 +224,9 @@ def test_lo_l1c(
 
     # Assert
     assert expected_logical_source == output_dataset[0].attrs["Logical_source"]
+    # Verify that pivot_angle is passed through from l1b_de
+    assert "pivot_angle" in output_dataset[0]
+    assert output_dataset[0]["pivot_angle"].values[0] == 45.0
 
 
 def test_filter_goodtimes(l1b_de, anc_dependencies):


### PR DESCRIPTION
This moves the pivot_angle variable into l1b_de, which can then be referenced for derates and pset. Meaning the dependency tree will be updated to move the nhk dependency to the l1b-de instead of l1b-derates.

