### PR TITLE
GLOWS - make epoch midpoint

### DIFF
--- a/imap_processing/glows/l1a/glows_l1a.py
+++ b/imap_processing/glows/l1a/glows_l1a.py
@@ -375,7 +375,9 @@ def generate_histogram_dataset(
     }
 
     for index, hist in enumerate(hist_l1a_list):
-        epoch_time = met_to_ttj2000ns(hist.imap_start_time.to_seconds())
+        epoch_time = met_to_ttj2000ns(
+            hist.imap_start_time.to_seconds() + hist.imap_time_offset.to_seconds() / 2
+        )
         # Assign histogram data, padding with zeros if shorter than max_bins
         hist_len = len(hist.histogram)
         hist_data[index, :hist_len] = hist.histogram

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -94,11 +94,10 @@ def create_l2_dataset(
     xarray.Dataset
         L2 dataset for output to CDF file.
     """
-    # Each L2 file only has one timestamp.
-    # TODO: If we want this to point to the start time, we need to set the attribute
-    #  variable BIN_LOCATION to 0. Otherwise, we need this to be halfway between start
-    #  time and end time.
-    time_data = np.array([histogram_l2.start_time], dtype=np.float64)
+    # Each L2 file only has one timestamp: the midpoint between start and end time.
+    time_data = np.array(
+        [(histogram_l2.start_time + histogram_l2.end_time) / 2], dtype=np.float64
+    )
     # TODO: Create CDF attributes
     epoch_time = xr.DataArray(
         time_data,

--- a/imap_processing/tests/glows/test_glows_l1a_cdf.py
+++ b/imap_processing/tests/glows/test_glows_l1a_cdf.py
@@ -13,6 +13,7 @@ from imap_processing.glows.l1a.glows_l1a import (
 )
 from imap_processing.glows.l1a.glows_l1a_data import HistogramL1A
 from imap_processing.glows.utils.constants import TimeTuple
+from imap_processing.spice.time import met_to_ttj2000ns
 
 
 def test_generate_histogram_dataset(l1a_test_data):
@@ -41,6 +42,12 @@ def test_generate_histogram_dataset(l1a_test_data):
 
     for i in range(len(dataset["histogram"].data)):
         assert (dataset["histogram"].data[i] == histogram_l1a[i].histogram).all()
+
+    for i, hist in enumerate(histogram_l1a):
+        expected_epoch = met_to_ttj2000ns(
+            hist.imap_start_time.to_seconds() + hist.imap_time_offset.to_seconds() / 2
+        )
+        assert dataset["epoch"].data[i] == expected_epoch
 
 
 def test_generate_histogram_dataset_filters_empty(l1a_test_data):

--- a/imap_processing/tests/glows/test_glows_l1a_data.py
+++ b/imap_processing/tests/glows/test_glows_l1a_data.py
@@ -557,12 +557,15 @@ def test_expected_hist_results(l1a_dataset):
     ]
 
     for data in out["output"]:
-        epoch_val = met_to_ttj2000ns(
-            TimeTuple(
-                data["imap_start_time"]["seconds"],
-                data["imap_start_time"]["subseconds"],
-            ).to_seconds()
-        )
+        imap_start = TimeTuple(
+            data["imap_start_time"]["seconds"],
+            data["imap_start_time"]["subseconds"],
+        ).to_seconds()
+        imap_offset = TimeTuple(
+            data["imap_end_time_offset"]["seconds"],
+            data["imap_end_time_offset"]["subseconds"],
+        ).to_seconds()
+        epoch_val = met_to_ttj2000ns(imap_start + imap_offset / 2)
 
         # Validation data spans the two obs days, so this selects the correct output
         dataset_index = 1 if epoch_val > end_time else 0

--- a/imap_processing/tests/glows/test_glows_l1b_data.py
+++ b/imap_processing/tests/glows/test_glows_l1b_data.py
@@ -158,7 +158,10 @@ def test_validation_data_histogram(
     }
 
     for validation_output in out["output"]:
-        epoch_val = met_to_ttj2000ns(validation_output["imap_start_time"])
+        epoch_val = met_to_ttj2000ns(
+            validation_output["imap_start_time"]
+            + validation_output["imap_end_time_offset"] / 2
+        )
 
         # Skip validation data that doesn't match our single dataset timerange
         if epoch_val > end_time:

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -4,12 +4,13 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.glows.l1b.glows_l1b import glows_l1b
 from imap_processing.glows.l1b.glows_l1b_data import (
     HistogramL1B,
     PipelineSettings,
 )
-from imap_processing.glows.l2.glows_l2 import glows_l2
+from imap_processing.glows.l2.glows_l2 import create_l2_dataset, glows_l2
 from imap_processing.glows.l2.glows_l2_data import DailyLightcurve, HistogramL2
 from imap_processing.glows.utils.constants import GlowsConstants
 from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
@@ -156,6 +157,14 @@ def test_generate_l2(
         )
         assert np.isclose(
             l2.hv_voltage_std_dev, expected_values["hv_voltage_std_dev"], 0.01
+        )
+
+        cdf_attrs = ImapCdfAttributes()
+        cdf_attrs.add_instrument_global_attrs("glows")
+        cdf_attrs.add_instrument_variable_attrs("glows", "l2")
+        assert (
+            create_l2_dataset(l2, cdf_attrs)["epoch"].data[0]
+            == (l2.start_time + l2.end_time) / 2
         )
 
         # Test case 2: L1B dataset has no good times (all flags 0)


### PR DESCRIPTION
This pull request updates how time values are calculated and validated for the GLOWS L1A and L2 data products, ensuring that time stamps represent the midpoint of the relevant intervals rather than the start. It also adds corresponding tests to verify the new logic.

**Time Calculation Improvements:**

* In `generate_histogram_dataset`, the epoch time for each L1A histogram is now set to the midpoint of the interval by adding half the `imap_time_offset` to the `imap_start_time` before converting to epoch nanoseconds.
* In `create_l2_dataset`, the single timestamp for each L2 dataset is now the average (midpoint) of `start_time` and `end_time`, instead of just the start time.

**Testing Enhancements:**

* The L1A dataset test now checks that each `epoch` value matches the expected midpoint calculation, using the updated logic.
* The L2 dataset test verifies that the `epoch` value is correctly set to the midpoint between `start_time` and `end_time`, using the new calculation.
* Added necessary imports to support the new tests and time calculations. [[1]](diffhunk://#diff-7a04277c289e7130328b09c2b3fede44bc177bc93bd39b73da277a9a3f5bb928R16) [[2]](diffhunk://#diff-f2202fd899749ebea2edcae146a1b56288e89648cc8aeae2f9612037c0ec6d03R7-R13)