### PR TITLE
Fix 'Getting started' link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Join the IMAP Git repository to be part of an exciting scientific endeavor, cont
 
 [IMAP Processing Documentation](https://imap-processing.readthedocs.io/en/latest/)
 
-[Getting started](https://imap-processing.readthedocs.io/en/latest/development-guide/getting-started.html)
+[Getting started](https://imap-processing.readthedocs.io/en/latest/development/index.html)
 
 # Credits
 [LASP (Laboratory of Atmospheric and Space Physics)](https://lasp.colorado.edu/)


### PR DESCRIPTION
Updated the link for the 'Getting started' section in the README. Noticed this link went to 404.
