### PR TITLE
Glows L1b - Fix spin angle offset calculation in histogram flags

### DIFF
--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -1086,7 +1086,7 @@ class HistogramL1B:
         # Rotate spin-angle bin centers by the instrument position-angle offset
         # so azimuth=0 aligns with the instrument pointing direction.
         azimuth = (
-            self.imap_spin_angle_bin_cntr + self.position_angle_offset_average
+            self.imap_spin_angle_bin_cntr - self.position_angle_offset_average
         ) % 360.0
         # Ephemeris start time of the histogram accumulation.
         data_start_time_et = sct_to_et(met_to_sclkticks(self.imap_start_time))

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -1067,6 +1067,43 @@ class HistogramL1B:
 
         return np.concatenate([onboard_flags, ground_flags])
 
+    @staticmethod
+    def calculate_look_vectors_dps(
+        imap_spin_angle_bin_cntr: np.ndarray, position_angle_offset_average: np.double
+    ) -> np.ndarray:
+        """
+        Calculate the look direction vectors in DPS frame for a histogramming block.
+
+        Parameters
+        ----------
+        imap_spin_angle_bin_cntr : numpy.ndarray
+            Array of shape (3600) representing the centers of the spin angle bins.
+        position_angle_offset_average : float
+            Effective offset angle defined in section 10.6 of the algorithm document,
+            i.e. Angle from GLOWS instrument to spin angle 0 in DPS frame.
+
+        Returns
+        -------
+        look_vecs_dps : numpy.ndarray
+            Array of shape (nbin, 3) representing the look directions in DPS frame
+            for each of the bins.
+        """
+        azimuth = (imap_spin_angle_bin_cntr - position_angle_offset_average) % 360.0
+
+        # Instrument pointing direction in the DPS frame.
+        az_el = get_instrument_mounting_az_el(SpiceFrame.IMAP_GLOWS)
+        elevation = az_el[1]
+
+        spherical = np.stack(
+            [np.ones_like(azimuth), azimuth, np.full_like(azimuth, elevation)],
+            axis=-1,
+        )  # (nbin, 3)
+
+        # Convert to unit cartesian vectors.
+        look_vecs_dps = spherical_to_cartesian(spherical)  # (nbin, 3)
+
+        return look_vecs_dps
+
     def flag_uv_and_excluded(self, exclusions: AncillaryExclusions) -> tuple:
         """
         Create boolean mask where True means bin is within radius of UV source.
@@ -1083,25 +1120,12 @@ class HistogramL1B:
         inside_excluded_region : np.ndarray
             Boolean mask for inside excluded region.
         """
-        # Rotate spin-angle bin centers by the instrument position-angle offset
-        # so azimuth=0 aligns with the instrument pointing direction.
-        azimuth = (
-            self.imap_spin_angle_bin_cntr - self.position_angle_offset_average
-        ) % 360.0
-        # Ephemeris start time of the histogram accumulation.
         data_start_time_et = sct_to_et(met_to_sclkticks(self.imap_start_time))
 
-        # Instrument pointing direction in the DPS frame.
-        az_el = get_instrument_mounting_az_el(SpiceFrame.IMAP_GLOWS)
-        elevation = az_el[1]
-
-        spherical = np.stack(
-            [np.ones_like(azimuth), azimuth, np.full_like(azimuth, elevation)],
-            axis=-1,
-        )  # (nbin, 3)
-
-        # Convert to unit cartesian vectors.
-        look_vecs_dps = spherical_to_cartesian(spherical)  # (nbin, 3)
+        # Calculate unit cartesian vectors in DPS.
+        look_vecs_dps = self.calculate_look_vectors_dps(
+            self.imap_spin_angle_bin_cntr, self.position_angle_offset_average
+        )
 
         # Transform unit cartesian vectors to ECLIPJ2000 frame.
         look_vecs_ecl = frame_transform(
@@ -1138,7 +1162,6 @@ class HistogramL1B:
         # the same direction and needs mask.
         # If dot product -> 0 the two directions are perpendicular on the sky.
         uv_cos_sep = look_vecs_ecl @ uv_vecs.T  # (nbin, n_src)
-
         # Determine if the pixel is too close to any of the source radii.
         close_to_uv_source = np.any(
             uv_cos_sep >= np.cos(uv_radius)[None, :], axis=1

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -643,28 +643,26 @@ def test_hist_spice_output(
         # TODO: Maxine will validate actual data with GLOWS team
 
 
-@pytest.mark.external_kernel
 def test_calculate_calculate_look_vectors_dps_uses_correct_azimuth_calculation(
     furnish_kernels,
 ):
     kernels = [
-        "naif0012.tls",
-        "de440s.bsp",
-        "imap_sclk_0000.tsc",
         "imap_130.tf",
-        "imap_science_120.tf",
-        "sim_1yr_imap_attitude.bc",
-        "sim_1yr_imap_pointing_frame.bc",
     ]
     with furnish_kernels(kernels):
-        expected_imap_spin_angle_bin_cntr = np.array([0, 90, 180, 270])
-        expected_position_angle_offset_average = 71.5
-        expected_azimuth = np.array([360 - 71.5, 90 - 71.5, 180 - 71.5, 270 - 71.5])
+        imap_spin_angle_bin_cntr = np.array([0, 90, 180, 270])
+        some_position_angle_offset_average = np.double(41.5)
+
+        expected_azimuth = (
+            np.array([360, 90, 180, 270]) - some_position_angle_offset_average
+        )
         expected_radius = np.array([1, 1, 1, 1])
+
+        # As-built mounting elevation of GLOWS in the s/c frame is 15.025791 degrees
         expected_elevation = np.array([15.025791, 15.025791, 15.025791, 15.025791])
 
         look_vectors = HistogramL1B.calculate_look_vectors_dps(
-            expected_imap_spin_angle_bin_cntr, expected_position_angle_offset_average
+            imap_spin_angle_bin_cntr, some_position_angle_offset_average
         )
 
         actual_spherical = cartesian_to_spherical(look_vectors)

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -20,6 +20,7 @@ from imap_processing.glows.l1b.glows_l1b_data import (
     HistogramL1B,
     PipelineSettings,
 )
+from imap_processing.spice.geometry import cartesian_to_spherical
 from imap_processing.spice.time import met_to_datetime64
 from imap_processing.tests.glows.conftest import mock_update_spice_parameters
 
@@ -342,76 +343,6 @@ def test_process_histogram(
     assert test_l1b.flags[16] == 1  # is_beyond_background
 
 
-@pytest.mark.external_kernel
-@pytest.mark.usefixtures("use_fake_spin_data_for_time")
-@patch("imap_processing.spice.geometry.imap_state")
-def test_process_histogram_calculates_correct_angle_offset(
-    mock_imap_state,
-    use_fake_spin_data_for_time,
-    furnish_kernels,
-    mock_ancillary_exclusions,
-    mock_ancillary_parameters,
-    mock_pipeline_settings,
-):
-    # Mock the imap_state function
-    mock_imap_state.return_value = np.array(
-        [
-            [1.0, 2.0, 3.0, 0.1, 0.2, 0.3],  # Example position and velocity data
-            [4.0, 5.0, 6.0, 0.4, 0.5, 0.6],
-        ]
-    )
-
-    # Generate a fake spin data for time
-    data_start_time = 504975600.125  # 2026-01-01T15:00:00.125
-    use_fake_spin_data_for_time(data_start_time)
-
-    params = {
-        "histogram": np.zeros(3600),
-        "seq_count_in_pkts_file": 0,
-        "first_spin_id": 0,
-        "last_spin_id": 0,
-        "flags_set_onboard": 0,
-        "is_generated_on_ground": 1,
-        "number_of_spins_per_block": 1,
-        "number_of_bins_per_histogram": 3600,
-        "number_of_events": 0,
-        "filter_temperature_average": 20.0,
-        "filter_temperature_variance": 0.0,
-        "hv_voltage_average": 1000.0,
-        "hv_voltage_variance": 0.0,
-        "spin_period_average": 10.0,
-        "spin_period_variance": 0.0,
-        "pulse_length_average": 50.0,
-        "pulse_length_variance": 0.0,
-        "imap_start_time": 504975603.125,
-        "imap_time_offset": 200.0,
-        "glows_start_time": 504975603.125,
-        "glows_time_offset": 200.0,
-        "ancillary_exclusions": mock_ancillary_exclusions,
-        "ancillary_parameters": mock_ancillary_parameters,
-        "pipeline_settings": PipelineSettings(
-            mock_pipeline_settings.sel(
-                epoch=mock_pipeline_settings.epoch[0], method="nearest"
-            ),
-        ),
-    }
-
-    kernels = [
-        "naif0012.tls",
-        "de440s.bsp",
-        "imap_sclk_0000.tsc",
-        "imap_130.tf",
-        "imap_science_120.tf",
-        "sim_1yr_imap_attitude.bc",
-        "sim_1yr_imap_pointing_frame.bc",
-    ]
-    with furnish_kernels(kernels):
-        hist_data = HistogramL1B(**params)
-
-        assert np.all(hist_data.histogram_flag_array[0, 1397:1437] == 1)
-        assert hist_data.histogram_flag_array[1, 1417] == 2
-
-
 @patch.object(
     HistogramL1B,
     "flag_uv_and_excluded",
@@ -699,6 +630,9 @@ def test_hist_spice_output(
         # (since the 0.05° threshold is exactly half the 0.1° bin spacing.
         assert np.count_nonzero(region_mask) == 1
 
+        assert np.all(uv_mask[1397:1437])
+        assert region_mask[1417]
+
         # Test flag_from_mask_dataset using the fixture data
         instr_mask = hist_data.flag_from_mask_dataset(
             day_exclusions.exclusions_by_instr_team
@@ -707,3 +641,37 @@ def test_hist_spice_output(
         assert np.count_nonzero(instr_mask) == 10
 
         # TODO: Maxine will validate actual data with GLOWS team
+
+
+@pytest.mark.external_kernel
+def test_calculate_calculate_look_vectors_dps_uses_correct_azimuth_calculation(
+    furnish_kernels,
+):
+    kernels = [
+        "naif0012.tls",
+        "de440s.bsp",
+        "imap_sclk_0000.tsc",
+        "imap_130.tf",
+        "imap_science_120.tf",
+        "sim_1yr_imap_attitude.bc",
+        "sim_1yr_imap_pointing_frame.bc",
+    ]
+    with furnish_kernels(kernels):
+        expected_imap_spin_angle_bin_cntr = np.array([0, 90, 180, 270])
+        expected_position_angle_offset_average = 71.5
+        expected_azimuth = np.array([360 - 71.5, 90 - 71.5, 180 - 71.5, 270 - 71.5])
+        expected_radius = np.array([1, 1, 1, 1])
+        expected_elevation = np.array([15.025791, 15.025791, 15.025791, 15.025791])
+
+        look_vectors = HistogramL1B.calculate_look_vectors_dps(
+            expected_imap_spin_angle_bin_cntr, expected_position_angle_offset_average
+        )
+
+        actual_spherical = cartesian_to_spherical(look_vectors)
+        actual_azimuth = actual_spherical[:, 1]
+        actual_radius = actual_spherical[:, 0]
+        actual_elevation = actual_spherical[:, 2]
+
+        np.testing.assert_allclose(expected_azimuth, actual_azimuth)
+        np.testing.assert_allclose(expected_radius, actual_radius)
+        np.testing.assert_allclose(expected_elevation, actual_elevation)

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -342,6 +342,76 @@ def test_process_histogram(
     assert test_l1b.flags[16] == 1  # is_beyond_background
 
 
+@pytest.mark.external_kernel
+@pytest.mark.usefixtures("use_fake_spin_data_for_time")
+@patch("imap_processing.spice.geometry.imap_state")
+def test_process_histogram_calculates_correct_angle_offset(
+    mock_imap_state,
+    use_fake_spin_data_for_time,
+    furnish_kernels,
+    mock_ancillary_exclusions,
+    mock_ancillary_parameters,
+    mock_pipeline_settings,
+):
+    # Mock the imap_state function
+    mock_imap_state.return_value = np.array(
+        [
+            [1.0, 2.0, 3.0, 0.1, 0.2, 0.3],  # Example position and velocity data
+            [4.0, 5.0, 6.0, 0.4, 0.5, 0.6],
+        ]
+    )
+
+    # Generate a fake spin data for time
+    data_start_time = 504975600.125  # 2026-01-01T15:00:00.125
+    use_fake_spin_data_for_time(data_start_time)
+
+    params = {
+        "histogram": np.zeros(3600),
+        "seq_count_in_pkts_file": 0,
+        "first_spin_id": 0,
+        "last_spin_id": 0,
+        "flags_set_onboard": 0,
+        "is_generated_on_ground": 1,
+        "number_of_spins_per_block": 1,
+        "number_of_bins_per_histogram": 3600,
+        "number_of_events": 0,
+        "filter_temperature_average": 20.0,
+        "filter_temperature_variance": 0.0,
+        "hv_voltage_average": 1000.0,
+        "hv_voltage_variance": 0.0,
+        "spin_period_average": 10.0,
+        "spin_period_variance": 0.0,
+        "pulse_length_average": 50.0,
+        "pulse_length_variance": 0.0,
+        "imap_start_time": 504975603.125,
+        "imap_time_offset": 200.0,
+        "glows_start_time": 504975603.125,
+        "glows_time_offset": 200.0,
+        "ancillary_exclusions": mock_ancillary_exclusions,
+        "ancillary_parameters": mock_ancillary_parameters,
+        "pipeline_settings": PipelineSettings(
+            mock_pipeline_settings.sel(
+                epoch=mock_pipeline_settings.epoch[0], method="nearest"
+            ),
+        ),
+    }
+
+    kernels = [
+        "naif0012.tls",
+        "de440s.bsp",
+        "imap_sclk_0000.tsc",
+        "imap_130.tf",
+        "imap_science_120.tf",
+        "sim_1yr_imap_attitude.bc",
+        "sim_1yr_imap_pointing_frame.bc",
+    ]
+    with furnish_kernels(kernels):
+        hist_data = HistogramL1B(**params)
+
+        assert np.all(hist_data.histogram_flag_array[0, 1397:1437] == 1)
+        assert hist_data.histogram_flag_array[1, 1417] == 2
+
+
 @patch.object(
     HistogramL1B,
     "flag_uv_and_excluded",


### PR DESCRIPTION
 Fix bug in how spin angle offset is used when calculating histogram flags, addressing issue #2946 
 
# Change Summary

## Overview

Changed the calculation of the azimuth to use the correct operation (- instead of +) to match equation 29 in the algorithm document.

<img width="1272" height="274" alt="histogram_flags" src="https://github.com/user-attachments/assets/e8a0a0ed-7f99-4fae-b880-8d3eca01beec" />

## File changes

- glows_l1b_data.py
- test_glows_l1b.py

## Testing

Added test that asserts that the range of spin angles that are flagged for being close to a UV source and being excluded are accurate to the updated equation.