### PR TITLE
I-ALiRT - fix time conversion

### DIFF
--- a/imap_processing/ialirt/l0/process_hit.py
+++ b/imap_processing/ialirt/l0/process_hit.py
@@ -168,15 +168,16 @@ def process_hit(xarray_data: xr.Dataset) -> list[dict]:
             incomplete_groups.append(group)
             continue
 
-        hit_met = grouped_data["hit_met"][(grouped_data["group"] == group).values]
-        mid_measurement = int((hit_met[0] + hit_met[-1]) // 2)
+        hit_met = int(
+            grouped_data["hit_met"][(grouped_data["group"] == group).values].values[0]
+        )
 
         status_values = grouped_data["hit_status"][
             (grouped_data["group"] == group).values
         ]
 
         if np.any(status_values == 0):
-            logger.info(f"Off-nominal value detected at {met_to_utc(mid_measurement)}")
+            logger.info(f"Off-nominal value detected at {met_to_utc(hit_met)}")
             continue
 
         fast_rate_1 = grouped_data["hit_fast_rate_1"][
@@ -196,7 +197,7 @@ def process_hit(xarray_data: xr.Dataset) -> list[dict]:
             _populate_instrument_header_items(met)
             | {
                 "instrument": "hit",
-                "hit_epoch": int(met_to_ttj2000ns(mid_measurement)),
+                "hit_epoch": int(met_to_ttj2000ns(hit_met)),
                 "hit_e_a_side_low_en": Decimal(
                     f"{l1['IALRT_RATE_1'] + l1['IALRT_RATE_2']:.3f}"
                 ),

--- a/imap_processing/ialirt/utils/create_xarray.py
+++ b/imap_processing/ialirt/utils/create_xarray.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import xarray as xr
+from cdflib.epochs import CDFepoch
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.codice.constants import (
@@ -19,7 +20,6 @@ from imap_processing.ialirt.utils.constants import (
     hit_restricted_fields,
     swe_energy,
 )
-from imap_processing.spice.time import et_to_ttj2000ns, str_to_et
 
 
 def create_xarray_from_records(records: list[dict]) -> xr.Dataset:  # noqa: PLR0912
@@ -53,11 +53,39 @@ def create_xarray_from_records(records: list[dict]) -> xr.Dataset:  # noqa: PLR0
     dt = datetime.fromisoformat(date)
 
     # Start and end of that UTC day
-    start_str = dt.date().isoformat() + "T00:00:00Z"
-    end_str = (dt.date() + timedelta(days=1)).isoformat() + "T00:00:00Z"
+    start_dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_dt = start_dt + timedelta(days=1)
 
-    start_ttj2000 = et_to_ttj2000ns(str_to_et(start_str))
-    end_ttj2000 = et_to_ttj2000ns(str_to_et(end_str))
+    start_ttj2000 = int(
+        CDFepoch.compute_tt2000(
+            [
+                start_dt.year,
+                start_dt.month,
+                start_dt.day,
+                start_dt.hour,
+                start_dt.minute,
+                start_dt.second,
+                0,
+                0,
+                0,  # ms, us, ns
+            ]
+        )
+    )
+    end_ttj2000 = int(
+        CDFepoch.compute_tt2000(
+            [
+                end_dt.year,
+                end_dt.month,
+                end_dt.day,
+                end_dt.hour,
+                end_dt.minute,
+                end_dt.second,
+                0,
+                0,
+                0,  # ms, us, ns
+            ]
+        )
+    )
 
     for record in records:
         inst = record.get("instrument")


### PR DESCRIPTION
# Change Summary

## Overview
I realized that I don't have SPICE kernels loaded in my lambda. So I had this error. Instead of adding SPICE to my lambda, I decided to use the time conversion in cdflib.

  "errorType": "SpiceNOLEAPSECONDS",
  "requestId": "83491479-0e1c-41ee-9b2f-9785aae2481f",
  "stackTrace": [
    "  File \"/var/task/ialirt_archive.py\", line 127, in lambda_handler\n    dataset = create_xarray_from_records(all_items)\n",
    "  File \"/var/lang/lib/python3.12/site-packages/imap_processing/ialirt/utils/create_xarray.py\", line 59, in create_xarray_from_records\n    start_ttj2000 = et_to_ttj2000ns(str_to_et(start_str))\n",

## Updated Files
- create_xarray.py
   - Update time conversion
