### PR TITLE
MNT: Use pivot_angle from Lo when defining DE direction

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -20,7 +20,7 @@ from imap_processing.spice.geometry import (
     SpiceFrame,
     cartesian_to_latitudinal,
     frame_transform,
-    instrument_pointing,
+    lo_instrument_pointing,
 )
 from imap_processing.spice.repoint import get_pointing_times
 from imap_processing.spice.spin import get_spin_data, get_spin_number
@@ -1129,9 +1129,10 @@ def set_pointing_direction(l1b_de: xr.Dataset) -> xr.Dataset:
     # Get the pointing bin for each DE
     et = ttj2000ns_to_et(l1b_de["epoch"])
     # get the direction in HAE coordinates
-    direction = instrument_pointing(
-        et, SpiceFrame.IMAP_LO_BASE, SpiceFrame.IMAP_HAE, cartesian=True
+    direction = lo_instrument_pointing(
+        et, l1b_de["pivot_angle"].values[0], SpiceFrame.IMAP_HAE, cartesian=True
     )
+
     # TODO: Need to ask Lo what to do if a latitude is outside of the
     # +/-2 degree range. Is that possible?
     l1b_de["hae_x"] = xr.DataArray(

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -135,7 +135,7 @@ def l1a_hist():
     return_value=np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]),
 )
 @patch(
-    "imap_processing.lo.l1b.lo_l1b.instrument_pointing",
+    "imap_processing.lo.l1b.lo_l1b.lo_instrument_pointing",
     return_value=np.zeros((2000, 3)),
 )
 @patch(
@@ -149,7 +149,7 @@ def l1a_hist():
 )
 def test_lo_l1b_de(
     mock_frame_transform,
-    mock_instrument_pointing,
+    mock_lo_instrument_pointing,
     mocked_get_pointing_times,
     mock_spin_number,
     mock_cartesian_to_latitudinal,
@@ -730,13 +730,15 @@ def test_set_bad_or_goodtimes(anc_dependencies):
 
 
 @patch(
-    "imap_processing.lo.l1b.lo_l1b.instrument_pointing",
+    "imap_processing.lo.l1b.lo_l1b.lo_instrument_pointing",
     return_value=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]),
 )
-def test_set_direction(imap_ena_sim_metakernel):
+def test_set_direction(mock_lo_instrument_pointing, imap_ena_sim_metakernel):
     # Arrange
     l1b_de = xr.Dataset(
-        {},
+        {
+            "pivot_angle": ("epoch", [0, 0, 0, 0]),
+        },
         coords={
             "epoch": [0, 1, 2, 3],
         },


### PR DESCRIPTION
The default IMAP_LO_BASE is 0 degrees, but the nominal pivot angle is 90 degrees, which we need to use when defining look directions in the sky.

Testing locally, I get off_angles right in the middle at index 20 now rather than off the edge at 40 like we did previously. This brings up the question of what does off-angle mean if we have a pivot angle that is not sweeping out a perpendicular stripe. I _think_ it may all work out with how we've defined the transforms, but I don't know for sure. i.e. will the off-angle be 15 +/- 2 instead of 0 +/- 2 if we have a pivot-angle not directly at 90 degrees. I'm just writing this down so I don't forget about this later.

closes #2614 