### PR TITLE
MAG L1B: round time_shift to int64 ns to preserve TT2000 precision

### DIFF
--- a/imap_processing/mag/l1b/mag_l1b.py
+++ b/imap_processing/mag/l1b/mag_l1b.py
@@ -398,7 +398,7 @@ def shift_time(epoch_times: xr.DataArray, time_shift: xr.DataArray) -> xr.DataAr
     if time_shift.size != 1:
         raise ValueError("Time shift must be a single value.")
     # Time shift is in seconds
-    time_shift_ns = time_shift.data * 1e9
+    time_shift_ns = np.int64(round(time_shift.data.item() * 1e9))
 
     return epoch_times + time_shift_ns
 
@@ -426,7 +426,7 @@ def timeshift_vectors_per_second(
     str
         The updated vectors per second attribute.
     """
-    time_shift_ns = time_shift.data * 1e9
+    time_shift_ns = np.int64(round(time_shift.data.item() * 1e9))
 
     vecsec = vectors_per_second_from_string(vectors_per_second)
     new_vecsec = ""

--- a/imap_processing/tests/mag/test_mag_l1b.py
+++ b/imap_processing/tests/mag/test_mag_l1b.py
@@ -11,6 +11,8 @@ from imap_processing.mag.l1b.mag_l1b import (
     mag_l1b,
     mag_l1b_processing,
     rescale_vector,
+    shift_time,
+    timeshift_vectors_per_second,
 )
 from imap_processing.tests.mag.conftest import (
     mag_l1a_dataset_generator,
@@ -226,3 +228,29 @@ def test_l1a_to_l1b(validation_l1a, mag_l1b_cal_dataset):
 
     assert len(l1b[0]["vectors"].data) > 0
     assert len(l1b[1]["vectors"].data) > 0
+
+
+def test_shift_time_preserves_int64_precision():
+    # Issue #3102: TT2000 epochs near 8e17 ns must stay int64; float promotion
+    # silently quantizes them.
+    epoch = xr.DataArray(
+        np.array(
+            [813411068230810679, 813411068238623179, 813411068246435679],
+            dtype=np.int64,
+        ),
+        dims="epoch",
+    )
+
+    zero = shift_time(epoch, xr.DataArray(np.array([0.0]), dims="epoch"))
+    np.testing.assert_array_equal(zero.values, epoch.values)
+
+    shifted = shift_time(epoch, xr.DataArray(np.array([1.2345e-5]), dims="epoch"))
+    np.testing.assert_array_equal(shifted.values, epoch.values + 12345)
+
+
+def test_timeshift_vectors_per_second_preserves_int64_precision():
+    shift = xr.DataArray(np.array([1.2345e-5]), dims="epoch")
+    out = timeshift_vectors_per_second(
+        "813411068230810679:128,813411500000000000:128", shift
+    )
+    assert out == "813411068230823024:128,813411500000012345:128"

--- a/imap_processing/tests/mag/test_mag_l1b.py
+++ b/imap_processing/tests/mag/test_mag_l1b.py
@@ -245,6 +245,7 @@ def test_shift_time_preserves_int64_precision():
     np.testing.assert_array_equal(zero.values, epoch.values)
 
     shifted = shift_time(epoch, xr.DataArray(np.array([1.2345e-5]), dims="epoch"))
+    assert shifted.dtype == np.int64
     np.testing.assert_array_equal(shifted.values, epoch.values + 12345)
 
 


### PR DESCRIPTION
## Summary

Fixes #3102.

`mag_l1b.py` had two lines that multiplied a calibration `time_shift` by `1e9` and left the result as `float64`:

```python
time_shift_ns = time_shift.data * 1e9
```

When that float was added to the `int64` TT2000 epoch array (values near `8e17` ns), NumPy promoted everything to `float64`, which can't represent those integers exactly. So each epoch was silently quantized by ~20-100 ns. This adds sub-microsecond cadence jitter to every L1B epoch even when the calibration shift is effectively zero, and the noise propagates to L1C, L1D, and L2. 

The fix rounds the time shift to integer nanoseconds in both spots:

```python
time_shift_ns = np.int64(round(time_shift.data.item() * 1e9))
```

`int64 + int64` stays `int64`, so TT2000 precision is preserved. Everything else in those functions is unchanged.

## New tests

`test_shift_time_preserves_int64_precision` covers `shift_time` with both a zero shift and a nonzero shift on TT2000-scale epochs. The zero-shift case is the most striking demonstration of the bug ("I added 0 and the values changed?"); the nonzero case proves the shift actually applies and stays integer.

`test_timeshift_vectors_per_second_preserves_int64_precision` is a separate test because it covers a different function and a different assertion shape (string equality on the formatted attribute).

## Test plan

- [x] New tests above pass with the fix and would fail without it.
- [x] Existing `test_mag_l1b.py` suite passes (9/9).
- [x] Full MAG suite passes (96 passed, 12 deselected for external data).
- [x] `pre-commit run --files` clean (ruff, codespell, numpydoc, mypy).
