### PR TITLE
Minimally Fix MAG L1C gap-fill bugs: pass validation tests T015 and T016

### DIFF
--- a/imap_processing/mag/l1c/interpolation_methods.py
+++ b/imap_processing/mag/l1c/interpolation_methods.py
@@ -296,7 +296,9 @@ def linear_filtered(
     input_filtered, vectors_filtered = cic_filter(
         input_vectors, input_timestamps, output_timestamps, input_rate, output_rate
     )
-    return linear(vectors_filtered, input_filtered, output_timestamps)
+    return linear(
+        vectors_filtered, input_filtered, output_timestamps, extrapolate=True
+    )
 
 
 def quadratic_filtered(

--- a/imap_processing/mag/l1c/mag_l1c.py
+++ b/imap_processing/mag/l1c/mag_l1c.py
@@ -340,6 +340,11 @@ def process_mag_l1c(
             normal_vecsec_dict = None
 
         gaps = find_all_gaps(norm_epoch, normal_vecsec_dict, day_start_ns, day_end_ns)
+        # Filter out micro-gaps at config mode transitions (1 missing sample)
+        if gaps.shape[0] > 0:
+            cadences = 1e9 / gaps[:, 2]
+            durations = gaps[:, 1] - gaps[:, 0]
+            gaps = gaps[durations > 2 * cadences]
     else:
         norm_epoch = [day_start_ns, day_end_ns]
         gaps = np.array(
@@ -499,8 +504,8 @@ def interpolate_gaps(
         burst_start = max(0, burst_gap_start - burst_buffer)
         burst_end = min(len(burst_epochs) - 1, burst_gap_end + burst_buffer)
 
-        gap_timeline = filled_norm_timeline[
-            (filled_norm_timeline > gap[0]) & (filled_norm_timeline < gap[1])
+        gap_timeline = filled_norm_timeline[:, 0][
+            (filled_norm_timeline[:, 0] > gap[0]) & (filled_norm_timeline[:, 0] < gap[1])
         ]
 
         short = (gap_timeline >= burst_epochs[burst_start]) & (
@@ -515,8 +520,8 @@ def interpolate_gaps(
         gap_timeline = gap_timeline[short]
         # do not include range
         adjusted_gap_timeline, gap_fill = interpolation_function(
-            burst_vectors[burst_start:burst_end, :3],
-            burst_epochs[burst_start:burst_end],
+            burst_vectors[burst_start : burst_end + 1, :3],
+            burst_epochs[burst_start : burst_end + 1],
             gap_timeline,
             input_rate=burst_rate,
             output_rate=norm_rate,
@@ -548,7 +553,7 @@ def interpolate_gaps(
                     "Self-inconsistent data. "
                     "Gaps not included in final timeline should be missing."
                 )
-            np.delete(filled_norm_timeline, timeline_index)
+            pass
 
     return filled_norm_timeline
 
@@ -734,8 +739,9 @@ def generate_missing_timestamps(gap: np.ndarray) -> np.ndarray:
     full_timeline: numpy.ndarray
         Completed timeline.
     """
-    # Generated timestamps should always be 0.5 seconds apart
-    difference_ns = 0.5 * 1e9
+    # Use the gap's declared vector rate for cadence; fall back to 0.5s (2 Hz)
+    vectors_per_second = int(gap[2]) if len(gap) > 2 else 2
+    difference_ns = int(1e9 / vectors_per_second)
     output: np.ndarray = np.arange(gap[0], gap[1], difference_ns)
     return output
 

--- a/imap_processing/tests/mag/test_mag_l1c.py
+++ b/imap_processing/tests/mag/test_mag_l1c.py
@@ -112,7 +112,9 @@ def test_interpolation_methods():
 def test_process_mag_l1c(norm_dataset, burst_dataset):
     l1c = process_mag_l1c(norm_dataset, burst_dataset, InterpolationFunction.linear)
     expected_output_timeline = (
-        np.array([0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.25, 4.75, 5.25, 5.5, 5.75, 6])
+        np.array(
+            [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.25, 4.5, 4.75, 5, 5.25, 5.5, 5.75, 6]
+        )
         * 1e9
     )
     assert np.array_equal(l1c[:, 0], expected_output_timeline)
@@ -122,12 +124,12 @@ def test_process_mag_l1c(norm_dataset, burst_dataset):
         np.count_nonzero([np.sum(l1c[i, 1:4]) for i in range(l1c.shape[0])])
         == l1c.shape[0] - 1
     )
-    expected_flags = np.zeros(15)
+    expected_flags = np.zeros(17)
     # filled sections should have 1 as a flag
     expected_flags[5:8] = 1
-    expected_flags[10:11] = 1
+    expected_flags[10:13] = 1
     # last datapoint in the gap is missing a value
-    expected_flags[11] = -1
+    expected_flags[13] = -1
     assert np.array_equal(l1c[:, 5], expected_flags)
     assert np.array_equal(l1c[:5, 1:5], norm_dataset["vectors"].data[:5, :])
     for i in range(5, 8):
@@ -140,7 +142,7 @@ def test_process_mag_l1c(norm_dataset, burst_dataset):
         assert np.allclose(l1c[i, 1:5], burst_vectors, rtol=0, atol=1)
 
     assert np.array_equal(l1c[8:10, 1:5], norm_dataset["vectors"].data[5:7, :])
-    for i in range(10, 11):
+    for i in range(10, 13):
         e = l1c[i, 0]
         burst_vectors = burst_dataset.sel(epoch=int(e), method="nearest")[
             "vectors"
@@ -149,7 +151,7 @@ def test_process_mag_l1c(norm_dataset, burst_dataset):
         # identical.
         assert np.allclose(l1c[i, 1:5], burst_vectors, rtol=0, atol=1)
 
-    assert np.array_equal(l1c[11, 1:5], [0, 0, 0, 0])
+    assert np.array_equal(l1c[13, 1:5], [0, 0, 0, 0])
 
 
 def test_interpolate_gaps(norm_dataset, mag_l1b_dataset):

--- a/imap_processing/tests/mag/test_mag_validation.py
+++ b/imap_processing/tests/mag/test_mag_validation.py
@@ -260,10 +260,7 @@ def test_mag_l1b_validation(test_number, mocks):
 @pytest.mark.parametrize(("sensor"), ["mago", "magi"])
 @pytest.mark.external_test_data
 def test_mag_l1c_validation(test_number, sensor):
-    if test_number not in ["013", "014", "024"]:
-        pytest.skip("All L1C edge cases are not yet complete")
-
-    # We expect tests 013 and 014 to pass. 015 and 016 are not yet complete.
+    #
     # timestamp = (
     #     (np.datetime64("2025-03-11T12:22:50.706034") - np.datetime64(TTJ2000_EPOCH))
     #     / np.timedelta64(1, "ns")


### PR DESCRIPTION
## Summary (From Claude)

Five surgical bug fixes to the existing MAG L1C gap-fill code to un-skip and pass validation tests T015 and T016, while keeping T013, T014, and T024 passing. **No architectural changes, no new functions or classes, no rewrite of the pipeline flow.**

This supersedes the earlier, heavier draft PR at sapols/imap_processing#2 (`claude/mag-l1c-fix`), which rewrote the gap-fill architecture with new dataclasses, helper functions, and a BM-only algorithm. After feedback from @alastairtree and @maxinelasp -- that the existing code was developed collaboratively with the MAG team and that deviations from the algorithm document may be intentional simplifications -- we went back to `dev` and identified the smallest set of changes needed to make the validation tests pass. The result is ~25 lines changed across 4 files instead of hundreds.

Closes #1993

## Bug fixes

### Fix A: 2D array indexing in `interpolate_gaps()` (`mag_l1c.py`)

`filled_norm_timeline` is an (n, 8) array, but the gap-timeline extraction was comparing the entire 2D array against scalar timestamps without specifying a column. The boolean mask broadcasted across all 8 columns, producing garbled results.

**Fix**: Index column 0 explicitly: `filled_norm_timeline[:, 0][...]`

### Fix B: Off-by-one burst slice in `interpolate_gaps()` (`mag_l1c.py`)

`burst_end` was clamped to `len(burst_epochs) - 1`, but the subsequent Python slice `[burst_start:burst_end]` excludes the right endpoint, silently dropping the last burst sample from interpolation.

**Fix**: Use `burst_start : burst_end + 1` in slices.

### Fix C: CIC filter edge loss in `linear_filtered()` (`interpolation_methods.py`)

After the CIC filter truncates samples to compensate for group delay, the filtered timestamps are shorter than the originals. `linear()` then calls `remove_invalid_output_timestamps()`, which clips valid output timestamps to the now-shorter filtered range -- discarding data at the edges that should be extrapolated.

**Fix**: Pass `extrapolate=True` to `linear()`, matching the spec reference CIC code which uses IUS (extrapolates by default).

### Fix D: Spurious micro-gaps at config mode transitions (`mag_l1c.py`)

When MAG switches vector rates, the declared rate-transition timestamp does not perfectly align with the actual cadence change in the data. `find_all_gaps()` splits the timeline at declared transitions, and `find_gaps()` misidentifies the boundary misalignment as 1-sample gaps. These phantom gaps cause downstream interpolation failures.

**Fix**: Filter out gaps whose duration spans at most 2 cadence periods (i.e., a single missing sample artifact) after `find_all_gaps()` returns.

### Fix E: Hardcoded 0.5s cadence in `generate_missing_timestamps()` (`mag_l1c.py`)

Gap-fill timestamps were always generated at 0.5s (2 Hz) intervals regardless of the gap declared vector rate. For rate=4 (0.25s) or rate=1 (1.0s) gaps, this produced the wrong number of timestamps and misaligned with the MAG team expected validation outputs.

**Fix**: Read the rate from the gap descriptor third element (`gap[2]`) and compute cadence as `int(1e9 / vectors_per_second)`. The `int()` cast also fixes nanosecond floating-point precision issues in `np.arange()`.

### Bonus: Dead code removal

Removed a no-op `np.delete(filled_norm_timeline, timeline_index)` call whose return value was never assigned.

## Files changed

| File | Lines | What |
|------|-------|------|
| `mag/l1c/mag_l1c.py` | ~15 | Fixes A, B, D, E + dead code removal |
| `mag/l1c/interpolation_methods.py` | 3 | Fix C (extrapolate=True) |
| `tests/mag/test_mag_validation.py` | -3 | Remove `pytest.skip()` guard for T015/T016 |
| `tests/mag/test_mag_l1c.py` | ~10 | Update unit test expectations for rate-aware cadence |

## Test results

All 102 MAG tests pass, including the previously-skipped T015 and T016 for both mago and magi:

```
102 passed, 32 warnings in 17.83s
```

## Why this approach instead of the earlier PR

The earlier PR (sapols/imap_processing#2) took a comprehensive approach: rewriting the gap-fill pipeline with `GapFillPlan` dataclasses, `build_gap_fill_plan()`, `_find_rate_segments()`, and a BM-only interpolation algorithm. While technically sound, it replaced code that was developed in close collaboration with the MAG instrument team and made assumptions about which deviations from the algorithm document were bugs vs. intentional simplifications.

This PR takes the opposite approach: start from the existing code, identify the specific bugs preventing T015/T016 from passing, and fix only those. The 5 bugs found are all unambiguous correctness issues (wrong array dimensions, off-by-one slicing, clipped interpolation range, phantom gap detection, wrong cadence). No judgment calls about algorithm design were needed.
