### PR TITLE
GLOWS - propagate packets files

### DIFF
--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -71,11 +71,11 @@ def glows_l2(
         logger.warning("All flux and exposure times are zero. Returning empty list.")
         return []
     else:
-        return [create_l2_dataset(l2, cdf_attrs, input_dataset)]
+        return [create_l2_dataset(l2, cdf_attrs, input_dataset.attrs)]
 
 
 def create_l2_dataset(
-    histogram_l2: HistogramL2, attrs: ImapCdfAttributes, input_dataset: xr.Dataset
+    histogram_l2: HistogramL2, attrs: ImapCdfAttributes, input_attrs: dict
 ) -> xr.Dataset:
     """
     Create a xarray dataset from a HistogramL2 dataclass.
@@ -88,8 +88,8 @@ def create_l2_dataset(
         L2 data.
     attrs : ImapCdfAttributes
         CDF attributes for GLOWS L2.
-    input_dataset : xarray.Dataset
-        Input L1B dataset. Used to propagate global attributes.
+    input_attrs : dict
+        Global attributes from the input L1B dataset to propagate.
 
     Returns
     -------
@@ -151,10 +151,10 @@ def create_l2_dataset(
         attrs=attrs.get_global_attributes("imap_glows_l2_hist"),
     )
 
-    output.attrs["flight_software_version"] = input_dataset.attrs.get(
+    output.attrs["flight_software_version"] = input_attrs.get(
         "flight_software_version", ""
     )
-    output.attrs["pkts_file_name"] = input_dataset.attrs.get("pkts_file_name", [])
+    output.attrs["pkts_file_name"] = input_attrs.get("pkts_file_name", [])
 
     ecliptic_variables = [
         "spacecraft_location_average",

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -71,11 +71,11 @@ def glows_l2(
         logger.warning("All flux and exposure times are zero. Returning empty list.")
         return []
     else:
-        return [create_l2_dataset(l2, cdf_attrs)]
+        return [create_l2_dataset(l2, cdf_attrs, input_dataset)]
 
 
 def create_l2_dataset(
-    histogram_l2: HistogramL2, attrs: ImapCdfAttributes
+    histogram_l2: HistogramL2, attrs: ImapCdfAttributes, input_dataset: xr.Dataset
 ) -> xr.Dataset:
     """
     Create a xarray dataset from a HistogramL2 dataclass.
@@ -88,6 +88,8 @@ def create_l2_dataset(
         L2 data.
     attrs : ImapCdfAttributes
         CDF attributes for GLOWS L2.
+    input_dataset : xarray.Dataset
+        Input L1B dataset. Used to propagate global attributes.
 
     Returns
     -------
@@ -148,6 +150,11 @@ def create_l2_dataset(
         },
         attrs=attrs.get_global_attributes("imap_glows_l2_hist"),
     )
+
+    output.attrs["flight_software_version"] = input_dataset.attrs.get(
+        "flight_software_version", ""
+    )
+    output.attrs["pkts_file_name"] = input_dataset.attrs.get("pkts_file_name", [])
 
     ecliptic_variables = [
         "spacecraft_location_average",

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -72,6 +72,10 @@ def test_glows_l2(
     l2 = glows_l2(l1b_hist_dataset, mock_pipeline_settings, mock_calibration_dataset)[0]
     assert l2.attrs["Logical_source"] == "imap_glows_l2_hist"
     assert np.allclose(l2["filter_temperature_average"].values, [57.6], rtol=0.1)
+    assert "flight_software_version" in l2.attrs
+    assert "pkts_file_name" in l2.attrs
+    assert "flight_software_version" not in l2.data_vars
+    assert "pkts_file_name" not in l2.data_vars
 
     # Test case 2: L1B dataset has no good times (all flags 0)
     l1b_hist_dataset_no_good_times = l1b_hist_dataset.copy(deep=True)
@@ -163,7 +167,7 @@ def test_generate_l2(
         cdf_attrs.add_instrument_global_attrs("glows")
         cdf_attrs.add_instrument_variable_attrs("glows", "l2")
         assert (
-            create_l2_dataset(l2, cdf_attrs)["epoch"].data[0]
+            create_l2_dataset(l2, cdf_attrs, l1b_hist_dataset)["epoch"].data[0]
             == (l2.start_time + l2.end_time) / 2
         )
 

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -167,7 +167,7 @@ def test_generate_l2(
         cdf_attrs.add_instrument_global_attrs("glows")
         cdf_attrs.add_instrument_variable_attrs("glows", "l2")
         assert (
-            create_l2_dataset(l2, cdf_attrs, l1b_hist_dataset)["epoch"].data[0]
+            create_l2_dataset(l2, cdf_attrs, l1b_hist_dataset.attrs)["epoch"].data[0]
             == (l2.start_time + l2.end_time) / 2
         )
 


### PR DESCRIPTION
This pull request updates the GLOWS L2 data processing to ensure that important global attributes from the input L1B dataset are propagated to the output L2 dataset. It modifies both the implementation and the corresponding tests to support and verify this change.

**Enhancements to attribute propagation:**

* The `create_l2_dataset` function now accepts the input L1B dataset as an argument, allowing it to copy over the `flight_software_version` and `pkts_file_name` attributes to the output L2 dataset's global attributes. [[1]](diffhunk://#diff-c2e7fba73fc872329507f67dc2372435d38085b1f6f4fe35986177e087c41028L74-R78) [[2]](diffhunk://#diff-c2e7fba73fc872329507f67dc2372435d38085b1f6f4fe35986177e087c41028R91-R92) [[3]](diffhunk://#diff-c2e7fba73fc872329507f67dc2372435d38085b1f6f4fe35986177e087c41028R154-R158)

**Test updates:**

* Tests for `glows_l2` and `create_l2_dataset` have been updated to check that the new global attributes are present in the output dataset's attributes, and not erroneously included as data variables. [[1]](diffhunk://#diff-f2202fd899749ebea2edcae146a1b56288e89648cc8aeae2f9612037c0ec6d03R75-R78) [[2]](diffhunk://#diff-f2202fd899749ebea2edcae146a1b56288e89648cc8aeae2f9612037c0ec6d03L166-R170)