### PR TITLE
SWE: Adding missing attributes to "acquisition_time"

### DIFF
--- a/imap_processing/cdf/config/imap_swe_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l1b_variable_attrs.yaml
@@ -138,9 +138,12 @@ acquisition_time:
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Acquisition time by volt step and spin sector
   FILLVAL: -9223372036854775808
+  FORMAT: I10
   LABL_PTR_1: esa_step_label
   LABL_PTR_2: spin_sector_label
   UNITS: sec
+  VALIDMAX: 3155716869184000000  # 2100-01-01T00:00:00 mission end
+  VALIDMIN: 315576066184000000   # 2010-01-01T00:00:00 mission start (APL 0 epoch)
   VAR_NOTES: >
     This stores the acquisition times of each measurement. This time is
     calculated by combining ACQ_START_COARSE, ACQ_START_FINE,


### PR DESCRIPTION
# Change Summary

## Overview

VALIDMIN and VALIDMAX were missing. This fixes the error with https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/3106. 

The problem was, the rest of the code was automatically adding in these attributes as "None". cdflib used to drop attributes with "None", but now attempts to add them as empty strings. The issue is that VALIDMIN and VALIDMAX if they exist can't be strings - they need to actually be numbers. So this ensures that those attributes are numbers. 
