### PR TITLE
IDEX l1b handle empty event msg datasets

### DIFF
--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -117,7 +117,7 @@ class TriggerMode(Enum):
         return f"{channel.upper()}{TriggerMode(mode).name}"
 
 
-def idex_l1b(l1a_dataset: xr.Dataset, descriptor: str) -> xr.Dataset:
+def idex_l1b(l1a_dataset: xr.Dataset, descriptor: str) -> xr.Dataset | None:
     """
     Process IDEX l1a data to create l1b data products based on the descriptor.
 
@@ -142,7 +142,7 @@ def idex_l1b(l1a_dataset: xr.Dataset, descriptor: str) -> xr.Dataset:
         raise ValueError(f"Unsupported descriptor: {descriptor}")
 
 
-def idex_l1b_msg(l1a_dataset: xr.Dataset) -> xr.Dataset:
+def idex_l1b_msg(l1a_dataset: xr.Dataset) -> xr.Dataset | None:
     """
     Will process IDEX l1a msg data.
 
@@ -205,6 +205,11 @@ def idex_l1b_msg(l1a_dataset: xr.Dataset) -> xr.Dataset:
     # (either science or pulser)
     null_event = (pulser_on == 255) & (science_on == 255)
     l1b_dataset = l1b_dataset.isel(epoch=~null_event)
+    if len(l1b_dataset["epoch"]) == 0:
+        logger.warning(
+            "No science or pulser events found. No l1b dataset will be created."
+        )
+        return None
     logger.info("IDEX L1B MSG data processing completed.")
     return l1b_dataset
 

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -403,3 +403,19 @@ def test_l1b_msg_processing(decom_test_data_msg: xr.Dataset):
     expected_science_on[3] = 0
     np.testing.assert_array_equal(test_l1b_msg["pulser_on"].data, expected_pulser_on)
     np.testing.assert_array_equal(test_l1b_msg["science_on"].data, expected_science_on)
+
+
+def test_no_valid_messages(decom_test_data_msg: xr.Dataset):
+    """Verify that if there are no valid pulser and science events then no dataset is
+    returned.
+
+    Parameters
+    ----------
+    decom_test_data_msg : xr.Dataset
+        A dataset containing the MSG data produced by the l1a processing.
+    """
+    msg_ds = decom_test_data_msg.copy()
+    # Set all messages to a value that is not a valid pulser on or off event
+    msg_ds.messages[:] = "Not a science or pulser event"
+    result = idex_l1b(msg_ds, "msg")
+    assert result is None


### PR DESCRIPTION
# Change Summary

## Overview

If there are no events for l1b msg products, skip writing out a dataset. 

## File changes

imap_processing/idex/idex_l1b.py
- return None if there are no events of interest. 


## Testing
Tested this locally. 
