### PR TITLE
ULTRA l1a image processing error handling

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1a.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1a.py
@@ -1,8 +1,5 @@
 """Test ULTRA L1a CDFs."""
 
-import logging
-from unittest import mock
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -522,33 +519,3 @@ def test_get_event_id():
         counters_for_met.append(event_id & np.int64(0x7FFFFFFF))
 
     assert counters_for_met == [0, 0, 0, 1]
-
-
-def test_tof_decompression_error_handling(ccsds_path_tof_high_angular, caplog):
-    """Test that ultra_l1a handles TOF decom errors gracefully."""
-
-    caplog.set_level(logging.ERROR)
-
-    # Create side effect function to simulate IndexError
-    def mock_process_ultra_tof(*args):
-        raise IndexError(
-            "Attempted to read past the end of binary string. "
-            "Current position: 32648, Requested bits: 4, String length: 32648"
-        )
-
-    # Use monkeypatch to replace process_ultra_tof
-    with mock.patch(
-        "imap_processing.ultra.l1a.ultra_l1a.process_ultra_tof"
-    ) as mocked_tof:
-        mocked_tof.side_effect = mock_process_ultra_tof
-
-        # Should NOT raise an exception - should catch and log
-        result = ultra_l1a(
-            ccsds_path_tof_high_angular, apid_input=ULTRA_PHXTOF_HIGH_ANGULAR.apid[0]
-        )
-
-    # Test that the result is still returned
-    assert isinstance(result, list)
-
-    # Verify error was logged
-    assert "Error processing TOF data" in caplog.text

--- a/imap_processing/ultra/l1a/ultra_l1a.py
+++ b/imap_processing/ultra/l1a/ultra_l1a.py
@@ -129,18 +129,10 @@ def ultra_l1a(  # noqa: PLR0912
                 gattr_key = ULTRA_AUX.logical_source[ULTRA_AUX.apid.index(apid)]
             elif apid in all_l1a_image_apids:
                 packet_props = all_l1a_image_apids[apid]
-                # TODO there is a known issue with the decom of some tof packets.
-                #   This is being tracked in issue #2557.
-                try:
-                    decom_ultra_dataset = process_ultra_tof(
-                        datasets_by_apid[apid], packet_props
-                    )
-                    gattr_key = packet_props.logical_source[
-                        packet_props.apid.index(apid)
-                    ]
-                except IndexError as e:
-                    logger.error(f"Error processing TOF data for APID {apid}: {e}")
-                    continue
+                decom_ultra_dataset = process_ultra_tof(
+                    datasets_by_apid[apid], packet_props
+                )
+                gattr_key = packet_props.logical_source[packet_props.apid.index(apid)]
             elif apid in ULTRA_RATES.apid:
                 decom_ultra_dataset = process_ultra_rates(datasets_by_apid[apid])
                 decom_ultra_dataset = decom_ultra_dataset.drop_vars("fastdata_00")


### PR DESCRIPTION
# Change Summary
I had error handling logic in to deal with this issue https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/2557. Greg fixed it in https://github.com/IMAP-Science-Operations-Center/imap_processing/pull/2581. This PR just removes the TODO, temporary fix, and test. 

## Updated Files
- imap_processing/ultra/l1a/ultra_l1a.py
   - Remove todo and try catch. 

## Testing
Remove the test that checked the temporary fix. 
