### PR TITLE
Fix some Lo L1A issues with SAMMI injecting DEPEND_O when not wanted

### DIFF
--- a/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
@@ -80,6 +80,7 @@ spin_default_attrs: &spin_default
 
 esa_step_label:
    CATDESC: ESA Steps
+   DEPEND_1: esa_step
    FIELDNAM: ESA Steps
    FORMAT: A1
    VAR_TYPE: metadata
@@ -91,7 +92,6 @@ esa_step_coord:
   VALIDMAX: 7
   FORMAT: I1
   CATDESC: Energy Step
-  DEPEND_1: esa_step
   FIELDNAM: Energy Step
   LABLAXIS: ESA
   LABL_PTR_1: esa_step_label
@@ -109,6 +109,7 @@ shcoarse:
 ## Coordinates
 direct_events_label:
    CATDESC: Direct Events
+   DEPEND_1: direct_events
    FIELDNAM: DE
    FORMAT: A15
    VAR_TYPE: metadata
@@ -238,6 +239,7 @@ passes:
 ## Coordinates
 azimuth_6_label:
   CATDESC: azimuth spin bins (<num packets>, 6 degrees)
+  DEPEND_1: azimuth_6
   FIELDNAM: Azimuth bins
   FORMAT: A3
   VAR_TYPE: metadata
@@ -248,12 +250,12 @@ azimuth_6:
   VALIDMAX: 59
   CATDESC: azimuth spin bins (<num packets>, 6 degrees)
   FIELDNAM: Azimuth bins
-  DEPEND_1: azimuth_6
   LABLAXIS: Az bins
   LABL_PTR_1: azimuth_6_label
 
 azimuth_60_label:
   CATDESC: azimuth spin bins (<num packets>, 60 degrees)
+  DEPEND_1: azimuth_60
   FIELDNAM: Azimuth bins
   FORMAT: A3
   VAR_TYPE: metadata
@@ -264,7 +266,6 @@ azimuth_60:
   VALIDMAX: 5
   CATDESC: azimuth spin bins (<num packets>, 60 degrees)
   FIELDNAM: Azimuth bins
-  DEPEND_1: azimuth_60
   LABLAXIS: Az bins
   LABL_PTR_1: azimuth_60_label
 
@@ -413,13 +414,13 @@ spin:
   <<: *default_uint16
   CATDESC: Spin numbers in pointing
   FIELDNAM: Spin numbers
-  DEPEND_1: spin
   VAR_TYPE: support_data
   LABLAXIS: Spin numbers
 
 spin_label:
   CATDESC: Spin numbers in pointing
   FIELDNAM: Spin numbers
+  DEPEND_1: spin
   FORMAT: A3
   VAR_TYPE: metadata
 

--- a/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1a_variable_attrs.yaml
@@ -80,7 +80,6 @@ spin_default_attrs: &spin_default
 
 esa_step_label:
    CATDESC: ESA Steps
-   DEPEND_1: esa_step
    FIELDNAM: ESA Steps
    FORMAT: A1
    VAR_TYPE: metadata
@@ -109,7 +108,6 @@ shcoarse:
 ## Coordinates
 direct_events_label:
    CATDESC: Direct Events
-   DEPEND_1: direct_events
    FIELDNAM: DE
    FORMAT: A15
    VAR_TYPE: metadata
@@ -239,7 +237,6 @@ passes:
 ## Coordinates
 azimuth_6_label:
   CATDESC: azimuth spin bins (<num packets>, 6 degrees)
-  DEPEND_1: azimuth_6
   FIELDNAM: Azimuth bins
   FORMAT: A3
   VAR_TYPE: metadata
@@ -255,7 +252,6 @@ azimuth_6:
 
 azimuth_60_label:
   CATDESC: azimuth spin bins (<num packets>, 60 degrees)
-  DEPEND_1: azimuth_60
   FIELDNAM: Azimuth bins
   FORMAT: A3
   VAR_TYPE: metadata
@@ -420,7 +416,6 @@ spin:
 spin_label:
   CATDESC: Spin numbers in pointing
   FIELDNAM: Spin numbers
-  DEPEND_1: spin
   FORMAT: A3
   VAR_TYPE: metadata
 

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -216,7 +216,7 @@ def parse_events(dataset: xr.Dataset, attr_mgr: ImapCdfAttributes) -> xr.Dataset
         dataset[field] = xr.DataArray(
             np.full(num_de, attr_mgr.get_variable_attributes(field)["FILLVAL"]),
             dims="direct_events",
-            attrs=attr_mgr.get_variable_attributes(field),
+            attrs=attr_mgr.get_variable_attributes(field, check_schema=False),
         )
     dataset["passes"] = xr.DataArray(
         np.full(

--- a/imap_processing/lo/l0/lo_science.py
+++ b/imap_processing/lo/l0/lo_science.py
@@ -213,10 +213,11 @@ def parse_events(dataset: xr.Dataset, attr_mgr: ImapCdfAttributes) -> xr.Dataset
     # data will use a direct event index for the
     # pointing as its coordinate/dimension
     for field in de_fields:
+        attrs = attr_mgr.get_variable_attributes(field, check_schema=False)
         dataset[field] = xr.DataArray(
-            np.full(num_de, attr_mgr.get_variable_attributes(field)["FILLVAL"]),
+            np.full(num_de, attrs["FILLVAL"]),
             dims="direct_events",
-            attrs=attr_mgr.get_variable_attributes(field, check_schema=False),
+            attrs=attrs,
         )
     dataset["passes"] = xr.DataArray(
         np.full(

--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -180,21 +180,25 @@ def add_dataset_attrs(
     # Get global attributes
     dataset.attrs.update(attr_mgr.get_global_attributes(logical_source))
     # Get attributes for shcoarse and epoch
-    dataset.shcoarse.attrs.update(attr_mgr.get_variable_attributes("shcoarse"))
-    dataset.epoch.attrs.update(attr_mgr.get_variable_attributes("epoch"))
+    dataset.shcoarse.attrs.update(
+        attr_mgr.get_variable_attributes("shcoarse", check_schema=False)
+    )
+    dataset.epoch.attrs.update(
+        attr_mgr.get_variable_attributes("epoch", check_schema=False)
+    )
 
     if logical_source == "imap_lo_l1a_spin":
         spin = xr.DataArray(
             data=np.arange(0, 28, dtype=np.uint8),
             name="spin",
             dims=["spin"],
-            attrs=attr_mgr.get_variable_attributes("spin"),
+            attrs=attr_mgr.get_variable_attributes("spin", check_schema=False),
         )
         spin_label = xr.DataArray(
             data=spin.values.astype(str),
             name="spin_label",
             dims=["spin_label"],
-            attrs=attr_mgr.get_variable_attributes("spin_label"),
+            attrs=attr_mgr.get_variable_attributes("spin_label", check_schema=False),
         )
 
         dataset = dataset.assign_coords(spin=spin, spin_label=spin_label)
@@ -226,11 +230,6 @@ def add_dataset_attrs(
                 "chksum",
             ]
         )
-        # An empty DEPEND_0 is being added to support_data
-        # variables that should only have DEPEND_1
-        # Removing Depend_0 here.
-        # TODO: Should look for a fix to this issue
-        del dataset["spin"].attrs["DEPEND_0"]
 
     elif logical_source == "imap_lo_l1a_histogram":
         # Create coordinates for the dataset
@@ -238,7 +237,7 @@ def add_dataset_attrs(
             data=np.arange(0, 6, dtype=np.uint8),
             name="azimuth_60",
             dims=["azimuth_60"],
-            attrs=attr_mgr.get_variable_attributes("azimuth_60"),
+            attrs=attr_mgr.get_variable_attributes("azimuth_60", check_schema=False),
         )
         azimuth_60_label = xr.DataArray(
             data=azimuth_60.values.astype(str),
@@ -250,7 +249,7 @@ def add_dataset_attrs(
             data=np.arange(0, 60, dtype=np.uint8),
             name="azimuth_6",
             dims=["azimuth_6"],
-            attrs=attr_mgr.get_variable_attributes("azimuth_6"),
+            attrs=attr_mgr.get_variable_attributes("azimuth_6", check_schema=False),
         )
         azimuth_6_label = xr.DataArray(
             data=azimuth_6.values.astype(str),
@@ -263,13 +262,17 @@ def add_dataset_attrs(
             data=np.arange(1, 8, dtype=np.uint8),
             name="esa_step",
             dims=["esa_step"],
-            attrs=attr_mgr.get_variable_attributes("esa_step_coord"),
+            attrs=attr_mgr.get_variable_attributes(
+                "esa_step_coord", check_schema=False
+            ),
         )
         esa_step_label = xr.DataArray(
             esa_step.values.astype(str),
             name="esa_step_label",
             dims=["esa_step_label"],
-            attrs=attr_mgr.get_variable_attributes("esa_step_label"),
+            attrs=attr_mgr.get_variable_attributes(
+                "esa_step_label", check_schema=False
+            ),
         )
 
         dataset = dataset.assign_coords(
@@ -294,13 +297,6 @@ def add_dataset_attrs(
                 "pkt_len",
             ]
         )
-        # An empty DEPEND_0 is being added to support_data
-        # variables that should only have DEPEND_1
-        # Removing Depend_0 here.
-        # TODO: Should look for a fix to this issue
-        del dataset["azimuth_60"].attrs["DEPEND_0"]
-        del dataset["azimuth_6"].attrs["DEPEND_0"]
-        del dataset["esa_step"].attrs["DEPEND_0"]
 
     elif logical_source == "imap_lo_l1a_de":
         # Create the coordinates for the dataset
@@ -308,14 +304,16 @@ def add_dataset_attrs(
             data=np.arange(sum(dataset["de_count"].values), dtype=np.uint16),
             name="direct_events",
             dims=["direct_events"],
-            attrs=attr_mgr.get_variable_attributes("direct_events"),
+            attrs=attr_mgr.get_variable_attributes("direct_events", check_schema=False),
         )
 
         direct_events_label = xr.DataArray(
             direct_events.values.astype(str),
             name="direct_events_label",
             dims=["direct_events_label"],
-            attrs=attr_mgr.get_variable_attributes("direct_events_label"),
+            attrs=attr_mgr.get_variable_attributes(
+                "direct_events_label", check_schema=False
+            ),
         )
 
         # For DEs, shcoarse applies to each ASC group and is not per individual epoch
@@ -340,24 +338,6 @@ def add_dataset_attrs(
                 "data",
             ]
         )
-        # An empty DEPEND_0 is being added to support_data
-        # variables that should only have DEPEND_1
-        # Removing Depend_0 here.
-        # TODO: Should look for a fix to this issue
-        for var in [
-            "direct_events",
-            "coincidence_type",
-            "de_time",
-            "mode",
-            "esa_step",
-            "tof0",
-            "tof1",
-            "tof2",
-            "tof3",
-            "pos",
-            "cksm",
-        ]:
-            dataset[var].attrs.pop("DEPEND_0")
 
     return dataset
 

--- a/imap_processing/tests/lo/test_lo_l1a.py
+++ b/imap_processing/tests/lo/test_lo_l1a.py
@@ -45,8 +45,8 @@ def test_lo_l1a():
         output_dataset, expected_logical_source, strict=False
     ):
         assert logical_source == dataset.attrs["Logical_source"]
-        for var in no_depend_0_vars:
-            if var in dataset:
+        for var in dataset:
+            if var in no_depend_0_vars or var.endswith("label"):
                 assert "DEPEND_0" not in dataset[var].attrs
 
 

--- a/imap_processing/tests/lo/test_lo_l1a.py
+++ b/imap_processing/tests/lo/test_lo_l1a.py
@@ -23,10 +23,31 @@ def test_lo_l1a():
 
     # Assert
     assert len(output_dataset) == len(expected_logical_source)
+
+    no_depend_0_vars = [
+        "direct_events",
+        "coincidence_type",
+        "de_time",
+        "mode",
+        "esa_step",
+        "tof0",
+        "tof1",
+        "tof2",
+        "tof3",
+        "pos",
+        "cksm",
+        "spin",
+        "azimuth_6",
+        "azimuth_60",
+        "spin_label",
+    ]
     for dataset, logical_source in zip(
         output_dataset, expected_logical_source, strict=False
     ):
         assert logical_source == dataset.attrs["Logical_source"]
+        for var in no_depend_0_vars:
+            if var in dataset:
+                assert "DEPEND_0" not in dataset[var].attrs
 
 
 def test_lo_l1a_dataset():


### PR DESCRIPTION
# Change Summary
This PR cleans up some issues with Lo L1A metadata. The changes are all related to SAMMI injecting a DEPEND_0 attribute when called without `check_schema=False`.

- fixed up some entries in the YAML
- added the `check_schema=False` for appropriate variables
- removed no longer needed pop statements manually removing DEPEND_0
- added test coverage to verify that attributes are correct after Lo L1A processing

Closes: #2643 
