### PR TITLE
[codex] Preserve MAG L1B epoch precision

### DIFF
--- a/imap_processing/mag/l1b/mag_l1b.py
+++ b/imap_processing/mag/l1b/mag_l1b.py
@@ -395,12 +395,31 @@ def shift_time(epoch_times: xr.DataArray, time_shift: xr.DataArray) -> xr.DataAr
         The shifted epoch times, equal to epoch_times with time_shift added to each
         value.
     """
-    if time_shift.size != 1:
-        raise ValueError("Time shift must be a single value.")
-    # Time shift is in seconds
-    time_shift_ns = time_shift.data * 1e9
+    time_shift_ns = _time_shift_to_nanoseconds(time_shift)
 
     return epoch_times + time_shift_ns
+
+
+def _time_shift_to_nanoseconds(time_shift: xr.DataArray) -> np.int64:
+    """
+    Convert a scalar time shift from seconds to integer nanoseconds.
+
+    Parameters
+    ----------
+    time_shift : xarray.DataArray
+        The time shift to apply for the given sensor. This should be one value and is
+        in seconds.
+
+    Returns
+    -------
+    numpy.int64
+        The time shift rounded to the nearest integer nanosecond.
+    """
+    if time_shift.size != 1:
+        raise ValueError("Time shift must be a single value.")
+
+    time_shift_seconds = float(np.asarray(time_shift.data).item())
+    return np.int64(round(time_shift_seconds * 1e9))
 
 
 def timeshift_vectors_per_second(
@@ -426,12 +445,12 @@ def timeshift_vectors_per_second(
     str
         The updated vectors per second attribute.
     """
-    time_shift_ns = time_shift.data * 1e9
+    time_shift_ns = _time_shift_to_nanoseconds(time_shift)
 
     vecsec = vectors_per_second_from_string(vectors_per_second)
     new_vecsec = ""
     for time, rate in vecsec.items():
         new_time = time + time_shift_ns
-        new_vecsec += f"{new_time.astype(np.int64)}:{rate},"
+        new_vecsec += f"{int(new_time)}:{rate},"
 
     return new_vecsec[:-1]

--- a/imap_processing/tests/mag/test_mag_l1b.py
+++ b/imap_processing/tests/mag/test_mag_l1b.py
@@ -11,6 +11,8 @@ from imap_processing.mag.l1b.mag_l1b import (
     mag_l1b,
     mag_l1b_processing,
     rescale_vector,
+    shift_time,
+    timeshift_vectors_per_second,
 )
 from imap_processing.tests.mag.conftest import (
     mag_l1a_dataset_generator,
@@ -207,6 +209,47 @@ def test_calibrate_vector():
     expected_vector = [4584.1029091, 27238.73161294, -38405.22240195, 0.0]
 
     assert np.allclose(cal_vector, expected_vector, atol=1e-9)
+
+
+def test_shift_time_preserves_int64_epoch_precision():
+    epoch_values = np.array(
+        [813411068230810679, 813411068238623179, 813411068246435679],
+        dtype=np.int64,
+    )
+    epoch_times = xr.DataArray(epoch_values, name="epoch", dims=["epoch"])
+    time_shift = xr.DataArray(np.array([0.0]), dims=["epoch"])
+
+    shifted_times = shift_time(epoch_times, time_shift)
+
+    assert shifted_times.dtype == np.int64
+    np.testing.assert_array_equal(shifted_times.data, epoch_values)
+    np.testing.assert_array_equal(np.diff(shifted_times.data), [7812500, 7812500])
+
+
+def test_shift_time_uses_integer_nanosecond_shift():
+    epoch_values = np.array(
+        [813411068230810679, 813411068238623179, 813411068246435679],
+        dtype=np.int64,
+    )
+    epoch_times = xr.DataArray(epoch_values, name="epoch", dims=["epoch"])
+    time_shift = xr.DataArray(np.array([1.23e-7]), dims=["epoch"])
+
+    shifted_times = shift_time(epoch_times, time_shift)
+
+    expected_times = epoch_values + 123
+    assert shifted_times.dtype == np.int64
+    np.testing.assert_array_equal(shifted_times.data, expected_times)
+    np.testing.assert_array_equal(np.diff(shifted_times.data), [7812500, 7812500])
+
+
+def test_timeshift_vectors_per_second_matches_epoch_shift():
+    time_shift = xr.DataArray(np.array([1.23e-7]), dims=["epoch"])
+
+    shifted_vecsec = timeshift_vectors_per_second(
+        "813411068230810679:128,813411070230810679:64", time_shift
+    )
+
+    assert shifted_vecsec == "813411068230810802:128,813411070230810802:64"
 
 
 def test_l1a_to_l1b(validation_l1a, mag_l1b_cal_dataset):


### PR DESCRIPTION
## Summary

- Preserve MAG L1B TT2000 epoch precision by converting calibration time shifts to integer nanoseconds before adding them to int64 epoch arrays.
- Reuse the same integer nanosecond shift for the `vectors_per_second` global attribute so metadata stays aligned with shifted epochs.
- Add regression coverage for zero-shift precision, nonzero nanosecond shifts, and `vectors_per_second` alignment.

## Root Cause

MAG L1B `shift_time()` multiplied the scalar calibration shift by `1e9` as a float and added that float directly to int64 TT2000 epochs. Around modern MAG epochs, float64 cannot exactly represent the large nanosecond values, so the operation introduced small L1B-only timestamp quantization noise.

Closes #3102.

## Validation

- `conda run -n imap poetry run pytest imap_processing/tests/mag/test_mag_l1b.py -q`
- `conda run -n imap poetry run pre-commit run ruff-format --files imap_processing/mag/l1b/mag_l1b.py imap_processing/tests/mag/test_mag_l1b.py`
- `conda run -n imap poetry run pre-commit run ruff-check --files imap_processing/mag/l1b/mag_l1b.py imap_processing/tests/mag/test_mag_l1b.py`
- `conda run -n imap poetry run pre-commit run codespell --files imap_processing/mag/l1b/mag_l1b.py imap_processing/tests/mag/test_mag_l1b.py`
- `conda run -n imap poetry run pre-commit run trailing-whitespace --files imap_processing/mag/l1b/mag_l1b.py imap_processing/tests/mag/test_mag_l1b.py`
- `conda run -n imap poetry run pre-commit run numpydoc-validation --files imap_processing/mag/l1b/mag_l1b.py`
- `conda run -n imap poetry run pre-commit run mypy --files imap_processing/mag/l1b/mag_l1b.py`