### PR TITLE
Fix issue with cdf attributes in Lo l1a datasets

### DIFF
--- a/imap_processing/lo/l1a/lo_l1a.py
+++ b/imap_processing/lo/l1a/lo_l1a.py
@@ -243,7 +243,9 @@ def add_dataset_attrs(
             data=azimuth_60.values.astype(str),
             name="azimuth_60_label",
             dims=["azimuth_60_label"],
-            attrs=attr_mgr.get_variable_attributes("azimuth_60_label"),
+            attrs=attr_mgr.get_variable_attributes(
+                "azimuth_60_label", check_schema=False
+            ),
         )
         azimuth_6 = xr.DataArray(
             data=np.arange(0, 60, dtype=np.uint8),
@@ -255,7 +257,9 @@ def add_dataset_attrs(
             data=azimuth_6.values.astype(str),
             name="azimuth_6_label",
             dims=["azimuth_6_label"],
-            attrs=attr_mgr.get_variable_attributes("azimuth_6_label"),
+            attrs=attr_mgr.get_variable_attributes(
+                "azimuth_6_label", check_schema=False
+            ),
         )
 
         esa_step = xr.DataArray(

--- a/imap_processing/tests/lo/test_lo_l1a.py
+++ b/imap_processing/tests/lo/test_lo_l1a.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 from imap_processing import imap_module_directory
+from imap_processing.cdf.utils import write_cdf
 from imap_processing.lo.l1a.lo_l1a import lo_l1a
 
 
@@ -44,6 +45,9 @@ def test_lo_l1a():
     for dataset, logical_source in zip(
         output_dataset, expected_logical_source, strict=False
     ):
+        # Try writing out the dataset to cdf in an attempt to catch any issues
+        # with attributes that cdflib doesn't like
+        _ = write_cdf(dataset)
         assert logical_source == dataset.attrs["Logical_source"]
         for var in dataset:
             if var in no_depend_0_vars or var.endswith("label"):


### PR DESCRIPTION
# Change Summary

## Overview

When getting attributes for two label variables that do not have a defined DEPEND_0, the `check_schema=False` keyword was not getting set. This resulted in SAMMI populating DEPEND_0 with an empty value which `cdflib` doesn't like. This fixes that and should get Lo L1A processing back on track.


Closes: #3208
