### PR TITLE
GLOWS - change to int

### DIFF
--- a/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
@@ -404,11 +404,12 @@ bad_time_flag_occurrences:
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
   DISPLAY_TYPE: no_plot
   FIELDNAM: Occurrences of bad-time flags
-  FILLVAL: -1.0E+31
+  FILLVAL: 65535
   FORMAT: I5
   LABLAXIS: No. of cases
   LABL_PTR_1: flags_label # MS: I do not understand this
-  VALIDMAX: 20000
+  VALIDMIN: 0
+  VALIDMAX: 65535
 
 spin_angle:
   <<: *lightcurve_defaults

--- a/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
@@ -408,8 +408,8 @@ bad_time_flag_occurrences:
   FORMAT: I5
   LABLAXIS: No. of cases
   LABL_PTR_1: flags_label # MS: I do not understand this
-  VALIDMIN: 0
   VALIDMAX: 65535
+  VALIDMIN: 0
 
 spin_angle:
   <<: *lightcurve_defaults

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -394,7 +394,7 @@ class HistogramL2:
         repointing = l1b_dataset.attrs.get("Repointing")
         self.identifier = int(repointing.replace("repoint", ""))
         # TODO fill this in
-        self.bad_time_flag_occurrences = np.zeros((1, FLAG_LENGTH))
+        self.bad_time_flag_occurrences = np.zeros((1, FLAG_LENGTH), dtype=np.uint16)
 
         if len(good_data["epoch"]) != 0:
             # Generate outputs that are passed in directly from L1B

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -179,6 +179,7 @@ def test_generate_l2(
         ds = HistogramL2(l1b_hist_dataset, pipeline_settings, mock_calibration_dataset)
         expected_number_of_good_l1b_inputs = 0
         assert ds.number_of_good_l1b_inputs == expected_number_of_good_l1b_inputs
+        assert ds.bad_time_flag_occurrences.dtype == np.uint16
 
 
 def test_bin_exclusions(l1b_hists):


### PR DESCRIPTION
This pull request updates the handling of the `bad_time_flag_occurrences` variable in the GLOWS L2 data processing pipeline to use an unsigned 16-bit integer type, increases its valid range, and adds a test to verify the new data type. These changes ensure the variable can represent a larger range of values and are consistent across the configuration, code, and tests.

**Data type and range updates:**

* Changed the `bad_time_flag_occurrences` array in `glows_l2_data.py` to use `np.uint16` for a wider valid range and better memory efficiency.
* Updated the configuration in `imap_glows_l2_variable_attrs.yaml` to set `FILLVAL` to `65535`, and changed `VALIDMIN` to `0` and `VALIDMAX` to `65535`, aligning with the new data type.

**Testing improvements:**

* Added a test in `test_glows_l2.py` to assert that `bad_time_flag_occurrences` uses the `np.uint16` data type, ensuring correctness of the change.