### PR TITLE
Implement fallback to linear interpolation in interpolate_map_flux_to…

### DIFF
--- a/imap_processing/ena_maps/utils/corrections.py
+++ b/imap_processing/ena_maps/utils/corrections.py
@@ -880,16 +880,24 @@ def interpolate_map_flux_to_helio_frame(
         stat_unc_left = stat_unc.isel({"energy": left_idx_da})
         stat_unc_right = stat_unc.isel({"energy": right_idx_da})
         sys_err_left = sys_err.isel({"energy": left_idx_da})
+        sys_err_right = sys_err.isel({"energy": right_idx_da})
 
-        # Step 3: Perform power-law interpolation to spacecraft energy
-        # slope = log(f_right/f_left) / log(e_right/e_left)
-        # flux_sc = f_left * (energy_sc / e_left)^slope
+        # Step 3: Perform interpolation to spacecraft energy
+        # Use power-law interpolation when both bounding fluxes are positive,
+        # otherwise fall back to linear interpolation to avoid log(0) issues.
+
+        # Interpolation fraction for linear fallback
+        interp_fraction = (energy_sc - energy_left) / (energy_right - energy_left)
+
+        # Determine which pixels need linear interpolation (zero/negative flux)
+        use_linear = (flux_left <= 0) | (flux_right <= 0)
+
         with np.errstate(divide="ignore", invalid="ignore"):
-            # Calculate slope for power-law interpolation
+            # === Power-law interpolation (Equations 72-76) ===
+            # slope = log(f_right/f_left) / log(e_right/e_left)
+            # flux_sc = f_left * (energy_sc / e_left)^slope
             slope = np.log(flux_right / flux_left) / np.log(energy_right / energy_left)
-
-            # Interpolate flux using power-law
-            flux_sc = flux_left * ((energy_sc / energy_left) ** slope)
+            flux_sc_powerlaw = flux_left * ((energy_sc / energy_left) ** slope)
 
             # Interpolation factor for uncertainty propagation (Equations 75 & 76)
             unc_factor = np.log(energy_sc / energy_left) / np.log(
@@ -899,7 +907,7 @@ def interpolate_map_flux_to_helio_frame(
             # Statistical uncertainty propagation (Equation 75):
             # δJ = J * sqrt((δJ_left/J_left)^2 * (1 + unc_factor^2)
             #               + unc_factor^2 * (δJ_right/J_right)^2)
-            stat_unc_sc = flux_sc * np.sqrt(
+            stat_unc_sc_powerlaw = flux_sc_powerlaw * np.sqrt(
                 (stat_unc_left / flux_left) ** 2 * (1.0 + unc_factor**2)
                 + unc_factor**2 * (stat_unc_right / flux_right) ** 2
             )
@@ -908,7 +916,28 @@ def interpolate_map_flux_to_helio_frame(
             # σJ^g = σJ^src_kref * (⟨E^s_kref⟩ / E^ESA_kref)^γ_kref * (E^h / ⟨E^s_kref⟩)
             # Systematic error scales proportionally with flux during power-law
             # interpolation
-            sys_err_sc = sys_err_left * ((energy_sc / energy_left) ** slope)
+            sys_err_sc_powerlaw = sys_err_left * ((energy_sc / energy_left) ** slope)
+
+            # === Linear interpolation (fallback for zero/negative flux) ===
+            # flux_sc = flux_left + (flux_right - flux_left) * f
+            # where f = (energy_sc - energy_left) / (energy_right - energy_left)
+            flux_sc_linear = flux_left + (flux_right - flux_left) * interp_fraction
+
+            # Statistical uncertainty: sqrt((1-f)^2 * σ_left^2 + f^2 * σ_right^2)
+            stat_unc_sc_linear = np.sqrt(
+                (1 - interp_fraction) ** 2 * stat_unc_left**2
+                + interp_fraction**2 * stat_unc_right**2
+            )
+
+            # Systematic error: linear interpolation
+            sys_err_sc_linear = (
+                sys_err_left + (sys_err_right - sys_err_left) * interp_fraction
+            )
+
+        # Merge: use linear where needed, power-law otherwise
+        flux_sc = xr.where(use_linear, flux_sc_linear, flux_sc_powerlaw)
+        stat_unc_sc = xr.where(use_linear, stat_unc_sc_linear, stat_unc_sc_powerlaw)
+        sys_err_sc = xr.where(use_linear, sys_err_sc_linear, sys_err_sc_powerlaw)
 
         # Step 4: Energy scaling transformation (Liouville theorem)
         # flux_helio = flux_sc * (helio_energy / energy_sc)
@@ -919,6 +948,9 @@ def interpolate_map_flux_to_helio_frame(
             flux_helio = flux_sc * energy_ratio
             stat_unc_helio = stat_unc_sc * energy_ratio
             sys_err_helio = sys_err_sc * energy_ratio
+
+        # Clamp negative fluxes to zero (can occur from linear extrapolation)
+        flux_helio = flux_helio.where(flux_helio >= 0, 0.0)
 
         # Set any location where the value is not finite to NaN (converts +/-inf to NaN)
         flux_helio = flux_helio.where(np.isfinite(flux_helio), np.nan)

--- a/imap_processing/tests/ena_maps/test_corrections.py
+++ b/imap_processing/tests/ena_maps/test_corrections.py
@@ -1611,6 +1611,334 @@ class TestInterpolateMapFluxToHelioFrame:
         # Allow for some numerical variation due to interpolation
         np.testing.assert_allclose(ratio, 0.2, rtol=0.01)
 
+    def test_linear_fallback_when_flux_left_zero(self):
+        """Test that linear interpolation is used when flux_left is zero."""
+        n_energy = 3
+        n_spatial = 2
+
+        esa_energies_vals = np.array([500.0, 1000.0, 2000.0])
+
+        # Create flux where one pixel has zero flux at energy index 0
+        flux = np.array(
+            [
+                [0.0, 1.0],  # energy 0: pixel 0 is zero
+                [1.0, 2.0],  # energy 1
+                [0.5, 1.5],  # energy 2
+            ]
+        )
+        stat_unc = 0.1 * np.maximum(flux, 0.1)
+        sys_err = 0.05 * np.maximum(flux, 0.1)
+
+        # Set energy_sc to be between energy channels 0 and 1
+        energy_sc = np.array(
+            [
+                [750.0, 750.0],  # interpolating between 500 and 1000
+                [1500.0, 1500.0],  # interpolating between 1000 and 2000
+                [1800.0, 1800.0],  # near the boundary
+            ]
+        )
+
+        map_ds = xr.Dataset(
+            {
+                "ena_intensity": (["energy", "spatial"], flux),
+                "ena_intensity_stat_uncert": (["energy", "spatial"], stat_unc),
+                "ena_intensity_sys_err": (["energy", "spatial"], sys_err),
+                "energy_sc": (["energy", "spatial"], energy_sc),
+            },
+            coords={
+                "energy": np.arange(n_energy),
+                "spatial": np.arange(n_spatial),
+            },
+        )
+
+        esa_energies = xr.DataArray(
+            esa_energies_vals,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+        helio_energies = esa_energies.copy()
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
+        )
+
+        # Verify results are finite (not NaN) where we expect valid values
+        result_flux = result_ds["ena_intensity"].values
+
+        # With linear fallback, pixel 0 at energy 0 should produce a valid result
+        # because we're interpolating between 0 (at 500eV) and 1 (at 1000eV)
+        # Linear interpolation at 750eV: 0 + (1-0) * (750-500)/(1000-500) = 0.5
+        # Then energy scaling: 0.5 * (500/750) = 1/3
+        expected_flux = 0.5 * (500.0 / 750.0)  # = 1/3
+        np.testing.assert_allclose(
+            result_flux[0, 0],
+            expected_flux,
+            rtol=1e-10,
+            err_msg="Linear fallback should produce correct interpolated value",
+        )
+
+        # Statistical uncertainty should also be finite
+        result_stat_unc = result_ds["ena_intensity_stat_uncert"].values
+        assert np.isfinite(result_stat_unc[0, 0]), (
+            "Statistical uncertainty should be finite with linear fallback"
+        )
+
+    def test_linear_fallback_when_flux_right_zero(self):
+        """Test that linear interpolation is used when flux_right is zero."""
+        n_energy = 3
+        n_spatial = 2
+
+        esa_energies_vals = np.array([500.0, 1000.0, 2000.0])
+
+        # Create flux where one pixel has zero flux at energy index 1
+        flux = np.array(
+            [
+                [1.0, 1.0],  # energy 0
+                [0.0, 2.0],  # energy 1: pixel 0 is zero
+                [0.5, 1.5],  # energy 2
+            ]
+        )
+        stat_unc = 0.1 * np.maximum(flux, 0.1)
+        sys_err = 0.05 * np.maximum(flux, 0.1)
+
+        # Set energy_sc to be between energy channels 0 and 1
+        energy_sc = np.array(
+            [
+                [750.0, 750.0],  # interpolating between 500 and 1000
+                [1500.0, 1500.0],  # interpolating between 1000 and 2000
+                [1800.0, 1800.0],  # near the boundary
+            ]
+        )
+
+        map_ds = xr.Dataset(
+            {
+                "ena_intensity": (["energy", "spatial"], flux),
+                "ena_intensity_stat_uncert": (["energy", "spatial"], stat_unc),
+                "ena_intensity_sys_err": (["energy", "spatial"], sys_err),
+                "energy_sc": (["energy", "spatial"], energy_sc),
+            },
+            coords={
+                "energy": np.arange(n_energy),
+                "spatial": np.arange(n_spatial),
+            },
+        )
+
+        esa_energies = xr.DataArray(
+            esa_energies_vals,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+        helio_energies = esa_energies.copy()
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
+        )
+
+        result_flux = result_ds["ena_intensity"].values
+
+        # With linear fallback, pixel 0 at energy 0 should produce a valid result
+        # Linear interpolation from flux=1 at 500eV to flux=0 at 1000eV
+        # At 750eV: 1 + (0-1) * (750-500)/(1000-500) = 1 - 0.5 = 0.5
+        # Then energy scaling: 0.5 * (500/750) = 1/3
+        expected_flux = 0.5 * (500.0 / 750.0)  # = 1/3
+        np.testing.assert_allclose(
+            result_flux[0, 0],
+            expected_flux,
+            rtol=1e-10,
+            err_msg="Linear fallback should produce correct interpolated value",
+        )
+
+    def test_linear_fallback_when_both_fluxes_zero(self):
+        """Test that both bounding fluxes being zero produces zero output."""
+        n_energy = 3
+        n_spatial = 2
+
+        esa_energies_vals = np.array([500.0, 1000.0, 2000.0])
+
+        # Create flux where pixel 0 has zero flux at both energy 0 and 1
+        flux = np.array(
+            [
+                [0.0, 1.0],  # energy 0: pixel 0 is zero
+                [0.0, 2.0],  # energy 1: pixel 0 is zero
+                [0.5, 1.5],  # energy 2
+            ]
+        )
+        stat_unc = 0.1 * np.maximum(flux, 0.1)
+        sys_err = 0.05 * np.maximum(flux, 0.1)
+
+        # Set energy_sc to be between energy channels 0 and 1 for first energy
+        energy_sc = np.array(
+            [
+                [750.0, 750.0],  # interpolating between 500 and 1000
+                [1500.0, 1500.0],
+                [1800.0, 1800.0],
+            ]
+        )
+
+        map_ds = xr.Dataset(
+            {
+                "ena_intensity": (["energy", "spatial"], flux),
+                "ena_intensity_stat_uncert": (["energy", "spatial"], stat_unc),
+                "ena_intensity_sys_err": (["energy", "spatial"], sys_err),
+                "energy_sc": (["energy", "spatial"], energy_sc),
+            },
+            coords={
+                "energy": np.arange(n_energy),
+                "spatial": np.arange(n_spatial),
+            },
+        )
+
+        esa_energies = xr.DataArray(
+            esa_energies_vals,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+        helio_energies = esa_energies.copy()
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
+        )
+
+        result_flux = result_ds["ena_intensity"].values
+
+        # When both bounding fluxes are zero, linear interpolation gives 0
+        # Result should be 0 (not NaN)
+        assert result_flux[0, 0] == 0.0, (
+            "When both bounding fluxes are zero, result should be 0"
+        )
+
+    def test_negative_interpolated_flux_clamped_to_zero(self):
+        """Test that negative interpolated flux is clamped to zero."""
+        n_energy = 3
+        n_spatial = 1
+
+        esa_energies_vals = np.array([500.0, 1000.0, 2000.0])
+
+        # Create flux that decreases steeply - linear extrapolation could go negative
+        flux = np.array(
+            [
+                [2.0],  # energy 0
+                [0.1],  # energy 1: much smaller
+                [0.5],  # energy 2
+            ]
+        )
+        stat_unc = 0.1 * flux
+        sys_err = 0.05 * flux
+
+        # Set energy_sc beyond the range to trigger extrapolation
+        # At energy index 0, set energy_sc below 500eV to extrapolate
+        energy_sc = np.array(
+            [
+                [400.0],  # Below lowest ESA energy - will use channels 0,1
+                [800.0],
+                [1500.0],
+            ]
+        )
+
+        map_ds = xr.Dataset(
+            {
+                "ena_intensity": (["energy", "spatial"], flux),
+                "ena_intensity_stat_uncert": (["energy", "spatial"], stat_unc),
+                "ena_intensity_sys_err": (["energy", "spatial"], sys_err),
+                "energy_sc": (["energy", "spatial"], energy_sc),
+            },
+            coords={
+                "energy": np.arange(n_energy),
+                "spatial": np.arange(n_spatial),
+            },
+        )
+
+        esa_energies = xr.DataArray(
+            esa_energies_vals,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+        helio_energies = esa_energies.copy()
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
+        )
+
+        result_flux = result_ds["ena_intensity"].values
+
+        # All flux values should be non-negative
+        assert np.all(result_flux >= 0), "All interpolated flux values should be >= 0"
+
+    def test_linear_and_powerlaw_mixed(self):
+        """Test correct interpolation method for mixed zero/positive flux."""
+        n_energy = 3
+        n_spatial = 4
+
+        esa_energies_vals = np.array([500.0, 1000.0, 2000.0])
+
+        # Create mixed flux data:
+        # - Pixel 0: zero at left boundary (needs linear)
+        # - Pixel 1: zero at right boundary (needs linear)
+        # - Pixel 2: all positive (can use power-law)
+        # - Pixel 3: zero at both (needs linear, result=0)
+        flux = np.array(
+            [
+                [0.0, 1.0, 1.0, 0.0],  # energy 0
+                [1.0, 0.0, 2.0, 0.0],  # energy 1
+                [0.5, 0.5, 1.5, 0.5],  # energy 2
+            ]
+        )
+        stat_unc = 0.1 * np.maximum(flux, 0.1)
+        sys_err = 0.05 * np.maximum(flux, 0.1)
+
+        # Set energy_sc to be between energy channels 0 and 1
+        energy_sc = np.full((n_energy, n_spatial), 750.0)
+        energy_sc[1, :] = 1500.0
+        energy_sc[2, :] = 1800.0
+
+        map_ds = xr.Dataset(
+            {
+                "ena_intensity": (["energy", "spatial"], flux),
+                "ena_intensity_stat_uncert": (["energy", "spatial"], stat_unc),
+                "ena_intensity_sys_err": (["energy", "spatial"], sys_err),
+                "energy_sc": (["energy", "spatial"], energy_sc),
+            },
+            coords={
+                "energy": np.arange(n_energy),
+                "spatial": np.arange(n_spatial),
+            },
+        )
+
+        esa_energies = xr.DataArray(
+            esa_energies_vals,
+            dims=["energy"],
+            coords={"energy": np.arange(n_energy)},
+        )
+        helio_energies = esa_energies.copy()
+
+        result_ds = interpolate_map_flux_to_helio_frame(
+            map_ds, esa_energies, helio_energies, ["ena_intensity"]
+        )
+
+        result_flux = result_ds["ena_intensity"].values
+
+        # Check that all pixels at energy 0 have finite, non-negative results
+        assert np.all(np.isfinite(result_flux[0, :])), (
+            "All pixels should have finite results"
+        )
+        assert np.all(result_flux[0, :] >= 0), "All flux values should be non-negative"
+
+        # Pixel 0: Linear interpolation from 0 to 1 at 750eV should give positive
+        assert result_flux[0, 0] > 0, (
+            "Pixel 0 should have positive flux (linear from 0 to 1)"
+        )
+
+        # Pixel 1: Linear interpolation from 1 to 0 at 750eV should give positive
+        assert result_flux[0, 1] > 0, (
+            "Pixel 1 should have positive flux (linear from 1 to 0)"
+        )
+
+        # Pixel 2: Power-law interpolation should give positive
+        assert result_flux[0, 2] > 0, "Pixel 2 should have positive flux (power-law)"
+
+        # Pixel 3: Both bounds zero, should be zero
+        assert result_flux[0, 3] == 0.0, "Pixel 3 should be zero (both bounds zero)"
+
 
 class TestGetPsetDirectionalMask:
     """Test suite for get_pset_direction_bin_mask function."""


### PR DESCRIPTION
…_helio_frame method

# Change Summary

## Overview

  Fixes #3149 - Adds linear interpolation fallback for zero-flux cases in the Compton-Getting correction.

  When one or more fluxes are zero, the power-law interpolation in interpolate_map_flux_to_helio_frame produces NaN because log(0) is undefined. This PR detects these conditions and falls back to linear interpolation.

  Changes

  imap_processing/ena_maps/utils/corrections.py

  Modified interpolate_map_flux_to_helio_frame to:

  - Detect when either bounding flux is zero or negative (use_linear = (flux_left <= 0) | (flux_right <= 0))
  - Compute linear interpolation as a fallback:
    - Flux: flux_left + (flux_right - flux_left) * f
    - Statistical uncertainty: sqrt((1-f)² * σ_left² + f² * σ_right²)
    - Systematic error: sys_err_left + (sys_err_right - sys_err_left) * f
  - Use xr.where() to select linear interpolation where needed, power-law otherwise
  - Clamp negative flux values to zero (can occur from linear extrapolation)

  imap_processing/tests/ena_maps/test_corrections.py

  Added 5 new test cases:

  - test_linear_fallback_when_flux_left_zero - Verifies correct interpolation when left bounding flux is zero
  - test_linear_fallback_when_flux_right_zero - Verifies correct interpolation when right bounding flux is zero
  - test_linear_fallback_when_both_fluxes_zero - Verifies result is zero (not NaN) when both bounds are zero
  - test_negative_interpolated_flux_clamped_to_zero - Verifies negative fluxes are clamped to zero
  - test_linear_and_powerlaw_mixed - Verifies correct method selection in mixed scenarios

Closes: #3149 
