### PR TITLE
ULTRA l1c fix energy when interpolating efficiency 

### DIFF
--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.interpolate import RegularGridInterpolator
 
 from imap_processing import imap_module_directory
 from imap_processing.quality_flags import ImapDEOutliersUltraFlags
@@ -22,6 +23,7 @@ from imap_processing.ultra.l1b.ultra_l1b_extended import (
     get_de_energy_kev,
     get_de_velocity,
     get_efficiency,
+    get_efficiency_interpolator,
     get_energy_pulse_height,
     get_energy_ssd,
     get_event_times,
@@ -818,3 +820,17 @@ def test_is_coin_ph_valid(test_fixture, ancillary_files):
     assert len(etof) == np.count_nonzero(combined_mask) + np.count_nonzero(
         quality_flags
     )
+
+
+def test_get_efficiency_interpolator(ancillary_files):
+
+    # Test that the interpolator is created and that the min/max values are correct
+    eff_interpolator, theta_min_max, phi_min_max, e_min_max = (
+        get_efficiency_interpolator(ancillary_files, "ultra45")
+    )
+
+    assert isinstance(eff_interpolator, RegularGridInterpolator)
+
+    assert theta_min_max == (-52.7, 52.7)
+    assert phi_min_max == (-60, 60)
+    assert e_min_max == (3, 80)

--- a/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
+++ b/imap_processing/tests/ultra/unit/test_ultra_l1b_extended.py
@@ -822,6 +822,7 @@ def test_is_coin_ph_valid(test_fixture, ancillary_files):
     )
 
 
+@pytest.mark.external_test_data
 def test_get_efficiency_interpolator(ancillary_files):
 
     # Test that the interpolator is created and that the min/max values are correct

--- a/imap_processing/ultra/l1b/ultra_l1b_extended.py
+++ b/imap_processing/ultra/l1b/ultra_l1b_extended.py
@@ -1171,7 +1171,7 @@ def get_fwhm(
 def get_efficiency_interpolator(
     ancillary_files: dict,
     sensor: str,
-) -> tuple[RegularGridInterpolator, tuple, tuple]:
+) -> tuple[RegularGridInterpolator, tuple, tuple, tuple]:
     """
     Return a callable function that interpolates efficiency values for each event.
 
@@ -1190,6 +1190,8 @@ def get_efficiency_interpolator(
         Minimum and maximum theta values in the lookup table.
     phi_min_max : tuple
         Minimum and maximum phi values in the lookup table.
+    energy_min_max : tuple
+        Minimum and maximum energy values in the lookup table.
     """
     lookup_table = get_energy_efficiencies(ancillary_files, sensor)
 
@@ -1205,6 +1207,7 @@ def get_efficiency_interpolator(
     # Find the min and max values for theta and phi
     theta_min_max = (theta_vals.min(), theta_vals.max())
     phi_min_max = (phi_vals.min(), phi_vals.max())
+    energy_min_max = (np.asarray(energy_vals).min(), np.asarray(energy_vals).max())
 
     interpolator = RegularGridInterpolator(
         (theta_vals, phi_vals, energy_vals),
@@ -1213,7 +1216,7 @@ def get_efficiency_interpolator(
         fill_value=FILLVAL_FLOAT32,
     )
 
-    return interpolator, theta_min_max, phi_min_max
+    return interpolator, theta_min_max, phi_min_max, energy_min_max
 
 
 def get_efficiency(
@@ -1249,7 +1252,7 @@ def get_efficiency(
         Interpolated efficiency values.
     """
     if not interpolator:
-        interpolator, _, _ = get_efficiency_interpolator(ancillary_files, sensor)
+        interpolator, _, _, _ = get_efficiency_interpolator(ancillary_files, sensor)
 
     return interpolator((theta_inst, phi_inst, energy))
 

--- a/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
+++ b/imap_processing/ultra/l1c/ultra_l1c_pset_bins.py
@@ -577,8 +577,8 @@ def get_efficiencies_and_geometric_function(
     """
     sensor_name = f"ultra{sensor_id}"
     # Load callable efficiency interpolator function
-    eff_interpolator, theta_min_max, phi_min_max = get_efficiency_interpolator(
-        ancillary_files, sensor_name
+    eff_interpolator, theta_min_max, phi_min_max, e_min_max = (
+        get_efficiency_interpolator(ancillary_files, sensor_name)
     )
     # load geometric factor lookup table
     geometric_lookup_table = load_geometric_factor_tables(
@@ -649,7 +649,7 @@ def get_efficiencies_and_geometric_function(
             )
             energy = energy_bin_geometric_means[energy_bin_idx]
             # Clip energy to calibrated range
-            energy_clipped = np.clip(energy, 3.0, 80.0)
+            energy_clipped = np.clip(energy, e_min_max[0], e_min_max[1])
             eff_values = get_efficiency(
                 np.full(pixel_inds.size, energy_clipped),
                 phi_at_spin_clipped[pixel_inds],


### PR DESCRIPTION
# Change Summary
closes #3190
## Overview

I need to clip the energy values to be within the min and max of the valid energy values from the efficiency files. This error was discovered by George Clark when new efficiency files were provided and contained a lower valid energy. 

## File changes

imap_processing/ultra/l1b/ultra_l1b_extended.py
- Remove hardcoded energy mix and max values and replace with relevant edges.  


## Testing

I tested this locally with a new pset. Added a small test to check min and max energy values. 
