### PR TITLE
IDEX l1b filter for desired evt messages

### DIFF
--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -200,6 +200,11 @@ def idex_l1b_msg(l1a_dataset: xr.Dataset) -> xr.Dataset:
         name="science_on",
         attrs=idex_attrs.get_variable_attributes("science_on"),
     )
+
+    # Filter dataset to only include rows where there is an event
+    # (either science or pulser)
+    null_event = (pulser_on == 255) & (science_on == 255)
+    l1b_dataset = l1b_dataset.isel(epoch=~null_event)
     logger.info("IDEX L1B MSG data processing completed.")
     return l1b_dataset
 

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -392,14 +392,14 @@ def test_l1b_msg_processing(decom_test_data_msg: xr.Dataset):
 
     # Check that the pulser_on variable is correct
     expected_pulser_on = np.ones_like(test_l1b_msg["pulser_on"]) * 255
-    # The pulser_on variable should be 1 for the 2nd and 0 for the 3rd event, and
+    # The pulser_on variable should be 1 for the 1st and 0 for the 2nd event, and
     # 255 for all other events
-    expected_pulser_on[2] = 1
-    expected_pulser_on[3] = 0
-    np.testing.assert_array_equal(test_l1b_msg["pulser_on"].data, expected_pulser_on)
+    expected_pulser_on[0] = 1
+    expected_pulser_on[1] = 0
     # Check that the science_on variable is correct
     expected_science_on = np.ones_like(test_l1b_msg["pulser_on"]) * 255
-    # The science_on variable should be 1 for the 10th event and 0 for the 11th event
-    expected_science_on[10] = 1
-    expected_science_on[11] = 0
+    # The science_on variable should be 1 for the 3rd event and 0 for the 4th event
+    expected_science_on[2] = 1
+    expected_science_on[3] = 0
+    np.testing.assert_array_equal(test_l1b_msg["pulser_on"].data, expected_pulser_on)
     np.testing.assert_array_equal(test_l1b_msg["science_on"].data, expected_science_on)


### PR DESCRIPTION
# Change Summary

## Overview

Filter the l1b event message dataset to only include messages that are for pulser on / off and science on/off

## File changes
imap_processing/idex/idex_l1b.py
- Remove inds where both science on and pulser on are null


## Testing
Update test