### PR TITLE
I-ALiRT - Coordinated coverage schedule

### DIFF
--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -1,6 +1,7 @@
 """Module for constants and useful shared classes used in I-ALiRT processing."""
 
 from dataclasses import dataclass
+from datetime import time
 from typing import NamedTuple
 
 import numpy as np
@@ -48,6 +49,8 @@ class StationProperties(NamedTuple):
     latitude: float  # latitude in degrees
     altitude: float  # altitude in kilometers
     min_elevation_deg: float  # minimum elevation angle in degrees
+    schedule_start: time | None  # station schedule start
+    schedule_end: time | None  # station schedule end
 
 
 # Verified by Kiel and KSWC Observatory staff.
@@ -59,23 +62,31 @@ STATIONS = {
         latitude=54.2632,  # degrees North
         altitude=0.1,  # approx 100 meters
         min_elevation_deg=5,  # 5 degrees is the requirement
+        schedule_start=None,
+        schedule_end=None,
     ),
     "Korea": StationProperties(
         longitude=126.2958,  # degrees East
         latitude=33.4273,  # degrees North
         altitude=0.1,  # approx 100 meters
         min_elevation_deg=5,  # 5 degrees is the requirement
+        schedule_start=None,
+        schedule_end=None,
     ),
     "Manaus": StationProperties(
         longitude=-59.969334,  # degrees East (negative = West)
         latitude=-2.891257,  # degrees North (negative = South)
         altitude=0.1,  # approx 100 meters
         min_elevation_deg=5,  # 5 degrees is the requirement
+        schedule_start=None,
+        schedule_end=None,
     ),
     "SANSA": StationProperties(
         longitude=27.714,  # degrees East (negative = West)
         latitude=-25.888,  # degrees North (negative = South)
         altitude=1.542,  # approx 1542 meters
         min_elevation_deg=2,  # 5 degrees is the requirement
+        schedule_start=None,
+        schedule_end=None,
     ),
 }

--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -49,8 +49,8 @@ class StationProperties(NamedTuple):
     latitude: float  # latitude in degrees
     altitude: float  # altitude in kilometers
     min_elevation_deg: float  # minimum elevation angle in degrees
-    schedule_start: time | None  # station schedule start
-    schedule_end: time | None  # station schedule end
+    schedule_start: time | None = None  # station schedule start
+    schedule_end: time | None = None  # station schedule end
 
 
 # Verified by Kiel and KSWC Observatory staff.

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -4,7 +4,7 @@ import logging
 
 import numpy as np
 
-from imap_processing.ialirt.constants import STATIONS
+from imap_processing.ialirt.constants import STATIONS, StationProperties
 from imap_processing.ialirt.process_ephemeris import calculate_azimuth_and_elevation
 from imap_processing.spice.time import et_to_utc, str_to_et
 
@@ -26,6 +26,55 @@ ALL_STATIONS = [
     "DSS-74",
     "DSS-75",
 ]
+
+
+def create_schedule_mask(
+    station: StationProperties, time_range: np.ndarray
+) -> np.ndarray:
+    """
+    Create a boolean mask based on the static daily operating schedule.
+
+    Parameters
+    ----------
+    station : StationProperties
+        Ground station configuration.
+    time_range : np.ndarray
+        Array of ephemeris time (ET) values corresponding to the
+        coverage time.
+
+    Returns
+    -------
+    schedule_mask : np.ndarray
+        Boolean array True is operating window.
+    """
+    if station.schedule_start is None and station.schedule_end is None:
+        return np.ones(time_range.shape, dtype=bool)
+
+    utc_times = et_to_utc(time_range, format_str="ISOC")
+    utc_dt = utc_times.astype("datetime64[s]")
+
+    # seconds since midnight (UTC), vectorized
+    sec_of_day = (utc_dt - utc_dt.astype("datetime64[D]")) / np.timedelta64(1, "s")
+
+    schedule_mask = np.ones(time_range.shape, dtype=bool)
+
+    if station.schedule_start is not None:
+        start_sec = (
+            station.schedule_start.hour * 3600
+            + station.schedule_start.minute * 60
+            + station.schedule_start.second
+        )
+        schedule_mask &= sec_of_day >= start_sec
+
+    if station.schedule_end is not None:
+        end_sec = (
+            station.schedule_end.hour * 3600
+            + station.schedule_end.minute * 60
+            + station.schedule_end.second
+        )
+        schedule_mask &= sec_of_day <= end_sec
+
+    return schedule_mask
 
 
 def generate_coverage(
@@ -76,11 +125,18 @@ def generate_coverage(
                 end_et = str_to_et(end)
                 dsn_outage_mask |= (time_range >= start_et) & (time_range <= end_et)
 
-    for station_name, (lon, lat, alt, min_elevation) in stations.items():
+    for station_name, station in stations.items():
         _azimuth, elevation = calculate_azimuth_and_elevation(
-            lon, lat, alt, time_range, obsref="IAU_EARTH"
+            station.longitude,
+            station.latitude,
+            station.altitude,
+            time_range,
+            obsref="IAU_EARTH",
         )
-        visible = elevation > min_elevation
+        visible = elevation > station.min_elevation_deg
+
+        schedule_mask = create_schedule_mask(station, time_range)
+        visible &= schedule_mask
 
         outage_mask = np.zeros(time_range.shape, dtype=bool)
         if outages and station_name in outages:
@@ -133,9 +189,9 @@ def generate_coverage(
     coverage_dict["total_coverage_percent"] = total_coverage_percent
 
     # Ensure all stations are present in both dicts
-    for station in ALL_STATIONS:
-        coverage_dict.setdefault(station, np.array([], dtype="<U23"))
-        outage_dict.setdefault(station, np.array([], dtype="<U23"))
+    for station_name in ALL_STATIONS:
+        coverage_dict.setdefault(station_name, np.array([], dtype="<U23"))
+        outage_dict.setdefault(station_name, np.array([], dtype="<U23"))
 
     return coverage_dict, outage_dict
 

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -32,7 +32,7 @@ NON_DSN_STATIONS = {
 }
 
 
-def generate_coverage(
+def generate_coverage(  # noqa: PLR0912
     start_time: str,
     outages: dict | None = None,
     dsn: dict | None = None,
@@ -73,16 +73,18 @@ def generate_coverage(
     dsn_outage_mask = np.zeros(time_range.shape, dtype=bool)
     if dsn:
         for dsn_station, dsn_contacts in dsn.items():
-            for start, end in dsn_contacts:
-                start_et = str_to_et(start)
-                end_et = str_to_et(end)
-                dsn_contact_mask |= (time_range >= start_et) & (time_range <= end_et)
+            for contact_start, contact_end in dsn_contacts:
+                contact_start_et = str_to_et(contact_start)
+                contact_end_et = str_to_et(contact_end)
+                dsn_contact_mask |= (time_range >= contact_start_et) & (
+                    time_range <= contact_end_et
+                )
 
-                if outages and dsn_station in outages:
-                    for start, end in outages[dsn_station]:
-                        dsn_outage_mask |= (time_range >= str_to_et(start)) & (
-                            time_range <= str_to_et(end)
-                        )
+            if outages and dsn_station in outages:
+                for outage_start, outage_end in outages[dsn_station]:
+                    dsn_outage_mask |= (time_range >= str_to_et(outage_start)) & (
+                        time_range <= str_to_et(outage_end)
+                    )
 
     dsn_occupied_mask = dsn_contact_mask & ~dsn_outage_mask
 

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -26,6 +26,10 @@ ALL_STATIONS = [
     "DSS-74",
     "DSS-75",
 ]
+# Non-DSN stations must be listed in order of priority.
+NON_DSN_STATIONS = {
+    "Kiel": STATIONS["Kiel"],
+}
 
 
 def generate_coverage(
@@ -55,10 +59,6 @@ def generate_coverage(
     duration_seconds = 24 * 60 * 60  # 86400 seconds in 24 hours
     time_step = 5 * 60  # 5 min in seconds
 
-    # Non-DSN stations must be listed in order of priority.
-    stations = {
-        "Kiel": STATIONS["Kiel"],
-    }
     coverage_dict = {}
     outage_dict = {}
 
@@ -79,7 +79,7 @@ def generate_coverage(
 
     # Blocks later stations.
     non_dsn_occupied_mask = np.zeros(time_range.shape, dtype=bool)
-    for station_name, (lon, lat, alt, min_elevation) in stations.items():
+    for station_name, (lon, lat, alt, min_elevation) in NON_DSN_STATIONS.items():
         _azimuth, elevation = calculate_azimuth_and_elevation(
             lon, lat, alt, time_range, obsref="IAU_EARTH"
         )

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -26,13 +26,9 @@ ALL_STATIONS = [
     "DSS-74",
     "DSS-75",
 ]
-# Non-DSN stations must be listed in order of priority.
-NON_DSN_STATIONS = {
-    "Kiel": STATIONS["Kiel"],
-}
 
 
-def generate_coverage(  # noqa: PLR0912
+def generate_coverage(
     start_time: str,
     outages: dict | None = None,
     dsn: dict | None = None,
@@ -59,6 +55,9 @@ def generate_coverage(  # noqa: PLR0912
     duration_seconds = 24 * 60 * 60  # 86400 seconds in 24 hours
     time_step = 5 * 60  # 5 min in seconds
 
+    stations = {
+        "Kiel": STATIONS["Kiel"],
+    }
     coverage_dict = {}
     outage_dict = {}
 
@@ -68,33 +67,20 @@ def generate_coverage(  # noqa: PLR0912
     time_range = np.arange(start_et_input, stop_et_input, time_step)
     total_visible_mask = np.zeros(time_range.shape, dtype=bool)
 
-    # Precompute DSN occupied mask for non-DSN stations
-    dsn_contact_mask = np.zeros(time_range.shape, dtype=bool)
+    # Precompute DSN outage mask for non-DSN stations
     dsn_outage_mask = np.zeros(time_range.shape, dtype=bool)
     if dsn:
-        for dsn_station, dsn_contacts in dsn.items():
-            for contact_start, contact_end in dsn_contacts:
-                contact_start_et = str_to_et(contact_start)
-                contact_end_et = str_to_et(contact_end)
-                dsn_contact_mask |= (time_range >= contact_start_et) & (
-                    time_range <= contact_end_et
-                )
+        for dsn_contacts in dsn.values():
+            for start, end in dsn_contacts:
+                start_et = str_to_et(start)
+                end_et = str_to_et(end)
+                dsn_outage_mask |= (time_range >= start_et) & (time_range <= end_et)
 
-            if outages and dsn_station in outages:
-                for outage_start, outage_end in outages[dsn_station]:
-                    dsn_outage_mask |= (time_range >= str_to_et(outage_start)) & (
-                        time_range <= str_to_et(outage_end)
-                    )
-
-    dsn_occupied_mask = dsn_contact_mask & ~dsn_outage_mask
-
-    # Blocks later stations.
-    non_dsn_occupied_mask = np.zeros(time_range.shape, dtype=bool)
-    for station_name, (lon, lat, alt, min_elevation) in NON_DSN_STATIONS.items():
+    for station_name, (lon, lat, alt, min_elevation) in stations.items():
         _azimuth, elevation = calculate_azimuth_and_elevation(
             lon, lat, alt, time_range, obsref="IAU_EARTH"
         )
-        visible_unblocked = elevation > min_elevation
+        visible = elevation > min_elevation
 
         outage_mask = np.zeros(time_range.shape, dtype=bool)
         if outages and station_name in outages:
@@ -103,13 +89,9 @@ def generate_coverage(  # noqa: PLR0912
                 end_et = str_to_et(end)
                 outage_mask |= (time_range >= start_et) & (time_range <= end_et)
 
-        # Block this station if DSN is active OR already-occupied by earlier stations
-        unavailable_mask = outage_mask | dsn_occupied_mask | non_dsn_occupied_mask
-        visible = visible_unblocked & ~unavailable_mask
-
-        # This station now occupies these times and will block later stations
-        non_dsn_occupied_mask |= visible
-
+        visible[outage_mask] = False
+        # DSN contacts block other stations
+        visible[dsn_outage_mask] = False
         total_visible_mask |= visible
 
         coverage_dict[station_name] = et_to_utc(time_range[visible], format_str="ISOC")

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -69,13 +69,22 @@ def generate_coverage(
     total_visible_mask = np.zeros(time_range.shape, dtype=bool)
 
     # Precompute DSN occupied mask for non-DSN stations
-    dsn_occupied_mask = np.zeros(time_range.shape, dtype=bool)
+    dsn_contact_mask = np.zeros(time_range.shape, dtype=bool)
+    dsn_outage_mask = np.zeros(time_range.shape, dtype=bool)
     if dsn:
-        for dsn_contacts in dsn.values():
+        for dsn_station, dsn_contacts in dsn.items():
             for start, end in dsn_contacts:
                 start_et = str_to_et(start)
                 end_et = str_to_et(end)
-                dsn_occupied_mask |= (time_range >= start_et) & (time_range <= end_et)
+                dsn_contact_mask |= (time_range >= start_et) & (time_range <= end_et)
+
+                if outages and dsn_station in outages:
+                    for start, end in outages[dsn_station]:
+                        dsn_outage_mask |= (time_range >= str_to_et(start)) & (
+                            time_range <= str_to_et(end)
+                        )
+
+    dsn_occupied_mask = dsn_contact_mask & ~dsn_outage_mask
 
     # Blocks later stations.
     non_dsn_occupied_mask = np.zeros(time_range.shape, dtype=bool)

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -55,6 +55,7 @@ def generate_coverage(
     duration_seconds = 24 * 60 * 60  # 86400 seconds in 24 hours
     time_step = 5 * 60  # 5 min in seconds
 
+    # Non-DSN stations must be listed in order of priority.
     stations = {
         "Kiel": STATIONS["Kiel"],
     }
@@ -67,20 +68,22 @@ def generate_coverage(
     time_range = np.arange(start_et_input, stop_et_input, time_step)
     total_visible_mask = np.zeros(time_range.shape, dtype=bool)
 
-    # Precompute DSN outage mask for non-DSN stations
-    dsn_outage_mask = np.zeros(time_range.shape, dtype=bool)
+    # Precompute DSN occupied mask for non-DSN stations
+    dsn_occupied_mask = np.zeros(time_range.shape, dtype=bool)
     if dsn:
         for dsn_contacts in dsn.values():
             for start, end in dsn_contacts:
                 start_et = str_to_et(start)
                 end_et = str_to_et(end)
-                dsn_outage_mask |= (time_range >= start_et) & (time_range <= end_et)
+                dsn_occupied_mask |= (time_range >= start_et) & (time_range <= end_et)
 
+    # Blocks later stations.
+    non_dsn_occupied_mask = np.zeros(time_range.shape, dtype=bool)
     for station_name, (lon, lat, alt, min_elevation) in stations.items():
         _azimuth, elevation = calculate_azimuth_and_elevation(
             lon, lat, alt, time_range, obsref="IAU_EARTH"
         )
-        visible = elevation > min_elevation
+        visible_unblocked = elevation > min_elevation
 
         outage_mask = np.zeros(time_range.shape, dtype=bool)
         if outages and station_name in outages:
@@ -89,9 +92,13 @@ def generate_coverage(
                 end_et = str_to_et(end)
                 outage_mask |= (time_range >= start_et) & (time_range <= end_et)
 
-        visible[outage_mask] = False
-        # DSN contacts block other stations
-        visible[dsn_outage_mask] = False
+        # Block this station if DSN is active OR already-occupied by earlier stations
+        unavailable_mask = outage_mask | dsn_occupied_mask | non_dsn_occupied_mask
+        visible = visible_unblocked & ~unavailable_mask
+
+        # This station now occupies these times and will block later stations
+        non_dsn_occupied_mask |= visible
+
         total_visible_mask |= visible
 
         coverage_dict[station_name] = et_to_utc(time_range[visible], format_str="ISOC")

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -1,11 +1,14 @@
 """Test processEphemeris functions."""
 
-from datetime import datetime
+from datetime import datetime, time
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
 from imap_processing.ialirt.generate_coverage import (
+    create_schedule_mask,
     format_coverage_summary,
     generate_coverage,
 )
@@ -109,3 +112,58 @@ def test_dsn(furnish_kernels):
 
         assert "I-ALiRT Coverage Summary" in output["summary"]
         assert 40.6 == output["total_coverage_percent"]
+
+
+@patch("imap_processing.ialirt.generate_coverage.et_to_utc")
+def test_create_schedule_mask(mock_et_to_utc):
+    """
+    Test create_schedule_mask.
+    """
+
+    mock_et_to_utc.return_value = np.array(
+        [
+            "2026-09-22T11:30:00.000",
+            "2026-09-22T11:35:00.000",
+            "2026-09-22T11:40:00.000",
+            "2026-09-22T11:45:00.000",
+            "2026-09-22T11:50:00.000",
+            "2026-09-22T11:55:00.000",
+            "2026-09-22T12:00:00.000",
+            "2026-09-22T12:05:00.000",
+            "2026-09-22T12:10:00.000",
+            "2026-09-22T12:15:00.000",
+            "2026-09-22T12:20:00.000",
+            "2026-09-22T12:25:00.000",
+            "2026-09-22T12:30:00.000",
+        ]
+    )
+
+    time_range = np.arange(13)
+
+    station = SimpleNamespace(
+        schedule_start=time(12, 0),
+        schedule_end=None,
+    )
+
+    mask = create_schedule_mask(station, time_range)
+
+    expected = np.array(
+        [
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+        ],
+        dtype=bool,
+    )
+
+    np.testing.assert_array_equal(mask, expected)

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -1,10 +1,12 @@
 """Test processEphemeris functions."""
 
 from datetime import datetime
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+from imap_processing.ialirt.constants import STATIONS
 from imap_processing.ialirt.generate_coverage import (
     format_coverage_summary,
     generate_coverage,
@@ -109,3 +111,50 @@ def test_dsn(furnish_kernels):
 
         assert "I-ALiRT Coverage Summary" in output["summary"]
         assert 40.6 == output["total_coverage_percent"]
+
+
+@pytest.mark.external_kernel
+def test_non_dsn_priority_blocking_with_kernels(furnish_kernels):
+    "Test that non-dsn station block other non-dsn stations."
+    kernels = ["naif0012.tls", "pck00011.tpc", "de440s.bsp", "imap_spk_demo.bsp"]
+    start_time = "2026-09-22T00:00:00Z"
+
+    with furnish_kernels(kernels):
+        # Kiel-only coverage
+        with patch(
+            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
+            new={"Kiel": STATIONS["Kiel"]},
+        ):
+            cov_kiel, _ = generate_coverage(start_time)
+
+        kiel_times = cov_kiel["Kiel"]
+
+        # Manaus-only coverage
+        with patch(
+            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
+            new={"Manaus": STATIONS["Manaus"]},
+        ):
+            cov_manaus_only, _ = generate_coverage(start_time)
+
+        manaus_only_times = cov_manaus_only["Manaus"]
+
+        overlap = np.intersect1d(kiel_times, manaus_only_times)
+        # Assert the times overlap.
+        assert overlap.size > 0
+
+        # Kiel first, then Manaus
+        with patch(
+            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
+            new={
+                "Kiel": STATIONS["Kiel"],
+                "Manaus": STATIONS["Manaus"],
+            },
+        ):
+            coverage, _ = generate_coverage(start_time)
+
+        manaus_coverage = coverage["Manaus"]
+
+        # Manaus should have no overlap with Kiel.
+        blocked_overlap = np.intersect1d(kiel_times, manaus_coverage)
+        assert blocked_overlap.size == 0
+        assert manaus_coverage[0] > kiel_times[-1]

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -1,12 +1,10 @@
 """Test processEphemeris functions."""
 
 from datetime import datetime
-from unittest.mock import patch
 
 import numpy as np
 import pytest
 
-from imap_processing.ialirt.constants import STATIONS
 from imap_processing.ialirt.generate_coverage import (
     format_coverage_summary,
     generate_coverage,
@@ -110,107 +108,4 @@ def test_dsn(furnish_kernels):
         )
 
         assert "I-ALiRT Coverage Summary" in output["summary"]
-        assert 42.0 == output["total_coverage_percent"]
-
-
-@pytest.mark.external_kernel
-def test_non_dsn_priority_blocking_with_kernels(furnish_kernels):
-    "Test that non-dsn station block other non-dsn stations."
-    kernels = ["naif0012.tls", "pck00011.tpc", "de440s.bsp", "imap_spk_demo.bsp"]
-    start_time = "2026-09-22T00:00:00Z"
-
-    with furnish_kernels(kernels):
-        # Kiel-only coverage
-        with patch(
-            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
-            new={"Kiel": STATIONS["Kiel"]},
-        ):
-            coverage_kiel, _ = generate_coverage(start_time)
-
-        kiel_times = coverage_kiel["Kiel"]
-
-        # Manaus-only coverage
-        with patch(
-            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
-            new={"Manaus": STATIONS["Manaus"]},
-        ):
-            coverage_manaus_only, _ = generate_coverage(start_time)
-
-        manaus_only_times = coverage_manaus_only["Manaus"]
-
-        overlap = np.intersect1d(kiel_times, manaus_only_times)
-        # Assert the times overlap.
-        assert overlap.size > 0
-
-        # Kiel first, then Manaus
-        with patch(
-            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
-            new={
-                "Kiel": STATIONS["Kiel"],
-                "Manaus": STATIONS["Manaus"],
-            },
-        ):
-            coverage, _ = generate_coverage(start_time)
-
-        manaus_coverage = coverage["Manaus"]
-
-        # Manaus should have no overlap with Kiel.
-        blocked_overlap = np.intersect1d(kiel_times, manaus_coverage)
-        assert blocked_overlap.size == 0
-        assert manaus_coverage[0] > kiel_times[-1]
-
-
-@pytest.mark.external_kernel
-def test_dsn_outage_allows_ground_station_coverage(furnish_kernels):
-    """
-    DSN contacts block non-DSN stations, but DSN outages remove blocking.
-    """
-    kernels = ["naif0012.tls", "pck00011.tpc", "de440s.bsp", "imap_spk_demo.bsp"]
-    start_time = "2026-09-22T00:00:00Z"
-
-    with furnish_kernels(kernels):
-        # Baseline Kiel-only coverage (no DSN)
-        with patch(
-            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
-            new={"Kiel": STATIONS["Kiel"]},
-        ):
-            coverage_base, _ = generate_coverage(start_time)
-
-        kiel_times = coverage_base["Kiel"]
-
-        contact_start = kiel_times[10]  # inside Kiel coverage
-        contact_end = kiel_times[16]  # 30 min later (inclusive logic in your code)
-
-        # Outage inside the DSN contact
-        outage_start = kiel_times[12]
-        outage_end = kiel_times[14]
-
-        dsn = {"DSS-75": [(contact_start, contact_end)]}
-
-        # DSN contact, no DSN outage
-        # Kiel should be blocked during the full contact window
-        with patch(
-            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
-            new={"Kiel": STATIONS["Kiel"]},
-        ):
-            coverage_blocked, _ = generate_coverage(start_time, dsn=dsn, outages=None)
-
-        kiel_blocked = coverage_blocked["Kiel"]
-
-        assert not np.any(np.isin(kiel_times[10:16], kiel_blocked))
-
-        # DSN contact + DSN outage
-        # Kiel allowed during outage sub-window
-        outages = {"DSS-75": [(outage_start, outage_end)]}
-
-        with patch(
-            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
-            new={"Kiel": STATIONS["Kiel"]},
-        ):
-            coverage_punched, _ = generate_coverage(
-                start_time, dsn=dsn, outages=outages
-            )
-
-        kiel_punched = coverage_punched["Kiel"]
-
-        assert np.all(np.isin(kiel_times[12:14], kiel_punched))
+        assert 40.6 == output["total_coverage_percent"]

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -110,7 +110,7 @@ def test_dsn(furnish_kernels):
         )
 
         assert "I-ALiRT Coverage Summary" in output["summary"]
-        assert 40.6 == output["total_coverage_percent"]
+        assert 42.0 == output["total_coverage_percent"]
 
 
 @pytest.mark.external_kernel

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -125,18 +125,18 @@ def test_non_dsn_priority_blocking_with_kernels(furnish_kernels):
             "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
             new={"Kiel": STATIONS["Kiel"]},
         ):
-            cov_kiel, _ = generate_coverage(start_time)
+            coverage_kiel, _ = generate_coverage(start_time)
 
-        kiel_times = cov_kiel["Kiel"]
+        kiel_times = coverage_kiel["Kiel"]
 
         # Manaus-only coverage
         with patch(
             "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
             new={"Manaus": STATIONS["Manaus"]},
         ):
-            cov_manaus_only, _ = generate_coverage(start_time)
+            coverage_manaus_only, _ = generate_coverage(start_time)
 
-        manaus_only_times = cov_manaus_only["Manaus"]
+        manaus_only_times = coverage_manaus_only["Manaus"]
 
         overlap = np.intersect1d(kiel_times, manaus_only_times)
         # Assert the times overlap.
@@ -158,3 +158,59 @@ def test_non_dsn_priority_blocking_with_kernels(furnish_kernels):
         blocked_overlap = np.intersect1d(kiel_times, manaus_coverage)
         assert blocked_overlap.size == 0
         assert manaus_coverage[0] > kiel_times[-1]
+
+
+@pytest.mark.external_kernel
+def test_dsn_outage_allows_ground_station_coverage(furnish_kernels):
+    """
+    DSN contacts block non-DSN stations, but DSN outages remove blocking.
+    """
+    kernels = ["naif0012.tls", "pck00011.tpc", "de440s.bsp", "imap_spk_demo.bsp"]
+    start_time = "2026-09-22T00:00:00Z"
+
+    with furnish_kernels(kernels):
+        # Baseline Kiel-only coverage (no DSN)
+        with patch(
+            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
+            new={"Kiel": STATIONS["Kiel"]},
+        ):
+            coverage_base, _ = generate_coverage(start_time)
+
+        kiel_times = coverage_base["Kiel"]
+
+        contact_start = kiel_times[10]  # inside Kiel coverage
+        contact_end = kiel_times[16]  # 30 min later (inclusive logic in your code)
+
+        # Outage inside the DSN contact
+        outage_start = kiel_times[12]
+        outage_end = kiel_times[14]
+
+        dsn = {"DSS-75": [(contact_start, contact_end)]}
+
+        # DSN contact, no DSN outage
+        # Kiel should be blocked during the full contact window
+        with patch(
+            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
+            new={"Kiel": STATIONS["Kiel"]},
+        ):
+            coverage_blocked, _ = generate_coverage(start_time, dsn=dsn, outages=None)
+
+        kiel_blocked = coverage_blocked["Kiel"]
+
+        assert not np.any(np.isin(kiel_times[10:16], kiel_blocked))
+
+        # DSN contact + DSN outage
+        # Kiel allowed during outage sub-window
+        outages = {"DSS-75": [(outage_start, outage_end)]}
+
+        with patch(
+            "imap_processing.ialirt.generate_coverage.NON_DSN_STATIONS",
+            new={"Kiel": STATIONS["Kiel"]},
+        ):
+            coverage_punched, _ = generate_coverage(
+                start_time, dsn=dsn, outages=outages
+            )
+
+        kiel_punched = coverage_punched["Kiel"]
+
+        assert np.all(np.isin(kiel_times[12:14], kiel_punched))


### PR DESCRIPTION
# Change Summary

## Overview
I've been asked to start to plan for overlapping stations and creating schedules for them. 

## Updated Files
- generate_coverage.py
   - Handle stations so that they get priority. For example, we will always seek the most coverage from Kiel and inform other stations to not attempt to take data when Kiel is available. 
   - Add capability for stations to fill in gaps if there is ever a DSN outage.

## Testing
- test_generate_coverage.py