### PR TITLE
GLOWS L2 - Add ecliptic coordinates for histogram bin centers

### DIFF
--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -147,8 +147,12 @@ class DailyLightcurve:
             self.exposure_times = np.roll(self.exposure_times, roll)
             self.flux_uncertainties = np.roll(self.flux_uncertainties, roll)
             self.histogram_flag_array = np.roll(self.histogram_flag_array, roll)
+
+            # Get the midpoint start time covered by repointing kernels
+            # needed to compute ecliptic coordinates
+            mid_idx = len(l1b_data["imap_start_time"]) // 2
             et_imap_start_time = sct_to_et(
-                met_to_sclkticks(l1b_data["imap_start_time"][0].data)
+                met_to_sclkticks(l1b_data["imap_start_time"][mid_idx].data)
             )
             self.ecliptic_lon, self.ecliptic_lat = (
                 self.compute_ecliptic_coords_of_bin_centers(

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -183,10 +183,8 @@ class DailyLightcurve:
         """
         Compute the ecliptic coordinates of the histogram bin centers.
 
-        Histogram bin centers represent the center spin angle for each bin in the imap
-        frame, which corresponds to a specific pointing direction in space. This method
-        transforms the instrument pointing direction for each bin center from the IMAP
-        spacecraft frame to the ECLIPJ2000 frame.
+        This method transforms the instrument pointing direction for each bin
+        center from the IMAP Pointing frame (IMAP_DPS) to the ECLIPJ2000 frame.
 
         Parameters
         ----------

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -151,12 +151,12 @@ class DailyLightcurve:
             # Get the midpoint start time covered by repointing kernels
             # needed to compute ecliptic coordinates
             mid_idx = len(l1b_data["imap_start_time"]) // 2
-            et_imap_start_time = sct_to_et(
+            pointing_midpoint_time_et = sct_to_et(
                 met_to_sclkticks(l1b_data["imap_start_time"][mid_idx].data)
             )
             self.ecliptic_lon, self.ecliptic_lat = (
                 self.compute_ecliptic_coords_of_bin_centers(
-                    et_imap_start_time, self.spin_angle
+                    pointing_midpoint_time_et, self.spin_angle
                 )
             )
 
@@ -182,7 +182,7 @@ class DailyLightcurve:
 
     @staticmethod
     def compute_ecliptic_coords_of_bin_centers(
-        data_start_time_et: float, spin_angle_bin_centers: NDArray
+        data_time_et: float, spin_angle_bin_centers: NDArray
     ) -> tuple[np.ndarray, np.ndarray]:
         """
         Compute the ecliptic coordinates of the histogram bin centers.
@@ -192,8 +192,8 @@ class DailyLightcurve:
 
         Parameters
         ----------
-        data_start_time_et : float
-            Ephemeris time corresponding to the start of the histogram accumulation.
+        data_time_et : float
+            Ephemeris time corresponding to the midpoint of the histogram accumulation.
 
         spin_angle_bin_centers : numpy.ndarray
             Spin angle bin centers for the histogram bins, measured in the IMAP frame,
@@ -218,7 +218,7 @@ class DailyLightcurve:
 
         # Transform coordinates to ECLIPJ2000 frame using SPICE transformations.
         ecliptic_coords = frame_transform_az_el(
-            data_start_time_et,
+            data_time_et,
             az_el,
             SpiceFrame.IMAP_DPS,
             SpiceFrame.ECLIPJ2000,

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -8,6 +8,7 @@ from numpy.typing import NDArray
 
 from imap_processing.glows import FLAG_LENGTH
 from imap_processing.glows.l1b.glows_l1b_data import PipelineSettings
+from imap_processing.glows.utils.constants import GlowsConstants
 from imap_processing.spice.geometry import (
     SpiceFrame,
     frame_transform_az_el,
@@ -127,11 +128,6 @@ class DailyLightcurve:
         else:
             self.histogram_flag_array = np.zeros(self.number_of_bins, dtype=np.uint8)
 
-        # Get ecliptic longitude and latitude of bin centers
-        self.ecliptic_lon, self.ecliptic_lat = (
-            self.compute_ecliptic_coords_of_bin_centers(l1b_data)
-        )
-
         if self.number_of_bins:
             # imap_spin_angle_bin_cntr is the raw IMAP spin angle ψ (0 - 360°,
             # bin midpoints).
@@ -151,8 +147,14 @@ class DailyLightcurve:
             self.exposure_times = np.roll(self.exposure_times, roll)
             self.flux_uncertainties = np.roll(self.flux_uncertainties, roll)
             self.histogram_flag_array = np.roll(self.histogram_flag_array, roll)
-            self.ecliptic_lon = np.roll(self.ecliptic_lon, roll)
-            self.ecliptic_lat = np.roll(self.ecliptic_lat, roll)
+            et_imap_start_time = sct_to_et(
+                met_to_sclkticks(l1b_data["imap_start_time"][0].data)
+            )
+            self.ecliptic_lon, self.ecliptic_lat = (
+                self.compute_ecliptic_coords_of_bin_centers(
+                    et_imap_start_time, self.spin_angle
+                )
+            )
 
     @staticmethod
     def calculate_histogram_sums(histograms: NDArray) -> NDArray:
@@ -176,28 +178,25 @@ class DailyLightcurve:
 
     @staticmethod
     def compute_ecliptic_coords_of_bin_centers(
-        l1b_data: xr.Dataset,
+        data_start_time_et: float, spin_angle_bin_centers: NDArray
     ) -> tuple[np.ndarray, np.ndarray]:
         """
         Compute the ecliptic coordinates of the histogram bin centers.
 
         Histogram bin centers represent the center spin angle for each bin in the imap
-        frame and are stored in the "imap_spin_angle_bin_cntr" variable in the L1B
-        dataset.
-
-        The ecliptic coordinates of the bin centers are computed as follows:
-            - Get the fixed elevation angle from the instrument pointing direction in
-              the DPS frame.
-            - Align azimuth with instrument pointing direction by rotating the center
-              spin angle for the bins by the position angle offset.
-            - Transform the resulting DPS coordinates into the ECLIPJ2000 frame using
-              SPICE transformations.
+        frame, which corresponds to a specific pointing direction in space. This method
+        transforms the instrument pointing direction for each bin center from the IMAP
+        spacecraft frame to the ECLIPJ2000 frame.
 
         Parameters
         ----------
-        l1b_data : xarray.Dataset
-            L1B data filtered by good times, good angles, and good bins for one
-            observation day.
+        data_start_time_et : float
+            Ephemeris time corresponding to the start of the histogram accumulation.
+
+        spin_angle_bin_centers : numpy.ndarray
+            Spin angle bin centers for the histogram bins, measured in the IMAP frame,
+            with shape (n_bins,), and already corrected for the northernmost point of
+            the scanning circle.
 
         Returns
         -------
@@ -205,19 +204,12 @@ class DailyLightcurve:
             Longitude and latitudes in the ECLIPJ2000 frame representing the pointing
             direction of each histogram bin center, with shape (n_bins,).
         """
-        # Ephemeris start time of the histogram accumulation.
-        data_start_time_et = sct_to_et(met_to_sclkticks(l1b_data["imap_start_time"]))
+        # In the IMAP frame, the azimuth corresponds to the spin angle bin centers
+        azimuth = spin_angle_bin_centers
 
         # Get elevation from instrument pointing direction in the DPS frame.
-        az_el = get_instrument_mounting_az_el(SpiceFrame.IMAP_GLOWS)
-        elevation = az_el[1]
-
-        # Rotate spin-angle bin centers by the instrument position-angle offset
-        # so azimuth=0 aligns with the instrument pointing direction.
-        azimuth = (
-            l1b_data["imap_spin_angle_bin_cntr"]
-            + l1b_data["position_angle_offset_average"]
-        ) % 360.0
+        az_el_instrument_mounting = get_instrument_mounting_az_el(SpiceFrame.IMAP_GLOWS)
+        elevation = az_el_instrument_mounting[1]
 
         # Create array of azimuth, elevation coordinates in the DPS frame (n_bins, 2)
         az_el = np.stack((azimuth, np.full_like(azimuth, elevation)), axis=-1)

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -220,7 +220,7 @@ class DailyLightcurve:
         ) % 360.0
 
         # Create array of azimuth, elevation coordinates in the DPS frame (n_bins, 2)
-        az_el = np.column_stack((azimuth, np.full_like(azimuth, elevation)))
+        az_el = np.stack((azimuth, np.full_like(azimuth, elevation)), axis=-1)
 
         # Transform coordinates to ECLIPJ2000 frame using SPICE transformations.
         ecliptic_coords = frame_transform_az_el(

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -8,8 +8,12 @@ from numpy.typing import NDArray
 
 from imap_processing.glows import FLAG_LENGTH
 from imap_processing.glows.l1b.glows_l1b_data import PipelineSettings
-from imap_processing.glows.utils.constants import GlowsConstants
-from imap_processing.spice.geometry import SpiceFrame, get_instrument_mounting_az_el
+from imap_processing.spice.geometry import (
+    SpiceFrame,
+    frame_transform_az_el,
+    get_instrument_mounting_az_el,
+)
+from imap_processing.spice.time import met_to_sclkticks, sct_to_et
 
 
 @dataclass
@@ -122,8 +126,11 @@ class DailyLightcurve:
             )
         else:
             self.histogram_flag_array = np.zeros(self.number_of_bins, dtype=np.uint8)
-        self.ecliptic_lon = np.zeros(self.number_of_bins)
-        self.ecliptic_lat = np.zeros(self.number_of_bins)
+
+        # Get ecliptic longitude and latitude of bin centers
+        self.ecliptic_lon, self.ecliptic_lat = (
+            self.compute_ecliptic_coords_of_bin_centers(l1b_data)
+        )
 
         if self.number_of_bins:
             # imap_spin_angle_bin_cntr is the raw IMAP spin angle ψ (0 - 360°,
@@ -166,6 +173,65 @@ class DailyLightcurve:
         # Zero out areas where HISTOGRAM_FILLVAL (i.e. unused bins)
         histograms[histograms == GlowsConstants.HISTOGRAM_FILLVAL] = 0
         return np.sum(histograms, axis=0, dtype=np.int64)
+
+    @staticmethod
+    def compute_ecliptic_coords_of_bin_centers(
+        l1b_data: xr.Dataset,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Compute the ecliptic coordinates of the histogram bin centers.
+
+        Histogram bin centers represent the center spin angle for each bin in the imap
+        frame and are stored in the "imap_spin_angle_bin_cntr" variable in the L1B
+        dataset.
+
+        The ecliptic coordinates of the bin centers are computed as follows:
+            - Get the fixed elevation angle from the instrument pointing direction in
+              the DPS frame.
+            - Align azimuth with instrument pointing direction by rotating the center
+              spin angle for the bins by the position angle offset.
+            - Transform the resulting DPS coordinates into the ECLIPJ2000 frame using
+              SPICE transformations.
+
+        Parameters
+        ----------
+        l1b_data : xarray.Dataset
+            L1B data filtered by good times, good angles, and good bins for one
+            observation day.
+
+        Returns
+        -------
+        tuple[numpy.ndarray, numpy.ndarray]
+            Longitude and latitudes in the ECLIPJ2000 frame representing the pointing
+            direction of each histogram bin center, with shape (n_bins,).
+        """
+        # Ephemeris start time of the histogram accumulation.
+        data_start_time_et = sct_to_et(met_to_sclkticks(l1b_data["imap_start_time"]))
+
+        # Get elevation from instrument pointing direction in the DPS frame.
+        az_el = get_instrument_mounting_az_el(SpiceFrame.IMAP_GLOWS)
+        elevation = az_el[1]
+
+        # Rotate spin-angle bin centers by the instrument position-angle offset
+        # so azimuth=0 aligns with the instrument pointing direction.
+        azimuth = (
+            l1b_data["imap_spin_angle_bin_cntr"]
+            + l1b_data["position_angle_offset_average"]
+        ) % 360.0
+
+        # Create array of azimuth, elevation coordinates in the DPS frame (n_bins, 2)
+        az_el = np.column_stack((azimuth, np.full_like(azimuth, elevation)))
+
+        # Transform coordinates to ECLIPJ2000 frame using SPICE transformations.
+        ecliptic_coords = frame_transform_az_el(
+            data_start_time_et,
+            az_el,
+            SpiceFrame.IMAP_DPS,
+            SpiceFrame.ECLIPJ2000,
+        )
+
+        # Return ecliptic longitudes and latitudes as separate arrays.
+        return ecliptic_coords[:, 0], ecliptic_coords[:, 1]
 
 
 @dataclass

--- a/imap_processing/tests/glows/conftest.py
+++ b/imap_processing/tests/glows/conftest.py
@@ -281,7 +281,7 @@ def mock_pipeline_settings():
 
 @pytest.fixture
 def mock_ecliptic_bin_centers(monkeypatch):
-    """Keep DailyLightcurve unit tests independent of SPICE/time conversions."""
+    """Mock ecliptic coordinates for bin centers."""
 
     def _mock_compute_coords(
         _data_start_time_et: float, spin_angle: np.ndarray

--- a/imap_processing/tests/glows/conftest.py
+++ b/imap_processing/tests/glows/conftest.py
@@ -13,6 +13,7 @@ from imap_processing.glows.l1b.glows_l1b_data import (
     AncillaryParameters,
 )
 from imap_processing.glows.l2.glows_l2 import glows_l2
+from imap_processing.glows.l2.glows_l2_data import DailyLightcurve
 
 
 @pytest.fixture
@@ -276,6 +277,23 @@ def mock_pipeline_settings():
     )
 
     return mock_pipeline_dataset
+
+
+@pytest.fixture
+def mock_ecliptic_bin_centers(monkeypatch):
+    """Keep DailyLightcurve unit tests independent of SPICE/time conversions."""
+
+    def _mock_compute_coords(
+        _data_start_time_et: float, spin_angle: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        n_bins = len(spin_angle)
+        return np.zeros(n_bins, dtype=float), np.zeros(n_bins, dtype=float)
+
+    monkeypatch.setattr(
+        DailyLightcurve,
+        "compute_ecliptic_coords_of_bin_centers",
+        staticmethod(_mock_compute_coords),
+    )
 
 
 def mock_update_spice_parameters(self, *args, **kwargs):

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -96,7 +96,6 @@ def test_generate_l2(
     mock_ancillary_exclusions,
     mock_pipeline_settings,
     mock_conversion_table_dict,
-    furnish_kernels,
     mock_ecliptic_bin_centers,
 ):
     mock_spice_function.side_effect = mock_update_spice_parameters

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -15,22 +15,9 @@ from imap_processing.glows.l2.glows_l2 import (
 from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
 from imap_processing.glows.utils.constants import GlowsConstants
 from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
-from imap_processing.tests.glows.conftest import mock_update_spice_parameters
-
-
-@pytest.fixture
-def mock_ecliptic_bin_centers(monkeypatch):
-    """Keep DailyLightcurve unit tests independent from SPICE/time conversions."""
-
-    def _mock_compute_coords(l1b_data: xr.Dataset) -> tuple[np.ndarray, np.ndarray]:
-        n_bins = l1b_data["histogram"].shape[1]
-        return np.zeros(n_bins, dtype=float), np.zeros(n_bins, dtype=float)
-
-    monkeypatch.setattr(
-        DailyLightcurve,
-        "compute_ecliptic_coords_of_bin_centers",
-        staticmethod(_mock_compute_coords),
-    )
+from imap_processing.tests.glows.conftest import (
+    mock_update_spice_parameters,
+)
 
 
 @pytest.fixture

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -19,6 +19,21 @@ from imap_processing.tests.glows.conftest import mock_update_spice_parameters
 
 
 @pytest.fixture
+def mock_ecliptic_bin_centers(monkeypatch):
+    """Keep DailyLightcurve unit tests independent from SPICE/time conversions."""
+
+    def _mock_compute_coords(l1b_data: xr.Dataset) -> tuple[np.ndarray, np.ndarray]:
+        n_bins = l1b_data["histogram"].shape[1]
+        return np.zeros(n_bins, dtype=float), np.zeros(n_bins, dtype=float)
+
+    monkeypatch.setattr(
+        DailyLightcurve,
+        "compute_ecliptic_coords_of_bin_centers",
+        staticmethod(_mock_compute_coords),
+    )
+
+
+@pytest.fixture
 def l1b_hists():
     epoch = xr.DataArray(np.arange(4), name="epoch", dims=["epoch"])
     bins = xr.DataArray(np.arange(5), name="bins", dims=["bins"])
@@ -51,6 +66,7 @@ def test_glows_l2(
     mock_ancillary_exclusions,
     mock_pipeline_settings,
     mock_conversion_table_dict,
+    mock_ecliptic_bin_centers,
     caplog,
 ):
     mock_spice_function.side_effect = mock_update_spice_parameters
@@ -93,6 +109,8 @@ def test_generate_l2(
     mock_ancillary_exclusions,
     mock_pipeline_settings,
     mock_conversion_table_dict,
+    furnish_kernels,
+    mock_ecliptic_bin_centers,
 ):
     mock_spice_function.side_effect = mock_update_spice_parameters
 

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -95,8 +95,7 @@ def l1b_dataset():
 def test_ecliptic_coords_computation(furnish_kernels):
     """Test method that computes ecliptic coordinates."""
 
-    # Start time is 2026-01-01 since J2000 which is covered by
-    # the spice kernels
+    # Use a met value within the SPICE kernel coverage (2026-01-01).
     data_start_time_et = sct_to_et(met_to_sclkticks(504975603.125))
     n_bins = 4
     spin_angle = np.linspace(0, 270, n_bins)

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -10,6 +10,21 @@ from imap_processing.glows.utils.constants import GlowsConstants
 
 
 @pytest.fixture
+def mock_ecliptic_bin_centers(monkeypatch):
+    """Keep DailyLightcurve unit tests independent from SPICE/time conversions."""
+
+    def _mock_compute_coords(l1b_data: xr.Dataset) -> tuple[np.ndarray, np.ndarray]:
+        n_bins = l1b_data["histogram"].shape[1]
+        return np.zeros(n_bins, dtype=float), np.zeros(n_bins, dtype=float)
+
+    monkeypatch.setattr(
+        DailyLightcurve,
+        "compute_ecliptic_coords_of_bin_centers",
+        staticmethod(_mock_compute_coords),
+    )
+
+
+@pytest.fixture
 def pipeline_settings():
     """PipelineSettings with flags matching the default pipeline settings JSON.
 
@@ -78,6 +93,8 @@ def l1b_dataset():
             "spin_period_average": (["epoch"], [15.0, 15.0]),
             "number_of_spins_per_block": (["epoch"], [5, 5]),
             "imap_spin_angle_bin_cntr": (["epoch", "bins"], spin_angle),
+            "position_angle_offset_average": (["epoch"], [0.0, 0.0]),
+            "imap_start_time": (["epoch"], [0.0, 1.0]),
             "histogram_flag_array": (
                 ["epoch", "bad_angle_flags", "bins"],
                 histogram_flag_array,
@@ -89,7 +106,7 @@ def l1b_dataset():
     return ds
 
 
-def test_photon_flux(l1b_dataset):
+def test_photon_flux(l1b_dataset, mock_ecliptic_bin_centers):
     """Flux = sum(histograms) / sum(exposure_times) per bin (Eq. 50)."""
     lc = DailyLightcurve(l1b_dataset, position_angle=0.0)
 
@@ -108,7 +125,7 @@ def test_photon_flux(l1b_dataset):
     assert np.allclose(lc.photon_flux, expected_flux)
 
 
-def test_flux_uncertainty(l1b_dataset):
+def test_flux_uncertainty(l1b_dataset, mock_ecliptic_bin_centers):
     """Uncertainty = sqrt(sum_hist) / exposure per bin (Eq. 54)."""
     lc = DailyLightcurve(l1b_dataset, position_angle=0.0)
 
@@ -116,7 +133,7 @@ def test_flux_uncertainty(l1b_dataset):
     assert np.allclose(lc.flux_uncertainties, expected_uncertainty)
 
 
-def test_zero_exposure_bins(l1b_dataset):
+def test_zero_exposure_bins(l1b_dataset, mock_ecliptic_bin_centers):
     """Bins with all-masked histograms get zero flux and uncertainty.
 
     Exposure time still accumulates uniformly from each good-time file even
@@ -132,16 +149,18 @@ def test_zero_exposure_bins(l1b_dataset):
     assert np.allclose(lc.exposure_times, expected_exposure)
 
 
-def test_number_of_bins(l1b_dataset):
+def test_number_of_bins(l1b_dataset, mock_ecliptic_bin_centers):
     lc = DailyLightcurve(l1b_dataset, position_angle=0.0)
     assert lc.number_of_bins == 4
     assert len(lc.spin_angle) == 4
     assert len(lc.photon_flux) == 4
     assert len(lc.flux_uncertainties) == 4
     assert len(lc.exposure_times) == 4
+    assert len(lc.ecliptic_lon) == 4
+    assert len(lc.ecliptic_lat) == 4
 
 
-def test_histogram_flag_array_or_propagation(l1b_dataset):
+def test_histogram_flag_array_or_propagation(l1b_dataset, mock_ecliptic_bin_centers):
     """histogram_flag_array is OR'd across all L1B epochs and flag rows per bin.
 
     Per Section 12.3.4: a flag is True in L2 if it is True in any L1B block.
@@ -163,7 +182,7 @@ def test_histogram_flag_array_or_propagation(l1b_dataset):
     assert lc.histogram_flag_array[3] == 0  # no flags on bin 3
 
 
-def test_histogram_flag_array_zero_epochs():
+def test_histogram_flag_array_zero_epochs(mock_ecliptic_bin_centers):
     """histogram_flag_array is all zeros when the input dataset is empty.
 
     Note: this is NEVER expected to happen in production
@@ -179,6 +198,8 @@ def test_histogram_flag_array_zero_epochs():
             "spin_period_average": (["epoch"], []),
             "number_of_spins_per_block": (["epoch"], []),
             "imap_spin_angle_bin_cntr": (["epoch", "bins"], spin_angle),
+            "position_angle_offset_average": (["epoch"], []),
+            "imap_start_time": (["epoch"], []),
             "histogram_flag_array": (
                 ["epoch", "bad_angle_flags", "bins"],
                 histogram_flag_array,

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -7,6 +7,7 @@ import xarray as xr
 from imap_processing.glows.l1b.glows_l1b_data import PipelineSettings
 from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
 from imap_processing.glows.utils.constants import GlowsConstants
+from imap_processing.spice.time import met_to_ttj2000ns
 
 
 @pytest.fixture
@@ -104,6 +105,35 @@ def l1b_dataset():
         coords={"epoch": epoch, "bins": bins},
     )
     return ds
+
+
+@pytest.mark.external_kernel
+def test_ecliptic_coords_computation(furnish_kernels, l1b_dataset):
+    """Test method that computes ecliptic coordinates."""
+
+    # Update the epoch and imap_start time to real values
+    # for 2026-01-01 and 2026-01-02 in seconds since J2000
+    # with leap seconds included
+    l1b_dataset = l1b_dataset.assign_coords(
+        epoch=xr.DataArray(
+            [met_to_ttj2000ns(504975603.125), met_to_ttj2000ns(505975604.125)],
+            dims=["epoch"],
+        )
+    )
+    l1b_dataset["imap_start_time"] = (["epoch"], [504975603.125, 505975604.125])
+    kernels = [
+        "naif0012.tls",
+        "de440s.bsp",
+        "imap_sclk_0000.tsc",
+        "imap_130.tf",
+        "imap_science_120.tf",
+        "sim_1yr_imap_attitude.bc",
+        "sim_1yr_imap_pointing_frame.bc",
+    ]
+    with furnish_kernels(kernels):
+        lc = DailyLightcurve(l1b_dataset)
+        assert np.all(lc.ecliptic_lon == 0)
+        assert np.all(lc.ecliptic_lat == 0)
 
 
 def test_photon_flux(l1b_dataset, mock_ecliptic_bin_centers):

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -7,22 +7,7 @@ import xarray as xr
 from imap_processing.glows.l1b.glows_l1b_data import PipelineSettings
 from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
 from imap_processing.glows.utils.constants import GlowsConstants
-from imap_processing.spice.time import met_to_ttj2000ns
-
-
-@pytest.fixture
-def mock_ecliptic_bin_centers(monkeypatch):
-    """Keep DailyLightcurve unit tests independent from SPICE/time conversions."""
-
-    def _mock_compute_coords(l1b_data: xr.Dataset) -> tuple[np.ndarray, np.ndarray]:
-        n_bins = l1b_data["histogram"].shape[1]
-        return np.zeros(n_bins, dtype=float), np.zeros(n_bins, dtype=float)
-
-    monkeypatch.setattr(
-        DailyLightcurve,
-        "compute_ecliptic_coords_of_bin_centers",
-        staticmethod(_mock_compute_coords),
-    )
+from imap_processing.spice.time import met_to_sclkticks, sct_to_et
 
 
 @pytest.fixture
@@ -94,7 +79,6 @@ def l1b_dataset():
             "spin_period_average": (["epoch"], [15.0, 15.0]),
             "number_of_spins_per_block": (["epoch"], [5, 5]),
             "imap_spin_angle_bin_cntr": (["epoch", "bins"], spin_angle),
-            "position_angle_offset_average": (["epoch"], [0.0, 0.0]),
             "imap_start_time": (["epoch"], [0.0, 1.0]),
             "histogram_flag_array": (
                 ["epoch", "bad_angle_flags", "bins"],
@@ -108,32 +92,45 @@ def l1b_dataset():
 
 
 @pytest.mark.external_kernel
-def test_ecliptic_coords_computation(furnish_kernels, l1b_dataset):
+def test_ecliptic_coords_computation(furnish_kernels):
     """Test method that computes ecliptic coordinates."""
 
-    # Update the epoch and imap_start time to real values
-    # for 2026-01-01 and 2026-01-02 in seconds since J2000
-    # with leap seconds included
-    l1b_dataset = l1b_dataset.assign_coords(
-        epoch=xr.DataArray(
-            [met_to_ttj2000ns(504975603.125), met_to_ttj2000ns(505975604.125)],
-            dims=["epoch"],
-        )
-    )
-    l1b_dataset["imap_start_time"] = (["epoch"], [504975603.125, 505975604.125])
+    # Start time is 2026-01-01 since J2000 which is covered by
+    # the spice kernels
+    data_start_time_et = sct_to_et(met_to_sclkticks(504975603.125))
+    n_bins = 4
+    spin_angle = np.linspace(0, 270, n_bins)
+
     kernels = [
         "naif0012.tls",
-        "de440s.bsp",
         "imap_sclk_0000.tsc",
         "imap_130.tf",
         "imap_science_120.tf",
-        "sim_1yr_imap_attitude.bc",
         "sim_1yr_imap_pointing_frame.bc",
     ]
+
     with furnish_kernels(kernels):
-        lc = DailyLightcurve(l1b_dataset)
-        assert np.all(lc.ecliptic_lon == 0)
-        assert np.all(lc.ecliptic_lat == 0)
+        ecliptic_lon, ecliptic_lat = (
+            DailyLightcurve.compute_ecliptic_coords_of_bin_centers(
+                data_start_time_et, spin_angle
+            )
+        )
+
+    # ecliptic_lon and ecliptic_lat must have one entry per bin
+    assert len(ecliptic_lon) == n_bins
+    assert len(ecliptic_lat) == n_bins
+
+    # ecliptic longitude must be in [0, 360)
+    assert np.all(ecliptic_lon >= 0.0)
+    assert np.all(ecliptic_lon < 360.0)
+
+    # ecliptic latitude must be in [-90, 90]
+    assert np.all(ecliptic_lat >= -90.0)
+    assert np.all(ecliptic_lat <= 90.0)
+
+    # values must be finite (no NaN / Inf from SPICE)
+    assert np.all(np.isfinite(ecliptic_lon))
+    assert np.all(np.isfinite(ecliptic_lat))
 
 
 def test_photon_flux(l1b_dataset, mock_ecliptic_bin_centers):
@@ -228,8 +225,6 @@ def test_histogram_flag_array_zero_epochs(mock_ecliptic_bin_centers):
             "spin_period_average": (["epoch"], []),
             "number_of_spins_per_block": (["epoch"], []),
             "imap_spin_angle_bin_cntr": (["epoch", "bins"], spin_angle),
-            "position_angle_offset_average": (["epoch"], []),
-            "imap_start_time": (["epoch"], []),
             "histogram_flag_array": (
                 ["epoch", "bad_angle_flags", "bins"],
                 histogram_flag_array,
@@ -263,7 +258,7 @@ def test_filter_good_times():
 # ── spin_angle tests ──────────────────────────────────────────────────────────
 
 
-def test_spin_angle_offset_formula(l1b_dataset):
+def test_spin_angle_offset_formula(l1b_dataset, mock_ecliptic_bin_centers):
     """spin_angle = (imap_spin_angle_bin_cntr - position_angle + 360) % 360.
 
     Fixture spin_angle_bin_cntr = [0, 90, 180, 270], position_angle = 90.
@@ -275,7 +270,7 @@ def test_spin_angle_offset_formula(l1b_dataset):
     assert np.allclose(lc.spin_angle, expected)
 
 
-def test_spin_angle_starts_at_minimum(l1b_dataset):
+def test_spin_angle_starts_at_minimum(l1b_dataset, mock_ecliptic_bin_centers):
     """After rolling, lc.spin_angle[0] is the minimum value.
 
     Fixture spin_angle_bin_cntr = [0, 90, 180, 270], position_angle = 45.
@@ -352,7 +347,9 @@ def l1b_dataset_full():
     )
 
 
-def test_position_angle_offset_average(l1b_dataset_full, pipeline_settings):
+def test_position_angle_offset_average(
+    l1b_dataset_full, pipeline_settings, mock_ecliptic_bin_centers
+):
     """position_angle_offset_average is a scalar equal to the result of
     compute_position_angle (Eq. 30, Section 10.6). It is constant across the
     observational day since it depends only on instrument mounting geometry.


### PR DESCRIPTION
This PR adds a new method to compute the ecliptic longitude and latitude for each histogram bin center in the GLOWS L2 product using SPICE transformations. It also adds a unit test and mocking of these computations in existing tests where appropriate to remain independent of SPICE/time conversions.

**Code Updates**
* Added the `compute_ecliptic_coords_of_bin_centers` static method to `DailyLightcurve`, which transforms instrument pointing directions from the IMAP spacecraft frame to the ECLIPJ2000 frame using SPICE, providing ecliptic longitude and latitude for each histogram bin center.
* Updated the `__post_init__` method of `DailyLightcurve` to compute and assign `ecliptic_lon` and `ecliptic_lat` using the new method, replacing the previous placeholder arrays.

**Testing**
* Added a `mock_ecliptic_bin_centers` test fixture to mock ecliptic coordinate computations, ensuring unit tests for `DailyLightcurve` are independent of SPICE/time conversions.
* Updated all affected tests in `test_glows_l2_data.py` and `test_glows_l2.py to use the new fixture, ensuring their reliability and isolation from 
* Added a unit test to test the output of the new method

Closes #2722 