### PR TITLE
Changes to filter Lo maps to ~90 deg pivot angle.

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -64,6 +64,7 @@ from imap_processing.idex.idex_l1a import PacketParser
 from imap_processing.idex.idex_l1b import idex_l1b
 from imap_processing.idex.idex_l2a import idex_l2a
 from imap_processing.idex.idex_l2b import idex_l2b
+from imap_processing.lo.constants import LoConstants
 from imap_processing.lo.l1a import lo_l1a
 from imap_processing.lo.l1b import lo_l1b
 from imap_processing.lo.l1c import lo_l1c
@@ -1133,6 +1134,53 @@ class Idex(ProcessInstrument):
 class Lo(ProcessInstrument):
     """Process IMAP-Lo."""
 
+    def pre_processing(self) -> ProcessingInputCollection:
+        """
+        Complete pre-processing.
+
+        Extends the base pre-processing by filtering Lo PSET science inputs to
+        only those whose ``pivot_angle`` is within
+        ``LoConstants.PSET_PIVOT_ANGLE_TOLERANCE`` of
+        ``LoConstants.PSET_PIVOT_ANGLE``. PSET files that fall outside this
+        range are dropped before processing begins.
+
+        Returns
+        -------
+        dependencies : ProcessingInputCollection
+            Object containing dependencies to process.
+        """
+        datasets = super().pre_processing()
+        new_datasets = ProcessingInputCollection()
+
+        for processing_input in datasets.get_processing_inputs():
+            if (
+                processing_input.source == "lo"
+                and processing_input.descriptor == "pset"
+            ):
+                valid_filenames = []
+                for imap_file_path in processing_input.imap_file_paths:
+                    pset = load_cdf(imap_file_path.construct_path())
+                    if "pivot_angle" in pset:
+                        if (
+                            abs(
+                                pset["pivot_angle"].item()
+                                - LoConstants.PSET_PIVOT_ANGLE
+                            )
+                            < LoConstants.PSET_PIVOT_ANGLE_TOLERANCE
+                        ):
+                            valid_filenames.append(str(imap_file_path.filename))
+                        else:
+                            logger.info(
+                                f"Dropping pset {imap_file_path.filename} because "
+                                f"pivot angle is not in range."
+                            )
+                if valid_filenames:
+                    new_datasets.add(type(processing_input)(*valid_filenames))
+            else:
+                new_datasets.add(processing_input)
+
+        return new_datasets
+
     def do_processing(
         self, dependencies: ProcessingInputCollection
     ) -> list[xr.Dataset]:
@@ -1193,6 +1241,10 @@ class Lo(ProcessInstrument):
             anc_dependencies = dependencies.get_file_paths(data_type="ancillary")
 
             # Load all pset files into datasets
+            if not science_files:
+                logger.info("No valid psets found for L2 processing.")
+                return datasets
+
             psets = [load_cdf(file) for file in science_files]
             data_dict[psets[0].attrs["Logical_source"]] = psets
             datasets = lo_l2.lo_l2(data_dict, anc_dependencies, self.descriptor)

--- a/imap_processing/lo/constants.py
+++ b/imap_processing/lo/constants.py
@@ -1,0 +1,21 @@
+"""Constants for IMAP-Lo."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LoConstants:
+    """
+    Constants for Lo which can be used across different levels.
+
+    Attributes
+    ----------
+    PSET_PIVOT_ANGLE : float
+        Expected pivot angle [degrees] for pointing sets for generating map products.
+    PSET_PIVOT_ANGLE_TOLERANCE : float
+        Absolute tolerance [degrees] for accepting a pset's pivot angle
+        as sufficiently close to the required value.
+    """
+
+    PSET_PIVOT_ANGLE: float = 90.0
+    PSET_PIVOT_ANGLE_TOLERANCE: float = 2.0

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -429,7 +429,8 @@ def test_hi_l1b_goodtimes(mock_hi_goodtimes, mock_instrument_dependencies):
 
 
 @mock.patch("imap_processing.cli.lo_l2.lo_l2", autospec=True)
-def test_lo_l2(mock_lo_l2, mock_instrument_dependencies):
+@mock.patch("imap_processing.cli.Lo.pre_processing")
+def test_lo_l2(mock_lo_pre_processing, mock_lo_l2, mock_instrument_dependencies):
     mocks = mock_instrument_dependencies
 
     descriptor = "some-ena-map-descriptor"
@@ -445,7 +446,7 @@ def test_lo_l2(mock_lo_l2, mock_instrument_dependencies):
     )
 
     mocks["mock_load_cdf"].side_effect = [mock_loaded_pset_1, sentinel.loaded_pset_2]
-    mocks["mock_pre_processing"].return_value = processing_input
+    mock_lo_pre_processing.return_value = processing_input
 
     output_l2_dataset = xr.Dataset()
     mock_lo_l2.return_value = [output_l2_dataset]

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -469,6 +469,42 @@ def test_lo_l2(mock_lo_l2, mock_instrument_dependencies):
     mocks["mock_write_cdf"].assert_called_once_with(output_l2_dataset)
 
 
+@mock.patch("imap_processing.cli.load_cdf")
+@mock.patch("imap_processing.cli.ProcessInstrument.pre_processing")
+def test_lo_pre_processing_pivot_angle_filter(mock_super_pre_processing, mock_load_cdf):
+    valid_pset = "imap_lo_l1c_pset_20250415_v001.cdf"
+    invalid_pset = "imap_lo_l1c_pset_20250416_v001.cdf"
+    non_pset = "imap_lo_l1a_de_20260415-repoint00217_v001.cdf"
+
+    base_collection = ProcessingInputCollection(
+        ScienceInput(valid_pset, invalid_pset),
+        ScienceInput(non_pset),
+    )
+    mock_super_pre_processing.return_value = base_collection
+    mock_load_cdf.side_effect = [
+        xr.Dataset({"pivot_angle": xr.DataArray(90.1)}),
+        xr.Dataset({"pivot_angle": xr.DataArray(105.0)}),
+    ]
+
+    instrument = Lo(
+        "l2",
+        "some-descriptor",
+        base_collection.serialize(),
+        "20250415",
+        "20250416",
+        "v001",
+        False,
+    )
+    result = instrument.pre_processing()
+
+    result_inputs = list(result.get_processing_inputs())
+    assert len(result_inputs) == 2
+
+    pset_input, non_pset_input = result_inputs
+    assert [str(fp.filename) for fp in pset_input.imap_file_paths] == [valid_pset]
+    assert [str(fp.filename) for fp in non_pset_input.imap_file_paths] == [non_pset]
+
+
 @mock.patch("imap_processing.cli.quaternions.process_quaternions", autospec=True)
 def test_spacecraft(mock_spacecraft_l1a, mock_instrument_dependencies):
     """Test coverage for cli.Spacecraft class"""


### PR DESCRIPTION
# Change Summary

## Overview

Fixes issue #2794 

## File changes

-  Added logic in `Lo.pre_processing` to filter out pset(s) whose pivot angle falls out of the required range.
- Added a `lo/constants.py` file to hold the desired pivot angle / tolerance for filtering.


## Testing

Added a test `test_lo_pre_processing_pivot_angle_filter` in `test_cli.py` that makes sure that the pset with off-nominal pivot angle is filtered out.
