### PR TITLE
Change CDF output variables to UTC string, matching algorithm document

### DIFF
--- a/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
@@ -40,11 +40,11 @@ support_data_defaults: &support_data_defaults
 
 time_data_defaults: &time_data_defaults
   <<: *support_data_defaults
-  FILLVAL: 0
-  FORMAT: I1000
+  FILLVAL: ' '
+  FORMAT: A30
   UNITS: N/A
-  VALIDMIN: 0
-  VALIDMAX: 0
+  VALIDMIN: ' '
+  VALIDMAX: ' '
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal
 
 lightcurve_defaults: &lightcurve_defaults

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -12,7 +12,12 @@ from imap_processing.glows.l1b.glows_l1b_data import (
     PipelineSettings,
 )
 from imap_processing.glows.l2.glows_l2_data import HistogramL2
-from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
+from imap_processing.spice.time import (
+    et_to_datetime64,
+    met_to_utc,
+    ttj2000ns_to_et,
+    ttj2000ns_to_met,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +150,8 @@ def create_l2_dataset(
         "spin_axis_orientation_std_dev",
     ]
 
+    utc_time_variables = ["start_time", "end_time"]
+
     for key, value in dataclasses.asdict(histogram_l2).items():
         if key in ecliptic_variables:
             output[key] = xr.DataArray(
@@ -164,7 +171,12 @@ def create_l2_dataset(
                 dims=["epoch", "flags"],
                 attrs=attrs.get_variable_attributes(key),
             )
-
+        elif key in utc_time_variables:
+            # Convert time to UTC
+            utc_string = [met_to_utc(ttj2000ns_to_met(value))]
+            output[key] = xr.DataArray(
+                utc_string, dims=["epoch"], attrs=attrs.get_variable_attributes(key)
+            )
         elif key != "daily_lightcurve":
             val = value
             if type(value) is not np.ndarray:

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -27,7 +27,7 @@ def glows_l2(
     pipeline_settings_dataset: xr.Dataset,
 ) -> list[xr.Dataset]:
     """
-    Will process GLoWS L2 data from L1 data.
+    Will process GLOWS L2 data from L1 data.
 
     Parameters
     ----------


### PR DESCRIPTION
# Change Summary

## Overview

Converts `start_time` and `end_time` in the GLOWS L2 CDF output from raw J2000
nanoseconds to UTC strings, matching the format specified in the algorithm
document. Fixes a CDF writing error caused by mismatched attribute types.

## File changes

- **`imap_processing/glows/l2/glows_l2.py`**: Added `utc_time_variables` list
  (`start_time`, `end_time`) and a conversion step in `create_l2_dataset` that
  calls `met_to_utc(ttj2000ns_to_met(value))` before writing these fields to
  the output dataset.

- **`imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml`**: Updated
  `time_data_defaults` to use string-compatible CDF attributes (`FILLVAL: ' '`,
  `FORMAT: A30`, `VALIDMIN/VALIDMAX: ' '`). The previous `FILLVAL: 0` and
  `FORMAT: I1000` caused a cdflib `ValueError` when writing string data because
  cdflib infers CDF_CHAR type from the string data but then fails to convert an
  integer FILLVAL to that type.
