### PR TITLE
BUG - Lo L1a DE dimension mismatch

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -428,7 +428,7 @@ def initialize_l1b_de(
         # attrs=attr_mgr.get_variable_attributes("esa_step"),
     )
     l1b_de["shcoarse"] = xr.DataArray(
-        np.repeat(l1a_de["shcoarse"].values, l1a_de["de_count"].values),
+        np.repeat(l1a_de["met"].values, l1a_de["de_count"].values),
         dims=["epoch"],
         # TODO: Add shcoarse to YAML file
         # attrs=attr_mgr.get_variable_attributes("shcoarse"),
@@ -804,7 +804,7 @@ def get_spin_start_times(
     """
     # Get the actual spin start times from the spin data
     # Use the individual spin start times rather than calculating from ASC averages
-    spin_start_times = interpolate_spin_data(l1a_de["shcoarse"].values)[
+    spin_start_times = interpolate_spin_data(l1a_de["met"].values)[
         "spin_start_met"
     ].values
     spin_start_times = np.repeat(spin_start_times, l1a_de["de_count"].values)

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -516,12 +516,9 @@ def test_get_spin_start_times(mock_interpolate_spin_data):
     )
     mock_interpolate_spin_data.return_value = mock_spin_df
 
-    # shcoarse is longer than met, simulating when segmented packets have
-    # occurred
     l1a_de = xr.Dataset(
         {
             "met": ("epoch", [15, 35]),
-            "shcoarse": ("shcoarse", [15, 16, 35]),
             "de_count": ("epoch", [2, 3]),
             "de_time": ("direct_event", [0, 1000, 2000, 3000, 4000]),
         },
@@ -557,13 +554,10 @@ def test_set_event_met(mock_interpolate_spin_data):
     )
     mock_interpolate_spin_data.return_value = mock_spin_df
 
-    # shcoarse is longer than met, simulating when segmented packets have
-    # occurred
     l1b_de = xr.Dataset()
     l1a_de = xr.Dataset(
         {
             "met": ("epoch", [15, 35]),
-            "shcoarse": ("shcoarse", [15, 16, 35]),
             "de_count": ("epoch", [2, 3]),
             "de_time": ("direct_event", [0, 1000, 2000, 3000, 4000]),
         },

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -516,17 +516,20 @@ def test_get_spin_start_times(mock_interpolate_spin_data):
     )
     mock_interpolate_spin_data.return_value = mock_spin_df
 
+    # shcoarse is longer than met, simulating when segmented packets have
+    # occurred
     l1a_de = xr.Dataset(
         {
-            "shcoarse": ("epoch", [15, 35]),
+            "met": ("epoch", [15, 35]),
+            "shcoarse": ("shcoarse", [15, 16, 35]),
             "de_count": ("epoch", [2, 3]),
             "de_time": ("direct_event", [0, 1000, 2000, 3000, 4000]),
         },
         coords={"epoch": [0, 1], "direct_event": [0, 1, 2, 3, 4]},
     )
 
-    # Expected: shcoarse 15 should match spin at index 0 (10 < 15 < 20)
-    # shcoarse 35 should match spin at index 2 (30 < 35 < 40)
+    # Expected: met 15 should match spin at index 0 (10 < 15 < 20)
+    # met 35 should match spin at index 2 (30 < 35 < 40)
     # Repeated by de_count: [2, 3] -> [index0, index0, index2, index2, index2]
     spin_start_times_expected = np.array(
         [10.5, 10.5, 30.1, 30.1, 30.1]  # 10 + 0.5e6*1e-6  # 30 + 0.1e6*1e-6
@@ -554,10 +557,13 @@ def test_set_event_met(mock_interpolate_spin_data):
     )
     mock_interpolate_spin_data.return_value = mock_spin_df
 
+    # shcoarse is longer than met, simulating when segmented packets have
+    # occurred
     l1b_de = xr.Dataset()
     l1a_de = xr.Dataset(
         {
-            "shcoarse": ("epoch", [15, 35]),
+            "met": ("epoch", [15, 35]),
+            "shcoarse": ("shcoarse", [15, 16, 35]),
             "de_count": ("epoch", [2, 3]),
             "de_time": ("direct_event", [0, 1000, 2000, 3000, 4000]),
         },
@@ -567,7 +573,7 @@ def test_set_event_met(mock_interpolate_spin_data):
         },
     )
 
-    # shcoarse 15 -> spin_start 10, shcoarse 35 -> spin_start 30
+    # met 15 -> spin_start 10, met 35 -> spin_start 30
     # event_met = spin_start + de_time * DE_CLOCK_TICK_S
     expected_event_met = np.array(
         [


### PR DESCRIPTION
Fixes #2650

# Change Summary
Change L1b DE references to use L1a DE "met" field instead of "shcoarse". The former is the same dimension as the "epoch" field, whereas the latter can be longer when segmented packets are present.

## File changes

## Testing

Manual testing consisting of generation of DE products from 20251215 and 20260212, days which had previously failed and passed, respectfully, prior to this change.
