### PR TITLE
ULTRA add code for ultra90 efficiencies

### DIFF
--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -483,6 +483,8 @@ def ancillary_files():
     return {
         "l1b-45sensor-logistic-interpolation": path
         / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv",
+        "l1b-90sensor-logistic-interpolation": path
+        / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv",
         "l1b-sensor-gf-noblades": path
         / "imap_ultra_l1b-sensor-gf-noblades_20250101_v000.csv",
         "l1b-sensor-gf-blades": path

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -113,7 +113,7 @@ def test_get_angular_profiles():
 def test_get_energy_efficiencies(ancillary_files):
     """Tests function get_get_energy_efficiencies."""
 
-    u45_efficiencies = get_energy_efficiencies(ancillary_files)
+    u45_efficiencies = get_energy_efficiencies(ancillary_files, "ultra45")
 
     assert u45_efficiencies.shape == (58081, 157)
 

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -117,6 +117,10 @@ def test_get_energy_efficiencies(ancillary_files):
 
     assert u45_efficiencies.shape == (58081, 157)
 
+    # Test that the function can also read the ultra90 efficiencies
+    u90_efficiencies = get_energy_efficiencies(ancillary_files, "ultra90")
+    assert u90_efficiencies.shape == (58081, 157)
+
 
 @pytest.mark.external_test_data
 def test_get_geometric_function(ancillary_files):

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -694,7 +694,7 @@ def test_get_efficiency():
         / "imap_ultra_l1b-45sensor-logistic-interpolation_20250101_v000.csv"
     }
 
-    efficiency = get_efficiency(energy, phi, theta, ancillary_files)
+    efficiency = get_efficiency(energy, phi, theta, ancillary_files, "ultra45")
     expected_efficiency = np.array([0.0593281, 0.21803386, 0.0593281, 0.0628940])
 
     np.testing.assert_allclose(efficiency, expected_efficiency, atol=1e-03, rtol=0)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -374,6 +374,7 @@ def test_get_eff_and_gf(imap_ena_sim_metakernel, ancillary_files, spun_index_dat
         mock_theta,
         mock_phi,
         npix=pix,
+        sensor_id=45,
         ancillary_files=ancillary_files,
         apply_bsf=False,
     )

--- a/imap_processing/ultra/l1b/de.py
+++ b/imap_processing/ultra/l1b/de.py
@@ -375,7 +375,11 @@ def calculate_de(
         ancillary_files,
     )
     de_dict["event_efficiency"] = get_efficiency(
-        de_dict["tof_energy"], de_dict["phi"], de_dict["theta"], ancillary_files
+        de_dict["tof_energy"],
+        de_dict["phi"],
+        de_dict["theta"],
+        ancillary_files,
+        f"ultra{sensor}",
     )
     de_dict["geometric_factor_blades"] = get_geometric_factor(
         de_dict["phi"],

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -210,7 +210,7 @@ def get_angular_profiles(
     return lookup_table
 
 
-def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
+def get_energy_efficiencies(ancillary_files: dict, sensor: str) -> pd.DataFrame:
     """
     Lookup table for efficiencies for theta and phi.
 
@@ -221,14 +221,22 @@ def get_energy_efficiencies(ancillary_files: dict) -> pd.DataFrame:
     ----------
     ancillary_files : dict[Path]
         Ancillary files.
+    sensor : str
+        Sensor name: "ultra45" or "ultra90".
 
     Returns
     -------
     lookup_table : DataFrame
         Efficiencies lookup table for a given sensor.
     """
-    # TODO: add sensor to input when new lookup tables are available.
-    lookup_table = pd.read_csv(ancillary_files["l1b-45sensor-logistic-interpolation"])
+    if sensor == "ultra45":
+        lookup_table = pd.read_csv(
+            ancillary_files["l1b-45sensor-logistic-interpolation"]
+        )
+    else:
+        lookup_table = pd.read_csv(
+            ancillary_files["l1b-90sensor-logistic-interpolation"]
+        )
 
     return lookup_table
 

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -1170,6 +1170,7 @@ def get_fwhm(
 
 def get_efficiency_interpolator(
     ancillary_files: dict,
+    sensor: str,
 ) -> tuple[RegularGridInterpolator, tuple, tuple]:
     """
     Return a callable function that interpolates efficiency values for each event.
@@ -1178,6 +1179,8 @@ def get_efficiency_interpolator(
     ----------
     ancillary_files : dict
         Ancillary files.
+    sensor : str
+        Sensor name: "ultra45" or "ultra90".
 
     Returns
     -------
@@ -1188,7 +1191,7 @@ def get_efficiency_interpolator(
     phi_min_max : tuple
         Minimum and maximum phi values in the lookup table.
     """
-    lookup_table = get_energy_efficiencies(ancillary_files)
+    lookup_table = get_energy_efficiencies(ancillary_files, sensor)
 
     theta_vals = np.sort(lookup_table["theta (deg)"].unique())
     phi_vals = np.sort(lookup_table["phi (deg)"].unique())
@@ -1218,6 +1221,7 @@ def get_efficiency(
     phi_inst: NDArray,
     theta_inst: NDArray,
     ancillary_files: dict,
+    sensor: str,
     interpolator: RegularGridInterpolator = None,
 ) -> np.ndarray:
     """
@@ -1233,6 +1237,8 @@ def get_efficiency(
         Instrument-frame elevation angle for each event.
     ancillary_files : dict
         Ancillary files.
+    sensor : str
+        Sensor name: "ultra45" or "ultra90".
     interpolator : RegularGridInterpolator, optional
         Precomputed interpolator to use for efficiency lookup.
         If None, a new interpolator will be created from the ancillary files.
@@ -1243,7 +1249,7 @@ def get_efficiency(
         Interpolated efficiency values.
     """
     if not interpolator:
-        interpolator, _, _ = get_efficiency_interpolator(ancillary_files)
+        interpolator, _, _ = get_efficiency_interpolator(ancillary_files, sensor)
 
     return interpolator((theta_inst, phi_inst, energy))
 

--- a/imap_processing/ultra/l1c/helio_pset.py
+++ b/imap_processing/ultra/l1c/helio_pset.py
@@ -187,6 +187,7 @@ def calculate_helio_pset(
         theta_vals.values,
         phi_vals.values,
         n_pix,
+        sensor_id,
         ancillary_files,
         apply_bsf,
     )

--- a/imap_processing/ultra/l1c/spacecraft_pset.py
+++ b/imap_processing/ultra/l1c/spacecraft_pset.py
@@ -176,6 +176,7 @@ def calculate_spacecraft_pset(
         theta_vals,
         phi_vals,
         n_pix,
+        sensor_id,
         ancillary_files,
         apply_bsf,
     )

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -501,6 +501,7 @@ def get_efficiencies_and_geometric_function(
     theta_vals: np.ndarray,
     phi_vals: np.ndarray,
     npix: int,
+    sensor_id: int,
     ancillary_files: dict,
     apply_bsf: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -529,6 +530,8 @@ def get_efficiencies_and_geometric_function(
         corresponding phi for each pixel (and energy, if present).
     npix : int
         Number of HEALPix pixels.
+    sensor_id : int
+        Sensor ID, either 45 or 90.
     ancillary_files : dict
         Dictionary containing ancillary files.
     apply_bsf : bool, optional
@@ -543,9 +546,10 @@ def get_efficiencies_and_geometric_function(
         Averaged efficiencies across all spin phases.
         Shape = (n_energy_bins, npix).
     """
+    sensor_name = f"ultra{sensor_id}"
     # Load callable efficiency interpolator function
     eff_interpolator, theta_min_max, phi_min_max = get_efficiency_interpolator(
-        ancillary_files
+        ancillary_files, sensor_name
     )
     # load geometric factor lookup table
     geometric_lookup_table = load_geometric_factor_tables(
@@ -622,6 +626,7 @@ def get_efficiencies_and_geometric_function(
                 phi_at_spin_clipped[pixel_inds],
                 theta_at_spin_clipped[pixel_inds],
                 ancillary_files,
+                sensor_name,
                 interpolator=eff_interpolator,
             )
 


### PR DESCRIPTION
# Change Summary

## Overview

Very simple PR to use efficiencies for ULTRA90. Before this, the ULTRA team instructed us to use 45 efficiencies for both because they hadn't gotten around to making them for 90 yet. Nick sent me new efficiency ancillary files for both 90 and 45 yesterday. I will be uploading those as soon as the goodtimes/culling is set to get pushed to prod. 

## File changes

<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->


## Testing
Fix tests. 