### PR TITLE
Add epoch_delta_minus to L2 maps variables

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -82,12 +82,23 @@ epoch:
   CATDESC: Map time range start, number of nanoseconds since J2000 with leap seconds included
   FIELDNAM: J2000 Nanoseconds
   DELTA_PLUS_VAR: epoch_delta
+  DELTA_MINUS_VAR: epoch_delta_minus
   BIN_LOCATION: 0
 
 epoch_delta:
   <<: *default_int64
   CATDESC: Number of nanoseconds covered by data included in this map product.
   FIELDNAM: epoch delta
+  UNITS: ns
+  VAR_TYPE: support_data
+  DISPLAY_TYPE: no_plot
+  TIME_SCALE: Terrestrial Time
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal
+
+epoch_delta_minus:
+  <<: *default_int64
+  CATDESC: Number of nanoseconds before epoch included in this map product (always equal to zero).
+  FIELDNAM: epoch delta minus
   UNITS: ns
   VAR_TYPE: support_data
   DISPLAY_TYPE: no_plot

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1456,7 +1456,7 @@ class RectangularSkyMap(AbstractSkyMap):
                 )
             # Set the correct delta values for the time coordinate
             if coord_name == CoordNames.TIME.value:
-                # Delta minus is always zero b/c epoch is the start time
+                # Delta minus is always zero because epoch is the start time
                 cdf_ds[f"{coord_name}_delta_minus"] = xr.DataArray(
                     xr.zeros_like(cdf_ds[coord_name]),
                     name=f"{coord_name}_delta_minus",

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1454,13 +1454,20 @@ class RectangularSkyMap(AbstractSkyMap):
                     name=f"{coord_name}_label",
                     dims=[coord_name],
                 )
-            # We can set the correct delta value of the spatial coordinates
+            # Set the correct delta values for the time coordinate
             if coord_name == CoordNames.TIME.value:
+                # Delta minus is always zero b/c epoch is the start time
+                cdf_ds[f"{coord_name}_delta_minus"] = xr.DataArray(
+                    xr.zeros_like(cdf_ds[coord_name]),
+                    name=f"{coord_name}_delta_minus",
+                    dims=[coord_name],
+                )
                 cdf_ds[f"{coord_name}_delta"] = xr.DataArray(
                     xr.full_like(cdf_ds[coord_name], self.max_epoch - self.min_epoch),
                     name=f"{coord_name}_delta",
                     dims=[coord_name],
                 )
+            # Set the correct delta values of the spatial coordinates
             elif coord_name in self.spatial_coords:
                 cdf_ds[f"{coord_name}_delta"] = xr.DataArray(
                     xr.full_like(cdf_ds[coord_name], self.spacing_deg / 2),

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -994,9 +994,6 @@ class TestRectangularSkyMap:
         # Check the epoch values
         assert CoordNames.TIME.value in cdf_dataset
         assert cdf_dataset[CoordNames.TIME.value].values[0] == skymap.min_epoch
-        assert (
-            cdf_dataset[CoordNames.TIME.value].attrs["DELTA_PLUS_VAR"] == "epoch_delta"
-        )
         # Check epoch_delta
         assert (
             cdf_dataset[CoordNames.TIME.value].attrs["DELTA_PLUS_VAR"]

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -998,11 +998,22 @@ class TestRectangularSkyMap:
             cdf_dataset[CoordNames.TIME.value].attrs["DELTA_PLUS_VAR"] == "epoch_delta"
         )
         # Check epoch_delta
+        assert (
+            cdf_dataset[CoordNames.TIME.value].attrs["DELTA_PLUS_VAR"]
+            == f"{CoordNames.TIME.value}_delta"
+        )
+        assert (
+            cdf_dataset[CoordNames.TIME.value].attrs["DELTA_MINUS_VAR"]
+            == f"{CoordNames.TIME.value}_delta_minus"
+        )
         assert f"{CoordNames.TIME.value}_delta" in cdf_dataset
         assert (
             cdf_dataset[f"{CoordNames.TIME.value}_delta"].values[0]
             == skymap.max_epoch - skymap.min_epoch
         )
+        # Check epoch_delta_minus
+        assert f"{CoordNames.TIME.value}_delta_minus" in cdf_dataset
+        assert cdf_dataset[f"{CoordNames.TIME.value}_delta_minus"].values[0] == 0
 
         # Energy related checks
         assert CoordNames.ENERGY_L2.value in cdf_dataset

--- a/imap_processing/tests/ena_maps/test_ena_maps.py
+++ b/imap_processing/tests/ena_maps/test_ena_maps.py
@@ -1010,7 +1010,7 @@ class TestRectangularSkyMap:
         )
         # Check epoch_delta_minus
         assert f"{CoordNames.TIME.value}_delta_minus" in cdf_dataset
-        assert cdf_dataset[f"{CoordNames.TIME.value}_delta_minus"].values[0] == 0
+        assert cdf_dataset[f"{CoordNames.TIME.value}_delta_minus"].values == 0
 
         # Energy related checks
         assert CoordNames.ENERGY_L2.value in cdf_dataset

--- a/imap_processing/tests/hi/test_hi_l2.py
+++ b/imap_processing/tests/hi/test_hi_l2.py
@@ -176,7 +176,7 @@ def test_hi_l2(
     assert l2_dataset.attrs["Logical_source"] == f"imap_hi_l2_{descriptor_str}"
     assert "Hi90" in l2_dataset.attrs["Logical_source_description"]
 
-    assert len(l2_dataset.data_vars) == 15
+    assert len(l2_dataset.data_vars) == 16
     np.testing.assert_array_equal(
         l2_dataset["ena_intensity"].dims, ["epoch", "energy", "longitude", "latitude"]
     )

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -472,6 +472,12 @@ class TestUltraL2:
         # Check energy deltas
         assert "energy_delta_plus" in map_dataset
         assert "energy_delta_minus" in map_dataset
+        # Check epoch deltas
+        assert map_dataset["epoch"].attrs["DELTA_PLUS_VAR"] == "epoch_delta"
+        assert map_dataset["epoch"].attrs["DELTA_MINUS_VAR"] == "epoch_delta_minus"
+        assert "epoch_delta" in map_dataset
+        assert "epoch_delta_minus" in map_dataset
+        assert map_dataset["epoch_delta_minus"].values == 0
 
     @pytest.mark.external_test_data
     @pytest.mark.usefixtures("_setup_spice_kernels_list")

--- a/imap_processing/tests/ultra/unit/test_ultra_l2.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l2.py
@@ -477,7 +477,7 @@ class TestUltraL2:
         assert map_dataset["epoch"].attrs["DELTA_MINUS_VAR"] == "epoch_delta_minus"
         assert "epoch_delta" in map_dataset
         assert "epoch_delta_minus" in map_dataset
-        assert map_dataset["epoch_delta_minus"].values == 0
+        np.testing.assert_array_equal(map_dataset["epoch_delta_minus"].values, 0)
 
     @pytest.mark.external_test_data
     @pytest.mark.usefixtures("_setup_spice_kernels_list")

--- a/imap_processing/ultra/l2/ultra_l2.py
+++ b/imap_processing/ultra/l2/ultra_l2.py
@@ -807,6 +807,12 @@ def ultra_l2(
         map_dataset["ena_intensity_stat_uncert"],
     )
 
+    # Add epoch_delta_minus
+    map_dataset.coords["epoch_delta_minus"] = xr.DataArray(
+        [0],
+        dims=(CoordNames.TIME.value,),
+    )
+    map_dataset.coords["epoch"].attrs["DELTA_MINUS_VAR"] = "epoch_delta_minus"
     # Add epoch_delta
     map_dataset.coords["epoch_delta"] = xr.DataArray(
         [


### PR DESCRIPTION
# Change Summary

This PR adds the epoch_delta_minus variable to the ENA L2 Map products. This was requested for use in CAVA.

Closes: #2316 
