### PR TITLE
Codice l2 hi sectored dim reversal

### DIFF
--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -1078,6 +1078,8 @@ def process_hi_sectored(dependencies: ProcessingInputCollection) -> xr.Dataset:
     spin_angle = (L2_HI_SECTORED_ANGLE[:, np.newaxis] + elevation_angles) % 360.0
 
     # Add spin angle variable using the new elevation_angle dimension
+    # Spin angle needs to be transposed to have dimensions
+    # (spin_sector, elevation_angle) to match the L2 dataset dimensions
     l2_dataset["spin_angle"] = (("spin_sector", "elevation_angle"), spin_angle.T)
     l2_dataset["spin_angle"].attrs = cdf_attrs.get_variable_attributes(
         "spin_angle", check_schema=False

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -1078,7 +1078,7 @@ def process_hi_sectored(dependencies: ProcessingInputCollection) -> xr.Dataset:
     spin_angle = (L2_HI_SECTORED_ANGLE[:, np.newaxis] + elevation_angles) % 360.0
 
     # Add spin angle variable using the new elevation_angle dimension
-    l2_dataset["spin_angle"] = (("spin_sector", "elevation_angle"), spin_angle)
+    l2_dataset["spin_angle"] = (("spin_sector", "elevation_angle"), spin_angle.T)
     l2_dataset["spin_angle"].attrs = cdf_attrs.get_variable_attributes(
         "spin_angle", check_schema=False
     )


### PR DESCRIPTION
# Change Summary

## Overview

Michael realized that the CoDICE hi l2 sectored data had the spin_angle array transposed. The dimensions were elevation_angle by spin sector but they should have been reversed. This PR fixes them. 

## File changes

<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->

imap_processing/codice/codice_l2.py 

Transpose array 
