### PR TITLE
fix(idex): preserve integer placeholder type in monthly count products

### DIFF
--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -44,6 +44,7 @@ from imap_processing.idex.idex_utils import get_idex_attrs
 from imap_processing.spice.time import epoch_to_doy, et_to_datetime64, ttj2000ns_to_et
 
 logger = logging.getLogger(__name__)
+
 # Bin edges
 MASS_BIN_EDGES = np.array(
     [
@@ -81,6 +82,8 @@ SPIN_PHASE_BIN_EDGES = np.array([0, 90, 180, 270, 360])
 SKY_GRID = AzElSkyGrid(IDEX_SPACING_DEG)
 LON_BINS_EDGES = SKY_GRID.az_bin_edges
 LAT_BINS_EDGES = SKY_GRID.el_bin_edges
+
+IDEX_INT_FILLVAL = np.iinfo(np.int64).min
 
 
 def idex_l2b(
@@ -366,16 +369,16 @@ def idex_l2b(
 
     l2c_dataset.attrs.update(map_attrs)
 
-    # We're inserting a NaN block here for the 2026 June release while the
+    # We're inserting a placeholder block here for the 2026 June release while the
     # IDEX science team works through validating the fitting routines and
     # derived values.
 
     # L2B Block
     l2b_dataset["counts_by_mass"].data = np.full(
-        l2b_dataset["counts_by_mass"].shape, np.nan
+        l2b_dataset["counts_by_mass"].shape, IDEX_INT_FILLVAL, dtype=np.int64
     )
     l2b_dataset["counts_by_charge"].data = np.full(
-        l2b_dataset["counts_by_charge"].shape, np.nan
+        l2b_dataset["counts_by_charge"].shape, IDEX_INT_FILLVAL, dtype=np.int64
     )
     l2b_dataset["rate_by_mass"].data = np.full(
         l2b_dataset["rate_by_mass"].shape, np.nan
@@ -386,10 +389,10 @@ def idex_l2b(
 
     # L2C Block
     l2c_dataset["counts_by_mass_map"].data = np.full(
-        l2c_dataset["counts_by_mass_map"].shape, np.nan
+        l2c_dataset["counts_by_mass_map"].shape, IDEX_INT_FILLVAL, dtype=np.int64
     )
     l2c_dataset["counts_by_charge_map"].data = np.full(
-        l2c_dataset["counts_by_charge_map"].shape, np.nan
+        l2c_dataset["counts_by_charge_map"].shape, IDEX_INT_FILLVAL, dtype=np.int64
     )
     l2c_dataset["rate_by_mass_map"].data = np.full(
         l2c_dataset["rate_by_mass_map"].shape, np.nan

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -1,5 +1,6 @@
 """Tests the L2b processing for IDEX data"""
 
+import cdflib
 import numpy as np
 import pytest
 import xarray as xr
@@ -23,6 +24,8 @@ from imap_processing.idex.idex_l2b import (
     get_science_acquisition_on_percentage,
     idex_l2b,
 )
+
+INT_FILLVAL = np.iinfo(np.int64).min
 
 
 @pytest.fixture
@@ -66,6 +69,12 @@ def test_l2b_logical_source_and_cdf(l2b_and_l2c_datasets: list[xr.Dataset]):
 
     assert file_name.exists()
     assert file_name.name == "imap_idex_l2b_sci-1mo_20251017_v999.cdf"
+    with cdflib.CDF(file_name) as cdf_file:
+        for variable_name in ("counts_by_charge", "counts_by_mass"):
+            var_info = cdf_file.varinq(variable_name)
+            var_attrs = cdf_file.varattsget(variable_name)
+            assert var_info.Data_Type_Description == "CDF_INT8"
+            assert int(var_attrs["FILLVAL"]) == INT_FILLVAL
 
 
 def test_l2c_attrs_and_vars(
@@ -105,16 +114,30 @@ def test_l2c_attrs_and_vars(
     rect_file_name = write_cdf(l2c_dataset)
     assert rect_file_name.exists()
     assert rect_file_name.name == "imap_idex_l2c_rectangular-map-1mo_20251017_v999.cdf"
+    with cdflib.CDF(rect_file_name) as cdf_file:
+        for variable_name in ("counts_by_charge_map", "counts_by_mass_map"):
+            var_info = cdf_file.varinq(variable_name)
+            var_attrs = cdf_file.varattsget(variable_name)
+            assert var_info.Data_Type_Description == "CDF_INT8"
+            assert int(var_attrs["FILLVAL"]) == INT_FILLVAL
 
     for var in l2c_dataset.data_vars:
         assert "DICT_KEY" in l2c_dataset[var].attrs, (
             f"Variable {var} is missing the DICT_KEY attribute for SPASE metadata."
         )
 
-    # TODO: This NAN check to be REMOVED in future
-    expected_nan_vars = [
+    expected_fill_vars = [
         "counts_by_charge_map",
         "counts_by_mass_map",
+    ]
+    for var in expected_fill_vars:
+        expected_fill = np.full(l2c_dataset[var].shape, INT_FILLVAL, dtype=np.int64)
+        assert np.array_equal(l2c_dataset[var].data, expected_fill), (
+            f"Variable {var} should be fully set to the integer fill value "
+            "for the temporary L2B/L2C patch."
+        )
+
+    expected_nan_vars = [
         "rate_by_charge_map",
         "rate_by_mass_map",
     ]
@@ -150,10 +173,18 @@ def test_l2b_cdf_variables(l2b_and_l2c_datasets: list[xr.Dataset]):
             f"Variable {var} is missing the DICT_KEY attribute for SPASE metadata."
         )
 
-    # TODO: This NAN check to be REMOVED in future
-    expected_nan_vars = [
+    expected_fill_vars = [
         "counts_by_charge",
         "counts_by_mass",
+    ]
+    for var in expected_fill_vars:
+        expected_fill = np.full(l2b_dataset[var].shape, INT_FILLVAL, dtype=np.int64)
+        assert np.array_equal(l2b_dataset[var].data, expected_fill), (
+            f"Variable {var} should be fully set to the integer fill value "
+            "for the temporary L2B patch."
+        )
+
+    expected_nan_vars = [
         "rate_by_charge",
         "rate_by_mass",
     ]


### PR DESCRIPTION
## Summary

Preserve integer placeholder typing in the monthly IDEX count products.

This PR is a small part of the broader ISTP / metadata cleanup tracked in issue #2577. In that larger effort, this branch addresses one specific remaining file-level metadata mismatch in the monthly IDEX outputs by making the written count-variable types agree with their declared CDF metadata.

Scope:
- `imap_idex_l2b_sci-1mo`
- `imap_idex_l2c_rectangular-map-1mo`

## Why

The monthly IDEX products intentionally blank several derived outputs while the science team continues validating the fitting routines and derived values.

Before this change, the placeholder block applied `np.nan` to both:
- floating-point rate variables
- integer count variables

That promoted the monthly count variables to floating-point in the written CDFs, while their metadata remained integer-style. The result was an ISTP/SPDF mismatch in the emitted files for:

- `counts_by_charge`
- `counts_by_mass`
- `counts_by_charge_map`
- `counts_by_mass_map`

So within the broader metadata cleanup under #2577, this PR fixes the IDEX monthly count-placeholder type mismatch at the source.

## What Changed

### Preserve integer placeholder typing for monthly counts

For the monthly count variables only, replace the `NaN` placeholder behavior with the standard `int64` CDF fill sentinel:

- `counts_by_charge`
- `counts_by_mass`
- `counts_by_charge_map`
- `counts_by_mass_map`

These variables now:
- stay `np.int64`
- use `-9223372036854775808` as the placeholder fill value

### Leave monthly rate placeholders unchanged

The monthly rate placeholders are intentionally unchanged and still use `NaN`:

- `rate_by_charge`
- `rate_by_mass`
- `rate_by_charge_map`
- `rate_by_mass_map`

That remains valid because those variables are already float-typed and their metadata matches the written data.

### Update tests accordingly

The monthly IDEX regression tests now:
- assert that the count placeholders are filled with the integer fill sentinel
- keep the existing `NaN` assertions for the rate placeholders
- verify that the written monthly count variables serialize as integer CDF types with the expected integer `FILLVAL`

## Testing

Validated locally with:

```bash
pytest -q imap_processing/tests/idex/test_idex_l2b.py
pre-commit run --files \
  imap_processing/idex/idex_l2b.py \
  imap_processing/tests/idex/test_idex_l2b.py