### PR TITLE
2815 bug   hi l1c goodtimes

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -790,7 +790,7 @@ class Hi(ProcessInstrument):
         datasets: list[xr.Dataset] = []
 
         # Check self.repointing is not None (for mypy type checking)
-        if self.repointing is None:
+        if self.data_level != "l2" and self.repointing is None:
             raise ValueError("Repointing must be provided for Hi processing.")
 
         if self.data_level == "l1a":

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -772,7 +772,7 @@ class Hi(ProcessInstrument):
 
     def do_processing(  # noqa: PLR0912
         self, dependencies: ProcessingInputCollection
-    ) -> list[xr.Dataset | Path]:
+    ) -> list[xr.Dataset]:
         """
         Perform IMAP-Hi specific processing.
 
@@ -789,10 +789,6 @@ class Hi(ProcessInstrument):
         print(f"Processing IMAP-Hi {self.data_level}")
         datasets: list[xr.Dataset] = []
 
-        # Check self.repointing is not None (for mypy type checking)
-        if self.data_level != "l2" and self.repointing is None:
-            raise ValueError("Repointing must be provided for Hi processing.")
-
         if self.data_level == "l1a":
             science_files = dependencies.get_file_paths(source="hi")
             if len(science_files) != 1:
@@ -806,6 +802,12 @@ class Hi(ProcessInstrument):
             if l0_files:
                 datasets = hi_l1b.housekeeping(l0_files[0])
             elif "goodtimes" in self.descriptor:
+                # Check self.repointing is not None (for mypy type checking)
+                if self.repointing is None:
+                    raise ValueError(
+                        "Repointing must be provided for Hi Goodtimes processing."
+                    )
+
                 # Goodtimes processing
                 l1b_de_paths = dependencies.get_file_paths(
                     source="hi", data_type="l1b", descriptor="de"

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -232,13 +232,24 @@ def _apply_goodtimes_filters(
 
     # Pre-compute qualified event masks for each dataset
     # These masks check BOTH coincidence_type AND TOF windows
-    qualified_masks: dict[int, np.ndarray] = {}
-    for i, l1b_de in enumerate(l1b_de_datasets):
+    for l1b_de in l1b_de_datasets:
         ccsds_index = l1b_de["ccsds_index"].values
-        esa_energy_steps = l1b_de["esa_energy_step"].values[ccsds_index]
 
-        qualified_masks[i] = compute_qualified_event_mask(
-            l1b_de, cal_product_config, esa_energy_steps
+        # Handle invalid events (FILLVAL trigger_id) to avoid IndexError
+        # For pointings with no valid events, trigger_id will be at FILLVAL
+        trigger_id_fillval = l1b_de["trigger_id"].attrs.get("FILLVAL", 65535)
+        valid_events = l1b_de["trigger_id"].values != trigger_id_fillval
+
+        # Initialize with -1 (won't match any config row since ESA energy steps > 0)
+        esa_energy_steps = np.full(len(ccsds_index), -1, dtype=np.int32)
+        if np.any(valid_events):
+            esa_energy_steps[valid_events] = l1b_de["esa_energy_step"].values[
+                ccsds_index[valid_events]
+            ]
+
+        l1b_de["qualified_mask"] = xr.DataArray(
+            compute_qualified_event_mask(l1b_de, cal_product_config, esa_energy_steps),
+            dims=["event_met"],
         )
     logger.info("Pre-computed qualified event masks for all datasets")
 
@@ -266,7 +277,6 @@ def _apply_goodtimes_filters(
         goodtimes_ds,
         l1b_de_datasets,
         current_index,
-        qualified_masks,
     )
 
     # 6. Statistical Filter 2 - short-lived event pulses
@@ -274,7 +284,6 @@ def _apply_goodtimes_filters(
     mark_statistical_filter_2(
         goodtimes_ds,
         current_l1b_de,
-        qualified_masks[current_index],
     )
 
 
@@ -1467,7 +1476,6 @@ def _compute_qualified_counts_per_sweep(
 
 def _build_per_sweep_datasets(
     l1b_de_datasets: list[xr.Dataset],
-    qualified_masks: dict[int, np.ndarray],
 ) -> dict[int, xr.Dataset]:
     """
     Build per-sweep datasets with qualified counts for each Pointing.
@@ -1475,10 +1483,9 @@ def _build_per_sweep_datasets(
     Parameters
     ----------
     l1b_de_datasets : list[xarray.Dataset]
-        List of L1B DE datasets for multiple Pointings.
-    qualified_masks : dict[int, np.ndarray]
-        Dictionary mapping dataset index to boolean mask indicating which events
-        qualify for calibration products (checking both coincidence_type AND TOF).
+        List of L1B DE datasets for multiple Pointings. Each dataset must
+        contain a "qualified_mask" DataArray indicating which events qualify
+        for calibration products.
 
     Returns
     -------
@@ -1492,7 +1499,7 @@ def _build_per_sweep_datasets(
         # Add esa_sweep coordinate and compute counts per 8-spin interval
         l1b_de_with_sweep = _add_sweep_indices(l1b_de)
         per_sweep = _compute_qualified_counts_per_sweep(
-            l1b_de_with_sweep, qualified_masks[i]
+            l1b_de_with_sweep, l1b_de["qualified_mask"].values
         )
         per_sweep_datasets[i] = per_sweep
 
@@ -1692,7 +1699,6 @@ def mark_statistical_filter_1(
     goodtimes_ds: xr.Dataset,
     l1b_de_datasets: list[xr.Dataset],
     current_index: int,
-    qualified_masks: dict[int, np.ndarray],
     consecutive_threshold_sigma: float = HiConstants.STAT_FILTER_1_CONSECUTIVE_SIGMA,
     extreme_threshold_sigma: float = HiConstants.STAT_FILTER_1_EXTREME_SIGMA,
     min_consecutive_intervals: int = HiConstants.STAT_FILTER_1_MIN_CONSECUTIVE,
@@ -1719,12 +1725,11 @@ def mark_statistical_filter_1(
         Goodtimes dataset for the current Pointing to update.
     l1b_de_datasets : list[xarray.Dataset]
         List of L1B DE datasets for surrounding Pointings. Typically includes
-        current plus 3 preceding and 3 following Pointings.
+        current plus 3 preceding and 3 following Pointings. Each dataset must
+        contain a "qualified_mask" DataArray indicating which events qualify
+        for calibration products (checking both coincidence_type AND TOF).
     current_index : int
         Index of the current Pointing in l1b_de_datasets.
-    qualified_masks : dict[int, np.ndarray]
-        Dictionary mapping dataset index to boolean mask indicating which events
-        qualify for calibration products (checking both coincidence_type AND TOF).
     consecutive_threshold_sigma : float, optional
         Sigma multiplier for consecutive interval check.
         Default is HiConstants.STAT_FILTER_1_CONSECUTIVE_SIGMA.
@@ -1767,7 +1772,7 @@ def mark_statistical_filter_1(
         )
 
     # Step 1: Build per-sweep datasets with qualified counts for each Pointing
-    per_sweep_datasets = _build_per_sweep_datasets(l1b_de_datasets, qualified_masks)
+    per_sweep_datasets = _build_per_sweep_datasets(l1b_de_datasets)
 
     # Step 2: Compute median and sigma per ESA energy step using xarray
     median_per_esa, sigma_per_esa = _compute_median_and_sigma_per_esa(
@@ -1909,13 +1914,14 @@ def _compute_bins_for_cluster(
     # Generate bin indices with wrapping using modulo
     bins_to_mark = np.arange(bin_low, bin_high + 1) % n_bins
 
+    logger.debug(f"Cluster {cluster_start} to {cluster_end} bins: {bins_to_mark}")
+
     return bins_to_mark
 
 
 def mark_statistical_filter_2(
     goodtimes_ds: xr.Dataset,
     l1b_de: xr.Dataset,
-    qualified_mask: np.ndarray,
     min_events: int = HiConstants.STAT_FILTER_2_MIN_EVENTS,
     max_time_delta: float = HiConstants.STAT_FILTER_2_MAX_TIME_DELTA,
     bin_padding: int = HiConstants.STAT_FILTER_2_BIN_PADDING,
@@ -1949,9 +1955,8 @@ def mark_statistical_filter_2(
         - coincidence_type: detector coincidence bitmap
         - nominal_bin: spacecraft spin bin (0-89)
         - esa_step: ESA energy step for each packet
-    qualified_mask : np.ndarray
-        Boolean mask indicating which events qualify for calibration products.
-        This mask should check BOTH coincidence_type AND TOF windows.
+        - qualified_mask: boolean mask indicating which events qualify for
+          calibration products (checking both coincidence_type AND TOF windows)
     min_events : int, optional
         Minimum events to form a pulse cluster.
         Default is HiConstants.STAT_FILTER_2_MIN_EVENTS.
@@ -1991,6 +1996,9 @@ def mark_statistical_filter_2(
         event_sweep=("event_met", esa_sweep[ccsds_index]),
         event_step=("event_met", esa_step[ccsds_index]),
     )
+
+    # Get qualified mask from the dataset
+    qualified_mask = l1b_de["qualified_mask"].values
 
     if not np.any(qualified_mask):
         logger.info("Statistical Filter 2: No qualified events found")

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -15,6 +15,7 @@ from imap_processing.hi.utils import (
     CalibrationProductConfig,
     CoincidenceBitmap,
     HiConstants,
+    compute_qualified_event_mask,
     parse_sensor_number,
 )
 from imap_processing.quality_flags import ImapHiL1bDeFlags
@@ -229,11 +230,17 @@ def _apply_goodtimes_filters(
     stats = goodtimes_ds.goodtimes.get_cull_statistics()
     logger.info(f"Initial good bins: {stats['good_bins']}/{stats['total_bins']}")
 
-    # Build set of qualified coincidence types from calibration product config
-    qualified_coincidence_types: set[int] = set()
-    for coin_types in cal_product_config["coincidence_type_values"]:
-        qualified_coincidence_types.update(coin_types)
-    logger.info(f"Qualified coincidence types: {qualified_coincidence_types}")
+    # Pre-compute qualified event masks for each dataset
+    # These masks check BOTH coincidence_type AND TOF windows
+    qualified_masks: dict[int, np.ndarray] = {}
+    for i, l1b_de in enumerate(l1b_de_datasets):
+        ccsds_index = l1b_de["ccsds_index"].values
+        esa_energy_steps = l1b_de["esa_energy_step"].values[ccsds_index]
+
+        qualified_masks[i] = compute_qualified_event_mask(
+            l1b_de, cal_product_config, esa_energy_steps
+        )
+    logger.info("Pre-computed qualified event masks for all datasets")
 
     # === Apply culling filters ===
 
@@ -259,7 +266,7 @@ def _apply_goodtimes_filters(
         goodtimes_ds,
         l1b_de_datasets,
         current_index,
-        qualified_coincidence_types,
+        qualified_masks,
     )
 
     # 6. Statistical Filter 2 - short-lived event pulses
@@ -267,7 +274,7 @@ def _apply_goodtimes_filters(
     mark_statistical_filter_2(
         goodtimes_ds,
         current_l1b_de,
-        qualified_coincidence_types,
+        qualified_masks[current_index],
     )
 
 
@@ -1390,7 +1397,7 @@ def mark_statistical_filter_0(
 
 def _compute_qualified_counts_per_sweep(
     l1b_de: xr.Dataset,
-    qualified_coincidence_types: set[int],
+    qualified_mask: np.ndarray,
 ) -> xr.Dataset:
     """
     Compute qualified calibration product counts per 8-spin interval and reshape.
@@ -1402,8 +1409,9 @@ def _compute_qualified_counts_per_sweep(
     ----------
     l1b_de : xarray.Dataset
         L1B Direct Event dataset with esa_sweep coordinate on epoch dimension.
-    qualified_coincidence_types : set[int]
-        Set of coincidence type integers that qualify for calibration products.
+    qualified_mask : np.ndarray
+        Boolean mask indicating which events qualify for calibration products.
+        This mask should check BOTH coincidence_type AND TOF windows.
 
     Returns
     -------
@@ -1416,13 +1424,12 @@ def _compute_qualified_counts_per_sweep(
         raise ValueError("Dataset must have esa_sweep coordinate")
 
     # Get values needed for counting
-    coincidence_type = l1b_de["coincidence_type"].values
     ccsds_index = l1b_de["ccsds_index"].values
     esa_sweep = l1b_de.coords["esa_sweep"].values
     esa_energy_step = l1b_de["esa_energy_step"].values
 
-    # Identify qualified events
-    is_qualified = np.isin(coincidence_type, list(qualified_coincidence_types))
+    # Use pre-computed qualified mask
+    is_qualified = qualified_mask
 
     # Map qualified events to their packet's (esa_sweep, esa_energy_step)
     qualified_packet_idx = ccsds_index[is_qualified]
@@ -1460,7 +1467,7 @@ def _compute_qualified_counts_per_sweep(
 
 def _build_per_sweep_datasets(
     l1b_de_datasets: list[xr.Dataset],
-    qualified_coincidence_types: set[int],
+    qualified_masks: dict[int, np.ndarray],
 ) -> dict[int, xr.Dataset]:
     """
     Build per-sweep datasets with qualified counts for each Pointing.
@@ -1469,8 +1476,9 @@ def _build_per_sweep_datasets(
     ----------
     l1b_de_datasets : list[xarray.Dataset]
         List of L1B DE datasets for multiple Pointings.
-    qualified_coincidence_types : set[int]
-        Set of coincidence type integers that qualify for calibration products.
+    qualified_masks : dict[int, np.ndarray]
+        Dictionary mapping dataset index to boolean mask indicating which events
+        qualify for calibration products (checking both coincidence_type AND TOF).
 
     Returns
     -------
@@ -1484,7 +1492,7 @@ def _build_per_sweep_datasets(
         # Add esa_sweep coordinate and compute counts per 8-spin interval
         l1b_de_with_sweep = _add_sweep_indices(l1b_de)
         per_sweep = _compute_qualified_counts_per_sweep(
-            l1b_de_with_sweep, qualified_coincidence_types
+            l1b_de_with_sweep, qualified_masks[i]
         )
         per_sweep_datasets[i] = per_sweep
 
@@ -1684,7 +1692,7 @@ def mark_statistical_filter_1(
     goodtimes_ds: xr.Dataset,
     l1b_de_datasets: list[xr.Dataset],
     current_index: int,
-    qualified_coincidence_types: set[int],
+    qualified_masks: dict[int, np.ndarray],
     consecutive_threshold_sigma: float = HiConstants.STAT_FILTER_1_CONSECUTIVE_SIGMA,
     extreme_threshold_sigma: float = HiConstants.STAT_FILTER_1_EXTREME_SIGMA,
     min_consecutive_intervals: int = HiConstants.STAT_FILTER_1_MIN_CONSECUTIVE,
@@ -1714,8 +1722,9 @@ def mark_statistical_filter_1(
         current plus 3 preceding and 3 following Pointings.
     current_index : int
         Index of the current Pointing in l1b_de_datasets.
-    qualified_coincidence_types : set[int]
-        Set of coincidence type integers that qualify for calibration products.
+    qualified_masks : dict[int, np.ndarray]
+        Dictionary mapping dataset index to boolean mask indicating which events
+        qualify for calibration products (checking both coincidence_type AND TOF).
     consecutive_threshold_sigma : float, optional
         Sigma multiplier for consecutive interval check.
         Default is HiConstants.STAT_FILTER_1_CONSECUTIVE_SIGMA.
@@ -1758,9 +1767,7 @@ def mark_statistical_filter_1(
         )
 
     # Step 1: Build per-sweep datasets with qualified counts for each Pointing
-    per_sweep_datasets = _build_per_sweep_datasets(
-        l1b_de_datasets, qualified_coincidence_types
-    )
+    per_sweep_datasets = _build_per_sweep_datasets(l1b_de_datasets, qualified_masks)
 
     # Step 2: Compute median and sigma per ESA energy step using xarray
     median_per_esa, sigma_per_esa = _compute_median_and_sigma_per_esa(
@@ -1908,7 +1915,7 @@ def _compute_bins_for_cluster(
 def mark_statistical_filter_2(
     goodtimes_ds: xr.Dataset,
     l1b_de: xr.Dataset,
-    qualified_coincidence_types: set[int],
+    qualified_mask: np.ndarray,
     min_events: int = HiConstants.STAT_FILTER_2_MIN_EVENTS,
     max_time_delta: float = HiConstants.STAT_FILTER_2_MAX_TIME_DELTA,
     bin_padding: int = HiConstants.STAT_FILTER_2_BIN_PADDING,
@@ -1942,9 +1949,9 @@ def mark_statistical_filter_2(
         - coincidence_type: detector coincidence bitmap
         - nominal_bin: spacecraft spin bin (0-89)
         - esa_step: ESA energy step for each packet
-    qualified_coincidence_types : set[int]
-        Set of coincidence type integers qualifying as calibration
-        products 1 or 2.
+    qualified_mask : np.ndarray
+        Boolean mask indicating which events qualify for calibration products.
+        This mask should check BOTH coincidence_type AND TOF windows.
     min_events : int, optional
         Minimum events to form a pulse cluster.
         Default is HiConstants.STAT_FILTER_2_MIN_EVENTS.
@@ -1981,19 +1988,15 @@ def mark_statistical_filter_2(
 
     # Add event-level coordinates for grouping
     l1b_de_with_sweep = l1b_de_with_sweep.assign_coords(
-        event_sweep=("event", esa_sweep[ccsds_index]),
-        event_step=("event", esa_step[ccsds_index]),
+        event_sweep=("event_met", esa_sweep[ccsds_index]),
+        event_step=("event_met", esa_step[ccsds_index]),
     )
 
-    # Filter to qualified events
-    coincidence_type = l1b_de_with_sweep["coincidence_type"].values
-    is_qualified = np.isin(coincidence_type, list(qualified_coincidence_types))
-
-    if not np.any(is_qualified):
+    if not np.any(qualified_mask):
         logger.info("Statistical Filter 2: No qualified events found")
         return
 
-    qualified_events = l1b_de_with_sweep.isel(event=is_qualified)
+    qualified_events = l1b_de_with_sweep.isel(event_met=qualified_mask)
 
     n_clusters_found = 0
     n_bins_marked = 0

--- a/imap_processing/hi/hi_l1c.py
+++ b/imap_processing/hi/hi_l1c.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import NamedTuple
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 from numpy import typing as npt
-from numpy._typing import NDArray
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import parse_filename_like
@@ -19,6 +17,7 @@ from imap_processing.hi.utils import (
     HiConstants,
     create_dataset_variables,
     full_dataarray,
+    iter_qualified_events_by_config,
     parse_sensor_number,
 )
 from imap_processing.spice.geometry import (
@@ -369,104 +368,35 @@ def pset_counts(
     )
     de_ds = de_ds.isel(event_met=good_mask)
 
+    # Get esa_energy_step for each event (recorded per packet, use ccsds_index)
+    esa_energy_steps = l1b_de_dataset["esa_energy_step"].data[de_ds["ccsds_index"].data]
+
     # The calibration product configuration potentially has different coincidence
     # types for each ESA and different TOF windows for each calibration product,
-    # esa energy step combination. Because of this we need to filter DEs that
-    # belong to each combo individually.
-    # Loop over the esa_energy_step values first
-    for esa_energy, esa_df in config_df.groupby(level="esa_energy_step"):
-        # Create a mask for all DEs at the current esa_energy_step.
-        # esa_energy_step is recorded for each packet rather than for each DE,
-        # so we use ccsds_index to get the esa_energy_step for each DE
-        esa_mask = (
-            l1b_de_dataset["esa_energy_step"].data[de_ds["ccsds_index"].data]
-            == esa_energy
+    # esa energy step combination. Use the shared generator to iterate over all
+    # config combinations and get qualified event masks.
+    for esa_energy, config_row, qualified_mask in iter_qualified_events_by_config(
+        de_ds, config_df, esa_energy_steps
+    ):
+        # Filter events using the qualified mask
+        filtered_de_ds = de_ds.isel(event_met=qualified_mask)
+
+        # Bin remaining DEs into spin-bins
+        i_esa = np.flatnonzero(pset_coords["esa_energy_step"].data == esa_energy)[0]
+        # spin_phase is in the range [0, 1). Multiplying by N_SPIN_BINS and
+        # truncating to an integer gives the correct bin index
+        spin_bin_indices = (filtered_de_ds["spin_phase"].data * N_SPIN_BINS).astype(int)
+        # When iterating over rows of a dataframe, the names of the multi-index
+        # are not preserved. Below, `config_row.Index[0]` gets the
+        # calibration_prod value from the namedtuple representing the
+        # dataframe row. We map this to the array index using cal_prod_to_index.
+        i_cal_prod = cal_prod_to_index[config_row.Index[0]]
+        np.add.at(
+            counts_var["counts"].data[0, i_esa, i_cal_prod],
+            spin_bin_indices,
+            1,
         )
-        # Now loop over the calibration products for the current ESA energy
-        for config_row in esa_df.itertuples():
-            # Remove DEs that are not at the current ESA energy and in the list
-            # of coincidence types for the current calibration product
-            type_mask = de_ds["coincidence_type"].isin(
-                config_row.coincidence_type_values
-            )
-            filtered_de_ds = de_ds.isel(event_met=(esa_mask & type_mask))
-
-            # Use the TOF window mask to remove DEs with TOFs outside the allowed range
-            tof_fill_vals = {
-                f"tof_{detector_pair}": l1b_de_dataset[f"tof_{detector_pair}"].attrs[
-                    "FILLVAL"
-                ]
-                for detector_pair in CalibrationProductConfig.tof_detector_pairs
-            }
-            tof_in_window_mask = get_tof_window_mask(
-                filtered_de_ds, config_row, tof_fill_vals
-            )
-            filtered_de_ds = filtered_de_ds.isel(event_met=tof_in_window_mask)
-
-            # Bin remaining DEs into spin-bins
-            i_esa = np.flatnonzero(pset_coords["esa_energy_step"].data == esa_energy)[0]
-            # spin_phase is in the range [0, 1). Multiplying by N_SPIN_BINS and
-            # truncating to an integer gives the correct bin index
-            spin_bin_indices = (filtered_de_ds["spin_phase"].data * N_SPIN_BINS).astype(
-                int
-            )
-            # When iterating over rows of a dataframe, the names of the multi-index
-            # are not preserved. Below, `config_row.Index[0]` gets the
-            # calibration_prod value from the namedtuple representing the
-            # dataframe row. We map this to the array index using cal_prod_to_index.
-            i_cal_prod = cal_prod_to_index[config_row.Index[0]]
-            np.add.at(
-                counts_var["counts"].data[0, i_esa, i_cal_prod],
-                spin_bin_indices,
-                1,
-            )
     return counts_var
-
-
-def get_tof_window_mask(
-    de_ds: xr.Dataset, prod_config_row: NamedTuple, fill_vals: dict
-) -> NDArray[bool]:
-    """
-    Generate a mask indicating which DEs to keep based on TOF windows.
-
-    Parameters
-    ----------
-    de_ds : xarray.Dataset
-        The Direct Event Dataset for the DEs to filter based on the TOF
-        windows.
-    prod_config_row : NamedTuple
-        A single row of the prod config dataframe represented as a named tuple.
-    fill_vals : dict
-        A dictionary containing the fill values used in the input DE TOF
-        dataframe values. This value should be derived from the L1B DE CDF
-        TOF variable attributes.
-
-    Returns
-    -------
-    window_mask : np.ndarray
-        A mask with one entry per DE in the input `de_df` indicating which DEs
-        contain TOF values within the windows specified by `prod_config_row`.
-        The mask is intended to directly filter the DE dataframe.
-    """
-    detector_pairs = CalibrationProductConfig.tof_detector_pairs
-    tof_in_window_mask = np.empty(
-        (len(detector_pairs), len(de_ds["event_met"])), dtype=bool
-    )
-    for i_pair, detector_pair in enumerate(detector_pairs):
-        low_limit = getattr(prod_config_row, f"tof_{detector_pair}_low")
-        high_limit = getattr(prod_config_row, f"tof_{detector_pair}_high")
-        tof_array = de_ds[f"tof_{detector_pair}"].data
-        # The TOF in window mask contains True wherever the TOF is within
-        # the configuration low/high bounds OR the FILLVAL is present. The
-        # FILLVAL indicates that the detector pair was not hit. DEs with
-        # the incorrect coincidence_type are already filtered out and this
-        # implementation simplifies combining the tof_in_window_masks in
-        # the next step.
-        tof_in_window_mask[i_pair] = np.logical_or(
-            np.logical_and(low_limit <= tof_array, tof_array <= high_limit),
-            tof_array == fill_vals[f"tof_{detector_pair}"],
-        )
-    return np.all(tof_in_window_mask, axis=0)
 
 
 def pset_backgrounds(pset_coords: dict[str, xr.DataArray]) -> dict[str, xr.DataArray]:

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -594,7 +594,7 @@ def get_tof_window_mask(
     tof_windows : dict[str, tuple[float, float]]
         Dictionary mapping TOF field names to (low, high) tuples defining the
         acceptable window for each TOF measurement.
-    tof_fill_vals : dict[str, float], optional
+    tof_fill_vals : dict[str, float]
         Fill values for each TOF field - events with fill values pass the check.
         If not provided, fill value handling is disabled.
 

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -578,7 +578,7 @@ class CalibrationProductConfig:
 def get_tof_window_mask(
     de_ds: xr.Dataset,
     tof_windows: dict[str, tuple[float, float]],
-    tof_fill_vals: dict[str, float] | None = None,
+    tof_fill_vals: dict[str, float],
 ) -> NDArray[np.bool_]:
     """
     Generate mask indicating which DEs pass TOF window checks.
@@ -603,9 +603,6 @@ def get_tof_window_mask(
     mask : numpy.ndarray
         Boolean mask where True = event passes all specified TOF window checks.
     """
-    if tof_fill_vals is None:
-        tof_fill_vals = {}
-
     # Start with all True mask
     n_events = len(de_ds["event_met"]) if "event_met" in de_ds.dims else 0
     if n_events == 0:
@@ -614,9 +611,6 @@ def get_tof_window_mask(
     combined_mask = np.ones(n_events, dtype=bool)
 
     for tof_field, (low, high) in tof_windows.items():
-        if tof_field not in de_ds:
-            continue
-
         tof_array = de_ds[tof_field].values
         # TOF is in window if between low/high bounds OR equals fill value
         in_window = (low <= tof_array) & (tof_array <= high)
@@ -710,8 +704,7 @@ def _build_tof_fill_vals(de_ds: xr.Dataset) -> dict[str, float]:
     tof_fill_vals = {}
     for pair in CalibrationProductConfig.tof_detector_pairs:
         tof_var = f"tof_{pair}"
-        if tof_var in de_ds:
-            tof_fill_vals[tof_var] = de_ds[tof_var].attrs.get("FILLVAL", np.nan)
+        tof_fill_vals[tof_var] = de_ds[tof_var].attrs.get("FILLVAL", np.nan)
     return tof_fill_vals
 
 

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -600,7 +600,7 @@ def get_tof_window_mask(
 
     Returns
     -------
-    mask : np.ndarray
+    mask : numpy.ndarray
         Boolean mask where True = event passes all specified TOF window checks.
     """
     if tof_fill_vals is None:
@@ -732,7 +732,7 @@ def iter_qualified_events_by_config(
     de_ds : xarray.Dataset
         Direct Event dataset with coincidence_type and TOF variables.
         TOF variables must have FILLVAL attribute for fill value handling.
-    cal_product_config : pd.DataFrame
+    cal_product_config : pandas.DataFrame
         Config DataFrame with multi-index (calibration_prod, esa_energy_step).
         Must have coincidence_type_values column and TOF window columns.
     esa_energy_steps : np.ndarray
@@ -798,7 +798,7 @@ def compute_qualified_event_mask(
     de_ds : xarray.Dataset
         Direct Event dataset with coincidence_type and TOF variables.
         TOF variables must have FILLVAL attribute for fill value handling.
-    cal_product_config : pd.DataFrame
+    cal_product_config : pandas.DataFrame
         Config DataFrame with multi-index (calibration_prod, esa_energy_step).
         Must have coincidence_type_values column and TOF window columns.
     esa_energy_steps : np.ndarray

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -614,8 +614,7 @@ def get_tof_window_mask(
         tof_array = de_ds[tof_field].values
         # TOF is in window if between low/high bounds OR equals fill value
         in_window = (low <= tof_array) & (tof_array <= high)
-        if tof_field in tof_fill_vals:
-            in_window |= tof_array == tof_fill_vals[tof_field]
+        in_window |= tof_array == tof_fill_vals[tof_field]
 
         combined_mask &= in_window
 

--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 from numpy import typing as npt
+from numpy.typing import NDArray
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 
@@ -571,3 +573,251 @@ class CalibrationProductConfig:
             .sort_values()
             .values
         )
+
+
+def get_tof_window_mask(
+    de_ds: xr.Dataset,
+    tof_windows: dict[str, tuple[float, float]],
+    tof_fill_vals: dict[str, float] | None = None,
+) -> NDArray[np.bool_]:
+    """
+    Generate mask indicating which DEs pass TOF window checks.
+
+    An event passes the TOF window check for a given detector pair if its TOF value
+    is within the (low, high) bounds OR equals the fill value (indicating the detector
+    pair was not hit).
+
+    Parameters
+    ----------
+    de_ds : xarray.Dataset
+        Direct Event Dataset with TOF variables (tof_ab, tof_ac1, tof_bc1, tof_c1c2).
+    tof_windows : dict[str, tuple[float, float]]
+        Dictionary mapping TOF field names to (low, high) tuples defining the
+        acceptable window for each TOF measurement.
+    tof_fill_vals : dict[str, float], optional
+        Fill values for each TOF field - events with fill values pass the check.
+        If not provided, fill value handling is disabled.
+
+    Returns
+    -------
+    mask : np.ndarray
+        Boolean mask where True = event passes all specified TOF window checks.
+    """
+    if tof_fill_vals is None:
+        tof_fill_vals = {}
+
+    # Start with all True mask
+    n_events = len(de_ds["event_met"]) if "event_met" in de_ds.dims else 0
+    if n_events == 0:
+        return np.array([], dtype=bool)
+
+    combined_mask = np.ones(n_events, dtype=bool)
+
+    for tof_field, (low, high) in tof_windows.items():
+        if tof_field not in de_ds:
+            continue
+
+        tof_array = de_ds[tof_field].values
+        # TOF is in window if between low/high bounds OR equals fill value
+        in_window = (low <= tof_array) & (tof_array <= high)
+        if tof_field in tof_fill_vals:
+            in_window |= tof_array == tof_fill_vals[tof_field]
+
+        combined_mask &= in_window
+
+    return combined_mask
+
+
+def filter_events_by_coincidence(
+    de_ds: xr.Dataset,
+    coincidence_types: Sequence[int],
+) -> NDArray[np.bool_]:
+    """
+    Filter events by coincidence type.
+
+    Parameters
+    ----------
+    de_ds : xarray.Dataset
+        Direct Event Dataset with coincidence_type variable.
+    coincidence_types : Sequence[int]
+        Sequence of coincidence type integers to match.
+
+    Returns
+    -------
+    mask : np.ndarray
+        Boolean mask where True = event's coincidence_type is in the provided list.
+    """
+    if "coincidence_type" not in de_ds:
+        raise ValueError("Dataset must have 'coincidence_type' variable")
+
+    coincidence_array = de_ds["coincidence_type"].values
+    return np.isin(coincidence_array, list(coincidence_types))
+
+
+def get_bin_range_with_wrap(
+    first_bin: int, last_bin: int, n_bins: int, extend_by: int
+) -> np.ndarray:
+    """
+    Get bin range with wraparound and optional extension.
+
+    Computes a range of bin indices from first_bin to last_bin, optionally
+    extending by a padding amount on each side, with proper wraparound
+    handling for circular bin structures (e.g., spin bins).
+
+    Parameters
+    ----------
+    first_bin : int
+        First bin index in the range.
+    last_bin : int
+        Last bin index in the range (may be less than first_bin if wrapping).
+    n_bins : int
+        Total number of bins (bins are 0 to n_bins-1).
+    extend_by : int
+        Number of bins to add on each side of the range.
+
+    Returns
+    -------
+    bins : np.ndarray
+        Array of bin indices in the range, with wrapping handled.
+    """
+    # Apply extension
+    bot = (first_bin - extend_by) % n_bins
+    top = (last_bin + extend_by) % n_bins
+
+    # Check if we need to wrap
+    if top >= bot:
+        # No wrap needed
+        return np.arange(bot, top + 1)
+    else:
+        # Wrap around: bins from bot to n_bins-1, then 0 to top
+        return np.concatenate([np.arange(bot, n_bins), np.arange(0, top + 1)])
+
+
+def _build_tof_fill_vals(de_ds: xr.Dataset) -> dict[str, float]:
+    """
+    Build TOF fill values dictionary from dataset attributes.
+
+    Parameters
+    ----------
+    de_ds : xarray.Dataset
+        Direct Event dataset with TOF variables containing FILLVAL attributes.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary mapping TOF variable names to their fill values.
+    """
+    tof_fill_vals = {}
+    for pair in CalibrationProductConfig.tof_detector_pairs:
+        tof_var = f"tof_{pair}"
+        if tof_var in de_ds:
+            tof_fill_vals[tof_var] = de_ds[tof_var].attrs.get("FILLVAL", np.nan)
+    return tof_fill_vals
+
+
+def iter_qualified_events_by_config(
+    de_ds: xr.Dataset,
+    cal_product_config: pd.DataFrame,
+    esa_energy_steps: NDArray[np.int_],
+) -> Generator[tuple[Any, Any, NDArray[np.bool_]], None, None]:
+    """
+    Iterate over calibration config, yielding masks for qualified events.
+
+    For each (esa_energy_step, calibration_prod) combination in the config,
+    yields a mask indicating which events qualify based on BOTH coincidence_type
+    AND TOF window checks.
+
+    Parameters
+    ----------
+    de_ds : xarray.Dataset
+        Direct Event dataset with coincidence_type and TOF variables.
+        TOF variables must have FILLVAL attribute for fill value handling.
+    cal_product_config : pd.DataFrame
+        Config DataFrame with multi-index (calibration_prod, esa_energy_step).
+        Must have coincidence_type_values column and TOF window columns.
+    esa_energy_steps : np.ndarray
+        ESA energy step for each event in de_ds.
+
+    Yields
+    ------
+    esa_energy : Any
+        The ESA energy step value.
+    config_row : namedtuple
+        The config row from itertuples() containing calibration product settings.
+    qualified_mask : np.ndarray
+        Boolean mask where True = event qualifies for this (esa, cal_prod).
+    """
+    n_events = len(de_ds["event_met"]) if "event_met" in de_ds.dims else 0
+
+    # Build TOF fill values from dataset attributes
+    tof_fill_vals = _build_tof_fill_vals(de_ds)
+
+    for esa_energy, esa_df in cal_product_config.groupby(level="esa_energy_step"):
+        # Mask for events at this ESA energy step
+        esa_mask = esa_energy_steps == esa_energy if n_events > 0 else np.array([])
+
+        for config_row in esa_df.itertuples():
+            if n_events == 0 or not np.any(esa_mask):
+                yield esa_energy, config_row, np.zeros(n_events, dtype=bool)
+                continue
+
+            # Check coincidence type
+            coin_mask = filter_events_by_coincidence(
+                de_ds, config_row.coincidence_type_values
+            )
+
+            # Build TOF windows dict from config row
+            tof_windows = {
+                f"tof_{pair}": (
+                    getattr(config_row, f"tof_{pair}_low"),
+                    getattr(config_row, f"tof_{pair}_high"),
+                )
+                for pair in CalibrationProductConfig.tof_detector_pairs
+            }
+
+            # Check TOF windows
+            tof_mask = get_tof_window_mask(de_ds, tof_windows, tof_fill_vals)
+
+            yield esa_energy, config_row, esa_mask & coin_mask & tof_mask
+
+
+def compute_qualified_event_mask(
+    de_ds: xr.Dataset,
+    cal_product_config: pd.DataFrame,
+    esa_energy_steps: NDArray[np.int_],
+) -> NDArray[np.bool_]:
+    """
+    Compute mask of events qualifying for ANY calibration product.
+
+    An event qualifies if it passes BOTH coincidence_type AND TOF window
+    checks for ANY (calibration_prod, esa_energy_step) combination in the
+    configuration.
+
+    Parameters
+    ----------
+    de_ds : xarray.Dataset
+        Direct Event dataset with coincidence_type and TOF variables.
+        TOF variables must have FILLVAL attribute for fill value handling.
+    cal_product_config : pd.DataFrame
+        Config DataFrame with multi-index (calibration_prod, esa_energy_step).
+        Must have coincidence_type_values column and TOF window columns.
+    esa_energy_steps : np.ndarray
+        ESA energy step for each event in de_ds.
+
+    Returns
+    -------
+    qualified_mask : np.ndarray
+        Boolean mask - True if event qualifies for at least one cal product.
+    """
+    n_events = len(de_ds["event_met"]) if "event_met" in de_ds.dims else 0
+    if n_events == 0:
+        return np.array([], dtype=bool)
+
+    qualified_mask = np.zeros(n_events, dtype=bool)
+
+    for _, _, mask in iter_qualified_events_by_config(
+        de_ds, cal_product_config, esa_energy_steps
+    ):
+        qualified_mask |= mask
+
+    return qualified_mask

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -2443,10 +2443,13 @@ class TestBuildPerSweepDatasets:
         """Test that per-sweep datasets are built correctly."""
         ds = self._create_test_dataset()
 
-        # Create qualified masks dict based on coincidence type 12
-        qualified_masks = {0: np.isin(ds["coincidence_type"].values, [12])}
+        # Add qualified mask based on coincidence type 12 directly to dataset
+        ds["qualified_mask"] = xr.DataArray(
+            np.isin(ds["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
 
-        per_sweep_datasets = _build_per_sweep_datasets([ds], qualified_masks)
+        per_sweep_datasets = _build_per_sweep_datasets([ds])
 
         # Should have per-sweep dataset for index 0 with 2D structure
         assert 0 in per_sweep_datasets
@@ -2470,13 +2473,17 @@ class TestBuildPerSweepDatasets:
         ds1 = self._create_test_dataset(base_met=1000.0)
         ds2 = self._create_test_dataset(base_met=2000.0)
 
-        # Create qualified masks dict for both datasets
-        qualified_masks = {
-            0: np.isin(ds1["coincidence_type"].values, [12]),
-            1: np.isin(ds2["coincidence_type"].values, [12]),
-        }
+        # Add qualified masks directly to datasets
+        ds1["qualified_mask"] = xr.DataArray(
+            np.isin(ds1["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
+        ds2["qualified_mask"] = xr.DataArray(
+            np.isin(ds2["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
 
-        per_sweep_datasets = _build_per_sweep_datasets([ds1, ds2], qualified_masks)
+        per_sweep_datasets = _build_per_sweep_datasets([ds1, ds2])
 
         # Should have per-sweep datasets for both indices
         assert 0 in per_sweep_datasets
@@ -2643,17 +2650,17 @@ class TestStatisticalFilter1:
             self._create_l1b_de_dataset(events_per_packet=10, base_met=3500.0),
         ]
 
-        # Create qualified masks dict based on coincidence type 12
-        qualified_masks = {
-            i: np.isin(ds["coincidence_type"].values, [12])
-            for i, ds in enumerate(l1b_de_datasets)
-        }
+        # Add qualified masks directly to datasets
+        for ds in l1b_de_datasets:
+            ds["qualified_mask"] = xr.DataArray(
+                np.isin(ds["coincidence_type"].values, [12]),
+                dims=["event_met"],
+            )
 
         mark_statistical_filter_1(
             goodtimes_for_filter1,
             l1b_de_datasets,
             current_index=2,
-            qualified_masks=qualified_masks,
         )
 
         # All times should still be good
@@ -2705,17 +2712,17 @@ class TestStatisticalFilter1:
             },
         )
 
-        # Create qualified masks dict based on coincidence type 12
-        qualified_masks = {
-            i: np.isin(ds["coincidence_type"].values, [12])
-            for i, ds in enumerate(l1b_de_datasets)
-        }
+        # Add qualified masks directly to datasets
+        for ds in l1b_de_datasets:
+            ds["qualified_mask"] = xr.DataArray(
+                np.isin(ds["coincidence_type"].values, [12]),
+                dims=["event_met"],
+            )
 
         mark_statistical_filter_1(
             goodtimes_for_filter1,
             l1b_de_datasets,
             current_index=2,
-            qualified_masks=qualified_masks,
         )
 
         # At least the first MET should be marked bad (extreme outlier)
@@ -2729,36 +2736,36 @@ class TestStatisticalFilter1:
             self._create_l1b_de_dataset(),
         ]
 
-        # Create qualified masks dict based on coincidence type 12
-        qualified_masks = {
-            i: np.isin(ds["coincidence_type"].values, [12])
-            for i, ds in enumerate(l1b_de_datasets)
-        }
+        # Add qualified masks directly to datasets
+        for ds in l1b_de_datasets:
+            ds["qualified_mask"] = xr.DataArray(
+                np.isin(ds["coincidence_type"].values, [12]),
+                dims=["event_met"],
+            )
 
         with pytest.raises(ValueError, match="At least 4 valid Pointings required"):
             mark_statistical_filter_1(
                 goodtimes_for_filter1,
                 l1b_de_datasets,
                 current_index=1,
-                qualified_masks=qualified_masks,
             )
 
     def test_current_index_out_of_range(self, goodtimes_for_filter1):
         """Test that current_index out of range raises ValueError."""
-        l1b_de_datasets = [self._create_l1b_de_dataset()] * 5
+        l1b_de_datasets = [self._create_l1b_de_dataset() for _ in range(5)]
 
-        # Create qualified masks dict based on coincidence type 12
-        qualified_masks = {
-            i: np.isin(ds["coincidence_type"].values, [12])
-            for i, ds in enumerate(l1b_de_datasets)
-        }
+        # Add qualified masks directly to datasets
+        for ds in l1b_de_datasets:
+            ds["qualified_mask"] = xr.DataArray(
+                np.isin(ds["coincidence_type"].values, [12]),
+                dims=["event_met"],
+            )
 
         with pytest.raises(ValueError, match="current_index.*out of range"):
             mark_statistical_filter_1(
                 goodtimes_for_filter1,
                 l1b_de_datasets,
                 current_index=10,
-                qualified_masks=qualified_masks,
             )
 
 
@@ -2974,13 +2981,15 @@ class TestStatisticalFilter2:
             dims=["event_met"],
         )
 
-        # Create qualified mask - no events match type 12
-        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
+        # Add qualified mask directly to dataset - no events match type 12
+        l1b_de["qualified_mask"] = xr.DataArray(
+            np.isin(l1b_de["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_mask,
             min_events=6,
             max_time_delta=10.0,
         )
@@ -3031,13 +3040,15 @@ class TestStatisticalFilter2:
             },
         )
 
-        # Create qualified mask based on coincidence type 12
-        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
+        # Add qualified mask directly to dataset
+        l1b_de["qualified_mask"] = xr.DataArray(
+            np.isin(l1b_de["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_mask,
             min_events=6,
             max_time_delta=0.2,
         )
@@ -3075,13 +3086,15 @@ class TestStatisticalFilter2:
             dims=["event_met"],
         )
 
-        # Create qualified mask based on coincidence type 12
-        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
+        # Add qualified mask directly to dataset
+        l1b_de["qualified_mask"] = xr.DataArray(
+            np.isin(l1b_de["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_mask,
             min_events=6,
             max_time_delta=0.1,
             bin_padding=1,
@@ -3124,13 +3137,15 @@ class TestStatisticalFilter2:
             dims=["event_met"],
         )
 
-        # Create qualified mask based on coincidence type 12
-        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
+        # Add qualified mask directly to dataset
+        l1b_de["qualified_mask"] = xr.DataArray(
+            np.isin(l1b_de["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_mask,
             min_events=6,
             max_time_delta=0.1,
             bin_padding=1,
@@ -3162,13 +3177,15 @@ class TestStatisticalFilter2:
             dims=["event_met"],
         )
 
-        # Create qualified mask based on coincidence type 12
-        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
+        # Add qualified mask directly to dataset
+        l1b_de["qualified_mask"] = xr.DataArray(
+            np.isin(l1b_de["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_mask,
             min_events=6,
             max_time_delta=0.1,
             bin_padding=2,
@@ -3214,14 +3231,16 @@ class TestStatisticalFilter2:
             dims=["event_met"],
         )
 
-        # Create qualified mask based on coincidence type 12
-        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
+        # Add qualified mask directly to dataset
+        l1b_de["qualified_mask"] = xr.DataArray(
+            np.isin(l1b_de["coincidence_type"].values, [12]),
+            dims=["event_met"],
+        )
 
         # With min_events=4, should detect cluster
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_mask,
             min_events=4,
             max_time_delta=0.1,
             bin_padding=1,
@@ -3287,8 +3306,9 @@ class TestStatisticalFilter2:
             },
         )
 
-        # Create qualified mask - only type 12 events are qualified
+        # Add qualified mask directly to dataset - only type 12 events are qualified
         qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
+        l1b_de["qualified_mask"] = xr.DataArray(qualified_mask, dims=["event_met"])
 
         # Verify our test setup: 6 unqualified, 6 qualified
         assert np.sum(~qualified_mask) == 6  # 6 unqualified
@@ -3297,7 +3317,6 @@ class TestStatisticalFilter2:
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_mask,
             min_events=6,
             max_time_delta=0.1,
             bin_padding=1,

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -2951,18 +2951,17 @@ class TestStatisticalFilter2:
 
         return xr.Dataset(
             {
-                # Event-level variables (event dimension)
-                "ccsds_index": (["event"], ccsds_index),
-                "event_met": (["event"], event_met_values),
-                "coincidence_type": (["event"], coincidence_type),
-                "nominal_bin": (["event"], nominal_bin),
                 # Packet-level variables (epoch dimension)
                 "ccsds_met": (["epoch"], packet_mets),
                 "esa_step": (["epoch"], packet_esa_steps),
+                # Event-level variables (event dimension)
+                "ccsds_index": (["event_met"], ccsds_index),
+                "coincidence_type": (["event_met"], coincidence_type),
+                "nominal_bin": (["even_met"], nominal_bin),
             },
             coords={
-                "event": np.arange(n_events),
                 "epoch": np.arange(n_packets),
+                "event_met": event_met_values,
             },
         )
 
@@ -2971,8 +2970,8 @@ class TestStatisticalFilter2:
         l1b_de = self._create_l1b_de_for_filter2()
         # Change all events to unqualified type
         l1b_de["coincidence_type"] = xr.DataArray(
-            np.full(len(l1b_de["event"]), 4, dtype=np.uint8),
-            dims=["event"],
+            np.full(len(l1b_de["event_met"]), 4, dtype=np.uint8),
+            dims=["event_met"],
         )
 
         # Create qualified mask - no events match type 12
@@ -3020,16 +3019,15 @@ class TestStatisticalFilter2:
 
         l1b_de = xr.Dataset(
             {
-                "ccsds_index": (["event"], ccsds_index),
-                "event_met": (["event"], event_met_values),
-                "coincidence_type": (["event"], coincidence_type),
-                "nominal_bin": (["event"], nominal_bin),
                 "ccsds_met": (["epoch"], packet_mets),
                 "esa_step": (["epoch"], packet_esa_steps),
+                "ccsds_index": (["event_met"], ccsds_index),
+                "coincidence_type": (["event_met"], coincidence_type),
+                "nominal_bin": (["event_met"], nominal_bin),
             },
             coords={
-                "event": np.arange(n_events),
                 "epoch": np.arange(n_packets),
+                "event_met": event_met_values,
             },
         )
 
@@ -3070,11 +3068,11 @@ class TestStatisticalFilter2:
                 ],
                 dtype=np.float64,
             ),
-            dims=["event"],
+            dims=["event_met"],
         )
         l1b_de["nominal_bin"] = xr.DataArray(
             np.array([40, 41, 42, 43, 44, 45, 10, 20, 30, 50], dtype=np.uint8),
-            dims=["event"],
+            dims=["event_met"],
         )
 
         # Create qualified mask based on coincidence type 12
@@ -3119,11 +3117,11 @@ class TestStatisticalFilter2:
                 ],
                 dtype=np.float64,
             ),
-            dims=["event"],
+            dims=["event_met"],
         )
         l1b_de["nominal_bin"] = xr.DataArray(
             np.array([10, 11, 12, 13, 14, 15, 70, 71, 72, 73, 74, 75], dtype=np.uint8),
-            dims=["event"],
+            dims=["event_met"],
         )
 
         # Create qualified mask based on coincidence type 12
@@ -3157,11 +3155,11 @@ class TestStatisticalFilter2:
             np.array(
                 [1000.01, 1000.02, 1000.03, 1000.04, 1000.05, 1000.06], dtype=np.float64
             ),
-            dims=["event"],
+            dims=["event_met"],
         )
         l1b_de["nominal_bin"] = xr.DataArray(
             np.array([0, 0, 1, 1, 2, 2], dtype=np.uint8),
-            dims=["event"],
+            dims=["event_met"],
         )
 
         # Create qualified mask based on coincidence type 12
@@ -3209,11 +3207,11 @@ class TestStatisticalFilter2:
                 ],
                 dtype=np.float64,
             ),
-            dims=["event"],
+            dims=["event_met"],
         )
         l1b_de["nominal_bin"] = xr.DataArray(
             np.array([40, 41, 42, 43, 10, 20, 30, 50, 60, 70], dtype=np.uint8),
-            dims=["event"],
+            dims=["event_met"],
         )
 
         # Create qualified mask based on coincidence type 12

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -2363,9 +2363,11 @@ class TestComputeQualifiedCountsPerSweep:
         # 10 packets, 2 packets per ESA step = 5 unique (esa_sweep, esa_step) combos
         # All in same sweep (no high-to-low transition), ESA steps 1-5
         ds = self._create_test_dataset(n_packets=10, events_per_packet=10)
-        qualified_types = {12}
 
-        result = _compute_qualified_counts_per_sweep(ds, qualified_types)
+        # Create qualified mask based on coincidence type 12
+        qualified_mask = np.isin(ds["coincidence_type"].values, [12])
+
+        result = _compute_qualified_counts_per_sweep(ds, qualified_mask)
 
         assert "qualified_count" in result.data_vars
         assert "esa_sweep" in result.dims
@@ -2392,8 +2394,11 @@ class TestComputeQualifiedCountsPerSweep:
             coords={"event_met": np.arange(2), "epoch": np.arange(1)},
         )
 
+        # Create qualified mask for coincidence type 12
+        qualified_mask = np.isin(ds["coincidence_type"].values, [12])
+
         with pytest.raises(ValueError, match="must have esa_sweep coordinate"):
-            _compute_qualified_counts_per_sweep(ds, {12})
+            _compute_qualified_counts_per_sweep(ds, qualified_mask)
 
 
 class TestBuildPerSweepDatasets:
@@ -2437,9 +2442,11 @@ class TestBuildPerSweepDatasets:
     def test_builds_per_sweep_datasets(self):
         """Test that per-sweep datasets are built correctly."""
         ds = self._create_test_dataset()
-        qualified_types = {12}
 
-        per_sweep_datasets = _build_per_sweep_datasets([ds], qualified_types)
+        # Create qualified masks dict based on coincidence type 12
+        qualified_masks = {0: np.isin(ds["coincidence_type"].values, [12])}
+
+        per_sweep_datasets = _build_per_sweep_datasets([ds], qualified_masks)
 
         # Should have per-sweep dataset for index 0 with 2D structure
         assert 0 in per_sweep_datasets
@@ -2462,9 +2469,14 @@ class TestBuildPerSweepDatasets:
         """Test with multiple datasets."""
         ds1 = self._create_test_dataset(base_met=1000.0)
         ds2 = self._create_test_dataset(base_met=2000.0)
-        qualified_types = {12}
 
-        per_sweep_datasets = _build_per_sweep_datasets([ds1, ds2], qualified_types)
+        # Create qualified masks dict for both datasets
+        qualified_masks = {
+            0: np.isin(ds1["coincidence_type"].values, [12]),
+            1: np.isin(ds2["coincidence_type"].values, [12]),
+        }
+
+        per_sweep_datasets = _build_per_sweep_datasets([ds1, ds2], qualified_masks)
 
         # Should have per-sweep datasets for both indices
         assert 0 in per_sweep_datasets
@@ -2630,13 +2642,18 @@ class TestStatisticalFilter1:
             self._create_l1b_de_dataset(events_per_packet=10, base_met=2500.0),
             self._create_l1b_de_dataset(events_per_packet=10, base_met=3500.0),
         ]
-        qualified_types = {12}
+
+        # Create qualified masks dict based on coincidence type 12
+        qualified_masks = {
+            i: np.isin(ds["coincidence_type"].values, [12])
+            for i, ds in enumerate(l1b_de_datasets)
+        }
 
         mark_statistical_filter_1(
             goodtimes_for_filter1,
             l1b_de_datasets,
             current_index=2,
-            qualified_coincidence_types=qualified_types,
+            qualified_masks=qualified_masks,
         )
 
         # All times should still be good
@@ -2688,13 +2705,17 @@ class TestStatisticalFilter1:
             },
         )
 
-        qualified_types = {12}
+        # Create qualified masks dict based on coincidence type 12
+        qualified_masks = {
+            i: np.isin(ds["coincidence_type"].values, [12])
+            for i, ds in enumerate(l1b_de_datasets)
+        }
 
         mark_statistical_filter_1(
             goodtimes_for_filter1,
             l1b_de_datasets,
             current_index=2,
-            qualified_coincidence_types=qualified_types,
+            qualified_masks=qualified_masks,
         )
 
         # At least the first MET should be marked bad (extreme outlier)
@@ -2707,27 +2728,37 @@ class TestStatisticalFilter1:
             self._create_l1b_de_dataset(),
             self._create_l1b_de_dataset(),
         ]
-        qualified_types = {12}
+
+        # Create qualified masks dict based on coincidence type 12
+        qualified_masks = {
+            i: np.isin(ds["coincidence_type"].values, [12])
+            for i, ds in enumerate(l1b_de_datasets)
+        }
 
         with pytest.raises(ValueError, match="At least 4 valid Pointings required"):
             mark_statistical_filter_1(
                 goodtimes_for_filter1,
                 l1b_de_datasets,
                 current_index=1,
-                qualified_coincidence_types=qualified_types,
+                qualified_masks=qualified_masks,
             )
 
     def test_current_index_out_of_range(self, goodtimes_for_filter1):
         """Test that current_index out of range raises ValueError."""
         l1b_de_datasets = [self._create_l1b_de_dataset()] * 5
-        qualified_types = {12}
+
+        # Create qualified masks dict based on coincidence type 12
+        qualified_masks = {
+            i: np.isin(ds["coincidence_type"].values, [12])
+            for i, ds in enumerate(l1b_de_datasets)
+        }
 
         with pytest.raises(ValueError, match="current_index.*out of range"):
             mark_statistical_filter_1(
                 goodtimes_for_filter1,
                 l1b_de_datasets,
                 current_index=10,
-                qualified_coincidence_types=qualified_types,
+                qualified_masks=qualified_masks,
             )
 
 
@@ -2944,12 +2975,13 @@ class TestStatisticalFilter2:
             dims=["event"],
         )
 
-        qualified_types = {12}  # Type 12 is qualified, but no events have it
+        # Create qualified mask - no events match type 12
+        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_types,
+            qualified_mask,
             min_events=6,
             max_time_delta=10.0,
         )
@@ -3001,12 +3033,13 @@ class TestStatisticalFilter2:
             },
         )
 
-        qualified_types = {12}
+        # Create qualified mask based on coincidence type 12
+        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_types,
+            qualified_mask,
             min_events=6,
             max_time_delta=0.2,
         )
@@ -3044,12 +3077,13 @@ class TestStatisticalFilter2:
             dims=["event"],
         )
 
-        qualified_types = {12}
+        # Create qualified mask based on coincidence type 12
+        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_types,
+            qualified_mask,
             min_events=6,
             max_time_delta=0.1,
             bin_padding=1,
@@ -3092,12 +3126,13 @@ class TestStatisticalFilter2:
             dims=["event"],
         )
 
-        qualified_types = {12}
+        # Create qualified mask based on coincidence type 12
+        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_types,
+            qualified_mask,
             min_events=6,
             max_time_delta=0.1,
             bin_padding=1,
@@ -3129,12 +3164,13 @@ class TestStatisticalFilter2:
             dims=["event"],
         )
 
-        qualified_types = {12}
+        # Create qualified mask based on coincidence type 12
+        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
 
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_types,
+            qualified_mask,
             min_events=6,
             max_time_delta=0.1,
             bin_padding=2,
@@ -3180,13 +3216,14 @@ class TestStatisticalFilter2:
             dims=["event"],
         )
 
-        qualified_types = {12}
+        # Create qualified mask based on coincidence type 12
+        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
 
         # With min_events=4, should detect cluster
         mark_statistical_filter_2(
             goodtimes_for_filter2,
             l1b_de,
-            qualified_types,
+            qualified_mask,
             min_events=4,
             max_time_delta=0.1,
             bin_padding=1,
@@ -3194,6 +3231,88 @@ class TestStatisticalFilter2:
 
         cull_flags = goodtimes_for_filter2["cull_flags"].sel(met=1000.0).values
         assert np.all(cull_flags[39:45] == CullCode.LOOSE)
+
+    def test_only_qualified_events_contribute_to_clusters(self, goodtimes_for_filter2):
+        """Test that only qualified events are used for cluster detection.
+
+        This test verifies the filtering behavior by creating a scenario where:
+        - Unqualified events (type 4) form a cluster if incorrectly included
+        - Qualified events (type 12) are spread out and don't form a cluster
+        - No cluster should be detected because only qualified events should be used
+        """
+        n_events = 12
+        # Create base dataset structure with correct event_met dimension
+        event_met_values = np.array(
+            [
+                # 6 unqualified events clustered together
+                1000.01,
+                1000.02,
+                1000.03,
+                1000.04,
+                1000.05,
+                1000.06,
+                # 6 qualified events spread out (no cluster)
+                1010.0,
+                1020.0,
+                1030.0,
+                1040.0,
+                1050.0,
+                1060.0,
+            ],
+            dtype=np.float64,
+        )
+
+        # First 6 events are unqualified (type 4), last 6 are qualified (type 12)
+        coincidence_type = np.array(
+            [4, 4, 4, 4, 4, 4, 12, 12, 12, 12, 12, 12], dtype=np.uint8
+        )
+
+        # All events at similar bins (so cluster would be detected if all included)
+        nominal_bin = np.array(
+            [40, 41, 42, 43, 44, 45, 40, 41, 42, 43, 44, 45], dtype=np.uint8
+        )
+
+        # Create ccsds_index - all events in same packet
+        ccsds_index = np.zeros(n_events, dtype=np.uint16)
+
+        l1b_de = xr.Dataset(
+            {
+                "ccsds_index": (["event_met"], ccsds_index),
+                "coincidence_type": (["event_met"], coincidence_type),
+                "nominal_bin": (["event_met"], nominal_bin),
+                "ccsds_met": (["epoch"], np.array([1000.0])),
+                "esa_step": (["epoch"], np.array([1], dtype=np.uint8)),
+            },
+            coords={
+                "event_met": event_met_values,
+                "epoch": np.arange(1),
+            },
+        )
+
+        # Create qualified mask - only type 12 events are qualified
+        qualified_mask = np.isin(l1b_de["coincidence_type"].values, [12])
+
+        # Verify our test setup: 6 unqualified, 6 qualified
+        assert np.sum(~qualified_mask) == 6  # 6 unqualified
+        assert np.sum(qualified_mask) == 6  # 6 qualified
+
+        mark_statistical_filter_2(
+            goodtimes_for_filter2,
+            l1b_de,
+            qualified_mask,
+            min_events=6,
+            max_time_delta=0.1,
+            bin_padding=1,
+        )
+
+        # No bins should be marked because:
+        # - The 6 unqualified events form a cluster but should be filtered out
+        # - The 6 qualified events are spread out and don't form a cluster
+        cull_flags = goodtimes_for_filter2["cull_flags"].sel(met=1000.0).values
+        assert np.all(cull_flags == 0), (
+            "Bins were incorrectly marked - unqualified events may have been "
+            "included in cluster detection"
+        )
 
 
 class TestFindCurrentPointingIndex:

--- a/imap_processing/tests/hi/test_hi_l1c.py
+++ b/imap_processing/tests/hi/test_hi_l1c.py
@@ -1,7 +1,6 @@
 """Test coverage for imap_processing.hi.l1c.hi_l1c.py"""
 
 import io
-from collections import namedtuple
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -10,10 +9,9 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-import imap_processing.hi.utils
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import load_cdf, write_cdf
-from imap_processing.hi import hi_l1c
+from imap_processing.hi import hi_l1c, utils
 from imap_processing.hi.utils import HIAPID, HiConstants
 from imap_processing.spice.time import met_to_ttj2000ns, ttj2000ns_to_et
 
@@ -225,7 +223,7 @@ def test_pset_counts(
     """Test coverage for pset_counts function."""
     l1b_de_path = hi_l1_test_data_path / "imap_hi_l1b_45sensor-de_20250415_v999.cdf"
     l1b_dataset = load_cdf(l1b_de_path)
-    cal_config_df = imap_processing.hi.utils.CalibrationProductConfig.from_csv(
+    cal_config_df = utils.CalibrationProductConfig.from_csv(
         hi_test_cal_prod_config_path
     )
     empty_pset = hi_l1c.empty_pset_dataset(
@@ -251,7 +249,7 @@ def test_pset_counts_empty_l1b(
     # remove all but one event and set its trigger_id to zero
     l1b_dataset = l1b_dataset.isel(event_met=[0])
     l1b_dataset["trigger_id"].data[0] = 0
-    cal_config_df = imap_processing.hi.utils.CalibrationProductConfig.from_csv(
+    cal_config_df = utils.CalibrationProductConfig.from_csv(
         hi_test_cal_prod_config_path
     )
     empty_pset = hi_l1c.empty_pset_dataset(
@@ -274,21 +272,13 @@ def test_get_tof_window_mask():
         "tof_bc1": -13,
         "tof_c1c2": -14,
     }
-    Row = namedtuple(
-        "Row",
-        [
-            "Index",
-            "tof_ab_low",
-            "tof_ab_high",
-            "tof_ac1_low",
-            "tof_ac1_high",
-            "tof_bc1_low",
-            "tof_bc1_high",
-            "tof_c1c2_low",
-            "tof_c1c2_high",
-        ],
-    )
-    prod_config_row = Row((1, 0), 0, 1, -1, 2, 1, 5, 4, 6)
+    # Use dict-based tof_windows instead of named tuple
+    tof_windows = {
+        "tof_ab": (0, 1),
+        "tof_ac1": (-1, 2),
+        "tof_bc1": (1, 5),
+        "tof_c1c2": (4, 6),
+    }
     synth_df = xr.Dataset(
         coords={
             "event_met": xr.DataArray(
@@ -323,7 +313,7 @@ def test_get_tof_window_mask():
         },
     )
     expected_mask = np.array([True, False, False, False, False, False, True])
-    window_mask = hi_l1c.get_tof_window_mask(synth_df, prod_config_row, fill_vals)
+    window_mask = utils.get_tof_window_mask(synth_df, tof_windows, fill_vals)
     np.testing.assert_array_equal(expected_mask, window_mask)
 
 
@@ -371,9 +361,7 @@ calibration_prod,esa_energy_step,geometric_factor,coincidence_type_list,tof_ab_l
     l1b_de_path = hi_l1_test_data_path / "imap_hi_l1b_45sensor-de_20250415_v999.cdf"
     l1b_dataset = load_cdf(l1b_de_path)
 
-    cal_config_df = imap_processing.hi.utils.CalibrationProductConfig.from_csv(
-        io.StringIO(csv_content)
-    )
+    cal_config_df = utils.CalibrationProductConfig.from_csv(io.StringIO(csv_content))
 
     # Create PSET with non-sequential calibration product numbers
     l1b_met = 482373065

--- a/imap_processing/tests/hi/test_utils.py
+++ b/imap_processing/tests/hi/test_utils.py
@@ -14,8 +14,12 @@ from imap_processing.hi.utils import (
     CalibrationProductConfig,
     CoincidenceBitmap,
     EsaEnergyStepLookupTable,
+    compute_qualified_event_mask,
     create_dataset_variables,
+    filter_events_by_coincidence,
     full_dataarray,
+    get_bin_range_with_wrap,
+    get_tof_window_mask,
     parse_sensor_number,
 )
 
@@ -406,3 +410,467 @@ calibration_prod,esa_energy_step,geometric_factor,coincidence_type_list,tof_ab_l
         # Should return sorted unique calibration product numbers
         np.testing.assert_array_equal(cal_prod_numbers, np.array([5, 10, 100]))
         assert isinstance(cal_prod_numbers, np.ndarray)
+
+
+class TestGetTofWindowMask:
+    """Test suite for get_tof_window_mask function."""
+
+    @pytest.fixture
+    def mock_de_dataset(self):
+        """Create a mock L1B DE dataset with TOF values."""
+        n_events = 10
+        return xr.Dataset(
+            {
+                "tof_ab": (
+                    ["event_met"],
+                    np.array([20, 50, 100, 30, 40, 60, 10, 80, 90, 55]),
+                ),
+                "tof_ac1": (
+                    ["event_met"],
+                    np.array([10, 30, -5, 50, 20, 40, 0, 60, 70, 35]),
+                ),
+                "tof_bc1": (
+                    ["event_met"],
+                    np.array([-30, 0, -20, 10, -40, -10, -50, 15, 20, 5]),
+                ),
+                "tof_c1c2": (
+                    ["event_met"],
+                    np.array([50, 60, 80, 30, 40, 70, 20, 90, 100, 55]),
+                ),
+            },
+            coords={"event_met": np.arange(n_events, dtype=float)},
+        )
+
+    def test_all_tofs_in_window(self, mock_de_dataset):
+        """Test that events with all TOFs in window pass."""
+        # Use wide windows that include all values
+        tof_windows = {
+            "tof_ab": (0, 200),
+            "tof_ac1": (-20, 100),
+            "tof_bc1": (-100, 50),
+            "tof_c1c2": (0, 200),
+        }
+        tof_fill_vals = {k: -9999 for k in tof_windows}
+        mask = get_tof_window_mask(mock_de_dataset, tof_windows, tof_fill_vals)
+        assert np.all(mask)
+
+    def test_some_tofs_out_of_window(self, mock_de_dataset):
+        """Test that events with TOFs outside window are filtered."""
+        # tof_ab values: [20, 50, 100, 30, 40, 60, 10, 80, 90, 55]
+        # Window (25, 75) should pass indices: 1, 3, 4, 5, 9 (values 50, 30, 40, 60, 55)
+        tof_windows = {
+            "tof_ab": (25, 75),
+        }
+        tof_fill_vals = {"tof_ab": -9999}
+        mask = get_tof_window_mask(mock_de_dataset, tof_windows, tof_fill_vals)
+        expected = np.array(
+            [False, True, False, True, True, True, False, False, False, True]
+        )
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_with_fill_values(self, mock_de_dataset):
+        """Test that events with fill values pass the filter."""
+        # Set some values to fill value
+        fill_val = -9999
+        mock_de_dataset["tof_ab"].values[0] = fill_val  # Was 20, now fill
+        mock_de_dataset["tof_ab"].values[2] = fill_val  # Was 100, now fill
+
+        tof_windows = {"tof_ab": (25, 75)}
+        tof_fill_vals = {"tof_ab": fill_val}
+
+        mask = get_tof_window_mask(mock_de_dataset, tof_windows, tof_fill_vals)
+        # Events 0, 2 have fill values (pass), events 1, 3, 4, 5, 9 are in window
+        expected = np.array(
+            [True, True, True, True, True, True, False, False, False, True]
+        )
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_multiple_tof_windows(self, mock_de_dataset):
+        """Test with multiple TOF windows - all must pass."""
+        # tof_ab:  [20, 50, 100, 30, 40, 60, 10, 80, 90, 55]
+        # tof_ac1: [10, 30, -5, 50, 20, 40, 0, 60, 70, 35]
+        tof_windows = {
+            "tof_ab": (20, 80),  # Passes: 0,1,3,4,5,7,9 (not 2,6,8)
+            "tof_ac1": (10, 60),  # Passes: 0,1,3,4,5,7,9 (not 2,6,8)
+        }
+        tof_fill_vals = {k: -9999 for k in tof_windows}
+        mask = get_tof_window_mask(mock_de_dataset, tof_windows, tof_fill_vals)
+        # Must pass both: 0, 1, 3, 4, 5, 7, 9
+        expected = np.array(
+            [True, True, False, True, True, True, False, True, False, True]
+        )
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_empty_dataset(self):
+        """Test with empty dataset."""
+        empty_ds = xr.Dataset(
+            {
+                "tof_ab": (["event_met"], np.array([])),
+                "tof_ac1": (["event_met"], np.array([])),
+                "tof_bc1": (["event_met"], np.array([])),
+                "tof_c1c2": (["event_met"], np.array([])),
+            },
+            coords={"event_met": np.array([])},
+        )
+        tof_windows = {"tof_ab": (0, 100)}
+        mask = get_tof_window_mask(empty_ds, tof_windows, {})
+        assert len(mask) == 0
+
+
+class TestFilterEventsByCoincidence:
+    """Test suite for filter_events_by_coincidence function."""
+
+    @pytest.fixture
+    def mock_de_dataset(self):
+        """Create a mock L1B DE dataset with coincidence types."""
+        # Coincidence bitmap: A=8, B=4, C1=2, C2=1
+        # ABC1C2 = 15, ABC1 = 14, AB = 12, AC1 = 10, BC1 = 6, etc.
+        return xr.Dataset(
+            {
+                "coincidence_type": (
+                    ["event_met"],
+                    np.array([15, 14, 12, 10, 6, 15, 8, 4, 2, 1]),
+                ),
+            },
+            coords={"event_met": np.arange(10, dtype=float)},
+        )
+
+    def test_single_coincidence_type(self, mock_de_dataset):
+        """Test filtering for a single coincidence type."""
+        # Filter for ABC1C2 (15)
+        mask = filter_events_by_coincidence(mock_de_dataset, [15])
+        expected = np.array(
+            [True, False, False, False, False, True, False, False, False, False]
+        )
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_multiple_coincidence_types(self, mock_de_dataset):
+        """Test filtering for multiple coincidence types."""
+        # Filter for ABC1C2 (15) or ABC1 (14)
+        mask = filter_events_by_coincidence(mock_de_dataset, [15, 14])
+        expected = np.array(
+            [True, True, False, False, False, True, False, False, False, False]
+        )
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_no_matching_coincidence(self, mock_de_dataset):
+        """Test when no events match the coincidence types."""
+        # Filter for type 3 which doesn't exist
+        mask = filter_events_by_coincidence(mock_de_dataset, [3])
+        assert not np.any(mask)
+
+    def test_all_matching_coincidence(self, mock_de_dataset):
+        """Test when all events match the coincidence types."""
+        all_types = [15, 14, 12, 10, 6, 8, 4, 2, 1]
+        mask = filter_events_by_coincidence(mock_de_dataset, all_types)
+        assert np.all(mask)
+
+    def test_empty_coincidence_list(self, mock_de_dataset):
+        """Test with empty coincidence type list."""
+        mask = filter_events_by_coincidence(mock_de_dataset, [])
+        assert not np.any(mask)
+
+    def test_empty_dataset(self):
+        """Test with empty dataset."""
+        empty_ds = xr.Dataset(
+            {
+                "coincidence_type": (["event_met"], np.array([], dtype=np.uint8)),
+            },
+            coords={"event_met": np.array([])},
+        )
+        mask = filter_events_by_coincidence(empty_ds, [15])
+        assert len(mask) == 0
+
+
+class TestGetBinRangeWithWrap:
+    """Test suite for get_bin_range_with_wrap function."""
+
+    def test_no_wrap_middle(self):
+        """Test range in middle of bins (no wraparound)."""
+        result = get_bin_range_with_wrap(
+            first_bin=10, last_bin=20, n_bins=90, extend_by=1
+        )
+        expected = np.arange(9, 22)  # 10-1 to 20+1
+        np.testing.assert_array_equal(result, expected)
+
+    def test_no_wrap_with_larger_extension(self):
+        """Test with larger extension value."""
+        result = get_bin_range_with_wrap(
+            first_bin=10, last_bin=20, n_bins=90, extend_by=3
+        )
+        expected = np.arange(7, 24)  # 10-3 to 20+3
+        np.testing.assert_array_equal(result, expected)
+
+    def test_wrap_at_end(self):
+        """Test wraparound at high end (88 -> 0 boundary)."""
+        result = get_bin_range_with_wrap(
+            first_bin=87, last_bin=1, n_bins=90, extend_by=1
+        )
+        # Should get bins 86, 87, 88, 89, 0, 1, 2
+        expected = np.array([86, 87, 88, 89, 0, 1, 2])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_wrap_at_start(self):
+        """Test wraparound near bin 0."""
+        result = get_bin_range_with_wrap(
+            first_bin=0, last_bin=5, n_bins=90, extend_by=1
+        )
+        # first-1 = -1 % 90 = 89, last+1 = 6
+        # This should NOT wrap (89 > 6), so we get 89,0,1,2,3,4,5,6
+        expected = np.array([89, 0, 1, 2, 3, 4, 5, 6])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_wrap_at_both_ends(self):
+        """Test when first_bin is near end and last_bin is near start."""
+        result = get_bin_range_with_wrap(
+            first_bin=88, last_bin=2, n_bins=90, extend_by=1
+        )
+        # bot = 87, top = 3
+        # Since 3 < 87, we wrap: [87, 88, 89] + [0, 1, 2, 3]
+        expected = np.array([87, 88, 89, 0, 1, 2, 3])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_single_bin_range(self):
+        """Test when first_bin equals last_bin."""
+        result = get_bin_range_with_wrap(
+            first_bin=45, last_bin=45, n_bins=90, extend_by=1
+        )
+        expected = np.array([44, 45, 46])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_zero_extension(self):
+        """Test with zero extension."""
+        result = get_bin_range_with_wrap(
+            first_bin=10, last_bin=15, n_bins=90, extend_by=0
+        )
+        expected = np.arange(10, 16)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_different_n_bins(self):
+        """Test with different number of bins."""
+        result = get_bin_range_with_wrap(
+            first_bin=350, last_bin=10, n_bins=360, extend_by=5
+        )
+        # bot = 345, top = 15
+        # Since 15 < 345, we wrap: [345..359] + [0..15]
+        expected = np.concatenate([np.arange(345, 360), np.arange(0, 16)])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_adjacent_to_boundary(self):
+        """Test bins adjacent to boundary (89 and 0)."""
+        result = get_bin_range_with_wrap(
+            first_bin=89, last_bin=89, n_bins=90, extend_by=1
+        )
+        # bot = 88, top = 0 (90 % 90)
+        # Since 0 < 88, we wrap: [88, 89] + [0]
+        expected = np.array([88, 89, 0])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_full_spin_wrap(self):
+        """Test wrapping that covers almost all bins."""
+        result = get_bin_range_with_wrap(
+            first_bin=85, last_bin=5, n_bins=90, extend_by=1
+        )
+        # bot = 84, top = 6
+        # Since 6 < 84, we wrap
+        expected = np.concatenate([np.arange(84, 90), np.arange(0, 7)])
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestComputeQualifiedEventMask:
+    """Test suite for compute_qualified_event_mask function."""
+
+    @pytest.fixture
+    def mock_cal_product_config(self):
+        """Create a mock calibration product config DataFrame."""
+        # Create a config with 2 calibration products, 2 ESA energy steps
+        # Coincidence bitmap: A=8, B=4, C1=2, C2=1
+        # ABC1C2=15, ABC1=14, AB=12
+        data = {
+            "coincidence_type_list": [
+                ("ABC1C2", "ABC1"),  # cal_prod=1, esa_energy=1
+                ("ABC1C2", "ABC1"),  # cal_prod=1, esa_energy=2
+                ("AB",),  # cal_prod=2, esa_energy=1
+                ("AB",),  # cal_prod=2, esa_energy=2
+            ],
+            "tof_ab_low": [10, 10, 10, 10],
+            "tof_ab_high": [100, 100, 100, 100],
+            "tof_ac1_low": [5, 5, 5, 5],
+            "tof_ac1_high": [80, 80, 80, 80],
+            "tof_bc1_low": [-50, -50, -50, -50],
+            "tof_bc1_high": [50, 50, 50, 50],
+            "tof_c1c2_low": [20, 20, 20, 20],
+            "tof_c1c2_high": [120, 120, 120, 120],
+        }
+        index = pd.MultiIndex.from_tuples(
+            [(1, 1), (1, 2), (2, 1), (2, 2)],
+            names=["calibration_prod", "esa_energy_step"],
+        )
+        df = pd.DataFrame(data, index=index)
+        # Trigger the accessor to add coincidence_type_values column
+        _ = df.cal_prod_config.number_of_products
+        return df
+
+    @pytest.fixture
+    def mock_de_dataset(self):
+        """Create a mock L1B DE dataset with events."""
+        # 10 events with various coincidence types and TOF values
+        # Coincidence bitmap: A=8, B=4, C1=2, C2=1
+        # ABC1C2=15, ABC1=14, AB=12, A=8
+        n_events = 10
+        fill_val = -9999.0
+        ds = xr.Dataset(
+            {
+                "coincidence_type": (
+                    ["event_met"],
+                    np.array([15, 14, 12, 8, 15, 14, 12, 8, 15, 12]),
+                ),
+                "tof_ab": (
+                    ["event_met"],
+                    np.array([50, 50, 50, 50, 200, 50, 50, 50, 50, 50]),
+                ),  # Event 4 out of window
+                "tof_ac1": (
+                    ["event_met"],
+                    np.array([30, 30, 30, 30, 30, 30, 30, 30, 30, 30]),
+                ),
+                "tof_bc1": (
+                    ["event_met"],
+                    np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                ),
+                "tof_c1c2": (
+                    ["event_met"],
+                    np.array([50, 50, 50, 50, 50, 50, 50, 50, 50, 50]),
+                ),
+            },
+            coords={"event_met": np.arange(n_events, dtype=float)},
+        )
+        # Add FILLVAL attributes to TOF variables
+        for tof_var in ["tof_ab", "tof_ac1", "tof_bc1", "tof_c1c2"]:
+            ds[tof_var].attrs["FILLVAL"] = fill_val
+        return ds
+
+    def test_qualifies_with_both_coincidence_and_tof(
+        self, mock_cal_product_config, mock_de_dataset
+    ):
+        """Events passing both coincidence and TOF checks qualify."""
+        # All events at ESA energy step 1
+        esa_energy_steps = np.ones(10, dtype=int)
+
+        mask = compute_qualified_event_mask(
+            mock_de_dataset, mock_cal_product_config, esa_energy_steps
+        )
+
+        # Events with coincidence_type in [15, 14, 12] and TOF in window should pass
+        # Event 4 has bad TOF (200, outside 10-100 window)
+        # Events 3, 7 have coincidence_type=8 (A only, not in config)
+        expected = np.array(
+            [True, True, True, False, False, True, True, False, True, True]
+        )
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_fails_coincidence_only(self, mock_cal_product_config, mock_de_dataset):
+        """Events with wrong coincidence type don't qualify."""
+        # All events at ESA energy step 1
+        esa_energy_steps = np.ones(10, dtype=int)
+
+        # Check events 3, 7 which have coincidence_type=8 (not in config)
+        mask = compute_qualified_event_mask(
+            mock_de_dataset, mock_cal_product_config, esa_energy_steps
+        )
+
+        # Events 3 and 7 should not qualify
+        assert mask[3] is np.False_
+        assert mask[7] is np.False_
+
+    def test_fails_tof_only(self, mock_cal_product_config, mock_de_dataset):
+        """Events with valid coincidence but bad TOF don't qualify."""
+        # All events at ESA energy step 1
+        esa_energy_steps = np.ones(10, dtype=int)
+
+        # Event 4 has coincidence_type=15 (valid) but tof_ab=200 (outside 10-100)
+        mask = compute_qualified_event_mask(
+            mock_de_dataset, mock_cal_product_config, esa_energy_steps
+        )
+
+        assert mask[4] is np.False_
+
+    def test_union_across_cal_products(self, mock_cal_product_config, mock_de_dataset):
+        """Events qualify if they pass for ANY cal product."""
+        esa_energy_steps = np.ones(10, dtype=int)
+
+        # Event 2 has coincidence_type=12 (AB), valid for cal_prod 2
+        # Event 0 has coincidence_type=15 (ABC1C2), valid for cal_prod 1
+        mask = compute_qualified_event_mask(
+            mock_de_dataset, mock_cal_product_config, esa_energy_steps
+        )
+
+        assert mask[0]  # Qualifies for cal_prod 1
+        assert mask[2]  # Qualifies for cal_prod 2
+
+    def test_fill_values_pass_tof(self, mock_cal_product_config, mock_de_dataset):
+        """Events with TOF fill values pass TOF check."""
+        esa_energy_steps = np.ones(10, dtype=int)
+
+        # Set event 4's TOF to fill value (it was failing due to high tof_ab)
+        # The FILLVAL attribute is already set by the fixture
+        fill_val = mock_de_dataset["tof_ab"].attrs["FILLVAL"]
+        mock_de_dataset["tof_ab"].values[4] = fill_val
+
+        mask = compute_qualified_event_mask(
+            mock_de_dataset, mock_cal_product_config, esa_energy_steps
+        )
+
+        # Event 4 should now pass (fill value passes TOF check)
+        assert mask[4]
+
+    def test_different_esa_energy_steps(self, mock_cal_product_config, mock_de_dataset):
+        """Events match config based on their ESA energy step."""
+        # Half events at ESA 1, half at ESA 2
+        esa_energy_steps = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2])
+
+        mask = compute_qualified_event_mask(
+            mock_de_dataset, mock_cal_product_config, esa_energy_steps
+        )
+
+        # Events 0-4 should match ESA 1 config
+        # Events 5-9 should match ESA 2 config
+        # Event 4 still fails due to bad TOF
+        # Events 7 fails due to bad coincidence type (8)
+        expected = np.array(
+            [True, True, True, False, False, True, True, False, True, True]
+        )
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_no_matching_esa_energy_step(
+        self, mock_cal_product_config, mock_de_dataset
+    ):
+        """Events with unmatched ESA energy step don't qualify."""
+        # All events at ESA energy step 99 (not in config)
+        esa_energy_steps = np.full(10, 99)
+
+        mask = compute_qualified_event_mask(
+            mock_de_dataset, mock_cal_product_config, esa_energy_steps
+        )
+
+        # No events should qualify
+        assert not np.any(mask)
+
+    def test_empty_dataset(self, mock_cal_product_config):
+        """Test with empty dataset."""
+        empty_ds = xr.Dataset(
+            {
+                "coincidence_type": (["event_met"], np.array([], dtype=np.uint8)),
+                "tof_ab": (["event_met"], np.array([])),
+                "tof_ac1": (["event_met"], np.array([])),
+                "tof_bc1": (["event_met"], np.array([])),
+                "tof_c1c2": (["event_met"], np.array([])),
+            },
+            coords={"event_met": np.array([])},
+        )
+        esa_energy_steps = np.array([])
+
+        mask = compute_qualified_event_mask(
+            empty_ds, mock_cal_product_config, esa_energy_steps
+        )
+
+        assert len(mask) == 0


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                       
                                                          
  Fixes a bug where statistical filters 1 and 2 in hi_goodtimes.py only checked coincidence_type when identifying "qualified" events. They now also check TOF window values, matching the logic in hi_l1c.py:pset_counts().                                     
                                                                                                                                                                                                                                                                
## Changes                                                                                                                                                                                                                                                       
                                                                             
  - Bug fix: Events must pass BOTH coincidence_type AND TOF window checks to be "qualified"
  - Bug fix: Changed dimension name from "event" to "event_met" in mark_statistical_filter_2()
  - Refactor: Added shared utility functions (iter_qualified_events_by_config, compute_qualified_event_mask, etc.) to utils.py, removing duplicate code between hi_l1c.py and hi_goodtimes.py
  - Tests: Added test_only_qualified_events_contribute_to_clusters to verify filtering behavior


Closes: #2815 
