### PR TITLE
FIX: The golden triple calculation needs to check mode bit == 1

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -828,7 +828,8 @@ def calculate_tof1_for_golden_triples(l1a_de: xr.Dataset) -> xr.Dataset:
         The L1A DE dataset with the TOF1 calculated for golden triples.
     """
     for idx, coin_type in enumerate(l1a_de["coincidence_type"].values):
-        if coin_type == 0 and l1a_de["mode"][idx] == 0:
+        # NOTE: mode bit of 1 is used to identify golden triple (event was compressed)
+        if coin_type == 0 and l1a_de["mode"][idx] == 1:
             # Calculate TOF1
             # TOF1 equation requires values to be right bit shifted. These values were
             # originally right bit shifted when packed in the telemetry packet, but were

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -581,7 +581,7 @@ def test_calculate_tof1_for_golden_triples():
             "coincidence_type": ("epoch", [0, 0, 0]),
             "mode": ("epoch", [0, 0, 1]),
             "tof0": ("epoch", [2, 4, 2]),
-            "tof1": ("epoch", [42, 36, 0]),
+            "tof1": ("epoch", [0, 0, 42]),
             "tof2": ("epoch", [2, 6, 2]),
             "tof3": ("epoch", [2, 8, 2]),
             "cksm": ("epoch", [2, 12, 2]),
@@ -592,7 +592,7 @@ def test_calculate_tof1_for_golden_triples():
     l1a_de = calculate_tof1_for_golden_triples(l1a_de)
 
     # Assert
-    assert l1a_de_expected.equals(l1a_de)
+    xr.testing.assert_equal(l1a_de, l1a_de_expected)
 
 
 def test_set_coincidence_type(attr_mgr_l1a):


### PR DESCRIPTION
This was a bug identified in computing the golden triples identified by the Lo team where the mode bit was being checked incorrectly when updating the TOF1 value.