### PR TITLE
2769 hi goodtimes   fix esa step field in output txt file

### DIFF
--- a/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_variable_attrs.yaml
@@ -674,23 +674,24 @@ hi_goodtimes_esa_step:
   VALIDMAX: 10
 
 hi_goodtimes_spin_bin:
-  <<: *default_uint8
   CATDESC: Spin angle bin index
   FIELDNAM: Spin Bin
+  FILLVAL: 255
   FORMAT: I2
   LABLAXIS: Spin Bin
   UNITS: " "
-  VAR_TYPE: support_data
   VALIDMIN: 0
   VALIDMAX: 89
+  VAR_TYPE: support_data
   VAR_NOTES: >
     Spin angle bins numbered 0-89, covering 0-360 degrees of spacecraft spin.
     Each bin is 4 degrees wide.
+  dtype: uint8
 
 hi_goodtimes_spin_bin_label:
   CATDESC: Label for spin bin
   FIELDNAM: Spin Bin Label
-  DEPEND_1: spin_bin
+  DEPEND_0: spin_bin
   FORMAT: A3
   VAR_TYPE: metadata
 

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -756,7 +756,8 @@ class GoodtimesAccessor:
 
         with open(output_path, "w") as f:
             # Write header info
-            if file_id := self._obj.attrs.get("Logical_file_id", None) is not None:
+            file_id = self._obj.attrs.get("Logical_file_id")
+            if file_id is not None:
                 f.write(
                     f"# Goodtimes txt file generated for input CDF: {file_id}" + "\n"
                 )

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -38,10 +38,16 @@ INTERVAL_DTYPE: np.dtype = np.dtype(
 
 
 class CullCode(IntEnum):
-    """Cull reason codes for good/bad time classification."""
+    """Cull reason codes for good/bad time classification (bit flags)."""
 
     GOOD = 0
-    LOOSE = 1
+    INCOMPLETE_SPIN = 1 << 0  # 1
+    DRF = 1 << 1  # 2
+    BAD_TDC_CAL = 1 << 2  # 4
+    OVERFLOW = 1 << 3  # 8
+    STAT_FILTER_0 = 1 << 4  # 16
+    STAT_FILTER_1 = 1 << 5  # 32
+    STAT_FILTER_2 = 1 << 6  # 64
 
 
 def hi_goodtimes(
@@ -145,7 +151,7 @@ def hi_goodtimes(
             f"expected 7 files, got {len(l1b_de_datasets)}. "
             "Marking all times as bad."
         )
-        goodtimes_ds["cull_flags"][:, :] = CullCode.LOOSE
+        goodtimes_ds["cull_flags"][:, :] = CullCode.INCOMPLETE_SPIN
 
     # Log final statistics
     stats = goodtimes_ds.goodtimes.get_cull_statistics()
@@ -533,14 +539,16 @@ class GoodtimesAccessor:
             # Subtract 1 to get the largest value <= met_val
             met_indices = np.searchsorted(met_values, met_array, side="right") - 1
 
-        # Set cull_flags for all indices
+        # Set cull_flags for all indices using bitwise OR to combine flags
         n_times = len(met_indices)
         n_bins = len(bins_array)
         logger.debug(
             f"Flagging {n_times} MET time(s) x {n_bins} spin bin(s) with "
             f"cull code {cull}"
         )
-        self._obj["cull_flags"].values[np.ix_(met_indices, bins_array)] = cull
+        self._obj["cull_flags"].values[np.ix_(met_indices, bins_array)] |= np.uint8(
+            cull
+        )
 
     def get_good_intervals(self) -> np.ndarray:
         """
@@ -862,7 +870,7 @@ class GoodtimesAccessor:
 def mark_incomplete_spin_sets(
     goodtimes_ds: xr.Dataset,
     l1b_de: xr.Dataset,
-    cull_code: int = CullCode.LOOSE,
+    cull_code: int = CullCode.INCOMPLETE_SPIN,
 ) -> None:
     """
     Filter out incomplete 8-spin histogram periods.
@@ -977,7 +985,7 @@ def mark_incomplete_spin_sets(
 def mark_drf_times(
     goodtimes_ds: xr.Dataset,
     hk: xr.Dataset,
-    cull_code: int = CullCode.LOOSE,
+    cull_code: int = CullCode.DRF,
 ) -> None:
     """
     Remove times during spacecraft drift restabilization.
@@ -1050,7 +1058,7 @@ def mark_overflow_packets(
     goodtimes_ds: xr.Dataset,
     l1b_de: xr.Dataset,
     config_df: pd.DataFrame,
-    cull_code: int = CullCode.LOOSE,
+    cull_code: int = CullCode.OVERFLOW,
 ) -> None:
     """
     Remove times when DE packets overflow with qualified events.
@@ -1176,7 +1184,7 @@ def mark_overflow_packets(
 def mark_bad_tdc_cal(
     goodtimes_ds: xr.Dataset,
     diagfee: xr.Dataset,
-    cull_code: int = CullCode.LOOSE,
+    cull_code: int = CullCode.BAD_TDC_CAL,
 ) -> None:
     """
     Remove times with failed TDC calibration (DIAG_FEE method).
@@ -1397,7 +1405,7 @@ def mark_statistical_filter_0(
     current_index: int,
     threshold_factor: float = HiConstants.STAT_FILTER_0_THRESHOLD_FACTOR,
     tof_ab_limit_ns: int = HiConstants.STAT_FILTER_0_TOF_AB_LIMIT_NS,
-    cull_code: int = CullCode.LOOSE,
+    cull_code: int = CullCode.STAT_FILTER_0,
     min_pointings: int = HiConstants.STAT_FILTER_MIN_POINTINGS,
 ) -> None:
     """
@@ -1832,7 +1840,7 @@ def mark_statistical_filter_1(
     consecutive_threshold_sigma: float = HiConstants.STAT_FILTER_1_CONSECUTIVE_SIGMA,
     extreme_threshold_sigma: float = HiConstants.STAT_FILTER_1_EXTREME_SIGMA,
     min_consecutive_intervals: int = HiConstants.STAT_FILTER_1_MIN_CONSECUTIVE,
-    cull_code: int = CullCode.LOOSE,
+    cull_code: int = CullCode.STAT_FILTER_1,
     min_pointings: int = HiConstants.STAT_FILTER_MIN_POINTINGS,
 ) -> None:
     """
@@ -2057,7 +2065,7 @@ def mark_statistical_filter_2(
     min_events: int = HiConstants.STAT_FILTER_2_MIN_EVENTS,
     max_time_delta: float = HiConstants.STAT_FILTER_2_MAX_TIME_DELTA,
     bin_padding: int = HiConstants.STAT_FILTER_2_BIN_PADDING,
-    cull_code: int = CullCode.LOOSE,
+    cull_code: int = CullCode.STAT_FILTER_2,
 ) -> None:
     """
     Apply Statistical Filter 2 to detect short-lived event pulses.

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -738,7 +738,11 @@ class GoodtimesAccessor:
         """
         logger.info(f"Writing intervals to file: {output_path}")
         pointing = int(self._obj.attrs["Repointing"].replace("repoint", ""))
-        sensor = self._obj.attrs["Sensor"]
+        sensor = (
+            parse_sensor_number(self._obj.attrs["Logical_source"])
+            if "Logical_source" in self._obj.attrs
+            else self._obj.attrs["Sensor"]
+        )
 
         intervals = self.get_good_intervals()
 
@@ -830,7 +834,6 @@ class GoodtimesAccessor:
             ds[coord_name].attrs = attr_mgr.get_variable_attributes(
                 attr_mgr_key, check_schema=False
             )
-        ds["spin_bin"].attrs = attr_mgr.get_variable_attributes("hi_goodtimes_spin_bin")
 
         # Add variable attributes
         for var_name in ds.data_vars:
@@ -839,7 +842,7 @@ class GoodtimesAccessor:
             )
 
         # Update global attributes
-        sensor_str = ds.attrs.pop("sensor")
+        sensor_str = ds.attrs.pop("Sensor")
         ds.attrs = attr_mgr.get_global_attributes("imap_hi_l1b_goodtimes_attrs")
 
         # Update Logical_source with sensor string

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -363,7 +363,7 @@ def create_goodtimes_dataset(l1b_de: xr.Dataset) -> xr.Dataset:
 
     # Create attributes
     sensor_number = parse_sensor_number(l1b_de.attrs["Logical_source"])
-    repointing = l1b_de.attrs.get("Repointing", "unknown_repointing")
+    repointing = l1b_de.attrs.get("Repointing", "repoint-9999")
     attrs = {
         "Sensor": f"{sensor_number}sensor",
         "Repointing": repointing,
@@ -749,7 +749,7 @@ class GoodtimesAccessor:
         sensor = (
             parse_sensor_number(self._obj.attrs["Logical_source"])
             if "Logical_source" in self._obj.attrs
-            else self._obj.attrs["Sensor"]
+            else self._obj.attrs["Sensor"].replace("sensor", "")
         )
 
         intervals = self.get_good_intervals()

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -1,7 +1,6 @@
 """IMAP-HI Goodtimes processing module."""
 
 import logging
-import re
 from enum import IntEnum
 from pathlib import Path
 
@@ -31,8 +30,9 @@ INTERVAL_DTYPE: np.dtype = np.dtype(
         ("met_end", np.float64),
         ("spin_bin_low", np.uint8),
         ("spin_bin_high", np.uint8),
-        ("n_good_bins", np.uint8),
-        ("esa_step", np.uint8),
+        ("n_bins", np.uint8),
+        ("esa_step_mask", np.uint16),  # Bitmask for ESA steps 1-10 (bit i = step i+1)
+        ("cull_value", np.uint8),
     ]
 )
 
@@ -357,15 +357,10 @@ def create_goodtimes_dataset(l1b_de: xr.Dataset) -> xr.Dataset:
 
     # Create attributes
     sensor_number = parse_sensor_number(l1b_de.attrs["Logical_source"])
-    match = re.match(r"repoint(?P<pointing_num>\d{5})", l1b_de.attrs["Repointing"])
-    if not match:
-        raise ValueError(
-            f"Unable to parse pointing number from l1b_de Repointing "
-            f"attribute: {l1b_de.attrs['Repointing']}"
-        )
+    repointing = l1b_de.attrs.get("Repointing", "unknown_repointing")
     attrs = {
-        "sensor": f"{sensor_number}sensor",
-        "pointing": int(match["pointing_num"]),
+        "Sensor": f"{sensor_number}sensor",
+        "Repointing": repointing,
     }
 
     return xr.Dataset(data_vars, coords, attrs)
@@ -549,33 +544,35 @@ class GoodtimesAccessor:
 
     def get_good_intervals(self) -> np.ndarray:
         """
-        Extract good time intervals for each MET timestamp.
+        Extract time intervals grouped by contiguous cull flag patterns.
 
-        Creates an interval for each MET time that has good bins. Since ESA step
-        changes at each MET, each MET gets its own interval(s).
+        Merges consecutive MET timestamps that have identical cull_flags patterns
+        into single intervals. Each interval spans a contiguous time range where
+        cull flags don't change.
 
-        If good bins wrap around the 89->0 boundary (e.g., bins 88,89,0,1), multiple
-        intervals are created for the same MET time, one for each contiguous set.
+        If cull flags have multiple contiguous regions with different values
+        (e.g., bins 0-44 good, 45-89 bad), multiple intervals are created for
+        the same time range, one per contiguous bin region.
 
         Returns
         -------
         numpy.ndarray
             Structured array with dtype INTERVAL_DTYPE containing:
-            - met_start: MET timestamp of interval
-            - met_end: MET timestamp of interval (same as met_start)
-            - spin_bin_low: Lowest good spin bin in interval
-            - spin_bin_high: Highest good spin bin in interval
-            - n_good_bins: Number of good bins
-            - esa_step: ESA step for this MET
+            - met_start: First MET timestamp of interval
+            - met_end: Last MET timestamp of interval
+            - spin_bin_low: Lowest spin bin in this contiguous region
+            - spin_bin_high: Highest spin bin in this contiguous region
+            - n_bins: Number of bins in this region
+            - esa_step_mask: Bitmask of ESA steps (1-10) included in interval
+            - cull_value: Cull flag value for this region (0=good, >0=bad)
 
         Notes
         -----
         This is used for generating the Good Times output files per algorithm
         document Section 2.3.2.5.
         """
-        logger.debug("Extracting good time intervals")
-        intervals: list[np.void] = []
-        met_values = self._obj.coords["met"].values
+        logger.debug("Extracting time intervals")
+        met_values = self._obj["met"].values
         cull_flags = self._obj["cull_flags"].values
         esa_steps = self._obj["esa_step"].values
 
@@ -583,29 +580,60 @@ class GoodtimesAccessor:
             logger.warning("No MET values found, returning empty intervals array")
             return np.array([], dtype=INTERVAL_DTYPE)
 
-        # Process each MET time
-        for met_idx in range(len(met_values)):
-            self._add_intervals_for_pattern(
-                intervals,
-                met_values[met_idx],
-                met_values[met_idx],  # met_start == met_end
-                cull_flags[met_idx, :],
-                esa_steps[met_idx],
-            )
+        # Group consecutive METs with identical cull patterns
+        # Each group becomes one or more intervals (one per contiguous bin region)
+        intervals: list[tuple] = []
 
-        logger.info(f"Extracted {len(intervals)} good time intervals")
+        # Start first group
+        group_start_idx = 0
+        current_pattern = cull_flags[0]
+        # Cast to int to avoid uint8 overflow when esa_step > 8
+        esa_step_mask = 1 << int(esa_steps[0] - 1)  # Bit i represents ESA step i+1
+
+        for met_idx in range(1, len(met_values)):
+            if np.array_equal(cull_flags[met_idx], current_pattern):
+                # Same pattern - extend current group
+                esa_step_mask |= 1 << int(esa_steps[met_idx] - 1)
+            else:
+                # Different pattern - close current group and start new one
+                self._add_intervals_for_pattern(
+                    intervals,
+                    met_values[group_start_idx],
+                    met_values[met_idx - 1],
+                    current_pattern,
+                    esa_step_mask,
+                )
+
+                # Start new group
+                group_start_idx = met_idx
+                current_pattern = cull_flags[met_idx]
+                esa_step_mask = 1 << int(esa_steps[met_idx] - 1)
+
+        # Close final group
+        self._add_intervals_for_pattern(
+            intervals,
+            met_values[group_start_idx],
+            met_values[-1],
+            current_pattern,
+            esa_step_mask,
+        )
+
+        logger.info(f"Extracted {len(intervals)} time intervals")
         return np.array(intervals, dtype=INTERVAL_DTYPE)
 
+    @staticmethod
     def _add_intervals_for_pattern(
-        self,
         intervals: list,
         met_start: float,
         met_end: float,
         pattern: np.ndarray,
-        esa_step: int,
+        esa_step_mask: int,
     ) -> None:
         """
-        Add interval(s) for a cull_flags pattern, splitting if bins wrap around.
+        Add interval(s) for a cull_flags pattern, one per contiguous bin region.
+
+        Creates an interval for each contiguous region of bins that share the
+        same cull value. This includes both good (cull=0) and bad (cull>0) regions.
 
         Parameters
         ----------
@@ -616,56 +644,39 @@ class GoodtimesAccessor:
         met_end : float
             End MET timestamp.
         pattern : numpy.ndarray
-            Cull flags pattern for spin bins.
-        esa_step : int
-            ESA step for this MET.
+            Cull flags pattern for spin bins (90 values).
+        esa_step_mask : int
+            Bitmask of ESA steps included in this time range.
         """
-        good_bins = np.nonzero(pattern == 0)[0]
+        # Find contiguous regions of bins with the same cull value
+        # diff != 0 indicates a change in cull value
+        changes = np.nonzero(np.diff(pattern) != 0)[0]
 
-        if len(good_bins) == 0:
-            return
-
-        # Check for gaps in good_bins (indicating separate contiguous regions)
-        # Bins are contiguous if difference between consecutive bins is 1
-        gaps = np.nonzero(np.diff(good_bins) > 1)[0]
-
-        if len(gaps) == 0:
-            # No gaps - single contiguous region
-            interval = (
-                met_start,
-                met_end,
-                good_bins[0],
-                good_bins[-1],
-                len(good_bins),
-                esa_step,
-            )
-            intervals.append(interval)
+        # Build list of (start_bin, end_bin) for each contiguous region
+        # If no changes, entire range is one region
+        if len(changes) == 0:
+            regions = [(0, 89)]
         else:
-            # Multiple contiguous regions - split at gaps
-            start_idx = 0
-            for gap_idx in gaps:
-                # Create interval for bins before the gap
-                bins_segment = good_bins[start_idx : gap_idx + 1]
-                interval = (
-                    met_start,
-                    met_end,
-                    bins_segment[0],
-                    bins_segment[-1],
-                    len(bins_segment),
-                    esa_step,
-                )
-                intervals.append(interval)
-                start_idx = gap_idx + 1
+            regions = []
+            start_bin = 0
+            for change_idx in changes:
+                regions.append((start_bin, change_idx))
+                start_bin = change_idx + 1
+            # Add final region
+            regions.append((start_bin, 89))
 
-            # Handle final segment after last gap
-            bins_segment = good_bins[start_idx:]
+        # Create an interval for each region
+        for start_bin, end_bin in regions:
+            cull_value = pattern[start_bin]
+            n_bins = end_bin - start_bin + 1
             interval = (
                 met_start,
                 met_end,
-                bins_segment[0],
-                bins_segment[-1],
-                len(bins_segment),
-                esa_step,
+                start_bin,
+                end_bin,
+                n_bins,
+                esa_step_mask,
+                cull_value,
             )
             intervals.append(interval)
 
@@ -706,11 +717,14 @@ class GoodtimesAccessor:
 
     def write_txt(self, output_path: Path) -> Path:
         """
-        Write good times to text file in the format specified by algorithm document.
+        Write time intervals to text file in the format specified by algorithm document.
 
         Format per Section 2.3.2.5:
-        pointing MET_start MET_end spin_bin_low spin_bin_high sensor esa_step
-        [rate/sigma values...]
+        pointing MET_start MET_end`tab`spin_bin_low spin_bin_high sensor`tab`
+        esa_steps[10] cull_value
+
+        The esa_steps field consists of 10 binary values (0 or 1) indicating whether
+        each ESA step (1-10) is included in this interval.
 
         Parameters
         ----------
@@ -722,24 +736,38 @@ class GoodtimesAccessor:
         pathlib.Path
             Path to the created file.
         """
-        logger.info(f"Writing good times to file: {output_path}")
+        logger.info(f"Writing intervals to file: {output_path}")
+        pointing = int(self._obj.attrs["Repointing"].replace("repoint", ""))
+        sensor = self._obj.attrs["Sensor"]
+
         intervals = self.get_good_intervals()
 
         with open(output_path, "w") as f:
+            # Write header info
+            if file_id := self._obj.attrs.get("Logical_file_id", None) is not None:
+                f.write(
+                    f"# Goodtimes txt file generated for input CDF: {file_id}" + "\n"
+                )
             for interval in intervals:
-                pointing = self._obj.attrs.get("pointing", 0)
-                sensor = self._obj.attrs["sensor"]
+                # Convert esa_step_mask bitmask to 10 binary values
+                # Bit i represents ESA step i+1, so check bits 0-9
+                esa_step_mask = int(interval["esa_step_mask"])
+                esa_step_flags = " ".join(
+                    "1" if (esa_step_mask >> i) & 1 else "0" for i in range(10)
+                )
 
                 # Format:
-                # pointing met_start met_end spin_bin_low spin_bin_high sensor esa_step
+                # pointing met_start met_end spin_bin_low spin_bin_high sensor
+                # esa_steps[10] cull_value
                 line = (
                     f"{pointing:05d} "
                     f"{int(interval['met_start'])} "
-                    f"{int(interval['met_end'])} "
+                    f"{int(interval['met_end'])}\t"
                     f"{interval['spin_bin_low']} "
                     f"{interval['spin_bin_high']} "
-                    f"{sensor} "
-                    f"{interval['esa_step']}"
+                    f"{sensor}\t"
+                    f"{esa_step_flags}\t"
+                    f"{interval['cull_value']}"
                 )
 
                 # TODO: Add rate/sigma values for each ESA step

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -146,8 +146,8 @@ class TestGoodtimesFromL1bDe:
 
     def test_from_l1b_de_attributes(self, goodtimes_instance):
         """Test that attributes are set correctly."""
-        assert goodtimes_instance.attrs["sensor"] == "45sensor"
-        assert goodtimes_instance.attrs["pointing"] == 42
+        assert goodtimes_instance.attrs["Sensor"] == "45sensor"
+        assert goodtimes_instance.attrs["Repointing"] == "repoint00042"
 
 
 class TestRemoveTimes:
@@ -817,7 +817,7 @@ class TestFinalizeDataset:
                 "esa_step": xr.DataArray(np.array([], dtype=np.uint8), dims=["met"]),
             },
             coords={"met": np.array([]), "spin_bin": np.arange(90)},
-            attrs={"sensor": "45sensor", "pointing": 1},
+            attrs={"Sensor": "45sensor", "Pointing": 1},
         )
 
         with patch("imap_processing.hi.hi_goodtimes.met_to_ttj2000ns") as mock_convert:

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -77,14 +77,29 @@ class TestCullCode:
     """Test suite for CullCode IntEnum."""
 
     def test_cull_code_values(self):
-        """Test CullCode enum values."""
+        """Test CullCode enum values are bit flags (powers of 2)."""
         assert CullCode.GOOD == 0
-        assert CullCode.LOOSE == 1
+        assert CullCode.INCOMPLETE_SPIN == 1
+        assert CullCode.DRF == 2
+        assert CullCode.BAD_TDC_CAL == 4
+        assert CullCode.OVERFLOW == 8
+        assert CullCode.STAT_FILTER_0 == 16
+        assert CullCode.STAT_FILTER_1 == 32
+        assert CullCode.STAT_FILTER_2 == 64
 
     def test_cull_code_is_int(self):
         """Test that CullCode values are integers."""
         assert isinstance(CullCode.GOOD, int)
-        assert isinstance(CullCode.LOOSE, int)
+        assert isinstance(CullCode.INCOMPLETE_SPIN, int)
+
+    def test_cull_codes_can_be_combined(self):
+        """Test that cull codes can be combined with bitwise OR."""
+        combined = CullCode.INCOMPLETE_SPIN | CullCode.DRF
+        assert combined == 3
+        # Check individual flags can be extracted with bitwise AND
+        assert combined & CullCode.INCOMPLETE_SPIN == CullCode.INCOMPLETE_SPIN
+        assert combined & CullCode.DRF == CullCode.DRF
+        assert combined & CullCode.BAD_TDC_CAL == 0
 
 
 class TestGoodtimesFromL1bDe:
@@ -157,11 +172,13 @@ class TestRemoveTimes:
         """Test flagging a single MET with all bins."""
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=None, cull=CullCode.LOOSE
+            met=met_val, bins=None, cull=CullCode.INCOMPLETE_SPIN
         )
 
         # Check that all bins for the first MET are flagged
-        assert np.all(goodtimes_instance["cull_flags"].values[0, :] == CullCode.LOOSE)
+        assert np.all(
+            goodtimes_instance["cull_flags"].values[0, :] == CullCode.INCOMPLETE_SPIN
+        )
 
         # Check that other METs are still good
         assert np.all(goodtimes_instance["cull_flags"].values[1:, :] == CullCode.GOOD)
@@ -171,12 +188,13 @@ class TestRemoveTimes:
         met_val = goodtimes_instance.coords["met"].values[0]
         bins_to_flag = np.array([0, 1, 2, 10])
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=bins_to_flag, cull=CullCode.LOOSE
+            met=met_val, bins=bins_to_flag, cull=CullCode.INCOMPLETE_SPIN
         )
 
         # Check that specified bins are flagged
         assert np.all(
-            goodtimes_instance["cull_flags"].values[0, bins_to_flag] == CullCode.LOOSE
+            goodtimes_instance["cull_flags"].values[0, bins_to_flag]
+            == CullCode.INCOMPLETE_SPIN
         )
 
         # Check that other bins are still good
@@ -189,11 +207,13 @@ class TestRemoveTimes:
         """Test flagging multiple METs."""
         met_vals = goodtimes_instance.coords["met"].values[:3]
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_vals, bins=None, cull=CullCode.LOOSE
+            met=met_vals, bins=None, cull=CullCode.INCOMPLETE_SPIN
         )
 
         # Check that first 3 METs are flagged
-        assert np.all(goodtimes_instance["cull_flags"].values[:3, :] == CullCode.LOOSE)
+        assert np.all(
+            goodtimes_instance["cull_flags"].values[:3, :] == CullCode.INCOMPLETE_SPIN
+        )
 
         # Check that other METs are still good
         assert np.all(goodtimes_instance["cull_flags"].values[3:, :] == CullCode.GOOD)
@@ -205,11 +225,13 @@ class TestRemoveTimes:
         met_end = met_vals[5]
 
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=(met_start, met_end), bins=None, cull=CullCode.LOOSE
+            met=(met_start, met_end), bins=None, cull=CullCode.INCOMPLETE_SPIN
         )
 
         # Check that METs 2-5 are flagged
-        assert np.all(goodtimes_instance["cull_flags"].values[2:6, :] == CullCode.LOOSE)
+        assert np.all(
+            goodtimes_instance["cull_flags"].values[2:6, :] == CullCode.INCOMPLETE_SPIN
+        )
 
         # Check that other METs are still good
         assert np.all(goodtimes_instance["cull_flags"].values[:2, :] == CullCode.GOOD)
@@ -247,19 +269,24 @@ class TestRemoveTimes:
         with pytest.raises(ValueError, match="MET value\\(s\\) "):
             goodtimes_instance.goodtimes.mark_bad_times(met=met_out_of_range)
 
-    def test_mark_bad_times_overwrites_existing_cull(self, goodtimes_instance):
-        """Test that new cull code overwrites existing one."""
+    def test_mark_bad_times_combines_cull_codes(self, goodtimes_instance):
+        """Test that cull codes are combined using bitwise OR."""
         met_val = goodtimes_instance.coords["met"].values[0]
 
-        # Flag with LOOSE
+        # Flag with INCOMPLETE_SPIN (1)
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=None, cull=CullCode.LOOSE
+            met=met_val, bins=None, cull=CullCode.INCOMPLETE_SPIN
         )
-        assert np.all(goodtimes_instance["cull_flags"].values[0, :] == CullCode.LOOSE)
+        assert np.all(
+            goodtimes_instance["cull_flags"].values[0, :] == CullCode.INCOMPLETE_SPIN
+        )
 
-        # Overwrite with a different cull code
-        goodtimes_instance.goodtimes.mark_bad_times(met=met_val, bins=None, cull=2)
-        assert np.all(goodtimes_instance["cull_flags"].values[0, :] == 2)
+        # Add another cull code with bitwise OR (1 | 2 = 3)
+        goodtimes_instance.goodtimes.mark_bad_times(
+            met=met_val, bins=None, cull=CullCode.DRF
+        )
+        expected = CullCode.INCOMPLETE_SPIN | CullCode.DRF  # 1 | 2 = 3
+        assert np.all(goodtimes_instance["cull_flags"].values[0, :] == expected)
 
 
 class TestGetGoodIntervals:
@@ -309,7 +336,7 @@ class TestGetGoodIntervals:
         # Flag bins 0-20 for first MET only
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=np.arange(21), cull=CullCode.LOOSE
+            met=met_val, bins=np.arange(21), cull=CullCode.INCOMPLETE_SPIN
         )
 
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
@@ -323,7 +350,7 @@ class TestGetGoodIntervals:
         assert intervals[0]["spin_bin_low"] == 0
         assert intervals[0]["spin_bin_high"] == 20
         assert intervals[0]["n_bins"] == 21
-        assert intervals[0]["cull_value"] == CullCode.LOOSE
+        assert intervals[0]["cull_value"] == CullCode.INCOMPLETE_SPIN
 
         # Check second interval (good bins 21-89)
         assert intervals[1]["spin_bin_low"] == 21
@@ -336,7 +363,7 @@ class TestGetGoodIntervals:
         # Flag bins 20-70 for first MET, leaving bins 0-19 and 71-89 as good
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=np.arange(20, 71), cull=CullCode.LOOSE
+            met=met_val, bins=np.arange(20, 71), cull=CullCode.INCOMPLETE_SPIN
         )
 
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
@@ -356,7 +383,7 @@ class TestGetGoodIntervals:
         assert intervals[0]["cull_value"] == 0
         assert intervals[1]["spin_bin_low"] == 20
         assert intervals[1]["spin_bin_high"] == 70
-        assert intervals[1]["cull_value"] == CullCode.LOOSE
+        assert intervals[1]["cull_value"] == CullCode.INCOMPLETE_SPIN
         assert intervals[2]["spin_bin_low"] == 71
         assert intervals[2]["spin_bin_high"] == 89
         assert intervals[2]["cull_value"] == 0
@@ -366,7 +393,7 @@ class TestGetGoodIntervals:
         # Flag all bins for first MET
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=None, cull=CullCode.LOOSE
+            met=met_val, bins=None, cull=CullCode.INCOMPLETE_SPIN
         )
 
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
@@ -375,7 +402,7 @@ class TestGetGoodIntervals:
         assert len(intervals) == 2
 
         # First interval is the culled MET
-        assert intervals[0]["cull_value"] == CullCode.LOOSE
+        assert intervals[0]["cull_value"] == CullCode.INCOMPLETE_SPIN
         assert intervals[0]["spin_bin_low"] == 0
         assert intervals[0]["spin_bin_high"] == 89
 
@@ -434,7 +461,7 @@ class TestGetCullStatistics:
         # Flag first MET, all bins
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=None, cull=CullCode.LOOSE
+            met=met_val, bins=None, cull=CullCode.INCOMPLETE_SPIN
         )
 
         stats = goodtimes_instance.goodtimes.get_cull_statistics()
@@ -444,7 +471,7 @@ class TestGetCullStatistics:
         assert stats["good_bins"] == total_bins - 90
         assert stats["culled_bins"] == 90
         assert stats["fraction_good"] == (total_bins - 90) / total_bins
-        assert stats["cull_code_counts"][CullCode.LOOSE] == 90
+        assert stats["cull_code_counts"][CullCode.INCOMPLETE_SPIN] == 90
 
     def test_get_cull_statistics_multiple_cull_codes(self, goodtimes_instance):
         """Test statistics with multiple cull codes."""
@@ -452,7 +479,7 @@ class TestGetCullStatistics:
 
         # Flag first MET with LOOSE
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_vals[0], bins=None, cull=CullCode.LOOSE
+            met=met_vals[0], bins=None, cull=CullCode.INCOMPLETE_SPIN
         )
 
         # Flag second MET with code 2
@@ -461,7 +488,7 @@ class TestGetCullStatistics:
         stats = goodtimes_instance.goodtimes.get_cull_statistics()
 
         assert stats["culled_bins"] == 180
-        assert stats["cull_code_counts"][CullCode.LOOSE] == 90
+        assert stats["cull_code_counts"][CullCode.INCOMPLETE_SPIN] == 90
         assert stats["cull_code_counts"][2] == 90
 
 
@@ -536,7 +563,7 @@ class TestToTxt:
         # Flag bins 0-20 for first MET
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=np.arange(21), cull=CullCode.LOOSE
+            met=met_val, bins=np.arange(21), cull=CullCode.INCOMPLETE_SPIN
         )
 
         output_path = tmp_path / "goodtimes.txt"
@@ -565,7 +592,7 @@ class TestToTxt:
         # Flag bins 20-70, leaving 0-19 and 71-89 as good
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
-            met=met_val, bins=np.arange(20, 71), cull=CullCode.LOOSE
+            met=met_val, bins=np.arange(20, 71), cull=CullCode.INCOMPLETE_SPIN
         )
 
         output_path = tmp_path / "goodtimes.txt"
@@ -680,7 +707,7 @@ class TestFinalizeDataset:
         goodtimes_instance.goodtimes.mark_bad_times(
             met=goodtimes_instance.coords["met"].values[0],
             bins=np.arange(10),
-            cull=CullCode.LOOSE,
+            cull=CullCode.INCOMPLETE_SPIN,
         )
         original_flags = goodtimes_instance["cull_flags"].values.copy()
 
@@ -1067,8 +1094,8 @@ class TestDropIncompleteSpinSets:
         # First 2 METs should be good, last 2 should be culled
         assert np.all(gt["cull_flags"].values[0, :] == CullCode.GOOD)
         assert np.all(gt["cull_flags"].values[1, :] == CullCode.GOOD)
-        assert np.all(gt["cull_flags"].values[2, :] == CullCode.LOOSE)
-        assert np.all(gt["cull_flags"].values[3, :] == CullCode.LOOSE)
+        assert np.all(gt["cull_flags"].values[2, :] == CullCode.INCOMPLETE_SPIN)
+        assert np.all(gt["cull_flags"].values[3, :] == CullCode.INCOMPLETE_SPIN)
 
     def test_mark_incomplete_spin_sets_with_invalid_spins(
         self, l1b_de_with_invalid_spins
@@ -1078,7 +1105,7 @@ class TestDropIncompleteSpinSets:
         mark_incomplete_spin_sets(gt, l1b_de_with_invalid_spins)
 
         # First MET should be culled (has spin invalid flag), second should be good
-        assert np.all(gt["cull_flags"].values[0, :] == CullCode.LOOSE)
+        assert np.all(gt["cull_flags"].values[0, :] == CullCode.INCOMPLETE_SPIN)
         assert np.all(gt["cull_flags"].values[1, :] == CullCode.GOOD)
 
     def test_mark_incomplete_spin_sets_no_de_packets(self):
@@ -1115,7 +1142,9 @@ class TestDropIncompleteSpinSets:
 
         # First and last METs should be good, middle one should be culled
         assert np.all(gt["cull_flags"].values[0, :] == CullCode.GOOD)
-        assert np.all(gt["cull_flags"].values[1, :] == CullCode.LOOSE)  # No packets
+        assert np.all(
+            gt["cull_flags"].values[1, :] == CullCode.INCOMPLETE_SPIN
+        )  # No packets
         assert np.all(gt["cull_flags"].values[2, :] == CullCode.GOOD)
 
     def test_mark_incomplete_spin_sets_mixed_cadence(self):
@@ -1132,7 +1161,7 @@ class TestDropIncompleteSpinSets:
         mark_incomplete_spin_sets(gt, l1b_de)
 
         # Should be culled (invalid pattern)
-        assert np.all(gt["cull_flags"].values[0, :] == CullCode.LOOSE)
+        assert np.all(gt["cull_flags"].values[0, :] == CullCode.INCOMPLETE_SPIN)
 
     def test_mark_incomplete_spin_sets_duplicate_spin_num(self):
         """Test that duplicate last_spin_num values are culled."""
@@ -1148,7 +1177,7 @@ class TestDropIncompleteSpinSets:
         mark_incomplete_spin_sets(gt, l1b_de)
 
         # Should be culled (duplicate spin numbers)
-        assert np.all(gt["cull_flags"].values[0, :] == CullCode.LOOSE)
+        assert np.all(gt["cull_flags"].values[0, :] == CullCode.INCOMPLETE_SPIN)
 
     def test_mark_incomplete_spin_sets_custom_cull_code(self, l1b_de_incomplete):
         """Test that custom cull code is used."""
@@ -1292,7 +1321,7 @@ class TestDropDrfTimes:
         # Check that METs in the window are culled (indices 0-30)
         for i in range(31):
             assert np.all(
-                goodtimes_for_drf["cull_flags"].values[i, :] == CullCode.LOOSE
+                goodtimes_for_drf["cull_flags"].values[i, :] == CullCode.DRF
             ), (
                 f"MET at index {i} (value "
                 f"{goodtimes_for_drf.coords['met'].values[i]}) should be culled"
@@ -1319,7 +1348,7 @@ class TestDropDrfTimes:
         # Check first window (indices 0-30)
         for i in range(31):
             assert np.all(
-                goodtimes_for_drf["cull_flags"].values[i, :] == CullCode.LOOSE
+                goodtimes_for_drf["cull_flags"].values[i, :] == CullCode.DRF
             ), f"MET at index {i} should be culled (first window)"
 
         # Check between windows (indices 31-59, should be good)
@@ -1331,7 +1360,7 @@ class TestDropDrfTimes:
         # Check second window (indices 60-90)
         for i in range(60, 91):
             assert np.all(
-                goodtimes_for_drf["cull_flags"].values[i, :] == CullCode.LOOSE
+                goodtimes_for_drf["cull_flags"].values[i, :] == CullCode.DRF
             ), f"MET at index {i} should be culled (second window)"
 
         # Check after second window (indices 91+, should be good)
@@ -1386,11 +1415,9 @@ class TestDropDrfTimes:
 
         mark_drf_times(goodtimes_for_drf, hk_single_drf_transition)
 
-        # First 5 METs should now be LOOSE (overwritten), not 2
+        # First 5 METs should now be DRF (overwritten via bitwise OR with existing 2)
         for i in range(5):
-            assert np.all(
-                goodtimes_for_drf["cull_flags"].values[i, :] == CullCode.LOOSE
-            )
+            assert np.all(goodtimes_for_drf["cull_flags"].values[i, :] == CullCode.DRF)
 
     def test_mark_drf_times_transition_at_start(self):
         """Test DRF transition near the start - window exactly at data start."""
@@ -1429,7 +1456,7 @@ class TestDropDrfTimes:
         # Window: 3800 - 1800 = 2000 to 3800
         # This includes METs from 2000 to 3800 (indices 0-30)
         for i in range(31):
-            assert np.all(gt["cull_flags"].values[i, :] == CullCode.LOOSE), (
+            assert np.all(gt["cull_flags"].values[i, :] == CullCode.DRF), (
                 f"MET at index {i} should be culled"
             )
 
@@ -1475,7 +1502,7 @@ class TestDropDrfTimes:
         # Transition at last index (MET ~2940)
         # Should remove 30-minute window before it
         # Most METs should still be good except the last ~30
-        n_culled = np.sum(gt["cull_flags"].values[:, 0] == CullCode.LOOSE)
+        n_culled = np.sum(gt["cull_flags"].values[:, 0] == CullCode.DRF)
         assert n_culled > 0  # Some should be culled
         assert n_culled <= 31  # But not all (only last ~30 minutes)
 
@@ -1566,7 +1593,7 @@ class TestMarkBadTdcCal:
         # MET 1100 (index 2) should be culled
         idx_1100 = np.where(met_values == 1100.0)[0][0]
         assert np.all(
-            goodtimes_for_tdc["cull_flags"].values[idx_1100, :] == CullCode.LOOSE
+            goodtimes_for_tdc["cull_flags"].values[idx_1100, :] == CullCode.BAD_TDC_CAL
         )
 
         # METs before 1100 should still be good
@@ -1627,7 +1654,7 @@ class TestMarkBadTdcCal:
         # MET 1050 (index 1) should be culled
         idx_1050 = np.where(met_values == 1050.0)[0][0]
         assert np.all(
-            goodtimes_for_tdc["cull_flags"].values[idx_1050, :] == CullCode.LOOSE
+            goodtimes_for_tdc["cull_flags"].values[idx_1050, :] == CullCode.BAD_TDC_CAL
         )
 
     def test_mark_bad_tdc_cal_tdc3_fails(self, goodtimes_for_tdc):
@@ -1649,7 +1676,7 @@ class TestMarkBadTdcCal:
         # TDC3 fails at packet 0 (MET 1000), should mark times from 1000 to 1050
         # MET 1000 (index 0) should be culled
         assert np.all(
-            goodtimes_for_tdc["cull_flags"].values[0, :] == CullCode.LOOSE
+            goodtimes_for_tdc["cull_flags"].values[0, :] == CullCode.BAD_TDC_CAL
         )  # 1000
 
         # MET 1050 should be good (next DIAG_FEE packet starts good window)
@@ -1692,7 +1719,7 @@ class TestMarkBadTdcCal:
         for i, met in enumerate(met_values):
             if met >= 1150:
                 assert np.all(
-                    goodtimes_for_tdc["cull_flags"].values[i, :] == CullCode.LOOSE
+                    goodtimes_for_tdc["cull_flags"].values[i, :] == CullCode.BAD_TDC_CAL
                 )
             else:
                 assert np.all(
@@ -1805,8 +1832,8 @@ class TestMarkOverflowPackets:
         mark_overflow_packets(mock_goodtimes, l1b_de, mock_config_df)
 
         # MET ~1006 should be culled (maps to goodtimes MET 1000)
-        # The MET 1000 bin should have all spin bins culled
-        assert mock_goodtimes["cull_flags"].values[0, :].sum() == 90
+        # The MET 1000 bin should have all spin bins culled with OVERFLOW flag
+        assert np.all(mock_goodtimes["cull_flags"].values[0, :] == CullCode.OVERFLOW)
 
     def test_full_packet_with_unqualified_event(self, mock_goodtimes, mock_config_df):
         """Test that full packet with unqualified final event is NOT culled."""
@@ -2330,7 +2357,9 @@ class TestStatisticalFilter0:
 
         # Current sweeps have 5x the events, should be culled
         # Check that at least some METs are culled
-        assert np.any(goodtimes_for_filter["cull_flags"].values == CullCode.LOOSE)
+        assert np.any(
+            goodtimes_for_filter["cull_flags"].values == CullCode.STAT_FILTER_0
+        )
 
     def test_insufficient_pointings(self, goodtimes_for_filter):
         """Test that fewer than min_pointings raises ValueError."""
@@ -2416,7 +2445,7 @@ class TestStatisticalFilter0:
         second_sweep_flags = goodtimes_for_filter["cull_flags"].values[9:, :]
 
         assert np.all(first_sweep_flags == CullCode.GOOD)
-        assert np.all(second_sweep_flags == CullCode.LOOSE)
+        assert np.all(second_sweep_flags == CullCode.STAT_FILTER_0)
 
 
 class TestIdentifyCullPattern:
@@ -3030,7 +3059,9 @@ class TestStatisticalFilter1:
         )
 
         # At least the first MET should be marked bad (extreme outlier)
-        assert np.any(goodtimes_for_filter1["cull_flags"].values == CullCode.LOOSE)
+        assert np.any(
+            goodtimes_for_filter1["cull_flags"].values == CullCode.STAT_FILTER_1
+        )
 
     def test_insufficient_pointings(self, goodtimes_for_filter1):
         """Test that fewer than min_pointings raises ValueError."""
@@ -3406,7 +3437,7 @@ class TestStatisticalFilter2:
 
         # Bins 39-46 should be marked for MET 1000.0 (first MET)
         cull_flags = goodtimes_for_filter2["cull_flags"].sel(met=1000.0).values
-        assert np.all(cull_flags[39:47] == CullCode.LOOSE)
+        assert np.all(cull_flags[39:47] == CullCode.STAT_FILTER_2)
         # Other bins should be unmarked
         assert np.all(cull_flags[:39] == 0)
         assert np.all(cull_flags[47:] == 0)
@@ -3457,9 +3488,9 @@ class TestStatisticalFilter2:
 
         cull_flags = goodtimes_for_filter2["cull_flags"].sel(met=1000.0).values
         # First cluster: bins 9-16
-        assert np.all(cull_flags[9:17] == CullCode.LOOSE)
+        assert np.all(cull_flags[9:17] == CullCode.STAT_FILTER_2)
         # Second cluster: bins 69-76
-        assert np.all(cull_flags[69:77] == CullCode.LOOSE)
+        assert np.all(cull_flags[69:77] == CullCode.STAT_FILTER_2)
         # Middle bins should be unmarked
         assert np.all(cull_flags[17:69] == 0)
 
@@ -3497,9 +3528,9 @@ class TestStatisticalFilter2:
 
         cull_flags = goodtimes_for_filter2["cull_flags"].sel(met=1000.0).values
         # Bins 0-4 should be marked (cluster at 0-2 + padding of 2)
-        assert np.all(cull_flags[0:5] == CullCode.LOOSE)
+        assert np.all(cull_flags[0:5] == CullCode.STAT_FILTER_2)
         # Bins 88-89 should also be marked due to wrapping (bin -2 and -1)
-        assert np.all(cull_flags[88:90] == CullCode.LOOSE)
+        assert np.all(cull_flags[88:90] == CullCode.STAT_FILTER_2)
         # Middle bins should be unmarked
         assert np.all(cull_flags[5:88] == 0)
         # Check that no cull_flags were set on any other METs
@@ -3551,7 +3582,7 @@ class TestStatisticalFilter2:
         )
 
         cull_flags = goodtimes_for_filter2["cull_flags"].sel(met=1000.0).values
-        assert np.all(cull_flags[39:45] == CullCode.LOOSE)
+        assert np.all(cull_flags[39:45] == CullCode.STAT_FILTER_2)
 
     def test_only_qualified_events_contribute_to_clusters(self, goodtimes_for_filter2):
         """Test that only qualified events are used for cluster detection.

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -579,7 +579,7 @@ class TestToTxt:
         parts = lines[0].strip().split()
         assert int(parts[3]) == 0  # bin_low
         assert int(parts[4]) == 20  # bin_high
-        assert parts[16] == "1"  # cull_value (LOOSE)
+        assert parts[16] == "1"  # cull_value (INCOMPLETE_SPIN)
 
         # Second interval: good bins 21-89
         parts = lines[1].strip().split()

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -269,9 +269,8 @@ class TestGetGoodIntervals:
         """Test getting intervals when all times are good."""
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
 
-        # Should have one interval per MET
-        n_met = len(goodtimes_instance.coords["met"])
-        assert len(intervals) == n_met
+        # When all cull flags are identical (all zeros), should merge into 1 interval
+        assert len(intervals) == 1
 
         # Check interval structure
         assert intervals.dtype == INTERVAL_DTYPE
@@ -285,23 +284,29 @@ class TestGetGoodIntervals:
         assert "met_end" in intervals.dtype.names
         assert "spin_bin_low" in intervals.dtype.names
         assert "spin_bin_high" in intervals.dtype.names
-        assert "n_good_bins" in intervals.dtype.names
-        assert "esa_step" in intervals.dtype.names
+        assert "n_bins" in intervals.dtype.names
+        assert "esa_step_mask" in intervals.dtype.names
+        assert "cull_value" in intervals.dtype.names
 
     def test_get_good_intervals_all_good_values(self, goodtimes_instance):
         """Test interval values when all bins are good."""
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
 
-        # When all bins are good, should have bins 0-89
-        for interval in intervals:
-            assert interval["spin_bin_low"] == 0
-            assert interval["spin_bin_high"] == 89
-            assert interval["n_good_bins"] == 90
-            assert interval["met_start"] == interval["met_end"]
+        # Single interval spanning all METs with all bins good
+        assert len(intervals) == 1
+        interval = intervals[0]
+        assert interval["spin_bin_low"] == 0
+        assert interval["spin_bin_high"] == 89
+        assert interval["n_bins"] == 90
+        assert interval["cull_value"] == 0
+        # met_start should be first MET, met_end should be last MET
+        met_values = goodtimes_instance.coords["met"].values
+        assert interval["met_start"] == met_values[0]
+        assert interval["met_end"] == met_values[-1]
 
     def test_get_good_intervals_with_culled_bins(self, goodtimes_instance):
         """Test intervals when some bins are culled."""
-        # Flag bins 0-20 for first MET
+        # Flag bins 0-20 for first MET only
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
             met=met_val, bins=np.arange(21), cull=CullCode.LOOSE
@@ -309,13 +314,25 @@ class TestGetGoodIntervals:
 
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
 
-        # First interval should only have bins 21-89
-        assert intervals[0]["spin_bin_low"] == 21
-        assert intervals[0]["spin_bin_high"] == 89
-        assert intervals[0]["n_good_bins"] == 69
+        # First MET has different pattern, creates separate intervals
+        # First MET: 2 intervals (bins 0-20 culled, bins 21-89 good)
+        # Remaining METs: 1 interval (all bins good)
+        assert len(intervals) == 3
+
+        # Check first interval (culled bins 0-20)
+        assert intervals[0]["spin_bin_low"] == 0
+        assert intervals[0]["spin_bin_high"] == 20
+        assert intervals[0]["n_bins"] == 21
+        assert intervals[0]["cull_value"] == CullCode.LOOSE
+
+        # Check second interval (good bins 21-89)
+        assert intervals[1]["spin_bin_low"] == 21
+        assert intervals[1]["spin_bin_high"] == 89
+        assert intervals[1]["n_bins"] == 69
+        assert intervals[1]["cull_value"] == 0
 
     def test_get_good_intervals_with_gaps(self, goodtimes_instance):
-        """Test intervals when good bins have gaps (wraparound)."""
+        """Test intervals when bins have gaps in cull values."""
         # Flag bins 20-70 for first MET, leaving bins 0-19 and 71-89 as good
         met_val = goodtimes_instance.coords["met"].values[0]
         goodtimes_instance.goodtimes.mark_bad_times(
@@ -324,18 +341,25 @@ class TestGetGoodIntervals:
 
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
 
-        # Should create 2 intervals for the first MET (bins split by gap)
-        # Plus 11 more intervals for the remaining METs (12 total METs)
-        assert len(intervals) == 13
+        # First MET has 3 regions (0-19 good, 20-70 culled, 71-89 good)
+        # Remaining METs merged into 1 interval (all bins good)
+        assert len(intervals) == 4
 
-        # First two intervals should be for the same MET
-        assert intervals[0]["met_start"] == intervals[1]["met_start"]
+        # First MET intervals should have same met_start == met_end
+        assert intervals[0]["met_start"] == intervals[0]["met_end"]
+        assert intervals[1]["met_start"] == intervals[1]["met_end"]
+        assert intervals[2]["met_start"] == intervals[2]["met_end"]
 
-        # Check the two segments
+        # Check the three segments for first MET
         assert intervals[0]["spin_bin_low"] == 0
         assert intervals[0]["spin_bin_high"] == 19
-        assert intervals[1]["spin_bin_low"] == 71
-        assert intervals[1]["spin_bin_high"] == 89
+        assert intervals[0]["cull_value"] == 0
+        assert intervals[1]["spin_bin_low"] == 20
+        assert intervals[1]["spin_bin_high"] == 70
+        assert intervals[1]["cull_value"] == CullCode.LOOSE
+        assert intervals[2]["spin_bin_low"] == 71
+        assert intervals[2]["spin_bin_high"] == 89
+        assert intervals[2]["cull_value"] == 0
 
     def test_get_good_intervals_all_bins_culled(self, goodtimes_instance):
         """Test intervals when all bins are culled for a MET."""
@@ -347,11 +371,17 @@ class TestGetGoodIntervals:
 
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
 
-        # Should have 11 intervals (one per good MET, excluding the first, 12-1=11)
-        assert len(intervals) == 11
+        # Should have 2 intervals: one for culled first MET, one for remaining METs
+        assert len(intervals) == 2
 
-        # First interval should be for the second MET
-        assert intervals[0]["met_start"] == goodtimes_instance.coords["met"].values[1]
+        # First interval is the culled MET
+        assert intervals[0]["cull_value"] == CullCode.LOOSE
+        assert intervals[0]["spin_bin_low"] == 0
+        assert intervals[0]["spin_bin_high"] == 89
+
+        # Second interval is remaining good METs
+        assert intervals[1]["cull_value"] == 0
+        assert intervals[1]["met_start"] == goodtimes_instance.coords["met"].values[1]
 
     def test_get_good_intervals_empty(self):
         """Test intervals with empty goodtimes dataset."""
@@ -370,14 +400,19 @@ class TestGetGoodIntervals:
         intervals = gt.goodtimes.get_good_intervals()
         assert len(intervals) == 0
 
-    def test_get_good_intervals_esa_step_included(self, goodtimes_instance):
-        """Test that ESA step is included in intervals."""
+    def test_get_good_intervals_esa_step_mask(self, goodtimes_instance):
+        """Test that ESA step mask includes all ESA steps in the interval."""
         intervals = goodtimes_instance.goodtimes.get_good_intervals()
 
-        # Check that each interval has an ESA step
-        for i, interval in enumerate(intervals):
-            expected_esa_step = goodtimes_instance["esa_step"].values[i]
-            assert interval["esa_step"] == expected_esa_step
+        # Single interval should include all ESA steps from all METs
+        assert len(intervals) == 1
+        esa_step_mask = intervals[0]["esa_step_mask"]
+
+        # Check that the mask has bits set for all unique ESA steps
+        unique_esa_steps = set(goodtimes_instance["esa_step"].values)
+        for esa_step in unique_esa_steps:
+            bit_position = esa_step - 1  # ESA step 1 -> bit 0, etc.
+            assert (esa_step_mask >> bit_position) & 1 == 1
 
 
 class TestGetCullStatistics:
@@ -449,14 +484,17 @@ class TestToTxt:
         with open(output_path) as f:
             lines = f.readlines()
 
-        # Should have one line per interval (12 METs, all good)
-        assert len(lines) == 12
+        # Should have 1 line (all METs merged into single interval)
+        assert len(lines) == 1
 
         # Check format of first line
+        # Format: pointing met_start met_end bin_low bin_high sensor
+        # esa_steps[10] cull_value
         parts = lines[0].strip().split()
-        assert len(parts) == 7
+        assert len(parts) == 17  # 6 base fields + 10 ESA step flags + cull_value
         assert parts[0] == "00042"  # pointing
         assert parts[5] == "45sensor"  # sensor
+        assert parts[16] == "0"  # cull_value (all good)
 
     def test_to_txt_values(self, goodtimes_instance, tmp_path):
         """Test the values in the output file."""
@@ -467,15 +505,31 @@ class TestToTxt:
             line = f.readline()
 
         parts = line.strip().split()
-        pointing, met_start, met_end, bin_low, bin_high, sensor, esa_step = parts
+        # Format: pointing met_start met_end bin_low bin_high sensor
+        # esa_steps[10] cull_value
+        pointing = parts[0]
+        met_start = parts[1]
+        met_end = parts[2]
+        bin_low = parts[3]
+        bin_high = parts[4]
+        sensor = parts[5]
+        esa_step_flags = parts[6:16]
+        cull_value = parts[16]
 
         assert pointing == "00042"
         assert int(met_start) == int(goodtimes_instance.coords["met"].values[0])
-        assert int(met_end) == int(goodtimes_instance.coords["met"].values[0])
+        assert int(met_end) == int(goodtimes_instance.coords["met"].values[-1])
         assert int(bin_low) == 0
         assert int(bin_high) == 89
         assert sensor == "45sensor"
-        assert int(esa_step) == goodtimes_instance["esa_step"].values[0]
+        assert cull_value == "0"
+
+        # Check ESA step flags - should have 1s for all unique ESA steps
+        unique_esa_steps = set(goodtimes_instance["esa_step"].values)
+        for i, flag in enumerate(esa_step_flags):
+            esa_step = i + 1  # ESA steps are 1-indexed
+            expected = "1" if esa_step in unique_esa_steps else "0"
+            assert flag == expected
 
     def test_to_txt_with_culled_bins(self, goodtimes_instance, tmp_path):
         """Test output when some bins are culled."""
@@ -489,15 +543,22 @@ class TestToTxt:
         goodtimes_instance.goodtimes.write_txt(output_path)
 
         with open(output_path) as f:
-            first_line = f.readline()
+            lines = f.readlines()
 
-        parts = first_line.strip().split()
-        bin_low = int(parts[3])
-        bin_high = int(parts[4])
+        # Should have 3 intervals: culled bins (0-20), good bins (21-89), remaining METs
+        assert len(lines) == 3
 
-        # First interval should only include bins 21-89
-        assert bin_low == 21
-        assert bin_high == 89
+        # First interval: culled bins 0-20
+        parts = lines[0].strip().split()
+        assert int(parts[3]) == 0  # bin_low
+        assert int(parts[4]) == 20  # bin_high
+        assert parts[16] == "1"  # cull_value (LOOSE)
+
+        # Second interval: good bins 21-89
+        parts = lines[1].strip().split()
+        assert int(parts[3]) == 21  # bin_low
+        assert int(parts[4]) == 89  # bin_high
+        assert parts[16] == "0"  # cull_value (good)
 
     def test_to_txt_with_gaps(self, goodtimes_instance, tmp_path):
         """Test output when bins have gaps."""
@@ -513,19 +574,22 @@ class TestToTxt:
         with open(output_path) as f:
             lines = f.readlines()
 
-        # Should have 13 lines (2 for first MET, 1 for each of 11 remaining METs)
-        assert len(lines) == 13
+        # Should have 4 lines (3 for first MET with gap pattern, 1 for remaining METs)
+        assert len(lines) == 4
 
-        # First two lines should be for same MET
+        # First three lines should be for same MET (first MET)
         parts1 = lines[0].strip().split()
         parts2 = lines[1].strip().split()
-        assert parts1[1] == parts2[1]  # Same met_start
+        parts3 = lines[2].strip().split()
+        assert parts1[1] == parts2[1] == parts3[1]  # Same met_start
 
-        # Check bin ranges
-        assert int(parts1[3]) == 0
-        assert int(parts1[4]) == 19
-        assert int(parts2[3]) == 71
-        assert int(parts2[4]) == 89
+        # Check the regions: bins 0-19 (good), 20-70 (culled), 71-89 (good)
+        np.testing.assert_array_equal(parts1[3:5], ["0", "19"])
+        assert parts1[16] == "0"
+        np.testing.assert_array_equal(parts2[3:5], ["20", "70"])
+        assert parts2[16] == "1"
+        np.testing.assert_array_equal(parts3[3:5], ["71", "89"])
+        assert parts3[16] == "0"
 
 
 class TestFinalizeDataset:
@@ -775,8 +839,9 @@ class TestIntervalDtype:
         assert "met_end" in field_names
         assert "spin_bin_low" in field_names
         assert "spin_bin_high" in field_names
-        assert "n_good_bins" in field_names
-        assert "esa_step" in field_names
+        assert "n_bins" in field_names
+        assert "esa_step_mask" in field_names
+        assert "cull_value" in field_names
 
     def test_interval_dtype_types(self):
         """Test that INTERVAL_DTYPE has correct field types."""
@@ -784,8 +849,9 @@ class TestIntervalDtype:
         assert INTERVAL_DTYPE["met_end"] == np.float64
         assert INTERVAL_DTYPE["spin_bin_low"] == np.uint8
         assert INTERVAL_DTYPE["spin_bin_high"] == np.uint8
-        assert INTERVAL_DTYPE["n_good_bins"] == np.uint8
-        assert INTERVAL_DTYPE["esa_step"] == np.uint8
+        assert INTERVAL_DTYPE["n_bins"] == np.uint8
+        assert INTERVAL_DTYPE["esa_step_mask"] == np.uint16
+        assert INTERVAL_DTYPE["cull_value"] == np.uint8
 
 
 def _create_l1b_de_dataset(

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -520,7 +520,7 @@ class TestToTxt:
         parts = lines[0].strip().split()
         assert len(parts) == 17  # 6 base fields + 10 ESA step flags + cull_value
         assert parts[0] == "00042"  # pointing
-        assert parts[5] == "45sensor"  # sensor
+        assert parts[5] == "45"  # sensor
         assert parts[16] == "0"  # cull_value (all good)
 
     def test_to_txt_values(self, goodtimes_instance, tmp_path):
@@ -548,7 +548,7 @@ class TestToTxt:
         assert int(met_end) == int(goodtimes_instance.coords["met"].values[-1])
         assert int(bin_low) == 0
         assert int(bin_high) == 89
-        assert sensor == "45sensor"
+        assert sensor == "45"
         assert cull_value == "0"
 
         # Check ESA step flags - should have 1s for all unique ESA steps


### PR DESCRIPTION
##  Summary
                                                                                                                                                                                                                                                                
This PR adds unique bit-flag cull codes for each goodtimes filter, enabling tracking of which specific checks flagged each time bin. It also includes fixes to the goodtimes txt file format and spin_bin coordinate metadata.

## Changes

  Unique Cull Codes (Bit Flags)

  - Replaced single CullCode.LOOSE with unique bit flags for each filter:
    - INCOMPLETE_SPIN = 1 (incomplete 8-spin periods)
    - DRF = 2 (drift restabilization)
    - BAD_TDC_CAL = 4 (failed TDC calibration)
    - OVERFLOW = 8 (DE packet overflow)
    - STAT_FILTER_0 = 16 (penetrating background changes)
    - STAT_FILTER_1 = 32 (isotropic count rate increases)
    - STAT_FILTER_2 = 64 (short-lived event pulses)
  - Updated mark_bad_times() to use bitwise OR (|=) so multiple flags can be combined
  - Each filter function now defaults to its specific cull code

  Other Fixes

  - Fixed INTERVAL_DTYPE to include cull_value and rename n_good_bins to n_bins
  - Fixed get_good_intervals() to track cull values in intervals
  - Updated dataset attributes from sensor/pointing to Sensor/Repointing for consistency

Closes: #2769 