### PR TITLE
Changes in ram/anti-ram thresholds based on specific pivot angle ranges

### DIFF
--- a/imap_processing/lo/constants.py
+++ b/imap_processing/lo/constants.py
@@ -53,18 +53,23 @@ class LoConstants:
     # Minimum non-zero background rate floor = nominal / divisor
     BG_RATE_FLOOR_DIVISOR: ClassVar[dict[str, float]] = {"H": 50.0, "O": 150.0}
 
-    # Maximum acceptable background count rates [counts/s]. There are separate
-    # thresholds for RAM vs. anti-RAM, and for pivot near 90 deg vs. others.
-    THRESHOLD_BG_RATE_RAM_90: float = 0.014
-    THRESHOLD_BG_RATE_ANTI_RAM_90: float = 0.007
-    THRESHOLD_BG_RATE_RAM_NON_90: float = 0.0175
-    THRESHOLD_BG_RATE_ANTI_RAM_NON_90: float = 0.00875
+    # Background-rate thresholds [counts/s] by pivot-angle range (low, high) [deg].
+    # Each value is (ram_threshold, anti_ram_threshold).
+    # The first matching open interval (low < pivot < high) is used; if none matches,
+    # THRESHOLD_BG_RATE_RAM_DEFAULT / THRESHOLD_BG_RATE_ANTI_RAM_DEFAULT apply.
+    PIVOT_ANGLE_THRESHOLDS: ClassVar[dict[tuple[float, float], tuple[float, float]]] = {
+        (88.0, 92.0): (0.014, 0.007),
+        (73.0, 77.0): (0.0175, 0.00875),
+        (103.0, 107.0): (0.0112, 0.0056),
+    }
+
+    # Default background-rate thresholds [counts/s] when no pivot range matches.
+    THRESHOLD_BG_RATE_RAM_DEFAULT: float = 0.0175
+    THRESHOLD_BG_RATE_ANTI_RAM_DEFAULT: float = 0.00875
 
     # Maximum time gap [s] between consecutive histogram epochs before treating them as
     # separate intervals.
     DELAY_MAX: int = 100
-    # Pivot angles within this range [degrees] are treated as "near 90".
-    PIVOT_90_RANGE: tuple[float, float] = 88.0, 92.0
     # Fraction of each cycle duration that contributes actual exposure.
     EXPOSURE_FACTOR: float = 0.5
     # Padding [s] added to begin/end of each goodtime interval to ensure complete

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2561,12 +2561,13 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     epoch_doy = epoch_start_dt.timetuple().tm_yday
 
     # Choose background rate thresholds based on pivot orientation.
-    if c.PIVOT_90_RANGE[0] < pivot < c.PIVOT_90_RANGE[1]:
-        bg_rate_ram_nominal = c.THRESHOLD_BG_RATE_RAM_90
-        bg_rate_anti_ram_nominal = c.THRESHOLD_BG_RATE_ANTI_RAM_90
-    else:
-        bg_rate_ram_nominal = c.THRESHOLD_BG_RATE_RAM_NON_90
-        bg_rate_anti_ram_nominal = c.THRESHOLD_BG_RATE_ANTI_RAM_NON_90
+    bg_rate_ram_nominal = c.THRESHOLD_BG_RATE_RAM_DEFAULT
+    bg_rate_anti_ram_nominal = c.THRESHOLD_BG_RATE_ANTI_RAM_DEFAULT
+    for (low, high), (ram_thresh, anti_ram_thresh) in c.PIVOT_ANGLE_THRESHOLDS.items():
+        if low < pivot < high:
+            bg_rate_ram_nominal = ram_thresh
+            bg_rate_anti_ram_nominal = anti_ram_thresh
+            break
 
     # Manual overrides of the anti-RAM threshold for anomalous days.
     overrides_anc_files = [

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -2915,10 +2915,10 @@ def test_l1b_bgrates_sigma_when_anti_ram_nominal_is_zero(
         "imap_lo_l1b_nhk": xr.Dataset(),
     }
 
-    # Zero the anti-RAM threshold so bg_rate_anti_ram_nominal = 0
+    # Zero the anti-RAM threshold so bg_rate_anti_ram_nominal = 0 for any pivot angle
     with (
-        patch.object(LoConstants, "THRESHOLD_BG_RATE_ANTI_RAM_90", 0.0),
-        patch.object(LoConstants, "THRESHOLD_BG_RATE_ANTI_RAM_NON_90", 0.0),
+        patch.object(LoConstants, "PIVOT_ANGLE_THRESHOLDS", {}),
+        patch.object(LoConstants, "THRESHOLD_BG_RATE_ANTI_RAM_DEFAULT", 0.0),
     ):
         bgrates_ds, _ = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840


### PR DESCRIPTION
Closes issue #3186

# Change Summary

## Overview

Background rates thresholds in the RAM and anti-RAM directions are now angle-specific (75, 105) instead of simply being near 90 or off-90.

## File changes

In `lo/constants.py`, instead of `THRESHOLD_BG_RATE_RAM_90`/`THRESHOLD_BG_RATE_ANTI_RAM_90` etc., now we have `PIVOT_ANGLE_THRESHOLDS` with keys as the open range pivot angles, and the values as the (ram-threshold, anti-ram-threshold tuples). The fallback values are the same as before.


## Testing

Changed a test to patch the dict instead of a constant.
