### PR TITLE
MNT: Add sc velocity to Lo pointing sets in l1c

### DIFF
--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -9,6 +9,7 @@ import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.ena_maps.utils.corrections import add_spacecraft_velocity_to_pset
 from imap_processing.lo import lo_ancillary
 from imap_processing.lo.l1b.lo_l1b import set_bad_or_goodtimes
 from imap_processing.spice.geometry import (
@@ -201,6 +202,9 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
             "off_angle": OFF_ANGLE_BIN_CENTERS,
         }
     )
+
+    # add the spacecraft velocity and direction
+    pset = add_spacecraft_velocity_to_pset(pset)
 
     return [pset]
 

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -219,7 +219,9 @@ def expected_bg():
 @patch("imap_processing.lo.l1c.lo_l1c.set_background_rates")
 @patch("imap_processing.lo.l1c.lo_l1c.filter_goodtimes")
 @patch("imap_processing.lo.l1c.lo_l1c.set_pointing_directions")
+@patch("imap_processing.lo.l1c.lo_l1c.add_spacecraft_velocity_to_pset")
 def test_lo_l1c(
+    mock_add_spacecraft_velocity,
     mock_set_pointing_directions,
     mock_filter_goodtimes,
     mock_set_background_rates,
@@ -245,16 +247,20 @@ def test_lo_l1c(
         np.ones(PSET_SHAPE, dtype=np.float32),
         dims=["epoch", "esa_energy_step", "spin_angle", "off_angle"],
     )
+    mock_add_spacecraft_velocity.side_effect = lambda pset: pset
     expected_logical_source = "imap_lo_l1c_pset"
 
     # Act
-    output_dataset = lo_l1c(data, anc_dependencies)
+    output_dataset = lo_l1c(data, anc_dependencies)[0]
 
     # Assert
-    assert expected_logical_source == output_dataset[0].attrs["Logical_source"]
+    assert expected_logical_source == output_dataset.attrs["Logical_source"]
     # Verify that pivot_angle is passed through from l1b_de
-    assert "pivot_angle" in output_dataset[0]
-    assert output_dataset[0]["pivot_angle"].values[0] == 45.0
+    assert "pivot_angle" in output_dataset
+    assert output_dataset["pivot_angle"].values[0] == 45.0
+    # We want sc velocity and direction added to the l1c pointing sets,
+    # not waiting until CG is needed.
+    mock_add_spacecraft_velocity.assert_called_once()
 
 
 def test_filter_goodtimes(l1b_de, anc_dependencies):


### PR DESCRIPTION
Lo doesn't want to wait until CG calculations and wants this information in the l1c pointing set itself when created.

@subagonsouth I started down the path of removing this from the L2 code as well for Lo, but then ran into issues because of the IBEX test datasets that don't have this variable yet. So I figured it is worthwhile just leaving the sc_velocity addition in the L2 pipeline even if it is already added in L1c pointing sets (I did do a quick check that we can overwrite it without any errors). I figure we can tackle that later if desired to remove the duplication.

closes #2618