### PR TITLE
Pivot angle filtering tolerance relaxation

### DIFF
--- a/imap_processing/lo/constants.py
+++ b/imap_processing/lo/constants.py
@@ -12,7 +12,7 @@ class LoConstants:
     PSET_PIVOT_ANGLE: float = 90.0
     # Absolute tolerance [degrees] for accepting a pset's pivot angle
     # as sufficiently close to the required value.
-    PSET_PIVOT_ANGLE_TOLERANCE: float = 2.0
+    PSET_PIVOT_ANGLE_TOLERANCE: float = 45.0
 
     # Ion species tracked. "H" is mandatory; any others for which we have histrates
     # may be added here.

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -484,7 +484,7 @@ def test_lo_pre_processing_pivot_angle_filter(mock_super_pre_processing, mock_lo
     mock_super_pre_processing.return_value = base_collection
     mock_load_cdf.side_effect = [
         xr.Dataset({"pivot_angle": xr.DataArray(90.1)}),
-        xr.Dataset({"pivot_angle": xr.DataArray(105.0)}),
+        xr.Dataset({"pivot_angle": xr.DataArray(30.0)}),
     ]
 
     instrument = Lo(


### PR DESCRIPTION
# Change Summary

Addresses issue #3171 

## Overview

<!--Add a list or paragraph giving an overview of your changes-->

## File changes

Relaxed tolerance `PSET_PIVOT_ANGLE_TOLERANCE` to `45` (per @jtniehof  and @nschwadron) to allow all angles in.


## Testing

Test changed to see if it filters out `30.0` instead of the previous `105` (which is now valid).

Closes: #3171 
