### PR TITLE
fix(swapi): replace sci rate VALIDMAX placeholders and fix sci_start_…

### DIFF
--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -83,7 +83,7 @@ rate_uncertainty_default: &rate_uncertainty_default
   LABL_PTR_1: esa_step_label
   SCALETYP: linear
   UNITS: counts
-  VALIDMAX: 1.7976931348623157e+308 # TODO: find actual value
+  VALIDMAX: 4.519655172413793E+05 # 65535 counts / 0.145 s livetime
   VALIDMIN: 0.0
   VAR_TYPE: data
 
@@ -97,7 +97,7 @@ rate_default: &rate_default
   LABL_PTR_1: esa_step_label
   SCALETYP: linear
   UNITS: counts/s
-  VALIDMAX: 1.7976931348623157e+308 # TODO: find actual value
+  VALIDMAX: 4.519655172413793E+05 # 65535 counts / 0.145 s livetime
   VALIDMIN: 0.0
   VAR_TYPE: data
 
@@ -133,7 +133,7 @@ sci_start_time:
   DEPEND_0: epoch
   DICT_KEY: "SPASE>Support>SupportQantity:Temporal"
   FIELDNAM: Science Start time
-  FORMAT: " "
+  FORMAT: A23
   VAR_TYPE: support_data
 
 # Minimum attrs setting for HK data

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import patch
 
+import cdflib
 import numpy as np
 import pandas as pd
 import pytest
@@ -15,6 +16,8 @@ from imap_processing.swapi.l2.swapi_l2 import (
     swapi_l2,
 )
 from imap_processing.swapi.swapi_utils import read_swapi_lut_table
+
+SWAPI_RATE_VALIDMAX = 65535 / SWAPI_LIVETIME
 
 
 @pytest.fixture(scope="session")
@@ -125,6 +128,26 @@ def test_swapi_l2_cdf(
     )
     l2_cdf = write_cdf(l2_dataset)
     assert l2_cdf.name == "imap_swapi_l2_sci_20240924_v999.cdf"
+    cdf_file = cdflib.CDF(l2_cdf)
+    esa_energy_info = cdf_file.varinq("esa_energy")
+    sci_start_time_attrs = cdf_file.varattsget("sci_start_time")
+    assert esa_energy_info.Data_Type_Description == "CDF_DOUBLE"
+    assert sci_start_time_attrs["FORMAT"] == "A23"
+
+    rate_variables = [
+        "swp_pcem_rate",
+        "swp_scem_rate",
+        "swp_coin_rate",
+        "swp_pcem_rate_stat_uncert_plus",
+        "swp_pcem_rate_stat_uncert_minus",
+        "swp_scem_rate_stat_uncert_plus",
+        "swp_scem_rate_stat_uncert_minus",
+        "swp_coin_rate_stat_uncert_plus",
+        "swp_coin_rate_stat_uncert_minus",
+    ]
+    for variable in rate_variables:
+        variable_attrs = cdf_file.varattsget(variable)
+        assert np.isclose(variable_attrs["VALIDMAX"], SWAPI_RATE_VALIDMAX)
 
     # Test uncertainty variables are as expected
     np.testing.assert_array_equal(


### PR DESCRIPTION
## Summary

This PR cleans up the remaining SWAPI `sci` ISTP metadata issues related to rate-domain `VALIDMAX` values and `sci_start_time` formatting.

Parent issue: #2577

## What Changed

### Finite `VALIDMAX` for SWAPI rate variables
The SWAPI L2 rate and rate-uncertainty variables were still using an effectively infinite `VALIDMAX` placeholder in the attribute template.

This PR replaces that placeholder with a finite upper bound derived from the current L2 data model:

- count-domain `VALIDMAX`: `65535`
- fixed SWAPI livetime: `0.145 s`
- rate-domain `VALIDMAX`: `65535 / 0.145 = 4.519655172413793e+05`

That bound is applied to:

- `swp_pcem_rate`
- `swp_scem_rate`
- `swp_coin_rate`
- `swp_pcem_rate_stat_uncert_plus`
- `swp_pcem_rate_stat_uncert_minus`
- `swp_scem_rate_stat_uncert_plus`
- `swp_scem_rate_stat_uncert_minus`
- `swp_coin_rate_stat_uncert_plus`
- `swp_coin_rate_stat_uncert_minus`

### `sci_start_time` format cleanup
`sci_start_time` previously used a blank `FORMAT` value. This PR updates it to `A23`, matching the 23-character UTC timestamp strings written by the current pipeline.

## Testing

Added written-CDF regression coverage in `test_swapi_l2.py` to verify:

- `sci_start_time` is emitted with `FORMAT = A23`
- all 9 affected rate/rate-uncertainty variables write the expected finite `VALIDMAX`
