### PR TITLE
2822 hi l1b goodtimes   implement bad tdc cal culling algorithm

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -832,14 +832,24 @@ class Hi(ProcessInstrument):
                         f"got {len(cal_prod_paths)}"
                     )
 
+                l1a_diagfee_paths = dependencies.get_file_paths(
+                    source="hi", data_type="l1a", descriptor="diagfee"
+                )
+                if len(l1a_diagfee_paths) != 1:
+                    raise ValueError(
+                        f"Expected one L1A DIAG_FEE file, got {len(l1a_diagfee_paths)}"
+                    )
+
                 # Load CDFs before passing to hi_goodtimes
                 l1b_de_datasets = [load_cdf(path) for path in l1b_de_paths]
                 l1b_hk = load_cdf(l1b_hk_paths[0])
+                l1a_diagfee = load_cdf(l1a_diagfee_paths[0])
 
                 datasets = hi_goodtimes.hi_goodtimes(
-                    l1b_de_datasets,
                     self.repointing,
+                    l1b_de_datasets,
                     l1b_hk,
+                    l1a_diagfee,
                     cal_prod_paths[0],
                 )
             else:

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -1212,7 +1212,10 @@ def mark_bad_tdc_cal(
         # Remove times from this DIAG_FEE packet until next. We are skipping the
         # first packet of a duplicate pair, so determining the window based on the
         # current packet met and next packet met covers the time window between
-        # non-duplicate DIAG_FEE packets.
+        # non-duplicate DIAG_FEE packets. We can ignore the ~10 seconds of slop
+        # around duplicate packets because these packets should only be produced
+        # when IMAP-Hi is transitioning to HVSCI mode which means that there will
+        # be no DE packets being produced.
         df_time = diagfee_met[i]
         next_df_time = diagfee_met[i + 1] if i < len(diagfee_met) - 1 else np.inf
 

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -1208,7 +1208,7 @@ def mark_bad_tdc_cal(
     tdc_failed_indices = np.nonzero(~is_duplicate & tdc_failed)[0]
 
     n_times_removed = 0
-    for i in failed_indices:
+    for i in tdc_failed_indices:
         # Remove times from this DIAG_FEE packet until next. We are skipping the
         # first packet of a duplicate pair, so determining the window based on the
         # current packet met and next packet met covers the time window between

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -211,7 +211,7 @@ def _apply_goodtimes_filters(
     """
     Apply all goodtimes culling filters to the dataset.
 
-    Modifies goodtimes_ds in place by applying filters 1-6.
+    Modifies goodtimes_ds in place by applying filters 1-7.
 
     Parameters
     ----------
@@ -1191,7 +1191,10 @@ def mark_bad_tdc_cal(
     # Based on sample code in culling_v2.c, skip this check if we have fewer
     # than two diag_fee packets.
     if len(diagfee.epoch) < 2:
-        logger.warning("No DIAG_FEE data to use for selecting good times")
+        logger.warning(
+            f"Insufficient DIAG_FEE packets to select good times "
+            f"(found {len(diagfee.epoch)}, need at least 2)"
+        )
         return
 
     df_met = diagfee["shcoarse"].values

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -1145,20 +1145,18 @@ def mark_overflow_packets(
 def mark_bad_tdc_cal(
     goodtimes_ds: xr.Dataset,
     diagfee: xr.Dataset,
-    check_tdc1: bool = True,
-    check_tdc2: bool = True,
-    check_tdc3: bool = True,
     cull_code: int = CullCode.LOOSE,
 ) -> None:
     """
     Remove times with failed TDC calibration (DIAG_FEE method).
 
-    Based on C reference: drop_bad_tdc_diagfee in culling.c
+    Based on C reference: drop_bad_tdc_diagfee in culling_v2.c provided by
+    IMAP-Hi team.
 
     This function scans DIAG_FEE packets chronologically and checks the TDC
-    calibration status for each packet. If any checked TDC has failed
-    calibration, all times from that DIAG_FEE packet until the next DIAG_FEE
-    packet are marked as bad.
+    calibration status for each packet. If any TDC has failed calibration,
+    all times from that DIAG_FEE packet until the next DIAG_FEE packet are
+    marked as bad.
 
     Parameters
     ----------
@@ -1170,12 +1168,6 @@ def mark_bad_tdc_cal(
         - tdc1_cal_ctrl_stat: TDC1 calibration status (bit 1 = success)
         - tdc2_cal_ctrl_stat: TDC2 calibration status (bit 1 = success)
         - tdc3_cal_ctrl_stat: TDC3 calibration status (bit 1 = success)
-    check_tdc1 : bool, optional
-        Whether to check TDC1 calibration status. Default is True.
-    check_tdc2 : bool, optional
-        Whether to check TDC2 calibration status. Default is True.
-    check_tdc3 : bool, optional
-        Whether to check TDC3 calibration status. Default is True.
     cull_code : int, optional
         Cull code to use for marking bad times. Default is CullCode.LOOSE.
 
@@ -1197,36 +1189,39 @@ def mark_bad_tdc_cal(
         )
         return
 
-    df_met = diagfee["shcoarse"].values
-    met_values = goodtimes_ds.coords["met"].values
+    diagfee_met = diagfee["shcoarse"].values
+    goodtimes_met = goodtimes_ds.coords["met"].values
+
+    # Identify duplicate packets: skip if followed by another within 10 seconds
+    time_gaps = np.diff(diagfee_met)
+    is_duplicate = np.concatenate([time_gaps < 10, [False]])
+
+    # Identify any packets where any of the three TDC calibrations failed.
+    # TDC failure check (bit 1: 1=good, 0=bad)
+    tdc_failed = (
+        ((diagfee["tdc1_cal_ctrl_stat"].values & 2) == 0)
+        | ((diagfee["tdc2_cal_ctrl_stat"].values & 2) == 0)
+        | ((diagfee["tdc3_cal_ctrl_stat"].values & 2) == 0)
+    )
+
+    # Only loop over non-duplicate packets with TDC failures
+    failed_indices = np.nonzero(~is_duplicate & tdc_failed)[0]
+
     n_times_removed = 0
+    for i in failed_indices:
+        # Remove times from this DIAG_FEE packet until next. We are skipping the
+        # first packet of a duplicate pair, so determining the window based on the
+        # current packet met and next packet met covers the time window between
+        # non-duplicate DIAG_FEE packets.
+        df_time = diagfee_met[i]
+        next_df_time = diagfee_met[i + 1] if i < len(diagfee_met) - 1 else np.inf
 
-    for i in range(len(df_met)):
-        # Skip duplicate DIAG_FEE packets (within 10 seconds of next)
-        if i < len(df_met) - 1 and df_met[i] + 10 > df_met[i + 1]:
-            continue
+        in_window = (goodtimes_met >= df_time) & (goodtimes_met < next_df_time)
+        mets_to_cull = goodtimes_met[in_window]
 
-        # Check TDC calibration status (bit 1: 1=good, 0=bad)
-        any_tdc_failed = False
-
-        if check_tdc1 and (diagfee["tdc1_cal_ctrl_stat"].values[i] & 2) == 0:
-            any_tdc_failed = True
-        if check_tdc2 and (diagfee["tdc2_cal_ctrl_stat"].values[i] & 2) == 0:
-            any_tdc_failed = True
-        if check_tdc3 and (diagfee["tdc3_cal_ctrl_stat"].values[i] & 2) == 0:
-            any_tdc_failed = True
-
-        if any_tdc_failed:
-            # Remove times from this DIAG_FEE until next
-            df_time = df_met[i]
-            next_df_time = df_met[i + 1] if i < len(df_met) - 1 else np.inf
-
-            in_window = (met_values >= df_time) & (met_values < next_df_time)
-            mets_to_cull = met_values[in_window]
-
-            if len(mets_to_cull) > 0:
-                goodtimes_ds.goodtimes.mark_bad_times(met=mets_to_cull, cull=cull_code)
-                n_times_removed += len(mets_to_cull)
+        if len(mets_to_cull) > 0:
+            goodtimes_ds.goodtimes.mark_bad_times(met=mets_to_cull, cull=cull_code)
+            n_times_removed += len(mets_to_cull)
 
     logger.info(f"Dropped {n_times_removed} time(s) due to bad TDC calibration")
 

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -45,9 +45,10 @@ class CullCode(IntEnum):
 
 
 def hi_goodtimes(
-    l1b_de_datasets: list[xr.Dataset],
     current_repointing: str,
+    l1b_de_datasets: list[xr.Dataset],
     l1b_hk: xr.Dataset,
+    l1a_diagfee: xr.Dataset,
     cal_product_config_path: Path,
 ) -> list[xr.Dataset]:
     """
@@ -58,23 +59,26 @@ def hi_goodtimes(
 
     1. mark_incomplete_spin_sets - Remove incomplete 8-spin histogram periods
     2. mark_drf_times - Remove times during spacecraft drift restabilization
-    3. mark_overflow_packets - Remove times when DE packets overflow
-    4. mark_statistical_filter_0 - Detect drastic penetrating background changes
-    5. mark_statistical_filter_1 - Detect isotropic count rate increases
-    6. mark_statistical_filter_2 - Detect short-lived event pulses
+    3. mark_bad_tdc_cal - Remove times with failed TDC calibration
+    4. mark_overflow_packets - Remove times when DE packets overflow
+    5. mark_statistical_filter_0 - Detect drastic penetrating background changes
+    6. mark_statistical_filter_1 - Detect isotropic count rate increases
+    7. mark_statistical_filter_2 - Detect short-lived event pulses
 
     Parameters
     ----------
+    current_repointing : str
+        Repointing identifier for the current pointing (e.g., "repoint00001").
+        Used to identify which dataset in l1b_de_datasets is the current one.
     l1b_de_datasets : list[xr.Dataset]
         L1B DE datasets for surrounding pointings. Typically includes
         current plus 3 preceding and 3 following pointings (7 total).
         Statistical filters 0 and 1 use all datasets; other filters use
         only the current pointing.
-    current_repointing : str
-        Repointing identifier for the current pointing (e.g., "repoint00001").
-        Used to identify which dataset in l1b_de_datasets is the current one.
     l1b_hk : xr.Dataset
         L1B housekeeping dataset containing DRF status.
+    l1a_diagfee : xr.Dataset
+        L1A DIAG_FEE dataset containing TDC calibration status.
     cal_product_config_path : Path
         Path to calibration product configuration CSV file.
 
@@ -131,6 +135,7 @@ def hi_goodtimes(
             l1b_de_datasets,
             current_index,
             l1b_hk,
+            l1a_diagfee,
             cal_product_config_path,
         )
     else:
@@ -200,6 +205,7 @@ def _apply_goodtimes_filters(
     l1b_de_datasets: list[xr.Dataset],
     current_index: int,
     l1b_hk: xr.Dataset,
+    l1a_diagfee: xr.Dataset,
     cal_product_config_path: Path,
 ) -> None:
     """
@@ -217,6 +223,8 @@ def _apply_goodtimes_filters(
         Index of the current pointing in l1b_de_datasets.
     l1b_hk : xr.Dataset
         L1B housekeeping dataset.
+    l1a_diagfee : xr.Dataset
+        L1A DIAG_FEE dataset containing TDC calibration status.
     cal_product_config_path : Path
         Path to calibration product configuration CSV file.
     """
@@ -263,15 +271,19 @@ def _apply_goodtimes_filters(
     logger.info("Applying filter: mark_drf_times")
     mark_drf_times(goodtimes_ds, l1b_hk)
 
-    # 3. Mark overflow packets
+    # 3. Mark bad TDC calibration times
+    logger.info("Applying filter: mark_bad_tdc_cal")
+    mark_bad_tdc_cal(goodtimes_ds, l1a_diagfee)
+
+    # 4. Mark overflow packets
     logger.info("Applying filter: mark_overflow_packets")
     mark_overflow_packets(goodtimes_ds, current_l1b_de, cal_product_config)
 
-    # 4. Statistical Filter 0 - drastic background changes
+    # 5. Statistical Filter 0 - drastic background changes
     logger.info("Applying filter: mark_statistical_filter_0")
     mark_statistical_filter_0(goodtimes_ds, l1b_de_datasets, current_index)
 
-    # 5. Statistical Filter 1 - isotropic count rate increases
+    # 6. Statistical Filter 1 - isotropic count rate increases
     logger.info("Applying filter: mark_statistical_filter_1")
     mark_statistical_filter_1(
         goodtimes_ds,
@@ -279,7 +291,7 @@ def _apply_goodtimes_filters(
         current_index,
     )
 
-    # 6. Statistical Filter 2 - short-lived event pulses
+    # 7. Statistical Filter 2 - short-lived event pulses
     logger.info("Applying filter: mark_statistical_filter_2")
     mark_statistical_filter_2(
         goodtimes_ds,
@@ -1128,6 +1140,92 @@ def mark_overflow_packets(
         f"Found {len(full_packet_indices)} full packet(s), "
         f"dropped {len(mets_to_cull)} 8-spin period(s) due to overflow packets"
     )
+
+
+def mark_bad_tdc_cal(
+    goodtimes_ds: xr.Dataset,
+    diagfee: xr.Dataset,
+    check_tdc1: bool = True,
+    check_tdc2: bool = True,
+    check_tdc3: bool = True,
+    cull_code: int = CullCode.LOOSE,
+) -> None:
+    """
+    Remove times with failed TDC calibration (DIAG_FEE method).
+
+    Based on C reference: drop_bad_tdc_diagfee in culling.c
+
+    This function scans DIAG_FEE packets chronologically and checks the TDC
+    calibration status for each packet. If any checked TDC has failed
+    calibration, all times from that DIAG_FEE packet until the next DIAG_FEE
+    packet are marked as bad.
+
+    Parameters
+    ----------
+    goodtimes_ds : xr.Dataset
+        Goodtimes dataset to update with cull flags.
+    diagfee : xr.Dataset
+        DIAG_FEE dataset containing TDC calibration status fields:
+        - shcoarse: Mission Elapsed Time (MET)
+        - tdc1_cal_ctrl_stat: TDC1 calibration status (bit 1 = success)
+        - tdc2_cal_ctrl_stat: TDC2 calibration status (bit 1 = success)
+        - tdc3_cal_ctrl_stat: TDC3 calibration status (bit 1 = success)
+    check_tdc1 : bool, optional
+        Whether to check TDC1 calibration status. Default is True.
+    check_tdc2 : bool, optional
+        Whether to check TDC2 calibration status. Default is True.
+    check_tdc3 : bool, optional
+        Whether to check TDC3 calibration status. Default is True.
+    cull_code : int, optional
+        Cull code to use for marking bad times. Default is CullCode.LOOSE.
+
+    Notes
+    -----
+    This function modifies goodtimes_ds in place.
+
+    Quirk: Two DIAG_FEE packets are generated when entering HVSCI mode.
+    The first packet is skipped if two packets appear within 10 seconds.
+    """
+    logger.info("Running mark_bad_tdc_cal culling")
+
+    # Based on sample code in culling_v2.c, skip this check if we have fewer
+    # than two diag_fee packets.
+    if len(diagfee.epoch) < 2:
+        logger.warning("No DIAG_FEE data to use for selecting good times")
+        return
+
+    df_met = diagfee["shcoarse"].values
+    met_values = goodtimes_ds.coords["met"].values
+    n_times_removed = 0
+
+    for i in range(len(df_met)):
+        # Skip duplicate DIAG_FEE packets (within 10 seconds of next)
+        if i < len(df_met) - 1 and df_met[i] + 10 > df_met[i + 1]:
+            continue
+
+        # Check TDC calibration status (bit 1: 1=good, 0=bad)
+        any_tdc_failed = False
+
+        if check_tdc1 and (diagfee["tdc1_cal_ctrl_stat"].values[i] & 2) == 0:
+            any_tdc_failed = True
+        if check_tdc2 and (diagfee["tdc2_cal_ctrl_stat"].values[i] & 2) == 0:
+            any_tdc_failed = True
+        if check_tdc3 and (diagfee["tdc3_cal_ctrl_stat"].values[i] & 2) == 0:
+            any_tdc_failed = True
+
+        if any_tdc_failed:
+            # Remove times from this DIAG_FEE until next
+            df_time = df_met[i]
+            next_df_time = df_met[i + 1] if i < len(df_met) - 1 else np.inf
+
+            in_window = (met_values >= df_time) & (met_values < next_df_time)
+            mets_to_cull = met_values[in_window]
+
+            if len(mets_to_cull) > 0:
+                goodtimes_ds.goodtimes.mark_bad_times(met=mets_to_cull, cull=cull_code)
+                n_times_removed += len(mets_to_cull)
+
+    logger.info(f"Dropped {n_times_removed} time(s) due to bad TDC calibration")
 
 
 def _get_sweep_indices(esa_step: np.ndarray) -> np.ndarray:

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -1205,7 +1205,7 @@ def mark_bad_tdc_cal(
     )
 
     # Only loop over non-duplicate packets with TDC failures
-    failed_indices = np.nonzero(~is_duplicate & tdc_failed)[0]
+    tdc_failed_indices = np.nonzero(~is_duplicate & tdc_failed)[0]
 
     n_times_removed = 0
     for i in failed_indices:

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -3646,6 +3646,7 @@ class TestApplyGoodtimesFilters:
             patch("imap_processing.hi.hi_goodtimes.mark_incomplete_spin_sets"),
             patch("imap_processing.hi.hi_goodtimes.mark_drf_times"),
             patch("imap_processing.hi.hi_goodtimes.mark_overflow_packets"),
+            patch("imap_processing.hi.hi_goodtimes.mark_bad_tdc_cal"),
             patch("imap_processing.hi.hi_goodtimes.mark_statistical_filter_0"),
             patch("imap_processing.hi.hi_goodtimes.mark_statistical_filter_1"),
             patch("imap_processing.hi.hi_goodtimes.mark_statistical_filter_2"),

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -23,6 +23,7 @@ from imap_processing.hi.hi_goodtimes import (
     _identify_cull_pattern,
     create_goodtimes_dataset,
     hi_goodtimes,
+    mark_bad_tdc_cal,
     mark_drf_times,
     mark_incomplete_spin_sets,
     mark_overflow_packets,
@@ -1411,6 +1412,255 @@ class TestDropDrfTimes:
         n_culled = np.sum(gt["cull_flags"].values[:, 0] == CullCode.LOOSE)
         assert n_culled > 0  # Some should be culled
         assert n_culled <= 31  # But not all (only last ~30 minutes)
+
+
+class TestMarkBadTdcCal:
+    """Test suite for mark_bad_tdc_cal() function."""
+
+    @pytest.fixture
+    def goodtimes_for_tdc(self):
+        """Create a goodtimes dataset with METs spanning a range."""
+        # Create METs every 50 seconds for 200 seconds (5 METs)
+        n_mets = 5
+        met_values = np.arange(1000.0, 1000.0 + n_mets * 50, 50)
+
+        gt = xr.Dataset(
+            {
+                "cull_flags": xr.DataArray(
+                    np.zeros((n_mets, 90), dtype=np.uint8), dims=["met", "spin_bin"]
+                ),
+                "esa_step": xr.DataArray(np.ones(n_mets, dtype=np.uint8), dims=["met"]),
+            },
+            coords={"met": met_values, "spin_bin": np.arange(90)},
+            attrs={"sensor": "45sensor", "pointing": 1},
+        )
+        return gt
+
+    @pytest.fixture
+    def diagfee_all_good(self):
+        """Create DIAG_FEE dataset where all TDC calibrations pass."""
+        # 4 DIAG_FEE packets, all with bit 1 set (=2, meaning calibration good)
+        return xr.Dataset(
+            {
+                "shcoarse": (["epoch"], np.array([1000, 1050, 1100, 1150])),
+                "tdc1_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+                "tdc2_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+                "tdc3_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+            }
+        )
+
+    @pytest.fixture
+    def diagfee_tdc1_fails(self):
+        """Create DIAG_FEE dataset where TDC1 fails at packet index 2."""
+        # TDC1 fails at index 2 (bit 1 not set, so value 0)
+        return xr.Dataset(
+            {
+                "shcoarse": (["epoch"], np.array([1000, 1050, 1100, 1150])),
+                "tdc1_cal_ctrl_stat": (
+                    ["epoch"],
+                    np.array([2, 2, 0, 2]),
+                ),  # fails at idx 2
+                "tdc2_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+                "tdc3_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+            }
+        )
+
+    @pytest.fixture
+    def diagfee_with_duplicate(self):
+        """Create DIAG_FEE dataset with duplicate packets within 10 seconds."""
+        # First two packets are within 10 seconds (should skip first)
+        return xr.Dataset(
+            {
+                "shcoarse": (["epoch"], np.array([1000, 1005, 1100, 1150])),
+                "tdc1_cal_ctrl_stat": (
+                    ["epoch"],
+                    np.array([0, 2, 2, 2]),
+                ),  # First would fail but is skipped
+                "tdc2_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+                "tdc3_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+            }
+        )
+
+    def test_mark_bad_tdc_cal_all_good(self, goodtimes_for_tdc, diagfee_all_good):
+        """Test that no times are marked when all TDC calibrations pass."""
+        mark_bad_tdc_cal(goodtimes_for_tdc, diagfee_all_good)
+
+        # All times should remain good
+        assert np.all(goodtimes_for_tdc["cull_flags"].values == CullCode.GOOD)
+
+    def test_mark_bad_tdc_cal_tdc1_fails(self, goodtimes_for_tdc, diagfee_tdc1_fails):
+        """Test that times are marked when TDC1 fails."""
+        mark_bad_tdc_cal(goodtimes_for_tdc, diagfee_tdc1_fails)
+
+        # TDC1 fails at packet 2 (MET 1100), should mark times from 1100 to 1150
+        # goodtimes METs are [1000, 1050, 1100, 1150, 1200]
+        # MET 1100 falls in window [1100, 1150), so MET 1100 should be culled
+        met_values = goodtimes_for_tdc.coords["met"].values
+
+        # MET 1100 (index 2) should be culled
+        idx_1100 = np.where(met_values == 1100.0)[0][0]
+        assert np.all(
+            goodtimes_for_tdc["cull_flags"].values[idx_1100, :] == CullCode.LOOSE
+        )
+
+        # METs before 1100 should still be good
+        assert np.all(
+            goodtimes_for_tdc["cull_flags"].values[0, :] == CullCode.GOOD
+        )  # 1000
+        assert np.all(
+            goodtimes_for_tdc["cull_flags"].values[1, :] == CullCode.GOOD
+        )  # 1050
+
+    def test_mark_bad_tdc_cal_skip_duplicate_packets(
+        self, goodtimes_for_tdc, diagfee_with_duplicate
+    ):
+        """Test that duplicate DIAG_FEE packets within 10 seconds are skipped."""
+        mark_bad_tdc_cal(goodtimes_for_tdc, diagfee_with_duplicate)
+
+        # First packet (MET 1000) has TDC1 fail but should be skipped
+        # because it's within 10 seconds of the next packet (MET 1005)
+        # So all times should remain good
+        assert np.all(goodtimes_for_tdc["cull_flags"].values == CullCode.GOOD)
+
+    def test_mark_bad_tdc_cal_insufficient_packets(self, goodtimes_for_tdc):
+        """Test that less than 2 packets logs warning and returns early."""
+        # Create DIAG_FEE with only 1 packet
+        diagfee_single = xr.Dataset(
+            {
+                "shcoarse": (["epoch"], np.array([1000])),
+                "tdc1_cal_ctrl_stat": (["epoch"], np.array([0])),  # Fails but ignored
+                "tdc2_cal_ctrl_stat": (["epoch"], np.array([2])),
+                "tdc3_cal_ctrl_stat": (["epoch"], np.array([2])),
+            }
+        )
+
+        mark_bad_tdc_cal(goodtimes_for_tdc, diagfee_single)
+
+        # All times should remain good (no culling due to insufficient packets)
+        assert np.all(goodtimes_for_tdc["cull_flags"].values == CullCode.GOOD)
+
+    def test_mark_bad_tdc_cal_selective_tdc_checking(
+        self, goodtimes_for_tdc, diagfee_tdc1_fails
+    ):
+        """Test that TDC checking can be selectively disabled."""
+        # Disable TDC1 checking - should not cull even though TDC1 fails
+        mark_bad_tdc_cal(
+            goodtimes_for_tdc, diagfee_tdc1_fails, check_tdc1=False, check_tdc2=True
+        )
+
+        # All times should remain good since TDC1 checking is disabled
+        assert np.all(goodtimes_for_tdc["cull_flags"].values == CullCode.GOOD)
+
+    def test_mark_bad_tdc_cal_tdc2_fails(self, goodtimes_for_tdc):
+        """Test that times are marked when TDC2 fails."""
+        diagfee_tdc2_fails = xr.Dataset(
+            {
+                "shcoarse": (["epoch"], np.array([1000, 1050, 1100, 1150])),
+                "tdc1_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+                "tdc2_cal_ctrl_stat": (
+                    ["epoch"],
+                    np.array([2, 0, 2, 2]),
+                ),  # fails at idx 1
+                "tdc3_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+            }
+        )
+
+        mark_bad_tdc_cal(goodtimes_for_tdc, diagfee_tdc2_fails)
+
+        # TDC2 fails at packet 1 (MET 1050), should mark times from 1050 to 1100
+        met_values = goodtimes_for_tdc.coords["met"].values
+
+        # MET 1050 (index 1) should be culled
+        idx_1050 = np.where(met_values == 1050.0)[0][0]
+        assert np.all(
+            goodtimes_for_tdc["cull_flags"].values[idx_1050, :] == CullCode.LOOSE
+        )
+
+    def test_mark_bad_tdc_cal_tdc3_fails(self, goodtimes_for_tdc):
+        """Test that times are marked when TDC3 fails."""
+        diagfee_tdc3_fails = xr.Dataset(
+            {
+                "shcoarse": (["epoch"], np.array([1000, 1050, 1100, 1150])),
+                "tdc1_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+                "tdc2_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+                "tdc3_cal_ctrl_stat": (
+                    ["epoch"],
+                    np.array([0, 2, 2, 2]),
+                ),  # fails at idx 0
+            }
+        )
+
+        mark_bad_tdc_cal(goodtimes_for_tdc, diagfee_tdc3_fails)
+
+        # TDC3 fails at packet 0 (MET 1000), should mark times from 1000 to 1050
+        # MET 1000 (index 0) should be culled
+        assert np.all(
+            goodtimes_for_tdc["cull_flags"].values[0, :] == CullCode.LOOSE
+        )  # 1000
+
+        # MET 1050 should be good (next DIAG_FEE packet starts good window)
+        assert np.all(
+            goodtimes_for_tdc["cull_flags"].values[1, :] == CullCode.GOOD
+        )  # 1050
+
+    def test_mark_bad_tdc_cal_custom_cull_code(
+        self, goodtimes_for_tdc, diagfee_tdc1_fails
+    ):
+        """Test that custom cull code is used."""
+        custom_cull_code = 5
+        mark_bad_tdc_cal(
+            goodtimes_for_tdc, diagfee_tdc1_fails, cull_code=custom_cull_code
+        )
+
+        # Check that culled times use custom code
+        assert np.any(goodtimes_for_tdc["cull_flags"].values == custom_cull_code)
+
+    def test_mark_bad_tdc_cal_last_packet_fails(self, goodtimes_for_tdc):
+        """Test behavior when the last DIAG_FEE packet has TDC failure."""
+        diagfee_last_fails = xr.Dataset(
+            {
+                "shcoarse": (["epoch"], np.array([1000, 1050, 1100, 1150])),
+                "tdc1_cal_ctrl_stat": (
+                    ["epoch"],
+                    np.array([2, 2, 2, 0]),
+                ),  # fails at last
+                "tdc2_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+                "tdc3_cal_ctrl_stat": (["epoch"], np.array([2, 2, 2, 2])),
+            }
+        )
+
+        mark_bad_tdc_cal(goodtimes_for_tdc, diagfee_last_fails)
+
+        # TDC1 fails at last packet (MET 1150), should mark all times >= 1150
+        met_values = goodtimes_for_tdc.coords["met"].values
+
+        # METs >= 1150 should be culled
+        for i, met in enumerate(met_values):
+            if met >= 1150:
+                assert np.all(
+                    goodtimes_for_tdc["cull_flags"].values[i, :] == CullCode.LOOSE
+                )
+            else:
+                assert np.all(
+                    goodtimes_for_tdc["cull_flags"].values[i, :] == CullCode.GOOD
+                )
+
+    def test_mark_bad_tdc_cal_empty_diagfee(self, goodtimes_for_tdc):
+        """Test that function handles empty DIAG_FEE data gracefully."""
+        diagfee_empty = xr.Dataset(
+            {
+                "shcoarse": (["epoch"], np.array([], dtype=np.float64)),
+                "tdc1_cal_ctrl_stat": (["epoch"], np.array([], dtype=np.uint8)),
+                "tdc2_cal_ctrl_stat": (["epoch"], np.array([], dtype=np.uint8)),
+                "tdc3_cal_ctrl_stat": (["epoch"], np.array([], dtype=np.uint8)),
+            }
+        )
+
+        # Should log warning and return without error
+        mark_bad_tdc_cal(goodtimes_for_tdc, diagfee_empty)
+
+        # All times should remain good
+        assert np.all(goodtimes_for_tdc["cull_flags"].values == CullCode.GOOD)
 
 
 class TestMarkOverflowPackets:
@@ -3407,13 +3657,14 @@ class TestApplyGoodtimesFilters:
                 [mock_l1b_de],
                 current_index=0,
                 l1b_hk=mock_hk,
+                l1a_diagfee=MagicMock(),
                 cal_product_config_path=cal_path,
             )
 
             mock_cal_load.assert_called_once_with(cal_path)
 
     def test_calls_all_filters(self, tmp_path):
-        """Test that all 6 filters are called."""
+        """Test that all 7 filters are called."""
         mock_goodtimes = MagicMock()
         mock_goodtimes.goodtimes.get_cull_statistics.return_value = {
             "good_bins": 100,
@@ -3432,22 +3683,24 @@ class TestApplyGoodtimesFilters:
                 "imap_processing.hi.hi_goodtimes.mark_incomplete_spin_sets"
             ) as mock_f1,
             patch("imap_processing.hi.hi_goodtimes.mark_drf_times") as mock_f2,
-            patch("imap_processing.hi.hi_goodtimes.mark_overflow_packets") as mock_f3,
+            patch("imap_processing.hi.hi_goodtimes.mark_bad_tdc_cal") as mock_f3,
+            patch("imap_processing.hi.hi_goodtimes.mark_overflow_packets") as mock_f4,
             patch(
                 "imap_processing.hi.hi_goodtimes.mark_statistical_filter_0"
-            ) as mock_f4,
-            patch(
-                "imap_processing.hi.hi_goodtimes.mark_statistical_filter_1"
             ) as mock_f5,
             patch(
-                "imap_processing.hi.hi_goodtimes.mark_statistical_filter_2"
+                "imap_processing.hi.hi_goodtimes.mark_statistical_filter_1"
             ) as mock_f6,
+            patch(
+                "imap_processing.hi.hi_goodtimes.mark_statistical_filter_2"
+            ) as mock_f7,
         ):
             _apply_goodtimes_filters(
                 mock_goodtimes,
                 [mock_l1b_de],
                 current_index=0,
                 l1b_hk=mock_hk,
+                l1a_diagfee=MagicMock(),
                 cal_product_config_path=tmp_path / "cal.csv",
             )
 
@@ -3457,6 +3710,7 @@ class TestApplyGoodtimesFilters:
             mock_f4.assert_called_once()
             mock_f5.assert_called_once()
             mock_f6.assert_called_once()
+            mock_f7.assert_called_once()
 
     def test_raises_statistical_filter_0_errors(self, tmp_path):
         """Test that ValueError from statistical filter 0 is raised."""
@@ -3476,6 +3730,7 @@ class TestApplyGoodtimesFilters:
             ),
             patch("imap_processing.hi.hi_goodtimes.mark_incomplete_spin_sets"),
             patch("imap_processing.hi.hi_goodtimes.mark_drf_times"),
+            patch("imap_processing.hi.hi_goodtimes.mark_bad_tdc_cal"),
             patch("imap_processing.hi.hi_goodtimes.mark_overflow_packets"),
             patch(
                 "imap_processing.hi.hi_goodtimes.mark_statistical_filter_0",
@@ -3488,6 +3743,7 @@ class TestApplyGoodtimesFilters:
                     [mock_l1b_de],
                     current_index=0,
                     l1b_hk=mock_hk,
+                    l1a_diagfee=MagicMock(),
                     cal_product_config_path=tmp_path / "cal.csv",
                 )
 
@@ -3509,6 +3765,7 @@ class TestApplyGoodtimesFilters:
             ),
             patch("imap_processing.hi.hi_goodtimes.mark_incomplete_spin_sets"),
             patch("imap_processing.hi.hi_goodtimes.mark_drf_times"),
+            patch("imap_processing.hi.hi_goodtimes.mark_bad_tdc_cal"),
             patch("imap_processing.hi.hi_goodtimes.mark_overflow_packets"),
             patch("imap_processing.hi.hi_goodtimes.mark_statistical_filter_0"),
             patch(
@@ -3522,6 +3779,7 @@ class TestApplyGoodtimesFilters:
                     [mock_l1b_de],
                     current_index=0,
                     l1b_hk=mock_hk,
+                    l1a_diagfee=MagicMock(),
                     cal_product_config_path=tmp_path / "cal.csv",
                 )
 
@@ -3547,9 +3805,10 @@ class TestHiGoodtimes:
                 ValueError, match="Goodtimes cannot yet be processed for repoint00001"
             ):
                 _ = hi_goodtimes(
-                    l1b_de_datasets=[mock_de],
                     current_repointing="repoint00001",
+                    l1b_de_datasets=[mock_de],
                     l1b_hk=mock_hk,
+                    l1a_diagfee=MagicMock(),
                     cal_product_config_path=tmp_path / "cal.csv",
                 )
 
@@ -3587,9 +3846,10 @@ class TestHiGoodtimes:
             patch("imap_processing.hi.hi_goodtimes._apply_goodtimes_filters"),
         ):
             hi_goodtimes(
-                l1b_de_datasets=mock_datasets,
                 current_repointing="repoint00004",
+                l1b_de_datasets=mock_datasets,
                 l1b_hk=mock_hk,
+                l1a_diagfee=MagicMock(),
                 cal_product_config_path=tmp_path / "cal.csv",
             )
 
@@ -3629,9 +3889,10 @@ class TestHiGoodtimes:
             ),
         ):
             hi_goodtimes(
-                l1b_de_datasets=mock_datasets,
                 current_repointing="repoint00001",
+                l1b_de_datasets=mock_datasets,
                 l1b_hk=mock_hk,
+                l1a_diagfee=MagicMock(),
                 cal_product_config_path=tmp_path / "cal.csv",
             )
 
@@ -3673,9 +3934,10 @@ class TestHiGoodtimes:
             ) as mock_apply,
         ):
             hi_goodtimes(
-                l1b_de_datasets=mock_datasets,
                 current_repointing="repoint00004",
+                l1b_de_datasets=mock_datasets,
                 l1b_hk=mock_hk,
+                l1a_diagfee=MagicMock(),
                 cal_product_config_path=tmp_path / "cal.csv",
             )
 
@@ -3715,9 +3977,10 @@ class TestHiGoodtimes:
             patch("imap_processing.hi.hi_goodtimes._apply_goodtimes_filters"),
         ):
             result = hi_goodtimes(
-                l1b_de_datasets=mock_datasets,
                 current_repointing="repoint00004",
+                l1b_de_datasets=mock_datasets,
                 l1b_hk=mock_hk,
+                l1a_diagfee=MagicMock(),
                 cal_product_config_path=tmp_path / "cal.csv",
             )
 

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -1539,18 +1539,6 @@ class TestMarkBadTdcCal:
         # All times should remain good (no culling due to insufficient packets)
         assert np.all(goodtimes_for_tdc["cull_flags"].values == CullCode.GOOD)
 
-    def test_mark_bad_tdc_cal_selective_tdc_checking(
-        self, goodtimes_for_tdc, diagfee_tdc1_fails
-    ):
-        """Test that TDC checking can be selectively disabled."""
-        # Disable TDC1 checking - should not cull even though TDC1 fails
-        mark_bad_tdc_cal(
-            goodtimes_for_tdc, diagfee_tdc1_fails, check_tdc1=False, check_tdc2=True
-        )
-
-        # All times should remain good since TDC1 checking is disabled
-        assert np.all(goodtimes_for_tdc["cull_flags"].values == CullCode.GOOD)
-
     def test_mark_bad_tdc_cal_tdc2_fails(self, goodtimes_for_tdc):
         """Test that times are marked when TDC2 fails."""
         diagfee_tdc2_fails = xr.Dataset(

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -373,21 +373,8 @@ def test_hi_l1b_goodtimes(mock_hi_goodtimes, mock_instrument_dependencies):
     mock_hi_goodtimes.return_value = [mock_goodtimes_ds]
     mocks["mock_write_cdf"].return_value = Path("/path/to/goodtimes_output.cdf")
 
-    # Mock load_cdf to return xr.Dataset objects
-    mock_de_dataset = xr.Dataset()
-    mock_hk_dataset = xr.Dataset()
-    # 7 DE files + 1 HK file = 8 total calls to load_cdf
-    mocks["mock_load_cdf"].side_effect = [
-        mock_de_dataset,
-        mock_de_dataset,
-        mock_de_dataset,
-        mock_de_dataset,
-        mock_de_dataset,
-        mock_de_dataset,
-        mock_de_dataset,
-        mock_hk_dataset,
-    ]
-
+    # set load_cdf to return empty datasets
+    mocks["mock_load_cdf"].return_value = xr.Dataset()
     # Set up the input collection with required dependencies
     input_collection = ProcessingInputCollection(
         ScienceInput("imap_hi_l1b_45sensor-de_20250415-repoint00001_v001.cdf"),
@@ -398,6 +385,7 @@ def test_hi_l1b_goodtimes(mock_hi_goodtimes, mock_instrument_dependencies):
         ScienceInput("imap_hi_l1b_45sensor-de_20250415-repoint00006_v001.cdf"),
         ScienceInput("imap_hi_l1b_45sensor-de_20250415-repoint00007_v001.cdf"),
         ScienceInput("imap_hi_l1b_45sensor-hk_20250415-repoint00004_v001.cdf"),
+        ScienceInput("imap_hi_l1a_45sensor-diagfee_20250415-repoint00004_v001.cdf"),
         AncillaryInput("imap_hi_45sensor-cal-prod_20240101_v001.csv"),
     )
     mocks["mock_pre_processing"].return_value = input_collection
@@ -416,17 +404,18 @@ def test_hi_l1b_goodtimes(mock_hi_goodtimes, mock_instrument_dependencies):
     instrument.process()
 
     # Verify load_cdf was called for DE files and HK file
-    assert mocks["mock_load_cdf"].call_count == 8  # 7 DE + 1 HK
+    assert mocks["mock_load_cdf"].call_count == 9  # 7 DE + 1 HK + 1 DIAG_FEE
 
     # Verify hi_goodtimes was called with correct arguments
     assert mock_hi_goodtimes.call_count == 1
     call_args = mock_hi_goodtimes.call_args
 
     # Check that datasets (not paths) were passed for l1b_de_datasets and l1b_hk
-    assert isinstance(call_args.args[0], list)  # l1b_de_datasets is a list
-    assert len(call_args.args[0]) == 7  # 7 DE datasets
+    assert call_args.args[0] == "repoint00004"  # current_repointing
+    assert isinstance(call_args.args[1], list)  # l1b_de_datasets is a list
+    assert len(call_args.args[1]) == 7  # 7 DE datasets
     assert isinstance(call_args.args[2], xr.Dataset)  # l1b_hk is a dataset
-    assert call_args.args[1] == "repoint00004"  # current_repointing
+    assert isinstance(call_args.args[3], xr.Dataset)  # l1a_diagfee is a dataset
 
     # goodtimes now returns xr.Dataset, so write_cdf should be called
     assert mocks["mock_write_cdf"].call_count == 1


### PR DESCRIPTION
 ## Summary
                                                                                                                                                                                                                                                                
  - Implement mark_bad_tdc_cal culling algorithm - Add new goodtimes filter that removes times with failed TDC calibration based on DIAG_FEE packet data
  - Integrate L1A DIAG_FEE dependency - Add l1a_diagfee parameter to hi_goodtimes() and _apply_goodtimes_filters() functions
  - Update CLI to load DIAG_FEE data - Add file path retrieval and CDF loading for L1A DIAG_FEE in the Hi goodtimes processing path
  - Reorder hi_goodtimes parameters - Move current_repointing to first positional argument for consistency

##  Details

  mark_bad_tdc_cal Algorithm

  Based on C reference (drop_bad_tdc_diagfee in culling.c):
  - Scans DIAG_FEE packets chronologically and checks TDC1/TDC2/TDC3 calibration status (bit 1 = success)
  - If any checked TDC has failed calibration, marks all times from that DIAG_FEE packet until the next as bad
  - Skips duplicate DIAG_FEE packets that appear within 10 seconds (quirk when entering HVSCI mode)
  - Requires at least 2 DIAG_FEE packets to perform checking

  Filter Order Update

  Goodtimes filters now apply in order:
  1. mark_incomplete_spin_sets
  2. mark_drf_times
  3. mark_bad_tdc_cal (new)
  4. mark_overflow_packets
  5. mark_statistical_filter_0
  6. mark_statistical_filter_1
  7. mark_statistical_filter_2


Closes: #2822
