### PR TITLE
Update glows_l1b_data.py, replace glows_time_offset with imap_time_of…

### DIFF
--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -897,7 +897,6 @@ class HistogramL1B:
     def update_spice_parameters(self) -> None:
         """Update SPICE parameters based on the current state."""
         data_start_met = self.imap_start_time
-        # use of imap_start_time and glows_time_offset is correct.
         data_end_met = np.double(self.imap_start_time) + np.double(
             self.imap_time_offset
         )

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -899,7 +899,7 @@ class HistogramL1B:
         data_start_met = self.imap_start_time
         # use of imap_start_time and glows_time_offset is correct.
         data_end_met = np.double(self.imap_start_time) + np.double(
-            self.glows_time_offset
+            self.imap_time_offset
         )
         data_start_time_et = sct_to_et(met_to_sclkticks(data_start_met))
         data_end_time_et = sct_to_et(met_to_sclkticks(data_end_met))

--- a/imap_processing/tests/glows/test_glows_l1b_data.py
+++ b/imap_processing/tests/glows/test_glows_l1b_data.py
@@ -402,7 +402,7 @@ def test_update_spice_parameters_spin_axis_near_wrapping_point(
     class MockHistogram:
         def __init__(self):
             self.imap_start_time = 100.0
-            self.glows_time_offset = 5.0  # 5 second duration
+            self.imap_time_offset = 5.0  # 5 second duration
 
     mock_hist = MockHistogram()
 


### PR DESCRIPTION
glows_time_offset should be replaced here with imap_time_offset here. Both IMAP and GLOWS clock readings are included in GLOWS histogram packets, but the two clocks are separate instances and their readings should not be mixed.

# Change Summary

## Overview

One line changed to replace glows_time_offset with imap_time_offset

## File changes

This part of code sets time bounds for computations of SPICE-related variables. Two clocks readings should not be mixed here.

## Testing

<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
