### PR TITLE
I-ALiRT - add dsn

### DIFF
--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -6,7 +6,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-STATIONS = ["Kiel", "UKSA"]
+STATIONS = ["Kiel", "UKSA", "tlmrelay"]
 
 
 def packets_created(start_file_creation: datetime, lines: list) -> dict:

--- a/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
+++ b/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
@@ -32,6 +32,14 @@ def test_packets_created():
             "last_data_received": [],
             "rate_kbps": [],
         },
+        "tlmrelay": {
+            "last_data_received": [
+                "2026-01-01T00:00:00Z",
+            ],
+            "rate_kbps": [
+                0.0,
+            ],
+        },
     }
 
     assert actual_output == expected


### PR DESCRIPTION
This pull request makes a small update to the list of stations in the `calculate_ingest.py` file by adding a new station.

- Added `"tlmrelay"` to the `STATIONS` list in `imap_processing/ialirt/calculate_ingest.py` to include it in processing.
