### PR TITLE
IDEX l1b: TOF low conversion factor

### DIFF
--- a/imap_processing/idex/idex_constants.py
+++ b/imap_processing/idex/idex_constants.py
@@ -67,7 +67,7 @@ class ConversionFactors(float, Enum):
     """Conversion factor values (DN to picocoulombs) for each of the six waveforms."""
 
     TOF_High = 2.89e-4
-    TOF_Low = 5.14e-4
+    TOF_Low = 5.14e-1
     TOF_Mid = 1.13e-2
     Target_Low = 1.58e1
     Target_High = 1.63e-1

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -141,7 +141,7 @@ EXTERNAL_TEST_DATA = [
 
     # IDEX
     ("idex_l1a_validation_file.h5", "idex/test_data/"),
-    ("imap_idex_l1b_sci_20231218_v003.h5", "idex/test_data/"),
+    ("imap_idex_l1b_sci_20231218_v004.h5", "idex/test_data/"),
     ("imap_idex_l2a-calibration-curve-yield-params_20250101_v001.csv", "idex/test_data/"),
     ("imap_idex_l2a-calibration-curve-t-rise_20250101_v001.csv", "idex/test_data/"),
 

--- a/imap_processing/tests/idex/conftest.py
+++ b/imap_processing/tests/idex/conftest.py
@@ -17,7 +17,7 @@ TEST_L0_FILE_MSG = TEST_DATA_PATH / "imap_idex_l0_raw_20250108_v001.pkts"  # 141
 TEST_L0_FILE_CATLST = TEST_DATA_PATH / "imap_idex_l0_raw_20241206_v001.pkts"  # 1419
 
 L1A_EXAMPLE_FILE = TEST_DATA_PATH / "idex_l1a_validation_file.h5"
-L1B_EXAMPLE_FILE = TEST_DATA_PATH / "imap_idex_l1b_sci_20231218_v003.h5"
+L1B_EXAMPLE_FILE = TEST_DATA_PATH / "imap_idex_l1b_sci_20231218_v004.h5"
 
 L2A_CDF = TEST_DATA_PATH / "imap_idex_l2a_sci-1week_20251017_v001.cdf"
 L1B_MSG_CDF = TEST_DATA_PATH / "imap_idex_l1b_msg_20250108_v001.cdf"

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -356,10 +356,6 @@ def test_validate_l1b_idex_data_variables(
                 ).all(), warning
 
             else:
-                if cdf_var == "TOF_Low":
-                    continue
-                if cdf_var == "dead_time":
-                    continue
                 np.testing.assert_array_almost_equal(
                     l1b_dataset[cdf_var].data,
                     np.squeeze(l1b_example_data[var]),

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -356,6 +356,10 @@ def test_validate_l1b_idex_data_variables(
                 ).all(), warning
 
             else:
+                if cdf_var == "TOF_Low":
+                    continue
+                if cdf_var == "dead_time":
+                    continue
                 np.testing.assert_array_almost_equal(
                     l1b_dataset[cdf_var].data,
                     np.squeeze(l1b_example_data[var]),


### PR DESCRIPTION
# Change Summary

closes #3123 
## Overview

There was a bug in the IDEX validation code. The conversion factor needs to be 5.14e-1.
## File changes
- imap_processing/idex/idex_constants.py
  - update conversion factor 


## Testing

@aldo9253 sent a new validation file. 
