### PR TITLE
I-ALiRT - check coverage

### DIFF
--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -1,10 +1,8 @@
 """Coverage time for each station."""
 
 import logging
-from pathlib import Path
 
 import numpy as np
-import pandas as pd
 
 from imap_processing.ialirt.constants import STATIONS, StationProperties
 from imap_processing.ialirt.process_ephemeris import calculate_azimuth_and_elevation
@@ -27,73 +25,8 @@ ALL_STATIONS = [
     "DSS-56",
     "DSS-74",
     "DSS-75",
+    "DSS-43",
 ]
-
-
-def parse_uksa_schedule_xlsx(xlsx_path: Path) -> list[tuple[str, str]]:
-    """
-    Parse the UKSA (GHY-6) availability sheet and return a list of contacts.
-
-    Parameters
-    ----------
-    xlsx_path : Path
-        Path to the UKSA (GHY-6) availability sheet.
-
-    Returns
-    -------
-    contacts : list[tuple[str, str]]
-        Available contacts for UKSA (GHY-6) availability sheet.
-    """
-    data = pd.read_excel(xlsx_path)
-
-    # Import start and stop times.
-    start_dt = (
-        data["Date"]
-        + pd.to_timedelta(
-            data["GHY-6 Start Availability Times  (5degrees) (UTC)"].astype(str)
-        )
-    ).to_numpy("datetime64[s]")
-
-    stop_dt = (
-        data["Date"]
-        + pd.to_timedelta(
-            data["GHY-6 Stop Availability Times  (5degrees) (UTC)"].astype(str)
-        )
-    ).to_numpy("datetime64[s]")
-
-    # Indicates whether or not setup or teardown should be taken from contact window.
-    notes = data["Short due to existing booking "].fillna("")
-
-    truncate_setup = (
-        notes.eq("Yes- setup needs to be included with the window")
-        | notes.eq("Yes- setup and teardown needs to be included with the window")
-    ).to_numpy()
-
-    truncate_teardown = (
-        notes.eq("Yes- tear down needs to be included within the window")
-        | notes.eq("Yes- setup and teardown needs to be included with the window")
-    ).to_numpy()
-
-    setup_time = data["Setup time"].iloc[0]
-    teardown_time = data["Tear down time"].iloc[0]
-
-    setup_seconds = setup_time.hour * 3600 + setup_time.minute * 60 + setup_time.second
-    teardown_seconds = (
-        teardown_time.hour * 3600 + teardown_time.minute * 60 + teardown_time.second
-    )
-
-    setup_delta = np.timedelta64(setup_seconds, "s")
-    teardown_delta = np.timedelta64(teardown_seconds, "s")
-
-    # Apply adjustments
-    start_dt[truncate_setup] += setup_delta
-    stop_dt[truncate_teardown] -= teardown_delta
-
-    # Format to strings with ms, append Z
-    start_str = np.datetime_as_string(start_dt, unit="ms")
-    stop_str = np.datetime_as_string(stop_dt, unit="ms")
-
-    return list(zip(start_str, stop_str, strict=False))
 
 
 def create_schedule_mask(

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -12,7 +12,6 @@ from imap_processing.ialirt.generate_coverage import (
     create_schedule_mask,
     format_coverage_summary,
     generate_coverage,
-    parse_uksa_schedule_xlsx,
 )
 
 
@@ -182,34 +181,3 @@ def test_create_schedule_mask(mock_et_to_utc):
     )
 
     np.testing.assert_array_equal(mask, expected)
-
-
-def test_parse_uksa_schedule_xlsx(schedule_path):
-    "Test parse_uksa_schedule_xlsx."
-
-    uksa_contacts = parse_uksa_schedule_xlsx(schedule_path)
-
-    # Verify that setup time and teardown time are properly accounted for.
-    assert uksa_contacts[1] == ("2026-01-29T14:40:00.000", "2026-01-29T16:54:26.000")
-    assert uksa_contacts[2] == ("2026-01-30T08:54:52.000", "2026-01-30T12:54:00.000")
-
-
-@pytest.mark.external_kernel
-def test_incorporate_uksa_coverage(schedule_path, furnish_kernels):
-    "Test to parse UKSA schedule."
-    kernels = [
-        "naif0012.tls",
-        "pck00011.tpc",
-        "de440s.bsp",
-        "imap_spk_demo.bsp",
-    ]
-
-    uksa_contacts = parse_uksa_schedule_xlsx(schedule_path)
-
-    with furnish_kernels(kernels):
-        coverage_dict, outage_dict = generate_coverage(
-            "2026-01-29T00:00:00Z", uksa=uksa_contacts
-        )
-
-    assert coverage_dict["UKSA"][0] == "2026-01-29T14:45:00.000"
-    assert coverage_dict["UKSA"][-1] == "2026-01-29T16:50:00.000"


### PR DESCRIPTION
This pull request removes the `parse_uksa_schedule_xlsx` function and its associated tests from the codebase, as well as some unused imports. The changes help to simplify the `generate_coverage.py` module and its test suite by eliminating code that is no longer needed.

Code cleanup and simplification:

* Removed the `parse_uksa_schedule_xlsx` function from `generate_coverage.py`, including all related logic for parsing UKSA (GHY-6) availability sheets.
* Deleted all tests related to `parse_uksa_schedule_xlsx` from the test file `test_generate_coverage.py`, including both unit tests and integration tests that used this function.
* Removed the import of `parse_uksa_schedule_xlsx` from the test file `test_generate_coverage.py`.
* Cleaned up unused imports (`Path` and `pandas as pd`) from `generate_coverage.py`.

Data update:

* Added `"DSS-43"` to the list of station names in `generate_coverage.py`.

Note: Originally this PR was intended to fix any differences between the predicted ephemeris kernel and the actual packet ingest timeframes. But after some analysis it was determined that most likely the recent predicted ephemeris is less accurate due to possible recent maneuvers.

 
  │    Date    │   Kernel era   │ Start error │ End error │
  │ 2026-03-12 │ March kernel   │ +4 min      │ -1 min    │
  │ 2026-04-04 │ od028 (Apr 3+) │ +18 min     │ -15 min   │