### PR TITLE
lo l1b goodtimes and bgrates write out bad cdfs

### DIFF
--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2654,26 +2654,23 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
 
     epoch_values = met_to_ttj2000ns(np.array([r[0] for r in goodtime_rows]))
 
-    l1b_combined_ds.assign_coords(
-        epoch=xr.DataArray(
-            data=epoch_values,
-            name="epoch",
-            dims=["epoch"],
-            attrs=attr_mgr_l1b.get_variable_attributes("epoch", check_schema=False),
-        )
+    l1b_combined_ds["epoch"] = xr.DataArray(
+        data=epoch_values,
+        name="epoch",
+        dims=["epoch"],
+        attrs=attr_mgr_l1b.get_variable_attributes("epoch", check_schema=False),
     )
 
     # esa_step is a coordinate in this dataset, so pop the DEPEND_0 attribute
     esa_step_attrs = attr_mgr_l1b.get_variable_attributes("esa_step")
     esa_step_attrs.pop("DEPEND_0")
-    l1b_combined_ds.assign_coords(
-        esa_step=xr.DataArray(
-            data=np.arange(c.N_ESA_LEVELS + 1),
-            name="esa_step",
-            dims=["esa_step"],
-            attrs=esa_step_attrs,
-        )
+    l1b_combined_ds["esa_step"] = xr.DataArray(
+        data=np.arange(c.N_ESA_LEVELS, dtype=np.uint8) + 1,
+        name="esa_step",
+        dims=["esa_step"],
+        attrs=esa_step_attrs,
     )
+    l1b_combined_ds = l1b_combined_ds.set_coords(["epoch", "esa_step"])
 
     l1b_combined_ds["pivot"] = xr.DataArray(
         data=np.float32(pivot),

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -2208,6 +2208,8 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
 
     # Check that bgrates dataset is cdf-able by writing to file
     _ = write_cdf(l1b_bgrates_ds)
+    assert "epoch" in l1b_bgrates_ds.coords
+    assert "esa_step" in l1b_bgrates_ds.coords
 
     # Check bgrates dataset structure (BACKGROUND_RATE_FIELDS)
     assert "h_background_rates" in l1b_bgrates_ds.data_vars
@@ -2221,6 +2223,7 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
 
     # Check that goodtimes dataset is cdf-able by writing to file
     _ = write_cdf(l1b_goodtimes_ds)
+    assert "epoch" in l1b_goodtimes_ds.coords
 
     # Check goodtimes dataset structure (GOODTIMES_FIELDS)
     assert "gt_start_met" in l1b_goodtimes_ds.data_vars


### PR DESCRIPTION
# Change Summary

## Overview

Fix bug from latest Lo bugfix that caused coordinates to not be in the dataset. I introduced this bug by miscalling assign_coords.
Added check that coordinates are in output datasets.


Closes: #3217 
