### PR TITLE
A rotated NaN is still a NaN

### DIFF
--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -18,6 +18,8 @@ import numpy.typing as npt
 import spiceypy
 from numpy.typing import NDArray
 
+from imap_processing.mag import constants
+
 logger = logging.getLogger(__name__)
 
 
@@ -316,6 +318,10 @@ def frame_transform(
     # Multiple et single pos:  (n, 3, 3),(3, 1) -> (n, 3, 1)
     # Multiple et/positions :  (n, 3, 3),(n, 3, 1) -> (n, 3, 1)
     result = np.squeeze(rotate @ position[..., np.newaxis])
+
+    # For every FILLVAL in the input position, ensure the output is also NaN or FILLVAL
+    if np.isnan(position).any() or (position == constants.FILLVAL).any():
+        result = np.where(np.isnan(position) | (position == constants.FILLVAL), constants.FILLVAL, result)
 
     return result
 

--- a/imap_processing/spice/geometry.py
+++ b/imap_processing/spice/geometry.py
@@ -321,7 +321,11 @@ def frame_transform(
 
     # For every FILLVAL in the input position, ensure the output is also NaN or FILLVAL
     if np.isnan(position).any() or (position == constants.FILLVAL).any():
-        result = np.where(np.isnan(position) | (position == constants.FILLVAL), constants.FILLVAL, result)
+        result = np.where(
+            np.isnan(position) | (position == constants.FILLVAL),
+            constants.FILLVAL,
+            result,
+        )
 
     return result
 

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -2,6 +2,7 @@
 
 from unittest import mock
 
+from imap_processing.mag import constants
 import numpy as np
 import pytest
 import spiceypy
@@ -159,6 +160,19 @@ def test_get_spacecraft_to_instrument_spin_phase_offset(
             SpiceFrame.IMAP_SPACECRAFT,
             SpiceFrame.IMAP_DPS,
         ),
+        # single et, single NaN/FILL_VAL vector
+        (
+            ["2025-04-30T12:00:00.000"],
+            np.array(
+                [
+                    [0, 0, 0],
+                    [constants.FILLVAL, constants.FILLVAL, constants.FILLVAL],
+                    [np.nan, np.nan, np.nan]
+                ]
+                ),
+            SpiceFrame.IMAP_SPACECRAFT,
+            SpiceFrame.IMAP_DPS,
+        ),
     ],
 )
 def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_kernels):
@@ -202,6 +216,12 @@ def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_ker
             rotation_matrix = spiceypy.pxform(from_frame.name, to_frame.name, spice_et)
             spice_result = spiceypy.mxv(rotation_matrix, spice_position)
             np.testing.assert_allclose(test_result, spice_result, atol=1e-12)
+
+        # Ensure that NaN/FILL_VAL inputs are preserved exactly as FILL_VAL outputs
+        # and not just really close to but not quite FILL_VAL
+        for input_vec, output_vec in zip(position, result):
+            if np.isnan(input_vec).all() or (input_vec == constants.FILLVAL).all():
+                assert (output_vec == constants.FILLVAL).all()
 
 
 @pytest.mark.parametrize(

--- a/imap_processing/tests/spice/test_geometry.py
+++ b/imap_processing/tests/spice/test_geometry.py
@@ -2,11 +2,11 @@
 
 from unittest import mock
 
-from imap_processing.mag import constants
 import numpy as np
 import pytest
 import spiceypy
 
+from imap_processing.mag import constants
 from imap_processing.spice.geometry import (
     SpiceBody,
     SpiceFrame,
@@ -167,9 +167,9 @@ def test_get_spacecraft_to_instrument_spin_phase_offset(
                 [
                     [0, 0, 0],
                     [constants.FILLVAL, constants.FILLVAL, constants.FILLVAL],
-                    [np.nan, np.nan, np.nan]
+                    [np.nan, np.nan, np.nan],
                 ]
-                ),
+            ),
             SpiceFrame.IMAP_SPACECRAFT,
             SpiceFrame.IMAP_DPS,
         ),
@@ -219,7 +219,7 @@ def test_frame_transform(et_strings, position, from_frame, to_frame, furnish_ker
 
         # Ensure that NaN/FILL_VAL inputs are preserved exactly as FILL_VAL outputs
         # and not just really close to but not quite FILL_VAL
-        for input_vec, output_vec in zip(position, result):
+        for input_vec, output_vec in zip(position, result, strict=False):
             if np.isnan(input_vec).all() or (input_vec == constants.FILLVAL).all():
                 assert (output_vec == constants.FILLVAL).all()
 


### PR DESCRIPTION
Fix rotations outside of spice so they maintain FILL_VAL during rotation.
Before this we were introducing nearly but not quite NaN/FILL_VAL meaning very bad field data.

After this is merged and released please can the SDC regenerate new versions of  all MAG L2 BURST science (not normal - as it has no NaNs).

## Testing

Added failing unit test to repro the issue. We see this when publishing L2 science data.
