### PR TITLE
Ultra l1b extended spin voltage cull

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1b_variable_attrs.yaml
@@ -526,3 +526,46 @@ quality_scattering:
   LABLAXIS: quality_scattering
   # TODO: come back to format
   UNITS: " "
+
+quality_low_voltage:
+  <<: *default_uint16
+  CATDESC: Quality flag for low voltage spins.
+  FIELDNAM: quality_low_voltage
+  LABLAXIS: quality_low_voltage
+  # TODO: come back to format
+  UNITS: " "
+
+quality_high_energy:
+  <<: *default_uint16
+  CATDESC: Quality flag for high energy spins.
+  FIELDNAM: quality_high_energy
+  LABLAXIS: quality_high_energy
+  # TODO: come back to format
+  UNITS: " "
+
+quality_statistics:
+  <<: *default_uint16
+  CATDESC: Quality flag for spins that are statistically inconsistent.
+  FIELDNAM: quality_statistics
+  LABLAXIS: quality_statistics
+  # TODO: come back to format
+  UNITS: " "
+
+
+energy_range_edges:
+  <<: *default_float64
+  CATDESC: Energy range edges for culling data at l1b.
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: Energy Range Edges
+  LABLAXIS: Energy Edges
+  UNITS: keV
+  VALIDMIN: 0.0
+  VALIDMAX: 9223372036854775807
+
+energy_range_flags:
+  <<: *default_float64
+  CATDESC: Bit flags for each culling energy range
+  DISPLAY_TYPE: no_plot
+  FIELDNAM: Energy Range Flags
+  LABLAXIS: Range Flags
+  UNITS: " "

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -130,7 +130,7 @@ def idex_l1b(l1a_dataset: xr.Dataset) -> xr.Dataset:
     prefixes = ["shcoarse", "shfine", "time_high_sample", "time_low_sample"]
     data_vars = processed_vars | waveforms_converted | trigger_settings | spice_data
     l1b_dataset = setup_dataset(l1a_dataset, prefixes, idex_attrs, data_vars)
-    l1b_dataset.attrsf = idex_attrs.get_global_attributes("imap_idex_l1b_sci")
+    l1b_dataset.attrs = idex_attrs.get_global_attributes("imap_idex_l1b_sci")
 
     # Convert variables
     l1b_dataset = convert_raw_to_eu(

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -130,7 +130,7 @@ def idex_l1b(l1a_dataset: xr.Dataset) -> xr.Dataset:
     prefixes = ["shcoarse", "shfine", "time_high_sample", "time_low_sample"]
     data_vars = processed_vars | waveforms_converted | trigger_settings | spice_data
     l1b_dataset = setup_dataset(l1a_dataset, prefixes, idex_attrs, data_vars)
-    l1b_dataset.attrs = idex_attrs.get_global_attributes("imap_idex_l1b_sci")
+    l1b_dataset.attrsf = idex_attrs.get_global_attributes("imap_idex_l1b_sci")
 
     # Convert variables
     l1b_dataset = convert_raw_to_eu(

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -149,6 +149,9 @@ EXTERNAL_TEST_DATA = [
     # Ultra
     ("FM90_Startup_20230711T081655.CCSDS", "ultra/data/l0/"),
     ("IMAP-Ultra45_r1_L1_V0_shortened.csv", "ultra/data/l1/"),
+    ("extendedspin_test_data_repoint00047.csv", "ultra/data/l1/"),
+    ("status_test_data_repoint00047.csv", "ultra/data/l1/"),
+    ("voltage_culling_results_repoint00047.csv", "ultra/data/l1/"),
     ("FM45_UltraFM45Extra_TV_Tests_2024-01-22T0930_20240122T093008.CCSDS", "ultra/data/l0/"),
     ("ultra45_raw_sc_rawnrgevnt_19840122_00.csv", "ultra/data/l0/"),
     ("ultra45_raw_sc_enaphxtofhnrgimg_FM45_UltraFM45Extra_TV_Tests_2024-01-22T0930_20240122T093008.csv",

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -647,9 +647,10 @@ def mock_goodtimes_dataset():
     return xr.Dataset(
         {
             "spin_number": ("epoch", np.zeros(5)),
-            "energy_bin_flags": ("energy_bins", np.zeros(10, dtype=np.uint16)),
+            "energy_bin_flags": ("energy_flags", np.zeros(10, dtype=np.uint16)),
             "quality_low_voltage": ("spin_number", np.zeros(5, dtype=np.uint16)),
             "quality_high_energy": ("spin_number", np.zeros(5, dtype=np.uint16)),
             "quality_statistics": ("spin_number", np.zeros(5, dtype=np.uint16)),
+            "energy_range_edges": ("energy_ranges", np.zeros(11, dtype=np.uint16)),
         }
     )

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -647,7 +647,7 @@ def mock_goodtimes_dataset():
     return xr.Dataset(
         {
             "spin_number": ("epoch", np.zeros(5)),
-            "energy_bin_flags": ("energy_flags", np.zeros(10, dtype=np.uint16)),
+            "energy_range_flags": ("energy_flags", np.zeros(10, dtype=np.uint16)),
             "quality_low_voltage": ("spin_number", np.zeros(5, dtype=np.uint16)),
             "quality_high_energy": ("spin_number", np.zeros(5, dtype=np.uint16)),
             "quality_statistics": ("spin_number", np.zeros(5, dtype=np.uint16)),

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -27,6 +27,7 @@ from imap_processing.ultra.l0.ultra_utils import (
     ULTRA_EXTOF_HIGH_ANGULAR,
     ULTRA_EXTOF_HIGH_ENERGY,
     ULTRA_EXTOF_HIGH_TIME,
+    ULTRA_HK,
     ULTRA_MACROS_CHECKSUM,
     ULTRA_PHXTOF_HIGH_ANGULAR,
     ULTRA_PHXTOF_HIGH_ENERGY,
@@ -439,6 +440,13 @@ def aux_dataset(ccsds_path_theta_0):
 
 
 @pytest.fixture
+def status_dataset(ccsds_path_theta_0):
+    """L1A test data"""
+    test_data = ultra_l1a(ccsds_path_theta_0, apid_input=ULTRA_HK.apid[3])
+    return test_data[0]
+
+
+@pytest.fixture
 def faux_aux_dataset():
     """Fixture to compute and return aux test data."""
 
@@ -631,3 +639,17 @@ def mock_helio_pointing_lookups():
         mock_lookup.return_value = ds
 
         yield mock_lookup
+
+
+@pytest.fixture
+def mock_goodtimes_dataset():
+    """Create a mock goodtimes dataset."""
+    return xr.Dataset(
+        {
+            "spin_number": ("epoch", np.zeros(5)),
+            "energy_bin_flags": ("energy_bins", np.zeros(10, dtype=np.uint16)),
+            "quality_low_voltage": ("spin_number", np.zeros(5, dtype=np.uint16)),
+            "quality_high_energy": ("spin_number", np.zeros(5, dtype=np.uint16)),
+            "quality_statistics": ("spin_number", np.zeros(5, dtype=np.uint16)),
+        }
+    )

--- a/imap_processing/tests/ultra/unit/test_goodtimes.py
+++ b/imap_processing/tests/ultra/unit/test_goodtimes.py
@@ -22,11 +22,14 @@ def test_calculate_goodtimes_attitude():
         ImapRatesUltraFlags.NONE.value,
         dtype=np.uint16,
     )
-
+    quality_low_voltage = np.full_like(
+        quality_attitude, ImapAttitudeUltraFlags.NONE.value
+    )
     ds = xr.Dataset(
         {
             "epoch": (("spin_number",), np.array([0, 1], dtype="datetime64[ns]")),
             "quality_attitude": (("spin_number",), quality_attitude),
+            "quality_low_voltage": (("spin_number",), quality_low_voltage),
             "quality_ena_rates": (
                 ("energy_bin_geometric_mean", "spin_number"),
                 quality_ena_rates,
@@ -40,6 +43,8 @@ def test_calculate_goodtimes_attitude():
     )
 
     result_ds = calculate_goodtimes(ds, name="imap_ultra_l1b_45sensor-goodtimes")
+    for var in ["quality_attitude", "quality_low_voltage", "quality_ena_rates"]:
+        assert var in result_ds
 
     np.testing.assert_array_equal(result_ds["spin_number"].values, np.array([0, 1]))
 

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -80,7 +80,7 @@ def test_calculate_spacecraft_pset(
                 particle_velocity_dps_spacecraft,
             ),
             "energy_spacecraft": (["epoch"], energy_dps_spacecraft),
-            "spin_number": (["epoch"], df["Spin"].values),
+            "spin": (["epoch"], df["Spin"].values),
             "quality_scattering": (
                 ["epoch"],
                 np.zeros(len(df["Spin"].values), dtype=np.uint16),
@@ -173,8 +173,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         de_dict["velocity_dps_sc"] = sc_dps_velocity
         de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
         # Made up data for spin_number and energy_bin_geometric_mean
-        de_dict["spin_number"] = np.full(len(sc_dps_velocity), 0)
-        de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
+        de_dict["spin"] = np.full(len(sc_dps_velocity), 0)
         de_dict["quality_scattering"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
         de_dict["quality_outliers"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
         de_dict["ebin"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
@@ -244,7 +243,7 @@ def test_validate_exposure_time_and_sensitivities(
     # Create a minimal dataset to pass to the function
     dataset = xr.Dataset(
         {
-            "spin_number": (["epoch"], np.array([1, 2, 3])),
+            "spin": (["epoch"], np.array([1, 2, 3])),
         }
     )
     dataset.attrs["Repointing"] = "repoint00000"

--- a/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
+++ b/imap_processing/tests/ultra/unit/test_spacecraft_pset.py
@@ -33,6 +33,7 @@ TEST_PATH = imap_module_directory / "tests" / "ultra" / "data" / "l1"
 def test_calculate_spacecraft_pset(
     aux_dataset,
     rates_dataset,
+    mock_goodtimes_dataset,
     imap_ena_sim_metakernel,
     use_fake_spin_data_for_time,
     ancillary_files,
@@ -102,7 +103,7 @@ def test_calculate_spacecraft_pset(
     ):
         spacecraft_pset = calculate_spacecraft_pset(
             test_l1b_de_dataset,
-            test_l1b_de_dataset,  # placeholder for goodtimes_dataset
+            mock_goodtimes_dataset,
             rates_dataset,
             aux_dataset,
             "imap_ultra_l1c_45sensor-spacecraftpset",
@@ -121,6 +122,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     ancillary_files,
     aux_dataset,
     rates_dataset,
+    mock_goodtimes_dataset,
     imap_ena_sim_metakernel,
     use_fake_spin_data_for_time,
     mock_spacecraft_pointing_lookups,
@@ -171,7 +173,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         de_dict["velocity_dps_sc"] = sc_dps_velocity
         de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
         # Made up data for spin_number and energy_bin_geometric_mean
-        de_dict["spin_number"] = np.full(len(sc_dps_velocity), 128)
+        de_dict["spin_number"] = np.full(len(sc_dps_velocity), 0)
         de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
         de_dict["quality_scattering"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
         de_dict["quality_outliers"] = np.zeros(len(sc_dps_velocity), dtype=np.uint16)
@@ -189,7 +191,7 @@ def test_calculate_spacecraft_pset_with_cdf(
         ):
             spacecraft_pset = calculate_spacecraft_pset(
                 dataset,
-                dataset,  # placeholder for goodtimes_dataset
+                mock_goodtimes_dataset,
                 rates_dataset,
                 aux_dataset,
                 "imap_ultra_l1c_45sensor-spacecraftpset",

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -227,7 +227,7 @@ def test_ultra_l1b_extendedspin(
 def test_cdf_extendedspin(
     use_fake_spin_data_for_time, aux_dataset, rates_dataset, status_dataset
 ):
-    use_fake_spin_data_for_time(0, 141 * 150)
+    use_fake_spin_data_for_time(0, 141 * 15)
     l1b_de_dataset_path = (
         TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf"
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -190,9 +190,10 @@ def test_cdf_de_flags(
     assert np.all((flags & ImapDEOutliersUltraFlags.DURINGREPOINT.value) != 0)
 
 
+@mock.patch("imap_processing.ultra.l1b.extendedspin.UltraConstants.SPIN_BIN_SIZE", 5)
 @pytest.mark.external_test_data
 def test_ultra_l1b_extendedspin(
-    use_fake_spin_data_for_time, aux_dataset, rates_dataset
+    use_fake_spin_data_for_time, aux_dataset, rates_dataset, status_dataset
 ):
     """Tests that L1b data is created."""
     use_fake_spin_data_for_time(0, 141 * 15)
@@ -209,6 +210,7 @@ def test_ultra_l1b_extendedspin(
     }
     data_dict["imap_ultra_l1a_45sensor-aux"] = aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+    data_dict["imap_ultra_l1b_45sensor-status"] = status_dataset
 
     ancillary_files = {}
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
@@ -220,9 +222,12 @@ def test_ultra_l1b_extendedspin(
     )
 
 
+@mock.patch("imap_processing.ultra.l1b.extendedspin.UltraConstants.SPIN_BIN_SIZE", 5)
 @pytest.mark.external_test_data
-def test_cdf_extendedspin(use_fake_spin_data_for_time, aux_dataset, rates_dataset):
-    use_fake_spin_data_for_time(0, 141 * 15)
+def test_cdf_extendedspin(
+    use_fake_spin_data_for_time, aux_dataset, rates_dataset, status_dataset
+):
+    use_fake_spin_data_for_time(0, 141 * 150)
     l1b_de_dataset_path = (
         TEST_PATH / "imap_ultra_l1b_45sensor-de_20240207-repoint99999_v999.cdf"
     )
@@ -237,6 +242,7 @@ def test_cdf_extendedspin(use_fake_spin_data_for_time, aux_dataset, rates_datase
     }
     data_dict["imap_ultra_l1a_45sensor-aux"] = aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+    data_dict["imap_ultra_l1b_45sensor-status"] = status_dataset
 
     ancillary_files = {}
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
@@ -252,8 +258,11 @@ def test_cdf_extendedspin(use_fake_spin_data_for_time, aux_dataset, rates_datase
     )
 
 
+@mock.patch("imap_processing.ultra.l1b.extendedspin.UltraConstants.SPIN_BIN_SIZE", 5)
 @pytest.mark.external_test_data
-def test_cdf_goodtimes(use_fake_spin_data_for_time, aux_dataset, rates_dataset):
+def test_cdf_goodtimes(
+    use_fake_spin_data_for_time, aux_dataset, rates_dataset, status_dataset
+):
     """Tests that CDF file is created and contains same attributes as xarray."""
     use_fake_spin_data_for_time(0, 141 * 15)
     l1b_de_dataset_path = (
@@ -270,6 +279,7 @@ def test_cdf_goodtimes(use_fake_spin_data_for_time, aux_dataset, rates_dataset):
     }
     data_dict["imap_ultra_l1a_45sensor-aux"] = aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+    data_dict["imap_ultra_l1b_45sensor-status"] = status_dataset
 
     ancillary_files = {}
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
@@ -289,8 +299,11 @@ def test_cdf_goodtimes(use_fake_spin_data_for_time, aux_dataset, rates_dataset):
     )
 
 
+@mock.patch("imap_processing.ultra.l1b.extendedspin.UltraConstants.SPIN_BIN_SIZE", 5)
 @pytest.mark.external_test_data
-def test_cdf_badtimes(use_fake_spin_data_for_time, aux_dataset, rates_dataset):
+def test_cdf_badtimes(
+    use_fake_spin_data_for_time, aux_dataset, rates_dataset, status_dataset
+):
     """Tests that CDF file is created and contains same attributes as xarray."""
     use_fake_spin_data_for_time(0, 141 * 15)
     l1b_de_dataset_path = (
@@ -307,6 +320,7 @@ def test_cdf_badtimes(use_fake_spin_data_for_time, aux_dataset, rates_dataset):
     }
     data_dict["imap_ultra_l1a_45sensor-aux"] = aux_dataset
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
+    data_dict["imap_ultra_l1b_45sensor-status"] = status_dataset
 
     ancillary_files = {}
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -414,7 +414,7 @@ def test_get_energy_and_spin_dependent_rejection_mask():
             "quality_low_voltage": np.full(n_spins, 0),
             "quality_high_energy": np.full(n_spins, 0),
             "quality_statistics": np.full(n_spins, 0),
-            "energy_bin_flags": np.array(
+            "energy_range_flags": np.array(
                 [2**1, 2**2, 2**3]
             ),  # Example flags for energy bins
             "energy_range_edges": np.array([3, 5, 7, 18]),  # Example energy bin edges

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -17,12 +17,14 @@ from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
     compare_aux_univ_spin_table,
     count_rejected_events_per_spin,
+    expand_bin_flags_to_spins,
     flag_attitude,
     flag_hk,
     flag_imap_instruments,
     flag_low_voltage,
     flag_rates,
     flag_scattering,
+    get_binned_spins_edges,
     get_de_rejection_mask,
     get_energy_and_spin_dependent_rejection_mask,
     get_energy_histogram,
@@ -321,7 +323,7 @@ def test_flag_low_voltage(test_data):
     n_spins = 20
     mock_status_dataset = xr.Dataset(
         data_vars={
-            "epoch": np.arange(n_spins),
+            "shcoarse": np.arange(n_spins),
             # Set Voltage below threshold
             "rightdeflection_v": np.full(n_spins, 0.5),
             "leftdeflection_v": np.full(n_spins, 1.5),
@@ -332,25 +334,27 @@ def test_flag_low_voltage(test_data):
     spin_bin_size = 5
     spin_period = np.full(n_spins, 15.0)
     spin_starttime = np.arange(n_spins)
-    quality_flags = flag_low_voltage(
-        spins, spin_starttime, spin_period, mock_status_dataset, spin_bin_size
+    spin_tbin_edges = get_binned_spins_edges(
+        spins, spin_period, spin_starttime, spin_bin_size
     )
+    quality_flags = flag_low_voltage(spin_tbin_edges, mock_status_dataset)
 
-    # check quality flag
-    assert quality_flags.shape == spins.shape
+    # There should be an extra bin edge for the last bin to indicate the end of the last
+    # spin bin
+    assert len(spin_tbin_edges) == (n_spins // 5) + 1
+    # Check quality flag shape
+    assert quality_flags.shape == (len(spin_tbin_edges) - 1,)
     # Check that every spin is flagged for low voltage
     assert np.all(quality_flags == flagged)
 
     # Set only the first spin to be below threshold
     mock_status_dataset["rightdeflection_v"].data[1:] += 5000
     mock_status_dataset["leftdeflection_v"].data[1:] += 5000
-    quality_flags = flag_low_voltage(
-        spins, spin_starttime, spin_period, mock_status_dataset, spin_bin_size
-    )
+    quality_flags = flag_low_voltage(spin_tbin_edges, mock_status_dataset)
     # Check that only the first spin is flagged for low voltage
-    assert np.all(quality_flags[0:spin_bin_size] == flagged)
+    assert np.all(quality_flags[0] == flagged)
     # The rest should not be flagged
-    assert np.all(quality_flags[spin_bin_size:] == 0)
+    assert np.all(quality_flags[1:] == 0)
 
 
 def test_flag_low_voltage_incomplete_bins(test_data):
@@ -358,7 +362,7 @@ def test_flag_low_voltage_incomplete_bins(test_data):
     n_spins = 12  # Not a multiple of spin_bin_size to test incomplete bins
     mock_status_dataset = xr.Dataset(
         data_vars={
-            "epoch": np.arange(n_spins),
+            "shcoarse": np.arange(n_spins),
             # Set Voltage below threshold
             "rightdeflection_v": np.full(n_spins, 0.5),
             "leftdeflection_v": np.full(n_spins, 1.5),
@@ -369,18 +373,39 @@ def test_flag_low_voltage_incomplete_bins(test_data):
     spin_bin_size = 5
     spin_period = np.full(n_spins, 15.0)
     spin_starttime = np.arange(n_spins)
-    quality_flags = flag_low_voltage(
-        spins, spin_starttime, spin_period, mock_status_dataset, spin_bin_size
+    spin_tbin_edges = get_binned_spins_edges(
+        spins, spin_period, spin_starttime, spin_bin_size
     )
+    quality_flags = flag_low_voltage(spin_tbin_edges, mock_status_dataset)
 
     # check quality flag
-    assert quality_flags.shape == spins.shape
+    assert quality_flags.shape == (n_spins // spin_bin_size,)
     # Check that every spin is flagged for low voltage
     # Even the last incomplete bin should be flagged since it contains low voltage
     # events
     flagged = 65535
     # TODO Bobs code skips the last bin if it is incomplete.
     assert np.all(quality_flags == flagged)
+
+
+def test_expand_bin_flags_to_spins(caplog):
+    """Tests expand_bin_flags_to_spins function."""
+    spin_bin_size = 5
+    n_spins = 12
+    # Mock the shape of binned quality flags for 12 spins and a bin size of 5
+    binned_qf = np.full((n_spins // spin_bin_size), 1)
+    quality_flags = expand_bin_flags_to_spins(n_spins, binned_qf, spin_bin_size)
+    # Check the size
+    assert quality_flags.shape == (n_spins,)
+    # The first 10 spins should be flagged since they fall into the first two bins
+    assert np.all(quality_flags[:10] == 1)
+    # The last 2 spins should not be flagged since they fall into the last incomplete
+    # bin
+    assert np.all(quality_flags[10:] == 0)
+    binned_qf = np.full((n_spins // spin_bin_size) + 1, 1)
+    # test that a warning is logged when there are impartial bins found
+    expand_bin_flags_to_spins(n_spins, binned_qf, spin_bin_size)
+    assert "Found impartial spin bin at the end with 3 spins" in caplog.text
 
 
 def test_get_energy_and_spin_dependent_rejection_mask():

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -24,7 +24,7 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_rates,
     flag_scattering,
     get_de_rejection_mask,
-    get_energy_bin_flags,
+    get_energy_and_spin_dependent_rejection_mask,
     get_energy_histogram,
     get_n_sigma,
     get_pulses_per_spin,
@@ -327,7 +327,7 @@ def test_flag_low_voltage(test_data):
             "leftdeflection_v": np.full(n_spins, 1.5),
         }
     )
-    flagged = sum(get_energy_bin_flags())
+    flagged = 65535
     spins = np.arange(n_spins)
     spin_bin_size = 5
     spin_period = np.full(n_spins, 15.0)
@@ -378,6 +378,49 @@ def test_flag_low_voltage_incomplete_bins(test_data):
     # Check that every spin is flagged for low voltage
     # Even the last incomplete bin should be flagged since it contains low voltage
     # events
-    flagged = sum(get_energy_bin_flags())
+    flagged = 65535
     # TODO Bobs code skips the last bin if it is incomplete.
     assert np.all(quality_flags == flagged)
+
+
+def test_get_energy_and_spin_dependent_rejection_mask():
+    """Tests get_energy_and_spin_dependent_rejection_mask function."""
+    n_spins = 10
+    goodtimes_dataset = xr.Dataset(
+        data_vars={
+            "spin_number": np.arange(n_spins),
+            "quality_low_voltage": np.full(n_spins, 0),
+            "quality_high_energy": np.full(n_spins, 0),
+            "quality_statistics": np.full(n_spins, 0),
+            "energy_bin_flags": np.array(
+                [2**1, 2**2, 2**3]
+            ),  # Example flags for energy bins
+        }
+    )
+    # update quality flags to test that events get rejected
+    # For spin 0, set energy bin 0 to be bad (flag = 2)
+    goodtimes_dataset["quality_low_voltage"].data[0] = 2
+    # For spin 2, set energy bin 1 to be bad (flag = 4)
+    goodtimes_dataset["quality_high_energy"].data[2] = 4
+    # For spin 4, set energy bin 2 to be bad (flag = 8)
+    # Energy corresponding to spin 5 will not be rejected since it is not
+    # within an energy bin
+    # TODO check this behavior
+    goodtimes_dataset["quality_high_energy"].data[4] = 8
+    # Create 6 fake events
+    energy = np.array(
+        [4, 7, 8, 9, 11, 15]
+    )  # Energy values that fall into different bins
+    spin_number = np.arange(6)
+    energy_bin_edges = [
+        (3, 5),
+        (7, 10),
+        (12, 18),
+    ]
+    rejected = get_energy_and_spin_dependent_rejection_mask(
+        goodtimes_dataset, energy, spin_number, energy_bin_edges
+    )
+
+    np.testing.assert_array_equal(
+        rejected, np.array([True, False, True, False, False, False])
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -20,9 +20,11 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_attitude,
     flag_hk,
     flag_imap_instruments,
+    flag_low_voltage,
     flag_rates,
     flag_scattering,
     get_de_rejection_mask,
+    get_energy_bin_flags,
     get_energy_histogram,
     get_n_sigma,
     get_pulses_per_spin,
@@ -312,3 +314,70 @@ def test_count_rejected_events_per_spin():
     )
 
     np.testing.assert_array_equal(counted, np.array([2, 2, 2]))
+
+
+def test_flag_low_voltage(test_data):
+    """Tests flag_low_voltage function."""
+    n_spins = 20
+    mock_status_dataset = xr.Dataset(
+        data_vars={
+            "epoch": np.arange(n_spins),
+            # Set Voltage below threshold
+            "rightdeflection_v": np.full(n_spins, 0.5),
+            "leftdeflection_v": np.full(n_spins, 1.5),
+        }
+    )
+    flagged = sum(get_energy_bin_flags())
+    spins = np.arange(n_spins)
+    spin_bin_size = 5
+    spin_period = np.full(n_spins, 15.0)
+    spin_starttime = np.arange(n_spins)
+    quality_flags = flag_low_voltage(
+        spins, spin_starttime, spin_period, mock_status_dataset, spin_bin_size
+    )
+
+    # check quality flag
+    assert quality_flags.shape == spins.shape
+    # Check that every spin is flagged for low voltage
+    assert np.all(quality_flags == flagged)
+
+    # Set only the first spin to be below threshold
+    mock_status_dataset["rightdeflection_v"].data[1:] += 5000
+    mock_status_dataset["leftdeflection_v"].data[1:] += 5000
+    quality_flags = flag_low_voltage(
+        spins, spin_starttime, spin_period, mock_status_dataset, spin_bin_size
+    )
+    # Check that only the first spin is flagged for low voltage
+    assert np.all(quality_flags[0:spin_bin_size] == flagged)
+    # The rest should not be flagged
+    assert np.all(quality_flags[spin_bin_size:] == 0)
+
+
+def test_flag_low_voltage_incomplete_bins(test_data):
+    """Tests flag_low_voltage function when there is an incomplete spin bin."""
+    n_spins = 12  # Not a multiple of spin_bin_size to test incomplete bins
+    mock_status_dataset = xr.Dataset(
+        data_vars={
+            "epoch": np.arange(n_spins),
+            # Set Voltage below threshold
+            "rightdeflection_v": np.full(n_spins, 0.5),
+            "leftdeflection_v": np.full(n_spins, 1.5),
+        }
+    )
+
+    spins = np.arange(n_spins)
+    spin_bin_size = 5
+    spin_period = np.full(n_spins, 15.0)
+    spin_starttime = np.arange(n_spins)
+    quality_flags = flag_low_voltage(
+        spins, spin_starttime, spin_period, mock_status_dataset, spin_bin_size
+    )
+
+    # check quality flag
+    assert quality_flags.shape == spins.shape
+    # Check that every spin is flagged for low voltage
+    # Even the last incomplete bin should be flagged since it contains low voltage
+    # events
+    flagged = sum(get_energy_bin_flags())
+    # TODO Bobs code skips the last bin if it is incomplete.
+    assert np.all(quality_flags == flagged)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -381,10 +381,7 @@ def test_flag_low_voltage_incomplete_bins(test_data):
     # check quality flag
     assert quality_flags.shape == (n_spins // spin_bin_size,)
     # Check that every spin is flagged for low voltage
-    # Even the last incomplete bin should be flagged since it contains low voltage
-    # events
     flagged = 65535
-    # TODO Bobs code skips the last bin if it is incomplete.
     assert np.all(quality_flags == flagged)
 
 
@@ -403,9 +400,9 @@ def test_expand_bin_flags_to_spins(caplog):
     # bin
     assert np.all(quality_flags[10:] == 0)
     binned_qf = np.full((n_spins // spin_bin_size) + 1, 1)
-    # test that a warning is logged when there are impartial bins found
+    # test that a warning is logged when there are incomplete bins found
     expand_bin_flags_to_spins(n_spins, binned_qf, spin_bin_size)
-    assert "Found impartial spin bin at the end with 3 spins" in caplog.text
+    assert "Found incomplete spin bin at the end with 3 spins" in caplog.text
 
 
 def test_get_energy_and_spin_dependent_rejection_mask():
@@ -420,6 +417,7 @@ def test_get_energy_and_spin_dependent_rejection_mask():
             "energy_bin_flags": np.array(
                 [2**1, 2**2, 2**3]
             ),  # Example flags for energy bins
+            "energy_range_edges": np.array([3, 5, 7, 18]),  # Example energy bin edges
         }
     )
     # update quality flags to test that events get rejected
@@ -430,22 +428,50 @@ def test_get_energy_and_spin_dependent_rejection_mask():
     # For spin 4, set energy bin 2 to be bad (flag = 8)
     # Energy corresponding to spin 5 will not be rejected since it is not
     # within an energy bin
-    # TODO check this behavior
     goodtimes_dataset["quality_high_energy"].data[4] = 8
     # Create 6 fake events
     energy = np.array(
-        [4, 7, 8, 9, 11, 15]
+        [4, 5, 6, 9, 18, 15]
     )  # Energy values that fall into different bins
     spin_number = np.arange(6)
-    energy_bin_edges = [
-        (3, 5),
-        (7, 10),
-        (12, 18),
-    ]
     rejected = get_energy_and_spin_dependent_rejection_mask(
-        goodtimes_dataset, energy, spin_number, energy_bin_edges
+        goodtimes_dataset, energy, spin_number
     )
 
     np.testing.assert_array_equal(
         rejected, np.array([True, False, True, False, False, False])
     )
+
+
+def test_validate_voltage_cull():
+    """Validate that low voltage spins are correctly flagged"""
+    # read test data from csv files
+    xspin = pd.read_csv(TEST_PATH / "extendedspin_test_data_repoint00047.csv")
+    validation_low_voltage_qf = np.loadtxt(
+        TEST_PATH / "voltage_culling_results_repoint00047.csv",
+        delimiter=",",
+        dtype=np.uint16,
+    )
+    status_df = pd.read_csv(TEST_PATH / "status_test_data_repoint00047.csv")
+    # build the status dataset including the variables needed for the low voltage flag
+    status_ds = xr.Dataset(
+        {
+            "shcoarse": ("epoch", status_df.shcoarse.values),
+            "rightdeflection_v": ("epoch", status_df.rightdeflection_v.values),
+            "leftdeflection_v": ("epoch", status_df.leftdeflection_v.values),
+        }
+    )
+    # Use constants from the code to ensure consistency with the actual culling code
+    spin_bin_size = UltraConstants.SPIN_BIN_SIZE
+    lv_threshold = UltraConstants.LOW_VOLTAGE_CULL_THRESHOLD
+    spin_tbin_edges = get_binned_spins_edges(
+        xspin.spin_number.values,
+        xspin.spin_period.values,
+        xspin.spin_start_time.values,
+        spin_bin_size,
+    )
+    lv_flags = flag_low_voltage(
+        spin_tbin_edges, status_ds, lv_threshold, low_voltage_flag=1
+    )
+
+    assert np.array_equal(lv_flags, validation_low_voltage_qf)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_culling.py
@@ -443,6 +443,7 @@ def test_get_energy_and_spin_dependent_rejection_mask():
     )
 
 
+@pytest.mark.external_test_data
 def test_validate_voltage_cull():
     """Validate that low voltage spins are correctly flagged"""
     # read test data from csv files

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -176,8 +176,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     de_dict["velocity_dps_sc"] = sc_dps_velocity
     de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
     # Made up data for spin_number and energy_bin_geometric_mean
-    de_dict["spin_number"] = np.full(len(sc_dps_velocity), 0)
-    de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
+    de_dict["spin"] = np.full(len(sc_dps_velocity), 0)
     de_dict["species"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
     de_dict["ebin"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
     de_dict["event_times"] = df_subset["tdb"].values
@@ -242,7 +241,7 @@ def test_calculate_helio_pset_with_cdf(
     de_dict = {}
 
     de_dict["epoch"] = df_subset["epoch"].values
-    de_dict["spin_number"] = np.full((len(df_subset["epoch"].values)), 0)
+    de_dict["spin"] = np.full((len(df_subset["epoch"].values)), 0)
     # Fake SCLK in seconds that matches SPICE.
     de_dict["event_times"] = np.full(len(df_subset), 2.41187e13)
     de_dict["ebin"] = np.ones(len(df_subset), dtype=np.uint8)
@@ -278,7 +277,6 @@ def test_calculate_helio_pset_with_cdf(
     de_dict["quality_outliers"] = np.zeros(len(helio_dps_velocity), dtype=np.uint16)
     de_dict["species"] = np.ones(len(helio_dps_velocity), dtype=np.uint8)
     de_dict["event_times"] = df_subset["tdb"].values
-    de_dict["energy_bin_geometric_mean"] = np.zeros(len(helio_dps_velocity))
 
     name = "imap_ultra_l1b_45sensor-de"
     dataset = create_dataset(de_dict, name, "l1b")

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c.py
@@ -124,6 +124,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     ancillary_files,
     rates_dataset,
     aux_dataset,
+    mock_goodtimes_dataset,
     imap_ena_sim_metakernel,
     use_fake_spin_data_for_time,
     mock_spacecraft_pointing_lookups,
@@ -175,7 +176,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     de_dict["velocity_dps_sc"] = sc_dps_velocity
     de_dict["energy_spacecraft"] = get_de_energy_kev(sc_dps_velocity, species_bin)
     # Made up data for spin_number and energy_bin_geometric_mean
-    de_dict["spin_number"] = np.full(len(sc_dps_velocity), 128)
+    de_dict["spin_number"] = np.full(len(sc_dps_velocity), 0)
     de_dict["energy_bin_geometric_mean"] = np.zeros(len(sc_dps_velocity))
     de_dict["species"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
     de_dict["ebin"] = np.ones(len(sc_dps_velocity), dtype=np.uint8)
@@ -187,7 +188,7 @@ def test_calculate_spacecraft_pset_with_cdf(
     data_dict = {
         "imap_ultra_l1b_45sensor-de": dataset,
         "imap_ultra_l1b_45sensor-extendedspin": dataset,  # placeholder
-        "imap_ultra_l1b_45sensor-goodtimes": dataset,  # placeholder
+        "imap_ultra_l1b_45sensor-goodtimes": mock_goodtimes_dataset,  # placeholder
         "imap_ultra_l1a_45sensor-rates": rates_dataset,
         "imap_ultra_l1a_45sensor-aux": aux_dataset,
     }
@@ -220,6 +221,7 @@ def test_calculate_helio_pset_with_cdf(
     mock_helio_pointing_lookups,
     aux_dataset,
     rates_dataset,
+    mock_goodtimes_dataset,
     use_fake_spin_data_for_time,
 ):
     """Tests ultra_l1c function with imported test data."""
@@ -240,6 +242,7 @@ def test_calculate_helio_pset_with_cdf(
     de_dict = {}
 
     de_dict["epoch"] = df_subset["epoch"].values
+    de_dict["spin_number"] = np.full((len(df_subset["epoch"].values)), 0)
     # Fake SCLK in seconds that matches SPICE.
     de_dict["event_times"] = np.full(len(df_subset), 2.41187e13)
     de_dict["ebin"] = np.ones(len(df_subset), dtype=np.uint8)
@@ -275,17 +278,15 @@ def test_calculate_helio_pset_with_cdf(
     de_dict["quality_outliers"] = np.zeros(len(helio_dps_velocity), dtype=np.uint16)
     de_dict["species"] = np.ones(len(helio_dps_velocity), dtype=np.uint8)
     de_dict["event_times"] = df_subset["tdb"].values
+    de_dict["energy_bin_geometric_mean"] = np.zeros(len(helio_dps_velocity))
+
     name = "imap_ultra_l1b_45sensor-de"
     dataset = create_dataset(de_dict, name, "l1b")
     dataset.attrs["Repointing"] = "repoint00001"
     data_dict = {
         "imap_ultra_l1b_45sensor-de": dataset,
         "imap_ultra_l1b_45sensor-extendedspin": xr.Dataset(),  # placeholder
-        "imap_ultra_l1b_45sensor-goodtimes": xr.Dataset(
-            {
-                "spin_number": ("epoch", np.zeros(5)),
-            }
-        ),  # placeholder
+        "imap_ultra_l1b_45sensor-goodtimes": mock_goodtimes_dataset,
         "imap_ultra_l1a_45sensor-rates": rates_dataset,
         "imap_ultra_l1a_45sensor-aux": aux_dataset,
     }

--- a/imap_processing/ultra/constants.py
+++ b/imap_processing/ultra/constants.py
@@ -90,6 +90,7 @@ class UltraConstants:
         300.0,
         1e5,
     ]
+
     PSET_ENERGY_BIN_EDGES: ClassVar[list] = [
         3.0,
         3.4,
@@ -181,3 +182,12 @@ class UltraConstants:
     EARTH_RADIUS_KM: float = 6378.1
     N_RE = 50
     DEFAULT_EARTH_CULLING_RADIUS = EARTH_RADIUS_KM * N_RE
+
+    # L1b extended spin culling parameters
+    LOW_VOLTAGE_CULL_THRESHOLD = 3000.0
+    SPIN_BIN_SIZE = 20
+    # TODO add thresholds for energies (different for 45 and 90)
+    # Number of energy bins to use in energy dependent culling
+    N_CULL_EBINS = 8
+    # Bin to start culling at
+    BASE_CULL_EBIN = 4

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -76,9 +76,11 @@ def calculate_extendedspin(
     voltage_qf = flag_low_voltage(spin_tbin_edges, status_dataset)
     # Get energy bins used at l1c
     intervals, _, _ = build_energy_bins()
-    # Get the
+    # Get the energy ranges
     energy_ranges = get_binned_energy_ranges(intervals)
     energy_bin_flags = get_binned_energy_range_flags(energy_ranges)
+    # TODO do not include low voltage spins in the calculation of the rest of the flag!!
+
     # Get the number of pulses per spin.
     pulses = get_pulses_per_spin(aux_dataset, rates_dataset)
 
@@ -126,17 +128,19 @@ def calculate_extendedspin(
     extendedspin_dict["quality_ena_rates"] = rates_qf
     extendedspin_dict["quality_hk"] = hk_qf
     extendedspin_dict["quality_instruments"] = inst_qf
-    extendedspin_dict["quality_low_voltage"] = voltage_qf
+    extendedspin_dict["quality_low_voltage"] = voltage_qf  # shape (nspin,)
     # TODO calculate flags for high energy (SEPS) and statistics culling
     # Initialize these flags to NONE for now.
     extendedspin_dict["quality_statistics"] = np.full_like(
         voltage_qf, ImapRatesUltraFlags.NONE.value, np.uint16
-    )
+    )  # shape (nspin,)
     extendedspin_dict["quality_high_energy"] = np.full_like(
         voltage_qf, ImapRatesUltraFlags.NONE.value, np.uint16
-    )
-    # Add an array of flags for each energy bin
-    extendedspin_dict["energy_bin_flags"] = energy_bin_flags
+    )  # shape (nspin,)
+    # Add an array of flags for each energy bin. Shape: (n_energy_bins)
+    extendedspin_dict["energy_range_flags"] = energy_bin_flags
+    # Add energy ranges  Shape: (n_energy_bins + 1)
+    extendedspin_dict["energy_range_edges"] = np.array(energy_ranges)
 
     extendedspin_dataset = create_dataset(extendedspin_dict, name, "l1b")
 

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -4,11 +4,14 @@ import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
 
+from imap_processing.quality_flags import ImapRatesUltraFlags
+from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
     count_rejected_events_per_spin,
     flag_attitude,
     flag_hk,
     flag_imap_instruments,
+    flag_low_voltage,
     flag_rates,
     get_energy_histogram,
     get_pulses_per_spin,
@@ -44,6 +47,7 @@ def calculate_extendedspin(
     aux_dataset = dict_datasets[f"imap_ultra_l1a_{instrument_id}sensor-aux"]
     rates_dataset = dict_datasets[f"imap_ultra_l1a_{instrument_id}sensor-rates"]
     de_dataset = dict_datasets[f"imap_ultra_l1b_{instrument_id}sensor-de"]
+    status_dataset = dict_datasets[f"imap_ultra_l1b_{instrument_id}sensor-status"]
 
     extendedspin_dict = {}
     rates_qf, spin, energy_bin_geometric_mean, n_sigma_per_energy = flag_rates(
@@ -60,6 +64,10 @@ def calculate_extendedspin(
     hk_qf = flag_hk(de_dataset["spin"].values)
     inst_qf = flag_imap_instruments(de_dataset["spin"].values)
 
+    spin_bin_size = UltraConstants.SPIN_BIN_SIZE
+    voltage_qf = flag_low_voltage(
+        spin, spin_starttime, spin_period, status_dataset, spin_bin_size
+    )
     # Get the number of pulses per spin.
     pulses = get_pulses_per_spin(aux_dataset, rates_dataset)
 
@@ -70,6 +78,7 @@ def calculate_extendedspin(
         de_dataset["quality_scattering"].values,
         de_dataset["quality_outliers"].values,
     )
+
     # These will be the coordinates.
     extendedspin_dict["spin_number"] = spin
     extendedspin_dict["energy_bin_geometric_mean"] = energy_bin_geometric_mean
@@ -104,6 +113,15 @@ def calculate_extendedspin(
     extendedspin_dict["quality_ena_rates"] = rates_qf
     extendedspin_dict["quality_hk"] = hk_qf
     extendedspin_dict["quality_instruments"] = inst_qf
+    extendedspin_dict["quality_low_voltage"] = voltage_qf
+    # TODO calculate flags for high energy (SEPS) and statistics culling
+    # Initialize these flags to NONE for now.
+    extendedspin_dict["quality_statistics"] = np.full_like(
+        voltage_qf, ImapRatesUltraFlags.NONE.value, np.uint16
+    )
+    extendedspin_dict["quality_high_energy"] = np.full_like(
+        voltage_qf, ImapRatesUltraFlags.NONE.value, np.uint16
+    )
 
     extendedspin_dataset = create_dataset(extendedspin_dict, name, "l1b")
 

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -8,12 +8,15 @@ from imap_processing.quality_flags import ImapRatesUltraFlags
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
     count_rejected_events_per_spin,
+    expand_bin_flags_to_spins,
     flag_attitude,
     flag_hk,
     flag_imap_instruments,
     flag_low_voltage,
     flag_rates,
     get_binned_energy_range_flags,
+    get_binned_energy_ranges,
+    get_binned_spins_edges,
     get_energy_histogram,
     get_pulses_per_spin,
 )
@@ -67,12 +70,15 @@ def calculate_extendedspin(
     inst_qf = flag_imap_instruments(de_dataset["spin"].values)
 
     spin_bin_size = UltraConstants.SPIN_BIN_SIZE
-    voltage_qf = flag_low_voltage(
-        spin, spin_starttime, spin_period, status_dataset, spin_bin_size
+    spin_tbin_edges = get_binned_spins_edges(
+        spin, spin_period, spin_starttime, spin_bin_size
     )
+    voltage_qf = flag_low_voltage(spin_tbin_edges, status_dataset)
     # Get energy bins used at l1c
     intervals, _, _ = build_energy_bins()
-    energy_bin_flags = get_binned_energy_range_flags(intervals)
+    # Get the
+    energy_ranges = get_binned_energy_ranges(intervals)
+    energy_bin_flags = get_binned_energy_range_flags(energy_ranges)
     # Get the number of pulses per spin.
     pulses = get_pulses_per_spin(aux_dataset, rates_dataset)
 
@@ -109,6 +115,8 @@ def calculate_extendedspin(
     stop_per_spin[valid] = pulses.stop_per_spin[idx[valid]]
     coin_per_spin[valid] = pulses.coin_per_spin[idx[valid]]
 
+    # Expand binned quality flags to individual spins.
+    voltage_qf = expand_bin_flags_to_spins(len(spin), voltage_qf, spin_bin_size)
     # account for rates spins which are not in the direct event spins
     extendedspin_dict["start_pulses_per_spin"] = start_per_spin
     extendedspin_dict["stop_pulses_per_spin"] = stop_per_spin

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -13,9 +13,11 @@ from imap_processing.ultra.l1b.ultra_l1b_culling import (
     flag_imap_instruments,
     flag_low_voltage,
     flag_rates,
+    get_binned_energy_range_flags,
     get_energy_histogram,
     get_pulses_per_spin,
 )
+from imap_processing.ultra.l1c.l1c_lookup_utils import build_energy_bins
 from imap_processing.ultra.utils.ultra_l1_utils import create_dataset
 
 FILLVAL_UINT16 = 65535
@@ -68,6 +70,9 @@ def calculate_extendedspin(
     voltage_qf = flag_low_voltage(
         spin, spin_starttime, spin_period, status_dataset, spin_bin_size
     )
+    # Get energy bins used at l1c
+    intervals, _, _ = build_energy_bins()
+    energy_bin_flags = get_binned_energy_range_flags(intervals)
     # Get the number of pulses per spin.
     pulses = get_pulses_per_spin(aux_dataset, rates_dataset)
 
@@ -122,6 +127,8 @@ def calculate_extendedspin(
     extendedspin_dict["quality_high_energy"] = np.full_like(
         voltage_qf, ImapRatesUltraFlags.NONE.value, np.uint16
     )
+    # Add an array of flags for each energy bin
+    extendedspin_dict["energy_bin_flags"] = energy_bin_flags
 
     extendedspin_dataset = create_dataset(extendedspin_dict, name, "l1b")
 

--- a/imap_processing/ultra/l1b/goodtimes.py
+++ b/imap_processing/ultra/l1b/goodtimes.py
@@ -88,6 +88,15 @@ def calculate_goodtimes(extendedspin_dataset: xr.Dataset, name: str) -> xr.Datas
         goodtimes_dataset["quality_attitude"] = xr.DataArray(
             np.array([FILLVAL_UINT16], dtype="uint16"), dims=["spin_number"]
         )
+        goodtimes_dataset["quality_low_voltage"] = xr.DataArray(
+            np.array([FILLVAL_UINT16], dtype="uint16"), dims=["spin_number"]
+        )
+        goodtimes_dataset["quality_high_energy"] = xr.DataArray(
+            np.array([FILLVAL_UINT16], dtype="uint16"), dims=["spin_number"]
+        )
+        goodtimes_dataset["quality_statistics"] = xr.DataArray(
+            np.array([FILLVAL_UINT16], dtype="uint16"), dims=["spin_number"]
+        )
         goodtimes_dataset["quality_hk"] = xr.DataArray(
             np.array([FILLVAL_UINT16], dtype="uint16"),
             dims=["spin_number"],

--- a/imap_processing/ultra/l1b/quality_flag_filters.py
+++ b/imap_processing/ultra/l1b/quality_flag_filters.py
@@ -8,12 +8,22 @@ from imap_processing.quality_flags import (
 )
 
 SPIN_QUALITY_FLAG_FILTERS: dict[str, list[FlagNameMixin]] = {
-    "quality_attitude": [],
+    "quality_attitude": [],  # This is empty for now but can be populated with attitude
+    # flags in the future
     "quality_ena_rates": [
         ImapRatesUltraFlags.FIRSTSPIN,
         ImapRatesUltraFlags.LASTSPIN,
     ],
 }
+# The following quality flag arrays contain flags that are dynamically created
+# In ULTRA l1b extended spin. The flags are created based on the number
+# Of bins that were used to group energies. If the flag array is in this list,
+# Then all flags in the array will be used for filtering.
+ENERGY_DEPENDENT_SPIN_QUALITY_FLAG_FILTERS: list = [
+    "quality_low_voltage",
+    "quality_high_energy",
+    "quality_statistics",
+]
 
 DE_QUALITY_FLAG_FILTERS: dict[str, list[FlagNameMixin]] = {
     "quality_outliers": [

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -51,6 +51,7 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
             and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
+            and f"imap_ultra_l1b_{instrument_id}sensor-status" in data_dict
         ):
             extendedspin_dataset = calculate_extendedspin(
                 {
@@ -65,6 +66,9 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
                     ],
                     f"imap_ultra_l1b_{instrument_id}sensor-de": data_dict[
                         f"imap_ultra_l1b_{instrument_id}sensor-de"
+                    ],
+                    f"imap_ultra_l1b_{instrument_id}sensor-status": data_dict[
+                        f"imap_ultra_l1b_{instrument_id}sensor-status"
                     ],
                 },
                 f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -21,7 +21,10 @@ from imap_processing.ultra.l1b.lookup_utils import (
     get_scattering_coefficients,
     get_scattering_thresholds,
 )
-from imap_processing.ultra.l1b.quality_flag_filters import DE_QUALITY_FLAG_FILTERS
+from imap_processing.ultra.l1b.quality_flag_filters import (
+    DE_QUALITY_FLAG_FILTERS,
+    ENERGY_DEPENDENT_SPIN_QUALITY_FLAG_FILTERS,
+)
 from imap_processing.ultra.l1b.ultra_l1b_extended import get_spin_info
 from imap_processing.ultra.l1c.l1c_lookup_utils import build_energy_bins
 
@@ -549,10 +552,13 @@ def get_energy_and_spin_dependent_rejection_mask(
     """
     # Get the ebin flags for each energy bin from the goodtimes dataset.
     energy_range_edges = goodtimes_dataset["energy_range_edges"].values
+    # Get the quality flag arrays "turned on" for energy dependent culling from the
+    # goodtimes dataset.
+    flag_arrays = [
+        goodtimes_dataset[flag_name].values
+        for flag_name in ENERGY_DEPENDENT_SPIN_QUALITY_FLAG_FILTERS
+    ]
     ebin_flags = goodtimes_dataset["energy_bin_flags"].values
-    low_voltage = goodtimes_dataset["quality_low_voltage"].values
-    high_energy = goodtimes_dataset["quality_high_energy"].values
-    statistics = goodtimes_dataset["quality_statistics"].values
     # Create a dict of spin_number to index in the goodtimes dataset
     spin_to_idx = {
         spin: idx for idx, spin in enumerate(goodtimes_dataset["spin_number"].values)
@@ -570,10 +576,11 @@ def get_energy_and_spin_dependent_rejection_mask(
         # If the flag is set for any of the quality arrays, then reject
         # the event.
         flagged_at_spins = (
-            (low_voltage[goodtimes_inds] & energy_bin_flag)
-            | (high_energy[goodtimes_inds] & energy_bin_flag)
-            | (statistics[goodtimes_inds] & energy_bin_flag)
-        ) > 0
+            np.bitwise_or.reduce(
+                [qf[goodtimes_inds] & energy_bin_flag for qf in flag_arrays]
+            )
+            > 0
+        )
 
         # Mark flagged events as rejected
         mask_indices = np.where(mask)[0]
@@ -671,21 +678,21 @@ def flag_low_voltage(
     return quality_flags
 
 
-def get_binned_energy_range_flags(energy_ranges: list[tuple[float, float]]) -> NDArray:
+def get_binned_energy_range_flags(energy_ranges_edges: NDArray) -> NDArray:
     """
     Get the energy bin flags for energy dependent culling.
 
     Parameters
     ----------
-    energy_ranges : list[tuple[float, float]]
-        List of (start, stop) tuples for each energy range.
+    energy_ranges_edges : NDArray
+        Array of energy range edges.
 
     Returns
     -------
     energy_bin_flags : NDArray
         Energy bin flags.
     """
-    num_bins = len(energy_ranges)
+    num_bins = len(energy_ranges_edges) - 1
     if num_bins > 16:
         raise ValueError(
             f"Number of culling energy bins ({num_bins}) "

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -558,7 +558,10 @@ def get_energy_and_spin_dependent_rejection_mask(
         goodtimes_dataset[flag_name].values
         for flag_name in ENERGY_DEPENDENT_SPIN_QUALITY_FLAG_FILTERS
     ]
-    ebin_flags = goodtimes_dataset["energy_bin_flags"].values
+    flagged = np.where(flag_arrays[0] != 0)
+    print(flagged)
+    print(goodtimes_dataset["spin_number"].values[flagged])
+    ebin_flags = goodtimes_dataset["energy_range_flags"].values
     # Create a dict of spin_number to index in the goodtimes dataset
     spin_to_idx = {
         spin: idx for idx, spin in enumerate(goodtimes_dataset["spin_number"].values)

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -129,9 +129,13 @@ def flag_attitude(
     spins = np.unique(spin_number)  # Get unique spins
     spin_df = get_spin_data()  # Load spin data
 
-    spin_period = spin_df.loc[spin_df.spin_number.isin(spins), "spin_period_sec"]
-    spin_starttime = spin_df.loc[spin_df.spin_number.isin(spins), "spin_start_met"]
-    spin_phase_valid = spin_df.loc[spin_df.spin_number.isin(spins), "spin_phase_valid"]
+    spin_period = spin_df.loc[spin_df.spin_number.isin(spins), "spin_period_sec"].values
+    spin_starttime = spin_df.loc[
+        spin_df.spin_number.isin(spins), "spin_start_met"
+    ].values
+    spin_phase_valid = spin_df.loc[
+        spin_df.spin_number.isin(spins), "spin_phase_valid"
+    ].values
     spin_period_valid = spin_df.loc[
         spin_df.spin_number.isin(spins), "spin_period_valid"
     ]
@@ -619,11 +623,8 @@ def count_rejected_events_per_spin(
 
 
 def flag_low_voltage(
-    spins: NDArray,
-    spin_start_times: NDArray,
-    spin_periods: NDArray,
+    spin_tbin_edges: NDArray,
     status_dataset: xr.Dataset,
-    spin_bin_size: int = UltraConstants.SPIN_BIN_SIZE,
     voltage_threshold: float = UltraConstants.LOW_VOLTAGE_CULL_THRESHOLD,
     low_voltage_flag: int = 65535,  # default is max uint16
 ) -> NDArray:
@@ -632,16 +633,10 @@ def flag_low_voltage(
 
     Parameters
     ----------
-    spins : NDArray
-        Spin time bin edges for grouping spins together.
-    spin_start_times : NDArray
-        Spin start times corresponding to the unique spin numbers.
-    spin_periods : NDArray
-        Spin periods corresponding to the unique spin numbers.
+    spin_tbin_edges : NDArray
+        Edges of the spin time bins.
     status_dataset : xarray.Dataset
         Status dataset containing voltage information.
-    spin_bin_size : int
-        The number of spins to group together in a bin.
     voltage_threshold : float
         Voltage threshold below which to flag low voltage events.
     low_voltage_flag : int
@@ -652,8 +647,11 @@ def flag_low_voltage(
     quality_flags : NDArray
         Quality flags.
     """
+    spin_bin_size = len(spin_tbin_edges) - 1
     # initialize all spins to have no low voltage flag
-    quality_flags = np.full(len(spins), ImapRatesUltraFlags.NONE.value, dtype=np.uint16)
+    quality_flags = np.full(
+        spin_bin_size, ImapRatesUltraFlags.NONE.value, dtype=np.uint16
+    )
     # Get the min voltage across both deflection plate at each epoch
     min_voltage = np.minimum(
         status_dataset["rightdeflection_v"].data,
@@ -665,38 +663,16 @@ def flag_low_voltage(
     if not low_voltage_inds.size:
         return quality_flags
 
-    # Append the last start time plus the spin period to account for low voltage times
-    # that occur after the last spin start time
-    spin_start_times = np.append(
-        spin_start_times, spin_start_times[-1] + spin_periods[-1]
-    )
-
-    low_voltage_times = status_dataset["epoch"].data[low_voltage_inds]
+    low_voltage_times = status_dataset["shcoarse"].data[low_voltage_inds]
     # For each low voltage time, find the corresponding spin time
     lv_spin_inds = np.atleast_1d(
-        np.searchsorted(spin_start_times, low_voltage_times, side="right") - 1
+        np.searchsorted(spin_tbin_edges, low_voltage_times, side="right") - 1
     )
-    # Ensure that the indices are within the valid range of spin bins
-    valid_spin_inds = (lv_spin_inds <= len(spins) - 1) & (lv_spin_inds >= 0)
-    lv_spin_inds = lv_spin_inds[valid_spin_inds]
-    # For each low voltage ind, flag the corresponding spins that fall within the same
-    # spin time bin with the LOW_VOLTAGE flag
-    for ind in lv_spin_inds:
-        # e.g. if ind = 2 and spin_bin_size = 4, then this maps to the first bin
-        # (spins at 0-4)
-        start_idx = (ind // spin_bin_size) * spin_bin_size
-        end_idx = start_idx + spin_bin_size
-        # Handle edge case where the last bin may not be full
-        # e.g. there are 12 spins, and spin_bin_size is 5, if ind is 10, then start_idx
-        # is 10 and end_idx is 15, but we only have spins up to index 11, so we need
-        # to cap the end_idx at 12
-        end_idx = min(end_idx, len(spins))
-        flag_inds = np.arange(start_idx, end_idx)
-        # Flag all the spins in the bin with all energy flags (voltage culling is
-        # independent of energy, so we flag all energy bins for the spins in the bin).
-        # We want to keep voltage quality flags consistent with stat culling and high
-        # energy culling flags
-        quality_flags[flag_inds] = low_voltage_flag
+    # Ensure that the indices are within the valid range of spin groups
+    valid_bin_inds = (lv_spin_inds >= 0) & (lv_spin_inds < spin_bin_size)
+    lv_spin_inds = lv_spin_inds[valid_bin_inds]
+    # For each low voltage ind, flag the corresponding flag
+    quality_flags[lv_spin_inds] = low_voltage_flag
 
     return quality_flags
 
@@ -759,3 +735,81 @@ def get_binned_energy_ranges(
         for i in range(n_complete_groups)
     ]
     return energy_ranges
+
+
+def get_binned_spins_edges(
+    spins: NDArray,
+    spin_periods: NDArray,
+    spin_start_times: NDArray,
+    spin_bin_size: int = UltraConstants.SPIN_BIN_SIZE,
+) -> NDArray:
+    """
+    Create spin bins for grouping spins together.
+
+    Parameters
+    ----------
+    spins : NDArray
+        Unique spin numbers.
+    spin_periods : NDArray
+        Spin periods corresponding to the unique spin numbers.
+    spin_start_times : NDArray
+        Spin start times corresponding to the unique spin numbers.
+    spin_bin_size : int
+        Number of spins to group together for voltage flagging.
+
+    Returns
+    -------
+    spin_tbin_edges : NDArray
+        Spin time bin edges.
+    """
+    # Create bins based on the number of spins per bin
+    n_spin_bins = len(spins) // spin_bin_size  # No partial bins
+    # TODO do we want to truncate and potentially miss the last few spins if they don't
+    #  fill a whole bin?
+    # Get the start time of each bin
+    spin_tbin_edges = spin_start_times[::spin_bin_size][:n_spin_bins]
+    if spin_tbin_edges.size == 0:
+        # If there are no valid spin bins, return an array with a single edge at 0
+        raise ValueError(
+            f"No valid spin bins found for bin size: {spin_bin_size}"
+            f" and number of spins: {len(spins)}."
+        )
+    # Append the last start time plus the spin period to account for low times
+    # that occur after the last spin start time
+    spin_tbin_edges = np.append(spin_tbin_edges, spin_tbin_edges[-1] + spin_periods[-1])
+    return spin_tbin_edges
+
+
+def expand_bin_flags_to_spins(
+    n_spins: int, binned_quality_flags: NDArray, spin_bin_size: int
+) -> NDArray:
+    """
+    Map binned spin flags back to individual spins.
+
+    Parameters
+    ----------
+    n_spins : int
+        Number of unique spin numbers.
+    binned_quality_flags : NDArray
+        Quality flags for each spin bin.
+    spin_bin_size : int
+        Number of spins that were grouped together for the binned quality flags.
+
+    Returns
+    -------
+    quality_flags : NDArray
+        Quality flags mapped to each individual spin.
+    """
+    quality_flags = np.full(n_spins, ImapRatesUltraFlags.NONE.value, dtype=np.uint16)
+    # Repeat each binned flag for the number of spins in each bin
+    repeated_flags = np.repeat(binned_quality_flags, spin_bin_size)
+    if len(repeated_flags) > n_spins:
+        logger.warning(
+            f"Found impartial spin bin at the end with"
+            f" {len(repeated_flags) - n_spins} spins. These spins will be "
+            f"ignored."
+        )
+        repeated_flags = repeated_flags[:n_spins]
+    quality_flags[: len(repeated_flags)] = repeated_flags
+
+    return quality_flags

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -132,14 +132,11 @@ def flag_attitude(
     spins = np.unique(spin_number)  # Get unique spins
     spin_df = get_spin_data()  # Load spin data
 
-    spin_period = spin_df.loc[spin_df.spin_number.isin(spins), "spin_period_sec"].values
-    spin_starttime = spin_df.loc[
-        spin_df.spin_number.isin(spins), "spin_start_met"
-    ].values
-    spin_phase_valid = spin_df.loc[spin_df.spin_number.isin(spins), "spin_phase_valid"]
-    spin_period_valid = spin_df.loc[
-        spin_df.spin_number.isin(spins), "spin_period_valid"
-    ]
+    spin_df = spin_df[spin_df.spin_number.isin(spins)]
+    spin_period = spin_df["spin_period_sec"].values
+    spin_starttime = spin_df["spin_start_met"].values
+    spin_phase_valid = spin_df["spin_phase_valid"].values
+    spin_period_valid = spin_df["spin_period_valid"].values
     spin_rates = 60 / spin_period  # 60 seconds in a minute
     bad_spin_rate_indices = (spin_rates < UltraConstants.CULLING_RPM_MIN) | (
         spin_rates > UltraConstants.CULLING_RPM_MAX
@@ -558,9 +555,6 @@ def get_energy_and_spin_dependent_rejection_mask(
         goodtimes_dataset[flag_name].values
         for flag_name in ENERGY_DEPENDENT_SPIN_QUALITY_FLAG_FILTERS
     ]
-    flagged = np.where(flag_arrays[0] != 0)
-    print(flagged)
-    print(goodtimes_dataset["spin_number"].values[flagged])
     ebin_flags = goodtimes_dataset["energy_range_flags"].values
     # Create a dict of spin_number to index in the goodtimes dataset
     spin_to_idx = {

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -133,9 +133,7 @@ def flag_attitude(
     spin_starttime = spin_df.loc[
         spin_df.spin_number.isin(spins), "spin_start_met"
     ].values
-    spin_phase_valid = spin_df.loc[
-        spin_df.spin_number.isin(spins), "spin_phase_valid"
-    ].values
+    spin_phase_valid = spin_df.loc[spin_df.spin_number.isin(spins), "spin_phase_valid"]
     spin_period_valid = spin_df.loc[
         spin_df.spin_number.isin(spins), "spin_period_valid"
     ]
@@ -531,7 +529,6 @@ def get_energy_and_spin_dependent_rejection_mask(
     goodtimes_dataset: xr.Dataset,
     energy: np.ndarray,
     spin_number: np.ndarray,
-    energy_bin_edges: list[tuple[float, float]],
 ) -> NDArray:
     """
     Create boolean mask where event is rejected due to relevant flags.
@@ -544,8 +541,6 @@ def get_energy_and_spin_dependent_rejection_mask(
         The particle energy.
     spin_number : np.ndarray
         Spin number at each direct event.
-    energy_bin_edges : list[tuple[float, float]]
-        List of tuples containing the energy bin edges for each energy bin.
 
     Returns
     -------
@@ -553,6 +548,7 @@ def get_energy_and_spin_dependent_rejection_mask(
         Rejected events where True = rejected.
     """
     # Get the ebin flags for each energy bin from the goodtimes dataset.
+    energy_range_edges = goodtimes_dataset["energy_range_edges"].values
     ebin_flags = goodtimes_dataset["energy_bin_flags"].values
     low_voltage = goodtimes_dataset["quality_low_voltage"].values
     high_energy = goodtimes_dataset["quality_high_energy"].values
@@ -563,13 +559,11 @@ def get_energy_and_spin_dependent_rejection_mask(
     }
 
     # Initialize all events to not rejected
-    # TODO should this be rejected? energies that fall outside the energy bins
-    #  should be rejected, but currently they will just be ignored
     rejected = np.full(energy.shape, False, dtype=bool)
     # loop through each energy bin and flag events that fall within an energy
     # bin and have the corresponding energy bin flag set in the goodtimes dataset.
-    for i, (e_min, e_max) in enumerate(energy_bin_edges):
-        mask = (energy >= e_min) & (energy < e_max)
+    for i in range(len(energy_range_edges) - 1):
+        mask = (energy >= energy_range_edges[i]) & (energy < energy_range_edges[i + 1])
         goodtimes_inds = [spin_to_idx[spin] for spin in spin_number[mask]]
         # Get the flag value for the current energy bin
         energy_bin_flag = ebin_flags[i]
@@ -702,7 +696,7 @@ def get_binned_energy_range_flags(energy_ranges: list[tuple[float, float]]) -> N
 
 def get_binned_energy_ranges(
     energy_bin_edges: list[tuple[float, float]],
-) -> list[tuple[float, float]]:
+) -> NDArray:
     """
     Create L1C energy ranges by grouping energy bins.
 
@@ -713,8 +707,9 @@ def get_binned_energy_ranges(
 
     Returns
     -------
-    energy_ranges : list[tuple[float, float]]
-        List of (start, stop) tuples for each grouped energy range.
+    energy_range_edges : NDArray
+        Array of bin edges. For N energy ranges, returns N+1 edge values.
+        Range i spans from energy_range_edges[i] to energy_range_edges[i+1].
     """
     # Get indices for group starts
     group_start_inds = np.arange(
@@ -722,18 +717,14 @@ def get_binned_energy_ranges(
         len(energy_bin_edges),
         UltraConstants.N_CULL_EBINS,
     )
-    # Get indices for group ends
-    group_end_inds = np.append(group_start_inds[1:] - 1, len(energy_bin_edges) - 1)
-    # Calculate the number of complete groups
-    n_complete_groups = len(group_start_inds) - 1
-    # Build a list of start and stop energy ranges for each complete group
-    energy_ranges = [
-        (
-            energy_bin_edges[group_start_inds[i]][0],
-            energy_bin_edges[group_end_inds[i]][1],
-        )
-        for i in range(n_complete_groups)
-    ]
+    energy_starts = [energy_bin_edges[i][0] for i in group_start_inds]
+    # Append the stop energy of the last bin to cover the full range
+    last_group_end_ind = min(
+        group_start_inds[-1] + UltraConstants.N_CULL_EBINS, len(energy_bin_edges)
+    )
+    energy_ranges = np.append(
+        energy_starts, energy_bin_edges[last_group_end_ind - 1][1]
+    )
     return energy_ranges
 
 
@@ -763,9 +754,8 @@ def get_binned_spins_edges(
         Spin time bin edges.
     """
     # Create bins based on the number of spins per bin
-    n_spin_bins = len(spins) // spin_bin_size  # No partial bins
-    # TODO do we want to truncate and potentially miss the last few spins if they don't
-    #  fill a whole bin?
+    # We will only use complete bins for culling so use integer division.
+    n_spin_bins = len(spins) // spin_bin_size
     # Get the start time of each bin
     spin_tbin_edges = spin_start_times[::spin_bin_size][:n_spin_bins]
     if spin_tbin_edges.size == 0:
@@ -805,7 +795,7 @@ def expand_bin_flags_to_spins(
     repeated_flags = np.repeat(binned_quality_flags, spin_bin_size)
     if len(repeated_flags) > n_spins:
         logger.warning(
-            f"Found impartial spin bin at the end with"
+            f"Found incomplete spin bin at the end with"
             f" {len(repeated_flags) - n_spins} spins. These spins will be "
             f"ignored."
         )

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -523,6 +523,67 @@ def get_de_rejection_mask(
     return rejected
 
 
+def get_energy_and_spin_dependent_rejection_mask(
+    goodtimes_dataset: xr.Dataset,
+    energy: np.ndarray,
+    spin_number: np.ndarray,
+    energy_bin_edges: list[tuple[float, float]],
+) -> NDArray:
+    """
+    Create boolean mask where event is rejected due to relevant flags.
+
+    Parameters
+    ----------
+    goodtimes_dataset : xr.Dataset
+        Dataset containing valid spins and energy bin flags.
+    energy : np.ndarray
+        The particle energy.
+    spin_number : np.ndarray
+        Spin number at each direct event.
+    energy_bin_edges : list[tuple[float, float]]
+        List of tuples containing the energy bin edges for each energy bin.
+
+    Returns
+    -------
+    rejected : NDArray
+        Rejected events where True = rejected.
+    """
+    # Get the ebin flags for each energy bin from the goodtimes dataset.
+    ebin_flags = goodtimes_dataset["energy_bin_flags"].values
+    low_voltage = goodtimes_dataset["quality_low_voltage"].values
+    high_energy = goodtimes_dataset["quality_high_energy"].values
+    statistics = goodtimes_dataset["quality_statistics"].values
+    # Create a dict of spin_number to index in the goodtimes dataset
+    spin_to_idx = {
+        spin: idx for idx, spin in enumerate(goodtimes_dataset["spin_number"].values)
+    }
+
+    # Initialize all events to not rejected
+    # TODO should this be rejected? energies that fall outside the energy bins
+    #  should be rejected, but currently they will just be ignored
+    rejected = np.full(energy.shape, False, dtype=bool)
+    # loop through each energy bin and flag events that fall within an energy
+    # bin and have the corresponding energy bin flag set in the goodtimes dataset.
+    for i, (e_min, e_max) in enumerate(energy_bin_edges):
+        mask = (energy >= e_min) & (energy < e_max)
+        goodtimes_inds = [spin_to_idx[spin] for spin in spin_number[mask]]
+        # Get the flag value for the current energy bin
+        energy_bin_flag = ebin_flags[i]
+        # If the flag is set for any of the quality arrays, then reject
+        # the event.
+        flagged_at_spins = (
+            (low_voltage[goodtimes_inds] & energy_bin_flag)
+            | (high_energy[goodtimes_inds] & energy_bin_flag)
+            | (statistics[goodtimes_inds] & energy_bin_flag)
+        ) > 0
+
+        # Mark flagged events as rejected
+        mask_indices = np.where(mask)[0]
+        rejected[mask_indices[flagged_at_spins]] = True
+
+    return rejected
+
+
 def count_rejected_events_per_spin(
     spins: NDArray, quality_scattering: NDArray, quality_outliers: NDArray
 ) -> NDArray:
@@ -564,6 +625,7 @@ def flag_low_voltage(
     status_dataset: xr.Dataset,
     spin_bin_size: int = UltraConstants.SPIN_BIN_SIZE,
     voltage_threshold: float = UltraConstants.LOW_VOLTAGE_CULL_THRESHOLD,
+    low_voltage_flag: int = 65535,  # default is max uint16
 ) -> NDArray:
     """
     Flag low voltage events.
@@ -582,13 +644,14 @@ def flag_low_voltage(
         The number of spins to group together in a bin.
     voltage_threshold : float
         Voltage threshold below which to flag low voltage events.
+    low_voltage_flag : int
+        The flag value to set for low voltage events.
 
     Returns
     -------
     quality_flags : NDArray
         Quality flags.
     """
-    low_voltage_flag = sum(get_energy_bin_flags())
     # initialize all spins to have no low voltage flag
     quality_flags = np.full(len(spins), ImapRatesUltraFlags.NONE.value, dtype=np.uint16)
     # Get the min voltage across both deflection plate at each epoch
@@ -611,7 +674,7 @@ def flag_low_voltage(
     low_voltage_times = status_dataset["epoch"].data[low_voltage_inds]
     # For each low voltage time, find the corresponding spin time
     lv_spin_inds = np.atleast_1d(
-        np.searchsorted(spin_start_times, low_voltage_times) - 1
+        np.searchsorted(spin_start_times, low_voltage_times, side="right") - 1
     )
     # Ensure that the indices are within the valid range of spin bins
     valid_spin_inds = (lv_spin_inds <= len(spins) - 1) & (lv_spin_inds >= 0)
@@ -638,31 +701,61 @@ def flag_low_voltage(
     return quality_flags
 
 
-def get_binned_energies_for_culling() -> NDArray:
-    """
-    Get the binned energy values for energy dependent culling.
-
-    Returns
-    -------
-    energy_bin_geometric_means : NDArray
-        Geometric mean of the energy bins.
-    """
-    pass
-
-
-def get_energy_bin_flags() -> NDArray:
+def get_binned_energy_range_flags(energy_ranges: list[tuple[float, float]]) -> NDArray:
     """
     Get the energy bin flags for energy dependent culling.
+
+    Parameters
+    ----------
+    energy_ranges : list[tuple[float, float]]
+        List of (start, stop) tuples for each energy range.
 
     Returns
     -------
     energy_bin_flags : NDArray
         Energy bin flags.
     """
-    n_ebins = UltraConstants.N_CULL_EBINS
-    if n_ebins > 16:
+    num_bins = len(energy_ranges)
+    if num_bins > 16:
         raise ValueError(
-            f"Number of culling energy bins ({n_ebins}) "
+            f"Number of culling energy bins ({num_bins}) "
             f"cannot exceed 16 due to uint16 bit limitations."
         )
-    return np.array([2**bit for bit in range(n_ebins)], dtype=np.uint16)
+    return np.array([2**bit for bit in range(num_bins)], dtype=np.uint16)
+
+
+def get_binned_energy_ranges(
+    energy_bin_edges: list[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    """
+    Create L1C energy ranges by grouping energy bins.
+
+    Parameters
+    ----------
+    energy_bin_edges : list[tuple[float, float]]
+        List of (start, stop) tuples for each energy bin.
+
+    Returns
+    -------
+    energy_ranges : list[tuple[float, float]]
+        List of (start, stop) tuples for each grouped energy range.
+    """
+    # Get indices for group starts
+    group_start_inds = np.arange(
+        UltraConstants.BASE_CULL_EBIN,
+        len(energy_bin_edges),
+        UltraConstants.N_CULL_EBINS,
+    )
+    # Get indices for group ends
+    group_end_inds = np.append(group_start_inds[1:] - 1, len(energy_bin_edges) - 1)
+    # Calculate the number of complete groups
+    n_complete_groups = len(group_start_inds) - 1
+    # Build a list of start and stop energy ranges for each complete group
+    energy_ranges = [
+        (
+            energy_bin_edges[group_start_inds[i]][0],
+            energy_bin_edges[group_end_inds[i]][1],
+        )
+        for i in range(n_complete_groups)
+    ]
+    return energy_ranges

--- a/imap_processing/ultra/l1b/ultra_l1b_culling.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_culling.py
@@ -555,3 +555,114 @@ def count_rejected_events_per_spin(
     )
 
     return rejected_counts
+
+
+def flag_low_voltage(
+    spins: NDArray,
+    spin_start_times: NDArray,
+    spin_periods: NDArray,
+    status_dataset: xr.Dataset,
+    spin_bin_size: int = UltraConstants.SPIN_BIN_SIZE,
+    voltage_threshold: float = UltraConstants.LOW_VOLTAGE_CULL_THRESHOLD,
+) -> NDArray:
+    """
+    Flag low voltage events.
+
+    Parameters
+    ----------
+    spins : NDArray
+        Spin time bin edges for grouping spins together.
+    spin_start_times : NDArray
+        Spin start times corresponding to the unique spin numbers.
+    spin_periods : NDArray
+        Spin periods corresponding to the unique spin numbers.
+    status_dataset : xarray.Dataset
+        Status dataset containing voltage information.
+    spin_bin_size : int
+        The number of spins to group together in a bin.
+    voltage_threshold : float
+        Voltage threshold below which to flag low voltage events.
+
+    Returns
+    -------
+    quality_flags : NDArray
+        Quality flags.
+    """
+    low_voltage_flag = sum(get_energy_bin_flags())
+    # initialize all spins to have no low voltage flag
+    quality_flags = np.full(len(spins), ImapRatesUltraFlags.NONE.value, dtype=np.uint16)
+    # Get the min voltage across both deflection plate at each epoch
+    min_voltage = np.minimum(
+        status_dataset["rightdeflection_v"].data,
+        status_dataset["leftdeflection_v"].data,
+    )
+    # Get the indices where the min voltage is below the threshold
+    low_voltage_inds = np.nonzero(min_voltage < voltage_threshold)[0]
+
+    if not low_voltage_inds.size:
+        return quality_flags
+
+    # Append the last start time plus the spin period to account for low voltage times
+    # that occur after the last spin start time
+    spin_start_times = np.append(
+        spin_start_times, spin_start_times[-1] + spin_periods[-1]
+    )
+
+    low_voltage_times = status_dataset["epoch"].data[low_voltage_inds]
+    # For each low voltage time, find the corresponding spin time
+    lv_spin_inds = np.atleast_1d(
+        np.searchsorted(spin_start_times, low_voltage_times) - 1
+    )
+    # Ensure that the indices are within the valid range of spin bins
+    valid_spin_inds = (lv_spin_inds <= len(spins) - 1) & (lv_spin_inds >= 0)
+    lv_spin_inds = lv_spin_inds[valid_spin_inds]
+    # For each low voltage ind, flag the corresponding spins that fall within the same
+    # spin time bin with the LOW_VOLTAGE flag
+    for ind in lv_spin_inds:
+        # e.g. if ind = 2 and spin_bin_size = 4, then this maps to the first bin
+        # (spins at 0-4)
+        start_idx = (ind // spin_bin_size) * spin_bin_size
+        end_idx = start_idx + spin_bin_size
+        # Handle edge case where the last bin may not be full
+        # e.g. there are 12 spins, and spin_bin_size is 5, if ind is 10, then start_idx
+        # is 10 and end_idx is 15, but we only have spins up to index 11, so we need
+        # to cap the end_idx at 12
+        end_idx = min(end_idx, len(spins))
+        flag_inds = np.arange(start_idx, end_idx)
+        # Flag all the spins in the bin with all energy flags (voltage culling is
+        # independent of energy, so we flag all energy bins for the spins in the bin).
+        # We want to keep voltage quality flags consistent with stat culling and high
+        # energy culling flags
+        quality_flags[flag_inds] = low_voltage_flag
+
+    return quality_flags
+
+
+def get_binned_energies_for_culling() -> NDArray:
+    """
+    Get the binned energy values for energy dependent culling.
+
+    Returns
+    -------
+    energy_bin_geometric_means : NDArray
+        Geometric mean of the energy bins.
+    """
+    pass
+
+
+def get_energy_bin_flags() -> NDArray:
+    """
+    Get the energy bin flags for energy dependent culling.
+
+    Returns
+    -------
+    energy_bin_flags : NDArray
+        Energy bin flags.
+    """
+    n_ebins = UltraConstants.N_CULL_EBINS
+    if n_ebins > 16:
+        raise ValueError(
+            f"Number of culling energy bins ({n_ebins}) "
+            f"cannot exceed 16 due to uint16 bit limitations."
+        )
+    return np.array([2**bit for bit in range(n_ebins)], dtype=np.uint16)

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -15,7 +15,6 @@ from imap_processing.spice.time import (
 )
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
-    get_binned_energy_ranges,
     get_de_rejection_mask,
     get_energy_and_spin_dependent_rejection_mask,
 )
@@ -107,14 +106,11 @@ def calculate_helio_pset(
 
     intervals, _, energy_bin_geometric_means = build_energy_bins()
 
-    energy_bin_ranges = get_binned_energy_ranges(intervals)
-
     # Now check energy dependent flags.
     energy_dependent_rejected = get_energy_and_spin_dependent_rejection_mask(
         goodtimes_dataset,
         species_dataset["energy_heliosphere"].values,
         species_dataset["spin_number"].values,
-        energy_bin_ranges,
     )
     species_dataset = species_dataset.isel(epoch=~energy_dependent_rejected)
     v_mag_helio_spacecraft = np.linalg.norm(

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -14,7 +14,11 @@ from imap_processing.spice.time import (
     ttj2000ns_to_et,
 )
 from imap_processing.ultra.constants import UltraConstants
-from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
+from imap_processing.ultra.l1b.ultra_l1b_culling import (
+    get_binned_energy_ranges,
+    get_de_rejection_mask,
+    get_energy_and_spin_dependent_rejection_mask,
+)
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     build_energy_bins,
     calculate_fwhm_spun_scattering,
@@ -94,7 +98,25 @@ def calculate_helio_pset(
         reject_scattering,
     )
     species_dataset = species_dataset.isel(epoch=~rejected)
+    # Check if spin_number is in the goodtimes dataset, if not then we can
+    #  reject all events for that spin without checking energy bin flags.
+    spin_rejected = ~np.isin(
+        species_dataset["spin_number"].values, goodtimes_dataset["spin_number"].values
+    )
+    species_dataset = species_dataset.isel(epoch=~spin_rejected)
 
+    intervals, _, energy_bin_geometric_means = build_energy_bins()
+
+    energy_bin_ranges = get_binned_energy_ranges(intervals)
+
+    # Now check energy dependent flags.
+    energy_dependent_rejected = get_energy_and_spin_dependent_rejection_mask(
+        goodtimes_dataset,
+        species_dataset["energy_heliosphere"].values,
+        species_dataset["spin_number"].values,
+        energy_bin_ranges,
+    )
+    species_dataset = species_dataset.isel(epoch=~energy_dependent_rejected)
     v_mag_helio_spacecraft = np.linalg.norm(
         species_dataset["velocity_dps_helio"].values, axis=1
     )
@@ -125,8 +147,6 @@ def calculate_helio_pset(
     theta_vals = helio_pointing_ds.theta
     phi_vals = helio_pointing_ds.phi
     fov_index = helio_pointing_ds.index
-
-    intervals, _, energy_bin_geometric_means = build_energy_bins()
 
     logger.info("calculating spun FWHM scattering values.")
     pixels_below_scattering, scattering_theta, scattering_phi, scattering_thresholds = (

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -100,7 +100,7 @@ def calculate_helio_pset(
     # Check if spin_number is in the goodtimes dataset, if not then we can
     #  reject all events for that spin without checking energy bin flags.
     spin_rejected = ~np.isin(
-        species_dataset["spin_number"].values, goodtimes_dataset["spin_number"].values
+        species_dataset["spin"].values, goodtimes_dataset["spin_number"].values
     )
     species_dataset = species_dataset.isel(epoch=~spin_rejected)
 
@@ -110,7 +110,7 @@ def calculate_helio_pset(
     energy_dependent_rejected = get_energy_and_spin_dependent_rejection_mask(
         goodtimes_dataset,
         species_dataset["energy_heliosphere"].values,
-        species_dataset["spin_number"].values,
+        species_dataset["spin"].values,
     )
     species_dataset = species_dataset.isel(epoch=~energy_dependent_rejected)
     v_mag_helio_spacecraft = np.linalg.norm(

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -408,10 +408,6 @@ def build_energy_bins(
     # Create energy bins.
     if energy_bin_edges is None:
         energy_bin_edges = np.array(UltraConstants.PSET_ENERGY_BIN_EDGES)
-        logger.info(
-            f"No energy bin file found, using default pointing bin energy"
-            f" edges {energy_bin_edges}"
-        )
 
     energy_midpoints = (energy_bin_edges[:-1] + energy_bin_edges[1:]) / 2
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -108,6 +108,7 @@ def calculate_spacecraft_pset(
 
     energy_bin_ranges = get_binned_energy_ranges(intervals)
 
+    # Now check energy dependent flags.
     energy_dependent_rejected = get_energy_and_spin_dependent_rejection_mask(
         goodtimes_dataset,
         species_dataset["energy_spacecraft"].values,

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -15,7 +15,6 @@ from imap_processing.spice.time import (
 )
 from imap_processing.ultra.constants import UltraConstants
 from imap_processing.ultra.l1b.ultra_l1b_culling import (
-    get_binned_energy_ranges,
     get_de_rejection_mask,
     get_energy_and_spin_dependent_rejection_mask,
 )
@@ -106,14 +105,11 @@ def calculate_spacecraft_pset(
 
     intervals, _, energy_bin_geometric_means = build_energy_bins()
 
-    energy_bin_ranges = get_binned_energy_ranges(intervals)
-
     # Now check energy dependent flags.
     energy_dependent_rejected = get_energy_and_spin_dependent_rejection_mask(
         goodtimes_dataset,
         species_dataset["energy_spacecraft"].values,
         species_dataset["spin_number"].values,
-        energy_bin_ranges,
     )
     species_dataset = species_dataset.isel(epoch=~energy_dependent_rejected)
 

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -99,7 +99,7 @@ def calculate_spacecraft_pset(
     # Check if spin_number is in the goodtimes dataset, if not then we can
     #  reject all events for that spin without checking energy bin flags.
     spin_rejected = ~np.isin(
-        species_dataset["spin_number"].values, goodtimes_dataset["spin_number"].values
+        species_dataset["spin"].values, goodtimes_dataset["spin_number"].values
     )
     species_dataset = species_dataset.isel(epoch=~spin_rejected)
 
@@ -109,10 +109,12 @@ def calculate_spacecraft_pset(
     energy_dependent_rejected = get_energy_and_spin_dependent_rejection_mask(
         goodtimes_dataset,
         species_dataset["energy_spacecraft"].values,
-        species_dataset["spin_number"].values,
+        species_dataset["spin"].values,
     )
+    print("HI")
+    print(np.where(energy_dependent_rejected))
+    print(species_dataset["spin"].values[~energy_dependent_rejected])
     species_dataset = species_dataset.isel(epoch=~energy_dependent_rejected)
-
     v_mag_dps_spacecraft = np.linalg.norm(
         species_dataset["velocity_dps_sc"].values, axis=1
     )

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -111,9 +111,6 @@ def calculate_spacecraft_pset(
         species_dataset["energy_spacecraft"].values,
         species_dataset["spin"].values,
     )
-    print("HI")
-    print(np.where(energy_dependent_rejected))
-    print(species_dataset["spin"].values[~energy_dependent_rejected])
     species_dataset = species_dataset.isel(epoch=~energy_dependent_rejected)
     v_mag_dps_spacecraft = np.linalg.norm(
         species_dataset["velocity_dps_sc"].values, axis=1

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -14,7 +14,11 @@ from imap_processing.spice.time import (
     ttj2000ns_to_et,
 )
 from imap_processing.ultra.constants import UltraConstants
-from imap_processing.ultra.l1b.ultra_l1b_culling import get_de_rejection_mask
+from imap_processing.ultra.l1b.ultra_l1b_culling import (
+    get_binned_energy_ranges,
+    get_de_rejection_mask,
+    get_energy_and_spin_dependent_rejection_mask,
+)
 from imap_processing.ultra.l1c.l1c_lookup_utils import (
     build_energy_bins,
     calculate_fwhm_spun_scattering,
@@ -85,13 +89,32 @@ def calculate_spacecraft_pset(
         logger.info(f"No data available for {name}")
         return None
 
+    ################ Reject events based on quality flags ################
     # Before we use the de_dataset to calculate the pointing set grid we need to filter.
-    rejected = get_de_rejection_mask(
+    de_rejected = get_de_rejection_mask(
         species_dataset["quality_scattering"].values,
         species_dataset["quality_outliers"].values,
         reject_scattering,
     )
-    species_dataset = species_dataset.isel(epoch=~rejected)
+    species_dataset = species_dataset.isel(epoch=~de_rejected)
+    # Check if spin_number is in the goodtimes dataset, if not then we can
+    #  reject all events for that spin without checking energy bin flags.
+    spin_rejected = ~np.isin(
+        species_dataset["spin_number"].values, goodtimes_dataset["spin_number"].values
+    )
+    species_dataset = species_dataset.isel(epoch=~spin_rejected)
+
+    intervals, _, energy_bin_geometric_means = build_energy_bins()
+
+    energy_bin_ranges = get_binned_energy_ranges(intervals)
+
+    energy_dependent_rejected = get_energy_and_spin_dependent_rejection_mask(
+        goodtimes_dataset,
+        species_dataset["energy_spacecraft"].values,
+        species_dataset["spin_number"].values,
+        energy_bin_ranges,
+    )
+    species_dataset = species_dataset.isel(epoch=~energy_dependent_rejected)
 
     v_mag_dps_spacecraft = np.linalg.norm(
         species_dataset["velocity_dps_sc"].values, axis=1
@@ -99,8 +122,6 @@ def calculate_spacecraft_pset(
     vhat_dps_spacecraft = (
         species_dataset["velocity_dps_sc"].values / v_mag_dps_spacecraft[:, np.newaxis]
     )
-
-    intervals, _, energy_bin_geometric_means = build_energy_bins()
 
     # Get lookup table for FOR indices by spin phase step
     (

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -185,6 +185,12 @@ def create_dataset(  # noqa: PLR0912
                 dims=["spin_phase_step"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
+        elif key in {"energy_bin_flags"}:
+            dataset[key] = xr.DataArray(
+                data,
+                dims=["energy_bins_for_culling"],
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            )
         else:
             dataset[key] = xr.DataArray(
                 data,

--- a/imap_processing/ultra/utils/ultra_l1_utils.py
+++ b/imap_processing/ultra/utils/ultra_l1_utils.py
@@ -185,10 +185,16 @@ def create_dataset(  # noqa: PLR0912
                 dims=["spin_phase_step"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
-        elif key in {"energy_bin_flags"}:
+        elif key in {"energy_range_edges"}:
             dataset[key] = xr.DataArray(
                 data,
-                dims=["energy_bins_for_culling"],
+                dims=["energy_range_edges"],
+                attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
+            )
+        elif key in {"energy_range_flags"}:
+            dataset[key] = xr.DataArray(
+                data,
+                dims=["energy_ranges"],
                 attrs=cdf_manager.get_variable_attributes(key, check_schema=False),
             )
         else:


### PR DESCRIPTION
# Change Summary

## Overview

Add low voltage flags to l1b goodtimes / extendedspin. Use this in l1c psets to reject events at spins dependent on energy. 

This makes the current goodtimes configuration a little tricky because the code was only set up to really cull spins across all energies. To remedy this, I just added energy dependent flags to the goodtimes dataset without culling full spins. Then at l1c, we can toss out events at spins that are flagged if the flag is for the energy of the event. 

The low voltage cull is only dependent on spins and not energy but I added the frame work for culling dependent on energy bins for future algorithms. 

Bob specifically wants us to be able to cull bins of spins and energy configurable with constants. 

closes #2709

## FIle changes 

See copilot below 

## 
Tests for new functions including validation test that uses bobs code
