### PR TITLE
Fix Lo L2 processing pointing set midpoint_j2000_et calculation

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -804,8 +804,8 @@ class LoPointingSet(LoHiBasePointingSet):
             The midpoint value [J2000 ET] of the pointing set.
         """
         epoch_delta = met_to_ttj2000ns(
-            self.data["pointing_end_met"].data - self.data["pointing_start_met"].data
-        )
+            self.data["pointing_end_met"].data
+        ) - met_to_ttj2000ns(self.data["pointing_start_met"].data)
         return float(ttj2000ns_to_et(self.epoch + epoch_delta / 2))
 
 

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -307,8 +307,9 @@ class TestLoPointingSet:
         # check that the midpoint_j2000_et property is equal to the expected value
         assert lo_pset.midpoint_j2000_et == ttj2000ns_to_et(
             lo_pset.epoch
-            + met_to_ttj2000ns(
-                lo_pset_ds.pointing_end_met - lo_pset_ds.pointing_start_met
+            + (
+                met_to_ttj2000ns(lo_pset_ds.pointing_end_met)
+                - met_to_ttj2000ns(lo_pset_ds.pointing_start_met)
             )
             / 2
         )


### PR DESCRIPTION
# Change Summary

## Overview
A recent change to how the L2 ENA maps are produced means the middle time of the pointing set is used when projecting pointing set values to the SkyMap object. The middle time of the Lo pointing set was being computed incorrectly before this change. However, there are no noticeable issues when producing L2 maps with this incorrect computation, because no projection is needed when producing Lo maps in IMAP_HAE since the IMAP_HAE coords are already known by the pset.

However, because the mapping tool can generate maps in other frames (non HAE), it is possible the incorrect computation of the time used to project the pset into the skymap could cause issues in this case.

## File changes
imap_processing/ena_maps/ena_maps.py
 - Fixed LoPointingSet.midpoint_j2000_et calculation by converting `pointing_end_met` and `pointing_start_met` to ttj2000ns before performing subtraction to compute the `epoch_delta`
