### PR TITLE
I-ALiRT - update HIT description

### DIFF
--- a/imap_processing/cdf/config/imap_ialirt_l1_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ialirt_l1_variable_attrs.yaml
@@ -348,18 +348,18 @@ hit_e_a_side_low_en:
   FIELDNAM: Low energy electron count rate (A-side)
   LABLAXIS: A-side e- >0.5 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   VAR_NOTES: A-side indicates the HIT aperture that is nominally looking in the anti-sunward direction. B-side indicates the aperture looking nominally in the sunward direction.
 
 hit_e_a_side_med_en:
   <<: *default_float32
-  CATDESC: Count rates from HIT for electrons below 1 MeV, A-side aperture (anti-sunward) look direction
+  CATDESC: Counts from HIT for electrons below 1 MeV, A-side aperture (sunward directed particles) look direction
   FIELDNAM: Medium energy electron count rate (A-side)
   LABLAXIS: A-side e- <1 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   FORMAT: F17.6
@@ -371,7 +371,7 @@ hit_e_a_side_high_en:
   FIELDNAM: High energy electron count rate (A-side)
   LABLAXIS: A-side e- >3 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   VAR_NOTES: A-side indicates the HIT aperture that is nominally looking in the anti-sunward direction. B-side indicates the aperture looking nominally in the sunward direction.
@@ -382,18 +382,18 @@ hit_e_b_side_low_en:
   FIELDNAM: Low energy electron count rate (B-side)
   LABLAXIS: B-side e- >0.5 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   VAR_NOTES: A-side indicates the HIT aperture that is nominally looking in the anti-sunward direction. B-side indicates the aperture looking nominally in the sunward direction.
 
 hit_e_b_side_med_en:
   <<: *default_float32
-  CATDESC: Count rates from HIT for electrons below 1 MeV, B-side aperture (sunward) look direction
+  CATDESC: Counts from HIT for electrons below 1 MeV, B-side aperture (anti-sunward directed particles) look direction
   FIELDNAM: Medium energy electron count rate (B-side)
   LABLAXIS: B-side e- <1 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   FORMAT: F17.6
@@ -405,18 +405,18 @@ hit_e_b_side_high_en:
   FIELDNAM: High energy electron count rate (B-side)
   LABLAXIS: B-side e- >3 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   VAR_NOTES: A-side indicates the HIT aperture that is nominally looking in the anti-sunward direction. B-side indicates the aperture looking nominally in the sunward direction.
 
 hit_h_omni_low_en:
   <<: *default_float32
-  CATDESC: Count rates from HIT for protons between 6 to 8 MeV, omnidirectional (sum of particles divided by full sky area)
+  CATDESC: Counts from HIT for protons between 6 to 8 MeV, omnidirectional
   FIELDNAM: Proton count rate 6 to 8 MeV (omni)
   LABLAXIS: Omni H+ 6 to 8 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   FORMAT: F17.6
@@ -424,11 +424,11 @@ hit_h_omni_low_en:
 
 hit_h_omni_med_en:
   <<: *default_float32
-  CATDESC: Count rates from HIT for protons between 12 to 15 MeV, omnidirectional (sum of particles divided by full sky area)
+  CATDESC: Counts from HIT for protons between 12 to 15 MeV, omnidirectional
   FIELDNAM: Proton count rate 12 to 15 MeV (omni)
   LABLAXIS: Omni H+ 12 to 15 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   FORMAT: F17.6
@@ -440,7 +440,7 @@ hit_h_a_side_high_en:
   FIELDNAM: Proton count rate >70 MeV (A-side)
   LABLAXIS: A-side H >70 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   VAR_NOTES: A-side indicates the HIT aperture that is nominally looking in the anti-sunward direction. B-side indicates the aperture looking nominally in the sunward direction.
@@ -451,18 +451,18 @@ hit_h_b_side_high_en:
   FIELDNAM: Proton count rate >70 MeV (B-side)
   LABLAXIS: B-side H >70 MeV
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   VAR_NOTES: A-side indicates the HIT aperture that is nominally looking in the anti-sunward direction. B-side indicates the aperture looking nominally in the sunward direction.
 
 hit_he_omni_low_en:
   <<: *default_float32
-  CATDESC: Count rates from HIT for He4 between 6 to 8 MeV/nuc, omnidirectional (sum of particles divided by full sky area)
+  CATDESC: Counts from HIT for He4 between 6 to 8 MeV/nuc, omnidirectional
   FIELDNAM: Helium count rate 6 to 8 MeV/nuc (omni)
   LABLAXIS: Omni He 6 to 8 MeV/nuc
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   FORMAT: F17.6
@@ -470,11 +470,11 @@ hit_he_omni_low_en:
 
 hit_he_omni_high_en:
   <<: *default_float32
-  CATDESC: Count rates from HIT for He4 between 15 to 70 MeV/nuc, omnidirectional (sum of particles divided by full sky area)
+  CATDESC: Counts from HIT for He4 between 15 to 70 MeV/nuc, omnidirectional
   FIELDNAM: Helium count rate 15 to 70 MeV/nuc (omni)
   LABLAXIS: Omni He 15 to 70 MeV/nuc
   DEPEND_0: hit_epoch
-  UNITS: counts per second
+  UNITS: counts
   VALIDMIN: 0
   VALIDMAX: 1000000000.0
   FORMAT: F17.6


### PR DESCRIPTION
This pull request updates the variable attribute configuration in `imap_ialirt_l1_variable_attrs.yaml` to standardize units and clarify descriptions for HIT instrument data. The main changes involve switching the `UNITS` field from "counts per second" to "counts" for several variables, and updating some `CATDESC` descriptions to better reflect the data and look direction.

**Units standardization:**
* Changed `UNITS` from "counts per second" to "counts" for all electron, proton, and helium variables to accurately represent the data as total counts rather than rates. [[1]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L351-R362) [[2]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L374-R374) [[3]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L385-R396) [[4]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L408-R431) [[5]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L443-R443) [[6]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L454-R477)

**Description clarifications:**
* Updated `CATDESC` for electron variables to clarify look direction and particle orientation (e.g., distinguishing between sunward and anti-sunward directions). [[1]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L351-R362) [[2]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L385-R396)
* Revised `CATDESC` for proton and helium omni-directional variables to remove references to "sum of particles divided by full sky area" and clarify that the value represents counts. [[1]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L408-R431) [[2]](diffhunk://#diff-8b5235995e3c4babb95560a117ece949fa119058525ac3e6b09da2701a3982d7L454-R477)
