### PR TITLE
IMAP-Lo - Pivot angle estimation window increased in size

### DIFF
--- a/imap_processing/lo/constants.py
+++ b/imap_processing/lo/constants.py
@@ -20,7 +20,7 @@ class LoConstants:
 
     # Hours into the day (UTC) for HK data to calculate median for pivot angle
     # estimation.
-    PIVOT_HK_HOUR_RANGE: tuple[int, int] = (3, 15)
+    PIVOT_HK_HOUR_RANGE: tuple[float, float] = (0.5, 22.5)
 
     N_CYCLE_SUM: int = 1  # Granularity of goodtime boundaries
     N_CYCLE_AVE: int = 7  # Cycles to average over when estimating background rates


### PR DESCRIPTION
# Change Summary

Addresses issue #3169 .

## Overview

@nschwadron decided to use the time window of `+0.5` hours after epoch 0 in the hk data, to `+22.5` hours. Since this is a mask, it will grab any data it can in that window, without getting too close to the edges of the maneuver.

## File changes

`PIVOT_HK_HOUR_RANGE` tweaked in `lo/constants.py`.

## Testing

<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
