### PR TITLE
Updates to pass pipeline settings thorugh GLOWS L2

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -742,11 +742,27 @@ class Glows(ProcessInstrument):
             science_files = dependencies.get_file_paths(source="glows")
             if len(science_files) != 1:
                 raise ValueError(
-                    f"GLOWS L1A requires exactly one input science file, received: "
-                    f"{science_files}."
+                    f"GLOWS L2 requires exactly one input science file, "
+                    f"received: {science_files}."
                 )
             input_dataset = load_cdf(science_files[0])
-            datasets = glows_l2(input_dataset)
+
+            # Load pipeline settings for L2 processing
+            current_day = np.datetime64(
+                f"{self.start_date[:4]}-{self.start_date[4:6]}-{self.start_date[6:]}"
+            )
+            day_buffer = current_day + np.timedelta64(3, "D")
+            pipeline_settings_input = dependencies.get_processing_inputs(
+                descriptor="pipeline-settings"
+            )[0]
+            pipeline_settings_combiner = GlowsAncillaryCombiner(
+                pipeline_settings_input, day_buffer
+            )
+
+            datasets = glows_l2(
+                input_dataset,
+                pipeline_settings_combiner.combined_dataset,
+            )
 
         return datasets
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -703,7 +703,7 @@ class Glows(ProcessInstrument):
                     descriptor="exclusions-by-instr-team"
                 )[0]
                 pipeline_settings = dependencies.get_processing_inputs(
-                    descriptor="pipeline-settings"
+                    descriptor="lxx-pipeline-settings"
                 )[0]
 
                 # Create combiners for each ancillary dataset
@@ -753,7 +753,7 @@ class Glows(ProcessInstrument):
             )
             day_buffer = current_day + np.timedelta64(3, "D")
             pipeline_settings_input = dependencies.get_processing_inputs(
-                descriptor="pipeline-settings"
+                descriptor="lxx-pipeline-settings"
             )[0]
             pipeline_settings_combiner = GlowsAncillaryCombiner(
                 pipeline_settings_input, day_buffer

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -703,7 +703,7 @@ class Glows(ProcessInstrument):
                     descriptor="exclusions-by-instr-team"
                 )[0]
                 pipeline_settings = dependencies.get_processing_inputs(
-                    descriptor="lxx-pipeline-settings"
+                    descriptor="pipeline-settings"
                 )[0]
 
                 # Create combiners for each ancillary dataset
@@ -753,7 +753,7 @@ class Glows(ProcessInstrument):
             )
             day_buffer = current_day + np.timedelta64(3, "D")
             pipeline_settings_input = dependencies.get_processing_inputs(
-                descriptor="lxx-pipeline-settings"
+                descriptor="pipeline-settings"
             )[0]
             pipeline_settings_combiner = GlowsAncillaryCombiner(
                 pipeline_settings_input, day_buffer

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -8,11 +8,18 @@ from numpy.typing import NDArray
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.glows import FLAG_LENGTH
-from imap_processing.glows.l1b.glows_l1b_data import HistogramL1B
+from imap_processing.glows.l1b.glows_l1b_data import (
+    HistogramL1B,
+    PipelineSettings,
+)
 from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
+from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
 
 
-def glows_l2(input_dataset: xr.Dataset) -> list[xr.Dataset]:
+def glows_l2(
+    input_dataset: xr.Dataset,
+    pipeline_settings_dataset: xr.Dataset,
+) -> list[xr.Dataset]:
     """
     Will process GLoWS L2 data from L1 data.
 
@@ -20,23 +27,36 @@ def glows_l2(input_dataset: xr.Dataset) -> list[xr.Dataset]:
     ----------
     input_dataset : xarray.Dataset
         Input L1B dataset.
+    pipeline_settings_dataset : xarray.Dataset
+        Dataset containing pipeline settings from
+        GlowsAncillaryCombiner.
 
     Returns
     -------
-    xarray.Dataset
-     Glows L2 Dataset.
+    list[xarray.Dataset]
+        Glows L2 Dataset.
     """
     cdf_attrs = ImapCdfAttributes()
     cdf_attrs.add_instrument_global_attrs("glows")
     cdf_attrs.add_instrument_variable_attrs("glows", "l2")
 
-    l2 = generate_l2(input_dataset)
+    # Select pipeline settings for the day matching
+    # the first epoch in the L1B data. Convert from
+    # TT J2000 nanoseconds to datetime64 for indexing.
+    day = et_to_datetime64(ttj2000ns_to_et(input_dataset["epoch"].data[0]))
+    pipeline_settings = PipelineSettings(
+        pipeline_settings_dataset.sel(epoch=day, method="nearest")
+    )
+
+    l2 = generate_l2(input_dataset, pipeline_settings)
 
     return [create_l2_dataset(l2, cdf_attrs)]
 
 
-# TODO: filter good times out
-def generate_l2(l1b_dataset: xr.Dataset) -> HistogramL2:
+def generate_l2(
+    l1b_dataset: xr.Dataset,
+    pipeline_settings: PipelineSettings,
+) -> HistogramL2:
     """
     Generate L2 data from L1B data.
 
@@ -46,15 +66,18 @@ def generate_l2(l1b_dataset: xr.Dataset) -> HistogramL2:
     ----------
     l1b_dataset : xarray.Dataset
         Input L1B dataset.
+    pipeline_settings : PipelineSettings
+        Pipeline settings for active flags and offsets.
 
     Returns
     -------
     HistogramL2
         L2 data in the form of a HistogramL2 dataclass.
     """
+    active_flags = np.array(pipeline_settings.active_bad_time_flags, dtype=float)
     # most of the values from L1B are averaged over a day
     good_data = l1b_dataset.isel(
-        epoch=return_good_times(l1b_dataset["flags"], np.ones((FLAG_LENGTH,)))
+        epoch=return_good_times(l1b_dataset["flags"], active_flags)
     )
     # todo: bad angle filter
     # TODO filter bad bins out. Needs to happen here while everything is still

--- a/imap_processing/tests/glows/conftest.py
+++ b/imap_processing/tests/glows/conftest.py
@@ -65,8 +65,8 @@ def l1b_hist_dataset(
 
 
 @pytest.fixture
-def l2_hist_dataset(l1b_datasets):
-    return glows_l2(l1b_datasets)
+def l2_hist_dataset(l1b_hist_dataset, mock_pipeline_settings):
+    return glows_l2(l1b_hist_dataset, mock_pipeline_settings)
 
 
 @pytest.fixture

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -5,13 +5,17 @@ import pytest
 import xarray as xr
 
 from imap_processing.glows.l1b.glows_l1b import glows_l1b
-from imap_processing.glows.l1b.glows_l1b_data import HistogramL1B
+from imap_processing.glows.l1b.glows_l1b_data import (
+    HistogramL1B,
+    PipelineSettings,
+)
 from imap_processing.glows.l2.glows_l2 import (
     generate_l2,
     glows_l2,
     return_good_times,
 )
 from imap_processing.glows.l2.glows_l2_data import DailyLightcurve
+from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
 from imap_processing.tests.glows.conftest import mock_update_spice_parameters
 
 
@@ -52,7 +56,7 @@ def test_glows_l2(
         mock_pipeline_settings,
         mock_conversion_table_dict,
     )
-    l2 = glows_l2(l1b_hist_dataset)[0]
+    l2 = glows_l2(l1b_hist_dataset, mock_pipeline_settings)[0]
     assert l2.attrs["Logical_source"] == "imap_glows_l2_hist"
 
     assert np.allclose(l2["filter_temperature_average"].values, [57.6], rtol=0.1)
@@ -91,7 +95,11 @@ def test_generate_l2(
         mock_pipeline_settings,
         mock_conversion_table_dict,
     )
-    l2 = generate_l2(l1b_hist_dataset)
+    day = et_to_datetime64(ttj2000ns_to_et(l1b_hist_dataset["epoch"].data[0]))
+    pipeline_settings = PipelineSettings(
+        mock_pipeline_settings.sel(epoch=day, method="nearest")
+    )
+    l2 = generate_l2(l1b_hist_dataset, pipeline_settings)
 
     expected_values = {
         "filter_temperature_average": [57.59],


### PR DESCRIPTION
# Change Summary
Small update which will support other L2 GLOWS  - passing ancillary files through to the processing. 

Similarly to the L1B changes this will have a corresponding change in SDS data manager. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Wires up ancillary file through L2 processing. 

Note: This PR was written primarily by Claude.