### PR TITLE
ULTRA L1c fix positional uncertainties 

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1c_pset_bins.py
@@ -290,6 +290,9 @@ def test_apply_deadtime_correction(
     assert np.all(exposure_pointing_adjusted[:, :inside_inds] > 0)
     # Assert that pixels outside the FOR remain at 0.
     assert np.all(exposure_pointing_adjusted[:, inside_inds:] == 0)
+    # Test that fwhm values are not all nans or zeros
+    assert np.any(fwhm_theta > 0)
+    assert np.any(fwhm_phi > 0)
 
 
 @pytest.mark.external_kernel

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -260,10 +260,18 @@ def calculate_accepted_pixels(  # noqa: PLR0912
                 if reject_scattering:
                     valid_pixels[i, e_ind, accepted_pix] = scattering_mask.flatten()
 
-                # Accumulate FWHM values
-                fwhm_theta_sum[e_ind, accepted_pix] += fwhm_theta.flatten()
-                fwhm_phi_sum[e_ind, accepted_pix] += fwhm_phi.flatten()
-                sample_count[e_ind, accepted_pix] += 1
+                # Accumulate FWHM values only where BOTH theta and phi are finite
+                valid_fwhm = np.isfinite(fwhm_theta) & np.isfinite(fwhm_phi)
+                fwhm_theta_sum[e_ind, accepted_pix] += np.where(
+                    valid_fwhm, fwhm_theta, 0.0
+                ).ravel()
+                fwhm_phi_sum[e_ind, accepted_pix] += np.where(
+                    valid_fwhm, fwhm_phi, 0.0
+                ).ravel()
+                sample_count[e_ind, accepted_pix] += valid_fwhm.ravel().astype(
+                    sample_count.dtype
+                )
+
         else:
             # Energy independent FOR indices
             if not np.any(for_inds):
@@ -300,18 +308,21 @@ def calculate_accepted_pixels(  # noqa: PLR0912
                     scattering_thresholds=scattering_thresholds_for_energy_mean,
                 )
             )
-            if reject_scattering:
-                valid_pixels[i, :, accepted_pix] = scattering_mask.T
+            # Accumulate FWHM values where theta and phi are finite
+            valid_fwhm = np.isfinite(fwhm_theta) & np.isfinite(
+                fwhm_phi
+            )  # (npix, n_energy)
+            fwhm_theta_sum[:, accepted_pix] += np.where(valid_fwhm, fwhm_theta, 0.0).T
+            fwhm_phi_sum[:, accepted_pix] += np.where(valid_fwhm, fwhm_phi, 0.0).T
+            sample_count[:, accepted_pix] += valid_fwhm.T.astype(sample_count.dtype)
 
-            # Accumulate FWHM values
-            fwhm_theta_sum[:, accepted_pix] += fwhm_theta.T
-            fwhm_phi_sum[:, accepted_pix] += fwhm_phi.T
-            sample_count[:, accepted_pix] += 1
-
+    print(np.any(fwhm_theta_sum > 0))
+    print(np.any(fwhm_phi_sum > 0))
     fwhm_phi_avg = np.zeros_like(fwhm_phi_sum)
     fwhm_theta_avg = np.zeros_like(fwhm_theta_sum)
     np.divide(fwhm_phi_sum, sample_count, out=fwhm_phi_avg, where=sample_count != 0)
     np.divide(fwhm_theta_sum, sample_count, out=fwhm_theta_avg, where=sample_count != 0)
+
     return (
         valid_pixels,
         fwhm_theta_avg,

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -308,6 +308,9 @@ def calculate_accepted_pixels(  # noqa: PLR0912
                     scattering_thresholds=scattering_thresholds_for_energy_mean,
                 )
             )
+            if reject_scattering:
+                valid_pixels[i, :, accepted_pix] = scattering_mask.T
+
             # Accumulate FWHM values where theta and phi are finite
             valid_fwhm = np.isfinite(fwhm_theta) & np.isfinite(
                 fwhm_phi

--- a/imap_processing/ultra/l1c/l1c_lookup_utils.py
+++ b/imap_processing/ultra/l1c/l1c_lookup_utils.py
@@ -319,8 +319,6 @@ def calculate_accepted_pixels(  # noqa: PLR0912
             fwhm_phi_sum[:, accepted_pix] += np.where(valid_fwhm, fwhm_phi, 0.0).T
             sample_count[:, accepted_pix] += valid_fwhm.T.astype(sample_count.dtype)
 
-    print(np.any(fwhm_theta_sum > 0))
-    print(np.any(fwhm_phi_sum > 0))
     fwhm_phi_avg = np.zeros_like(fwhm_phi_sum)
     fwhm_theta_avg = np.zeros_like(fwhm_theta_sum)
     np.divide(fwhm_phi_sum, sample_count, out=fwhm_phi_avg, where=sample_count != 0)


### PR DESCRIPTION
# Change Summary

closes #3067

## Overview

Only accumulate finite values. This was slowly propagating nans into the summation and the final arrays were all only zero or nan. 


## File changes

- imap_processing/ultra/l1c/l1c_lookup_utils.py
  - fix summation 


## Testing

Add test to ensure that values are not only zero or nan
