### PR TITLE
Fix Hi L2 flux correction convergence logic

### DIFF
--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -323,7 +323,7 @@ class PowerLawFluxCorrector:
             with np.errstate(divide="ignore", invalid="ignore"):
                 ratios_sq = (source_fluxes_new / source_fluxes_prev) ** 2
             # Compute chi per pixel (mean over energy axis)
-            chi_n = np.sqrt(np.mean(ratios_sq, axis=0)) - 1
+            chi_n = np.sqrt(np.nanmean(ratios_sq, axis=0)) - 1
 
             # Determine which pixels converged this iteration
             # Start with all False, then set True for newly converged pixels

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -287,6 +287,13 @@ class PowerLawFluxCorrector:
         converged = np.zeros(observed_fluxes.shape[1:], dtype=bool)
         n_iterations = np.zeros(observed_fluxes.shape[1:], dtype=int)
 
+        # Mark pixels that are all zeros or all NaNs as already converged
+        # These pixels have no meaningful data to iterate on
+        all_zero_or_nan = np.all(
+            (observed_fluxes == 0) | ~np.isfinite(observed_fluxes), axis=0
+        )
+        converged[all_zero_or_nan] = True
+
         for iteration in range(max_iterations):
             # Get mask for unconverged pixels
             not_converged = ~converged

--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -323,7 +323,7 @@ class PowerLawFluxCorrector:
             with np.errstate(divide="ignore", invalid="ignore"):
                 ratios_sq = (source_fluxes_new / source_fluxes_prev) ** 2
             # Compute chi per pixel (mean over energy axis)
-            chi_n = np.sqrt(np.nanmean(ratios_sq, axis=0)) - 1
+            chi_n = np.abs(np.sqrt(np.nanmean(ratios_sq, axis=0)) - 1)
 
             # Determine which pixels converged this iteration
             # Start with all False, then set True for newly converged pixels

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -114,7 +114,7 @@ class TestPowerLawFluxCorrector:
 
         corr = PowerLawFluxCorrector(lo_coeffs_file)
         # Create 2D arrays (n_energy, n_pixels)
-        fluxes = ((np.arange(7) * 1000**2)[::-1])[:, np.newaxis]
+        fluxes = ((np.ones(7) * 1000**2)[::-1])[:, np.newaxis]
         energies = np.arange(1, 8) + 1
         _, _, n_iter = corr.predictor_corrector_iteration(
             fluxes,
@@ -365,12 +365,13 @@ class TestPowerLawFluxCorrector:
         corr = PowerLawFluxCorrector(lo_coeffs_file)
 
         # Create 2D array with 7 energy levels and 8 spatial pixels
-        n_energy = 7
+        energies = np.array([16.35, 30.56, 56.42, 105.21, 199.79, 407.49, 795.28])
+        n_energy = len(energies)
         n_pixels = 8
-        energies = np.arange(1, n_energy + 1) + 1
 
         # Create base fluxes that vary across pixels
-        base_fluxes = ((np.arange(n_energy) + 1) * 1000**2)[::-1]
+        base_fluxes = np.array([1000, 800, 50, 200, 1, 30, 10])
+        # base_fluxes = ((np.arange(n_energy) + 1) * 1000**2)[::-1]
         fluxes = (
             base_fluxes[:, np.newaxis] * np.linspace(0.9, 1.1, n_pixels)[np.newaxis, :]
         )

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -235,6 +235,18 @@ class TestPowerLawFluxCorrector:
             corrected_fluxes.squeeze(), expected_corr_fluxes, rtol=1e-2
         )
 
+    def test_predictor_corrector_zero_flux_convergence(self, hi_coeffs_file):
+        """Test that convergence is achieved when we have a zero flux."""
+        flux_corr = PowerLawFluxCorrector(hi_coeffs_file)
+        energies, flux_dict, background_dict = self.create_hi_test_data()
+        # set flux for ESA 9 to zero
+        flux_dict["J"][-1] = 0
+        # Reshape to 2D arrays (n_energy, n_pixels)
+        _, _, n_iterations = flux_corr.predictor_corrector_iteration(
+            flux_dict["J"][:, np.newaxis], flux_dict["delta_J"][:, np.newaxis], energies
+        )
+        assert np.all(n_iterations < 20)
+
     @mock.patch(
         "imap_processing.ena_maps.utils.corrections.PowerLawFluxCorrector.predictor_corrector_iteration"
     )


### PR DESCRIPTION
# Change Summary

Fixes a bug in how convergence criteria was being calculated. The bug occurred when an input flux is zero causing the computed chi_n for that pixel to be NaN which will never be less than the convergence criteria. The easy fix is to just use a nanmean when computing the mean ratio. This is appropriate because zero fluxes will just stay zeros and thus are already converged.

## Testing
I first added the test confirming that when a zero is in the input flux, the max iterations is hit. Once the bug was fixed, the test passes.

Closes: #3142 