### PR TITLE
I-ALiRT - add sansa to prod

### DIFF
--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -6,7 +6,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-STATIONS = ["Kiel", "UKSA", "tlmrelay"]
+STATIONS = ["Kiel", "SANSA", "UKSA", "tlmrelay"]
 
 
 def packets_created(start_file_creation: datetime, lines: list) -> dict:

--- a/imap_processing/ialirt/constants.py
+++ b/imap_processing/ialirt/constants.py
@@ -93,9 +93,9 @@ STATIONS = {
         schedule_end=None,
     ),
     "SANSA": StationProperties(
-        longitude=27.714,  # degrees East (negative = West)
-        latitude=-25.888,  # degrees North (negative = South)
-        altitude=1.542,  # approx 1542 meters
+        longitude=27.707468,  # degrees East (negative = West)
+        latitude=-25.886476,  # degrees North (negative = South)
+        altitude=1.545,  # approx 1545 meters
         min_elevation_deg=2,  # 5 degrees is the requirement
         schedule_start=None,
         schedule_end=None,

--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 ALL_STATIONS = [
     "Kiel",
+    "SANSA",
     "DSS-24",
     "DSS-25",
     "DSS-26",
@@ -110,6 +111,7 @@ def generate_coverage(  # noqa: PLR0912
 
     stations = {
         "Kiel": STATIONS["Kiel"],
+        "SANSA": STATIONS["SANSA"],
     }
     coverage_dict = {}
     outage_dict = {}

--- a/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
+++ b/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
@@ -28,6 +28,10 @@ def test_packets_created():
             ],
             "rate_kbps": [2.0, 2.0],
         },
+        "SANSA": {
+            "last_data_received": [],
+            "rate_kbps": [],
+        },
         "UKSA": {
             "last_data_received": [],
             "rate_kbps": [],

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -125,7 +125,7 @@ def test_dsn(furnish_kernels):
         )
 
         assert "I-ALiRT Coverage Summary" in output["summary"]
-        assert 40.6 == output["total_coverage_percent"]
+        assert 49.3 == output["total_coverage_percent"]
 
 
 @patch("imap_processing.ialirt.generate_coverage.et_to_utc")


### PR DESCRIPTION
This pull request adds support for the "SANSA" station throughout the codebase, updating relevant station lists, properties, and test data. Additionally, it refines the geographical properties for SANSA.

**Support for SANSA station:**

* Added "SANSA" to the `STATIONS` list in `calculate_ingest.py` to ensure it is processed like other stations.
* Added "SANSA" to the `ALL_STATIONS` list and included it in the `stations` dictionary within `generate_coverage.py` for coverage calculations. [[1]](diffhunk://#diff-812191081e5e974895b3cbffe39db4f381650aeb5e92357d1d313e958cdea938R16) [[2]](diffhunk://#diff-812191081e5e974895b3cbffe39db4f381650aeb5e92357d1d313e958cdea938R114)

**Station property updates:**

* Updated the longitude, latitude, and altitude values for "SANSA" in `constants.py` to use more precise coordinates.

**Testing:**

* Updated the `test_packets_created` unit test to include "SANSA" with appropriate test data.