### PR TITLE
Drop invalid timestamps in GLOWS L1B

### DIFF
--- a/imap_processing/glows/l1b/glows_l1b.py
+++ b/imap_processing/glows/l1b/glows_l1b.py
@@ -82,7 +82,10 @@ def glows_l1b(
         input_dataset, ancillary_exclusions, ancillary_parameters, pipeline_settings
     )
     output_dataset = create_l1b_hist_output(
-        output_dataarrays, input_dataset["epoch"], input_dataset["bins"], cdf_attrs
+        output_dataarrays,
+        output_dataarrays[0].coords["epoch"],
+        input_dataset["bins"],
+        cdf_attrs,
     )
 
     output_dataset.attrs["flight_software_version"] = input_dataset.attrs[
@@ -347,7 +350,7 @@ def create_l1b_hist_output(
         fields in the HistogramL1B dataclass, which also describes each variable.
     epoch : xr.DataArray
         The epoch DataArray to use as a coordinate in the output dataset. Generally
-        equal to the L1A epoch.
+        equal to the L1A epoch, except when values are dropped for no data.
     bin_coord : xr.DataArray
         An arange DataArray for the bins coordinate. Nominally expected to be equal to
         `xr.DataArray(np.arange(number_of_bins_per_histogram), name="bins",

--- a/imap_processing/glows/l1b/glows_l1b.py
+++ b/imap_processing/glows/l1b/glows_l1b.py
@@ -1,6 +1,7 @@
 """Methods for processing GLOWS L1B data."""
 
 import dataclasses
+import logging
 
 import numpy as np
 import xarray as xr
@@ -15,6 +16,8 @@ from imap_processing.glows.l1b.glows_l1b_data import (
     PipelineSettings,
 )
 from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
+
+logger = logging.getLogger(__name__)
 
 
 def glows_l1b(
@@ -251,6 +254,16 @@ def process_histogram(
         The DataArrays for each variable in the L1B dataset. These can be assembled
         directly into a DataSet with the appropriate attributes.
     """
+    invalid_mask = l1a["imap_start_time"].values == 0.0
+    if invalid_mask.any():
+        logger.warning(
+            "GLOWS L1B: Skipping %d histogram(s) with imap_start_time=0.0 "
+            "(invalid timing data) at epochs: %s",
+            invalid_mask.sum(),
+            l1a["epoch"].values[invalid_mask],
+        )
+        l1a = l1a.isel(epoch=~invalid_mask)
+
     dataarrays = [l1a[i] for i in l1a.keys()]
 
     input_dims: list = [[] for i in l1a.keys()]

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -410,8 +410,10 @@ def test_process_histogram_skips_zero_imap_start_time(
         mock_ancillary_parameters,
         pipeline_settings,
     )
-    # 2 invalid epochs dropped; 18 valid epochs remain
-    assert output[0].sizes["epoch"] == 18
+    # 2 invalid epochs dropped; 18 valid epochs remain in every output DataArray
+    for da in output:
+        assert da.sizes["epoch"] == 18
+    assert len(output[0].coords["epoch"]) == 18
 
 
 def test_process_de(de_dataset, ancillary_dict, mock_ancillary_parameters):

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -45,7 +45,7 @@ def hist_dataset():
         "spin_period_variance": np.zeros((20,)),
         "pulse_length_average": np.zeros((20,)),
         "pulse_length_variance": np.zeros((20,)),
-        "imap_start_time": np.zeros((20,)),
+        "imap_start_time": np.arange(1, 21, dtype=np.float64),
         "imap_time_offset": np.zeros((20,)),
         "glows_start_time": np.zeros((20,)),
         "glows_time_offset": np.zeros((20,)),
@@ -377,6 +377,41 @@ def test_bins_from_histogram_not_nbins(
     for da in output:
         if "bins" in da.sizes:
             assert da.sizes["bins"] == 3600
+
+
+@patch.object(
+    HistogramL1B,
+    "flag_uv_and_excluded",
+    return_value=(np.zeros(3600, dtype=bool), np.zeros(3600, dtype=bool)),
+)
+@patch.object(HistogramL1B, "update_spice_parameters", autospec=True)
+def test_process_histogram_skips_zero_imap_start_time(
+    mock_spice_function,
+    mock_flag_uv_and_excluded,
+    hist_dataset,
+    mock_ancillary_exclusions,
+    mock_ancillary_parameters,
+    mock_pipeline_settings,
+):
+    mock_spice_function.side_effect = mock_update_spice_parameters
+    pipeline_settings = PipelineSettings(
+        mock_pipeline_settings.sel(
+            epoch=mock_pipeline_settings.epoch[0], method="nearest"
+        )
+    )
+
+    # Set two epochs to invalid time
+    hist_dataset["imap_start_time"].values[3] = 0.0
+    hist_dataset["imap_start_time"].values[7] = 0.0
+
+    output = process_histogram(
+        hist_dataset,
+        mock_ancillary_exclusions,
+        mock_ancillary_parameters,
+        pipeline_settings,
+    )
+    # 2 invalid epochs dropped; 18 valid epochs remain
+    assert output[0].sizes["epoch"] == 18
 
 
 def test_process_de(de_dataset, ancillary_dict, mock_ancillary_parameters):


### PR DESCRIPTION
# Change Summary
Addresses #3007. This isn't strictly required since the L1A processing drops start times anyway, but this fixes the problem for any old L1A files that might still be hanging around. 

This does complete #3007 and unblocks #2900.

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
This code filters out any timestamps that are zero, and logs out how many were filtered.

## File changes

<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->


## Testing

<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
There is a test to confirm that the filter works correctly.
