### PR TITLE
ULTRA l2 map duration descriptor 

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -726,13 +726,15 @@ class TestUltraL2:
         with furnish_kernels(self.required_kernel_names):
             output_map = ultra_l2.ultra_l2(
                 data_dict=mock_data_dict,
-                descriptor="u90-ena-h-sf-nsp-full-hae-nside32-6mo",
+                descriptor="u90-ena-h-sf-nsp-full-hae-nside32-3mo",
             )[0]
 
         assert "spacecraft frame" in output_map.attrs["Logical_source_description"]
+        # Check that the logical source contains the expected information from the
+        # descriptor string
         assert (
             output_map.attrs["Logical_source"]
-            == "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-nside32-6mo"
+            == "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-nside32-3mo"
         )
         assert output_map.attrs["Spice_reference_frame"] == "IMAP_HAE"
         assert output_map.attrs["HEALPix_nside"] == "32"

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -620,6 +620,7 @@ def ultra_l2(
         Wrapped in a list for consistency with other product levels.
     """
     inertial_frame = "unknown"
+    descriptor_duration: str | None = None
     if descriptor is not None:
         logger.info(
             f"Using the provided descriptor '{descriptor}' to set the map structure."
@@ -628,6 +629,8 @@ def ultra_l2(
         map_descriptor = MapDescriptor.from_string(descriptor)
         output_map_structure = map_descriptor.to_empty_map()
         inertial_frame = map_descriptor.frame_descriptor
+        # Keep descriptor duration token for output naming metadata.
+        descriptor_duration = str(map_descriptor.duration)
     inertial_frame_long_name = INERTIAL_FRAME_LONG_NAMES.get(inertial_frame, "unknown")
 
     # Object which holds CDF attributes for the map
@@ -667,9 +670,13 @@ def ultra_l2(
     # TODO: replace 1 day in ns below with the actual end time of the last PSET.
     # Currently assumes the end time of the last PSET is 1 day after its start.
     map_duration_ns = (pset_epochs.max() + (86400 * 1e9)) - pset_epochs.min()
-    map_duration_months_int = ns_to_duration_months(map_duration_ns)
-    map_duration = f"{map_duration_months_int}mo"
-
+    # Use the duration from the descriptor if it is provided, otherwise use the
+    # calculated duration from the PSET epochs.
+    if descriptor_duration is None:
+        map_duration_months_int = ns_to_duration_months(map_duration_ns)
+        map_duration = f"{map_duration_months_int}mo"
+    else:
+        map_duration = descriptor_duration
     # Always add the common (non-tiling specific) attributes to the attr handler.
     # These can be updated/overwritten by the tiling specific attributes.
     cdf_attrs.add_instrument_variable_attrs(instrument="enamaps", level="l2-common")

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -629,7 +629,6 @@ def ultra_l2(
         map_descriptor = MapDescriptor.from_string(descriptor)
         output_map_structure = map_descriptor.to_empty_map()
         inertial_frame = map_descriptor.frame_descriptor
-        # Keep descriptor duration token for output naming metadata.
         descriptor_duration = str(map_descriptor.duration)
     inertial_frame_long_name = INERTIAL_FRAME_LONG_NAMES.get(inertial_frame, "unknown")
 


### PR DESCRIPTION
# Change Summary

closes #3019

## Overview

Pass the cadence label from the input job descriptor to the output map descriptor. ULTRA code was recalculating the cadence label (e.g. 3mo, 6mo ect.) based on the actual psets passed into the job. This can cause unintended consequences (see linked issue). 

This is updating the ULTRA code to follow what Hi and Lo are doing. 

## File changes

imap_processing/ultra/l2/ultra_l2.py
  - pass the duration label along from the input desc.

## Testing

Update the input descriptor in the test to check that the output contains the same descriptor. 