### PR TITLE
FIX: Lo pivot angle needs to be from the middle of a pointing

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -274,7 +274,7 @@ def l1b_de(
     # Initialize the L1B DE dataset
     l1b_de = initialize_l1b_de(l1a_de, attr_mgr_l1b, logical_source)
     # Get the pivot angle from the housekeeping dataset
-    pivot_angle = _get_nearest_pivot_angle(l1b_de["epoch"].values[0], l1b_nhk)
+    pivot_angle = get_pivot_angle_from_nhk(l1b_nhk)
     l1b_de["pivot_angle"] = xr.DataArray([pivot_angle], dims=["pivot_angle"])
 
     pointing_start_met, pointing_end_met = get_pointing_times(
@@ -1922,14 +1922,15 @@ def calculate_de_rates(
     return ds
 
 
-def _get_nearest_pivot_angle(epoch: int, ds_nhk: xr.Dataset) -> float:
+def get_pivot_angle_from_nhk(ds_nhk: xr.Dataset) -> float:
     """
-    Get the nearest pivot angle for the given epoch from the NHK dataset.
+    Get the middle pivot angle from the NHK dataset.
+
+    The pivot platform moves at the beginning of each pointing period, so we
+    don't want to be near one of the start/end times, so just grab the middle value.
 
     Parameters
     ----------
-    epoch : int
-        The epoch in TTJ2000ns format.
     ds_nhk : xr.Dataset
         The NHK dataset containing pivot angle information.
 
@@ -1938,7 +1939,8 @@ def _get_nearest_pivot_angle(epoch: int, ds_nhk: xr.Dataset) -> float:
     pivot_angle : float
         The nearest pivot angle for the given epoch.
     """
-    return ds_nhk["pcc_cumulative_cnt_pri"].sel(epoch=epoch, method="nearest").item()
+    nitems = len(ds_nhk["pcc_cumulative_cnt_pri"])
+    return ds_nhk["pcc_cumulative_cnt_pri"].isel(epoch=nitems // 2).item()
 
 
 def _get_esa_level_indices(epochs: np.ndarray, anc_dependencies: list) -> np.ndarray:

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -23,6 +23,7 @@ from imap_processing.lo.l1b.lo_l1b import (
     create_datasets,
     filter_valid_star_records,
     get_avg_spin_durations_per_cycle,
+    get_pivot_angle_from_nhk,
     get_sampling_cadence_from_nhk,
     get_spin_start_times,
     identify_species,
@@ -2156,3 +2157,22 @@ class TestL1bStar:
         assert (
             l1b_star_ds.coords["epoch"].values[2] == met_to_ttj2000ns([128 * 15.0])[0]
         )
+
+
+def test_get_pivot_angle_from_nhk():
+    """Test get_pivot_angle_from_nhk function."""
+    # Arrange - Create a mock NHK dataset with pivot angle information
+    l1b_nhk = xr.Dataset(
+        {
+            # Previous 90 degrees at the beginning, then shifted to 75 degrees
+            "pcc_cumulative_cnt_pri": ("epoch", [90, 90, 75, 75, 75, 75, 75]),
+        },
+        coords={"epoch": [0, 1, 2, 3, 4, 5, 6]},
+    )
+    expected_pivot_angle = 75
+
+    # Act
+    pivot_angle = get_pivot_angle_from_nhk(l1b_nhk)
+
+    # Assert
+    assert pivot_angle == expected_pivot_angle


### PR DESCRIPTION
The start of a pointing has periods where the pivot angle is still at the previous position. Then it moves and sustains the new angle throughout the rest of the pointing. To account for this, we can use the middle value from the NHK dataset during that pointing.

closes #2672
