### PR TITLE
ULTRA l1b priority 1,2,3,4

### DIFF
--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -212,6 +212,54 @@ imap_ultra_l1b_90sensor-de:
     Logical_source: imap_ultra_l1b_90sensor-de
     Logical_source_description: IMAP-Ultra Instrument Level-1B Direct Event Data.
 
+imap_ultra_l1b_45sensor-priority-1-de:
+    <<: *instrument_base
+    Data_type: L1B_PRIORITY_1_DE>Level-1B Priority 1 Direct Event
+    Logical_source: imap_ultra_l1b_45sensor-priority-1-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1B Priority 1 Direct Event Data.
+
+imap_ultra_l1b_90sensor-priority-1-de:
+    <<: *instrument_base
+    Data_type: L1B_PRIORITY_1_DE>Level-1B Priority 1 Direct Event
+    Logical_source: imap_ultra_l1b_90sensor-priority-1-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1B Priority 1 Direct Event Data.
+
+imap_ultra_l1b_45sensor-priority-2-de:
+    <<: *instrument_base
+    Data_type: L1B_PRIORITY_2_DE>Level-1B Priority 2 Direct Event
+    Logical_source: imap_ultra_l1b_45sensor-priority-2-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1B Priority 2 Direct Event Data.
+
+imap_ultra_l1b_90sensor-priority-2-de:
+    <<: *instrument_base
+    Data_type: L1B_PRIORITY_2_DE>Level-1B Priority 2 Direct Event
+    Logical_source: imap_ultra_l1b_90sensor-priority-2-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1B Priority 2 Direct Event Data.
+
+imap_ultra_l1b_45sensor-priority-3-de:
+    <<: *instrument_base
+    Data_type: L1B_PRIORITY_3_DE>Level-1B Priority 3 Direct Event
+    Logical_source: imap_ultra_l1b_45sensor-priority-3-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1B Priority 3 Direct Event Data.
+
+imap_ultra_l1b_90sensor-priority-3-de:
+    <<: *instrument_base
+    Data_type: L1B_PRIORITY_3_DE>Level-1B Priority 3 Direct Event
+    Logical_source: imap_ultra_l1b_90sensor-priority-3-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1B Priority 3 Direct Event Data.
+
+imap_ultra_l1b_45sensor-priority-4-de:
+    <<: *instrument_base
+    Data_type: L1B_PRIORITY_4_DE>Level-1B Priority 4 Direct Event
+    Logical_source: imap_ultra_l1b_45sensor-priority-4-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1B Priority 4 Direct Event Data.
+
+imap_ultra_l1b_90sensor-priority-4-de:
+    <<: *instrument_base
+    Data_type: L1B_PRIORITY_4_DE>Level-1B Priority 4 Direct Event
+    Logical_source: imap_ultra_l1b_90sensor-priority-4-de
+    Logical_source_description: IMAP-Ultra Instrument Level-1B Priority 4 Direct Event Data.
+
 imap_ultra_l1b_45sensor-extendedspin:
     <<: *instrument_base
     Data_type: L1B_45Sensor-ExtendedSpin>Level-1B Extended Spin for Ultra45

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -374,3 +374,33 @@ def test_ultra_l1b_error(mock_data_l1a_rates_dict):
         ValueError, match="Data dictionary does not contain the expected keys."
     ):
         ultra_l1b(mock_data_l1a_rates_dict, ancillary_files)
+
+
+def test_ultra_l1b_priority_de(
+    mock_get_annotated_particle_velocity,
+    de_dataset,
+    aux_dataset,
+    use_fake_spin_data_for_time,
+    ancillary_files,
+    use_fake_repoint_data_for_time,
+):
+    """Tests that priority de datasets can be created"""
+    data_dict = {}
+    # Create a spin table that cover spin 0-141
+    use_fake_spin_data_for_time(443640487, 443642460)
+    # Use repoint data that will NOT cover the event times to test flag setting
+    use_fake_repoint_data_for_time(np.arange(0, +86400 * 5, 86400))
+    de_dataset.attrs["Repointing"] = "repoint00001"
+    # Set the logical source to match the priority de key
+    # Use the de dataset because it should be treated the same as the priority dataset
+    # and the priority dataset takes a long time to create.
+    data_dict["imap_ultra_l1a_45sensor-priority-1-de"] = de_dataset
+    data_dict[aux_dataset.attrs["Logical_source"]] = aux_dataset
+
+    l1b_de_dataset = ultra_l1b(data_dict, ancillary_files)
+
+    assert l1b_de_dataset[0]
+    assert (
+        l1b_de_dataset[0].attrs["Logical_source"]
+        == "imap_ultra_l1b_45sensor-priority-1-de"
+    )

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -376,6 +376,7 @@ def test_ultra_l1b_error(mock_data_l1a_rates_dict):
         ultra_l1b(mock_data_l1a_rates_dict, ancillary_files)
 
 
+@pytest.mark.external_test_data
 def test_ultra_l1b_priority_de(
     mock_get_annotated_particle_velocity,
     de_dataset,

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -235,7 +235,7 @@ def get_energy_efficiencies(ancillary_files: dict, sensor: str) -> pd.DataFrame:
         )
     else:
         lookup_table = pd.read_csv(
-            ancillary_files["l1b-45sensor-logistic-interpolation"]
+            ancillary_files["l1b-90sensor-logistic-interpolation"]
         )
 
     return lookup_table

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -235,7 +235,7 @@ def get_energy_efficiencies(ancillary_files: dict, sensor: str) -> pd.DataFrame:
         )
     else:
         lookup_table = pd.read_csv(
-            ancillary_files["l1b-90sensor-logistic-interpolation"]
+            ancillary_files["l1b-45sensor-logistic-interpolation"]
         )
 
     return lookup_table

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -50,9 +50,10 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
         if l1a_de_products:
             l1a_de_product = l1a_de_products[0]
             if len(l1a_de_products) > 1:
-                logger.warning(
-                    f"Multiple L1a de products found when we only expect"
-                    f" one. Using the first one: {l1a_de_product}"
+                raise ValueError(
+                    f"Multiple L1a de products found for instrument {instrument_id}. "
+                    f"Expected only one but found {len(l1a_de_products)}: "
+                    f"{l1a_de_products}"
                 )
             l1b_de_product = l1a_de_product.replace("l1a", "l1b")
             de_dataset = calculate_de(

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -1,11 +1,16 @@
 """Calculate ULTRA L1b."""
 
+import logging
+import re
+
 import xarray as xr
 
 from imap_processing.ultra.l1b.badtimes import calculate_badtimes
 from imap_processing.ultra.l1b.de import calculate_de
 from imap_processing.ultra.l1b.extendedspin import calculate_extendedspin
 from imap_processing.ultra.l1b.goodtimes import calculate_goodtimes
+
+logger = logging.getLogger(__name__)
 
 
 def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
@@ -32,18 +37,26 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
     3. l1b extended, goodtimes, badtimes created here
     """
     output_datasets = []
-
     # Account for possibility of having 45 and 90 in dictionary.
     for instrument_id in [45, 90]:
-        # L1b de data will be created if L1a de data is available
-        if f"imap_ultra_l1a_{instrument_id}sensor-de" in data_dict:
-            de_dataset = calculate_de(
-                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-de"],
-                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
-                f"imap_ultra_l1b_{instrument_id}sensor-de",
-                ancillary_files,
-            )
-            output_datasets.append(de_dataset)
+        # Find all DE-like products in insertion order (e.g. de, priority-1-de ...)
+        l1a_de_products = [
+            name
+            for name in data_dict.keys()
+            if re.search(rf"{instrument_id}sensor.*-de$", name)
+        ]
+        # L1b DE data will be created for every available L1a DE product,
+        # including priority DE products.
+        if l1a_de_products:
+            for l1a_de_product in l1a_de_products:
+                l1b_de_product = l1a_de_product.replace("l1a", "l1b")
+                de_dataset = calculate_de(
+                    data_dict[l1a_de_product],
+                    data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
+                    l1b_de_product,
+                    ancillary_files,
+                )
+                output_datasets.append(de_dataset)
         # L1b extended data will be created if L1a hk, rates,
         # aux, params, and l1b de data are available
         elif (

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -48,12 +48,12 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
         # L1b de data will be created if L1a de data is available
         # Including priority de products
         if l1a_de_products:
+            l1a_de_product = l1a_de_products[0]
             if len(l1a_de_products) > 1:
                 logger.warning(
                     f"Multiple L1a de products found when we only expect"
-                    f" one. Using the first one: {l1a_de_products}"
+                    f" one. Using the first one: {l1a_de_product}"
                 )
-            l1a_de_product = l1a_de_products[0]
             l1b_de_product = l1a_de_product.replace("l1a", "l1b")
             de_dataset = calculate_de(
                 data_dict[l1a_de_product],

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -43,7 +43,7 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
         l1a_de_products = [
             name
             for name in data_dict.keys()
-            if re.search(rf"{instrument_id}sensor.*-de$", name)
+            if re.search(rf"^imap_ultra_l1a_{instrument_id}sensor.*-de$", name)
         ]
         # L1b de data will be created if L1a de data is available
         # Including priority de products

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -39,24 +39,29 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
     output_datasets = []
     # Account for possibility of having 45 and 90 in dictionary.
     for instrument_id in [45, 90]:
-        # Find all DE-like products in insertion order (e.g. de, priority-1-de ...)
+        # Find any de product if it is in the data_dict
         l1a_de_products = [
             name
             for name in data_dict.keys()
             if re.search(rf"{instrument_id}sensor.*-de$", name)
         ]
-        # L1b DE data will be created for every available L1a DE product,
-        # including priority DE products.
+        # L1b de data will be created if L1a de data is available
+        # Including priority de products
         if l1a_de_products:
-            for l1a_de_product in l1a_de_products:
-                l1b_de_product = l1a_de_product.replace("l1a", "l1b")
-                de_dataset = calculate_de(
-                    data_dict[l1a_de_product],
-                    data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
-                    l1b_de_product,
-                    ancillary_files,
+            if len(l1a_de_products) > 1:
+                logger.warning(
+                    f"Multiple L1a de products found when we only expect"
+                    f" one. Using the first one: {l1a_de_products}"
                 )
-                output_datasets.append(de_dataset)
+            l1a_de_product = l1a_de_products[0]
+            l1b_de_product = l1a_de_product.replace("l1a", "l1b")
+            de_dataset = calculate_de(
+                data_dict[l1a_de_product],
+                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
+                l1b_de_product,
+                ancillary_files,
+            )
+            output_datasets.append(de_dataset)
         # L1b extended data will be created if L1a hk, rates,
         # aux, params, and l1b de data are available
         elif (

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -29,6 +29,11 @@ def ultra_l1c(
     """
     output_datasets = []
     create_helio_pset = True if "helio" in descriptor else False
+
+    # TODO
+    # Determine which l1b priority DE product to use in creating the l1c products.
+    # This will vary per-pointing by an ancillary file produced by the ULTRA team.
+
     # Account for the possibility of having 45 and 90 in the dictionary.
     for instrument_id in [45, 90]:
         if (


### PR DESCRIPTION
# Change Summary

Closes #2912

## Overview

Produce Priority 1,2,3, and 4 DE products. Eventually one of them will be used(varies by pointing) to produce the psets. 

## File changes

- imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
   - global attrs for priority l1b de products 
- imap_processing/ultra/l1b/ultra_l1b.py
   - Add handling for producing l1b de priority products. They are handled in the exact same way that raw de products are handled. 


## Testing

Test for priority product
