### PR TITLE
CoDICE l2 DE: keep nso and rgfo vars

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
@@ -84,7 +84,6 @@ data_quality:
   FIELDNAM: Data Quality
   FILLVAL: *uint8_fillval
   FORMAT: I3
-  LABLAXIS: Data Quality
   LABL_PTR_1: priority_label
   SCALETYP: linear
   UNITS: " "
@@ -324,6 +323,7 @@ esa_step:
   VALIDMAX: 127
   VALIDMIN: 0
   VAR_TYPE: data
+
 # ------------------------------- labels -------------------------------
 
 event_num_label:

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -1321,18 +1321,7 @@ def process_lo_direct_events(dependencies: ProcessingInputCollection) -> xr.Data
         kev.astype(np.float32).reshape(l2_dataset["energy_step"].shape),
     )
     # Drop unused variables
-    vars_to_drop = [
-        "spare",
-        "sw_bias_gain_mode",
-        "st_bias_gain_mode",
-        "k_factor",
-        "rgfo_esa_step",
-        "rgfo_spin_sector",
-        "rgfo_half_spin",
-        "nso_esa_step",
-        "nso_spin_sector",
-        "nso_half_spin",
-    ]
+    vars_to_drop = ["spare", "sw_bias_gain_mode", "st_bias_gain_mode", "k_factor"]
     l2_dataset = l2_dataset.drop_vars(vars_to_drop)
     # Update variable attributes
     l2_dataset.attrs.update(

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -1328,6 +1328,10 @@ def process_lo_direct_events(dependencies: ProcessingInputCollection) -> xr.Data
         cdf_attrs.get_global_attributes("imap_codice_l2_lo-direct-events")
     )
     for var in l2_dataset.data_vars:
+        if "nso" in var or "rgfo" in var:
+            # skip adding attributes for these variables. They should already
+            # have attrs carried over from l1a.
+            continue
         l2_dataset[var].attrs.update(cdf_attrs.get_variable_attributes(var))
     # Update coord attributes
     l2_dataset["priority"].attrs.update(


### PR DESCRIPTION
# Change Summary

closes #2698

## Overview

Keep nso and rgfo vars in de l2. 

## File changes

- imap_processing/codice/codice_l2.py
  - Drop vars

