### PR TITLE
I-ALiRT - bugfix for error propagation

### DIFF
--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -50,7 +50,7 @@ def packets_created(start_file_creation: datetime, lines: list) -> dict:
             # Handle end of year rollover
             prev = prev_doy[station]
 
-            if prev is not None and doy < prev:
+            if prev is not None and doy < prev and prev > 300 and doy < 30:
                 station_year[station] += 1
 
             prev_doy[station] = doy


### PR DESCRIPTION
This pull request makes a targeted fix to the logic that handles year rollover detection for station data in the `packets_created` function. The change ensures that a new year is only detected when the previous day-of-year is late in the year (over 300) and the current day-of-year is early (under 30), preventing incorrect year increments for other cases.

- Improved year rollover logic in `packets_created` (`imap_processing/ialirt/calculate_ingest.py`): Now only increments the year when transitioning from late in one year (DOY > 300) to early in the next (DOY < 30), reducing false positives.
