### PR TITLE
I-ALiRT - Hit data access

### DIFF
--- a/imap_processing/ialirt/l0/process_hit.py
+++ b/imap_processing/ialirt/l0/process_hit.py
@@ -11,7 +11,7 @@ from imap_processing.ialirt.utils.grouping import (
     find_groups,
 )
 from imap_processing.ialirt.utils.time import calculate_time
-from imap_processing.spice.time import met_to_ttj2000ns, met_to_utc
+from imap_processing.spice.time import met_to_ttj2000ns
 
 logger = logging.getLogger(__name__)
 
@@ -146,18 +146,6 @@ def process_hit(xarray_data: xr.Dataset) -> list[dict]:
     unique_groups = np.unique(grouped_data["group"])
 
     for group in unique_groups:
-        status_values = grouped_data["hit_status"][
-            (grouped_data["group"] == group).values
-        ]
-
-        if np.any(status_values == 0):
-            logger.info(
-                f"Off-nominal value detected at "
-                f"missing or duplicate pkt_counter values: "
-                f"{group}"
-            )
-            continue
-
         # Subcom values for the group should be 0-59 with no duplicates.
         subcom_values = grouped_data["hit_subcom"][
             (grouped_data["group"] == group).values
@@ -171,14 +159,6 @@ def process_hit(xarray_data: xr.Dataset) -> list[dict]:
         hit_met = int(
             grouped_data["hit_met"][(grouped_data["group"] == group).values].values[0]
         )
-
-        status_values = grouped_data["hit_status"][
-            (grouped_data["group"] == group).values
-        ]
-
-        if np.any(status_values == 0):
-            logger.info(f"Off-nominal value detected at {met_to_utc(hit_met)}")
-            continue
 
         fast_rate_1 = grouped_data["hit_fast_rate_1"][
             (grouped_data["group"] == group).values

--- a/imap_processing/ialirt/l0/process_hit.py
+++ b/imap_processing/ialirt/l0/process_hit.py
@@ -132,6 +132,7 @@ def process_hit(xarray_data: xr.Dataset) -> list[dict]:
     """
     hit_data = []
     incomplete_groups = []
+    status_groups = []
 
     # Subsecond time conversion specified in 7516-9054 GSW-FSW ICD.
     # Value of SCLK subseconds, unsigned, (LSB = 1/256 sec)
@@ -146,6 +147,13 @@ def process_hit(xarray_data: xr.Dataset) -> list[dict]:
     unique_groups = np.unique(grouped_data["group"])
 
     for group in unique_groups:
+        status_values = grouped_data["hit_status"][
+            (grouped_data["group"] == group).values
+        ]
+
+        if np.any(status_values == 0):
+            status_groups.append(group)
+
         # Subcom values for the group should be 0-59 with no duplicates.
         subcom_values = grouped_data["hit_subcom"][
             (grouped_data["group"] == group).values
@@ -206,6 +214,10 @@ def process_hit(xarray_data: xr.Dataset) -> list[dict]:
             f"The following hit groups were skipped due to "
             f"missing or duplicate pkt_counter values: "
             f"{incomplete_groups}"
+        )
+    if status_groups:
+        logger.warning(
+            f"The following hit groups have zero status values: {status_groups}"
         )
 
     return hit_data

--- a/imap_processing/tests/ialirt/unit/test_process_hit.py
+++ b/imap_processing/tests/ialirt/unit/test_process_hit.py
@@ -172,7 +172,7 @@ def test_process_hit(xarray_data, caplog):
 
     # Tests that it functions normally
     hit_product = process_hit(xarray_data)
-    assert len(hit_product) == 1
+    assert len(hit_product) == 15
 
     assert hit_product[0]["hit_e_a_side_low_en"] == 0
     assert hit_product[0]["hit_e_a_side_med_en"] == 0

--- a/imap_processing/tests/ialirt/unit/test_process_hit.py
+++ b/imap_processing/tests/ialirt/unit/test_process_hit.py
@@ -178,7 +178,7 @@ def test_process_hit(xarray_data, caplog):
     assert hit_product[0]["hit_e_a_side_med_en"] == 0
     assert hit_product[0]["hit_e_b_side_low_en"] == 0
     assert hit_product[0]["hit_e_b_side_high_en"] == 0
-    assert hit_product[0]["hit_e_b_side_med_en"] == 1
+    assert hit_product[0]["hit_e_b_side_med_en"] == 0
     assert hit_product[0]["hit_he_omni_high_en"] == 0
 
 


### PR DESCRIPTION
This pull request updates the `process_hit` function in `imap_processing/ialirt/l0/process_hit.py` to improve how hit groups with zero status values are handled and logged, and adjusts the corresponding unit test. The main changes group all hit groups with zero status values and log them together as a warning, rather than logging each occurrence individually and skipping processing. The test is updated to reflect the new behavior and expected output.

**Improvements to hit group status handling:**

* Modified `process_hit` to collect all hit groups with zero status values in a `status_groups` list and log them together as a warning at the end, instead of logging and skipping each group immediately. This change improves logging clarity and ensures all groups are processed. [[1]](diffhunk://#diff-2c68c0931ae91c5fb9d37d67976f98dab0f93ed5ac01ca869790f1a3754a0c51R135) [[2]](diffhunk://#diff-2c68c0931ae91c5fb9d37d67976f98dab0f93ed5ac01ca869790f1a3754a0c51L154-R155) [[3]](diffhunk://#diff-2c68c0931ae91c5fb9d37d67976f98dab0f93ed5ac01ca869790f1a3754a0c51R218-R221)
* Removed redundant status checks and logging for each group, simplifying the code and reducing unnecessary log output.
* Updated import statements to remove unused `met_to_utc` import, as it is no longer needed for per-group logging.

**Unit test updates:**

* Updated the `test_process_hit` unit test to expect 15 processed hits (instead of 1), and to match the new expected values for the hit product, reflecting the changes in how hit groups with zero status values are handled.