### PR TITLE
Adding valueerror

### DIFF
--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -323,6 +323,9 @@ class MagL2L1dBase:
         if self.epoch_et is not None:
             self.epoch_et = self.epoch_et[day_start_index:day_end_index]
 
+        if self.epoch.shape[0] == 0:
+            raise ValueError("After truncating to 24 hours, no data remains.")
+
     @staticmethod
     def calculate_magnitude(
         vectors: np.ndarray,

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -304,6 +304,30 @@ def test_midnight_boundary(norm_dataset):
     assert midnight not in l2.epoch
 
 
+def test_truncate_to_24h_no_data_raises(norm_dataset):
+    day = np.datetime64("2025-10-17").astype("datetime64[D]")
+
+    # Shift all timestamps 5 days forward so none fall within the target day
+    shifted_timestamps = norm_dataset["epoch"].data + int(5 * 8.64e13)
+
+    l2 = MagL2(
+        vectors=norm_dataset["vectors"].data[:, :3],
+        epoch=shifted_timestamps,
+        range=norm_dataset["vectors"].data[:, 3],
+        global_attributes={},
+        quality_flags=np.zeros(len(norm_dataset["epoch"].data)),
+        quality_bitmask=np.zeros(len(norm_dataset["epoch"].data)),
+        data_mode=DataMode.NORM,
+        offsets=np.zeros((len(norm_dataset["epoch"].data), 3)),
+        timedelta=np.zeros(len(norm_dataset["epoch"].data)),
+    )
+
+    with pytest.raises(
+        ValueError, match="After truncating to 24 hours, no data remains."
+    ):
+        l2.truncate_to_24h(day)
+
+
 @pytest.mark.parametrize(
     ("time_shift", "start_diff", "end_diff"),
     # 3 hours in ns


### PR DESCRIPTION
# Change Summary
Addresses the MAG bug in #2830 and helps with a failure case described in #3060. 

Just adds a value throw if no data is left after truncating to 24 hours. 

