### PR TITLE
GLOWS - bugfix

### DIFF
--- a/imap_processing/glows/l1a/glows_l1a.py
+++ b/imap_processing/glows/l1a/glows_l1a.py
@@ -136,7 +136,7 @@ def process_de_l0(
             l1a_output.append(first_de)
 
     # Filter out DE records with no direct_events (incomplete packet sequences)
-    l1a_output = [de for de in l1a_output if de.direct_events is not None]
+    l1a_output = [de for de in l1a_output if de.direct_events]
 
     return l1a_output
 

--- a/imap_processing/glows/l1a/glows_l1a_data.py
+++ b/imap_processing/glows/l1a/glows_l1a_data.py
@@ -441,6 +441,16 @@ class DirectEventL1A:
             An array containing DirectEvent objects.
         """
         # read the first direct event, which is always uncompressed
+
+        if len(direct_events) < 8:
+            print(direct_events)
+            logger.warning(
+                "GLOWS: Direct event data is too short to contain any events "
+                f"(got {len(direct_events)} bytes, need at least 8). "
+                "Returning empty event list."
+            )
+            return []
+        print(direct_events[:8])
         current_event = self._build_uncompressed_event(direct_events[:8])
         processed_events = [current_event]
 

--- a/imap_processing/glows/l1a/glows_l1a_data.py
+++ b/imap_processing/glows/l1a/glows_l1a_data.py
@@ -443,14 +443,12 @@ class DirectEventL1A:
         # read the first direct event, which is always uncompressed
 
         if len(direct_events) < 8:
-            print(direct_events)
             logger.warning(
                 "GLOWS: Direct event data is too short to contain any events "
                 f"(got {len(direct_events)} bytes, need at least 8). "
                 "Returning empty event list."
             )
             return []
-        print(direct_events[:8])
         current_event = self._build_uncompressed_event(direct_events[:8])
         processed_events = [current_event]
 

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -277,5 +277,6 @@ EXTERNAL_TEST_DATA = [
     ("swe_l0_unpacked-data_20240510_v001_VALIDATION_L2_bins_v0H_14_6.dat", "swe/l2_validation/"),
 
     # GLOWS
-    ("combined_de_l1a.csv", "glows/validation_data")
+    ("combined_de_l1a.csv", "glows/validation_data"),
+    ("imap_glows_l0_raw_20260202-repoint00145_v001.pkts", "glows/validation_data"),
 ]  # fmt: skip

--- a/imap_processing/tests/glows/conftest.py
+++ b/imap_processing/tests/glows/conftest.py
@@ -23,6 +23,16 @@ def packet_path():
 
 
 @pytest.fixture
+def repoint_packet_path():
+    current_directory = Path(__file__).parent
+    return (
+        current_directory
+        / "validation_data"
+        / "imap_glows_l0_raw_20260202-repoint00145_v001.pkts"
+    )
+
+
+@pytest.fixture
 def decom_test_data(packet_path):
     """Read test data from file"""
 

--- a/imap_processing/tests/glows/test_glows_l1a_data.py
+++ b/imap_processing/tests/glows/test_glows_l1a_data.py
@@ -591,6 +591,7 @@ def test_glows_l1a_no_packet_data(decom_packets_mock):
     assert output == []
 
 
+@pytest.mark.external_test_data
 def test_glows_l1a_empty_de_packet(repoint_packet_path):
     """Test that L1A processing handles packets with no direct event data."""
     result = glows_l1a(repoint_packet_path)

--- a/imap_processing/tests/glows/test_glows_l1a_data.py
+++ b/imap_processing/tests/glows/test_glows_l1a_data.py
@@ -589,3 +589,10 @@ def test_glows_l1a_no_packet_data(decom_packets_mock):
     decom_packets_mock.return_value = ([], [])
     output = glows_l1a("fake/filepath/packets.bin")
     assert output == []
+
+
+def test_glows_l1a_empty_de_packet(repoint_packet_path):
+    """Test that L1A processing handles packets with no direct event data."""
+    result = glows_l1a(repoint_packet_path)
+
+    assert len(result) == 2


### PR DESCRIPTION
This pull request improves the robustness of the GLOWS L1A data processing pipeline and enhances test coverage, particularly for handling packets with missing or insufficient direct event data. The changes include stricter filtering of incomplete records, improved logging and debugging output, the addition of new test data and fixtures, and a new test case for empty direct event packets.

**Improvements to GLOWS L1A data handling:**
* The filter for DE records now excludes records with empty `direct_events` lists, not just `None`, ensuring only complete records are processed.
* In `_generate_direct_events`, added a check for insufficient direct event data (<8 bytes), with logging and early return to prevent errors and aid debugging.

**Test data and coverage enhancements:**
* Added a new test data file (`imap_glows_l0_raw_20260202-repoint00145_v001.pkts`) to the external test data configuration for more comprehensive validation.
* Introduced a new pytest fixture `repoint_packet_path` to provide access to the new test data file.
* Added a test case `test_glows_l1a_empty_de_packet` to verify that L1A processing correctly handles packets with no direct event data.
