### PR TITLE
HIT L2 - Fix delta var attrs

### DIFF
--- a/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_l2_variable_attrs.yaml
@@ -349,8 +349,8 @@ h_standard_intensity:
   CATDESC: H Standard Omnidirectional Intensity in 12 energy bins
   LABLAXIS: h_energy_mean_label
   FIELDNAM: H Intensity Standard
-  DELTA_MINUS_VAR: h_total_uncert_plus
-  DELTA_PLUS_VAR: h_total_uncert_minus
+  DELTA_MINUS_VAR: h_total_uncert_minus
+  DELTA_PLUS_VAR: h_total_uncert_plus
 
 he3_standard_intensity:
   <<: *default_particle
@@ -358,8 +358,8 @@ he3_standard_intensity:
   CATDESC: He3 Standard Omnidirectional Intensity in 11 energy bins
   FIELDNAM: He3 Intensity Standard
   LABLAXIS: he3_energy_mean_label
-  DELTA_MINUS_VAR: he3_total_uncert_plus
-  DELTA_PLUS_VAR: he3_total_uncert_minus
+  DELTA_MINUS_VAR: he3_total_uncert_minus
+  DELTA_PLUS_VAR: he3_total_uncert_plus
 
 he4_standard_intensity:
   <<: *default_particle
@@ -367,8 +367,8 @@ he4_standard_intensity:
   CATDESC: He4 Standard Omnidirectional Intensity in 12 energy bins
   FIELDNAM: He4 Intensity Standard
   LABLAXIS: he4_energy_mean_label
-  DELTA_MINUS_VAR: he4_total_uncert_plus
-  DELTA_PLUS_VAR: he4_total_uncert_minus
+  DELTA_MINUS_VAR: he4_total_uncert_minus
+  DELTA_PLUS_VAR: he4_total_uncert_plus
 
 he_standard_intensity:
   <<: *default_particle
@@ -376,8 +376,8 @@ he_standard_intensity:
   CATDESC: He (total) Standard Omnidirectional Intensity in 11 energy bins
   FIELDNAM: He Intensity Standard
   LABLAXIS: he_energy_mean_label
-  DELTA_MINUS_VAR: he_total_uncert_plus
-  DELTA_PLUS_VAR: he_total_uncert_minus
+  DELTA_MINUS_VAR: he_total_uncert_minus
+  DELTA_PLUS_VAR: he_total_uncert_plus
 
 c_standard_intensity:
   <<: *default_particle
@@ -385,8 +385,8 @@ c_standard_intensity:
   CATDESC: C Standard Omnidirectional Intensity in 12 energy bins
   FIELDNAM: C Intensity Standard
   LABLAXIS: c_energy_mean_label
-  DELTA_MINUS_VAR: c_total_uncert_plus
-  DELTA_PLUS_VAR: c_total_uncert_minus
+  DELTA_MINUS_VAR: c_total_uncert_minus
+  DELTA_PLUS_VAR: c_total_uncert_plus
 
 o_standard_intensity:
   <<: *default_particle
@@ -394,8 +394,8 @@ o_standard_intensity:
   CATDESC: O Standard Omnidirectional Intensity in 12 energy bins
   FIELDNAM: O Intensity Standard
   LABLAXIS: o_energy_mean_label
-  DELTA_MINUS_VAR: o_total_uncert_plus
-  DELTA_PLUS_VAR: o_total_uncert_minus
+  DELTA_MINUS_VAR: o_total_uncert_minus
+  DELTA_PLUS_VAR: o_total_uncert_plus
 
 n_standard_intensity:
   <<: *default_particle
@@ -403,8 +403,8 @@ n_standard_intensity:
   CATDESC: N Standard Omnidirectional Intensity in 12 energy bins
   FIELDNAM: N Intensity Standard
   LABLAXIS: n_energy_mean_label
-  DELTA_MINUS_VAR: n_total_uncert_plus
-  DELTA_PLUS_VAR: n_total_uncert_minus
+  DELTA_MINUS_VAR: n_total_uncert_minus
+  DELTA_PLUS_VAR: n_total_uncert_plus
 
 ne_standard_intensity:
   <<: *default_particle
@@ -412,8 +412,8 @@ ne_standard_intensity:
   CATDESC: Ne Standard Omnidirectional Intensity in 13 energy bins
   FIELDNAM: Ne Intensity Standard
   LABLAXIS: ne_energy_mean_label
-  DELTA_MINUS_VAR: ne_total_uncert_plus
-  DELTA_PLUS_VAR: ne_total_uncert_minus
+  DELTA_MINUS_VAR: ne_total_uncert_minus
+  DELTA_PLUS_VAR: ne_total_uncert_plus
 
 na_standard_intensity:
   <<: *default_particle
@@ -421,8 +421,8 @@ na_standard_intensity:
   CATDESC: Na Standard Omnidirectional Intensity in 8 energy bins
   FIELDNAM: Na Intensity Standard
   LABLAXIS: na_energy_mean_label
-  DELTA_MINUS_VAR: na_total_uncert_plus
-  DELTA_PLUS_VAR: na_total_uncert_minus
+  DELTA_MINUS_VAR: na_total_uncert_minus
+  DELTA_PLUS_VAR: na_total_uncert_plus
 
 mg_standard_intensity:
   <<: *default_particle
@@ -430,8 +430,8 @@ mg_standard_intensity:
   CATDESC: Mg Standard Omnidirectional Intensity in 14 energy bins
   FIELDNAM: Mg Intensity Standard
   LABLAXIS: mg_energy_mean_label
-  DELTA_MINUS_VAR: mg_total_uncert_plus
-  DELTA_PLUS_VAR: mg_total_uncert_minus
+  DELTA_MINUS_VAR: mg_total_uncert_minus
+  DELTA_PLUS_VAR: mg_total_uncert_plus
 
 al_standard_intensity:
   <<: *default_particle
@@ -439,8 +439,8 @@ al_standard_intensity:
   CATDESC: Al Standard Omnidirectional Intensity in 9 energy bins
   FIELDNAM: Al Intensity Standard
   LABLAXIS: al_energy_mean_label
-  DELTA_MINUS_VAR: al_total_uncert_plus
-  DELTA_PLUS_VAR: al_total_uncert_minus
+  DELTA_MINUS_VAR: al_total_uncert_minus
+  DELTA_PLUS_VAR: al_total_uncert_plus
 
 si_standard_intensity:
   <<: *default_particle
@@ -448,8 +448,8 @@ si_standard_intensity:
   CATDESC: Si Standard Omnidirectional Intensity in 14 energy bins
   FIELDNAM: Si Intensity Standard
   LABLAXIS: si_energy_mean_label
-  DELTA_MINUS_VAR: si_total_uncert_plus
-  DELTA_PLUS_VAR: si_total_uncert_minus
+  DELTA_MINUS_VAR: si_total_uncert_minus
+  DELTA_PLUS_VAR: si_total_uncert_plus
 
 s_standard_intensity:
   <<: *default_particle
@@ -457,8 +457,8 @@ s_standard_intensity:
   CATDESC: S Standard Omnidirectional Intensity in 13 energy bins
   FIELDNAM: S Intensity Standard
   LABLAXIS: s_energy_mean_label
-  DELTA_MINUS_VAR: s_total_uncert_plus
-  DELTA_PLUS_VAR: s_total_uncert_minus
+  DELTA_MINUS_VAR: s_total_uncert_minus
+  DELTA_PLUS_VAR: s_total_uncert_plus
 
 ar_standard_intensity:
   <<: *default_particle
@@ -466,8 +466,8 @@ ar_standard_intensity:
   CATDESC: Ar Standard Omnidirectional Intensity in 13 energy bins
   FIELDNAM: Ar Intensity Standard
   LABLAXIS: ar_energy_mean_label
-  DELTA_MINUS_VAR: ar_total_uncert_plus
-  DELTA_PLUS_VAR: ar_total_uncert_minus
+  DELTA_MINUS_VAR: ar_total_uncert_minus
+  DELTA_PLUS_VAR: ar_total_uncert_plus
 
 ca_standard_intensity:
   <<: *default_particle
@@ -475,8 +475,8 @@ ca_standard_intensity:
   CATDESC: Ca Standard Omnidirectional Intensity in 13 energy bins
   FIELDNAM: Ca Intensity Standard
   LABLAXIS: ca_energy_mean_label
-  DELTA_MINUS_VAR: ca_total_uncert_plus
-  DELTA_PLUS_VAR: ca_total_uncert_minus
+  DELTA_MINUS_VAR: ca_total_uncert_minus
+  DELTA_PLUS_VAR: ca_total_uncert_plus
 
 fe_standard_intensity:
   <<: *default_particle
@@ -484,8 +484,8 @@ fe_standard_intensity:
   CATDESC: Fe Standard Omnidirectional Intensity in 16 energy bins
   FIELDNAM: Fe Intensity Standard
   LABLAXIS: fe_energy_mean_label
-  DELTA_MINUS_VAR: fe_total_uncert_plus
-  DELTA_PLUS_VAR: fe_total_uncert_minus
+  DELTA_MINUS_VAR: fe_total_uncert_minus
+  DELTA_PLUS_VAR: fe_total_uncert_plus
 
 ni_standard_intensity:
   <<: *default_particle
@@ -493,8 +493,8 @@ ni_standard_intensity:
   CATDESC: Ni Standard Omnidirectional Intensity in 9 energy bins
   FIELDNAM: Ni Intensity Standard
   LABLAXIS: ni_energy_mean_label
-  DELTA_MINUS_VAR: ni_total_uncert_plus
-  DELTA_PLUS_VAR: ni_total_uncert_minus
+  DELTA_MINUS_VAR: ni_total_uncert_minus
+  DELTA_PLUS_VAR: ni_total_uncert_plus
 
 # Summed Intensity Variables
 h_summed_intensity:
@@ -503,8 +503,8 @@ h_summed_intensity:
   CATDESC: H Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   LABLAXIS: h_energy_mean_label
   FIELDNAM: H intensity summed
-  DELTA_MINUS_VAR: h_total_uncert_plus
-  DELTA_PLUS_VAR: h_total_uncert_minus
+  DELTA_MINUS_VAR: h_total_uncert_minus
+  DELTA_PLUS_VAR: h_total_uncert_plus
 
 he3_summed_intensity:
   <<: *default_particle
@@ -512,8 +512,8 @@ he3_summed_intensity:
   CATDESC: He3 Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
   FIELDNAM: He3 intensity summed
   LABLAXIS: he3_energy_mean_label
-  DELTA_MINUS_VAR: he3_total_uncert_plus
-  DELTA_PLUS_VAR: he3_total_uncert_minus
+  DELTA_MINUS_VAR: he3_total_uncert_minus
+  DELTA_PLUS_VAR: he3_total_uncert_plus
 
 he4_summed_intensity:
   <<: *default_particle
@@ -521,8 +521,8 @@ he4_summed_intensity:
   CATDESC: He4 Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: He4 intensity summed
   LABLAXIS: he4_energy_mean_label
-  DELTA_MINUS_VAR: he4_total_uncert_plus
-  DELTA_PLUS_VAR: he4_total_uncert_minus
+  DELTA_MINUS_VAR: he4_total_uncert_minus
+  DELTA_PLUS_VAR: he4_total_uncert_plus
 
 he_summed_intensity:
   <<: *default_particle
@@ -530,8 +530,8 @@ he_summed_intensity:
   CATDESC: He (total) Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
   FIELDNAM: He intensity summed
   LABLAXIS: he_energy_mean_label
-  DELTA_MINUS_VAR: he_total_uncert_plus
-  DELTA_PLUS_VAR: he_total_uncert_minus
+  DELTA_MINUS_VAR: he_total_uncert_minus
+  DELTA_PLUS_VAR: he_total_uncert_plus
 
 c_summed_intensity:
   <<: *default_particle
@@ -539,8 +539,8 @@ c_summed_intensity:
   CATDESC: C Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: C intensity summed
   LABLAXIS: c_energy_mean_label
-  DELTA_MINUS_VAR: c_total_uncert_plus
-  DELTA_PLUS_VAR: c_total_uncert_minus
+  DELTA_MINUS_VAR: c_total_uncert_minus
+  DELTA_PLUS_VAR: c_total_uncert_plus
 
 o_summed_intensity:
   <<: *default_particle
@@ -548,8 +548,8 @@ o_summed_intensity:
   CATDESC: O Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: O intensity summed
   LABLAXIS: o_energy_mean_label
-  DELTA_MINUS_VAR: o_total_uncert_plus
-  DELTA_PLUS_VAR: o_total_uncert_minus
+  DELTA_MINUS_VAR: o_total_uncert_minus
+  DELTA_PLUS_VAR: o_total_uncert_plus
 
 n_summed_intensity:
   <<: *default_particle
@@ -557,8 +557,8 @@ n_summed_intensity:
   CATDESC: N Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: N intensity summed
   LABLAXIS: n_energy_mean_label
-  DELTA_MINUS_VAR: n_total_uncert_plus
-  DELTA_PLUS_VAR: n_total_uncert_minus
+  DELTA_MINUS_VAR: n_total_uncert_minus
+  DELTA_PLUS_VAR: n_total_uncert_plus
 
 ne_summed_intensity:
   <<: *default_particle
@@ -566,8 +566,8 @@ ne_summed_intensity:
   CATDESC: Ne Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: Ne intensity summed
   LABLAXIS: ne_energy_mean_label
-  DELTA_MINUS_VAR: ne_total_uncert_plus
-  DELTA_PLUS_VAR: ne_total_uncert_minus
+  DELTA_MINUS_VAR: ne_total_uncert_minus
+  DELTA_PLUS_VAR: ne_total_uncert_plus
 
 na_summed_intensity:
   <<: *default_particle
@@ -575,8 +575,8 @@ na_summed_intensity:
   CATDESC: Na Summed Omnidirectional Intensity in 2 energy bins (useful for quiet times)
   FIELDNAM: Na intensity summed
   LABLAXIS: na_energy_mean_label
-  DELTA_MINUS_VAR: na_total_uncert_plus
-  DELTA_PLUS_VAR: na_total_uncert_minus
+  DELTA_MINUS_VAR: na_total_uncert_minus
+  DELTA_PLUS_VAR: na_total_uncert_plus
 
 mg_summed_intensity:
   <<: *default_particle
@@ -584,8 +584,8 @@ mg_summed_intensity:
   CATDESC: Mg Summed Omnidirectional Intensity in 4 energy bins (useful for quiet times)
   FIELDNAM: Mg intensity summed
   LABLAXIS: mg_energy_mean_label
-  DELTA_MINUS_VAR: mg_total_uncert_plus
-  DELTA_PLUS_VAR: mg_total_uncert_minus
+  DELTA_MINUS_VAR: mg_total_uncert_minus
+  DELTA_PLUS_VAR: mg_total_uncert_plus
 
 al_summed_intensity:
   <<: *default_particle
@@ -593,8 +593,8 @@ al_summed_intensity:
   CATDESC: Al Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
   FIELDNAM: Al intensity summed
   LABLAXIS: al_energy_mean_label
-  DELTA_MINUS_VAR: al_total_uncert_plus
-  DELTA_PLUS_VAR: al_total_uncert_minus
+  DELTA_MINUS_VAR: al_total_uncert_minus
+  DELTA_PLUS_VAR: al_total_uncert_plus
 
 si_summed_intensity:
   <<: *default_particle
@@ -602,8 +602,8 @@ si_summed_intensity:
   CATDESC: Si Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: Si intensity summed
   LABLAXIS: si_energy_mean_label
-  DELTA_MINUS_VAR: si_total_uncert_plus
-  DELTA_PLUS_VAR: si_total_uncert_minus
+  DELTA_MINUS_VAR: si_total_uncert_minus
+  DELTA_PLUS_VAR: si_total_uncert_plus
 
 s_summed_intensity:
   <<: *default_particle
@@ -611,8 +611,8 @@ s_summed_intensity:
   CATDESC: S Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: S intensity summed
   LABLAXIS: s_energy_mean_label
-  DELTA_MINUS_VAR: s_total_uncert_plus
-  DELTA_PLUS_VAR: s_total_uncert_minus
+  DELTA_MINUS_VAR: s_total_uncert_minus
+  DELTA_PLUS_VAR: s_total_uncert_plus
 
 ar_summed_intensity:
   <<: *default_particle
@@ -620,8 +620,8 @@ ar_summed_intensity:
   CATDESC: Ar Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: Ar intensity summed
   LABLAXIS: ar_energy_mean_label
-  DELTA_MINUS_VAR: ar_total_uncert_plus
-  DELTA_PLUS_VAR: ar_total_uncert_minus
+  DELTA_MINUS_VAR: ar_total_uncert_minus
+  DELTA_PLUS_VAR: ar_total_uncert_plus
 
 ca_summed_intensity:
   <<: *default_particle
@@ -629,8 +629,8 @@ ca_summed_intensity:
   CATDESC: Ca Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: Ca intensity summed
   LABLAXIS: ca_energy_mean_label
-  DELTA_MINUS_VAR: ca_total_uncert_plus
-  DELTA_PLUS_VAR: ca_total_uncert_minus
+  DELTA_MINUS_VAR: ca_total_uncert_minus
+  DELTA_PLUS_VAR: ca_total_uncert_plus
 
 fe_summed_intensity:
   <<: *default_particle
@@ -638,8 +638,8 @@ fe_summed_intensity:
   CATDESC: Fe Summed Omnidirectional Intensity in 5 energy bins (useful for quiet times)
   FIELDNAM: Fe intensity summed
   LABLAXIS: fe_energy_mean_label
-  DELTA_MINUS_VAR: fe_total_uncert_plus
-  DELTA_PLUS_VAR: fe_total_uncert_minus
+  DELTA_MINUS_VAR: fe_total_uncert_minus
+  DELTA_PLUS_VAR: fe_total_uncert_plus
 
 ni_summed_intensity:
   <<: *default_particle
@@ -647,8 +647,8 @@ ni_summed_intensity:
   CATDESC: Ni Summed Omnidirectional Intensity in 3 energy bins (useful for quiet times)
   FIELDNAM: Ni intensity summed
   LABLAXIS: ni_energy_mean_label
-  DELTA_MINUS_VAR: ni_total_uncert_plus
-  DELTA_PLUS_VAR: ni_total_uncert_minus
+  DELTA_MINUS_VAR: ni_total_uncert_minus
+  DELTA_PLUS_VAR: ni_total_uncert_plus
 
 # Energy Delta Variables
 h_energy_delta_plus:
@@ -1584,8 +1584,8 @@ h_macropixel_intensity:
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: zenith_label
   FIELDNAM: H Intensity Macropixel
-  DELTA_MINUS_VAR: h_total_uncert_plus
-  DELTA_PLUS_VAR: h_total_uncert_minus
+  DELTA_MINUS_VAR: h_total_uncert_minus
+  DELTA_PLUS_VAR: h_total_uncert_plus
 
 he4_macropixel_intensity:
   <<: *default_particle
@@ -1597,8 +1597,8 @@ he4_macropixel_intensity:
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: zenith_label
   FIELDNAM: He4 Intensity Macropixel
-  DELTA_MINUS_VAR: he4_total_uncert_plus
-  DELTA_PLUS_VAR: he4_total_uncert_minus
+  DELTA_MINUS_VAR: he4_total_uncert_minus
+  DELTA_PLUS_VAR: he4_total_uncert_plus
 
 cno_macropixel_intensity:
   <<: *default_particle
@@ -1610,8 +1610,8 @@ cno_macropixel_intensity:
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: zenith_label
   FIELDNAM: CNO Intensity Macropixel
-  DELTA_MINUS_VAR: cno_total_uncert_plus
-  DELTA_PLUS_VAR: cno_total_uncert_minus
+  DELTA_MINUS_VAR: cno_total_uncert_minus
+  DELTA_PLUS_VAR: cno_total_uncert_plus
 
 nemgsi_macropixel_intensity:
   <<: *default_particle
@@ -1623,8 +1623,8 @@ nemgsi_macropixel_intensity:
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: zenith_label
   FIELDNAM: NeMgSi Intensity Macropixel
-  DELTA_MINUS_VAR: nemgsi_total_uncert_plus
-  DELTA_PLUS_VAR: nemgsi_total_uncert_minus
+  DELTA_MINUS_VAR: nemgsi_total_uncert_minus
+  DELTA_PLUS_VAR: nemgsi_total_uncert_plus
 
 fe_macropixel_intensity:
   <<: *default_particle
@@ -1636,8 +1636,8 @@ fe_macropixel_intensity:
   LABL_PTR_2: azimuth_label
   LABL_PTR_3: zenith_label
   FIELDNAM: Fe Intensity Macropixel
-  DELTA_MINUS_VAR: fe_total_uncert_plus
-  DELTA_PLUS_VAR: fe_total_uncert_minus
+  DELTA_MINUS_VAR: fe_total_uncert_minus
+  DELTA_PLUS_VAR: fe_total_uncert_plus
 
 # Energy Delta Variables
 cno_energy_delta_plus:


### PR DESCRIPTION
Fixes error in HIT L2 metadata where delta var attributes had reversed values assigned (minus and plus values assigned to the opposite delta attrs)

Closes Issue #2729
