### PR TITLE
[codex] Add MAG output epoch guard

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -25,6 +25,7 @@ import imap_data_access
 import numpy as np
 import spiceypy
 import xarray as xr
+from cdflib.epochs import CDFepoch
 from cdflib.xarray import xarray_to_cdf
 from cdflib.xarray.xarray_to_cdf import ISTPError
 from imap_data_access.io import IMAPDataAccessError, download
@@ -88,6 +89,28 @@ from imap_processing.ultra.l1c import ultra_l1c
 from imap_processing.ultra.l2 import ultra_l2
 
 logger = logging.getLogger(__name__)
+
+
+def _datetime64_to_tt2000(time: np.datetime64) -> np.int64:
+    """Convert a numpy datetime64 to CDF TT2000 nanoseconds."""
+    *parts, nanosecond = [
+        int(value) for value in re.split(r"[-T:.]", str(time.astype("datetime64[ns]")))
+    ]
+    return np.int64(
+        CDFepoch.compute_tt2000(
+            [
+                *parts,
+                nanosecond // 1_000_000,
+                (nanosecond // 1_000) % 1_000,
+                nanosecond % 1_000,
+            ]
+        )
+    )
+
+
+def _tt2000_to_string(epoch: np.int64) -> str:
+    """Convert CDF TT2000 nanoseconds to an ISO-8601 string."""
+    return CDFepoch.encode_tt2000(int(epoch))
 
 
 def _parse_args() -> argparse.Namespace:
@@ -577,6 +600,7 @@ class ProcessInstrument(ABC):
                     ds.attrs["Repointing"] = self.repointing
                 ds.attrs["Start_date"] = self.start_date
                 ds.attrs["Parents"] = parent_files
+                self._validate_output_dataset(ds)
                 products.append(write_cdf(ds))
             else:
                 # A path to a product that was already written out
@@ -584,6 +608,14 @@ class ProcessInstrument(ABC):
 
         self.upload_products(products)
         return products
+
+    def _validate_output_dataset(self, dataset: xr.Dataset) -> None:
+        """
+        Validate a processed dataset before writing it to CDF.
+
+        Subclasses can override this to enforce instrument-specific constraints.
+        """
+        return None
 
     @final
     def cleanup(self) -> None:
@@ -1348,6 +1380,69 @@ class Mag(ProcessInstrument):
                     f"monotonically increasing."
                 )
         return datasets
+
+    def _validate_output_dataset(self, dataset: xr.Dataset) -> None:
+        """
+        Validate MAG output epochs before writing them to CDF.
+
+        MAG L1A-L1C science products may include the 30 minute packet buffer on each
+        side of the processing day. L1D and L2 products are truncated to the UTC day.
+        """
+        ancillary_identifiers = {
+            "imap_mag_l1d_gradiometry-offsets-burst",
+            "imap_mag_l1d_gradiometry-offsets-norm",
+            "imap_mag_l1d_spin-offsets",
+        }
+        logical_source = dataset.attrs.get("Logical_source", "")
+        if isinstance(logical_source, list):
+            logical_source = logical_source[0]
+
+        if logical_source in ancillary_identifiers or "epoch" not in dataset:
+            return
+
+        source_parts = logical_source.split("_")
+        if len(source_parts) < 4 or source_parts[1] != "mag":
+            return
+
+        data_level = source_parts[2]
+        if data_level not in {"l1a", "l1b", "l1c", "l1d", "l2"}:
+            return
+
+        start_date = dataset.attrs.get("Start_date")
+        if start_date is None:
+            raise ValueError(
+                f"Cannot validate MAG epoch range for {logical_source}: "
+                "Start_date is not set."
+            )
+
+        day = np.datetime64(
+            f"{start_date[:4]}-{start_date[4:6]}-{start_date[6:]}", "ns"
+        )
+        buffer = (
+            np.timedelta64(30, "m")
+            if data_level in {"l1a", "l1b", "l1c"}
+            else np.timedelta64(0, "m")
+        )
+        min_epoch = _datetime64_to_tt2000(day - buffer)
+        max_epoch = _datetime64_to_tt2000(day + np.timedelta64(1, "D") + buffer)
+
+        epochs = np.asarray(dataset["epoch"].values, dtype=np.int64)
+        if epochs.size == 0:
+            return
+
+        actual_min = epochs.min()
+        actual_max = epochs.max()
+        if actual_min < min_epoch or actual_max > max_epoch:
+            raise ValueError(
+                f"MAG output epochs for {logical_source} fall outside the expected "
+                f"range for Start_date {start_date}. Expected "
+                f"{_tt2000_to_string(min_epoch)} to {_tt2000_to_string(max_epoch)}; "
+                f"first={_tt2000_to_string(epochs[0])}, "
+                f"last={_tt2000_to_string(epochs[-1])}, "
+                f"min={_tt2000_to_string(actual_min)}, "
+                f"max={_tt2000_to_string(actual_max)}, "
+                f"Parents={dataset.attrs.get('Parents', [])}."
+            )
 
     def post_processing(
         self,

--- a/imap_processing/tests/mag/test_mag_output_validation.py
+++ b/imap_processing/tests/mag/test_mag_output_validation.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import xarray as xr
+from cdflib.epochs import CDFepoch
+from imap_data_access.processing_input import ProcessingInputCollection, ScienceInput
+
+from imap_processing.cli import Mag
+
+
+def _tt2000(time: str) -> np.int64:
+    date_str, clock_str = time.split("T")
+    year, month, day = [int(value) for value in date_str.split("-")]
+    hour_minute_second, fraction = clock_str.split(".")
+    hour, minute, second = [int(value) for value in hour_minute_second.split(":")]
+    nanosecond = int(fraction.ljust(9, "0"))
+    return np.int64(
+        CDFepoch.compute_tt2000(
+            [
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                nanosecond // 1_000_000,
+                (nanosecond // 1_000) % 1_000,
+                nanosecond % 1_000,
+            ]
+        )
+    )
+
+
+def _mag_dataset(logical_source: str, epoch_times: list[str]) -> xr.Dataset:
+    epochs = np.array([_tt2000(time) for time in epoch_times], dtype=np.int64)
+    return xr.Dataset(
+        coords={"epoch": xr.DataArray(epochs, name="epoch", dims=["epoch"])},
+        attrs={"Logical_source": logical_source},
+    )
+
+
+def _mag_processor(data_level: str = "l1b") -> Mag:
+    return Mag(
+        data_level=data_level,
+        data_descriptor="burst-mago",
+        dependency_str="[]",
+        start_date="20251220",
+        repointing=None,
+        version="v001",
+        upload_to_sdc=False,
+    )
+
+
+def _dependencies() -> ProcessingInputCollection:
+    return ProcessingInputCollection(
+        ScienceInput("imap_mag_l1a_burst-mago_20251220_v001.cdf")
+    )
+
+
+def test_mag_l1b_epoch_validation_accepts_buffer_boundaries():
+    dataset = _mag_dataset(
+        "imap_mag_l1b_burst-mago",
+        ["2025-12-19T23:30:00.000000000", "2025-12-21T00:30:00.000000000"],
+    )
+
+    with patch(
+        "imap_processing.cli.write_cdf", return_value=Path("output.cdf")
+    ) as mock_write_cdf:
+        products = _mag_processor().post_processing([dataset], _dependencies())
+
+    assert products == [Path("output.cdf")]
+    mock_write_cdf.assert_called_once_with(dataset)
+
+
+def test_mag_l1b_epoch_validation_rejects_wrong_day_before_write():
+    dataset = _mag_dataset(
+        "imap_mag_l1b_burst-mago",
+        ["2025-12-29T23:59:58.667793920", "2025-12-30T00:00:00.000000000"],
+    )
+
+    with (
+        patch("imap_processing.cli.write_cdf") as mock_write_cdf,
+        pytest.raises(
+            ValueError,
+            match=(
+                "imap_mag_l1b_burst-mago.*Start_date 20251220.*"
+                "imap_mag_l1a_burst-mago_20251220_v001.cdf"
+            ),
+        ),
+    ):
+        _mag_processor().post_processing([dataset], _dependencies())
+
+    mock_write_cdf.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "logical_source",
+    [
+        "imap_mag_l1d_norm-srf",
+        "imap_mag_l2_norm-srf",
+    ],
+)
+def test_mag_day_truncated_outputs_reject_epoch_outside_utc_day(logical_source):
+    dataset = _mag_dataset(
+        logical_source,
+        ["2025-12-19T23:59:59.999999999", "2025-12-20T12:00:00.000000000"],
+    )
+
+    data_level = logical_source.split("_")[2]
+    with (
+        patch("imap_processing.cli.write_cdf") as mock_write_cdf,
+        pytest.raises(ValueError, match=f"{logical_source}.*Start_date 20251220"),
+    ):
+        _mag_processor(data_level).post_processing([dataset], _dependencies())
+
+    mock_write_cdf.assert_not_called()
+
+
+def test_mag_l1d_ancillary_outputs_skip_epoch_validation():
+    dataset = _mag_dataset(
+        "imap_mag_l1d_spin-offsets",
+        ["2025-12-30T00:00:00.000000000"],
+    )
+    dataset.attrs["Start_date"] = "20251220"
+    dataset.attrs["Parents"] = ["imap_mag_l1c_norm-mago_20251220_v001.cdf"]
+
+    _mag_processor("l1d")._validate_output_dataset(dataset)


### PR DESCRIPTION
## Summary
- add a per-instrument output dataset validation hook before CDF writes
- validate MAG output epoch ranges by data level before writing science CDFs
- cover MAG boundary, wrong-day, truncated-day, and ancillary-skip cases

## Validation
- conda run -n imap ruff check imap_processing/cli.py imap_processing/tests/mag/test_mag_output_validation.py
- conda run -n imap python -m pytest imap_processing/tests/mag/test_mag_output_validation.py imap_processing/tests/test_cli.py imap_processing/tests/mag/test_mag_l1d.py -q
