### PR TITLE
Minor changes towards issue 3135 (IMAP-Lo goodtimes)

### DIFF
--- a/imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
@@ -110,7 +110,7 @@ imap_lo_l1b_bgrates:
 imap_lo_l1b_goodtimes:
   <<: *instrument_base
   Data_type: L1B_goodtimes>Level-1B Goodtimes List
-  Logical_source: imap_lo_l1b_good-times
+  Logical_source: imap_lo_l1b_goodtimes
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1B Data
 
 imap_lo_l1c_goodtimes:

--- a/imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_global_cdf_attrs.yaml
@@ -110,7 +110,7 @@ imap_lo_l1b_bgrates:
 imap_lo_l1b_goodtimes:
   <<: *instrument_base
   Data_type: L1B_goodtimes>Level-1B Goodtimes List
-  Logical_source: imap_lo_l1b_goodtimes
+  Logical_source: imap_lo_l1b_good-times
   Logical_source_description: IMAP Mission IMAP-Lo Instrument Level-1B Data
 
 imap_lo_l1c_goodtimes:

--- a/imap_processing/lo/constants.py
+++ b/imap_processing/lo/constants.py
@@ -26,6 +26,7 @@ class LoConstants:
     N_CYCLE_AVE: int = 7  # Cycles to average over when estimating background rates
     N_ESA_LEVELS: int = 7  # Total number of ESA levels
     N_SPINS_PER_ESA_LEVEL: int = 4  # Spins per ESA step within one histogram cycle
+    N_SPIN_ANGLE_BINS: int = 60  # Number of angular bins within a spin
 
     # Nominal spin period [s]. True spin duration is NOT 15 seconds.
     NOMINAL_SPIN_PERIOD_SEC: float = 15.0

--- a/imap_processing/lo/constants.py
+++ b/imap_processing/lo/constants.py
@@ -14,8 +14,8 @@ class LoConstants:
     # as sufficiently close to the required value.
     PSET_PIVOT_ANGLE_TOLERANCE: float = 2.0
 
-    # Ion species tracked. "H" is mandatory; any others for which we have histrates
-    # may be added here.
+    # Ion species tracked. "H" is mandatory (and should be the first element);
+    # any others for which we have histrates may be added here.
     ELEMS = ("H", "O")
 
     # Hours into the day (UTC) for HK data to calculate median for pivot angle

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2592,7 +2592,7 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
         if f"{elem.lower()}_counts" in cdf_hist.data_vars:
             elem_counts = cdf_hist[f"{elem.lower()}_counts"].values
         else:
-            elem_counts = np.zeros((n_epochs, c.N_ESA_LEVELS, c.N_SPIN_ANGLE_BINS))
+            elem_counts = np.zeros_like(cdf_hist["h_counts"].values)
         elem_ram_counts[elem] = sum(
             np.sum(elem_counts[:, ram_esa_indices, b], axis=(1, 2))
             for b in c.RAM_HISTOGRAM_BINS
@@ -2686,7 +2686,7 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
             for elem in elems:
                 synthetic_floors[elem] += c.BG_RATES.get(elem, 0) * exposure
                 proxy_floors[elem] += np.sum(
-                    elem_anti_ram_counts["H"][window_sum_start:window_sum_end]
+                    elem_anti_ram_counts[elem][window_sum_start:window_sum_end]
                 )
 
             goodtime_exposure_avg += exposure
@@ -2798,7 +2798,7 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
             data=np.full(c.N_ESA_LEVELS, bg_rates_out[elem]),
             name=f"{elem_lower}_background_rates",
             attrs=attr_mgr_l1b.get_variable_attributes(
-                f"{elem_lower}_background_rates", check_schema=False
+                f"{elem_lower}_background_rates"
             ),
             dims=["esa_step"],
         )
@@ -2806,23 +2806,19 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
             data=np.full(c.N_ESA_LEVELS, sigma_bg_rates_out[elem]),
             name=f"{elem_lower}_background_variance",
             attrs=attr_mgr_l1b.get_variable_attributes(
-                f"{elem_lower}_background_variance", check_schema=False
+                f"{elem_lower}_background_variance"
             ),
             dims=["esa_step"],
         )
         l1b_combined_ds[f"{elem_lower}_synthetic_floor"] = xr.DataArray(
             data=np.float32(synthetic_floors[elem]),
             name=f"{elem_lower}_synthetic_floor",
-            attrs=attr_mgr_l1b.get_variable_attributes(
-                f"{elem_lower}_synthetic_floor", check_schema=False
-            ),
+            attrs=attr_mgr_l1b.get_variable_attributes(f"{elem_lower}_synthetic_floor"),
         )
         l1b_combined_ds[f"{elem_lower}_proxy_floor"] = xr.DataArray(
             data=np.float32(proxy_floors[elem]),
             name=f"{elem_lower}_proxy_floor",
-            attrs=attr_mgr_l1b.get_variable_attributes(
-                f"{elem_lower}_proxy_floor", check_schema=False
-            ),
+            attrs=attr_mgr_l1b.get_variable_attributes(f"{elem_lower}_proxy_floor"),
         )
 
     logger.info("L1B Background Rates and Bettertimes created successfully")
@@ -2867,10 +2863,15 @@ def split_backgrounds_and_goodtimes_dataset(
         "_synthetic_floor",
         "_proxy_floor",
     ]
-    background_rate_fields = []
-    for data_var in l1b_backgrounds_and_goodtimes_ds.data_vars:
-        if any(data_var.endswith(suffix) for suffix in background_rate_field_suffixes):
-            background_rate_fields.append(data_var)
+    background_rate_fields = sorted(
+        [
+            data_var
+            for data_var in l1b_backgrounds_and_goodtimes_ds.data_vars
+            if any(
+                data_var.endswith(suffix) for suffix in background_rate_field_suffixes
+            )
+        ]
+    )
 
     lib_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
     lib_bgrates_ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_bgrates")

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2873,7 +2873,9 @@ def split_backgrounds_and_goodtimes_dataset(
         ]
     )
 
-    lib_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
-    lib_bgrates_ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_bgrates")
+    l1b_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
+    l1b_bgrates_ds["epoch"] = l1b_backgrounds_and_goodtimes_ds["epoch"]
+    l1b_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
+    l1b_bgrates_ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_bgrates")
 
-    return lib_bgrates_ds, l1b_goodtimes_ds
+    return l1b_bgrates_ds, l1b_goodtimes_ds

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -173,23 +173,10 @@ MONITOR_RATE_FIELDS = [
     "spin_cycle",
 ]
 
-# Fields to include in the split background rates/goodtimes datasets
-BACKGROUND_RATE_FIELDS = [
-    "h_background_rates",
-    "h_background_variance",
-    "o_background_rates",
-    "o_background_variance",
-    "h_synthetic_floor",
-    "h_proxy_floor",
-    "o_synthetic_floor",
-    "o_proxy_floor",
-]
-
 GOODTIMES_FIELDS = ["gt_start_met", "gt_end_met", "pivot", "pivot_de"]
 
 # -------------------------------------------------------------------
 DE_CLOCK_TICK_S = 4.096e-3  # seconds per DE clock tick
-NUM_ESA_STEPS = 7
 
 
 def lo_l1b(
@@ -1847,7 +1834,7 @@ def calculate_de_rates(
         )
 
     # exposure time shape: (num_asc, num_esa_steps)
-    exposure_time: np.ndarray = np.zeros((num_asc, 7), dtype=float)
+    exposure_time: np.ndarray = np.zeros((num_asc, c.N_ESA_LEVELS), dtype=float)
     # exposure_time_6deg = N_SPINS_PER_ESA_LEVEL * avg_spin_per_asc / 60
     # N_SPINS_PER_ESA_LEVEL sweeps per ASC (28 / 7) in 60 bins
     asc_avg_spin_durations = (
@@ -1860,7 +1847,7 @@ def calculate_de_rates(
     )
 
     # Create output arrays
-    output_shape = (num_asc, 7, 60)
+    output_shape = (num_asc, c.N_ESA_LEVELS, c.N_SPIN_ANGLE_BINS)
     h_counts = np.zeros(output_shape)
     o_counts = np.zeros(output_shape)
     triple_counts = np.zeros(output_shape)
@@ -2602,7 +2589,10 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     elem_ram_counts = {}
     elem_anti_ram_counts = {}
     for elem in elems:
-        elem_counts = cdf_hist[f"{elem.lower()}_counts"].values
+        if f"{elem.lower()}_counts" in cdf_hist.data_vars:
+            elem_counts = cdf_hist[f"{elem.lower()}_counts"].values
+        else:
+            elem_counts = np.zeros((n_epochs, c.N_ESA_LEVELS, c.N_SPIN_ANGLE_BINS))
         elem_ram_counts[elem] = sum(
             np.sum(elem_counts[:, ram_esa_indices, b], axis=(1, 2))
             for b in c.RAM_HISTOGRAM_BINS
@@ -2694,7 +2684,7 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
                 begin = met[i]  # Start a new good-time interval
 
             for elem in elems:
-                synthetic_floors[elem] += c.BG_RATES[elem] * exposure
+                synthetic_floors[elem] += c.BG_RATES.get(elem, 0) * exposure
                 proxy_floors[elem] += np.sum(
                     elem_anti_ram_counts["H"][window_sum_start:window_sum_end]
                 )
@@ -2734,14 +2724,14 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     sigma_bg_rates_out = {}
     for elem in elems:
         if goodtime_exposure_avg == 0:
-            bg_rate = bg_rate_anti_ram_nominal * c.BG_RATE_FALLBACK_SCALE[elem]
+            bg_rate = bg_rate_anti_ram_nominal * c.BG_RATE_FALLBACK_SCALE.get(elem, 0)
             sigma_bg_rate = bg_rate
         else:
             bg_rate = synthetic_floors[elem] / goodtime_exposure_avg
             sigma_bg_rate = np.sqrt(synthetic_floors[elem]) / goodtime_exposure_avg
 
         if bg_rate == 0.0:
-            bg_rate = bg_rate_anti_ram_nominal / c.BG_RATE_FLOOR_DIVISOR[elem]
+            bg_rate = bg_rate_anti_ram_nominal / c.BG_RATE_FLOOR_DIVISOR.get(elem, 1)
             sigma_bg_rate = bg_rate
         if sigma_bg_rate == 0.0:
             sigma_bg_rate = bg_rate
@@ -2808,7 +2798,7 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
             data=np.full(c.N_ESA_LEVELS, bg_rates_out[elem]),
             name=f"{elem_lower}_background_rates",
             attrs=attr_mgr_l1b.get_variable_attributes(
-                f"{elem_lower}_background_rates"
+                f"{elem_lower}_background_rates", check_schema=False
             ),
             dims=["esa_step"],
         )
@@ -2816,19 +2806,23 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
             data=np.full(c.N_ESA_LEVELS, sigma_bg_rates_out[elem]),
             name=f"{elem_lower}_background_variance",
             attrs=attr_mgr_l1b.get_variable_attributes(
-                f"{elem_lower}_background_variance"
+                f"{elem_lower}_background_variance", check_schema=False
             ),
             dims=["esa_step"],
         )
         l1b_combined_ds[f"{elem_lower}_synthetic_floor"] = xr.DataArray(
             data=np.float32(synthetic_floors[elem]),
             name=f"{elem_lower}_synthetic_floor",
-            attrs=attr_mgr_l1b.get_variable_attributes(f"{elem_lower}_synthetic_floor"),
+            attrs=attr_mgr_l1b.get_variable_attributes(
+                f"{elem_lower}_synthetic_floor", check_schema=False
+            ),
         )
         l1b_combined_ds[f"{elem_lower}_proxy_floor"] = xr.DataArray(
             data=np.float32(proxy_floors[elem]),
             name=f"{elem_lower}_proxy_floor",
-            attrs=attr_mgr_l1b.get_variable_attributes(f"{elem_lower}_proxy_floor"),
+            attrs=attr_mgr_l1b.get_variable_attributes(
+                f"{elem_lower}_proxy_floor", check_schema=False
+            ),
         )
 
     logger.info("L1B Background Rates and Bettertimes created successfully")
@@ -2865,7 +2859,20 @@ def split_backgrounds_and_goodtimes_dataset(
     """
     l1b_goodtimes_ds = l1b_backgrounds_and_goodtimes_ds[GOODTIMES_FIELDS]
     l1b_goodtimes_ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_goodtimes")
-    lib_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[BACKGROUND_RATE_FIELDS]
+
+    # Suffixes for fields that we accept as belonging to `l1b_bgrates`.
+    background_rate_field_suffixes = [
+        "_background_rates",
+        "_background_variance",
+        "_synthetic_floor",
+        "_proxy_floor",
+    ]
+    background_rate_fields = []
+    for data_var in l1b_backgrounds_and_goodtimes_ds.data_vars:
+        if any(data_var.endswith(suffix) for suffix in background_rate_field_suffixes):
+            background_rate_fields.append(data_var)
+
+    lib_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
     lib_bgrates_ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_bgrates")
 
     return lib_bgrates_ds, l1b_goodtimes_ds

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2786,13 +2786,13 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     )
 
     l1b_combined_ds["gt_start_met"] = xr.DataArray(
-        data=np.array([r[0] for r in goodtime_rows], dtype=np.float32),
+        data=np.array([r[0] for r in goodtime_rows], dtype=np.float64),
         name="Goodtime_start",
         dims=["epoch"],
         attrs=attr_mgr_l1b.get_variable_attributes("gt_start_met"),
     )
     l1b_combined_ds["gt_end_met"] = xr.DataArray(
-        data=np.array([r[1] for r in goodtime_rows], dtype=np.float32),
+        data=np.array([r[1] for r in goodtime_rows], dtype=np.float64),
         name="Goodtime_end",
         dims=["epoch"],
         attrs=attr_mgr_l1b.get_variable_attributes("gt_end_met"),

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -10,6 +10,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import load_cdf
+from imap_processing.lo.constants import LoConstants
 from imap_processing.lo.l1b.lo_l1b import (
     DE_CLOCK_TICK_S,
     calculate_de_rates,
@@ -2841,3 +2842,87 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_high_to_low_to_high(
     # Background rates should be positive for all intervals
     assert np.all(l1b_bgrates_ds["h_background_rates"].values > 0)
     assert np.all(l1b_bgrates_ds["o_background_rates"].values > 0)
+
+
+def test_l1b_bgrates_when_synthetic_floor_is_zero(anc_dependencies, attr_mgr_l1b):
+    num_epochs = 100
+    met_start = 473389200
+    met_spacing = 42
+    met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
+    epoch_times = met_to_ttj2000ns(met_times)
+
+    # Low counts so that goodtime intervals are found
+    h_counts = np.ones((num_epochs, 7, 60)) * 0.00028
+    o_counts = np.ones((num_epochs, 7, 60)) * 0.000028
+
+    l1b_histrates = xr.Dataset(
+        {
+            "h_counts": (("epoch", "esa_step", "spin_bin_6"), h_counts),
+            "o_counts": (("epoch", "esa_step", "spin_bin_6"), o_counts),
+        },
+        coords={
+            "epoch": epoch_times,
+            "esa_step": np.arange(1, 8),
+            "spin_bin_6": np.arange(60),
+        },
+    )
+
+    sci_dependencies = {
+        "imap_lo_l1b_histrates": l1b_histrates,
+        "imap_lo_l1b_de": xr.Dataset(),
+        "imap_lo_l1b_nhk": xr.Dataset(),
+    }
+
+    patched_bg_rates = dict(LoConstants.BG_RATES)
+    patched_bg_rates["H"] = 0.0
+    with patch.object(LoConstants, "BG_RATES", patched_bg_rates):
+        bgrates_ds, _ = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
+
+    # After the floor: bg_rate = anti_ram_nominal / BG_RATE_FLOOR_DIVISOR["H"] > 0
+    assert np.all(bgrates_ds["h_background_rates"].values > 0)
+
+
+def test_l1b_bgrates_sigma_when_anti_ram_nominal_is_zero(
+    anc_dependencies, attr_mgr_l1b
+):
+    num_epochs = 50
+    met_start = 473389200
+    met_spacing = 42
+    met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
+    epoch_times = met_to_ttj2000ns(met_times)
+
+    # High counts everywhere so no goodtime intervals are found
+    h_counts = np.ones((num_epochs, 7, 60)) * 0.1
+    o_counts = np.ones((num_epochs, 7, 60)) * 0.01
+
+    l1b_histrates = xr.Dataset(
+        {
+            "h_counts": (("epoch", "esa_step", "spin_bin_6"), h_counts),
+            "o_counts": (("epoch", "esa_step", "spin_bin_6"), o_counts),
+        },
+        coords={
+            "epoch": epoch_times,
+            "esa_step": np.arange(1, 8),
+            "spin_bin_6": np.arange(60),
+        },
+    )
+
+    sci_dependencies = {
+        "imap_lo_l1b_histrates": l1b_histrates,
+        "imap_lo_l1b_de": xr.Dataset(),
+        "imap_lo_l1b_nhk": xr.Dataset(),
+    }
+
+    # Zero the anti-RAM threshold so bg_rate_anti_ram_nominal = 0
+    with (
+        patch.object(LoConstants, "THRESHOLD_BG_RATE_ANTI_RAM_90", 0.0),
+        patch.object(LoConstants, "THRESHOLD_BG_RATE_ANTI_RAM_NON_90", 0.0),
+    ):
+        bgrates_ds, _ = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
+
+    assert np.all(bgrates_ds["h_background_rates"].values == 0.0)
+    assert np.all(bgrates_ds["h_background_variance"].values == 0.0)


### PR DESCRIPTION
# Change Summary

## Overview

Minor changes in support for issue #3135 

## File changes

- `imap_processing/lo/l1b/lo_l1b.py` - increased precision for MET data - was causing issues when cross-checking against IMAP-Lo team's offline pipeline algorithm. Also made the code tolerant if we end up adding new species (besides 'O') in the future. Using existing constants when we can (added one new one - `N_SPIN_ANGLE_BINS`.

## Testing

<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
