### PR TITLE
IDEX l1b cli logic

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1037,9 +1037,13 @@ class Idex(ProcessInstrument):
                 )
             # get CDF file
             science_files = dependencies.get_file_paths(source="idex")
+            # Load all the science files. There should only be one, but in the case of
+            # multiple files, we want to make sure to load them all and sort them by
+            # time and pass in the latest one.
+            dependencies = [load_cdf(f) for f in science_files]
+            latest_file = sorted(dependencies, key=lambda ds: ds["epoch"].data[0])[-1]
             # process data
-            dependency = load_cdf(science_files[0])
-            datasets = [idex_l1b(dependency)]
+            datasets = [idex_l1b(latest_file)]
         elif self.data_level == "l2a":
             if len(dependency_list) != 3:
                 raise ValueError(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1038,10 +1038,12 @@ class Idex(ProcessInstrument):
             # get CDF file
             science_files = dependencies.get_file_paths(source="idex")
             # Load all the science files. There should only be one, but in the case of
-            # multiple files, we want to make sure to load them all and sort them by
-            # time and pass in the latest one.
-            dependencies = [load_cdf(f) for f in science_files]
-            latest_file = sorted(dependencies, key=lambda ds: ds["epoch"].data[0])[-1]
+            # multiple files, we want to make sure to load them all and select the one
+            # with the latest time.
+            science_datasets = [load_cdf(f) for f in science_files]
+            if not science_datasets:
+                raise ValueError("No science files found for IDEX L1B processing.")
+            latest_file = max(science_datasets, key=lambda ds: ds["epoch"].data[0])
             # process data
             datasets = [idex_l1b(latest_file)]
         elif self.data_level == "l2a":

--- a/imap_processing/hi/hi_l1c.py
+++ b/imap_processing/hi/hi_l1c.py
@@ -703,7 +703,7 @@ def good_time_and_phase_mask(
     met_indices = np.clip(met_indices, 0, len(gt_mets) - 1)
 
     # Convert nominal_bins to int32 for indexing
-    spin_bins = nominal_bins.astype(np.int32)
+    spin_bins: npt.NDArray[np.int32] = nominal_bins.astype(np.int32)
 
     # Look up cull_flags for each event/tick
     # Events are good if cull_flags == 0

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -625,6 +625,32 @@ def test_ultra_l2(mock_ultra_l2, mock_instrument_dependencies):
     assert mock_instrument_dependencies["mock_write_cdf"].call_count == 1
 
 
+@mock.patch("imap_processing.cli.idex_l1b")
+def test_idex_l1b(mock_idex_l1b, mock_instrument_dependencies):
+    """Test coverage for cli.Idex class with l2b data level"""
+    mocks = mock_instrument_dependencies
+    new_ds = xr.Dataset(data_vars={"epoch": [1]})
+    old_ds = xr.Dataset(data_vars={"epoch": [0]})
+    mocks["mock_load_cdf"].side_effect = [old_ds, new_ds]
+    input_collection = ProcessingInputCollection(
+        ScienceInput("imap_idex_l1b_sci-1week_20251017_v001.cdf"),
+        ScienceInput("imap_idex_l1b_sci-1week_20251012_v001.cdf"),
+        SPICEInput("naif0012.tls", "imap_sclk_0000.tsc"),
+    )
+    mocks["mock_pre_processing"].return_value = input_collection
+
+    dependency_str = input_collection.serialize()
+    instrument = Idex(
+        "l1b", "sci-1week", dependency_str, "20251017", "20251017", "v001", False
+    )
+
+    instrument.process()
+    assert mock_idex_l1b.call_count == 1
+    # Assert that the dataset with the newer epoch value was passed to idex_l1b for
+    # processing
+    assert mock_idex_l1b.call_args[0][0].epoch == new_ds.epoch
+
+
 @mock.patch("imap_processing.cli.idex_l2b")
 def test_idex_l2b(mock_idex_l2b, mock_instrument_dependencies):
     """Test coverage for cli.Idex class with l2b data level"""

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -18,6 +18,7 @@ from imap_data_access.processing_input import (
     ProcessingInputCollection,
     ScienceInput,
     SPICEInput,
+    SpinInput,
 )
 
 from imap_processing.cli import (
@@ -627,15 +628,18 @@ def test_ultra_l2(mock_ultra_l2, mock_instrument_dependencies):
 
 @mock.patch("imap_processing.cli.idex_l1b")
 def test_idex_l1b(mock_idex_l1b, mock_instrument_dependencies):
-    """Test coverage for cli.Idex class with l2b data level"""
+    """Test coverage for cli.Idex class with l1b data level"""
     mocks = mock_instrument_dependencies
     new_ds = xr.Dataset(data_vars={"epoch": [1]})
     old_ds = xr.Dataset(data_vars={"epoch": [0]})
     mocks["mock_load_cdf"].side_effect = [old_ds, new_ds]
     input_collection = ProcessingInputCollection(
-        ScienceInput("imap_idex_l1b_sci-1week_20251017_v001.cdf"),
-        ScienceInput("imap_idex_l1b_sci-1week_20251012_v001.cdf"),
+        ScienceInput(
+            "imap_idex_l1a_sci-1week_20251017_v001.cdf",
+            "imap_idex_l1a_sci-1week_20251012_v001.cdf",
+        ),
         SPICEInput("naif0012.tls", "imap_sclk_0000.tsc"),
+        SpinInput("imap_2025_306_2025_307_01.spin"),
     )
     mocks["mock_pre_processing"].return_value = input_collection
 
@@ -648,7 +652,7 @@ def test_idex_l1b(mock_idex_l1b, mock_instrument_dependencies):
     assert mock_idex_l1b.call_count == 1
     # Assert that the dataset with the newer epoch value was passed to idex_l1b for
     # processing
-    assert mock_idex_l1b.call_args[0][0].epoch == new_ds.epoch
+    xr.testing.assert_equal(mock_idex_l1b.call_args[0][0], new_ds)
 
 
 @mock.patch("imap_processing.cli.idex_l2b")


### PR DESCRIPTION
# Change Summary

## Overview

Now that IDEX l1b dependencies may have multiple science files pass in from batch starter, we want to make sure that we are only passing in the latest l1a file. 

## File changes
imap_processing/cli.py
- only pass in the latest idex l1a file to l1b. 


## Testing
Add a test to make sure the sorting is working. 
