### PR TITLE
Add a check for data that is more than a full day out of date in a file

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -77,7 +77,6 @@ from imap_processing.mag.l1d.mag_l1d import mag_l1d
 from imap_processing.mag.l2.mag_l2 import mag_l2
 from imap_processing.spacecraft import quaternions
 from imap_processing.spice import pointing_frame, repoint, spin
-from imap_processing.spice.time import et_to_ttj2000ns, str_to_et
 from imap_processing.swapi.l1.swapi_l1 import swapi_l1
 from imap_processing.swapi.l2.swapi_l2 import swapi_l2
 from imap_processing.swapi.swapi_utils import read_swapi_lut_table
@@ -88,7 +87,10 @@ from imap_processing.ultra.l1a import ultra_l1a
 from imap_processing.ultra.l1b import ultra_l1b
 from imap_processing.ultra.l1c import ultra_l1c
 from imap_processing.ultra.l2 import ultra_l2
-from imap_processing.utils import filter_day_boundary_data
+from imap_processing.utils import (
+    check_epochs_within_day_offsets,
+    filter_day_boundary_data,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -429,45 +431,6 @@ class ProcessInstrument(ABC):
                         logger.error(f"Upload failed with error: {msg}")
                 except Exception as e:
                     logger.error(f"Upload failed unknown error: {e}")
-
-    def _check_epochs_within_day(
-        self,
-        datasets: list[xr.Dataset],
-        day: np.datetime64,
-    ) -> None:
-        """
-        Raise an error if any dataset epoch falls more than 24 hours outside day.
-
-        A tolerance of ±24 hours around the expected processing day is allowed
-        to accommodate data that straddles midnight. Epochs beyond that window
-        may indicate the wrong input file was provided.
-
-        Parameters
-        ----------
-        datasets : list[xarray.Dataset]
-            Datasets whose ``epoch`` coordinate will be checked.
-        day : numpy.datetime64
-            The expected processing day (nominally self.start_date).
-
-        Raises
-        ------
-        ValueError
-            If any epoch value is more than 24 hours before ``day`` or more
-            than 24 hours after the end of ``day``.
-        """
-        lower = et_to_ttj2000ns(str_to_et(str(day - np.timedelta64(1, "D"))))
-        upper = et_to_ttj2000ns(str_to_et(str(day + np.timedelta64(2, "D"))))
-        for dataset in datasets:
-            epoch_ns = dataset["epoch"].values
-            if np.any(epoch_ns < lower) or np.any(epoch_ns >= upper):
-                dataset_logical_id = dataset.attrs.get(
-                    "Logical_source", "unknown dataset"
-                )
-
-                raise ValueError(
-                    f"Data in {dataset_logical_id} contains epochs more than 24 hours "
-                    f"outside the expected processing day {day}."
-                )
 
     @final
     def process(self) -> None:
@@ -1451,7 +1414,7 @@ class Mag(ProcessInstrument):
                 )
 
         # Will raise an error if any timestamps are outside the current day
-        self._check_epochs_within_day(datasets, current_day)
+        check_epochs_within_day_offsets(datasets, current_day)
 
         return datasets
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -459,9 +459,13 @@ class ProcessInstrument(ABC):
         for dataset in datasets:
             epoch_ns = dataset["epoch"].values
             if np.any(epoch_ns < lower) or np.any(epoch_ns >= upper):
+                dataset_logical_id = dataset.attrs.get(
+                    "Logical_source", "unknown dataset"
+                )
+
                 raise ValueError(
-                    f"Data contains epochs more than 24 hours outside "
-                    f"the expected processing day {day}."
+                    f"Data in {dataset_logical_id} contains epochs more than 24 hours "
+                    f"outside the expected processing day {day}."
                 )
 
     @final
@@ -1442,6 +1446,7 @@ class Mag(ProcessInstrument):
                     f"Timestamps for output file {ds.attrs['Logical_source']} are not "
                     f"monotonically increasing."
                 )
+
         # Will raise an error if any timestamps are outside the current day
         self._check_epochs_within_day(datasets, current_day)
 

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -77,6 +77,7 @@ from imap_processing.mag.l1d.mag_l1d import mag_l1d
 from imap_processing.mag.l2.mag_l2 import mag_l2
 from imap_processing.spacecraft import quaternions
 from imap_processing.spice import pointing_frame, repoint, spin
+from imap_processing.spice.time import et_to_ttj2000ns, str_to_et
 from imap_processing.swapi.l1.swapi_l1 import swapi_l1
 from imap_processing.swapi.l2.swapi_l2 import swapi_l2
 from imap_processing.swapi.swapi_utils import read_swapi_lut_table
@@ -427,6 +428,41 @@ class ProcessInstrument(ABC):
                         logger.error(f"Upload failed with error: {msg}")
                 except Exception as e:
                     logger.error(f"Upload failed unknown error: {e}")
+
+    def _check_epochs_within_day(
+        self,
+        datasets: list[xr.Dataset],
+        day: np.datetime64,
+    ) -> None:
+        """
+        Raise an error if any dataset epoch falls more than 24 hours outside day.
+
+        A tolerance of ±24 hours around the expected processing day is allowed
+        to accommodate data that straddles midnight. Epochs beyond that window
+        may indicate the wrong input file was provided.
+
+        Parameters
+        ----------
+        datasets : list[xarray.Dataset]
+            Datasets whose ``epoch`` coordinate will be checked.
+        day : numpy.datetime64
+            The expected processing day (nominally self.start_date).
+
+        Raises
+        ------
+        ValueError
+            If any epoch value is more than 24 hours before ``day`` or more
+            than 24 hours after the end of ``day``.
+        """
+        lower = et_to_ttj2000ns(str_to_et(str(day - np.timedelta64(1, "D"))))
+        upper = et_to_ttj2000ns(str_to_et(str(day + np.timedelta64(2, "D"))))
+        for dataset in datasets:
+            epoch_ns = dataset["epoch"].values
+            if np.any(epoch_ns < lower) or np.any(epoch_ns >= upper):
+                raise ValueError(
+                    f"Data contains epochs more than 24 hours outside "
+                    f"the expected processing day {day}."
+                )
 
     @final
     def process(self) -> None:
@@ -1406,6 +1442,9 @@ class Mag(ProcessInstrument):
                     f"Timestamps for output file {ds.attrs['Logical_source']} are not "
                     f"monotonically increasing."
                 )
+            # Will raise an error if any timestamps are outside the current day
+            self._check_epochs_within_day(ds, current_day)
+
         return datasets
 
     def post_processing(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1442,8 +1442,8 @@ class Mag(ProcessInstrument):
                     f"Timestamps for output file {ds.attrs['Logical_source']} are not "
                     f"monotonically increasing."
                 )
-            # Will raise an error if any timestamps are outside the current day
-            self._check_epochs_within_day(ds, current_day)
+        # Will raise an error if any timestamps are outside the current day
+        self._check_epochs_within_day(datasets, current_day)
 
         return datasets
 

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -901,38 +901,3 @@ def test_post_processing(
         "naif0012.tls",
         "imap_sclk_0001.tsc",
     ]
-
-
-@pytest.mark.parametrize(
-    "epoch_ns,raises",
-    [
-        # midday of expected day — passes
-        (int(1.5 * 86400 * 1e9), False),
-        # exactly at lower tolerance boundary (24h before day start) — passes
-        (0, False),
-        # 1 ns before lower bound — more than 24h outside, raises
-        (-1, True),
-        # 1 ns past upper bound — more than 24h outside, raises
-        (int(3 * 86400 * 1e9 + 1), True),
-    ],
-)
-def test_check_epochs_within_day(epoch_ns, raises):
-    """_check_epochs_within_day raises only when epoch is >24h outside expected day."""
-    # lower = expected_day - 1 day (J2000 ns = 0), upper = expected_day + 2 days
-    lower_ns = 0
-    upper_ns = int(3 * 86400 * 1e9)
-    instrument = Swe("l1a", "raw", "[]", "20250101", None, "v001", False)
-    day = np.datetime64("2025-01-01", "D")
-    ds = xr.Dataset({"epoch": xr.DataArray(np.array([epoch_ns], dtype=np.int64))})
-    with (
-        mock.patch("imap_processing.cli.str_to_et", return_value=0.0),
-        mock.patch(
-            "imap_processing.cli.et_to_ttj2000ns",
-            side_effect=[float(lower_ns), float(upper_ns)],
-        ),
-    ):
-        if raises:
-            with pytest.raises(ValueError, match="more than 24 hours outside"):
-                instrument._check_epochs_within_day([ds], day)
-        else:
-            instrument._check_epochs_within_day([ds], day)

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -893,3 +893,38 @@ def test_post_processing(
         "naif0012.tls",
         "imap_sclk_0001.tsc",
     ]
+
+
+@pytest.mark.parametrize(
+    "epoch_ns,raises",
+    [
+        # midday of expected day — passes
+        (int(1.5 * 86400 * 1e9), False),
+        # exactly at lower tolerance boundary (24h before day start) — passes
+        (0, False),
+        # 1 ns before lower bound — more than 24h outside, raises
+        (-1, True),
+        # 1 ns past upper bound — more than 24h outside, raises
+        (int(3 * 86400 * 1e9), True),
+    ],
+)
+def test_check_epochs_within_day(epoch_ns, raises):
+    """_check_epochs_within_day raises only when epoch is >24h outside expected day."""
+    # lower = expected_day - 1 day (J2000 ns = 0), upper = expected_day + 2 days
+    lower_ns = 0
+    upper_ns = int(3 * 86400 * 1e9)
+    instrument = Swe("l1a", "raw", "[]", "20250101", None, "v001", False)
+    day = np.datetime64("2025-01-01", "D")
+    ds = xr.Dataset({"epoch": xr.DataArray(np.array([epoch_ns], dtype=np.int64))})
+    with (
+        mock.patch("imap_processing.cli.str_to_et", return_value=0.0),
+        mock.patch(
+            "imap_processing.cli.et_to_ttj2000ns",
+            side_effect=[float(lower_ns), float(upper_ns)],
+        ),
+    ):
+        if raises:
+            with pytest.raises(ValueError, match="more than 24 hours outside"):
+                instrument._check_epochs_within_day([ds], day)
+        else:
+            instrument._check_epochs_within_day([ds], day)

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -905,7 +905,7 @@ def test_post_processing(
         # 1 ns before lower bound — more than 24h outside, raises
         (-1, True),
         # 1 ns past upper bound — more than 24h outside, raises
-        (int(3 * 86400 * 1e9), True),
+        (int(3 * 86400 * 1e9 + 1), True),
     ],
 )
 def test_check_epochs_within_day(epoch_ns, raises):

--- a/imap_processing/tests/test_utils.py
+++ b/imap_processing/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests coverage for imap_processing/utils.py"""
 
+from unittest import mock
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -8,6 +10,7 @@ import xarray as xr
 from imap_processing import imap_module_directory, utils
 from imap_processing.spice.time import str_yyyymmdd_to_ttj2000ns
 from imap_processing.ultra.utils.ultra_l1_utils import extract_data_dict
+from imap_processing.utils import check_epochs_within_day_offsets
 
 
 def test_convert_raw_to_eu(tmp_path):
@@ -424,5 +427,36 @@ def test_filter_day_boundary_data():
 
     result = utils.filter_day_boundary_data(ds, start_date)
 
-    assert result.dims["epoch"] == 3
+    assert result.sizes["epoch"] == 3
     np.testing.assert_array_equal(result["epoch"].values, epoch_values[1:4])
+
+
+@pytest.mark.parametrize(
+    "epoch_ns,raises",
+    [
+        # midday of expected day — passes
+        (int(1.5 * 86400 * 1e9), False),
+        # exactly at lower tolerance boundary (24h before day start) — passes
+        (0, False),
+        # 1 ns before lower bound — more than 24h outside, raises
+        (-1, True),
+        # 1 ns past upper bound — more than 24h outside, raises
+        (int(3 * 86400 * 1e9 + 1), True),
+    ],
+)
+def test_check_epochs_within_day(epoch_ns, raises):
+    """_check_epochs_within_day raises only when epoch is >24h outside expected day."""
+    # lower = expected_day - 1 day (J2000 ns = 0), upper = expected_day + 2 days
+    lower_ns = 0
+    upper_ns = int(3 * 86400 * 1e9)
+    day = np.datetime64("2025-01-01", "D")
+    ds = xr.Dataset({"epoch": xr.DataArray(np.array([epoch_ns], dtype=np.int64))})
+    with mock.patch(
+        "imap_processing.utils.str_yyyymmdd_to_ttj2000ns",
+        side_effect=[lower_ns, upper_ns],
+    ):
+        if raises:
+            with pytest.raises(ValueError, match="more than 24 hours outside"):
+                check_epochs_within_day_offsets([ds], day)
+        else:
+            check_epochs_within_day_offsets([ds], day)

--- a/imap_processing/utils.py
+++ b/imap_processing/utils.py
@@ -606,3 +606,50 @@ def filter_day_boundary_data(dataset: xr.Dataset, start_date: str) -> xr.Dataset
     end_ttj2000ns = str_yyyymmdd_to_ttj2000ns(next_day) - 1
     logger.info(f"Filtering dataset out of day boundary of {start_date}.")
     return dataset.sel(epoch=slice(start_ttj2000ns, end_ttj2000ns))
+
+
+def check_epochs_within_day_offsets(
+    datasets: list[xr.Dataset],
+    day: np.datetime64,
+) -> None:
+    """
+    Raise an error if any dataset epoch falls more than 24 hours outside day.
+
+    A tolerance of ±24 hours around the expected processing day is allowed
+    to accommodate data that straddles midnight. Epochs beyond that window
+    may indicate the wrong input file was provided.  Eg.
+              day = "202605012"
+              lower = "20260511"
+              upper = "20260513"
+
+    If any data outside of this range is found, this function throws an error.
+    Some instruments can have buffer times beyond daily file date, but they should not
+    be more than 24hrs from the daily file date.
+
+    Parameters
+    ----------
+    datasets : list[xarray.Dataset]
+        Datasets whose ``epoch`` coordinate will be checked.
+    day : numpy.datetime64
+        The expected processing day.
+
+    Raises
+    ------
+    ValueError
+        If any epoch value is more than 24 hours before ``day`` or more
+        than 24 hours after the end of ``day``.
+    """
+    lower = str_yyyymmdd_to_ttj2000ns(
+        str(day - np.timedelta64(1, "D")).replace("-", "")
+    )
+    upper = str_yyyymmdd_to_ttj2000ns(
+        str(day + np.timedelta64(2, "D")).replace("-", "")
+    )
+    for dataset in datasets:
+        epoch_ns = dataset["epoch"].values
+        if np.any(epoch_ns < lower) or np.any(epoch_ns >= upper):
+            dataset_logical_id = dataset.attrs.get("Logical_source", "unknown dataset")
+            raise ValueError(
+                f"Data in {dataset_logical_id} contains epochs more than"
+                f" 24 hours outside the expected processing day {day}."
+            )


### PR DESCRIPTION
# Change Summary

## Overview

Adds a day boundary check to MAG processing that raises an error if any output data contains epochs more than 24 hours outside the expected processing day set by `--start-date`. A tolerance of ±24 hours is allowed to accommodate data that straddles midnight.

## File changes

- **`imap_processing/cli.py`**: Adds `_check_epochs_within_day` to the `ProcessInstrument` base class. The method converts the expected day to TT J2000 ns bounds using SPICE and  raises a `ValueError` if any epoch in the provided datasets falls outside the ±24 hour  window.  The `Mag.do_processing` method calls this check  at all levels on output.

## Testing

- 1 parametrized test added (`test_check_epochs_within_day` with 4 cases) in
  `tests/test_cli.py` covering: epoch at midday (passes), epoch exactly at the lower
  tolerance boundary (passes), epoch 1 ns before the lower bound (raises), and epoch
  at the upper bound (raises). SPICE calls are mocked to avoid requiring furnished kernels.

Addresses #3060 .