### PR TITLE
GLOWS L2 - Updated Delta +/- uncertainties attribute for photon flux

### DIFF
--- a/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
@@ -407,6 +407,9 @@ photon_flux:
   FORMAT: F8.2
   VALIDMIN: 0.0
   VALIDMAX: 30000.0 # max 30000 cps in FDIR / from 1 to 3.37 cps-per-R
+  # uncertainties are symmetrcial, so same value is used for +/-
+  DELTA_MINUS_VAR: flux_uncertainties
+  DELTA_PLUS_VAR: flux_uncertainties
   # SPASE data pulled from TWINS 1 LAD metadata
   DICT_KEY: SPASE>Wave>WaveType:Electromagnetic,WaveQuantity:Intensity,Qualifier:Scalar
 


### PR DESCRIPTION
# Change Summary

Added the DELTA_PLUS_VAR, DELTA_MINUS_VAR attributes to the yaml. The flux uncertainties are symmetric so the same value can be used for both the plus and the minus

Ran CLI to test CDF creation

Closes #2315 