### PR TITLE
IDEX l1b: filter upstream dependencies correctly before processing

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1078,17 +1078,24 @@ class Idex(ProcessInstrument):
                     f"Unexpected dependencies found for IDEX L1B {self.descriptor}:"
                     f"{dependency_list}. Expected only {n_expected_deps} dependencies."
                 )
-            # get CDF file
             science_files = dependencies.get_file_paths(source="idex")
-            # Load all the science files. There should only be one, but in the case of
-            # multiple files, we want to make sure to load them all and select the one
-            # with the latest time.
-            science_datasets = [load_cdf(f) for f in science_files]
-            if not science_datasets:
+            if not science_files:
                 raise ValueError("No science files found for IDEX L1B processing.")
-            latest_file = max(science_datasets, key=lambda ds: ds["epoch"].data[0])
+            # IDEX l1b requires spice kernels and since there may be events that occur
+            # before the start date of the job, there is a buffer added to the upstream
+            # dependency query. This means that there may be multiple l1a science files
+            # that are returned but we only want to process the file with the same
+            # start date.
+            l1a_file = [f for f in science_files if self.start_date in f.name]
+            if not l1a_file:
+                raise ValueError(
+                    f"No L1A science file found for IDEX L1B processing with start "
+                    f"date {self.start_date}. Out of science files: {science_files}"
+                )
+            l1a_file = l1a_file[0]
+            logger.info(f"Processing IDEX l1b using l1a file: {l1a_file.name}")
             # process data
-            datasets = [idex_l1b(latest_file, self.descriptor)]
+            datasets = [idex_l1b(load_cdf(l1a_file), self.descriptor)]
         elif self.data_level == "l2a":
             if len(dependency_list) != 3:
                 raise ValueError(

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -623,8 +623,7 @@ def test_idex_l1b(mock_idex_l1b, mock_instrument_dependencies):
     """Test coverage for cli.Idex class with l1b data level"""
     mocks = mock_instrument_dependencies
     new_ds = xr.Dataset(data_vars={"epoch": [1]})
-    old_ds = xr.Dataset(data_vars={"epoch": [0]})
-    mocks["mock_load_cdf"].side_effect = [old_ds, new_ds]
+    mocks["mock_load_cdf"].side_effect = [new_ds]
     input_collection = ProcessingInputCollection(
         ScienceInput(
             "imap_idex_l1a_sci-1week_20251017_v001.cdf",
@@ -637,7 +636,7 @@ def test_idex_l1b(mock_idex_l1b, mock_instrument_dependencies):
 
     dependency_str = input_collection.serialize()
     instrument = Idex(
-        "l1b", "sci-1week", dependency_str, "20251017", "20251017", "v001", False
+        "l1b", "sci-1week", dependency_str, "20251017", None, "v001", False
     )
 
     instrument.process()


### PR DESCRIPTION
# Change Summary
 closes #3092


## Overview

This issue is caused by this problem #2843. 

Currently IDEX packets
- contain ~1weeks worth of data but can be more in some cases 
- They can contain events from months previous 

This is a pretty major problem because our infrastructure is not built to deal with this. 

The issue: 

Since IDEX l1b processing needs spice kernels, I added a buffer time in the upstream dependency querying logic for l1b jobs only. This ensures that we have spice coverage but also provides the job with extraneous l1a files. I thought I was handling this correctly by choosing the l1a file with the greatest epoch value. This was returning the incorrect l1a file for processing because we should really be using the file with the start date of the job. I thought these two would always be the same but Jamey noticed a case where a file with an older start date has a more recent epoch value! This is due to the jumbling of IDEX events (I think) because of the issue described in  #2843. Once this issue is resolved, this will no longer be a problem but as a small fix, I can pass the correct file to l1b processing by finding the one with the same start date. 

EXAMPLE: 
The max epoch value for the following files will illuminate the issue 
-  imap_idex_l1a_sci-1week_20251209_v005.cdf' max epoch = np.int64(818510673907323520)
-  imap_idex_l1a_sci-1week_20251218_v007.cdf' max epoch = np.int64(818509752656208384)
-  imap_idex_l1a_sci-1week_20251217_v005.cdf' max epoch = np.int64(819201872691961088


File with start date 20251217 has a greater max epoch than teh file with 20251218


## File changes

imap_processing/cli.py 

Fix file sorting logic 

## Testing

This was tested with the fie Jamey mentioned in this email. 
