### PR TITLE
Fix GLOWS L2 - add per-bin zero handling for flux calculations

### DIFF
--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -63,6 +63,16 @@ def glows_l2(
     if l2.number_of_good_l1b_inputs == 0:
         logger.warning("No good data found in L1B dataset. Returning empty list.")
         return []
+    elif (
+        np.all(l2.daily_lightcurve.photon_flux == 0)
+        and np.all(l2.daily_lightcurve.flux_uncertainties == 0)
+        and np.all(l2.daily_lightcurve.exposure_times == 0)
+    ):
+        logger.warning(
+            "All photon flux, flux uncertainties, and exposure times are zero. "
+            "Returning empty list."
+        )
+        return []
     else:
         return [create_l2_dataset(l2, cdf_attrs)]
 

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -68,10 +68,7 @@ def glows_l2(
         and np.all(l2.daily_lightcurve.flux_uncertainties == 0)
         and np.all(l2.daily_lightcurve.exposure_times == 0)
     ):
-        logger.warning(
-            "All photon flux, flux uncertainties, and exposure times are zero. "
-            "Returning empty list."
-        )
+        logger.warning("All flux and exposure times are zero. Returning empty list.")
         return []
     else:
         return [create_l2_dataset(l2, cdf_attrs)]

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -106,8 +106,7 @@ class DailyLightcurve:
         self.photon_flux = np.zeros(self.number_of_bins)
         self.flux_uncertainties = np.zeros(self.number_of_bins)
 
-        # TODO: Only where exposure counts != 0
-        if len(self.exposure_times) != 0:
+        if len(self.exposure_times) != 0 and self.exposure_times[0] > 0:
             self.photon_flux = self.raw_histograms / self.exposure_times
             self.flux_uncertainties = raw_uncertainties / self.exposure_times
 

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -106,7 +106,11 @@ class DailyLightcurve:
         self.photon_flux = np.zeros(self.number_of_bins)
         self.flux_uncertainties = np.zeros(self.number_of_bins)
 
-        if len(self.exposure_times) != 0 and self.exposure_times[0] > 0:
+        if (
+            len(self.exposure_times) != 0
+            and self.exposure_times[0] > 0
+            and len(np.unique(self.exposure_times)) == 1
+        ):
             self.photon_flux = self.raw_histograms / self.exposure_times
             self.flux_uncertainties = raw_uncertainties / self.exposure_times
 

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -74,9 +74,21 @@ def test_glows_l2(
     assert np.allclose(l2["filter_temperature_average"].values, [57.6], rtol=0.1)
 
     # Test case 2: L1B dataset has no good times (all flags 0)
-    l1b_hist_dataset["flags"].values = np.zeros(l1b_hist_dataset.flags.shape)
+    l1b_hist_dataset_no_good_times = l1b_hist_dataset.copy(deep=True)
+    l1b_hist_dataset_no_good_times["flags"].values = np.zeros(
+        l1b_hist_dataset_no_good_times.flags.shape
+    )
     caplog.set_level("WARNING")
-    result = glows_l2(l1b_hist_dataset, mock_pipeline_settings, None)
+    result = glows_l2(l1b_hist_dataset_no_good_times, mock_pipeline_settings, None)
+    assert result == []
+    assert any(record.levelname == "WARNING" for record in caplog.records)
+
+    # Test case 3: Dataset has zero exposure and flux values
+    l1b_hist_dataset_zero_values = l1b_hist_dataset.copy(deep=True)
+    l1b_hist_dataset_zero_values["spin_period_average"].data[:] = 0
+    l1b_hist_dataset_zero_values["number_of_spins_per_block"].data[:] = 0
+    caplog.set_level("WARNING")
+    result = glows_l2(l1b_hist_dataset_zero_values, mock_pipeline_settings, None)
     assert result == []
     assert any(record.levelname == "WARNING" for record in caplog.records)
 

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -175,6 +175,29 @@ def test_zero_exposure_bins(l1b_dataset, mock_ecliptic_bin_centers):
     assert np.allclose(lc.exposure_times, expected_exposure)
 
 
+def test_zero_exposure_values(l1b_dataset, mock_ecliptic_bin_centers):
+    """Zero exposure yields zero flux and zero uncertainty per bin.
+
+    Note: all bins have the same exposure time, so if one is zero all are zero.
+    """
+
+    # Update values used to calculate exposure times to
+    # ensure a zero exposure result.
+    l1b_dataset["spin_period_average"].data[:] = 0
+    l1b_dataset["number_of_spins_per_block"].data[:] = 0
+
+    with np.errstate(divide="raise", invalid="raise"):
+        lc = DailyLightcurve(l1b_dataset, position_angle=0.0)
+
+    expected = np.zeros(l1b_dataset.sizes["bins"], dtype=float)
+    assert lc.exposure_times.shape == expected.shape
+    assert np.array_equal(lc.exposure_times, expected)
+    assert np.array_equal(lc.photon_flux, expected)
+    assert np.array_equal(lc.flux_uncertainties, expected)
+    assert np.all(np.isfinite(lc.photon_flux))
+    assert np.all(np.isfinite(lc.flux_uncertainties))
+
+
 def test_number_of_bins(l1b_dataset, mock_ecliptic_bin_centers):
     lc = DailyLightcurve(l1b_dataset, position_angle=0.0)
     assert lc.number_of_bins == 4

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -176,10 +176,9 @@ def test_zero_exposure_bins(l1b_dataset, mock_ecliptic_bin_centers):
 
 
 def test_zero_exposure_values(l1b_dataset, mock_ecliptic_bin_centers):
-    """Zero exposure yields zero flux and zero uncertainty per bin.
+    """Zero exposure yields zero flux and zero uncertainty per bin."""
 
-    Note: all bins have the same exposure time, so if one is zero all are zero.
-    """
+    # Note: all bins have the same exposure time, so if one is zero all are zero.
 
     # Update values used to calculate exposure times to
     # ensure a zero exposure result.
@@ -191,6 +190,7 @@ def test_zero_exposure_values(l1b_dataset, mock_ecliptic_bin_centers):
 
     expected = np.zeros(l1b_dataset.sizes["bins"], dtype=float)
     assert lc.exposure_times.shape == expected.shape
+    assert len(np.unique(lc.exposure_times)) == 1
     assert np.array_equal(lc.exposure_times, expected)
     assert np.array_equal(lc.photon_flux, expected)
     assert np.array_equal(lc.flux_uncertainties, expected)


### PR DESCRIPTION
This pull request handles zero exposure values in the `DailyLightcurve` class to prevent division by zero errors and adds a corresponding test to ensure correct behavior.

Closes #2370 
