### PR TITLE
Support  for --dependency when its a path to an arbitrarily-located local .json file

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -27,7 +27,7 @@ import spiceypy
 import xarray as xr
 from cdflib.xarray import xarray_to_cdf
 from cdflib.xarray.xarray_to_cdf import ISTPError
-from imap_data_access.io import IMAPDataAccessError, download
+from imap_data_access.io import IMAPDataAccessError
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     ProcessingInputType,
@@ -267,8 +267,7 @@ def _parse_args() -> argparse.Namespace:
         logger.info(
             f"Interpreting dependency argument as a JSON file: {args.dependency}"
         )
-        dependency_filepath = download(args.dependency)
-        with open(dependency_filepath) as f:
+        with open(args.dependency) as f:
             args.dependency = f.read()
 
     return args

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -130,11 +130,8 @@ def test_parse_args_dependency_json_file(caplog, tmp_path):
         },
     ]
     test_json_filename = "imap_ultra_l2_test-dependency-json_20250520_v999.json"
-    test_json_dir = tmp_path / "imap/dependency/ultra/l2/2025/05/"
-    test_json_dir.mkdir(parents=True, exist_ok=True)
-    test_json_dst = test_json_dir / test_json_filename
 
-    with open(test_json_dst, "w") as f:
+    with open(test_json_filename, "w") as f:
         f.write(json.dumps(test_json_content))
 
     test_args = [
@@ -142,7 +139,7 @@ def test_parse_args_dependency_json_file(caplog, tmp_path):
         "--instrument",
         "mag",
         "--dependency",
-        str(test_json_dst),
+        str(test_json_filename),
         "--data-level",
         "l1a",
         "--start-date",


### PR DESCRIPTION
# Change Summary

`imap_cli ... --dependency dependency.json` now works correctly.

I'm still fairly new to this code so my apologies in advance if I'm misunderstanding something here!

## Overview

Support for `--dependency <local_json_file.json>` didn't exactly work when I tried it. It's my understanding that `.json` files for dependencies are not meant to be downloaded from the server (which is what the code was trying to do) but generated locally.

## File changes

`cli.py` now doesn't try to download the `.json` file but simply reads it for its contents.

## Testing

The associated test (modified now) originally only worked because it bypassed the logic of `download` by placing it at the correct place before testing the CLI command. This modified test will fail in the current code without the associated changes.