### PR TITLE
GLOWS - added pointing id

### DIFF
--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -325,7 +325,7 @@ class HistogramL2:
 
     number_of_good_l1b_inputs: int
     total_l1b_inputs: int
-    identifier: int  # TODO: Should be the official pointing number
+    identifier: int
     start_time: np.double
     end_time: np.double
     daily_lightcurve: DailyLightcurve
@@ -391,7 +391,8 @@ class HistogramL2:
 
         self.total_l1b_inputs = len(l1b_dataset["epoch"])
         self.number_of_good_l1b_inputs = len(good_data["epoch"])
-        self.identifier = -1  # TODO: retrieve from spin table
+        repointing = l1b_dataset.attrs.get("Repointing")
+        self.identifier = int(repointing.replace("repoint", ""))
         # TODO fill this in
         self.bad_time_flag_occurrences = np.zeros((1, FLAG_LENGTH))
 

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -67,11 +67,13 @@ def test_glows_l2(
         mock_pipeline_settings,
         mock_conversion_table_dict,
     )
+    l1b_hist_dataset.attrs["Repointing"] = "repoint00047"
 
     # Test case 1: L1B dataset has good times
     l2 = glows_l2(l1b_hist_dataset, mock_pipeline_settings, mock_calibration_dataset)[0]
     assert l2.attrs["Logical_source"] == "imap_glows_l2_hist"
     assert np.allclose(l2["filter_temperature_average"].values, [57.6], rtol=0.1)
+    assert l2["identifier"].values[0] == 47
     assert "flight_software_version" in l2.attrs
     assert "pkts_file_name" in l2.attrs
     assert "flight_software_version" not in l2.data_vars
@@ -130,6 +132,7 @@ def test_generate_l2(
         mock_pipeline_settings,
         mock_conversion_table_dict,
     )
+    l1b_hist_dataset.attrs["Repointing"] = "repoint00047"
     day = et_to_datetime64(ttj2000ns_to_et(l1b_hist_dataset["epoch"].data[0]))
     pipeline_settings = PipelineSettings(
         mock_pipeline_settings.sel(epoch=day, method="nearest")

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -483,6 +483,7 @@ def l1b_dataset_full():
             "imap_time_offset": (["epoch"], [60.0, 60.0]),
         },
         coords={"epoch": xr.DataArray(epoch, dims=["epoch"])},
+        attrs={"Repointing": "repoint00047"},
     )
 
 


### PR DESCRIPTION
This pull request updates the way the `identifier` field is set for `HistogramL2` objects in the GLOWS L2 data processing pipeline. Instead of using a placeholder value, the code now extracts the identifier from the `Repointing` attribute in the L1B dataset. The tests have also been updated to reflect this change and ensure correct behavior.

**Core logic update:**

* The `identifier` field in the `HistogramL2` class is now set by parsing the `Repointing` attribute from the L1B dataset, replacing the previous placeholder. This ensures that the identifier accurately reflects the repointing number from the data. [[1]](diffhunk://#diff-005b5cbd9791b3f3aa8c0acdaefafa606881303dfc5908000d752f44017c1d45L394-R395) [[2]](diffhunk://#diff-005b5cbd9791b3f3aa8c0acdaefafa606881303dfc5908000d752f44017c1d45L328-R328)

**Test updates:**

* The `Repointing` attribute is set in the test L1B datasets to `"repoint00047"` to match the new logic, and assertions are added to verify that the `identifier` is correctly extracted as `47`. [[1]](diffhunk://#diff-f2202fd899749ebea2edcae146a1b56288e89648cc8aeae2f9612037c0ec6d03R70-R76) [[2]](diffhunk://#diff-f2202fd899749ebea2edcae146a1b56288e89648cc8aeae2f9612037c0ec6d03R135) [[3]](diffhunk://#diff-85922de4b06d3b8b853330bbcaf5d45c1cac4405f6663481d8738eb2c19bd958R486)