### PR TITLE
I-ALiRT - remove duplicates

### DIFF
--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -16,7 +16,7 @@ def packets_created(start_file_creation: datetime, lines: list) -> dict:
     Parameters
     ----------
     start_file_creation : datetime
-        File creation time of last file minus 5 minutes.
+        File creation time of last file minus 48 hrs.
     lines : list
         All lines of log files.
 

--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -16,7 +16,7 @@ def packets_created(start_file_creation: datetime, lines: list) -> dict:
     Parameters
     ----------
     start_file_creation : datetime
-        File creation time of last file minus 48 hrs.
+        File creation time of last file minus 5 minutes.
     lines : list
         All lines of log files.
 
@@ -64,8 +64,9 @@ def packets_created(start_file_creation: datetime, lines: list) -> dict:
                 .isoformat()
                 .replace("+00:00", "Z")
             )
-            station_dict[station]["last_data_received"].append(dt)
-            station_dict[station]["rate_kbps"].append(rate)
+            if dt not in station_dict[station]["last_data_received"]:
+                station_dict[station]["last_data_received"].append(dt)
+                station_dict[station]["rate_kbps"].append(rate)
 
     return station_dict
 

--- a/imap_processing/ialirt/l0/process_codice.py
+++ b/imap_processing/ialirt/l0/process_codice.py
@@ -350,9 +350,9 @@ def calculate_ratios(
         mg_over_o_abundance = mg_over_o_abundance_num / o_abundance_denom
         fe_over_o_abundance = fe_over_o_abundance_num / o_abundance_denom
 
-        c_over_o_abundance = Decimal(f"{float(c_over_o_abundance):.3f}")
-        mg_over_o_abundance = Decimal(f"{float(mg_over_o_abundance):.3f}")
-        fe_over_o_abundance = Decimal(f"{float(fe_over_o_abundance):.3f}")
+        c_over_o_abundance = Decimal(f"{float(c_over_o_abundance):.6f}")
+        mg_over_o_abundance = Decimal(f"{float(mg_over_o_abundance):.6f}")
+        fe_over_o_abundance = Decimal(f"{float(fe_over_o_abundance):.6f}")
     else:
         c_over_o_abundance, mg_over_o_abundance, fe_over_o_abundance = (
             None,
@@ -365,7 +365,7 @@ def calculate_ratios(
             pseudo_density_dict["cplus6"] / pseudo_density_dict["cplus5"]
         )
 
-        c_plus_6_over_c_plus_5 = Decimal(f"{float(c_plus_6_over_c_plus_5):.3f}")
+        c_plus_6_over_c_plus_5 = Decimal(f"{float(c_plus_6_over_c_plus_5):.6f}")
     else:
         c_plus_6_over_c_plus_5 = None
 
@@ -373,7 +373,7 @@ def calculate_ratios(
         o_plus_7_over_o_plus_6 = (
             pseudo_density_dict["oplus7"] / pseudo_density_dict["oplus6"]
         )
-        o_plus_7_over_o_plus_6 = Decimal(f"{float(o_plus_7_over_o_plus_6):.3f}")
+        o_plus_7_over_o_plus_6 = Decimal(f"{float(o_plus_7_over_o_plus_6):.6f}")
     else:
         o_plus_7_over_o_plus_6 = None
 
@@ -381,7 +381,7 @@ def calculate_ratios(
         fe_low_over_fe_high = (
             pseudo_density_dict["fe_loq"] / pseudo_density_dict["fe_hiq"]
         )
-        fe_low_over_fe_high = Decimal(f"{float(fe_low_over_fe_high):.3f}")
+        fe_low_over_fe_high = Decimal(f"{float(fe_low_over_fe_high):.6f}")
     else:
         fe_low_over_fe_high = None
 


### PR DESCRIPTION
# Change Summary

## Overview
The script calculate_ingest.py is meant to parse the log files and return information on when packets are ingested as a function of station. This is then used to help provide info to stations to understand if their ingest has been successful. However, it was appearing like this:

  "Kiel": {
    "last_data_received": [      "2026-02-06T14:54:01Z",
      "2026-02-06T14:54:01Z",
      "2026-02-06T14:54:01Z",
      "2026-02-06T14:54:01Z",
      "2026-02-06T14:54:01Z"]

With many unwanted duplicates. This PR removes those duplicate values.

Also I did a quick fix for CoDICE because they wanted more floating points in their data product.

## Updated Files
- calculate_ingest.py
   - Removed duplicates
- process_codice.py
   - Changed floating points