### PR TITLE
MNT/FIX: Rename Lo background column to rate/sigma instead of type

### DIFF
--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -1078,9 +1078,9 @@ def set_background_rates(
         # for each energy step, set the background rate and uncertainty
         for esa_step in range(0, 7):
             value = row[f"E-Step{esa_step + 1}"]
-            if row["type"] == "rate":
+            if row["rate/sigma"] == "rate":
                 bg_rates[esa_step, bin_start:bin_end, :] = value
-            elif row["type"] == "sigma":
+            elif row["rate/sigma"] == "sigma":
                 bg_sys_err[esa_step, bin_start:bin_end, :] = value
             else:
                 raise ValueError("Unknown background type in ancillary file.")

--- a/imap_processing/tests/lo/test_anc/imap_lo_hydrogen-background-small_20250101_20270101_v001.csv
+++ b/imap_processing/tests/lo/test_anc/imap_lo_hydrogen-background-small_20250101_20270101_v001.csv
@@ -1,4 +1,4 @@
-YYYYDDD,GoodTime_start,GoodTime_end,bin_start,bin_end,Lo,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,type
+YYYYDDD,GoodTime_start,GoodTime_end,bin_start,bin_end,Lo,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,rate/sigma
 2025001,473389200.0,473472000.0,0,1,Lo,0.0098,0.0089,0.0118,0.0113,0.0056,0.0008,0.0000,rate
 2025001,473389200.0,473472000.0,0,1,Lo,0.0025,0.0020,0.0015,0.0015,0.0010,0.0008,0.0000,sigma
 2025001,473389200.0,473472000.0,1,2,Lo,0.0098,0.0089,0.0118,0.0113,0.0056,0.0008,0.0000,rate

--- a/imap_processing/tests/lo/test_anc/imap_lo_oxygen-background-small_20250101_20270101_v001.csv
+++ b/imap_processing/tests/lo/test_anc/imap_lo_oxygen-background-small_20250101_20270101_v001.csv
@@ -1,4 +1,4 @@
-YYYYDDD,GoodTime_start,GoodTime_end,bin_start,bin_end,Lo,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,type
+YYYYDDD,GoodTime_start,GoodTime_end,bin_start,bin_end,Lo,E-Step1,E-Step2,E-Step3,E-Step4,E-Step5,E-Step6,E-Step7,rate/sigma
 2025001,473389200.0,473472000.0,0,1,Lo,0.0098,0.0089,0.0118,0.0113,0.0056,0.0008,0.0000,rate
 2025001,473389200.0,473472000.0,0,1,Lo,0.0025,0.0020,0.0015,0.0015,0.0010,0.0008,0.0000,sigma
 2025001,473389200.0,473472000.0,1,2,Lo,0.0098,0.0089,0.0118,0.0113,0.0056,0.0008,0.0000,rate


### PR DESCRIPTION
# Change Summary

Lo changed the name of this in their ancillary dependency apparently, so updating here for the pipeline.

```
Processing IMAP-Lo l1c
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3641, in get_loc
    return self._engine.get_loc(casted_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pandas/_libs/index.pyx", line 168, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 197, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7668, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7676, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'type'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/usr/local/bin/imap_cli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/site-packages/imap_processing/cli.py", line 1604, in main
    instrument.process()
  File "/usr/local/lib/python3.12/site-packages/imap_processing/cli.py", line 447, in process
    products = self.do_processing(dependencies)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/imap_processing/cli.py", line 1053, in do_processing
    datasets = lo_l1c.lo_l1c(data_dict, anc_dependencies)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/imap_processing/lo/l1c/lo_l1c.py", line 172, in lo_l1c
    ) = set_background_rates(
        ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/imap_processing/lo/l1c/lo_l1c.py", line 1081, in set_background_rates
    if row["type"] == "rate":
       ~~~^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pandas/core/series.py", line 959, in __getitem__
    return self._get_value(key)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pandas/core/series.py", line 1046, in _get_value
    loc = self.index.get_loc(label)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3648, in get_loc
    raise KeyError(key) from err
KeyError: 'type'
```