### PR TITLE
Add SDS data manager documentation to imap_processing

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,6 +133,7 @@ nitpick_ignore_regex = [
     (r"py:class", r"^numpy\.(u?int(?:8|16|32|64))$"),
     (r"py:.*", r".*ProcessingInputCollection"),
     (r"py:.*", r"imap_data_access.*"),
+    (r"py:class", r"pandas\.core\.frame\.DataFrame"),
 ]
 
 # Ignore the inherited members from the <instrument>APID IntEnum class

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,8 +25,9 @@ The explicit code interfaces and structure are described in the :ref:`algorithm-
    IMAP Data Access Tool <data-access/index>
    CDF Metadata Resources <cdf-metadata/index>
    Filename Conventions <filename-convention/index>
-   SDC Project Management <project-management/index>
    Algorithm Code Documentation <algorithm-code-documentation/index>
+   SDC Project Management <project-management/index>
+   Infrastructure <infrastructure/index>
 
 
 If you make use of any ``imap_processing`` code, please consider citing it in your research.

--- a/docs/source/infrastructure/aws-setup.rst
+++ b/docs/source/infrastructure/aws-setup.rst
@@ -1,0 +1,47 @@
+AWS Setup
+=========
+
+Download/requirements
+~~~~~~~~~~~~~~~~~~~~~
+
+Ensure you have installed nodejs (newer than version 14), AWS CLI, and Docker
+
+- `nodejs <https://nodejs.org/en/download/>`_
+- `AWS CLI <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html>`_
+- `Docker <https://docs.docker.com/get-docker/>`_
+
+.. _aws-new-user:
+
+New User
+~~~~~~~~~
+
+#. Log-in to `AWS console <https://aws.amazon.com/console/>`_
+#. Use *imap-sdc-development* for Account ID
+#. Enter user name and password
+#. Select IAM from *Services* menu or search IAM
+#. Select *Users* from left menu
+#. Click your user button
+#. Select *Security Credentials* tab
+#. Click *Create Access Key*
+#. Make note of *Access Key ID* and *Secret Access Key*
+#. You can download the .csv file if you want
+#. Click *Close*
+
+Existing User
+~~~~~~~~~~~~~
+#. In command line, run the following command to set up the aws environment::
+
+    aws configure
+
+#. Enter your *Access Key ID* and *Secret Access Key* (If you don't have them, see :ref:`aws-new-user`)
+#. For region, set it to the AWS region you'd like to set up your SDS. For IMAP, we're using "us-west-2"::
+
+    [imap]
+    region=us-west-2
+    aws_access_key_id=<Access Key>
+    aws_secret_access_key=<Secret Key>
+
+#. Then, you can set the profile used by cdk by setting the AWS_PROFILE environment variable to the profile name (in this case, imap)::
+
+    export AWS_PROFILE=imap
+

--- a/docs/source/infrastructure/aws-setup.rst
+++ b/docs/source/infrastructure/aws-setup.rst
@@ -4,9 +4,9 @@ AWS Setup
 Download/requirements
 ~~~~~~~~~~~~~~~~~~~~~
 
-Ensure you have installed nodejs (newer than version 14), AWS CLI, and Docker
+Ensure you have installed Node.js (newer than version 14), AWS CLI, and Docker
 
-- `nodejs <https://nodejs.org/en/download/>`_
+- `Node.js <https://nodejs.org/en/download/>`_
 - `AWS CLI <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html>`_
 - `Docker <https://docs.docker.com/get-docker/>`_
 

--- a/docs/source/infrastructure/backup-deploy.rst
+++ b/docs/source/infrastructure/backup-deploy.rst
@@ -1,0 +1,21 @@
+Deploying to Backup Account
+===========================
+
+Some of the CDK code is used to deploy a backup bucket for S3 replication. This page covers how to deploy this code into a different account. This backup code can be deployed into the normal dev account as well.
+
+Steps for deploying
+^^^^^^^^^^^^^^^^^^^
+.. note::
+    First, you will need to deploy the SdsDataManager stack to the source account (dev or prod). The steps to set up and deploy that are in the :doc:`cdk-deployment` doc.
+
+#. Set up your backup account credentials if you're using another account. This can be done by adding a new profile to AWS (i.e. ``imap-backup``)
+#. Set your ``AWS_PROFILE`` environment variable to the backup account profile
+#. Set the ``source_account`` variable in the "backup" section of the cdk.json file to the account number for the _source_ bucket (where the backed up items originate)
+#. Update the ``account_name`` variable in the ``cdk.json`` file to "backup"
+#. Finally, you will need to copy the Role arn deployed in SdsDataManager into :file:`sds_data_manager/stacks/backup_bucket_construct.py`. This arn can be found by going to the IAM console in the source account and searching for "BackupRole".
+#. Run your ``cdk bootstrap`` command if you haven't already done so for the backup account.
+#. Run ``cdk synth --context account_name=backup`` and check to confirm that the only stack being deployed is the "BackupBucket" stack
+#. Run ``cdk deploy --context account_name=backup`` to deploy!
+
+.. note::
+    Once the Backup bucket is deployed to the other account, you still need to set up :doc:`s3-replication` in the source account.

--- a/docs/source/infrastructure/cdk-deployment-personal-aws.rst
+++ b/docs/source/infrastructure/cdk-deployment-personal-aws.rst
@@ -9,7 +9,7 @@ Deploy CDK to Personal AWS Account
    d. For "Root Group Email Address to Associate with Account", use your LASP email address
    e. For "Lead Technical Contact Name", use `Greg Lucas`
 
-2. Once the account is set up, `login in to AWS <https://signin.aws.amazon.com/signin?redirect_uri=https%3A%2F%2Fconsole.aws.amazon.com%2Fconsole%2Fhome%3FhashArgs%3D%2523%26isauthcode%3Dtrue%26state%3DhashArgsFromTB_us-east-2_bdb6cea710bddb8a&client_id=arn%3Aaws%3Asignin%3A%3A%3Aconsole%2Fcanvas&forceMobileApp=0&code_challenge=DSG8NACFeAjbOsDQjFFz6TvuW-ohRykiAIXkuEQriOI&code_challenge_method=SHA-256>`_ and create a user in IAM.
+2. Once the account is set up, `log in to AWS <https://signin.aws.amazon.com/signin?redirect_uri=https%3A%2F%2Fconsole.aws.amazon.com%2Fconsole%2Fhome%3FhashArgs%3D%2523%26isauthcode%3Dtrue%26state%3DhashArgsFromTB_us-east-2_bdb6cea710bddb8a&client_id=arn%3Aaws%3Asignin%3A%3A%3Aconsole%2Fcanvas&forceMobileApp=0&code_challenge=DSG8NACFeAjbOsDQjFFz6TvuW-ohRykiAIXkuEQriOI&code_challenge_method=SHA-256>`_ and create a user in IAM.
 
    a. You'll likely want to give your user the ``AdministratorAccess`` policy.
 
@@ -28,8 +28,8 @@ Deploy CDK to Personal AWS Account
         "region":"us-west-2"
     },
     "dev": {
-        "account": "449431850278",
-        "domain_name": "imap-mission.com",
+        "account": "111122223333",
+        "domain_name": "example.com",
         "region": "us-west-2"
     },
 

--- a/docs/source/infrastructure/cdk-deployment-personal-aws.rst
+++ b/docs/source/infrastructure/cdk-deployment-personal-aws.rst
@@ -1,0 +1,53 @@
+Deploy CDK to Personal AWS Account
+==================================
+
+1. Get a personal AWS account set up by submitting a `Service Desk ticket <https://servicedesk.lasp.colorado.edu/servicedesk/customer/portals>`_:
+
+   a. Use the request type "Create AWS Account" under the "Cloud" section.
+   b. For "Project/Program Name", use ``IMAP``
+   c. For "Speedtype", use the speedtype for the "IMAP SOC SDC SW and Sys Devl" project
+   d. For "Root Group Email Address to Associate with Account", use your LASP email address
+   e. For "Lead Technical Contact Name", use `Greg Lucas`
+
+2. Once the account is set up, `login in to AWS <https://signin.aws.amazon.com/signin?redirect_uri=https%3A%2F%2Fconsole.aws.amazon.com%2Fconsole%2Fhome%3FhashArgs%3D%2523%26isauthcode%3Dtrue%26state%3DhashArgsFromTB_us-east-2_bdb6cea710bddb8a&client_id=arn%3Aaws%3Asignin%3A%3A%3Aconsole%2Fcanvas&forceMobileApp=0&code_challenge=DSG8NACFeAjbOsDQjFFz6TvuW-ohRykiAIXkuEQriOI&code_challenge_method=SHA-256>`_ and create a user in IAM.
+
+   a. You'll likely want to give your user the ``AdministratorAccess`` policy.
+
+3. Next, go to ``Security Credentials`` for your new user and create an access key. This will be needed in step 6, so save the access key/secret access key.
+4. On your local system, add a new profile to ``~/.aws/config`` for your personal account. This can be named anything you want, we'll call it ``my_profile`` for this example.
+5. In your local command line, type ``aws configure`` to set up your credentials.
+6. Paste your IAM access key and secret access key from step 3.
+7. In the IMAP ``sds-data-manager`` repository, add a new context to ``cdk.json``. We'll call it ``my_context`` for this example. For example::
+
+    "backup": {
+        "account": "012345678901",
+        "source_account": "dev"
+    },
+    "my_context": {
+        "account":"234567890123",
+        "region":"us-west-2"
+    },
+    "dev": {
+        "account": "449431850278",
+        "domain_name": "imap-mission.com",
+        "region": "us-west-2"
+    },
+
+*Do not put a domain field for your personal context*
+
+8. In your local terminal, go to the top of the ``sds-data-manager`` repository and run the following:
+
+   a. ``cdk bootstrap --profile my_profile --context account_name=my_context``
+   b. ``cdk synth --profile my_profile --context account_name=my_context``
+   c. ``cdk deploy --profile my_profile --context account_name=my_context``
+
+      * Add ``--require-approval never`` to the end of step 9c if you don't want to be prompted for each stack.
+      * Note: Not sure if this happens to anyone else, but when the deployment gets this part of the deployment, there's no prompt and it hangs there forever. However, if I hit ``Enter``, a ``y/n`` prompt appears asking if I want to deploy. So if it gets stuck at that point, hit ``Enter``, then you can select ``y``. Terminal output example::
+
+            0af60606a7e1: Pushed
+            03f331fd9b29: Pushed
+            03f331fd9b29: Pushed
+            c3418b25bdeef0d97b84f41688fa22e9d1c8bdf0927d3774d77588d87763a2f9: digest: sha256:83e8fd9ae28cee020091b2caa4faa421a400505e4ddfdb29fd693dec8b2a7a1d size: 2628
+            29143fef993fc62aeb3447a224679eafa9e60eaba00aa3bfaa60f0de9f9815bb: digest: sha256:e3c8f122ade7a0c1f598b3c7bbc08488c694aa9b7279e1367227ed0d0fba6c33 size: 2628
+
+9. Before committing any changes, make sure to revert your ``cdk.json`` file to its original state.

--- a/docs/source/infrastructure/cdk-deployment.rst
+++ b/docs/source/infrastructure/cdk-deployment.rst
@@ -40,7 +40,9 @@ Then you can deploy the architecture with the following command::
     cdk deploy --context account_name="dev" [ stack | --all ]
 
 After about 20-30 minutes or so, you should have a brand-new SDS set up in AWS.
-This is the repository for the cloud infrastructure on the IMAP mission.
+The cloud infrastructure CDK source for the IMAP mission is maintained in the
+``sds-data-manager`` repository; this page is mirrored in ``imap_processing``
+for documentation and reference only.
 
 Cleanup Resources
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/infrastructure/cdk-deployment.rst
+++ b/docs/source/infrastructure/cdk-deployment.rst
@@ -1,0 +1,98 @@
+.. _cdk-deployment:
+
+CDK Deployment
+==============
+
+.. note::
+    In most cases, deployments should be performed via GitHub Actions rather
+    than manually. Manual deployment is intended for special cases only.
+
+Deploy
+~~~~~~
+The deploy configuration is controlled through the ``cdk.json`` file.
+Each account has a name and the associated configuration parameters associated with it.
+For example::
+
+    "dev": {
+        "account": "123456789012",
+        "domain_name": "website.com",
+        "region": "us-west-2"
+    }
+
+The parameters in this section are what control the deployment of the application.
+The account and region are the environment to deploy the stacks into, and the
+``domain_name`` is if you want to deploy it into a hosted domain name that you control.
+Optionally, if you want to deploy to a new account or different subdomain you can
+add an entirely new section with appropriate parameters.
+
+To deploy the application, you must have local credentials to be able to deploy to
+the specified account and region. This can be done through environment variables
+and AWS access key credentials::
+
+        export AWS_PROFILE=<profile>
+
+You'll then need to synthesize the CDK code with the command::
+
+        cdk synth --context account_name="dev"
+
+Then you can deploy the architecture with the following command::
+
+    cdk deploy --context account_name="dev" [ stack | --all ]
+
+After about 20-30 minutes or so, you should have a brand-new SDS set up in AWS.
+This is the repository for the cloud infrastructure on the IMAP mission.
+
+Cleanup Resources
+~~~~~~~~~~~~~~~~~
+During development, if you are creating resources that aren't intended to be shared,
+and you do not intend to use the resources for more than a couple of days you should
+do a destroy to avoid charges, especially with databases.::
+
+        cdk destroy --context account_name="dev" [ stack | --all ]
+
+Automatic Deployments
+~~~~~~~~~~~~~~~~~~~~~
+The CDK code is automatically deployed to the dev account when a pull request is
+merged into the dev branch. This is done through a GitHub Action that runs
+the ``cdk deploy`` command. The GitHub Action is defined in the
+``.github/workflows/deploy.yml`` file. It uses short lived credentials to deploy
+the code to the dev account. The credentials are obtained through an OIDC
+authentication process and an aws provided credentials action step.
+
+With a new account, there are several steps that are required to set this up
+and authorize GitHub to deploy to the account. A summary link to the steps
+is given here: https://github.com/aws-actions/configure-aws-credentials#OIDC
+with the explicit steps as follows:
+
+#. Setup GitHub as an OIDC provider in your AWS account. This can be done
+   manually via the console or through a cloudformation template. These links give
+   a step-by-step process that you can follow.
+   https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-the-identity-provider-to-aws
+   https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html
+#. Add a role and trust policy in AWS IAM that allows GitHub to assume the role.
+   https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#configuring-the-role-and-trust-policy
+   Specifically, make sure you restrict this role to only be invoked on the given
+   branches of your repository and not wide-open trust to the entire organization.
+#. Attach a policy to the role that allows the role to deploy the CDK stacks, giving
+   it the appropriate permissions for the resources you require.
+
+Troubleshooting Lambda Architectures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The project can be built on a local machine, but creating the layers can
+sometimes cause issues if a developer is running on an ARM architecture (e.g. Macs).
+The Lambda layers are designed to be built on an x86 architecture (GitHub Actions CI),
+so if you are running on ARM architecture you may need to set some additional
+environment variables to force the build to run on x86.
+
+Remove all Docker images and build artifacts before running the build command::
+
+    docker builder prune -a
+    docker image prune -a
+    # Remove the cdk.out directory where build artifacts are stored.
+    rm -rf cdk.out
+
+Then, set the environment variable to force Docker to use the x86 architecture::
+
+    DOCKER_DEFAULT_PLATFORM=linux/amd64 cdk synth --context account_name="dev"
+

--- a/docs/source/infrastructure/ialirt-setup.rst
+++ b/docs/source/infrastructure/ialirt-setup.rst
@@ -1,0 +1,65 @@
+I-ALiRT Setup
+=============
+
+Secrets Manager
+~~~~~~~~~~~~~~~
+
+Ensure you have a secret in AWS Secrets Manager with a username and password for the Nexus repo. The secret should be named `nexus-repo` and can be created using the following command::
+
+    aws secretsmanager create-secret --name nexus-credentials --description "Credentials for Nexus Docker registry" --secret-string '{"username":"your-username", "password":"your-password"}'
+
+Image Versioning
+~~~~~~~~~~~~~~~~
+We will rely on semantic versioning for the images MAJOR.MINOR (e.g., 1.0).
+
+- MAJOR: Major changes.
+- MINOR: Minor changes.
+
+For development we will keep the major changes at 0.
+
+Nexus Repo
+~~~~~~~~~~
+We will have a versioned image and latest image in the Nexus repo. The versioned image will be tagged with the version number (e.g., 1.0) and the latest image will be the same as the most recent version. The reason that we do this is to ease the ability to switch out images in ECS.
+
+#. Check that you are not already logged in by running::
+
+    cat ~/.docker/config.json
+
+#. Ensure that the Nexus registry URL is not in the list of logged in registries.
+#. Run the following command to login (you will be prompted for your WebIAM username and password)::
+
+    docker login docker-registry.pdmz.lasp.colorado.edu
+
+#.  Your `~/.docker/config.json` file should now contain a reference to the registry url.
+#.  Determine the appropriate version for your image based on the semantic versioning scheme (IOIS_MAJOR.IOIS_MINOR.DOCKER_VERSION).
+#. Build the image and tag it with the Nexus registry URL::
+
+    docker build -t ialirt:X.Y.Z --rm . --no-cache
+
+#. Tag with the Nexus registry URL::
+
+    docker tag ialirt:X.Y.Z docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y.Z
+    docker tag ialirt:X.Y.Z docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest_{dev | prod}
+
+#. Push the image::
+
+    docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y.Z
+    docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest_{dev | prod}
+
+#. Images may be viewed on the Nexus website: https://artifacts.pdmz.lasp.colorado.edu
+#. To verify that the latest image and the most recent version image are the same, run the following and compare the image IDs::
+
+    docker inspect --format='{{.Id}}' docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y.Z
+    docker inspect --format='{{.Id}}' docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest_{dev | prod}
+
+CDK Deployment
+~~~~~~~~~~~~~~
+:ref:`cdk-deployment`
+
+ECS Recognition of a New Image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To have ECS recognize a new image the cdk must be redeployed::
+
+    aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment --deployment-configuration maximumPercent=200,minimumHealthyPercent=0
+
+The reason that we can only have a single task running is that the same ports would be in use by the old task, and as a result, the new task will fail to start because it wouldn't be able bind to the required ports.

--- a/docs/source/infrastructure/index.rst
+++ b/docs/source/infrastructure/index.rst
@@ -1,0 +1,18 @@
+.. _infrastructure:
+
+Infrastructure
+==============
+
+This section covers the AWS cloud infrastructure and deployment documentation
+for the IMAP Science Data System (SDS). This is only relevant for SDC infrastructure developers
+directly updating infrastructure for running algorithm generation code.
+
+.. toctree::
+    :maxdepth: 1
+
+    aws-setup
+    cdk-deployment
+    cdk-deployment-personal-aws
+    backup-deploy
+    s3-replication
+    ialirt-setup

--- a/docs/source/infrastructure/s3-replication.rst
+++ b/docs/source/infrastructure/s3-replication.rst
@@ -20,14 +20,16 @@ Now, items placed in the source bucket will be automatically replicated to the b
 Copying items back into source account bucket
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To restore files from the backup bucket into the main account bucket, we are going to [assume the role](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-role-prereqs) created by SdsDataManager stack in the source account. Here, "source account" refers to the account with SdsDataManager deployed into it (i.e. dev or prod).
+To restore files from the backup bucket into the main account bucket, we are going to `assume the role <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-role-prereqs>`_ created by SdsDataManager stack in the source account. Here, "source account" refers to the account with SdsDataManager deployed into it (i.e. dev or prod).
 
 #. Update ``~/.aws/config`` to include a new profile for this role. Here, ``source_profile`` should be the source account profile
-```
-[profile backup-role]
-role_arn = arn:aws:iam::<source account number>:role/<role name>
-source_profile = imap
-```
+
+   .. code-block:: ini
+
+      [profile backup-role]
+      role_arn = arn:aws:iam::<source account number>:role/<role name>
+      source_profile = imap
+
 #. Update the role in the dev account to include a new principal:
 
     * Under the "Trust relationships" tab, edit the trust policy

--- a/docs/source/infrastructure/s3-replication.rst
+++ b/docs/source/infrastructure/s3-replication.rst
@@ -1,0 +1,39 @@
+S3 Replication
+==============
+
+Once you have finished :doc:`backup-deploy`, you can set up replication in the source bucket.
+
+Create a replication rule
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Open your source S3 bucket in the AWS console
+#. Under the "Management" tab, find the "Replication Rules" section
+#. Click "Create replication rule" to create a new rule
+#. Enter an ID. If this is a developer bucket, include your initials. Preferably, it should be clear this is a backup rule.
+#. Under "Source Bucket", select "Apply to all objects in this bucket"
+#. Under "Destination" select "Specify a bucket in another account" and enter the account number and bucket name
+#. Under "IAM role", select the "SdsDataManager-{account_name}-BackupRole"
+#. Then, save the rule, and select "Do not replicate existing objects" in the popup
+
+Now, items placed in the source bucket will be automatically replicated to the backup bucket!
+
+Copying items back into source account bucket
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To restore files from the backup bucket into the main account bucket, we are going to [assume the role](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-role-prereqs) created by SdsDataManager stack in the source account. Here, "source account" refers to the account with SdsDataManager deployed into it (i.e. dev or prod).
+
+#. Update ``~/.aws/config`` to include a new profile for this role. Here, ``source_profile`` should be the source account profile
+```
+[profile backup-role]
+role_arn = arn:aws:iam::<source account number>:role/<role name>
+source_profile = imap
+```
+#. Update the role in the dev account to include a new principal:
+
+    * Under the "Trust relationships" tab, edit the trust policy
+    * add a new principal to the trust policy with your username. You can do this via the GUI or just add under "principal": ``"AWS": "arn:aws:iam::<source account>>:user/hartnett"`` (update with your username)
+    * We can then assume this role in the AWS CLI with ``--profile``
+
+#. Check your credentials: ``aws s3 ls --profile backup-role s3://sds-data-dev``
+#. To transfer all files from the backup bucket to the main bucket: ``aws s3 sync --profile backup-role s3://sds-data-backup s3://sds-data-dev``
+#. If you have any issues, you can check permissions by downloading and uploading locally (replace one of the bucket names with a local file path)


### PR DESCRIPTION
# Change Summary
Adds all the existing infrastructure documentation from sds-data-manager to imap_processing, without making updates (except to remove the unneeded opensearch doc.) 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Adds a new section "Infrastructure" and moves docs from SDS into it. 
