### PR TITLE
Populate map principal data CATDESC from descriptor

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1422,20 +1422,10 @@ class RectangularSkyMap(AbstractSkyMap):
         )
 
         # And CATDESC for principal data
-        possible_principal_data = (
-            "dust_rate",
-            "ena_intensity",
-            "ena_spectral_index",
-            "glows_rate",
-            "isn_rate",
-            "isn_rate_bg_subtracted",
-        )
-        for principal_data in possible_principal_data:
-            if principal_data in cdf_ds:
-                catdesc = naming.MapDescriptor.from_string(descriptor).to_catdesc()
-                cdf_ds[principal_data].attrs["CATDESC"] = catdesc
-                # Only one principal variable
-                break
+        md = naming.MapDescriptor.from_string(descriptor)
+        principal_data = md.principal_data_var
+        if principal_data in cdf_ds:
+            cdf_ds[principal_data].attrs["CATDESC"] = md.to_catdesc()
 
         return cdf_ds
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -16,7 +16,7 @@ from numpy.typing import NDArray
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import load_cdf
-from imap_processing.ena_maps.utils import map_utils, spatial_utils
+from imap_processing.ena_maps.utils import map_utils, naming, spatial_utils
 
 # The coordinate names can vary between L1C and L2 data (e.g. azimuth vs longitude),
 # so we define an enum to handle the coordinate names.
@@ -1420,6 +1420,22 @@ class RectangularSkyMap(AbstractSkyMap):
         cdf_ds["epoch"].attrs.update(
             {"DELTA_PLUS_VAR": "epoch_delta", "BIN_LOCATION": 0}
         )
+
+        # And CATDESC for principal data
+        possible_principal_data = (
+            "dust_rate",
+            "ena_intensity",
+            "ena_spectral_index",
+            "glows_rate",
+            "isn_rate",
+            "isn_rate_bg_subtracted",
+        )
+        for principal_data in possible_principal_data:
+            if principal_data in cdf_ds:
+                catdesc = naming.MapDescriptor.from_string(descriptor).to_catdesc()
+                cdf_ds[principal_data].attrs["CATDESC"] = catdesc
+                # Only one principal variable
+                break
 
         return cdf_ds
 

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -199,7 +199,10 @@ class MapDescriptor:
                 if self.instrument_descriptor.startswith(desc)
             )
         )
-        sensor = "Comb" if self.sensor == "combined" else self.sensor
+        sensor = " Combined" if self.sensor == "combined" else self.sensor
+        species = self.species.title()
+        if species == "Uv":
+            species = "UV"
         m = re.match(
             r"^(drt|ena|int|isn|spx)(?:(?<=spx)\d+)?([^-_\s]*)$", self.principal_data
         )
@@ -207,13 +210,12 @@ class MapDescriptor:
             "drt": "Rate",
             "ena": "Inten",
             "int": "Inten",
-            "isn": "ISN Rate",
+            "isn": "Rate",
             "spx": "Spectral",
         }[m.group(1)]
+        if m.group(1) == "isn":
+            species = "ISN " + species
         extras = m.group(2)
-        species = self.species.title()
-        if species == "Uv":
-            species = "UV"
         coord = self.coordinate_system.upper()
         frame = {
             "hf": "Helio",
@@ -234,7 +236,7 @@ class MapDescriptor:
             if duration.endswith("Mo"):
                 duration += "n"
         catdesc = (
-            f"IMAP {instrument}{sensor} {quantity} {species}, {coord} "
+            f"IMAP {instrument}{sensor} {species} {quantity}, {coord} "
             f"{frame} Frame, {survival}, {spin_phase}, {resolution}, {duration}"
         )
         possible_extras = [

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -173,6 +173,80 @@ class MapDescriptor:
             ]
         )
 
+    def to_catdesc(self) -> str:
+        """
+        Convert the MapDescriptor instance to a human-readable CATDESC string.
+
+        Returns
+        -------
+        str
+            Information in descriptor converted to SPDF CATDESC attribute. This
+            is normally used for plot titles and should be under about 80 characters.
+        """
+        instrument_names = {
+            "l": "Lo",
+            "t": "Lo",
+            "ilo": "Lo",
+            "h": "Hi",
+            "u": "Ultra",
+            "idx": "IDEX",
+            "glx": "GLOWS",
+        }
+        instrument = next(
+            (
+                name
+                for desc, name in instrument_names.items()
+                if self.instrument_descriptor.startswith(desc)
+            )
+        )
+        sensor = "Comb" if self.sensor == "combined" else self.sensor
+        m = re.match(
+            r"^(drt|ena|int|isn|spx)(?:(?<=spx)\d+)?([^-_\s]*)$", self.principal_data
+        )
+        quantity = {
+            "drt": "Rate",
+            "ena": "Inten",
+            "int": "Inten",
+            "isn": "ISN Rate",
+            "spx": "Spectral",
+        }[m.group(1)]
+        extras = m.group(2)
+        species = self.species.title()
+        if species == "Uv":
+            species = "UV"
+        coord = self.coordinate_system.upper()
+        frame = {
+            "hf": "Helio",
+            "hk": "Helio Kin",
+            "sf": "SC",
+        }[self.frame_descriptor]
+        survival = "Surv Corr" if self.survival_corrected == "sp" else "No Surv Corr"
+        spin_phase = self.spin_phase.title()
+        if spin_phase == "Full":
+            spin_phase = "Full Spin"
+        m = re.match(r"^(\d+)deg|nside(\d+)", self.resolution_str)
+        resolution = f"{m.group(1)} deg" if m.group(1) else f"NSide {m.group(2)}"
+        if isinstance(self.duration, int):
+            duration = f"{self.duration} Day"
+        else:
+            m = re.match(r"^(\d+)(.*)$", self.duration)
+            duration = f"{m.group(1)} {m.group(2).title()}"
+            if duration.endswith("Mo"):
+                duration += "n"
+        catdesc = (
+            f"IMAP {instrument}{sensor} {quantity} {species}, {coord} "
+            f"{frame} Frame, {survival}, {spin_phase}, {resolution}, {duration}"
+        )
+        possible_extras = [
+            ("nbs", "No sputter/bootstrap"),
+            ("nbkgnd", "No bkgnd sub"),
+        ]
+        for extra, long_description in possible_extras:
+            if extras.startswith(extra):
+                catdesc += f", {long_description}"
+                break
+        return catdesc
+
     # Methods for parsing and building parts of the map descriptor string
     @staticmethod
     def get_instrument_descriptor(

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -183,26 +183,11 @@ class MapDescriptor:
             Information in descriptor converted to SPDF CATDESC attribute. This
             is normally used for plot titles and should be under about 80 characters.
         """
-        instrument_names = {
-            "l": "Lo",
-            "t": "Lo",
-            "ilo": "Lo",
-            "h": "Hi",
-            "u": "Ultra",
-            "idx": "IDEX",
-            "glx": "GLOWS",
-        }
-        instrument = next(
-            (
-                name
-                for desc, name in instrument_names.items()
-                if self.instrument_descriptor.startswith(desc)
-            )
-        )
+        instrument = self.instrument.name.split("_")[0]
+        if instrument not in ("IDEX", "GLOWS"):
+            instrument = instrument.title()
         sensor = " Combined" if self.sensor == "combined" else self.sensor
-        species = self.species.title()
-        if species == "Uv":
-            species = "UV"
+        species = "UV" if self.species == "uv" else self.species.title()
         m = re.match(
             r"^(drt|ena|int|isn|spx)(?:(?<=spx)\d+)?([^-_\s]*)$", self.principal_data
         )

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -234,6 +234,26 @@ class MapDescriptor:
                 break
         return catdesc
 
+    @property
+    def principal_data_var(self) -> str:
+        """
+        The name of the variable containing the principal data for the map.
+
+        Returns
+        -------
+        principal_data_var : str
+            CDF (dataset) variable name expected to contain the principal data.
+        """
+        if self.principal_data.startswith("isnnbkgnd"):
+            return "isn_rate"
+        return {
+            "drt": "dust_rate",
+            "ena": "ena_intensity",
+            "int": "glows_rate",
+            "isn": "isn_rate_bg_subtracted",
+            "spx": "ena_spectral_index",
+        }[self.principal_data[:3]]
+
     # Methods for parsing and building parts of the map descriptor string
     @staticmethod
     def get_instrument_descriptor(

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -974,7 +974,7 @@ class TestRectangularSkyMap:
         # Check CATDESC made from descriptor
         assert (
             cdf_dataset["ena_intensity"].attrs["CATDESC"]
-            == "IMAP Hi45 Inten H, HAE SC Frame, No Surv Corr, Ram, 6 deg, 6 Mon"
+            == "IMAP Hi45 H Inten, HAE SC Frame, No Surv Corr, Ram, 6 deg, 6 Mon"
         )
 
     @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -921,7 +921,11 @@ class TestRectangularSkyMap:
         skymap.min_epoch = 10
         skymap.max_epoch = 15
         cdf_dataset = skymap.build_cdf_dataset(
-            "hi", "l2", "foo_descriptor", sensor="45", drop_vars_with_no_attributes=True
+            "hi",
+            "l2",
+            "h45-ena-h-sf-nsp-ram-hae-6deg-6mo",
+            sensor="45",
+            drop_vars_with_no_attributes=True,
         )
 
         # Check that expected vars gets removed
@@ -967,6 +971,12 @@ class TestRectangularSkyMap:
                     f"attr '{attr}' should not be in variable attributes for '{var}'"
                 )
 
+        # Check CATDESC made from descriptor
+        assert (
+            cdf_dataset["ena_intensity"].attrs["CATDESC"]
+            == "IMAP Hi45 Inten H, HAE SC Frame, No Surv Corr, Ram, 6 deg, 6 Mon"
+        )
+
     @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
     def test_build_cdf_dataset_external_dataset(
         self, mock_to_dataset, mock_data_for_build_cdf_dataset
@@ -979,12 +989,16 @@ class TestRectangularSkyMap:
         skymap.min_epoch = 10
         skymap.max_epoch = 15
         cdf_dataset_standard = skymap.build_cdf_dataset(
-            "hi", "l2", "foo_descriptor", sensor="45", drop_vars_with_no_attributes=True
+            "hi",
+            "l2",
+            "h45-ena-h-sf-nsp-ram-hae-6deg-6mo",
+            sensor="45",
+            drop_vars_with_no_attributes=True,
         )
         cdf_dataset_external = skymap.build_cdf_dataset(
             "hi",
             "l2",
-            "foo_descriptor",
+            "h45-ena-h-sf-nsp-ram-hae-6deg-6mo",
             sensor="45",
             drop_vars_with_no_attributes=True,
             external_map_dataset=mock_data_for_build_cdf_dataset,
@@ -1019,7 +1033,9 @@ class TestRectangularSkyMap:
             KeyError,
             match="Required variable 'energy_delta_minus' not found in cdf Dataset.",
         ):
-            _ = skymap.build_cdf_dataset("hi", "l2", "foo_descriptor", sensor="45")
+            _ = skymap.build_cdf_dataset(
+                "hi", "l2", "h45-ena-h-sf-nsp-ram-hae-6deg-6mo", sensor="45"
+            )
 
     @mock.patch("imap_processing.ena_maps.ena_maps.RectangularSkyMap.to_dataset")
     def test_keep_vars_with_no_attributes(
@@ -1035,7 +1051,7 @@ class TestRectangularSkyMap:
         cdf_dataset = skymap.build_cdf_dataset(
             "hi",
             "l2",
-            "foo_descriptor",
+            "h45-ena-h-sf-nsp-ram-hae-6deg-6mo",
             sensor="45",
             drop_vars_with_no_attributes=False,
         )

--- a/imap_processing/tests/ena_maps/test_naming.py
+++ b/imap_processing/tests/ena_maps/test_naming.py
@@ -378,3 +378,18 @@ class TestMapDescriptor:
         md = MapDescriptor.from_string(descriptor_str)
         actual_catdesc = md.to_catdesc()
         assert actual_catdesc == expected_catdesc
+
+    @pytest.mark.parametrize(
+        "descriptor_str, expected_principal_data_var",
+        [
+            ("hic-ena-h-hf-sp-ram-hae-4deg-3mo", "ena_intensity"),
+            ("h45-spx0305-h-hf-sp-ram-hae-4deg-3mo", "ena_spectral_index"),
+            ("idx-drt-dust-sf-nsp-full-hae-6deg-1yr", "dust_rate"),
+            ("glx-int-uv-sf-nsp-full-hae-6deg-1yr", "glows_rate"),
+            ("l090-isnnbkgnd-h-sf-nsp-ram-hae-6deg-1yr", "isn_rate"),
+            ("l090-isn-h-sf-nsp-ram-hae-6deg-1yr", "isn_rate_bg_subtracted"),
+        ],
+    )
+    def test_principal_data_var(self, descriptor_str, expected_principal_data_var):
+        md = MapDescriptor.from_string(descriptor_str)
+        assert md.principal_data_var == expected_principal_data_var

--- a/imap_processing/tests/ena_maps/test_naming.py
+++ b/imap_processing/tests/ena_maps/test_naming.py
@@ -309,64 +309,65 @@ class TestMapDescriptor:
         cases = [
             (
                 "h45-spx-h-hf-sp-ram-hae-4deg-3mo",
-                "IMAP Hi45 Spectral H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+                "IMAP Hi45 H Spectral, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
             ),
             (
                 "h45-spx0305-h-hf-sp-ram-hae-4deg-3mo",
-                "IMAP Hi45 Spectral H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+                "IMAP Hi45 H Spectral, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
             ),
             (
                 "hic-ena-h-hf-sp-ram-hae-4deg-3mo",
-                "IMAP HiComb Inten H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+                "IMAP Hi Combined H Inten, HAE Helio Frame, Surv Corr, Ram,"
+                " 4 deg, 3 Mon",
             ),
             (
                 "u45-ena-h-hf-sp-ram-hae-4deg-3mo",
-                "IMAP Ultra45 Inten H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+                "IMAP Ultra45 H Inten, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
             ),
             (
                 "u45-ena-h-hf-sp-full-hae-4deg-3mo",
-                "IMAP Ultra45 Inten H, HAE Helio Frame, Surv Corr, Full Spin,"
+                "IMAP Ultra45 H Inten, HAE Helio Frame, Surv Corr, Full Spin,"
                 " 4 deg, 3 Mon",
             ),
             (
                 "u45-ena-h-hf-sp-ram-hae-nside128-3mo",
-                "IMAP Ultra45 Inten H, HAE Helio Frame, Surv Corr, Ram, NSide 128,"
+                "IMAP Ultra45 H Inten, HAE Helio Frame, Surv Corr, Ram, NSide 128,"
                 " 3 Mon",
             ),
             (
                 "u45-enaCUSTOM-h-hf-sp-ram-hae-4deg-3mo",
-                "IMAP Ultra45 Inten H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+                "IMAP Ultra45 H Inten, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
             ),
             (
                 "l090-enanbs-h-sf-nsp-ram-hae-6deg-1yr",
-                "IMAP Lo90 Inten H, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr,"
+                "IMAP Lo90 H Inten, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr,"
                 " No sputter/bootstrap",
             ),
             (
                 "t090-ena-o-sf-nsp-ram-hae-6deg-1yr",
-                "IMAP Lo90 Inten O, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
+                "IMAP Lo90 O Inten, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
             ),
             (
                 "l090-ena-h-hf-nsp-ram-gcs-6deg-1yr",
-                "IMAP Lo90 Inten H, GCS Helio Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
+                "IMAP Lo90 H Inten, GCS Helio Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
             ),
             (
                 "l090-isn-h-sf-nsp-ram-hae-6deg-1yr",
-                "IMAP Lo90 ISN Rate H, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
+                "IMAP Lo90 ISN H Rate, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
             ),
             (
                 "l090-isnnbkgnd-h-sf-nsp-ram-hae-6deg-1yr",
-                "IMAP Lo90 ISN Rate H, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr,"
+                "IMAP Lo90 ISN H Rate, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr,"
                 " No bkgnd sub",
             ),
             (
                 "glx-int-uv-sf-nsp-full-hae-6deg-1yr",
-                "IMAP GLOWS Inten UV, HAE SC Frame, No Surv Corr, Full Spin, 6 deg,"
+                "IMAP GLOWS UV Inten, HAE SC Frame, No Surv Corr, Full Spin, 6 deg,"
                 " 1 Yr",
             ),
             (
                 "idx-drt-dust-sf-nsp-full-hae-6deg-1yr",
-                "IMAP IDEX Rate Dust, HAE SC Frame, No Surv Corr, Full Spin, 6 deg,"
+                "IMAP IDEX Dust Rate, HAE SC Frame, No Surv Corr, Full Spin, 6 deg,"
                 " 1 Yr",
             ),
         ]

--- a/imap_processing/tests/ena_maps/test_naming.py
+++ b/imap_processing/tests/ena_maps/test_naming.py
@@ -305,8 +305,9 @@ class TestMapDescriptor:
         descriptor_str_ultra_combined = md_ultra_combined.to_string()
         assert descriptor_str_ultra_combined == "ulc-ena-h-sf-nsp-full-hae-nside32-1yr"
 
-    def test_to_catdesc(self):
-        cases = [
+    @pytest.mark.parametrize(
+        "descriptor_str, expected_catdesc",
+        [
             (
                 "h45-spx-h-hf-sp-ram-hae-4deg-3mo",
                 "IMAP Hi45 H Spectral, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
@@ -370,9 +371,10 @@ class TestMapDescriptor:
                 "IMAP IDEX Dust Rate, HAE SC Frame, No Surv Corr, Full Spin, 6 deg,"
                 " 1 Yr",
             ),
-        ]
-        for descriptor_str, expected_catdesc in cases:
-            # Use case is primarily from descriptor str to CATDESC
-            md = MapDescriptor.from_string(descriptor_str)
-            actual_catdesc = md.to_catdesc()
-            assert actual_catdesc == expected_catdesc
+        ],
+    )
+    def test_to_catdesc(self, descriptor_str, expected_catdesc):
+        # Use case is primarily from descriptor str to CATDESC
+        md = MapDescriptor.from_string(descriptor_str)
+        actual_catdesc = md.to_catdesc()
+        assert actual_catdesc == expected_catdesc

--- a/imap_processing/tests/ena_maps/test_naming.py
+++ b/imap_processing/tests/ena_maps/test_naming.py
@@ -304,3 +304,74 @@ class TestMapDescriptor:
         )
         descriptor_str_ultra_combined = md_ultra_combined.to_string()
         assert descriptor_str_ultra_combined == "ulc-ena-h-sf-nsp-full-hae-nside32-1yr"
+
+    def test_to_catdesc(self):
+        cases = [
+            (
+                "h45-spx-h-hf-sp-ram-hae-4deg-3mo",
+                "IMAP Hi45 Spectral H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+            ),
+            (
+                "h45-spx0305-h-hf-sp-ram-hae-4deg-3mo",
+                "IMAP Hi45 Spectral H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+            ),
+            (
+                "hic-ena-h-hf-sp-ram-hae-4deg-3mo",
+                "IMAP HiComb Inten H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+            ),
+            (
+                "u45-ena-h-hf-sp-ram-hae-4deg-3mo",
+                "IMAP Ultra45 Inten H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+            ),
+            (
+                "u45-ena-h-hf-sp-full-hae-4deg-3mo",
+                "IMAP Ultra45 Inten H, HAE Helio Frame, Surv Corr, Full Spin,"
+                " 4 deg, 3 Mon",
+            ),
+            (
+                "u45-ena-h-hf-sp-ram-hae-nside128-3mo",
+                "IMAP Ultra45 Inten H, HAE Helio Frame, Surv Corr, Ram, NSide 128,"
+                " 3 Mon",
+            ),
+            (
+                "u45-enaCUSTOM-h-hf-sp-ram-hae-4deg-3mo",
+                "IMAP Ultra45 Inten H, HAE Helio Frame, Surv Corr, Ram, 4 deg, 3 Mon",
+            ),
+            (
+                "l090-enanbs-h-sf-nsp-ram-hae-6deg-1yr",
+                "IMAP Lo90 Inten H, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr,"
+                " No sputter/bootstrap",
+            ),
+            (
+                "t090-ena-o-sf-nsp-ram-hae-6deg-1yr",
+                "IMAP Lo90 Inten O, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
+            ),
+            (
+                "l090-ena-h-hf-nsp-ram-gcs-6deg-1yr",
+                "IMAP Lo90 Inten H, GCS Helio Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
+            ),
+            (
+                "l090-isn-h-sf-nsp-ram-hae-6deg-1yr",
+                "IMAP Lo90 ISN Rate H, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr",
+            ),
+            (
+                "l090-isnnbkgnd-h-sf-nsp-ram-hae-6deg-1yr",
+                "IMAP Lo90 ISN Rate H, HAE SC Frame, No Surv Corr, Ram, 6 deg, 1 Yr,"
+                " No bkgnd sub",
+            ),
+            (
+                "glx-int-uv-sf-nsp-full-hae-6deg-1yr",
+                "IMAP GLOWS Inten UV, HAE SC Frame, No Surv Corr, Full Spin, 6 deg,"
+                " 1 Yr",
+            ),
+            (
+                "idx-drt-dust-sf-nsp-full-hae-6deg-1yr",
+                "IMAP IDEX Rate Dust, HAE SC Frame, No Surv Corr, Full Spin, 6 deg,"
+                " 1 Yr",
+            ),
+        ]
+        for descriptor_str, expected_catdesc in cases:
+            # Use case is primarily from descriptor str to CATDESC
+            md = MapDescriptor.from_string(descriptor_str)
+            actual_catdesc = md.to_catdesc()
+            assert actual_catdesc == expected_catdesc

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -579,6 +579,28 @@ class TestUltraL2:
         assert exposure_attrs["VAR_TYPE"] == "data"
         assert exposure_attrs["UNITS"] == "s"
 
+    @pytest.mark.external_test_data
+    @pytest.mark.usefixtures("_setup_spice_kernels_list")
+    def test_ultra_l2_rectangular_from_descriptor(
+        self, mock_data_dict, furnish_kernels
+    ):
+        with furnish_kernels(self.required_kernel_names):
+            [
+                rect_map_dataset,
+            ] = ultra_l2.ultra_l2(
+                data_dict=mock_data_dict,
+                energy_bin_edges_file=ENERGY_BIN_EDGES_PATH,
+                descriptor="u90-ena-h-hf-nsp-full-hae-6deg-1yr",
+                store_subdivision_depth=False,
+            )
+
+        # Variable Metadata spot checks
+        assert (
+            rect_map_dataset["ena_intensity"].attrs["CATDESC"]
+            == "IMAP Ultra90 H Inten, HAE Helio Frame, No Surv Corr, Full Spin,"
+            " 6 deg, 1 Yr"
+        )
+
     @pytest.mark.parametrize(
         "tiling",
         [

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -579,28 +579,6 @@ class TestUltraL2:
         assert exposure_attrs["VAR_TYPE"] == "data"
         assert exposure_attrs["UNITS"] == "s"
 
-    @pytest.mark.external_test_data
-    @pytest.mark.usefixtures("_setup_spice_kernels_list")
-    def test_ultra_l2_rectangular_from_descriptor(
-        self, mock_data_dict, furnish_kernels
-    ):
-        with furnish_kernels(self.required_kernel_names):
-            [
-                rect_map_dataset,
-            ] = ultra_l2.ultra_l2(
-                data_dict=mock_data_dict,
-                energy_bin_edges_file=ENERGY_BIN_EDGES_PATH,
-                descriptor="u90-ena-h-hf-nsp-full-hae-6deg-1yr",
-                store_subdivision_depth=False,
-            )
-
-        # Variable Metadata spot checks
-        assert (
-            rect_map_dataset["ena_intensity"].attrs["CATDESC"]
-            == "IMAP Ultra90 H Inten, HAE Helio Frame, No Surv Corr, Full Spin,"
-            " 6 deg, 1 Yr"
-        )
-
     @pytest.mark.parametrize(
         "tiling",
         [
@@ -734,6 +712,12 @@ class TestUltraL2:
 
         assert output_map.attrs["Spice_reference_frame"] == "IMAP_HAE"
         assert output_map.attrs["Spacing_degrees"] == "6.0"
+        # Variable Metadata spot checks
+        assert (
+            output_map["ena_intensity"].attrs["CATDESC"]
+            == "IMAP Ultra90 H Inten, HAE Helio Frame, No Surv Corr, Full Spin,"
+            " 6 deg, 6 Mon"
+        )
         write_cdf(output_map)
 
     @pytest.mark.usefixtures("_setup_spice_kernels_list")

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -850,4 +850,11 @@ def ultra_l2(
     map_dataset["obs_date"] = map_dataset["obs_date"].astype(np.int64)
     map_dataset["obs_date_range"] = map_dataset["obs_date_range"].astype(np.int64)
 
+    # Adjust CATDESC per descriptor
+    if descriptor is not None:
+        md = MapDescriptor.from_string(descriptor)
+        principal_data = md.principal_data_var
+        if principal_data in map_dataset:
+            map_dataset[principal_data].attrs["CATDESC"] = md.to_catdesc()
+
     return [map_dataset]


### PR DESCRIPTION
# Change Summary

## Overview

The CATDESC (and thus plot title in CAVA) for all ENA maps is "Mono-energetic ENA intensity". This doesn't provide much detail on what intensity is being shown, and the IMWG has requested that this be updated with a human-readable description of the map descriptor.

## File changes

- `ena_maps/utils/naming.py`: add function to parse a CATDESC from a MapDescriptor
- `tests/ena_maps/test_naming.py`: tests for above
- `ena_maps/ena_maps.py`: patch the CATDESC in `build_cdf_dataset`
- `tests/ena_maps/test_ena_maps.py`: update tests for above


## Testing

New test was added for `MapDescriptor.to_catdesc`; the test for `build_cdf_dataset` was updated to check the CATDESC was properly populated. `build_cdf_dataset` now requires a fairly well-constructed descriptor, so some tests were updated to provide that.

# Other notes

This PR is in draft while the IMWG reviews the actual contents of the CATDESC; there shouldn't be structural changes after that.

This does create a circular import between `ena_maps` and `ena_maps.utils.naming`. It doesn't seem to cause problems but I still don't like it.

There are several cases where a malformed map descriptor will cause a regex to fail and horrible exceptions to be thrown. I figure the implicit contract that deep in the code is that the descriptor is well-formed, and I usually avoid catching an exception just to throw another exception. Open to alternate approaches.