### PR TITLE
Mag L1C - Fix mixed norm+burst day-boundary gap collapse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,9 @@ cython_debug/
 # VSCode
 .vscode/
 
+# Claude
+.claude/
+
 # Data that is downloaded
 data/
 test_data/

--- a/imap_processing/mag/l1c/mag_l1c.py
+++ b/imap_processing/mag/l1c/mag_l1c.py
@@ -48,9 +48,6 @@ def mag_l1c(
     """
     # TODO:
     # find missing sequences and output them
-    # Fix gaps at the beginning of the day by going to previous day's file
-    # Fix gaps at the end of the day
-    # Allow for one input to be missing
     # Missing burst file - just pass through norm file
     # Missing norm file - go back to previous L1C file to find timestamps, then
     # interpolate the entire day from burst
@@ -68,10 +65,8 @@ def mag_l1c(
 
     interp_function = InterpolationFunction[configuration.L1C_INTERPOLATION_METHOD]
     if burst_mode_dataset is not None:
-        # Only use day_to_process if there is no norm data
-        day_to_process_arg = day_to_process if normal_mode_dataset is None else None
         full_interpolated_timeline: np.ndarray = process_mag_l1c(
-            normal_mode_dataset, burst_mode_dataset, interp_function, day_to_process_arg
+            normal_mode_dataset, burst_mode_dataset, interp_function, day_to_process
         )
     elif normal_mode_dataset is not None:
         full_interpolated_timeline = fill_normal_data(normal_mode_dataset)

--- a/imap_processing/tests/mag/test_mag_l1c.py
+++ b/imap_processing/tests/mag/test_mag_l1c.py
@@ -274,9 +274,7 @@ def test_mag_attributes():
 def _ttj2000_day_bounds(day: np.datetime64) -> tuple[int, int]:
     day_start = day.astype("datetime64[s]") - np.timedelta64(30, "m")
     day_end = (
-        day.astype("datetime64[s]")
-        + np.timedelta64(1, "D")
-        + np.timedelta64(30, "m")
+        day.astype("datetime64[s]") + np.timedelta64(1, "D") + np.timedelta64(30, "m")
     )
     return (
         int(et_to_ttj2000ns(str_to_et(str(day_start)))),
@@ -305,9 +303,7 @@ def _build_day_aligned_mixed_l1b(day: np.datetime64) -> tuple[xr.Dataset, xr.Dat
 
     nm_start = day_start_ns + 300 * 1_000_000_000
     nm_end = nm_start + 120 * 1_000_000_000
-    nm_epochs = np.arange(
-        nm_start, nm_end + 1, step=500_000_000, dtype=np.int64
-    )
+    nm_epochs = np.arange(nm_start, nm_end + 1, step=500_000_000, dtype=np.int64)
     norm = _build_mag_l1b(nm_epochs, "imap_mag_l1b_norm-mago", "0:2")
 
     burst_epochs = np.arange(
@@ -335,14 +331,15 @@ def test_process_mag_l1c_leading_burst_only_coverage():
     # NM starts 5 minutes into the day window and lasts 2 minutes at 2 vec/s.
     nm_start = day_start_ns + 300 * 1_000_000_000
     nm_end = nm_start + 120 * 1_000_000_000
-    nm_epochs = np.arange(
-        nm_start, nm_end + 1, step=500_000_000, dtype=np.int64
-    )
+    nm_epochs = np.arange(nm_start, nm_end + 1, step=500_000_000, dtype=np.int64)
     norm = _build_mag_l1b(nm_epochs, "imap_mag_l1b_norm-mago", "0:2")
 
-    # Burst covers day_start_ns through 10 minutes into the day at 8 vec/s.
+    # Burst starts after the day window, so uncovered leading timestamps stay missing.
+    burst_start = day_start_ns + 10 * 1_000_000_000
+
+    # Burst covers 10 s through 10 minutes into the day at 8 vec/s.
     burst_epochs = np.arange(
-        day_start_ns,
+        burst_start,
         day_start_ns + 600 * 1_000_000_000 + 1,
         step=125_000_000,
         dtype=np.int64,
@@ -353,8 +350,14 @@ def test_process_mag_l1c_leading_burst_only_coverage():
     epochs_out = result[:, 0]
     flags = result[:, 5]
 
-    leading_burst_mask = (epochs_out < nm_start) & (
-        flags == ModeFlags.BURST.value
+    pre_burst_mask = epochs_out < burst_start
+    assert pre_burst_mask.sum() > 0
+    assert np.all(flags[pre_burst_mask] == ModeFlags.MISSING.value)
+
+    leading_burst_mask = (
+        (epochs_out >= burst_start)
+        & (epochs_out < nm_start)
+        & (flags == ModeFlags.BURST.value)
     )
     assert leading_burst_mask.sum() > 0, (
         "leading burst-only coverage was dropped; day_to_process not honored"
@@ -374,9 +377,7 @@ def test_process_mag_l1c_trailing_burst_only_coverage():
     nm_center = (day_start_ns + day_end_ns) // 2
     nm_start = nm_center - 60 * 1_000_000_000
     nm_end = nm_center + 60 * 1_000_000_000
-    nm_epochs = np.arange(
-        nm_start, nm_end + 1, step=500_000_000, dtype=np.int64
-    )
+    nm_epochs = np.arange(nm_start, nm_end + 1, step=500_000_000, dtype=np.int64)
     norm = _build_mag_l1b(nm_epochs, "imap_mag_l1b_norm-mago", "0:2")
 
     # Burst picks up 30 s before NM end and continues 10 minutes past NM end.
@@ -392,9 +393,7 @@ def test_process_mag_l1c_trailing_burst_only_coverage():
     epochs_out = result[:, 0]
     flags = result[:, 5]
 
-    trailing_burst_mask = (epochs_out > nm_end) & (
-        flags == ModeFlags.BURST.value
-    )
+    trailing_burst_mask = (epochs_out > nm_end) & (flags == ModeFlags.BURST.value)
     assert trailing_burst_mask.sum() > 0, (
         "trailing burst-only coverage was dropped; day_to_process not honored"
     )
@@ -415,9 +414,7 @@ def test_mag_l1c_mixed_input_uses_day_to_process():
 
     nm_start = day_start_ns + 600 * 1_000_000_000
     nm_end = nm_start + 60 * 1_000_000_000
-    nm_epochs = np.arange(
-        nm_start, nm_end + 1, step=500_000_000, dtype=np.int64
-    )
+    nm_epochs = np.arange(nm_start, nm_end + 1, step=500_000_000, dtype=np.int64)
     norm = _build_mag_l1b(nm_epochs, "imap_mag_l1b_norm-mago", "0:2")
 
     burst_epochs = np.arange(

--- a/imap_processing/tests/mag/test_mag_l1c.py
+++ b/imap_processing/tests/mag/test_mag_l1c.py
@@ -237,11 +237,11 @@ def test_interpolate_gaps(norm_dataset, mag_l1b_dataset):
     assert np.allclose(output, expected_output)
 
 
-def test_mag_l1c(norm_dataset, burst_dataset):
-    # 2000-01-01 anchors the ±30 min day window near TTJ2000's zero point so the
-    # leading/trailing day-boundary gap fill stays bounded given the fixtures use
-    # small synthetic epoch values.
-    l1c = mag_l1c(burst_dataset, np.datetime64("2000-01-01"), norm_dataset)
+def test_mag_l1c():
+    day = np.datetime64("2025-01-01")
+    norm_dataset, burst_dataset = _build_day_aligned_mixed_l1b(day)
+
+    l1c = mag_l1c(burst_dataset, day, norm_dataset)
     assert l1c["vector_magnitude"].shape == (len(l1c["epoch"].data),)
     assert l1c["vector_magnitude"].data[0] == np.linalg.norm(l1c["vectors"].data[0][:4])
     assert l1c["vector_magnitude"].data[-1] == np.linalg.norm(
@@ -259,8 +259,11 @@ def test_mag_l1c(norm_dataset, burst_dataset):
         assert var in l1c.data_vars
 
 
-def test_mag_attributes(norm_dataset, burst_dataset):
-    output = mag_l1c(norm_dataset, np.datetime64("2000-01-01"), burst_dataset)
+def test_mag_attributes():
+    day = np.datetime64("2025-01-01")
+    norm_dataset, burst_dataset = _build_day_aligned_mixed_l1b(day)
+
+    output = mag_l1c(norm_dataset, day, burst_dataset)
     assert output.attrs["Logical_source"] == "imap_mag_l1c_norm-mago"
 
     expected_attrs = ["missing_sequences", "interpolation_method"]
@@ -297,6 +300,27 @@ def _build_mag_l1b(
     return dataset
 
 
+def _build_day_aligned_mixed_l1b(day: np.datetime64) -> tuple[xr.Dataset, xr.Dataset]:
+    day_start_ns, _ = _ttj2000_day_bounds(day)
+
+    nm_start = day_start_ns + 300 * 1_000_000_000
+    nm_end = nm_start + 120 * 1_000_000_000
+    nm_epochs = np.arange(
+        nm_start, nm_end + 1, step=500_000_000, dtype=np.int64
+    )
+    norm = _build_mag_l1b(nm_epochs, "imap_mag_l1b_norm-mago", "0:2")
+
+    burst_epochs = np.arange(
+        day_start_ns,
+        day_start_ns + 600 * 1_000_000_000 + 1,
+        step=125_000_000,
+        dtype=np.int64,
+    )
+    burst = _build_mag_l1b(burst_epochs, "imap_mag_l1b_burst-mago", "0:8")
+
+    return norm, burst
+
+
 def test_process_mag_l1c_leading_burst_only_coverage():
     """Burst coverage before the NM window must be interpolated as BURST.
 
@@ -305,7 +329,7 @@ def test_process_mag_l1c_leading_burst_only_coverage():
     emit a leading day-boundary gap and burst samples preceding the NM file were
     silently dropped.
     """
-    day = np.datetime64("2000-01-01")
+    day = np.datetime64("2025-01-01")
     day_start_ns, _ = _ttj2000_day_bounds(day)
 
     # NM starts 5 minutes into the day window and lasts 2 minutes at 2 vec/s.
@@ -343,7 +367,7 @@ def test_process_mag_l1c_leading_burst_only_coverage():
 
 def test_process_mag_l1c_trailing_burst_only_coverage():
     """Burst coverage after the NM window must be interpolated as BURST."""
-    day = np.datetime64("2000-01-01")
+    day = np.datetime64("2025-01-01")
     day_start_ns, day_end_ns = _ttj2000_day_bounds(day)
 
     # NM sits mid-day, spanning 2 minutes at 2 vec/s.
@@ -386,7 +410,7 @@ def test_mag_l1c_mixed_input_uses_day_to_process():
     End-to-end regression that guards the ``day_to_process`` pass-through in
     mag_l1c() against re-introduction of the old short-circuit to None.
     """
-    day = np.datetime64("2000-01-01")
+    day = np.datetime64("2025-01-01")
     day_start_ns, _ = _ttj2000_day_bounds(day)
 
     nm_start = day_start_ns + 600 * 1_000_000_000
@@ -411,6 +435,30 @@ def test_mag_l1c_mixed_input_uses_day_to_process():
         "mag_l1c output collapsed to NM window; day_to_process not honored"
     )
     assert int((epochs_out < nm_start).sum()) > 0
+
+
+def test_mag_l1c_burst_only_generates_l1c_output():
+    """Burst-only L1C generation still fills the day window from BM data."""
+    day = np.datetime64("2025-01-01")
+    day_start_ns, _ = _ttj2000_day_bounds(day)
+
+    # Burst covers the first 2 minutes of the day window at 8 vec/s.
+    burst_epochs = np.arange(
+        day_start_ns,
+        day_start_ns + 120 * 1_000_000_000 + 1,
+        step=125_000_000,
+        dtype=np.int64,
+    )
+    burst = _build_mag_l1b(burst_epochs, "imap_mag_l1b_burst-magi", "0:8")
+
+    output = mag_l1c(burst, day)
+    epochs_out = output["epoch"].data
+
+    assert output.attrs["Logical_source"] == "imap_mag_l1c_norm-magi"
+    assert len(epochs_out) > 0
+    assert epochs_out.min() >= burst_epochs.min()
+    assert epochs_out.max() <= burst_epochs.max()
+    assert np.all(output["generated_flag"].data == ModeFlags.BURST.value)
 
 
 def test_missing_burst_file(norm_dataset, burst_dataset):

--- a/imap_processing/tests/mag/test_mag_l1c.py
+++ b/imap_processing/tests/mag/test_mag_l1c.py
@@ -20,6 +20,7 @@ from imap_processing.mag.l1c.mag_l1c import (
     process_mag_l1c,
     vectors_per_second_from_string,
 )
+from imap_processing.spice.time import et_to_ttj2000ns, str_to_et
 from imap_processing.tests.mag.conftest import (
     generate_test_epoch,
     mag_l1a_dataset_generator,
@@ -237,7 +238,10 @@ def test_interpolate_gaps(norm_dataset, mag_l1b_dataset):
 
 
 def test_mag_l1c(norm_dataset, burst_dataset):
-    l1c = mag_l1c(burst_dataset, np.datetime64("2025-01-01"), norm_dataset)
+    # 2000-01-01 anchors the ±30 min day window near TTJ2000's zero point so the
+    # leading/trailing day-boundary gap fill stays bounded given the fixtures use
+    # small synthetic epoch values.
+    l1c = mag_l1c(burst_dataset, np.datetime64("2000-01-01"), norm_dataset)
     assert l1c["vector_magnitude"].shape == (len(l1c["epoch"].data),)
     assert l1c["vector_magnitude"].data[0] == np.linalg.norm(l1c["vectors"].data[0][:4])
     assert l1c["vector_magnitude"].data[-1] == np.linalg.norm(
@@ -256,12 +260,157 @@ def test_mag_l1c(norm_dataset, burst_dataset):
 
 
 def test_mag_attributes(norm_dataset, burst_dataset):
-    output = mag_l1c(norm_dataset, np.datetime64("2025-01-01"), burst_dataset)
+    output = mag_l1c(norm_dataset, np.datetime64("2000-01-01"), burst_dataset)
     assert output.attrs["Logical_source"] == "imap_mag_l1c_norm-mago"
 
     expected_attrs = ["missing_sequences", "interpolation_method"]
     for attr in expected_attrs:
         assert attr in output.attrs
+
+
+def _ttj2000_day_bounds(day: np.datetime64) -> tuple[int, int]:
+    day_start = day.astype("datetime64[s]") - np.timedelta64(30, "m")
+    day_end = (
+        day.astype("datetime64[s]")
+        + np.timedelta64(1, "D")
+        + np.timedelta64(30, "m")
+    )
+    return (
+        int(et_to_ttj2000ns(str_to_et(str(day_start)))),
+        int(et_to_ttj2000ns(str_to_et(str(day_end)))),
+    )
+
+
+def _build_mag_l1b(
+    epochs: np.ndarray, logical_source: str, vps_attr: str
+) -> xr.Dataset:
+    dataset = mag_l1a_dataset_generator(len(epochs))
+    dataset["epoch"] = xr.DataArray(
+        epochs.astype(np.int64), name="epoch", dims=["epoch"]
+    )
+    dataset.attrs["Logical_source"] = logical_source
+    dataset.attrs["vectors_per_second"] = vps_attr
+    vectors = np.array(
+        [[i, i, i, 2] for i in range(1, len(epochs) + 1)], dtype=np.float64
+    )
+    dataset["vectors"].data = vectors
+    return dataset
+
+
+def test_process_mag_l1c_leading_burst_only_coverage():
+    """Burst coverage before the NM window must be interpolated as BURST.
+
+    Regression for issue 2925: with both norm and burst L1B inputs present, the
+    previous code forced ``day_to_process`` to None, so ``find_all_gaps`` did not
+    emit a leading day-boundary gap and burst samples preceding the NM file were
+    silently dropped.
+    """
+    day = np.datetime64("2000-01-01")
+    day_start_ns, _ = _ttj2000_day_bounds(day)
+
+    # NM starts 5 minutes into the day window and lasts 2 minutes at 2 vec/s.
+    nm_start = day_start_ns + 300 * 1_000_000_000
+    nm_end = nm_start + 120 * 1_000_000_000
+    nm_epochs = np.arange(
+        nm_start, nm_end + 1, step=500_000_000, dtype=np.int64
+    )
+    norm = _build_mag_l1b(nm_epochs, "imap_mag_l1b_norm-mago", "0:2")
+
+    # Burst covers day_start_ns through 10 minutes into the day at 8 vec/s.
+    burst_epochs = np.arange(
+        day_start_ns,
+        day_start_ns + 600 * 1_000_000_000 + 1,
+        step=125_000_000,
+        dtype=np.int64,
+    )
+    burst = _build_mag_l1b(burst_epochs, "imap_mag_l1b_burst-mago", "0:8")
+
+    result = process_mag_l1c(norm, burst, InterpolationFunction.linear, day)
+    epochs_out = result[:, 0]
+    flags = result[:, 5]
+
+    leading_burst_mask = (epochs_out < nm_start) & (
+        flags == ModeFlags.BURST.value
+    )
+    assert leading_burst_mask.sum() > 0, (
+        "leading burst-only coverage was dropped; day_to_process not honored"
+    )
+
+    nm_mask = np.isin(epochs_out, nm_epochs)
+    assert nm_mask.sum() == nm_epochs.size
+    assert np.all(flags[nm_mask] == ModeFlags.NORM.value)
+
+
+def test_process_mag_l1c_trailing_burst_only_coverage():
+    """Burst coverage after the NM window must be interpolated as BURST."""
+    day = np.datetime64("2000-01-01")
+    day_start_ns, day_end_ns = _ttj2000_day_bounds(day)
+
+    # NM sits mid-day, spanning 2 minutes at 2 vec/s.
+    nm_center = (day_start_ns + day_end_ns) // 2
+    nm_start = nm_center - 60 * 1_000_000_000
+    nm_end = nm_center + 60 * 1_000_000_000
+    nm_epochs = np.arange(
+        nm_start, nm_end + 1, step=500_000_000, dtype=np.int64
+    )
+    norm = _build_mag_l1b(nm_epochs, "imap_mag_l1b_norm-mago", "0:2")
+
+    # Burst picks up 30 s before NM end and continues 10 minutes past NM end.
+    burst_epochs = np.arange(
+        nm_end - 30 * 1_000_000_000,
+        nm_end + 600 * 1_000_000_000 + 1,
+        step=125_000_000,
+        dtype=np.int64,
+    )
+    burst = _build_mag_l1b(burst_epochs, "imap_mag_l1b_burst-mago", "0:8")
+
+    result = process_mag_l1c(norm, burst, InterpolationFunction.linear, day)
+    epochs_out = result[:, 0]
+    flags = result[:, 5]
+
+    trailing_burst_mask = (epochs_out > nm_end) & (
+        flags == ModeFlags.BURST.value
+    )
+    assert trailing_burst_mask.sum() > 0, (
+        "trailing burst-only coverage was dropped; day_to_process not honored"
+    )
+
+    nm_mask = np.isin(epochs_out, nm_epochs)
+    assert nm_mask.sum() == nm_epochs.size
+    assert np.all(flags[nm_mask] == ModeFlags.NORM.value)
+
+
+def test_mag_l1c_mixed_input_uses_day_to_process():
+    """Public mag_l1c entry point must honor day_to_process on mixed inputs.
+
+    End-to-end regression that guards the ``day_to_process`` pass-through in
+    mag_l1c() against re-introduction of the old short-circuit to None.
+    """
+    day = np.datetime64("2000-01-01")
+    day_start_ns, _ = _ttj2000_day_bounds(day)
+
+    nm_start = day_start_ns + 600 * 1_000_000_000
+    nm_end = nm_start + 60 * 1_000_000_000
+    nm_epochs = np.arange(
+        nm_start, nm_end + 1, step=500_000_000, dtype=np.int64
+    )
+    norm = _build_mag_l1b(nm_epochs, "imap_mag_l1b_norm-mago", "0:2")
+
+    burst_epochs = np.arange(
+        day_start_ns,
+        day_start_ns + 900 * 1_000_000_000 + 1,
+        step=125_000_000,
+        dtype=np.int64,
+    )
+    burst = _build_mag_l1b(burst_epochs, "imap_mag_l1b_burst-mago", "0:8")
+
+    output = mag_l1c(norm, day, burst)
+    epochs_out = output["epoch"].data
+
+    assert epochs_out[0] < nm_start, (
+        "mag_l1c output collapsed to NM window; day_to_process not honored"
+    )
+    assert int((epochs_out < nm_start).sum()) > 0
 
 
 def test_missing_burst_file(norm_dataset, burst_dataset):


### PR DESCRIPTION
## Summary

Addresses part of issue #2925: Alastair's December 4-7 2025 MAG L1C [plots](https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/1993#issuecomment-3628066202) show large multi-hour gaps between stacked daily products even though the parent burst L1B files contain data in those intervals.

Root cause: on mixed norm+burst days, `mag_l1c()` was short-circuiting `day_to_process` to `None` before calling `process_mag_l1c()`. That prevented `find_all_gaps()` from emitting leading/trailing day-window gaps, so burst coverage preceding or following the NM file was silently dropped.

The fix passes `day_to_process` through unconditionally when burst data is present. The supporting gap machinery is now on `dev` from #2899, so this PR is a small logic fix plus regression coverage for the mixed NM+BM day-boundary path.

## Scope

- `mag_l1c.py`: remove the `day_to_process_arg = ... if normal_mode_dataset is None else None` conditional and pass `day_to_process` through unconditionally.
- `test_mag_l1c.py`: add regression coverage for leading burst-only coverage, trailing burst-only coverage, uncovered leading gaps, the public mixed-input path, and burst-only behavior.
- `test_mag_l1c.py`: align the existing synthetic mixed-input tests with the `day_to_process` they pass in, avoiding enormous synthetic day-window gaps.
- `.gitignore`: add `.claude/`.

## Scope not included

This does not implement inherited cross-day cadence selection from previous-day NM files. Based on discussion in the [earlier draft](https://github.com/sapols/imap_processing/pull/5), this PR should leave #2925 open after merge because that day-boundary cadence work is a larger follow-up.

## Verification

- `pytest imap_processing/tests/mag/test_mag_l1c.py -q` - 25 passed.
- `pytest imap_processing/tests/mag/test_mag_validation.py -k "013 or 014 or 015 or 016 or 024" -q` - 10 passed, 14 deselected.
- `pytest imap_processing/tests/mag -q` - 118 passed.
- `pre-commit run --all-files` - passed.

## Real-day CDF regeneration from the draft branch

The [earlier draft](https://github.com/sapols/imap_processing/pull/5) branch regenerated Dec 4-7 2025 L1C with the same parent L1B files used for the archived products. Results:

| Day | Archived rows | Regenerated rows | Archived first / last | Regenerated first / last |
|---|---:|---:|---|---|
| Dec 5 | 69,184 | 179,941 | 14:53:03 -> 00:29:34 | 23:30:05 -> 00:29:34 |
| Dec 6 | 104,256 | 180,023 | 23:29:51 -> 13:58:38 | 23:29:51 -> 00:30:02 Dec 7 |
| Dec 4, 7 | burst-only | unchanged | - | - |

Combined Dec 4-7 gap check:

- Archived: 2 gaps > 5s (51,783s on Dec 5 and 34,287s on Dec 6).
- Regenerated: 0 gaps > 5s.
