### PR TITLE
Rename function to find_last_de_packet_data

### DIFF
--- a/imap_processing/hi/hi_l1c.py
+++ b/imap_processing/hi/hi_l1c.py
@@ -628,7 +628,7 @@ def find_last_de_packet_data(l1b_dataset: xr.Dataset) -> xr.Dataset:
     # We don't need to worry about checking that the right number of packets
     # is present for each ESA step because that is done in the Goodtimes processing.
 
-    # Reduce the dataset to just the second packet entries
+    # Reduce the dataset to just the last packet entries
     data_subset = epoch_dataset.isel(epoch=last_esa_packet_idx)
     return data_subset
 

--- a/imap_processing/hi/hi_l1c.py
+++ b/imap_processing/hi/hi_l1c.py
@@ -605,7 +605,7 @@ def find_last_de_packet_data(l1b_dataset: xr.Dataset) -> xr.Dataset:
     # Get the indices of the packet before each ESA change.
     esa_step = epoch_dataset["esa_step"].values
     esa_energy_step = epoch_dataset["esa_energy_step"].values
-    # A change in esa_step should indicate the location of the second packet in
+    # A change in esa_step should indicate the location of the last packet in
     # each pair of DE packets at an esa_energy_step. In practice, during some
     # calibration activities, it was observed that the esa_energy_step can change
     # when the esa_step did not. So, we look for either to change and use the

--- a/imap_processing/hi/hi_l1c.py
+++ b/imap_processing/hi/hi_l1c.py
@@ -539,7 +539,7 @@ def pset_exposure(
 
     # Get a subset of the l1b_de_dataset that contains only the second
     # of each pair of packets at an ESA step.
-    data_subset = find_second_de_packet_data(l1b_de_dataset)
+    data_subset = find_last_de_packet_data(l1b_de_dataset)
 
     # Get the pandas dataframe with spin data
     spin_df = get_spin_data()
@@ -586,9 +586,9 @@ def pset_exposure(
     return exposure_var
 
 
-def find_second_de_packet_data(l1b_dataset: xr.Dataset) -> xr.Dataset:
+def find_last_de_packet_data(l1b_dataset: xr.Dataset) -> xr.Dataset:
     """
-    Find the telemetry entries for the second packet at an ESA step.
+    Find the telemetry entries for the last packet at an ESA step.
 
     Parameters
     ----------
@@ -598,10 +598,10 @@ def find_second_de_packet_data(l1b_dataset: xr.Dataset) -> xr.Dataset:
     Returns
     -------
     reduced_dataset : xarray.Dataset
-        A dataset containing only the entries for the second packet at an ESA step.
+        A dataset containing only the entries for the last packet at an ESA step.
     """
     epoch_dataset = l1b_dataset.drop_dims("event_met")
-    # We should get two CCSDS packets per 8-spin ESA step.
+    # We should get 2, 4, or 8 CCSDS packets per 8-spin ESA step.
     # Get the indices of the packet before each ESA change.
     esa_step = epoch_dataset["esa_step"].values
     esa_energy_step = epoch_dataset["esa_energy_step"].values
@@ -609,40 +609,27 @@ def find_second_de_packet_data(l1b_dataset: xr.Dataset) -> xr.Dataset:
     # each pair of DE packets at an esa_energy_step. In practice, during some
     # calibration activities, it was observed that the esa_energy_step can change
     # when the esa_step did not. So, we look for either to change and use the
-    # indices of those changes to identify the second packet in each pair. We
-    # also need to add the last packet index and assume an energy step change
-    # occurs after the last packet.
-    second_esa_packet_idx = np.append(
+    # indices of those changes to identify the last packet in each set. We
+    # also need to add the final packet index and assume an energy step change
+    # occurs after the final packet.
+    last_esa_packet_idx = np.append(
         np.flatnonzero((np.diff(esa_step) != 0) | (np.diff(esa_energy_step) != 0)),
         len(esa_step) - 1,
     )
     # Remove esa energy steps at 0 - these are calibrations
-    keep_mask = esa_energy_step[second_esa_packet_idx] != 0
+    keep_mask = esa_energy_step[last_esa_packet_idx] != 0
     # Remove esa energy steps at FILLVAL - these are unidentified
     keep_mask &= (
-        esa_energy_step[second_esa_packet_idx]
+        esa_energy_step[last_esa_packet_idx]
         != l1b_dataset["esa_energy_step"].attrs["FILLVAL"]
     )
-    second_esa_packet_idx = second_esa_packet_idx[keep_mask]
-    # Remove indices where we don't have two consecutive packets at the same ESA
-    if second_esa_packet_idx[0] == 0:
-        logger.warning(
-            f"Removing packet 0 with ESA step: {esa_step[0]} from"
-            f"calculation of exposure time due to missing matched pair."
-        )
-        second_esa_packet_idx = second_esa_packet_idx[1:]
-    missing_esa_pair_mask = (
-        esa_energy_step[second_esa_packet_idx - 1]
-        != esa_energy_step[second_esa_packet_idx]
-    )
-    if missing_esa_pair_mask.any():
-        logger.warning(
-            f"Removing {missing_esa_pair_mask.sum()} packets from exposure "
-            f"time calculation due to missing ESA step DE packet pairs."
-        )
-    second_esa_packet_idx = second_esa_packet_idx[~missing_esa_pair_mask]
+    last_esa_packet_idx = last_esa_packet_idx[keep_mask]
+
+    # We don't need to worry about checking that the right number of packets
+    # is present for each ESA step because that is done in the Goodtimes processing.
+
     # Reduce the dataset to just the second packet entries
-    data_subset = epoch_dataset.isel(epoch=second_esa_packet_idx)
+    data_subset = epoch_dataset.isel(epoch=last_esa_packet_idx)
     return data_subset
 
 

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -455,9 +455,9 @@ def test_pset_backgrounds():
 @mock.patch("imap_processing.hi.hi_l1c.get_spin_data", return_value=None)
 @mock.patch("imap_processing.hi.hi_l1c.get_instrument_spin_phase")
 @mock.patch("imap_processing.hi.hi_l1c.get_de_clock_ticks_for_esa_step")
-@mock.patch("imap_processing.hi.hi_l1c.find_second_de_packet_data")
+@mock.patch("imap_processing.hi.hi_l1c.find_last_de_packet_data")
 def test_pset_exposure(
-    mock_find_second_de_packet_data,
+    mock_find_last_de_packet_data,
     mock_de_clock_ticks,
     mock_spin_phase,
     mock_spin_data,
@@ -471,10 +471,10 @@ def test_pset_exposure(
     empty_pset = hi_l1c.empty_pset_dataset(
         100, l1b_energy_steps, np.array([0, 1]), HIAPID.H90_SCI_DE.sensor
     )
-    # Set the mock of find_second_de_packet_data to return a xr.Dataset
+    # Set the mock of find_last_de_packet_data to return a xr.Dataset
     # with some dummy data. ESA 1 will get binned data once, ESA 2 will get
     # binned data twice.
-    mock_find_second_de_packet_data.return_value = xr.Dataset(
+    mock_find_last_de_packet_data.return_value = xr.Dataset(
         coords={"epoch": xr.DataArray(np.arange(3), dims=["epoch"])},
         data_vars={
             "ccsds_met": xr.DataArray(np.arange(3), dims=["epoch"]),
@@ -528,10 +528,8 @@ def test_find_second_de_packet_data():
     # esa_energy: 1  2  2  3  3  4  5  5  6  6  0  0  7  7
     #
     # Expected second packet indices from diff logic: [0, 2, 4, 5, 7, 9, 11, 13]
-    # Remove index 0: missing pair (first packet in series)
-    # Remove index 5: esa_energy_step 4 doesn't match previous packet's 3
     # Remove index 11: esa_energy_step is 0 (calibration)
-    # Expected final indices: [2, 4, 7, 9, 13]
+    # Expected final indices: [0, 2, 4, 5, 7, 9, 13]
     esa_steps = np.array([1, 2, 2, 2, 2, 4, 5, 5, 6, 6, 0, 0, 7, 7])
     esa_energy_steps = np.array([1, 2, 2, 3, 3, 4, 5, 5, 6, 6, 0, 0, 7, 7])
     l1b_dataset = xr.Dataset(
@@ -561,8 +559,8 @@ def test_find_second_de_packet_data():
             ),
         },
     )
-    subset = hi_l1c.find_second_de_packet_data(l1b_dataset)
-    np.testing.assert_array_equal(subset.epoch.data, np.array([2, 4, 7, 9, 13]))
+    subset = hi_l1c.find_last_de_packet_data(l1b_dataset)
+    np.testing.assert_array_equal(subset.epoch.data, np.array([0, 2, 4, 5, 7, 9, 13]))
 
 
 @pytest.fixture(scope="module")

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -527,7 +527,7 @@ def test_find_second_de_packet_data():
     # esa_step:   1  2  2  2  2  4  5  5  6  6  0  0  7  7
     # esa_energy: 1  2  2  3  3  4  5  5  6  6  0  0  7  7
     #
-    # Expected second packet indices from diff logic: [0, 2, 4, 5, 7, 9, 11, 13]
+    # Expected last packet indices from diff logic: [0, 2, 4, 5, 7, 9, 11, 13]
     # Remove index 11: esa_energy_step is 0 (calibration)
     # Expected final indices: [0, 2, 4, 5, 7, 9, 13]
     esa_steps = np.array([1, 2, 2, 2, 2, 4, 5, 5, 6, 6, 0, 0, 7, 7])


### PR DESCRIPTION
Remove logic that checks for 2 DE packets at each ESA step

# Change Summary
Hi told me that the instrument will not always be configured to have 2 DE packets per 8-spin ESA step. This was a minor change to remove the references to the 2 DE packets. It also removes some logic that would remove last packet indices if 2 packets at that ESA are not present. This logic duplicates a check that occurs in Hi Goodtimes.
