### PR TITLE
Update L1B to inherit the number of bins from L1A

### DIFF
--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -826,10 +826,9 @@ class HistogramL1B:
 
         # Add SPICE related variables
         self.update_spice_parameters()
-        # Calculate the spin angle bin center
-        phi = (
-            np.arange(self.number_of_bins_per_histogram, dtype=np.float64) + 0.5
-        ) / self.number_of_bins_per_histogram
+        # Calculate the spin angle bin center using actual histogram length from L1A
+        n_bins = len(self.histogram)
+        phi = (np.arange(n_bins, dtype=np.float64) + 0.5) / n_bins
         self.imap_spin_angle_bin_cntr = phi * 360.0
 
         # TODO: This should probably be an AWS file
@@ -1076,7 +1075,7 @@ class HistogramL1B:
             Array of shape (4, 3600) with bad-angle flags for each bin.
         """
         histogram_flags = np.full(
-            (4, self.number_of_bins_per_histogram),
+            (4, len(self.histogram)),
             GLOWSL1bFlags.NONE.value,
             dtype=np.uint8,
         )

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -209,7 +209,7 @@ def test_histogram_mapping(
     # B = 69.5454
     expected_temp = 100
 
-    test_hists = np.zeros((200, 3600))
+    test_hists = np.zeros(3600)
     # For temp
     encoded_val = expected_temp * 2.318 + 69.5454
 
@@ -275,7 +275,7 @@ def test_process_histogram(
     # B = 69.5454
     expected_temp = 100
 
-    test_hists = np.zeros((200,))
+    test_hists = np.zeros(3600)
     # For temp
     encoded_val = np.single(expected_temp * 2.318 + 69.5454)
 
@@ -320,6 +320,38 @@ def test_process_histogram(
         pipeline_settings,
     )
     assert len(output) == len(dataclasses.asdict(test_l1b))
+
+
+@patch.object(HistogramL1B, "flag_uv_source", return_value=np.zeros(3600, dtype=bool))
+@patch.object(HistogramL1B, "update_spice_parameters", autospec=True)
+def test_bins_from_histogram_not_nbins(
+    mock_spice_function,
+    mock_flag_uv_source,
+    hist_dataset,
+    mock_ancillary_exclusions,
+    mock_ancillary_parameters,
+    mock_pipeline_settings,
+):
+    """Output bin arrays should use len(histogram), not number_of_bins_per_histogram."""
+    mock_spice_function.side_effect = mock_update_spice_parameters
+    # Set NBINS to a value that differs from the actual histogram length (3600)
+    hist_dataset["number_of_bins_per_histogram"][:] = 225
+
+    pipeline_settings = PipelineSettings(
+        mock_pipeline_settings.sel(
+            epoch=mock_pipeline_settings.epoch[0], method="nearest"
+        )
+    )
+    output = process_histogram(
+        hist_dataset,
+        mock_ancillary_exclusions,
+        mock_ancillary_parameters,
+        pipeline_settings,
+    )
+    # All output variables with a bins dimension must use len(histogram), not NBINS
+    for da in output:
+        if "bins" in da.sizes:
+            assert da.sizes["bins"] == 3600
 
 
 def test_process_de(de_dataset, ancillary_dict, mock_ancillary_parameters):
@@ -498,7 +530,7 @@ def test_hist_spice_output(
     data_start_time = 504975600.125  # 2026-01-01T15:00:00.125
     use_fake_spin_data_for_time(data_start_time)
     params = {
-        "histogram": np.zeros((1, 3600)),
+        "histogram": np.zeros(3600),
         "flight_software_version": "v0.0.1",
         "seq_count_in_pkts_file": 0,
         "first_spin_id": 0,


### PR DESCRIPTION
## Fix GLOWS L1B array sizing to use actual histogram length

### Background

Per ISTP/CDF convention, all variables must be allocated to the maximum expected size (3600 bins), with unused values filled with `FILLVAL`. In the GLOWS packet format, `HISTOGRAM_DATA` is a fixed 3600-element field. However, `NBINS` is a separate raw telemetry field propagated as `number_of_bins_per_histogram` — this encoded value (e.g. 225) is not the bin array length.

If we get sent fewer bins, we still want the output variables to be of len 3600. 

I found this issue when testing against validation data that is 255 bins long.

### Fix

Replace `self.number_of_bins_per_histogram` with `len(self.histogram)` wherever it sizes output arrays in `glows_l1b_data.py`. The field is retained in the dataclass output as a passthrough of the raw telemetry value.
