### PR TITLE
Add tests, rearrange GLOWS L2, fix exposure times

### DIFF
--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -4,15 +4,13 @@ import dataclasses
 
 import numpy as np
 import xarray as xr
-from numpy.typing import NDArray
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.glows import FLAG_LENGTH
 from imap_processing.glows.l1b.glows_l1b_data import (
-    HistogramL1B,
     PipelineSettings,
 )
-from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
+from imap_processing.glows.l2.glows_l2_data import HistogramL2
 from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
 
 
@@ -48,114 +46,9 @@ def glows_l2(
         pipeline_settings_dataset.sel(epoch=day, method="nearest")
     )
 
-    l2 = generate_l2(input_dataset, pipeline_settings)
+    l2 = HistogramL2(input_dataset, pipeline_settings)
 
     return [create_l2_dataset(l2, cdf_attrs)]
-
-
-def generate_l2(
-    l1b_dataset: xr.Dataset,
-    pipeline_settings: PipelineSettings,
-) -> HistogramL2:
-    """
-    Generate L2 data from L1B data.
-
-    Returns L2 data in the form of a HistogramL2 dataclass.
-
-    Parameters
-    ----------
-    l1b_dataset : xarray.Dataset
-        Input L1B dataset.
-    pipeline_settings : PipelineSettings
-        Pipeline settings for active flags and offsets.
-
-    Returns
-    -------
-    HistogramL2
-        L2 data in the form of a HistogramL2 dataclass.
-    """
-    active_flags = np.array(pipeline_settings.active_bad_time_flags, dtype=float)
-    # most of the values from L1B are averaged over a day
-    good_data = l1b_dataset.isel(
-        epoch=return_good_times(l1b_dataset["flags"], active_flags)
-    )
-    # todo: bad angle filter
-    # TODO filter bad bins out. Needs to happen here while everything is still
-    # per-timestamp.
-
-    # one dataset collects multiple epoch values which need to be averaged down into
-    # one value.
-    all_variables = dataclasses.fields(HistogramL1B)
-
-    daily_lightcurve = DailyLightcurve(good_data)
-
-    var_outputs = {
-        "total_l1b_inputs": len(good_data["epoch"]),
-        "number_of_good_l1b_inputs": len(good_data["epoch"]),
-        # TODO replace post-filter
-        "identifier": 100,  # TODO: retrieve from spin table
-        # TODO fill this in
-        "bad_time_flag_occurrences": np.zeros((1, FLAG_LENGTH)),
-        # Accumulate all the histograms from good times from the day into one
-        "daily_lightcurve": daily_lightcurve,
-    }
-
-    if len(good_data["epoch"]) != 0:
-        # Generate outputs that are passed in directly from L1B
-        var_outputs["start_time"] = good_data["epoch"].data[0]
-        var_outputs["end_time"] = good_data["epoch"].data[-1]
-
-    else:
-        # No good times in the file
-        var_outputs["start_time"] = l1b_dataset["imap_start_time"].data[0]
-        var_outputs["end_time"] = (
-            l1b_dataset["imap_start_time"].data[0]
-            + l1b_dataset["imap_time_offset"].data[0]
-        )
-
-    for field in all_variables:
-        var_name = field.name
-        if "average" in var_name:
-            # This results in a scalar value, so `keepdims=True` ensures we keep the
-            # epoch dimension.
-            var_outputs[var_name] = (
-                l1b_dataset[var_name].mean(dim="epoch", keepdims=True).data
-            )
-
-            var_outputs[var_name.replace("average", "std_dev")] = (
-                l1b_dataset[var_name].std(dim="epoch", keepdims=True).data
-            )
-
-    # l1b stuff is done
-    output = HistogramL2(**var_outputs)
-
-    return output
-
-
-def filter_bad_bins(histograms: NDArray, bin_exclusions: NDArray) -> NDArray:
-    """
-    Filter out bad bins from the histogram.
-
-    Parameters
-    ----------
-    histograms : numpy.ndarray
-        Histogram data, with shape (n_timestamps, n_bins).
-    bin_exclusions : numpy.ndarray
-        Array of bin exclusions. This 2d array has a timestamp and bin filter array
-        pair. The bin filter array indicates "1" if a bin is to be excluded.
-
-    Returns
-    -------
-    numpy.ndarray
-        Histogram data with bad bins marked with -1.
-    """
-    # TODO: will need ancillary file imap_glows_exclusions_by_instr_team
-    # TODO: complete once unique_block_identifier is implemented
-    # file contains timestamp & bin filter array pairs. For the timestamp, the
-    # filter should be applied such that 1 excludes the bin.
-
-    # excluded bins can be marked with -1
-    return histograms
 
 
 def create_l2_dataset(
@@ -292,31 +185,3 @@ def create_l2_dataset(
             )
 
     return output
-
-
-def return_good_times(flags: xr.DataArray, active_flags: NDArray) -> NDArray:
-    """
-    Return the good times based on the input flags.
-
-    Parameters
-    ----------
-    flags : xarray.DataArray
-        Flags dataset with shape (n_timestamps, n_flags). If a flag is active and set
-        to 1, the timestamp is considered good.
-
-    active_flags : numpy.ndarray
-        Array of active flags. If the flag is set to 1, it is considered active.
-
-    Returns
-    -------
-    numpy.ndarray
-        An array of indices for good times.
-    """
-    if len(active_flags) != flags.shape[1]:
-        print("Active flags don't matched expected length")
-
-    # A good time is where all the active flags are equal to one.
-    # Here, we mask the active indices using active_flags, and then return the times
-    # where all the active indices == 1.
-    good_times = np.where(np.all(flags[:, active_flags == 1] == 1, axis=1))[0]
-    return good_times

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -6,6 +6,9 @@ import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
 
+from imap_processing.glows import FLAG_LENGTH
+from imap_processing.glows.l1b.glows_l1b_data import PipelineSettings
+
 
 @dataclass
 class DailyLightcurve:
@@ -64,15 +67,17 @@ class DailyLightcurve:
         """
         self.raw_histograms = self.calculate_histogram_sums(l1b_data["histogram"].data)
 
-        exposure_times_per_timestamp = (
-            l1b_data["spin_period_average"]
-            * l1b_data["number_of_spins_per_block"]
-            / 3600
+        self.number_of_bins = l1b_data["histogram"].shape[1]
+
+        exposure_per_epoch = (
+            l1b_data["spin_period_average"].data
+            * l1b_data["number_of_spins_per_block"].data
+            / self.number_of_bins
         )
 
-        self.exposure_times = self.calculate_exposure_times(
-            l1b_data, exposure_times_per_timestamp
-        )
+        # Exposure is uniform across bins; sum over all good-time epochs
+        self.exposure_times = np.full(self.number_of_bins, np.sum(exposure_per_epoch))
+
         raw_uncertainties = np.sqrt(self.raw_histograms)
         self.photon_flux = np.zeros(len(self.raw_histograms))
         self.flux_uncertainties = np.zeros(len(self.raw_histograms))
@@ -85,36 +90,9 @@ class DailyLightcurve:
         # TODO: Average this, or should they all be the same?
         self.spin_angle = np.average(l1b_data["imap_spin_angle_bin_cntr"].data, axis=0)
 
-        # TODO: is the first number here ok? Would it change mid-obs day?
-        self.number_of_bins = len(self.spin_angle)
-
         self.histogram_flag_array = np.zeros(self.number_of_bins)
         self.ecliptic_lon = np.zeros(self.number_of_bins)
         self.ecliptic_lat = np.zeros(self.number_of_bins)
-
-    @staticmethod
-    def calculate_exposure_times(
-        good_times: xr.Dataset, exposure_count: xr.DataArray
-    ) -> NDArray:
-        """
-        Calculate exposure times for each bin across all the timestamps.
-
-        Parameters
-        ----------
-        good_times : xarray.Dataset
-            Dataset with only good times.
-        exposure_count : float
-            Exposure count for each valid timestamp and bin.
-
-        Returns
-        -------
-        numpy.ndarray
-            Array of summed exposure times for each bin.
-        """
-        weighted_sum = (good_times["histogram"].data != -1) * exposure_count.data[
-            :, np.newaxis
-        ]
-        return np.sum(weighted_sum, axis=0)
 
     @staticmethod
     def calculate_histogram_sums(histograms: NDArray) -> NDArray:
@@ -131,6 +109,7 @@ class DailyLightcurve:
         numpy.ndarray
             Sum of valid histograms across all timestamps.
         """
+        histograms = histograms.copy()
         histograms[histograms == -1] = 0
         return np.sum(histograms, axis=0, dtype=np.int64)
 
@@ -223,3 +202,173 @@ class HistogramL2:
     spacecraft_velocity_std_dev: np.ndarray[np.double]
     spin_axis_orientation_average: np.ndarray[np.double]
     bad_time_flag_occurrences: np.ndarray
+
+    def __init__(self, l1b_dataset: xr.Dataset, pipeline_settings: PipelineSettings):
+        """
+        Given an L1B dataset, process data into an output HistogramL2 object.
+
+        Parameters
+        ----------
+        l1b_dataset : xr.Dataset
+            GLOWS histogram L1B dataset, as produced by glows_l1b.py.
+        pipeline_settings : PipelineSettings
+            Pipeline settings object read from ancillary file.
+        """
+        active_flags = np.array(pipeline_settings.active_bad_time_flags, dtype=float)
+
+        # Select the good blocks (i.e. epoch values) according to the flags. Drop any
+        # bad blocks before processing.
+        good_data = l1b_dataset.isel(
+            epoch=self.return_good_times(l1b_dataset["flags"], active_flags)
+        )
+        # todo: bad angle filter
+        # TODO filter bad bins out. Needs to happen here while everything is still
+        # per-timestamp.
+
+        self.daily_lightcurve = DailyLightcurve(good_data)
+
+        self.total_l1b_inputs = len(good_data["epoch"])
+        self.number_of_good_l1b_inputs = len(good_data["epoch"])
+        self.identifier = -1  # TODO: retrieve from spin table
+        # TODO fill this in
+        self.bad_time_flag_occurrences = np.zeros((1, FLAG_LENGTH))
+
+        if len(good_data["epoch"]) != 0:
+            # Generate outputs that are passed in directly from L1B
+            self.start_time = good_data["epoch"].data[0]
+            self.end_time = good_data["epoch"].data[-1]
+        else:
+            # No good times in the file
+            self.start_time = l1b_dataset["imap_start_time"].data[0]
+            self.end_time = (
+                l1b_dataset["imap_start_time"].data[0]
+                + l1b_dataset["imap_time_offset"].data[0]
+            )
+
+        self.filter_temperature_average = (
+            good_data["filter_temperature_average"]
+            .mean(dim="epoch", keepdims=True)
+            .data
+        )
+        self.filter_temperature_std_dev = (
+            good_data["filter_temperature_average"].std(dim="epoch", keepdims=True).data
+        )
+        self.hv_voltage_average = (
+            good_data["hv_voltage_average"].mean(dim="epoch", keepdims=True).data
+        )
+        self.hv_voltage_std_dev = (
+            good_data["hv_voltage_average"].std(dim="epoch", keepdims=True).data
+        )
+        self.spin_period_average = (
+            good_data["spin_period_average"].mean(dim="epoch", keepdims=True).data
+        )
+        self.spin_period_std_dev = (
+            good_data["spin_period_average"].std(dim="epoch", keepdims=True).data
+        )
+        self.pulse_length_average = (
+            good_data["pulse_length_average"].mean(dim="epoch", keepdims=True).data
+        )
+        self.pulse_length_std_dev = (
+            good_data["pulse_length_average"].std(dim="epoch", keepdims=True).data
+        )
+        self.spin_period_ground_average = (
+            good_data["spin_period_ground_average"]
+            .mean(dim="epoch", keepdims=True)
+            .data
+        )
+        self.spin_period_ground_std_dev = (
+            good_data["spin_period_ground_average"].std(dim="epoch", keepdims=True).data
+        )
+        self.position_angle_offset_average = (
+            good_data["position_angle_offset_average"]
+            .mean(dim="epoch", keepdims=True)
+            .data
+        )
+        self.position_angle_offset_std_dev = (
+            good_data["position_angle_offset_average"]
+            .std(dim="epoch", keepdims=True)
+            .data
+        )
+        self.spacecraft_location_average = (
+            good_data["spacecraft_location_average"]
+            .mean(dim="epoch")
+            .data[np.newaxis, :]
+        )
+        self.spacecraft_location_std_dev = (
+            good_data["spacecraft_location_average"]
+            .std(dim="epoch")
+            .data[np.newaxis, :]
+        )
+        self.spacecraft_velocity_average = (
+            good_data["spacecraft_velocity_average"]
+            .mean(dim="epoch")
+            .data[np.newaxis, :]
+        )
+        self.spacecraft_velocity_std_dev = (
+            good_data["spacecraft_velocity_average"]
+            .std(dim="epoch")
+            .data[np.newaxis, :]
+        )
+        self.spin_axis_orientation_average = (
+            good_data["spin_axis_orientation_average"]
+            .mean(dim="epoch")
+            .data[np.newaxis, :]
+        )
+        self.spin_axis_orientation_std_dev = (
+            good_data["spin_axis_orientation_average"]
+            .std(dim="epoch")
+            .data[np.newaxis, :]
+        )
+
+    def filter_bad_bins(self, histograms: NDArray, bin_exclusions: NDArray) -> NDArray:
+        """
+        Filter out bad bins from the histogram.
+
+        Parameters
+        ----------
+        histograms : numpy.ndarray
+            Histogram data, with shape (n_timestamps, n_bins).
+        bin_exclusions : numpy.ndarray
+            Array of bin exclusions. This 2d array has a timestamp and bin filter array
+            pair. The bin filter array indicates "1" if a bin is to be excluded.
+
+        Returns
+        -------
+        numpy.ndarray
+            Histogram data with bad bins marked with -1.
+        """
+        # TODO: will need ancillary file imap_glows_exclusions_by_instr_team
+        # TODO: complete once unique_block_identifier is implemented
+        # file contains timestamp & bin filter array pairs. For the timestamp, the
+        # filter should be applied such that 1 excludes the bin.
+
+        # excluded bins can be marked with -1
+        return histograms
+
+    @staticmethod
+    def return_good_times(flags: xr.DataArray, active_flags: NDArray) -> NDArray:
+        """
+        Return the good times based on the input flags.
+
+        Parameters
+        ----------
+        flags : xarray.DataArray
+            Flags dataset with shape (n_timestamps, n_flags). If a flag is active and
+             set to 1, the timestamp is considered good.
+
+        active_flags : numpy.ndarray
+            Array of active flags. If the flag is set to 1, it is considered active.
+
+        Returns
+        -------
+        numpy.ndarray
+            An array of indices for good times.
+        """
+        if len(active_flags) != flags.shape[1]:
+            print("Active flags don't matched expected length")
+
+        # A good time is where all the active flags are equal to one.
+        # Here, we mask the active indices using active_flags, and then return the times
+        # where all the active indices == 1.
+        good_times = np.where(np.all(flags[:, active_flags == 1] == 1, axis=1))[0]
+        return good_times

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -121,6 +121,13 @@ class HistogramL2:
 
     This class collects multiple HistogramL1B classes into one L2 per observational day.
 
+    Parameters
+    ----------
+        l1b_dataset : xr.Dataset
+            GLOWS histogram L1B dataset, as produced by glows_l1b.py.
+        pipeline_settings : PipelineSettings
+            Pipeline settings object read from ancillary file.
+
     Attributes
     ----------
     number_of_good_l1b_inputs : int

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -10,11 +10,9 @@ from imap_processing.glows.l1b.glows_l1b_data import (
     PipelineSettings,
 )
 from imap_processing.glows.l2.glows_l2 import (
-    generate_l2,
     glows_l2,
-    return_good_times,
 )
-from imap_processing.glows.l2.glows_l2_data import DailyLightcurve
+from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
 from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
 from imap_processing.tests.glows.conftest import mock_update_spice_parameters
 
@@ -62,20 +60,6 @@ def test_glows_l2(
     assert np.allclose(l2["filter_temperature_average"].values, [57.6], rtol=0.1)
 
 
-def test_filter_good_times():
-    active_flags = np.ones((17,))
-    active_flags[16] = 0
-    test_flags = np.ones((4, 17))
-    test_flags[1, 0] = 0
-    test_flags[3, 16] = 0
-    flags = xr.DataArray(test_flags, dims=["epoch", "flags"])
-
-    good_times = return_good_times(flags, active_flags)
-    expected_good_times = [0, 2, 3]
-
-    assert np.array_equal(good_times, expected_good_times)
-
-
 @patch.object(HistogramL1B, "update_spice_parameters", autospec=True)
 def test_generate_l2(
     mock_spice_function,
@@ -99,7 +83,7 @@ def test_generate_l2(
     pipeline_settings = PipelineSettings(
         mock_pipeline_settings.sel(epoch=day, method="nearest")
     )
-    l2 = generate_l2(l1b_hist_dataset, pipeline_settings)
+    l2 = HistogramL2(l1b_hist_dataset, pipeline_settings)
 
     expected_values = {
         "filter_temperature_average": [57.59],
@@ -124,15 +108,6 @@ def test_generate_l2(
     assert np.isclose(
         l2.hv_voltage_std_dev, expected_values["hv_voltage_std_dev"], 0.01
     )
-
-
-def test_exposure_times(l1b_hists):
-    exposure_time = xr.DataArray([10, 10, 20, 10])
-    expected_times = np.array([20, 40, 50, 30, 50])
-
-    times = DailyLightcurve.calculate_exposure_times(l1b_hists, exposure_time)
-
-    assert np.array_equal(times, expected_times)
 
 
 def test_bin_exclusions(l1b_hists):

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -1,0 +1,153 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from imap_processing.glows.l1b.glows_l1b_data import PipelineSettings
+from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
+
+
+@pytest.fixture
+def pipeline_settings():
+    """PipelineSettings with flags matching the default pipeline settings JSON.
+
+    active_bad_time_flags has 17 entries (is_night and
+    is_spin_period_difference_beyond_threshold are False, all others True).
+    active_bad_angle_flags has 4 entries (all True).
+    """
+    active_bad_time_flags = [
+        True,  # is_pps_missing
+        True,  # is_time_status_missing
+        True,  # is_phase_missing
+        True,  # is_spin_period_missing
+        True,  # is_overexposed
+        True,  # is_direct_event_non_monotonic
+        False,  # is_night
+        True,  # is_hv_test_in_progress
+        True,  # is_test_pulse_in_progress
+        True,  # is_memory_error_detected
+        True,  # is_generated_on_ground
+        True,  # is_beyond_daily_statistical_error
+        True,  # is_temperature_std_dev_beyond_threshold
+        True,  # is_hv_voltage_std_dev_beyond_threshold
+        True,  # is_spin_period_std_dev_beyond_threshold
+        True,  # is_pulse_length_std_dev_beyond_threshold
+        False,  # is_spin_period_difference_beyond_threshold
+    ]
+    active_bad_angle_flags = [
+        True,  # is_close_to_uv_source
+        True,  # is_inside_excluded_region
+        True,  # is_excluded_by_instr_team
+        True,  # is_suspected_transient
+    ]
+    pipeline_dataset = xr.Dataset(
+        {
+            "active_bad_time_flags": xr.DataArray(active_bad_time_flags),
+            "active_bad_angle_flags": xr.DataArray(active_bad_angle_flags),
+        }
+    )
+    return PipelineSettings(pipeline_dataset)
+
+
+@pytest.fixture
+def l1b_dataset():
+    """Minimal L1B dataset for testing DailyLightcurve.
+
+    Two timestamps, four bins.
+    Bin 3 is masked (-1) at timestamp 0.
+    """
+    n_epochs, n_bins = 2, 4
+    epoch = xr.DataArray(np.arange(n_epochs), dims=["epoch"])
+    bins = xr.DataArray(np.arange(n_bins), dims=["bins"])
+
+    histogram = np.array([[10, 20, 30, -1], [10, 20, 30, 40]], dtype=float)
+    spin_angle = np.tile(np.linspace(0, 270, n_bins), (n_epochs, 1))
+
+    ds = xr.Dataset(
+        {
+            "histogram": (["epoch", "bins"], histogram),
+            "spin_period_average": (["epoch"], [15.0, 15.0]),
+            "number_of_spins_per_block": (["epoch"], [5, 5]),
+            "imap_spin_angle_bin_cntr": (["epoch", "bins"], spin_angle),
+        },
+        coords={"epoch": epoch, "bins": bins},
+    )
+    return ds
+
+
+def test_photon_flux(l1b_dataset):
+    """Flux = sum(histograms) / sum(exposure_times) per bin (Eq. 50)."""
+    lc = DailyLightcurve(l1b_dataset)
+
+    # l1b_exposure_time_per_bin = spin_period_average *
+    # number_of_spins_per_block / number_of_bins_per_histogram
+    exposure_per = 15.0 * 5 / 4
+    expected_raw = np.array([20, 40, 60, 40])
+    # Exposure accumulates uniformly per good-time file regardless of per-bin masking
+    expected_exposure = np.array(
+        [2 * exposure_per, 2 * exposure_per, 2 * exposure_per, 2 * exposure_per]
+    )
+    expected_flux = expected_raw / expected_exposure
+
+    assert np.allclose(lc.raw_histograms, expected_raw)
+    assert np.allclose(lc.exposure_times, expected_exposure)
+    assert np.allclose(lc.photon_flux, expected_flux)
+
+
+def test_flux_uncertainty(l1b_dataset):
+    """Uncertainty = sqrt(sum_hist) / exposure per bin (Eq. 54)."""
+    lc = DailyLightcurve(l1b_dataset)
+
+    expected_uncertainty = np.sqrt(lc.raw_histograms) / lc.exposure_times
+    assert np.allclose(lc.flux_uncertainties, expected_uncertainty)
+
+
+def test_zero_exposure_bins():
+    """Bins with all-masked histograms get zero flux and uncertainty.
+
+    Exposure time still accumulates uniformly from each good-time file even
+    when all histogram values are masked (-1). Flux and uncertainty are zero
+    because the raw histogram sums are zero.
+    """
+    n_epochs, n_bins = 2, 3
+    histogram = np.full((n_epochs, n_bins), -1, dtype=float)
+    spin_angle = np.tile(np.linspace(0, 240, n_bins), (n_epochs, 1))
+
+    ds = xr.Dataset(
+        {
+            "histogram": (["epoch", "bins"], histogram),
+            "spin_period_average": (["epoch"], [15.0, 15.0]),
+            "number_of_spins_per_block": (["epoch"], [5, 5]),
+            "imap_spin_angle_bin_cntr": (["epoch", "bins"], spin_angle),
+        },
+        coords={"epoch": xr.DataArray(np.arange(n_epochs), dims=["epoch"])},
+    )
+    lc = DailyLightcurve(ds)
+
+    expected_exposure = 2 * 15.0 * 5 / 3
+    assert np.all(lc.photon_flux == 0)
+    assert np.all(lc.flux_uncertainties == 0)
+    assert np.allclose(lc.exposure_times, expected_exposure)
+
+
+def test_number_of_bins(l1b_dataset):
+    lc = DailyLightcurve(l1b_dataset)
+    assert lc.number_of_bins == 4
+    assert len(lc.spin_angle) == 4
+    assert len(lc.photon_flux) == 4
+    assert len(lc.flux_uncertainties) == 4
+    assert len(lc.exposure_times) == 4
+
+
+def test_filter_good_times():
+    """Epochs where any active flag is 0 are excluded; inactive flags are ignored."""
+    active_flags = np.ones((17,))
+    active_flags[16] = 0  # flag 16 is inactive
+    test_flags = np.ones((4, 17))
+    test_flags[1, 0] = 0  # epoch 1 fails active flag 0 -> bad time
+    test_flags[3, 16] = 0  # epoch 3 fails inactive flag 16 -> still good time
+    flags = xr.DataArray(test_flags, dims=["epoch", "flags"])
+
+    good_times = HistogramL2.return_good_times(flags, active_flags)
+    expected_good_times = [0, 2, 3]
+
+    assert np.array_equal(good_times, expected_good_times)


### PR DESCRIPTION
# Change Summary

## Overview

Moves GLOWS L2 Histogram calculation into the dataclass to match other levels, fixes the L2 exposure time calculation, and adds additional unit tests.

A lot of these changes are just for moving calculations from glows_l2.py to glows_l2_data.py. Look at the specific updates in the file changes section for actual changes. The main ones are around exposure_times.

## File changes

- `glows_l2_data.py`: Fixes exposure time calculation in `DailyLightcurve`
  — divides by number of bins (not hardcoded 3600) and accumulates uniformly  across good-time epochs rather than per-bin. Removes the now-incorrect  `calculate_exposure_times` static method. Fixes an in-place mutation bug in   `calculate_histogram_sums`. Completes `HistogramL2.__init__` with all L2  averages and std devs computed over good-time blocks only, with correct  shapes for scalar (`keepdims=True`) and vector (`[np.newaxis, :]`) fields.  Converts `return_good_times` to a `@staticmethod`.

- `glows_l2.py`: Removes logic that was moved into `HistogramL2.__init__`.

- `test_glows_l2_data.py`: New test file covering `DailyLightcurve` (photon  flux, flux uncertainty, zero-exposure bins, number of bins) and  `HistogramL2.return_good_times`.

- `test_glows_l2.py`: Updates `test_generate_l2` assertions to match  corrected output values; removes `test_exposure_times` which tested the  removed `calculate_exposure_times` method.

## Testing

- 6 new unit tests added in `test_glows_l2_data.py`
- Existing integration tests in `test_glows_l2.py` updated to reflect  corrected calculation behavior

Tests were generated with Claude but checked by hand. The averaging steps in __init__ were also done with AI. Nothing else was completed with AI, although it was checked against the validation scripts with Claude.

Completes tickets: #2367

Also fixes an un-ticketed bug with exposure time calculation