### PR TITLE
epoch coord for daily H/O variables, set to midpoint of the pointing

### DIFF
--- a/imap_processing/cdf/config/imap_lo_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1b_variable_attrs.yaml
@@ -218,7 +218,8 @@ gt_end_met:
 
 h_background_rates:
   CATDESC: Hydrogen background rates per ESA level
-  DEPEND_0: esa_step
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
   FIELDNAM: H Background Rates
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -230,7 +231,8 @@ h_background_rates:
 
 h_background_variance:
   CATDESC: Hydrogen background rate variance per ESA level
-  DEPEND_0: esa_step
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
   FIELDNAM: H Background Variance
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -242,6 +244,7 @@ h_background_variance:
 
 h_synthetic_floor:
   CATDESC: Hydrogen synthetic background floor
+  DEPEND_0: epoch
   FIELDNAM: H Synthetic Floor
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -253,6 +256,7 @@ h_synthetic_floor:
 
 h_proxy_floor:
   CATDESC: Hydrogen proxy background floor
+  DEPEND_0: epoch
   FIELDNAM: H Proxy Floor
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -264,7 +268,8 @@ h_proxy_floor:
 
 o_background_rates:
   CATDESC: Oxygen background rates per ESA level
-  DEPEND_0: esa_step
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
   FIELDNAM: O Background Rates
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -276,7 +281,8 @@ o_background_rates:
 
 o_background_variance:
   CATDESC: Oxygen background rate variance per ESA level
-  DEPEND_0: esa_step
+  DEPEND_0: epoch
+  DEPEND_1: esa_step
   FIELDNAM: O Background Variance
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -288,6 +294,7 @@ o_background_variance:
 
 o_synthetic_floor:
   CATDESC: Oxygen synthetic background floor
+  DEPEND_0: epoch
   FIELDNAM: O Synthetic Floor
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6
@@ -299,6 +306,7 @@ o_synthetic_floor:
 
 o_proxy_floor:
   CATDESC: Oxygen proxy background floor
+  DEPEND_0: epoch
   FIELDNAM: O Proxy Floor
   FILLVAL: -1.0000000E+31
   FORMAT: F12.6

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2451,6 +2451,8 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     epoch_ttj2000 = cdf_hist["epoch"].values
     n_epochs = epoch_ttj2000.shape[0]
     met = ttj2000ns_to_met(epoch_ttj2000)
+    pointing_mid_met = get_pointing_mid_time(met[0])
+    pointing_mid_epoch = met_to_ttj2000ns(np.array([pointing_mid_met]))
 
     # Get year and day-of-year for the anti-RAM threshold override lookup
     epoch_start_dt = spiceypy.et2datetime(ttj2000ns_to_et(epoch_ttj2000[0]))
@@ -2738,7 +2740,7 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     logger.info("L1B Background Rates and Bettertimes created successfully")
 
     l1b_bgrates_ds, l1b_goodtimes_ds = split_backgrounds_and_goodtimes_dataset(
-        l1b_combined_ds, attr_mgr_l1b
+        l1b_combined_ds, attr_mgr_l1b, pointing_mid_epoch
     )
     datasets_to_return.extend([l1b_bgrates_ds, l1b_goodtimes_ds])
 
@@ -2746,7 +2748,9 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
 
 
 def split_backgrounds_and_goodtimes_dataset(
-    l1b_backgrounds_and_goodtimes_ds: xr.Dataset, attr_mgr_l1b: ImapCdfAttributes
+    l1b_backgrounds_and_goodtimes_ds: xr.Dataset,
+    attr_mgr_l1b: ImapCdfAttributes,
+    pointing_mid_epoch: int | np.ndarray,
 ) -> tuple[xr.Dataset, xr.Dataset]:
     """
     Separate the L1B backgrounds and goodtimes dataset.
@@ -2759,6 +2763,9 @@ def split_backgrounds_and_goodtimes_dataset(
     attr_mgr_l1b : ImapCdfAttributes
         Attribute manager used to get the L1B background rates and
         goodtimes dataset attributes.
+    pointing_mid_epoch : int | np.ndarray
+        Pointing midpoint time in TT2000 nanoseconds, used as the epoch coordinate for
+        the bgrates dataset. An int or a single-element ndarray.
 
     Returns
     -------
@@ -2788,7 +2795,28 @@ def split_backgrounds_and_goodtimes_dataset(
     )
 
     l1b_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
-    l1b_bgrates_ds["epoch"] = l1b_backgrounds_and_goodtimes_ds["epoch"]
+    l1b_bgrates_ds["epoch"] = xr.DataArray(
+        np.atleast_1d(pointing_mid_epoch).astype(np.int64),
+        dims=["epoch"],
+        attrs=attr_mgr_l1b.get_variable_attributes("epoch", check_schema=False),
+    )
+    l1b_bgrates_ds = l1b_bgrates_ds.set_coords(["epoch"])
+
+    # Expand variables to include epoch as DEPEND_0 in the CDF.
+    for var in background_rate_fields:
+        if var.endswith("_background_rates") or var.endswith("_background_variance"):
+            l1b_bgrates_ds[var] = xr.DataArray(
+                l1b_bgrates_ds[var].values[np.newaxis, :],
+                dims=["epoch", "esa_step"],
+                attrs=l1b_bgrates_ds[var].attrs,
+            )
+        elif var.endswith("_synthetic_floor") or var.endswith("_proxy_floor"):
+            l1b_bgrates_ds[var] = xr.DataArray(
+                np.atleast_1d(l1b_bgrates_ds[var].values),
+                dims=["epoch"],
+                attrs=l1b_bgrates_ds[var].attrs,
+            )
+
     l1b_bgrates_ds.attrs = attr_mgr_l1b.get_global_attributes("imap_lo_l1b_bgrates")
 
     return l1b_bgrates_ds, l1b_goodtimes_ds

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -2451,8 +2451,8 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     epoch_ttj2000 = cdf_hist["epoch"].values
     n_epochs = epoch_ttj2000.shape[0]
     met = ttj2000ns_to_met(epoch_ttj2000)
-    pointing_mid_met = get_pointing_mid_time(met[0])
-    pointing_mid_epoch = met_to_ttj2000ns(np.array([pointing_mid_met]))
+    pointing_start_met, _ = get_pointing_times(met[0])
+    pointing_start_epoch = met_to_ttj2000ns(np.array([pointing_start_met]))
 
     # Get year and day-of-year for the anti-RAM threshold override lookup
     epoch_start_dt = spiceypy.et2datetime(ttj2000ns_to_et(epoch_ttj2000[0]))
@@ -2740,7 +2740,7 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     logger.info("L1B Background Rates and Bettertimes created successfully")
 
     l1b_bgrates_ds, l1b_goodtimes_ds = split_backgrounds_and_goodtimes_dataset(
-        l1b_combined_ds, attr_mgr_l1b, pointing_mid_epoch
+        l1b_combined_ds, attr_mgr_l1b, pointing_start_epoch
     )
     datasets_to_return.extend([l1b_bgrates_ds, l1b_goodtimes_ds])
 
@@ -2750,7 +2750,7 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
 def split_backgrounds_and_goodtimes_dataset(
     l1b_backgrounds_and_goodtimes_ds: xr.Dataset,
     attr_mgr_l1b: ImapCdfAttributes,
-    pointing_mid_epoch: int | np.ndarray,
+    pointing_start_epoch: int | np.ndarray,
 ) -> tuple[xr.Dataset, xr.Dataset]:
     """
     Separate the L1B backgrounds and goodtimes dataset.
@@ -2763,8 +2763,8 @@ def split_backgrounds_and_goodtimes_dataset(
     attr_mgr_l1b : ImapCdfAttributes
         Attribute manager used to get the L1B background rates and
         goodtimes dataset attributes.
-    pointing_mid_epoch : int | np.ndarray
-        Pointing midpoint time in TT2000 nanoseconds, used as the epoch coordinate for
+    pointing_start_epoch : int | np.ndarray
+        Pointing start time in TT2000 nanoseconds, used as the epoch coordinate for
         the bgrates dataset. An int or a single-element ndarray.
 
     Returns
@@ -2796,7 +2796,7 @@ def split_backgrounds_and_goodtimes_dataset(
 
     l1b_bgrates_ds = l1b_backgrounds_and_goodtimes_ds[background_rate_fields]
     l1b_bgrates_ds["epoch"] = xr.DataArray(
-        np.atleast_1d(pointing_mid_epoch).astype(np.int64),
+        np.atleast_1d(pointing_start_epoch).astype(np.int64),
         dims=["epoch"],
         attrs=attr_mgr_l1b.get_variable_attributes("epoch", check_schema=False),
     )

--- a/imap_processing/lo/l1b/lo_l1b.py
+++ b/imap_processing/lo/l1b/lo_l1b.py
@@ -28,6 +28,7 @@ from imap_processing.spice.geometry import (
 from imap_processing.spice.repoint import (
     get_pointing_mid_time,
     get_pointing_times,
+    get_pointing_times_from_id,
     interpolate_repoint_data,
 )
 from imap_processing.spice.spin import (
@@ -2451,7 +2452,13 @@ def l1b_bgrates_and_goodtimes(  # noqa: PLR0912
     epoch_ttj2000 = cdf_hist["epoch"].values
     n_epochs = epoch_ttj2000.shape[0]
     met = ttj2000ns_to_met(epoch_ttj2000)
-    pointing_start_met, _ = get_pointing_times(met[0])
+
+    repoint_id = cdf_hist.attrs.get("Repointing", None)
+    if repoint_id is None:
+        raise ValueError(
+            "Repointing ID attribute is missing from the L1B hist dataset."
+        )
+    pointing_start_met, _ = get_pointing_times_from_id(repoint_id)
     pointing_start_epoch = met_to_ttj2000ns(np.array([pointing_start_met]))
 
     # Get year and day-of-year for the anti-RAM threshold override lookup

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -2187,6 +2187,7 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2197,7 +2198,7 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2285,6 +2286,7 @@ def test_l1b_bgrates_and_goodtimes_with_gap(anc_dependencies, attr_mgr_l1b):
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2295,7 +2297,7 @@ def test_l1b_bgrates_and_goodtimes_with_gap(anc_dependencies, attr_mgr_l1b):
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2353,6 +2355,7 @@ def test_l1b_bgrates_and_goodtimes_high_rate(anc_dependencies, attr_mgr_l1b):
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2363,7 +2366,7 @@ def test_l1b_bgrates_and_goodtimes_high_rate(anc_dependencies, attr_mgr_l1b):
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2403,6 +2406,7 @@ def test_l1b_bgrates_and_goodtimes_no_goodtimes(anc_dependencies, attr_mgr_l1b):
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2412,7 +2416,7 @@ def test_l1b_bgrates_and_goodtimes_no_goodtimes(anc_dependencies, attr_mgr_l1b):
     }
 
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         _, goodtimes_ds = l1b_bgrates_and_goodtimes(
@@ -2449,6 +2453,7 @@ def test_l1b_bgrates_and_goodtimes_empty_dataset(anc_dependencies, attr_mgr_l1b)
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2459,7 +2464,7 @@ def test_l1b_bgrates_and_goodtimes_empty_dataset(anc_dependencies, attr_mgr_l1b)
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2595,6 +2600,7 @@ def test_l1b_bgrates_and_goodtimes_ram_and_anti_ram_bins(
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     # Required dependencies added in the updated function signature
@@ -2608,7 +2614,7 @@ def test_l1b_bgrates_and_goodtimes_ram_and_anti_ram_bins(
     }
 
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2650,6 +2656,7 @@ def test_l1b_bgrates_and_goodtimes_variance_calculation(anc_dependencies, attr_m
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2660,7 +2667,7 @@ def test_l1b_bgrates_and_goodtimes_variance_calculation(anc_dependencies, attr_m
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2703,6 +2710,7 @@ def test_l1b_bgrates_and_goodtimes_offset_application(anc_dependencies, attr_mgr
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2713,7 +2721,7 @@ def test_l1b_bgrates_and_goodtimes_offset_application(anc_dependencies, attr_mgr
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2767,6 +2775,7 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_low_to_high(
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2777,7 +2786,7 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_low_to_high(
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2842,6 +2851,7 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_high_to_low_to_high(
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2852,7 +2862,7 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_high_to_low_to_high(
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
         return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
@@ -2898,6 +2908,7 @@ def test_l1b_bgrates_when_synthetic_floor_is_zero(anc_dependencies, attr_mgr_l1b
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2910,7 +2921,7 @@ def test_l1b_bgrates_when_synthetic_floor_is_zero(anc_dependencies, attr_mgr_l1b
     patched_bg_rates["H"] = 0.0
     with (
         patch(
-            "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+            "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
             return_value=(met_start, met_start + 1),
         ),
         patch.object(LoConstants, "BG_RATES", patched_bg_rates),
@@ -2946,6 +2957,7 @@ def test_l1b_bgrates_sigma_when_anti_ram_nominal_is_zero(
             "esa_step": np.arange(1, 8),
             "spin_bin_6": np.arange(60),
         },
+        attrs={"Repointing": "repoint00001"},
     )
 
     sci_dependencies = {
@@ -2957,7 +2969,7 @@ def test_l1b_bgrates_sigma_when_anti_ram_nominal_is_zero(
     # Zero the anti-RAM threshold so bg_rate_anti_ram_nominal = 0 for any pivot angle
     with (
         patch(
-            "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+            "imap_processing.lo.l1b.lo_l1b.get_pointing_times_from_id",
             return_value=(met_start, met_start + 1),
         ),
         patch.object(LoConstants, "PIVOT_ANGLE_THRESHOLDS", {}),

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -2169,7 +2169,6 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
     num_epochs = 100
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473391300  # 473389200 + 100*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2198,8 +2197,8 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2254,7 +2253,6 @@ def test_l1b_bgrates_and_goodtimes_with_gap(anc_dependencies, attr_mgr_l1b):
     met_start = 473389200
     met_spacing = 42
     gap_size = 10000  # Large gap (> delay_max + interval_nom)
-    met_midpoint = 473396300  # 473389200 + (50*42 + 10000 + 50*42) / 2
 
     # First segment
     met_times_first = np.arange(
@@ -2297,8 +2295,8 @@ def test_l1b_bgrates_and_goodtimes_with_gap(anc_dependencies, attr_mgr_l1b):
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2326,7 +2324,6 @@ def test_l1b_bgrates_and_goodtimes_high_rate(anc_dependencies, attr_mgr_l1b):
     num_epochs = 100
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473391300  # 473389200 + 100*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2366,8 +2363,8 @@ def test_l1b_bgrates_and_goodtimes_high_rate(anc_dependencies, attr_mgr_l1b):
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2389,7 +2386,6 @@ def test_l1b_bgrates_and_goodtimes_no_goodtimes(anc_dependencies, attr_mgr_l1b):
     num_epochs = 50
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473390250  # 473389200 + 50 * 42 / 2
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
 
@@ -2416,8 +2412,8 @@ def test_l1b_bgrates_and_goodtimes_no_goodtimes(anc_dependencies, attr_mgr_l1b):
     }
 
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         _, goodtimes_ds = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2435,7 +2431,6 @@ def test_l1b_bgrates_and_goodtimes_empty_dataset(anc_dependencies, attr_mgr_l1b)
     num_epochs = 10
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473389410  # 473389200 + 10*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2464,8 +2459,8 @@ def test_l1b_bgrates_and_goodtimes_empty_dataset(anc_dependencies, attr_mgr_l1b)
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2487,7 +2482,7 @@ def test_split_backgrounds_and_goodtimes_dataset(attr_mgr_l1b):
     n_esa = 7
     met_starts = np.arange(473389200, 473389200 + num_records * 420, 420)
     epoch_times = met_to_ttj2000ns(met_starts)
-    pointing_mid_epoch = met_to_ttj2000ns(met_starts[0] + 630).item()
+    pointing_start_epoch = met_to_ttj2000ns(met_starts[0]).item()
 
     combined_ds = xr.Dataset(
         coords={"epoch": epoch_times},
@@ -2519,7 +2514,7 @@ def test_split_backgrounds_and_goodtimes_dataset(attr_mgr_l1b):
 
     # Act
     bgrates_ds, goodtimes_ds = split_backgrounds_and_goodtimes_dataset(
-        combined_ds, attr_mgr_l1b, pointing_mid_epoch
+        combined_ds, attr_mgr_l1b, pointing_start_epoch
     )
 
     # Assert - _background_rates/_background_variance are (epoch, esa_step)
@@ -2544,7 +2539,7 @@ def test_split_backgrounds_and_goodtimes_dataset(attr_mgr_l1b):
         assert bgrates_ds[field].shape == (1,)
 
     assert len(bgrates_ds["epoch"]) == 1
-    np.testing.assert_array_equal(bgrates_ds["epoch"].values, pointing_mid_epoch)
+    np.testing.assert_array_equal(bgrates_ds["epoch"].values, pointing_start_epoch)
 
     # Assert - goodtimes dataset contains the expected fields
     assert "gt_start_met" in goodtimes_ds.data_vars
@@ -2571,7 +2566,6 @@ def test_l1b_bgrates_and_goodtimes_ram_and_anti_ram_bins(
     num_epochs = 30
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473389830  # 473389200 + 30*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2614,8 +2608,8 @@ def test_l1b_bgrates_and_goodtimes_ram_and_anti_ram_bins(
     }
 
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2634,7 +2628,6 @@ def test_l1b_bgrates_and_goodtimes_variance_calculation(anc_dependencies, attr_m
     num_epochs = 30
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473389830  # 473389200 + 30*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2667,8 +2660,8 @@ def test_l1b_bgrates_and_goodtimes_variance_calculation(anc_dependencies, attr_m
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2692,7 +2685,6 @@ def test_l1b_bgrates_and_goodtimes_offset_application(anc_dependencies, attr_mgr
     num_epochs = 30
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473389830  # 473389200 + 30*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2721,8 +2713,8 @@ def test_l1b_bgrates_and_goodtimes_offset_application(anc_dependencies, attr_mgr
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2752,7 +2744,6 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_low_to_high(
     num_epochs = 50  # Need at least 5 cycles (50 epochs / 10 per cycle)
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473390250  # 473389200 + 50*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2786,8 +2777,8 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_low_to_high(
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2825,7 +2816,6 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_high_to_low_to_high(
     num_epochs = 80
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473390880  # 473389200 + 80*42/2
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
 
@@ -2862,8 +2852,8 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_high_to_low_to_high(
 
     # Act
     with patch(
-        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-        return_value=met_midpoint,
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+        return_value=(met_start, met_start + 1),
     ):
         result = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
@@ -2891,7 +2881,6 @@ def test_l1b_bgrates_when_synthetic_floor_is_zero(anc_dependencies, attr_mgr_l1b
     num_epochs = 100
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473391300  # 473389200 + 100*42/2
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
 
@@ -2921,8 +2910,8 @@ def test_l1b_bgrates_when_synthetic_floor_is_zero(anc_dependencies, attr_mgr_l1b
     patched_bg_rates["H"] = 0.0
     with (
         patch(
-            "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-            return_value=met_midpoint,
+            "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+            return_value=(met_start, met_start + 1),
         ),
         patch.object(LoConstants, "BG_RATES", patched_bg_rates),
     ):
@@ -2940,7 +2929,6 @@ def test_l1b_bgrates_sigma_when_anti_ram_nominal_is_zero(
     num_epochs = 50
     met_start = 473389200
     met_spacing = 42
-    met_midpoint = 473390250  # 473389200 + 50*42/2
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
 
@@ -2969,8 +2957,8 @@ def test_l1b_bgrates_sigma_when_anti_ram_nominal_is_zero(
     # Zero the anti-RAM threshold so bg_rate_anti_ram_nominal = 0 for any pivot angle
     with (
         patch(
-            "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
-            return_value=met_midpoint,
+            "imap_processing.lo.l1b.lo_l1b.get_pointing_times",
+            return_value=(met_start, met_start + 1),
         ),
         patch.object(LoConstants, "PIVOT_ANGLE_THRESHOLDS", {}),
         patch.object(LoConstants, "THRESHOLD_BG_RATE_ANTI_RAM_DEFAULT", 0.0),

--- a/imap_processing/tests/lo/test_lo_l1b.py
+++ b/imap_processing/tests/lo/test_lo_l1b.py
@@ -2169,6 +2169,7 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
     num_epochs = 100
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473391300  # 473389200 + 100*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2196,9 +2197,13 @@ def test_l1b_bgrates_and_goodtimes_basic(anc_dependencies, attr_mgr_l1b):
     }
 
     # Act
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # Assert - Should return a list with two datasets
     assert isinstance(result, list)
@@ -2249,6 +2254,7 @@ def test_l1b_bgrates_and_goodtimes_with_gap(anc_dependencies, attr_mgr_l1b):
     met_start = 473389200
     met_spacing = 42
     gap_size = 10000  # Large gap (> delay_max + interval_nom)
+    met_midpoint = 473396300  # 473389200 + (50*42 + 10000 + 50*42) / 2
 
     # First segment
     met_times_first = np.arange(
@@ -2290,9 +2296,13 @@ def test_l1b_bgrates_and_goodtimes_with_gap(anc_dependencies, attr_mgr_l1b):
     }
 
     # Act
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # Assert
     l1b_bgrates_ds, l1b_goodtimes_ds = result
@@ -2316,6 +2326,7 @@ def test_l1b_bgrates_and_goodtimes_high_rate(anc_dependencies, attr_mgr_l1b):
     num_epochs = 100
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473391300  # 473389200 + 100*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2354,9 +2365,13 @@ def test_l1b_bgrates_and_goodtimes_high_rate(anc_dependencies, attr_mgr_l1b):
     }
 
     # Act
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # Assert
     l1b_bgrates_ds, l1b_goodtimes_ds = result
@@ -2374,7 +2389,7 @@ def test_l1b_bgrates_and_goodtimes_no_goodtimes(anc_dependencies, attr_mgr_l1b):
     num_epochs = 50
     met_start = 473389200
     met_spacing = 42
-
+    met_midpoint = 473390250  # 473389200 + 50 * 42 / 2
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
 
@@ -2400,9 +2415,13 @@ def test_l1b_bgrates_and_goodtimes_no_goodtimes(anc_dependencies, attr_mgr_l1b):
         "imap_lo_l1b_nhk": xr.Dataset(),
     }
 
-    _, goodtimes_ds = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        _, goodtimes_ds = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # When no goodtimes are detected a single fallback row (0, 0) is used.
     # The padding loop runs before the fallback is inserted, so the zeros are unchanged.
@@ -2416,6 +2435,7 @@ def test_l1b_bgrates_and_goodtimes_empty_dataset(anc_dependencies, attr_mgr_l1b)
     num_epochs = 10
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473389410  # 473389200 + 10*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2443,9 +2463,13 @@ def test_l1b_bgrates_and_goodtimes_empty_dataset(anc_dependencies, attr_mgr_l1b)
     }
 
     # Act
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # Assert - Should still create valid datasets even with minimal data
     l1b_bgrates_ds, l1b_goodtimes_ds = result
@@ -2457,11 +2481,13 @@ def test_l1b_bgrates_and_goodtimes_empty_dataset(anc_dependencies, attr_mgr_l1b)
 def test_split_backgrounds_and_goodtimes_dataset(attr_mgr_l1b):
     """Test split_backgrounds_and_goodtimes_dataset separates fields correctly."""
     # Arrange - Create a combined dataset matching the structure produced by
-    # l1b_bgrates_and_goodtimes: scalar background rate fields and epoch-indexed
-    # goodtime interval fields.
+    # l1b_bgrates_and_goodtimes: 1-D (esa_step) background rate fields and
+    # epoch-indexed goodtime interval fields.
     num_records = 3
+    n_esa = 7
     met_starts = np.arange(473389200, 473389200 + num_records * 420, 420)
     epoch_times = met_to_ttj2000ns(met_starts)
+    pointing_mid_epoch = met_to_ttj2000ns(met_starts[0] + 630).item()
 
     combined_ds = xr.Dataset(
         coords={"epoch": epoch_times},
@@ -2474,10 +2500,18 @@ def test_split_backgrounds_and_goodtimes_dataset(attr_mgr_l1b):
     )
     combined_ds["pivot"] = xr.DataArray(np.float32(90.0))
     combined_ds["pivot_de"] = xr.DataArray(np.float32(89.5))
-    combined_ds["h_background_rates"] = xr.DataArray(np.float32(0.01))
-    combined_ds["h_background_variance"] = xr.DataArray(np.float32(0.001))
-    combined_ds["o_background_rates"] = xr.DataArray(np.float32(0.002))
-    combined_ds["o_background_variance"] = xr.DataArray(np.float32(0.0002))
+    combined_ds["h_background_rates"] = xr.DataArray(
+        np.full(n_esa, np.float32(0.01)), dims=["esa_step"]
+    )
+    combined_ds["h_background_variance"] = xr.DataArray(
+        np.full(n_esa, np.float32(0.001)), dims=["esa_step"]
+    )
+    combined_ds["o_background_rates"] = xr.DataArray(
+        np.full(n_esa, np.float32(0.002)), dims=["esa_step"]
+    )
+    combined_ds["o_background_variance"] = xr.DataArray(
+        np.full(n_esa, np.float32(0.0002)), dims=["esa_step"]
+    )
     combined_ds["h_synthetic_floor"] = xr.DataArray(np.float32(5.0))
     combined_ds["h_proxy_floor"] = xr.DataArray(np.float32(4.0))
     combined_ds["o_synthetic_floor"] = xr.DataArray(np.float32(0.5))
@@ -2485,22 +2519,32 @@ def test_split_backgrounds_and_goodtimes_dataset(attr_mgr_l1b):
 
     # Act
     bgrates_ds, goodtimes_ds = split_backgrounds_and_goodtimes_dataset(
-        combined_ds, attr_mgr_l1b
+        combined_ds, attr_mgr_l1b, pointing_mid_epoch
     )
 
-    # Assert - bgrates dataset contains all background rate fields (scalar)
+    # Assert - _background_rates/_background_variance are (epoch, esa_step)
     for field in [
         "h_background_rates",
         "h_background_variance",
         "o_background_rates",
         "o_background_variance",
+    ]:
+        assert field in bgrates_ds.data_vars
+        assert bgrates_ds[field].dims == ("epoch", "esa_step")
+        assert bgrates_ds[field].shape == (1, n_esa)
+
+    for field in [
         "h_synthetic_floor",
         "h_proxy_floor",
         "o_synthetic_floor",
         "o_proxy_floor",
     ]:
         assert field in bgrates_ds.data_vars
-        assert bgrates_ds[field].dims == ()  # scalar
+        assert bgrates_ds[field].dims == ("epoch",)
+        assert bgrates_ds[field].shape == (1,)
+
+    assert len(bgrates_ds["epoch"]) == 1
+    np.testing.assert_array_equal(bgrates_ds["epoch"].values, pointing_mid_epoch)
 
     # Assert - goodtimes dataset contains the expected fields
     assert "gt_start_met" in goodtimes_ds.data_vars
@@ -2527,6 +2571,7 @@ def test_l1b_bgrates_and_goodtimes_ram_and_anti_ram_bins(
     num_epochs = 30
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473389830  # 473389200 + 30*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2568,9 +2613,13 @@ def test_l1b_bgrates_and_goodtimes_ram_and_anti_ram_bins(
         "imap_lo_l1b_nhk": cdf_hk,
     }
 
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
     l1b_bgrates_ds, l1b_goodtimes_ds = result
 
     # Should create goodtime intervals because RAM and anti-RAM bins have low counts
@@ -2585,6 +2634,7 @@ def test_l1b_bgrates_and_goodtimes_variance_calculation(anc_dependencies, attr_m
     num_epochs = 30
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473389830  # 473389200 + 30*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2616,9 +2666,13 @@ def test_l1b_bgrates_and_goodtimes_variance_calculation(anc_dependencies, attr_m
     }
 
     # Act
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # Assert
     l1b_bgrates_ds, l1b_goodtimes_ds = result
@@ -2638,6 +2692,7 @@ def test_l1b_bgrates_and_goodtimes_offset_application(anc_dependencies, attr_mgr
     num_epochs = 30
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473389830  # 473389200 + 30*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2665,9 +2720,13 @@ def test_l1b_bgrates_and_goodtimes_offset_application(anc_dependencies, attr_mgr
     }
 
     # Act
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # Assert
     l1b_bgrates_ds, l1b_goodtimes_ds = result
@@ -2693,6 +2752,7 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_low_to_high(
     num_epochs = 50  # Need at least 5 cycles (50 epochs / 10 per cycle)
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473390250  # 473389200 + 50*42/2
 
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
@@ -2725,9 +2785,13 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_low_to_high(
     }
 
     # Act
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # Assert
     l1b_bgrates_ds, l1b_goodtimes_ds = result
@@ -2761,7 +2825,7 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_high_to_low_to_high(
     num_epochs = 80
     met_start = 473389200
     met_spacing = 42
-
+    met_midpoint = 473390880  # 473389200 + 80*42/2
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
 
@@ -2797,9 +2861,13 @@ def test_l1b_bgrates_and_goodtimes_rate_transition_high_to_low_to_high(
     }
 
     # Act
-    result = l1b_bgrates_and_goodtimes(
-        sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
-    )
+    with patch(
+        "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+        return_value=met_midpoint,
+    ):
+        result = l1b_bgrates_and_goodtimes(
+            sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
+        )
 
     # Assert
     l1b_bgrates_ds, l1b_goodtimes_ds = result
@@ -2823,6 +2891,7 @@ def test_l1b_bgrates_when_synthetic_floor_is_zero(anc_dependencies, attr_mgr_l1b
     num_epochs = 100
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473391300  # 473389200 + 100*42/2
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
 
@@ -2850,7 +2919,13 @@ def test_l1b_bgrates_when_synthetic_floor_is_zero(anc_dependencies, attr_mgr_l1b
 
     patched_bg_rates = dict(LoConstants.BG_RATES)
     patched_bg_rates["H"] = 0.0
-    with patch.object(LoConstants, "BG_RATES", patched_bg_rates):
+    with (
+        patch(
+            "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+            return_value=met_midpoint,
+        ),
+        patch.object(LoConstants, "BG_RATES", patched_bg_rates),
+    ):
         bgrates_ds, _ = l1b_bgrates_and_goodtimes(
             sci_dependencies, anc_dependencies, attr_mgr_l1b, delay_max=840
         )
@@ -2865,6 +2940,7 @@ def test_l1b_bgrates_sigma_when_anti_ram_nominal_is_zero(
     num_epochs = 50
     met_start = 473389200
     met_spacing = 42
+    met_midpoint = 473390250  # 473389200 + 50*42/2
     met_times = np.arange(met_start, met_start + num_epochs * met_spacing, met_spacing)
     epoch_times = met_to_ttj2000ns(met_times)
 
@@ -2892,6 +2968,10 @@ def test_l1b_bgrates_sigma_when_anti_ram_nominal_is_zero(
 
     # Zero the anti-RAM threshold so bg_rate_anti_ram_nominal = 0 for any pivot angle
     with (
+        patch(
+            "imap_processing.lo.l1b.lo_l1b.get_pointing_mid_time",
+            return_value=met_midpoint,
+        ),
         patch.object(LoConstants, "PIVOT_ANGLE_THRESHOLDS", {}),
         patch.object(LoConstants, "THRESHOLD_BG_RATE_ANTI_RAM_DEFAULT", 0.0),
     ):


### PR DESCRIPTION
# Change Summary

Closes #3213 

## Overview

Added a leading `epoch` dimension to `*_background_rates`, `*_background_variance`, `*_floor`.

## File changes

Tweaked `l1b_bgrates_and_goodtimes` in `lo/lo_l1b.py` w.r.t. the Lo background rates dataset so that all six per-pointing scalar variables gain an explicit epoch leading dimension. The value of `epoch` is set to the midpoint of the pointing.


## Testing

Passing the correct value of `met_midpoint` to tests (correct value not relevant to the tests though). Asserting correct shape and values for `test_split_backgrounds_and_goodtimes_dataset`.
