### PR TITLE
3210 bug   lo l1b processing jobs failing due to cdf attributes

### DIFF
--- a/imap_processing/cdf/config/imap_lo_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1b_variable_attrs.yaml
@@ -218,6 +218,7 @@ gt_end_met:
 
 h_background_rates:
   CATDESC: Hydrogen background rates per ESA level
+  DEPEND_0: esa_step
   FIELDNAM: H Background Rates
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -229,6 +230,7 @@ h_background_rates:
 
 h_background_variance:
   CATDESC: Hydrogen background rate variance per ESA level
+  DEPEND_0: esa_step
   FIELDNAM: H Background Variance
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -262,6 +264,7 @@ h_proxy_floor:
 
 o_background_rates:
   CATDESC: Oxygen background rates per ESA level
+  DEPEND_0: esa_step
   FIELDNAM: O Background Rates
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -273,6 +276,7 @@ o_background_rates:
 
 o_background_variance:
   CATDESC: Oxygen background rate variance per ESA level
+  DEPEND_0: esa_step
   FIELDNAM: O Background Variance
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -1285,7 +1285,7 @@ def create_datasets(
         data=epoch_converted_time,
         name="epoch",
         dims=["epoch"],
-        attrs=attr_mgr.get_variable_attributes("epoch"),
+        attrs=attr_mgr.get_variable_attributes("epoch", check_schema=False),
     )
 
     if logical_source == "imap_lo_l1b_de":
@@ -1837,7 +1837,9 @@ def calculate_de_rates(
     ds = set_esa_mode(pointing_start_met, pointing_end_met, anc_dependencies, ds)
 
     ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_derates")
-    ds["epoch"].attrs = attr_mgr_l1b.get_variable_attributes("epoch")
+    ds["epoch"].attrs = attr_mgr_l1b.get_variable_attributes(
+        "epoch", check_schema=False
+    )
 
     return ds
 
@@ -2318,7 +2320,7 @@ def l1b_star(
             "epoch": xr.DataArray(
                 group_epochs,
                 dims=["epoch"],
-                attrs=attr_mgr_l1b.get_variable_attributes("epoch"),
+                attrs=attr_mgr_l1b.get_variable_attributes("epoch", check_schema=False),
             ),
             "spin_angle": xr.DataArray(
                 spin_angle,

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2654,23 +2654,36 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
 
     epoch_values = met_to_ttj2000ns(np.array([r[0] for r in goodtime_rows]))
 
-    l1b_combined_ds["epoch"] = xr.DataArray(
-        data=epoch_values,
-        name="epoch",
-        dims=["epoch"],
-        attrs=attr_mgr_l1b.get_variable_attributes("epoch"),
+    l1b_combined_ds.assign_coords(
+        epoch=xr.DataArray(
+            data=epoch_values,
+            name="epoch",
+            dims=["epoch"],
+            attrs=attr_mgr_l1b.get_variable_attributes("epoch", check_schema=False),
+        )
     )
-    l1b_combined_ds["epoch"].attrs["DEPEND_0"] = "epoch"
+
+    # esa_step is a coordinate in this dataset, so pop the DEPEND_0 attribute
+    esa_step_attrs = attr_mgr_l1b.get_variable_attributes("esa_step")
+    esa_step_attrs.pop("DEPEND_0")
+    l1b_combined_ds.assign_coords(
+        esa_step=xr.DataArray(
+            data=np.arange(c.N_ESA_LEVELS + 1),
+            name="esa_step",
+            dims=["esa_step"],
+            attrs=esa_step_attrs,
+        )
+    )
 
     l1b_combined_ds["pivot"] = xr.DataArray(
         data=np.float32(pivot),
         name="pivot",
-        attrs=attr_mgr_l1b.get_variable_attributes("pivot"),
+        attrs=attr_mgr_l1b.get_variable_attributes("pivot", check_schema=False),
     )
     l1b_combined_ds["pivot_de"] = xr.DataArray(
         data=np.float32(pivot_de),
         name="pivot_de",
-        attrs=attr_mgr_l1b.get_variable_attributes("pivot_de"),
+        attrs=attr_mgr_l1b.get_variable_attributes("pivot_de", check_schema=False),
     )
 
     l1b_combined_ds["gt_start_met"] = xr.DataArray(
@@ -2696,7 +2709,8 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
             data=np.full(c.N_ESA_LEVELS, bg_rates_out[elem]),
             name=f"{elem_lower}_background_rates",
             attrs=attr_mgr_l1b.get_variable_attributes(
-                f"{elem_lower}_background_rates"
+                f"{elem_lower}_background_rates",
+                check_schema=False,
             ),
             dims=["esa_step"],
         )
@@ -2704,19 +2718,24 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
             data=np.full(c.N_ESA_LEVELS, sigma_bg_rates_out[elem]),
             name=f"{elem_lower}_background_variance",
             attrs=attr_mgr_l1b.get_variable_attributes(
-                f"{elem_lower}_background_variance"
+                f"{elem_lower}_background_variance",
+                check_schema=False,
             ),
             dims=["esa_step"],
         )
         l1b_combined_ds[f"{elem_lower}_synthetic_floor"] = xr.DataArray(
             data=np.float32(synthetic_floors[elem]),
             name=f"{elem_lower}_synthetic_floor",
-            attrs=attr_mgr_l1b.get_variable_attributes(f"{elem_lower}_synthetic_floor"),
+            attrs=attr_mgr_l1b.get_variable_attributes(
+                f"{elem_lower}_synthetic_floor", check_schema=False
+            ),
         )
         l1b_combined_ds[f"{elem_lower}_proxy_floor"] = xr.DataArray(
             data=np.float32(proxy_floors[elem]),
             name=f"{elem_lower}_proxy_floor",
-            attrs=attr_mgr_l1b.get_variable_attributes(f"{elem_lower}_proxy_floor"),
+            attrs=attr_mgr_l1b.get_variable_attributes(
+                f"{elem_lower}_proxy_floor", check_schema=False
+            ),
         )
 
     logger.info("L1B Background Rates and Bettertimes created successfully")
@@ -2773,7 +2792,6 @@ def split_backgrounds_and_goodtimes_dataset(
 
     l1b_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
     l1b_bgrates_ds["epoch"] = l1b_backgrounds_and_goodtimes_ds["epoch"]
-    l1b_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
     l1b_bgrates_ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_bgrates")
 
     return l1b_bgrates_ds, l1b_goodtimes_ds

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -9,7 +9,7 @@ import xarray as xr
 
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.cdf.utils import load_cdf
+from imap_processing.cdf.utils import load_cdf, write_cdf
 from imap_processing.lo.constants import LoConstants
 from imap_processing.lo.l1b.lo_l1b import (
     DE_CLOCK_TICK_S,
@@ -308,8 +308,6 @@ def test_lo_l1b_histogram_rates(
     assert l1b_datasets[-1]["exposure_time_60deg"].values[0, 0, 0] == 20
 
 
-# @pytest.mark.external_kernel
-# @pytest.mark.use_test_metakernel("imap_ena_sim_metakernel.template")
 def test_create_datasets():
     attr_mgr = ImapCdfAttributes()
     attr_mgr.add_instrument_global_attrs(instrument="lo")
@@ -333,6 +331,9 @@ def test_create_datasets():
     ]
 
     dataset = create_datasets(attr_mgr, logical_source, data_fields)
+
+    # verify that epoch does not have a DEPEND_0 attribute
+    assert "DEPEND_0" not in dataset["epoch"].attrs
 
     assert len(dataset.tof0.shape) == 1
     assert dataset.tof0.shape[0] == 3
@@ -1445,6 +1446,10 @@ def test_calculate_de_rates(
 
     result = calculate_de_rates(sci_dependencies, anc_dependencies, attr_mgr_l1b)
 
+    # Test that result can be written to CDF - this verifies that
+    # attributes are ok with cdflib
+    _ = write_cdf(result)
+
     assert result.attrs["Logical_source"] == "imap_lo_l1b_derates"
     assert "epoch" in result.coords
     assert "esa_step" in result.coords
@@ -1975,6 +1980,9 @@ class TestL1bStar:
         l1b_star_ds = l1b_star(sci_dependencies, attr_mgr_l1b)
 
         # Assert - Check spin_angle coordinate attributes
+        # Check that resulting dataset is cdf-able by writing to file
+        _ = write_cdf(l1b_star_ds)
+
         assert l1b_star_ds.coords["spin_angle"].attrs["UNITS"] == "deg"
         assert l1b_star_ds.coords["spin_angle"].attrs["VALIDMIN"] == 0.0
         assert l1b_star_ds.coords["spin_angle"].attrs["VALIDMAX"] == 360.0

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -2206,6 +2206,9 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
 
     l1b_bgrates_ds, l1b_goodtimes_ds = result
 
+    # Check that bgrates dataset is cdf-able by writing to file
+    _ = write_cdf(l1b_bgrates_ds)
+
     # Check bgrates dataset structure (BACKGROUND_RATE_FIELDS)
     assert "h_background_rates" in l1b_bgrates_ds.data_vars
     assert "h_background_variance" in l1b_bgrates_ds.data_vars
@@ -2215,6 +2218,9 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
     assert "o_background_variance" in l1b_bgrates_ds.data_vars
     assert "o_synthetic_floor" in l1b_bgrates_ds.data_vars
     assert "o_proxy_floor" in l1b_bgrates_ds.data_vars
+
+    # Check that goodtimes dataset is cdf-able by writing to file
+    _ = write_cdf(l1b_goodtimes_ds)
 
     # Check goodtimes dataset structure (GOODTIMES_FIELDS)
     assert "gt_start_met" in l1b_goodtimes_ds.data_vars


### PR DESCRIPTION
# Change Summary

## Overview

There were some problems with Lo L1B product attributes that were causing failures when writing to CDF. This PR fixes those issues.

Note that the bgrates product may need additional work. Variables in the cdf don't depend on the epoch dimension as I believe that they should. In fact, I think that none of the variables in the dataset depend on epoch. It seems like it is just thrown in just to have an epoch variable.


Closes: #3210 
