### PR TITLE
fix(mag): align L2 vector and quality metadata

### DIFF
--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -49,9 +49,11 @@ vector_attrs: &vectors_default
     DEPEND_1: direction
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:DSRF,CoordinateRepresentation:Cartesian"
     FIELDNAM: Magnetic Field Vector
-    FILLVAL: 9223372036854775807
-    FORMAT: F12.5
+    FILLVAL: -1.0e31
+    FORMAT: F13.5
     LABL_PTR_1: direction_label
+    VALIDMAX: 1.0e+5
+    VALIDMIN: -1.0e+5
 
 # Frame-specific vector attributes
 vector_attrs_srf:

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -242,14 +242,14 @@ class MagL2L1dBase:
             self.quality_flags,
             name="quality_flags",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("qf_bitmask"),
+            attrs=attribute_manager.get_variable_attributes("qf"),
         )
 
         quality_bitmask = xr.DataArray(
             self.quality_bitmask,
             name="quality_bitmask",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("qf"),
+            attrs=attribute_manager.get_variable_attributes("qf_bitmask"),
         )
 
         rng = xr.DataArray(

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+import cdflib
 import numpy as np
 import pytest
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.cdf.utils import write_cdf
 from imap_processing.mag.constants import FILLVAL, DataMode
 from imap_processing.mag.l2.mag_l2 import mag_l2, retrieve_matrix_from_l2_calibration
 from imap_processing.mag.l2.mag_l2_data import MagL2, ValidFrames
@@ -140,6 +142,17 @@ def test_mag_l2(norm_dataset, mag_test_l2_data):
     for i, dataset in enumerate(l2):
         assert expected_frames[i].var_name in dataset.data_vars
         assert expected_frames[i].name in dataset.attrs["Data_type"]
+        dataset.attrs["Data_version"] = "001"
+        cdf_filepath = write_cdf(dataset)
+        with cdflib.CDF(cdf_filepath) as cdf_file:
+            vector_info = cdf_file.varinq(expected_frames[i].var_name)
+            vector_attrs = cdf_file.varattsget(expected_frames[i].var_name)
+
+        assert vector_info.Data_Type_Description == "CDF_FLOAT"
+        assert np.isclose(vector_attrs["FILLVAL"], np.float32(-1.0e31))
+        assert vector_attrs["FORMAT"] == "F13.5"
+        assert np.isclose(vector_attrs["VALIDMIN"], np.float32(-1.0e5))
+        assert np.isclose(vector_attrs["VALIDMAX"], np.float32(1.0e5))
 
 
 def test_mag_l2_some_epochs_not_in_spice(norm_dataset, mag_test_l2_data):
@@ -582,3 +595,14 @@ def test_qf(norm_dataset):
     assert "quality_bitmask" in output.data_vars
     assert np.array_equal(output["quality_flags"].data, qf)
     assert np.array_equal(output["quality_bitmask"].data, qf_bitmask)
+
+    output.attrs["Data_version"] = "001"
+    cdf_filepath = write_cdf(output)
+    with cdflib.CDF(cdf_filepath) as cdf_file:
+        qf_attrs = cdf_file.varattsget("quality_flags")
+        qf_bitmask_attrs = cdf_file.varattsget("quality_bitmask")
+
+    assert qf_attrs["FORMAT"] == "I1"
+    assert int(qf_attrs["VALIDMAX"]) == 1
+    assert qf_bitmask_attrs["FORMAT"] == "I3"
+    assert int(qf_bitmask_attrs["VALIDMAX"]) == 255


### PR DESCRIPTION
## Summary

Fix MAG L2 vector and quality metadata so the written CDF metadata matches the serialized variable types.

This PR is one small part of the broader ISTP / metadata cleanup tracked in issue #2577. Within that larger effort, this branch addresses the remaining MAG L2 metadata mismatches that were still showing up in the written normal-rate products.

Scope:
- `imap_mag_l2_norm-srf`
- shared MAG L2 vector metadata used by the other frame variants as well

## Why

During the broader file-level metadata cleanup under #2577, two MAG-specific issues remained:

1. the shared MAG vector attribute template still inherited unrealistic defaults, which caused SPDF width / range problems on `b_srf`
2. `quality_flags` and `quality_bitmask` were assigned the wrong attribute templates in MAG L2 dataset generation

The underlying science values were not the problem here. The issue was that the metadata applied to the written CDF variables did not correctly describe the product semantics and serialized types.

## What Changed

### Fix shared MAG vector metadata

Update the shared MAG L2 vector attribute template so the written metadata matches the floating-point magnetic-field vectors that are actually emitted.

Changes:
- keep `CDF_FLOAT`
- keep floating `FILLVAL = -1.0e31`
- set:
  - `FORMAT = F13.5`
  - `VALIDMIN = -1.0e5`
  - `VALIDMAX = 1.0e5`

This flows through the shared vector attrs used by:
- `b_srf`
- `b_gse`
- `b_gsm`
- `b_rtn`
- `b_dsrf`

### Fix quality metadata mapping

In MAG L2 dataset generation, swap the attr-template assignment so:
- `quality_flags` uses the `qf` attrs
- `quality_bitmask` uses the `qf_bitmask` attrs

This keeps:
- variable names unchanged
- data values unchanged

and only corrects the metadata applied to the written outputs.

## Testing

Extended the written-CDF MAG regression coverage to verify:
- representative MAG vector vars are written as `CDF_FLOAT`
- the vector `FILLVAL`, `FORMAT`, `VALIDMIN`, and `VALIDMAX` match the updated metadata
- `quality_flags` and `quality_bitmask` keep their values but now carry the correct written CDF attrs

Validated locally with:

```bash
pytest -q imap_processing/tests/mag/test_mag_l2.py
pre-commit run --files \
  imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml \
  imap_processing/mag/l2/mag_l2_data.py \
  imap_processing/tests/mag/test_mag_l2.py