### PR TITLE
Update "KeV" units to be "keV" in ultra l1c and enamaps l2 yaml files.

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -44,7 +44,7 @@ energy:
   FIELDNAM: energy_bin_geometric_mean
   LABLAXIS: Energy bin geometric mean
   SCALETYP: linear
-  UNITS: KeV
+  UNITS: keV
   VAR_TYPE: support_data
 
 energy_label:
@@ -63,7 +63,7 @@ energy_delta_minus:
   FIELDNAM: energy delta minus
   LABLAXIS: energy
   LABL_PTR_1: energy_label
-  UNITS: KeV
+  UNITS: keV
   VAR_TYPE: support_data
 
 energy_delta_plus:
@@ -75,7 +75,7 @@ energy_delta_plus:
   FIELDNAM: energy delta plus
   LABLAXIS: energy
   LABL_PTR_1: energy_label
-  UNITS: KeV
+  UNITS: keV
   VAR_TYPE: support_data
 
 epoch:

--- a/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_l1c_variable_attrs.yaml
@@ -208,7 +208,7 @@ energy_delta_minus:
   DISPLAY_TYPE: no_plot
   FIELDNAM: energy_bin_delta_minus
   LABLAXIS: energy
-  UNITS: KeV
+  UNITS: keV
   VAR_TYPE: support_data
 
 energy_delta_plus:
@@ -218,7 +218,7 @@ energy_delta_plus:
   DISPLAY_TYPE: no_plot
   FIELDNAM: energy_bin_delta_plus
   LABLAXIS: energy
-  UNITS: KeV
+  UNITS: keV
   VAR_TYPE: support_data
 
 


### PR DESCRIPTION
# Change Summary

## Overview

The kilo prefix should be a lowercase 'k'. 

## File changes

Change occurrences of "KeV" units to "keV" in metadata yaml files.

## Testing

N/A