### PR TITLE
GLOWS - fix empty issue

### DIFF
--- a/imap_processing/glows/l1a/glows_l1a.py
+++ b/imap_processing/glows/l1a/glows_l1a.py
@@ -338,6 +338,15 @@ def generate_histogram_dataset(
         )
     hist_l1a_list = valid_hists
 
+    # Filter out histograms with no recorded events (all-zero histogram data).
+    valid_hists = [hist for hist in hist_l1a_list if hist.number_of_events > 0]
+    if len(valid_hists) < len(hist_l1a_list):
+        logger.warning(
+            f"GLOWS: Filtered out {len(hist_l1a_list) - len(valid_hists)} "
+            f"histogram(s) with number_of_events == 0."
+        )
+    hist_l1a_list = valid_hists
+
     # Store timestamps for each HistogramL1A object.
     time_data: np.ndarray = np.zeros(len(hist_l1a_list), dtype=np.int64)
     # Data in lists, for each of the 25 time varying datapoints in HistogramL1A

--- a/imap_processing/tests/glows/test_glows_l1a_cdf.py
+++ b/imap_processing/tests/glows/test_glows_l1a_cdf.py
@@ -83,6 +83,22 @@ def test_generate_histogram_dataset_filters_zero_imap_start_time(l1a_test_data):
     assert len(dataset["epoch"].values) == 2
 
 
+def test_generate_histogram_dataset_filters_zero_events(l1a_test_data):
+    histogram_l1a, _ = l1a_test_data
+    glows_attrs = create_glows_attr_obj()
+
+    zero_event_hist = MagicMock()
+    zero_event_hist.number_of_bins_per_histogram = 3600
+    zero_event_hist.imap_start_time = histogram_l1a[0].imap_start_time
+    zero_event_hist.number_of_events = 0
+
+    mixed_list = [zero_event_hist, histogram_l1a[0], zero_event_hist, histogram_l1a[1]]
+
+    dataset = generate_histogram_dataset(mixed_list, glows_attrs)
+
+    assert len(dataset["epoch"].values) == 2
+
+
 def test_generate_de_dataset(l1a_test_data):
     _, de_l1a = l1a_test_data
     glows_attrs = create_glows_attr_obj()


### PR DESCRIPTION
This pull request improves the robustness of the `generate_histogram_dataset` function by filtering out invalid histogram data and adds a corresponding unit test to ensure this behavior. The main focus is on ignoring histograms with zero recorded events, which prevents them from affecting downstream data processing.

**Data filtering improvements:**

* Updated `generate_histogram_dataset` in `glows_l1a.py` to filter out `HistogramL1A` objects where `number_of_events == 0`, and added a warning log when such histograms are excluded.

**Testing enhancements:**

* Added a new test `test_generate_histogram_dataset_filters_zero_events` in `test_glows_l1a_cdf.py` to verify that histograms with zero events are filtered out and do not appear in the resulting dataset.