### PR TITLE
ULTRA priority de ancillary lookup table

### DIFF
--- a/imap_processing/tests/ultra/data/l1/imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv
+++ b/imap_processing/tests/ultra/data/l1/imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv
@@ -1,0 +1,2 @@
+repointing_id_start,repointing_id_end,de_product
+0,,imap_ultra_l1b_45sensor-de

--- a/imap_processing/tests/ultra/data/l1/imap_ultra_l1c-45sensor-de-product-lookup_20251001_v001.csv
+++ b/imap_processing/tests/ultra/data/l1/imap_ultra_l1c-45sensor-de-product-lookup_20251001_v001.csv
@@ -1,0 +1,2 @@
+repointing_id_start,repointing_id_end,de_product
+0,,imap_ultra_l1b_45sensor-de

--- a/imap_processing/tests/ultra/unit/conftest.py
+++ b/imap_processing/tests/ultra/unit/conftest.py
@@ -559,6 +559,10 @@ def ancillary_files():
         / "imap_ultra_l1c-45sensor-static-dead-times_20250101_v000.csv",
         "l1c-90sensor-static-dead-times": path
         / "imap_ultra_l1c-90sensor-static-dead-times_20250101_v000.csv",
+        "l1c-45sensor-de-product-lookup": path
+        / "imap_ultra_l1c-45sensor-de-product-lookup_20251001_v001.csv",
+        "l1c-90sensor-de-product-lookup": path
+        / "imap_ultra_l1c-45sensor-de-product-lookup_20251001_v001.csv",
     }
 
 

--- a/imap_processing/tests/ultra/unit/test_lookup_utils.py
+++ b/imap_processing/tests/ultra/unit/test_lookup_utils.py
@@ -9,6 +9,7 @@ from imap_processing.quality_flags import ImapDEOutliersUltraFlags
 from imap_processing.ultra.l1b.lookup_utils import (
     get_angular_profiles,
     get_back_position,
+    get_de_product_name,
     get_ebins,
     get_energy_efficiencies,
     get_energy_norm,
@@ -215,3 +216,80 @@ def test_get_scattering_thresholds(ancillary_files):
     assert thresholds[(8.0, 10.0)] == 8.0
     assert thresholds[(10.0, 20.0)] == 6.0
     assert thresholds[(20.0, np.inf)] == 4.0
+
+
+def test_get_de_product_name_no_repoint():
+    """Tests function get_de_product_name when the lookup is missing the repoint."""
+    ancillary_files = {
+        "l1b-45sensor-de-product-lookup": TEST_PATH
+        / "imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv"
+    }
+    with mock.patch(
+        "imap_processing.ultra.l1b.lookup_utils.pd.read_csv"
+    ) as mock_read_csv:
+        mock_read_csv.return_value = pd.DataFrame(
+            {
+                "repointing_id_start": [1, 2],
+                "repointing_id_end": [3, 4],
+                "de_product": [
+                    "imap_ultra_l1b_45sensor-de",
+                    "imap_ultra_l1b_45sensor-priority-1-de",
+                ],
+            }
+        )
+        with pytest.raises(ValueError, match="No DE product found for repoint ID 0"):
+            get_de_product_name("repoint00000", 45, "l1b", ancillary_files)
+
+
+def test_get_de_product_name_multiple_products():
+    """Tests function get_de_product_name when the lookup is ambiguous."""
+    ancillary_files = {
+        "l1b-45sensor-de-product-lookup": TEST_PATH
+        / "imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv"
+    }
+    with mock.patch(
+        "imap_processing.ultra.l1b.lookup_utils.pd.read_csv"
+    ) as mock_read_csv:
+        mock_read_csv.return_value = pd.DataFrame(
+            {
+                "repointing_id_start": [2, 2],
+                "repointing_id_end": [3, 4],
+                "de_product": [
+                    "imap_ultra_l1b_45sensor-de",
+                    "imap_ultra_l1b_45sensor-priority-1-de",
+                ],
+            }
+        )
+        with pytest.raises(ValueError, match="Multiple DE products found"):
+            get_de_product_name("repoint00002", 45, "l1b", ancillary_files)
+
+
+def test_get_de_product_name():
+    """Tests function get_de_product_name."""
+    ancillary_files = {
+        "l1b-45sensor-de-product-lookup": TEST_PATH
+        / "imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv"
+    }
+    with mock.patch(
+        "imap_processing.ultra.l1b.lookup_utils.pd.read_csv"
+    ) as mock_read_csv:
+        mock_read_csv.return_value = pd.DataFrame(
+            {
+                "repointing_id_start": [0, 2, 4],
+                "repointing_id_end": [1, 4, np.nan],
+                "de_product": [
+                    "imap_ultra_l1b_45sensor-de",
+                    "imap_ultra_l1b_45sensor-priority-1-de",
+                    "imap_ultra_l1b_45sensor-priority-2-de",
+                ],
+            }
+        )
+        # Test with a repoint in the future. Should return the priority 2 de product
+        # since the last repoint range does not have an end and should be assumed to
+        # cover all future repoints.
+        de_product = get_de_product_name("repoint00100", 45, "l1b", ancillary_files)
+        assert de_product == "imap_ultra_l1b_45sensor-priority-2-de"
+
+        # Test with valid repoint that falls in the second range.
+        de_product = get_de_product_name("repoint00003", 45, "l1b", ancillary_files)
+        assert de_product == "imap_ultra_l1b_45sensor-priority-1-de"

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b.py
@@ -227,7 +227,10 @@ def test_ultra_l1b_extendedspin(
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
     data_dict["imap_ultra_l1b_45sensor-status"] = status_dataset
 
-    ancillary_files = {}
+    ancillary_files = {
+        "l1b-45sensor-de-product-lookup": TEST_PATH
+        / "imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv"
+    }
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
 
     assert len(l1b_extendedspin_dataset) == 1
@@ -259,7 +262,10 @@ def test_cdf_extendedspin(
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
     data_dict["imap_ultra_l1b_45sensor-status"] = status_dataset
 
-    ancillary_files = {}
+    ancillary_files = {
+        "l1b-45sensor-de-product-lookup": TEST_PATH
+        / "imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv"
+    }
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
     """Tests that CDF file is created and contains same attributes as xarray."""
     l1b_extendedspin_dataset[0].attrs["Data_version"] = "999"
@@ -296,7 +302,10 @@ def test_cdf_goodtimes(
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
     data_dict["imap_ultra_l1b_45sensor-status"] = status_dataset
 
-    ancillary_files = {}
+    ancillary_files = {
+        "l1b-45sensor-de-product-lookup": TEST_PATH
+        / "imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv"
+    }
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
 
     goodtimes_dataset = ultra_l1b(
@@ -337,7 +346,10 @@ def test_cdf_badtimes(
     data_dict["imap_ultra_l1a_45sensor-rates"] = rates_dataset
     data_dict["imap_ultra_l1b_45sensor-status"] = status_dataset
 
-    ancillary_files = {}
+    ancillary_files = {
+        "l1b-45sensor-de-product-lookup": TEST_PATH
+        / "imap_ultra_l1b-45sensor-de-product-lookup_20251001_v001.csv"
+    }
     l1b_extendedspin_dataset = ultra_l1b(data_dict, ancillary_files)
 
     ancillary_files = {}

--- a/imap_processing/ultra/l1b/extendedspin.py
+++ b/imap_processing/ultra/l1b/extendedspin.py
@@ -32,6 +32,7 @@ FILLVAL_FLOAT32 = -1.0e31
 
 def calculate_extendedspin(
     dict_datasets: dict[str, xr.Dataset],
+    de_dataset: xr.Dataset,
     name: str,
     instrument_id: int,
 ) -> xr.Dataset:
@@ -42,6 +43,8 @@ def calculate_extendedspin(
     ----------
     dict_datasets : dict
         Dictionary containing all the datasets.
+    de_dataset : xarray.Dataset
+        Dataset containing the direct event data.
     name : str
         Name of the dataset.
     instrument_id : int
@@ -54,7 +57,6 @@ def calculate_extendedspin(
     """
     aux_dataset = dict_datasets[f"imap_ultra_l1a_{instrument_id}sensor-aux"]
     rates_dataset = dict_datasets[f"imap_ultra_l1a_{instrument_id}sensor-rates"]
-    de_dataset = dict_datasets[f"imap_ultra_l1b_{instrument_id}sensor-de"]
     status_dataset = dict_datasets[f"imap_ultra_l1b_{instrument_id}sensor-status"]
 
     extendedspin_dict = {}

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -638,7 +638,8 @@ def get_de_product_name(
     Parameters
     ----------
     repoint : str
-        The repointing ID in the format "repointXXX" where XXX is the repointing number.
+        The repointing ID in the format "repointXXXXX" where XXXXX is the repointing
+        number.
     sensor : int
         Sensor number, either 45 or 90.
     data_level : str
@@ -659,9 +660,7 @@ def get_de_product_name(
     # and de_product. If repointing_id_end is NaN that indicates that the de_product
     # should be used for all repoint IDs greater than or equal to repointing_id_start.
     file_name = f"{data_level}-{sensor}sensor-de-product-lookup"
-    de_lookup = pd.read_csv(
-        ancillary_files[f"{data_level}-{sensor}sensor-de-product-lookup"]
-    )
+    de_lookup = pd.read_csv(ancillary_files[file_name])
     repoint_id = int(repoint.replace("repoint", ""))
     # Filter the dataset to find where the current repoint ID falls within the
     # repointing_id_start and repointing_id_end range. OR if repointing_id_end is NaN,

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -1,5 +1,7 @@
 """Contains tools for lookup tables for l1b."""
 
+import logging
+
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -8,6 +10,8 @@ from numpy.typing import NDArray
 
 from imap_processing.quality_flags import ImapDEOutliersUltraFlags
 from imap_processing.ultra.constants import UltraConstants
+
+logger = logging.getLogger(__name__)
 
 
 def get_y_adjust(dy_lut: np.ndarray, ancillary_files: dict) -> npt.NDArray:
@@ -625,7 +629,7 @@ def get_de_product_name(
     Get the name of the de product to use for processing.
 
     This will be either the raw de product or a priority 1-4 de product, depending on
-    the pointing, data level.
+    the pointing and data level.
 
     Note: Currently the lookup tables are identical between ultra45 and ultra90,
     but this function accounts for the possibility of them being different in the
@@ -680,5 +684,8 @@ def get_de_product_name(
             f"repointing_id_start and repointing_id_end values are correct"
             f" and not overlapping."
         )
-
+    product = repoint_row["de_product"].values[0]
+    logger.info(
+        f"Using DE product {product} for repoint ID {repoint_id} based on lookup table"
+    )
     return repoint_row["de_product"].values[0]

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -235,7 +235,7 @@ def get_energy_efficiencies(ancillary_files: dict, sensor: str) -> pd.DataFrame:
         )
     else:
         lookup_table = pd.read_csv(
-            ancillary_files["l1b-45sensor-logistic-interpolation"]
+            ancillary_files["l1b-90sensor-logistic-interpolation"]
         )
 
     return lookup_table

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -616,3 +616,65 @@ def get_scattering_thresholds(ancillary_files: dict) -> dict:
     threshold_dict = {(row[0], row[1]): row[2] for row in thresholds}
 
     return threshold_dict
+
+
+def get_de_product_name(
+    repoint: str, sensor: int, data_level: str, ancillary_files: dict
+) -> str:
+    """
+    Get the name of the de product to use for processing.
+
+    This will be either the raw de product or a priority 1-4 de product, depending on
+    the pointing, data level, and sensor.
+
+    Parameters
+    ----------
+    repoint : str
+        The repointing ID in the format "repointXXX" where XXX is the repointing number.
+    sensor : int
+        Sensor number, either 45 or 90.
+    data_level : str
+        Data level, either "l1b" or "l1c".
+    ancillary_files : dict
+            Ancillary files containing the lookup tables to determine which DE product
+            to use based on the repointing ID.
+
+    Returns
+    -------
+    de_product_name : str
+        Name of the de product to use in calculating the extended spin dataset.
+    """
+    if data_level not in ["l1b", "l1c"]:
+        raise ValueError(f"Invalid data level: {data_level}. Must be 'l1b' or 'l1c'.")
+    # load the lookup table.
+    # The lookup table will have columns for repointing_id_start, repointing_id_end,
+    # and de_product. If repointing_id_end is NaN that indicates that the de_product
+    # should be used for all repoint IDs greater than or equal to repointing_id_start.
+    file_name = f"{data_level}-{sensor}sensor-de-product-lookup"
+    de_lookup = pd.read_csv(
+        ancillary_files[f"{data_level}-{sensor}sensor-de-product-lookup"]
+    )
+    repoint_id = int(repoint.replace("repoint", ""))
+    # Filter the dataset to find where the current repoint ID falls within the
+    # repointing_id_start and repointing_id_end range. OR if repointing_id_end is NaN,
+    # then just check if repoint_id is greater than or equal to repointing_id_start
+    repoint_row = de_lookup[
+        (de_lookup["repointing_id_start"] <= repoint_id)
+        & (
+            (de_lookup["repointing_id_end"] > repoint_id)
+            | (pd.isna(de_lookup["repointing_id_end"]))
+        )
+    ]
+    if repoint_row.empty:
+        raise ValueError(
+            f"No DE product found for repoint ID {repoint_id} in {file_name}"
+        )
+    if len(repoint_row) > 1:
+        raise ValueError(
+            f"Multiple DE products found for repoint ID {repoint_id} using "
+            f"ancillary file {file_name}. Check that the "
+            f"repointing_id_start and repointing_id_end values are correct"
+            f" and not overlapping."
+        )
+
+    return repoint_row["de_product"].values[0]

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -235,7 +235,7 @@ def get_energy_efficiencies(ancillary_files: dict, sensor: str) -> pd.DataFrame:
         )
     else:
         lookup_table = pd.read_csv(
-            ancillary_files["l1b-90sensor-logistic-interpolation"]
+            ancillary_files["l1b-45sensor-logistic-interpolation"]
         )
 
     return lookup_table

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -625,7 +625,11 @@ def get_de_product_name(
     Get the name of the de product to use for processing.
 
     This will be either the raw de product or a priority 1-4 de product, depending on
-    the pointing, data level, and sensor.
+    the pointing, data level.
+
+    Note: Currently the lookup tables are identical between ultra45 and ultra90,
+    but this function accounts for the possibility of them being different in the
+    future.
 
     Parameters
     ----------

--- a/imap_processing/ultra/l1b/lookup_utils.py
+++ b/imap_processing/ultra/l1b/lookup_utils.py
@@ -650,7 +650,7 @@ def get_de_product_name(
     Returns
     -------
     de_product_name : str
-        Name of the de product to use in calculating the extended spin dataset.
+        Name of the de product to use for processing.
     """
     if data_level not in ["l1b", "l1c"]:
         raise ValueError(f"Invalid data level: {data_level}. Must be 'l1b' or 'l1c'.")
@@ -688,4 +688,4 @@ def get_de_product_name(
     logger.info(
         f"Using DE product {product} for repoint ID {repoint_id} based on lookup table"
     )
-    return repoint_row["de_product"].values[0]
+    return product

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -50,9 +50,10 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
         if l1a_de_products:
             l1a_de_product = l1a_de_products[0]
             if len(l1a_de_products) > 1:
-                logger.warning(
-                    f"Multiple L1a de products found when we only expect"
-                    f" one. Using the first one: {l1a_de_product}"
+                raise ValueError(
+                    f"Multiple L1a de products found for instrument {instrument_id}. "
+                    f"Expected only one but found {len(l1a_de_products)}: "
+                    f"{l1a_de_products}"
                 )
             l1b_de_product = l1a_de_product.replace("l1a", "l1b")
             de_dataset = calculate_de(

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -95,11 +95,11 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
                     f"imap_ultra_l1a_{instrument_id}sensor-rates": data_dict[
                         f"imap_ultra_l1a_{instrument_id}sensor-rates"
                     ],
-                    de_product_desc: data_dict[de_product_desc],
                     f"imap_ultra_l1b_{instrument_id}sensor-status": data_dict[
                         f"imap_ultra_l1b_{instrument_id}sensor-status"
                     ],
                 },
+                data_dict[de_product_desc],
                 f"imap_ultra_l1b_{instrument_id}sensor-extendedspin",
                 instrument_id,
             )

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -84,6 +84,12 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
             de_product_desc = get_de_product_name(
                 repoint, instrument_id, "l1b", ancillary_files
             )
+            if de_product_desc not in data_dict:
+                raise ValueError(
+                    f"Selected L1B DE product '{de_product_desc}' for instrument "
+                    f"{instrument_id} is not present in data_dict. Available L1B DE "
+                    f"products: {data_dict.keys()}"
+                )
             extendedspin_dataset = calculate_extendedspin(
                 {
                     f"imap_ultra_l1a_{instrument_id}sensor-aux": data_dict[

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -9,6 +9,7 @@ from imap_processing.ultra.l1b.badtimes import calculate_badtimes
 from imap_processing.ultra.l1b.de import calculate_de
 from imap_processing.ultra.l1b.extendedspin import calculate_extendedspin
 from imap_processing.ultra.l1b.goodtimes import calculate_goodtimes
+from imap_processing.ultra.l1b.lookup_utils import get_de_product_name
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,17 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
             and f"imap_ultra_l1a_{instrument_id}sensor-params" in data_dict
             and f"imap_ultra_l1b_{instrument_id}sensor-status" in data_dict
         ):
+            # get repoint number
+            repoint = data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"].attrs.get(
+                "Repointing", None
+            )
+            if repoint is None:
+                raise ValueError("Repointing ID attribute is missing from the dataset.")
+            # Determine which l1b de product to use in calculating the goodtimes
+            # Will be either the raw de product or a priority 1-4 de product.
+            de_product_desc = get_de_product_name(
+                repoint, instrument_id, "l1b", ancillary_files
+            )
             extendedspin_dataset = calculate_extendedspin(
                 {
                     f"imap_ultra_l1a_{instrument_id}sensor-aux": data_dict[
@@ -83,9 +95,7 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
                     f"imap_ultra_l1a_{instrument_id}sensor-rates": data_dict[
                         f"imap_ultra_l1a_{instrument_id}sensor-rates"
                     ],
-                    f"imap_ultra_l1b_{instrument_id}sensor-de": data_dict[
-                        f"imap_ultra_l1b_{instrument_id}sensor-de"
-                    ],
+                    de_product_desc: data_dict[de_product_desc],
                     f"imap_ultra_l1b_{instrument_id}sensor-status": data_dict[
                         f"imap_ultra_l1b_{instrument_id}sensor-status"
                     ],

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -48,12 +48,12 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
         # L1b de data will be created if L1a de data is available
         # Including priority de products
         if l1a_de_products:
+            l1a_de_product = l1a_de_products[0]
             if len(l1a_de_products) > 1:
                 logger.warning(
                     f"Multiple L1a de products found when we only expect"
-                    f" one. Using the first one: {l1a_de_products}"
+                    f" one. Using the first one: {l1a_de_product}"
                 )
-            l1a_de_product = l1a_de_products[0]
             l1b_de_product = l1a_de_product.replace("l1a", "l1b")
             de_dataset = calculate_de(
                 data_dict[l1a_de_product],

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -43,7 +43,7 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
         l1a_de_products = [
             name
             for name in data_dict.keys()
-            if re.search(rf"{instrument_id}sensor.*-de$", name)
+            if re.search(rf"^imap_ultra_l1a_{instrument_id}sensor.*-de$", name)
         ]
         # L1b de data will be created if L1a de data is available
         # Including priority de products

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -39,24 +39,29 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
     output_datasets = []
     # Account for possibility of having 45 and 90 in dictionary.
     for instrument_id in [45, 90]:
-        # Find all DE-like products in insertion order (e.g. de, priority-1-de ...)
+        # Find any de product if it is in the data_dict
         l1a_de_products = [
             name
             for name in data_dict.keys()
             if re.search(rf"{instrument_id}sensor.*-de$", name)
         ]
-        # L1b DE data will be created for every available L1a DE product,
-        # including priority DE products.
+        # L1b de data will be created if L1a de data is available
+        # Including priority de products
         if l1a_de_products:
-            for l1a_de_product in l1a_de_products:
-                l1b_de_product = l1a_de_product.replace("l1a", "l1b")
-                de_dataset = calculate_de(
-                    data_dict[l1a_de_product],
-                    data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
-                    l1b_de_product,
-                    ancillary_files,
+            if len(l1a_de_products) > 1:
+                logger.warning(
+                    f"Multiple L1a de products found when we only expect"
+                    f" one. Using the first one: {l1a_de_products}"
                 )
-                output_datasets.append(de_dataset)
+            l1a_de_product = l1a_de_products[0]
+            l1b_de_product = l1a_de_product.replace("l1a", "l1b")
+            de_dataset = calculate_de(
+                data_dict[l1a_de_product],
+                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
+                l1b_de_product,
+                ancillary_files,
+            )
+            output_datasets.append(de_dataset)
         # L1b extended data will be created if L1a hk, rates,
         # aux, params, and l1b de data are available
         elif (

--- a/imap_processing/ultra/l1b/ultra_l1b.py
+++ b/imap_processing/ultra/l1b/ultra_l1b.py
@@ -39,30 +39,24 @@ def ultra_l1b(data_dict: dict, ancillary_files: dict) -> list[xr.Dataset]:
     output_datasets = []
     # Account for possibility of having 45 and 90 in dictionary.
     for instrument_id in [45, 90]:
-        # Find any de product if it is in the data_dict
+        # Find all DE-like products in insertion order (e.g. de, priority-1-de ...)
         l1a_de_products = [
             name
             for name in data_dict.keys()
-            if re.search(rf"^imap_ultra_l1a_{instrument_id}sensor.*-de$", name)
+            if re.search(rf"{instrument_id}sensor.*-de$", name)
         ]
-        # L1b de data will be created if L1a de data is available
-        # Including priority de products
+        # L1b DE data will be created for every available L1a DE product,
+        # including priority DE products.
         if l1a_de_products:
-            l1a_de_product = l1a_de_products[0]
-            if len(l1a_de_products) > 1:
-                raise ValueError(
-                    f"Multiple L1a de products found for instrument {instrument_id}. "
-                    f"Expected only one but found {len(l1a_de_products)}: "
-                    f"{l1a_de_products}"
+            for l1a_de_product in l1a_de_products:
+                l1b_de_product = l1a_de_product.replace("l1a", "l1b")
+                de_dataset = calculate_de(
+                    data_dict[l1a_de_product],
+                    data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
+                    l1b_de_product,
+                    ancillary_files,
                 )
-            l1b_de_product = l1a_de_product.replace("l1a", "l1b")
-            de_dataset = calculate_de(
-                data_dict[l1a_de_product],
-                data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
-                l1b_de_product,
-                ancillary_files,
-            )
-            output_datasets.append(de_dataset)
+                output_datasets.append(de_dataset)
         # L1b extended data will be created if L1a hk, rates,
         # aux, params, and l1b de data are available
         elif (

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -3,6 +3,7 @@
 import xarray as xr
 
 from imap_processing.ultra.constants import UltraConstants
+from imap_processing.ultra.l1b.lookup_utils import get_de_product_name
 from imap_processing.ultra.l1c.helio_pset import calculate_helio_pset
 from imap_processing.ultra.l1c.spacecraft_pset import calculate_spacecraft_pset
 
@@ -36,15 +37,32 @@ def ultra_l1c(
 
     # Account for the possibility of having 45 and 90 in the dictionary.
     for instrument_id in [45, 90]:
+        # All l1c products require a l1b de dependency so check that first
+        # and calculate the correct l1b de product to use based on the repointing ID
+        # and ancillary files.
+        if f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict:
+            # get repoint number
+            repoint = data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"].attrs.get(
+                "Repointing", None
+            )
+            if repoint is None:
+                raise ValueError("Repointing ID attribute is missing from the dataset.")
+            # Determine which l1b de product to use in calculating the l1c products.
+            # Will be either the raw de product or a priority 1-4 de product.
+            de_product_desc = get_de_product_name(
+                repoint, instrument_id, "l1c", ancillary_files
+            )
+        else:
+            continue
         if (
             f"imap_ultra_l1b_{instrument_id}sensor-goodtimes" in data_dict
-            and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
+            and de_product_desc in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
             and create_helio_pset
         ):
             helio_pset = calculate_helio_pset(
-                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
+                data_dict[de_product_desc],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-goodtimes"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
@@ -56,12 +74,12 @@ def ultra_l1c(
             output_datasets = [helio_pset]
         elif (
             f"imap_ultra_l1b_{instrument_id}sensor-goodtimes" in data_dict
-            and f"imap_ultra_l1b_{instrument_id}sensor-de" in data_dict
+            and de_product_desc in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-rates" in data_dict
             and f"imap_ultra_l1a_{instrument_id}sensor-aux" in data_dict
         ):
             spacecraft_pset = calculate_spacecraft_pset(
-                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
+                data_dict[de_product_desc],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-goodtimes"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],
@@ -72,7 +90,7 @@ def ultra_l1c(
             )
             output_datasets = [spacecraft_pset]
             spacecraft_pset_non_proton = calculate_spacecraft_pset(
-                data_dict[f"imap_ultra_l1b_{instrument_id}sensor-de"],
+                data_dict[de_product_desc],
                 data_dict[f"imap_ultra_l1b_{instrument_id}sensor-goodtimes"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-rates"],
                 data_dict[f"imap_ultra_l1a_{instrument_id}sensor-aux"],

--- a/imap_processing/ultra/l1c/ultra_l1c.py
+++ b/imap_processing/ultra/l1c/ultra_l1c.py
@@ -52,6 +52,12 @@ def ultra_l1c(
             de_product_desc = get_de_product_name(
                 repoint, instrument_id, "l1c", ancillary_files
             )
+            if de_product_desc not in data_dict:
+                raise ValueError(
+                    f"Selected L1B DE product '{de_product_desc}' for instrument "
+                    f"{instrument_id} is not present in data_dict. Available L1B DE "
+                    f"products: {data_dict.keys()}"
+                )
         else:
             continue
         if (


### PR DESCRIPTION
# Change Summary

## Overview

Add logic to read in an ancillary file at l1b and l1c. This table is used to determine which de product to use in the goodtimes algorithm and for psets.


## File changes

- imap_processing/ultra/l1b/lookup_utils.py 
  - function to determine which l1b product to use. 
- imap_processing/ultra/l1b/ultra_l1b.py and imap_processing/ultra/l1c/ultra_l1c.py
  - call function and carry through the correct l1b file


## Testing
Add tests to ensure the correct product is chosen. 
