### PR TITLE
I-ALiRT CoDICE-Hi - update to include spin angle

### DIFF
--- a/imap_processing/cdf/config/imap_ialirt_l1_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ialirt_l1_variable_attrs.yaml
@@ -242,17 +242,17 @@ codice_hi_spin_sector:
 
 codice_hi_spin_angle:
   CATDESC: CoDICE-Hi spin angle for each spin sector and polar angle pair
-  FIELDNAM: CoDICE-Hi spin angle
-  FORMAT: F12.6
-  VAR_TYPE: support_data
-  SCALETYP: linear
-  UNITS: degrees
-  VALIDMIN: 0.0
-  VALIDMAX: 360.0
-  FILLVAL: -1.0e31
-  dtype: float32
   DEPEND_1: codice_hi_spin_sector
   DEPEND_2: codice_hi_polar
+  FIELDNAM: CoDICE-Hi spin angle
+  FILLVAL: -1.0e31
+  FORMAT: F12.6
+  SCALETYP: linear
+  UNITS: degrees
+  VALIDMAX: 360.0
+  VALIDMIN: 0.0
+  VAR_TYPE: support_data
+  dtype: float32
 
 codice_hi_spin_sector_labels:
   CATDESC: CoDICE-Hi spin sector labels

--- a/imap_processing/cdf/config/imap_ialirt_l1_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ialirt_l1_variable_attrs.yaml
@@ -279,7 +279,8 @@ codice_hi_h:
   CATDESC: Proton flux from CoDICE-Hi in 15 energy bins between 0.02 to 3.62 MeV over 4 spin angles and 4 polar angles
   DEPEND_0: codice_hi_epoch
   DEPEND_1: codice_hi_energy_center
-  DEPEND_2: codice_hi_spin_angle
+  DEPEND_2: codice_hi_spin_sector
+  DEPEND_3: codice_hi_polar
   DISPLAY_TYPE: no_plot
   FIELDNAM: H+ intensity
   FORMAT: F11.1

--- a/imap_processing/cdf/config/imap_ialirt_l1_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ialirt_l1_variable_attrs.yaml
@@ -240,6 +240,20 @@ codice_hi_spin_sector:
   VAR_TYPE: support_data
   dtype: int32
 
+codice_hi_spin_angle:
+  CATDESC: CoDICE-Hi spin angle for each spin sector and polar angle pair
+  FIELDNAM: CoDICE-Hi spin angle
+  FORMAT: F12.6
+  VAR_TYPE: support_data
+  SCALETYP: linear
+  UNITS: degrees
+  VALIDMIN: 0.0
+  VALIDMAX: 360.0
+  FILLVAL: -1.0e31
+  dtype: float32
+  DEPEND_1: codice_hi_spin_sector
+  DEPEND_2: codice_hi_polar
+
 codice_hi_spin_sector_labels:
   CATDESC: CoDICE-Hi spin sector labels
   FIELDNAM: CoDICE-Hi spin sector labels
@@ -265,8 +279,7 @@ codice_hi_h:
   CATDESC: Proton flux from CoDICE-Hi in 15 energy bins between 0.02 to 3.62 MeV over 4 spin angles and 4 polar angles
   DEPEND_0: codice_hi_epoch
   DEPEND_1: codice_hi_energy_center
-  DEPEND_2: codice_hi_spin_sector
-  DEPEND_3: codice_hi_polar
+  DEPEND_2: codice_hi_spin_angle
   DISPLAY_TYPE: no_plot
   FIELDNAM: H+ intensity
   FORMAT: F11.1

--- a/imap_processing/ialirt/utils/create_xarray.py
+++ b/imap_processing/ialirt/utils/create_xarray.py
@@ -12,6 +12,7 @@ from imap_processing.codice.constants import (
     HI_IALIRT_ELEVATION_ANGLE,
 )
 from imap_processing.ialirt.utils.constants import (
+    HI_IALIRT_SPIN_ANGLE,
     IALIRT_DIMS,
     IALIRT_DTYPES,
     codice_hi_energy_center,
@@ -232,6 +233,15 @@ def create_xarray_from_records(records: list[dict]) -> xr.Dataset:  # noqa: PLR0
         ),
     )
 
+    spin_angle = xr.DataArray(
+        data=HI_IALIRT_SPIN_ANGLE.T.astype(np.float32),
+        name="codice_hi_spin_angle",
+        dims=["codice_hi_spin_sector", "codice_hi_polar"],
+        attrs=cdf_manager.get_variable_attributes(
+            "codice_hi_spin_angle", check_schema=False
+        ),
+    )
+
     spin_sector_labels = xr.DataArray(
         [
             "0",
@@ -267,6 +277,7 @@ def create_xarray_from_records(records: list[dict]) -> xr.Dataset:  # noqa: PLR0
         "codice_hi_polar": polar,
         "codice_hi_polar_labels": polar_labels,
         "codice_hi_spin_sector": spin_sector,
+        "codice_hi_spin_angle": spin_angle,
         "codice_hi_spin_sector_labels": spin_sector_labels,
         "swe_electron_energy": swe_electron_energy,
     }

--- a/imap_processing/tests/ialirt/unit/test_create_xarray.py
+++ b/imap_processing/tests/ialirt/unit/test_create_xarray.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.testing as npt
 
 from imap_processing.cdf.utils import write_cdf
-from imap_processing.ialirt.utils.constants import swe_energy
+from imap_processing.ialirt.utils.constants import HI_IALIRT_SPIN_ANGLE, swe_energy
 from imap_processing.ialirt.utils.create_xarray import create_xarray_from_records
 
 
@@ -166,3 +166,12 @@ def test_create_dataset():
     )
 
     assert test_data_path.exists()
+
+    # codice_hi_spin_angle should be a 2D array of actual spin angles (degrees).
+    # Shape: (spin_sector=4, polar=4).
+    spin_angle = dataset["codice_hi_spin_angle"]
+    assert spin_angle.dims == ("codice_hi_spin_sector", "codice_hi_polar")
+    assert spin_angle.shape == (4, 4)
+    npt.assert_allclose(
+        spin_angle.values, HI_IALIRT_SPIN_ANGLE.T.astype(np.float32), rtol=1e-6
+    )


### PR DESCRIPTION
This pull request introduces a new variable, `codice_hi_spin_angle`, to the IALIRT Level 1 data processing pipeline and updates the data model and tests to support it. The main goal is to provide explicit spin angle information for each spin sector and polar angle pair, improving data clarity and downstream usability. Additionally, dependencies for the `codice_hi_h` variable are updated to use the new spin angle variable.

**Additions and updates to data model:**

* Added a new variable definition for `codice_hi_spin_angle` in `imap_ialirt_l1_variable_attrs.yaml`, including its attributes, units, valid range, and dependencies (`codice_hi_spin_sector`, `codice_hi_polar`).
* Updated the dependency for `codice_hi_h` to use `codice_hi_spin_angle` instead of `codice_hi_spin_sector` and `codice_hi_polar`, reflecting the new data structure.

**Code and pipeline changes:**

* Updated `create_xarray_from_records` in `create_xarray.py` to generate the `codice_hi_spin_angle` DataArray, using the `HI_IALIRT_SPIN_ANGLE` constant and appropriate attributes. [[1]](diffhunk://#diff-10163c36568a7ec608baaaeb7cfc81a15565cb63cbeeee580e8aa86c4cb574baR236-R244) [[2]](diffhunk://#diff-10163c36568a7ec608baaaeb7cfc81a15565cb63cbeeee580e8aa86c4cb574baR280)
* Imported `HI_IALIRT_SPIN_ANGLE` where needed to support the new variable.

**Testing improvements:**

* Added assertions in `test_create_xarray.py` to verify the presence, shape, and values of the new `codice_hi_spin_angle` variable in the dataset, ensuring correctness.
* Updated test imports to include `HI_IALIRT_SPIN_ANGLE`.