### PR TITLE
GLOWS Ancillary file rename

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -758,10 +758,15 @@ class Glows(ProcessInstrument):
             pipeline_settings_combiner = GlowsAncillaryCombiner(
                 pipeline_settings_input, day_buffer
             )
+            calibration_input = dependencies.get_processing_inputs(
+                descriptor="l2-calibration"
+            )[0]
+            calibration_combiner = GlowsAncillaryCombiner(calibration_input, day_buffer)
 
             datasets = glows_l2(
                 input_dataset,
                 pipeline_settings_combiner.combined_dataset,
+                calibration_combiner.combined_dataset,
             )
 
         return datasets

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -676,7 +676,7 @@ class Glows(ProcessInstrument):
 
             # Load conversion table (needed for both hist and DE)
             conversion_table_file = dependencies.get_processing_inputs(
-                descriptor="conversion-table-for-anc-data"
+                descriptor="l1b-conversion-table-for-anc-data"
             )[0]
 
             with open(conversion_table_file.imap_file_paths[0].construct_path()) as f:
@@ -691,16 +691,16 @@ class Glows(ProcessInstrument):
             if "hist" in self.descriptor:
                 # Create file lists for each ancillary type
                 excluded_regions_files = dependencies.get_processing_inputs(
-                    descriptor="map-of-excluded-regions"
+                    descriptor="l1b-map-of-excluded-regions"
                 )[0]
                 uv_sources_files = dependencies.get_processing_inputs(
-                    descriptor="map-of-uv-sources"
+                    descriptor="l1b-map-of-uv-sources"
                 )[0]
                 suspected_transients_files = dependencies.get_processing_inputs(
-                    descriptor="suspected-transients"
+                    descriptor="l1b-suspected-transients"
                 )[0]
                 exclusions_by_instr_team_files = dependencies.get_processing_inputs(
-                    descriptor="exclusions-by-instr-team"
+                    descriptor="l1b-exclusions-by-instr-team"
                 )[0]
                 pipeline_settings = dependencies.get_processing_inputs(
                     descriptor="pipeline-settings"

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 def glows_l2(
     input_dataset: xr.Dataset,
     pipeline_settings_dataset: xr.Dataset,
+    calibration_dataset: xr.Dataset,
 ) -> list[xr.Dataset]:
     """
     Will process GLOWS L2 data from L1 data.
@@ -36,6 +37,9 @@ def glows_l2(
         Input L1B dataset.
     pipeline_settings_dataset : xarray.Dataset
         Dataset containing pipeline settings from
+        GlowsAncillaryCombiner.
+    calibration_dataset : xarray.Dataset
+        Dataset containing calibration data from
         GlowsAncillaryCombiner.
 
     Returns

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -66,14 +66,14 @@ def test_glows_l2(
     )
 
     # Test case 1: L1B dataset has good times
-    l2 = glows_l2(l1b_hist_dataset, mock_pipeline_settings)[0]
+    l2 = glows_l2(l1b_hist_dataset, mock_pipeline_settings, None)[0]
     assert l2.attrs["Logical_source"] == "imap_glows_l2_hist"
     assert np.allclose(l2["filter_temperature_average"].values, [57.6], rtol=0.1)
 
     # Test case 2: L1B dataset has no good times (all flags 0)
     l1b_hist_dataset["flags"].values = np.zeros(l1b_hist_dataset.flags.shape)
     caplog.set_level("WARNING")
-    result = glows_l2(l1b_hist_dataset, mock_pipeline_settings)
+    result = glows_l2(l1b_hist_dataset, mock_pipeline_settings, None)
     assert result == []
     assert any(record.levelname == "WARNING" for record in caplog.records)
 


### PR DESCRIPTION
# Change Summary
Address the changes in #2878 to rename ancillary files used. 

This also passes the calibration file through to L2 processing to make #2886 easier.

As a note: this will not run in production without the matching changes in sds-data-manager (PR up now.)
