### PR TITLE
Glows imap start time

### DIFF
--- a/imap_processing/glows/l1a/glows_l1a.py
+++ b/imap_processing/glows/l1a/glows_l1a.py
@@ -329,6 +329,15 @@ def generate_histogram_dataset(
         hist for hist in hist_l1a_list if hist.number_of_bins_per_histogram > 0
     ]
 
+    # Filter out histograms with imap_start_time == 0 (invalid timing data).
+    valid_hists = [hist for hist in hist_l1a_list if hist.imap_start_time.seconds != 0]
+    if len(valid_hists) < len(hist_l1a_list):
+        logger.warning(
+            f"GLOWS: Filtered out {len(hist_l1a_list) - len(valid_hists)} "
+            f"histogram(s) with imap_start_time == 0."
+        )
+    hist_l1a_list = valid_hists
+
     # Store timestamps for each HistogramL1A object.
     time_data: np.ndarray = np.zeros(len(hist_l1a_list), dtype=np.int64)
     # Data in lists, for each of the 25 time varying datapoints in HistogramL1A

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -279,4 +279,5 @@ EXTERNAL_TEST_DATA = [
     # GLOWS
     ("combined_de_l1a.csv", "glows/validation_data"),
     ("imap_glows_l0_raw_20260202-repoint00145_v001.pkts", "glows/validation_data"),
+    ("imap_glows_l0_raw_20251113-repoint00047_v001.pkts", "glows/validation_data")
 ]  # fmt: skip

--- a/imap_processing/tests/glows/conftest.py
+++ b/imap_processing/tests/glows/conftest.py
@@ -33,10 +33,28 @@ def repoint_packet_path():
 
 
 @pytest.fixture
+def in_flight_packet_path():
+    current_directory = Path(__file__).parent
+    return (
+        current_directory
+        / "validation_data"
+        / "imap_glows_l0_raw_20251113-repoint00047_v001.pkts"
+    )
+
+
+@pytest.fixture
 def decom_test_data(packet_path):
     """Read test data from file"""
 
     data_packet_list = decom_glows.decom_packets(packet_path)
+    return data_packet_list
+
+
+@pytest.fixture
+def in_flight_decom_test_data(in_flight_packet_path):
+    """Read test data from file"""
+
+    data_packet_list = decom_glows.decom_packets(in_flight_packet_path)
     return data_packet_list
 
 

--- a/imap_processing/tests/glows/test_glows_l1a_cdf.py
+++ b/imap_processing/tests/glows/test_glows_l1a_cdf.py
@@ -1,17 +1,17 @@
 import dataclasses
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
 
+from imap_processing.glows.l0.decom_glows import decom_packets
 from imap_processing.glows.l1a.glows_l1a import (
     create_glows_attr_obj,
     generate_de_dataset,
     generate_histogram_dataset,
+    glows_l1a,
 )
+from imap_processing.glows.l1a.glows_l1a_data import HistogramL1A
 from imap_processing.glows.utils.constants import TimeTuple
-
-VALIDATION_DATA = Path(__file__).parent / "validation_data"
 
 
 def test_generate_histogram_dataset(l1a_test_data):
@@ -100,8 +100,13 @@ def test_generate_de_dataset(l1a_test_data):
     ).all()
 
 
-def test_glows_l1a_no_zero_imap_start_time():
-    pkts = VALIDATION_DATA / "imap_glows_l0_raw_20260202-repoint00145_v001.pkts"
-    datasets = glows_l1a(pkts)
+def test_glows_l1a_no_zero_imap_start_time(in_flight_packet_path):
+    hist_l0, _ = decom_packets(in_flight_packet_path)
+    hist_l1a = [HistogramL1A(h) for h in hist_l0]
+    non_empty = [h for h in hist_l1a if h.number_of_bins_per_histogram > 0]
+    excluded = [h for h in non_empty if h.imap_start_time.seconds == 0]
+
+    datasets = glows_l1a(in_flight_packet_path)
     hist_dataset = next(ds for ds in datasets if "hist" in ds.attrs["Logical_source"])
     assert (hist_dataset["imap_start_time"].values != 0).all()
+    assert len(excluded) == 77

--- a/imap_processing/tests/glows/test_glows_l1a_cdf.py
+++ b/imap_processing/tests/glows/test_glows_l1a_cdf.py
@@ -2,6 +2,7 @@ import dataclasses
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 from imap_processing.glows.l0.decom_glows import decom_packets
 from imap_processing.glows.l1a.glows_l1a import (
@@ -100,6 +101,7 @@ def test_generate_de_dataset(l1a_test_data):
     ).all()
 
 
+@pytest.mark.external_test_data
 def test_glows_l1a_no_zero_imap_start_time(in_flight_packet_path):
     hist_l0, _ = decom_packets(in_flight_packet_path)
     hist_l1a = [HistogramL1A(h) for h in hist_l0]

--- a/imap_processing/tests/glows/test_glows_l1a_cdf.py
+++ b/imap_processing/tests/glows/test_glows_l1a_cdf.py
@@ -1,4 +1,5 @@
 import dataclasses
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -9,6 +10,8 @@ from imap_processing.glows.l1a.glows_l1a import (
     generate_histogram_dataset,
 )
 from imap_processing.glows.utils.constants import TimeTuple
+
+VALIDATION_DATA = Path(__file__).parent / "validation_data"
 
 
 def test_generate_histogram_dataset(l1a_test_data):
@@ -57,6 +60,21 @@ def test_generate_histogram_dataset_filters_empty(l1a_test_data):
     assert len(dataset["epoch"].values) == 2
 
 
+def test_generate_histogram_dataset_filters_zero_imap_start_time(l1a_test_data):
+    histogram_l1a, _ = l1a_test_data
+    glows_attrs = create_glows_attr_obj()
+
+    zero_time_hist = MagicMock()
+    zero_time_hist.number_of_bins_per_histogram = 3600
+    zero_time_hist.imap_start_time = TimeTuple(0, 0)
+
+    mixed_list = [zero_time_hist, histogram_l1a[0], zero_time_hist, histogram_l1a[1]]
+
+    dataset = generate_histogram_dataset(mixed_list, glows_attrs)
+
+    assert len(dataset["epoch"].values) == 2
+
+
 def test_generate_de_dataset(l1a_test_data):
     _, de_l1a = l1a_test_data
     glows_attrs = create_glows_attr_obj()
@@ -80,3 +98,10 @@ def test_generate_de_dataset(l1a_test_data):
             [event.to_list() for event in de_l1a[-1].direct_events], ((0, 651), (0, 0))
         )
     ).all()
+
+
+def test_glows_l1a_no_zero_imap_start_time():
+    pkts = VALIDATION_DATA / "imap_glows_l0_raw_20260202-repoint00145_v001.pkts"
+    datasets = glows_l1a(pkts)
+    hist_dataset = next(ds for ds in datasets if "hist" in ds.attrs["Logical_source"])
+    assert (hist_dataset["imap_start_time"].values != 0).all()


### PR DESCRIPTION
This pull request improves the robustness of the GLOWS L1A processing pipeline by filtering out histogram data with invalid timing information and enhances test coverage to ensure this behavior. The most important changes are grouped below:

**Data Validation Improvements:**

* The `generate_histogram_dataset` function in `glows_l1a.py` now filters out histograms where `imap_start_time.seconds == 0`, logging a warning when such entries are found. This prevents invalid timing data from being included in downstream processing.

**Testing Enhancements:**

* Added new pytest fixtures (`in_flight_packet_path`, `in_flight_decom_test_data`) in `conftest.py` to support testing with in-flight packet data containing edge cases. [[1]](diffhunk://#diff-389463cbfceb9686483b7bd157641b6c18f88c02b7310b61fa1c3203a336f8e4R25-R34) [[2]](diffhunk://#diff-389463cbfceb9686483b7bd157641b6c18f88c02b7310b61fa1c3203a336f8e4R43-R50)
* Introduced `test_generate_histogram_dataset_filters_zero_imap_start_time` to verify that histograms with zero `imap_start_time` are correctly excluded from the dataset.
* Added `test_glows_l1a_no_zero_imap_start_time` to confirm that the full L1A processing pipeline produces datasets without any zero `imap_start_time` values, and to check the number of excluded histograms.

**Test Setup and Imports:**

* Updated imports in `test_glows_l1a_cdf.py` to include necessary modules and classes for the new tests.
