### PR TITLE
fix(codice): normalize epoch_delta metadata and epoch links

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -14,25 +14,25 @@ max_epoch: &max_epoch 3155630469184000000
 epoch_delta_minus:
     CATDESC: Time from acquisition start to acquisition center
     FIELDNAM: epoch_delta_minus
-    FILLVAL: *real_fillval
-    FORMAT: F30.9
+    FILLVAL: *int_fillval
+    FORMAT: I19
     LABLAXIS: epoch_delta_minus
     SCALETYP: linear
     UNITS: ns
-    VALIDMAX: *max_int
-    VALIDMIN: *min_int
+    VALIDMAX: 128000000000
+    VALIDMIN: 0
     VAR_TYPE: support_data
 
 epoch_delta_plus:
     CATDESC: Time from acquisition center to acquisition end
     FIELDNAM: epoch_delta_plus
-    FILLVAL: *real_fillval
-    FORMAT: F30.9
+    FILLVAL: *int_fillval
+    FORMAT: I19
     LABLAXIS: epoch_delta_plus
     SCALETYP: linear
     UNITS: ns
-    VALIDMAX: *max_epoch
-    VALIDMIN: *min_epoch
+    VALIDMAX: 128000000000
+    VALIDMIN: 0
     VAR_TYPE: support_data
 
 esa_step:

--- a/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
@@ -38,12 +38,12 @@ epoch_delta_minus:
   DISPLAY_TYPE: 'no_plot'
   FIELDNAM: epoch delta minus
   FILLVAL: -9223372036854775808
-  FORMAT: I18
+  FORMAT: I19
   LABLAXIS: Epoch Delta Minus
   SCALETYP: linear
   UNITS: ns
-  VALIDMAX: *max_int
-  VALIDMIN: *min_int
+  VALIDMAX: 128000000000
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 epoch_delta_plus:
@@ -53,12 +53,12 @@ epoch_delta_plus:
   DISPLAY_TYPE: 'no_plot'
   FIELDNAM: epoch delta plus
   FILLVAL: -9223372036854775808
-  FORMAT: I18
+  FORMAT: I19
   LABLAXIS: Epoch Delta Plus
   SCALETYP: linear
   UNITS: ns
-  VALIDMAX: *max_int
-  VALIDMIN: *min_int
+  VALIDMAX: 128000000000
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 # ------------------------------- Data Variables -------------------------------

--- a/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
@@ -5,6 +5,10 @@ min_int: &min_int -9223372036854775808
 max_int: &max_int 9223372036854775807
 
 # ------------------------------- Coordinates -------------------------------
+epoch:
+  DELTA_MINUS_VAR: epoch_delta_minus
+  DELTA_PLUS_VAR: epoch_delta_plus
+
 priority:
   CATDESC: Priority Level
   DICT_KEY: SPASE>Support>SupportQuantity:Other

--- a/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
@@ -31,8 +31,8 @@ epoch_delta_minus:
   LABLAXIS: Epoch Delta Minus
   SCALETYP: linear
   UNITS: ns
-  VALIDMAX: *max_int
-  VALIDMIN: *min_int
+  VALIDMAX: 128000000000
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 epoch_delta_plus:
@@ -44,8 +44,8 @@ epoch_delta_plus:
   LABLAXIS: Epoch Delta Plus
   SCALETYP: linear
   UNITS: ns
-  VALIDMAX: *max_int
-  VALIDMIN: *min_int
+  VALIDMAX: 128000000000
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 energy_cno:

--- a/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
@@ -22,6 +22,10 @@ energy_attrs: &energy_default
   VAR_TYPE: support_data
 
 # ------------------------------- Coordinates -------------------------------
+epoch:
+  DELTA_MINUS_VAR: epoch_delta_minus
+  DELTA_PLUS_VAR: epoch_delta_plus
+
 epoch_delta_minus:
   CATDESC: Time from acquisition start to acquisition center
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty

--- a/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
@@ -29,8 +29,8 @@ epoch_delta_minus:
   LABLAXIS: Epoch Delta Minus
   SCALETYP: linear
   UNITS: ns
-  VALIDMAX: *max_int
-  VALIDMIN: *min_int
+  VALIDMAX: 128000000000
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 epoch_delta_plus:
@@ -42,8 +42,8 @@ epoch_delta_plus:
   LABLAXIS: Epoch Delta Plus
   SCALETYP: linear
   UNITS: ns
-  VALIDMAX: *max_int
-  VALIDMIN: *min_int
+  VALIDMAX: 128000000000
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 elevation_angle:

--- a/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
@@ -20,6 +20,10 @@ energy_attrs: &energy_default
   VAR_TYPE: support_data
 
 # ------------------------------- Coordinates -------------------------------
+epoch:
+  DELTA_MINUS_VAR: epoch_delta_minus
+  DELTA_PLUS_VAR: epoch_delta_plus
+
 epoch_delta_minus:
   CATDESC: Time from acquisition start to acquisition center
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty

--- a/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
@@ -37,12 +37,12 @@ epoch_delta_minus:
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
   FIELDNAM: epoch delta minus
   FILLVAL: -9223372036854775808
-  FORMAT: I18
+  FORMAT: I19
   LABLAXIS: Epoch Delta Minus
   SCALETYP: linear
   UNITS: ns
-  VALIDMAX: *max_int
-  VALIDMIN: *min_int
+  VALIDMAX: 128000000000
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 epoch_delta_plus:
@@ -51,12 +51,12 @@ epoch_delta_plus:
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
   FIELDNAM: epoch delta plus
   FILLVAL: -9223372036854775808
-  FORMAT: I18
+  FORMAT: I19
   LABLAXIS: Epoch Delta Plus
   SCALETYP: linear
   UNITS: ns
-  VALIDMAX: *max_int
-  VALIDMIN: *min_int
+  VALIDMAX: 128000000000
+  VALIDMIN: 0
   VAR_TYPE: support_data
 
 # ------------------------------- Data Variables -------------------------------

--- a/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
@@ -5,6 +5,10 @@ real_fillval: &real_fillval -1.0e+31
 min_int: &min_int -9223372036854775808
 max_int: &max_int 9223372036854775807
 # ------------------------------- Coordinates -------------------------------
+epoch:
+  DELTA_MINUS_VAR: epoch_delta_minus
+  DELTA_PLUS_VAR: epoch_delta_plus
+
 priority:
   CATDESC: Priority Level
   DICT_KEY: SPASE>Support>SupportQuantity:Other

--- a/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
@@ -5,6 +5,10 @@ max_float: &max_float 3.4028235e+38
 species_valid_max: &species_valid_max 1e20
 
 # ------------------------------- Coordinates -------------------------------
+epoch:
+  DELTA_MINUS_VAR: epoch_delta_minus
+  DELTA_PLUS_VAR: epoch_delta_plus
+
 elevation_angle:
   CATDESC: Elevation Angle
   FIELDNAM: Elevation Angle

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -566,6 +566,28 @@ def process_lo_species_intensity(
     return dataset
 
 
+def _attach_epoch_delta_links(dataset: xr.Dataset) -> xr.Dataset:
+    """
+    Attach ISTP delta-variable links to the final epoch coordinate.
+
+    Parameters
+    ----------
+    dataset : xarray.Dataset
+        The final CoDICE L2 dataset to update.
+
+    Returns
+    -------
+    xarray.Dataset
+        The input dataset with ``epoch`` delta-link attrs attached when the
+        required variables are present.
+    """
+    if {"epoch", "epoch_delta_minus", "epoch_delta_plus"}.issubset(dataset.variables):
+        dataset["epoch"].attrs["DELTA_MINUS_VAR"] = "epoch_delta_minus"
+        dataset["epoch"].attrs["DELTA_PLUS_VAR"] = "epoch_delta_plus"
+
+    return dataset
+
+
 def process_hi_omni(dependencies: ProcessingInputCollection) -> xr.Dataset:
     """
     Process the hi-omni L1B dataset to calculate omni-directional intensities.
@@ -779,9 +801,6 @@ def process_hi_omni(dependencies: ProcessingInputCollection) -> xr.Dataset:
         "epoch_delta_minus": l1b_dataset["epoch_delta_minus"],
     }
 
-    l1b_dataset["epoch"].attrs["DELTA_MINUS_VAR"] = "epoch_delta_minus"
-    l1b_dataset["epoch"].attrs["DELTA_PLUS_VAR"] = "epoch_delta_plus"
-
     l1b_dataset = l1b_dataset.assign_coords(new_coords)
 
     return l1b_dataset
@@ -905,9 +924,6 @@ def process_hi_sectored(dependencies: ProcessingInputCollection) -> xr.Dataset:
         },
         attrs=cdf_attrs.get_global_attributes("imap_codice_l2_hi-sectored"),
     )
-
-    l1b_dataset["epoch"].attrs["DELTA_MINUS_VAR"] = "epoch_delta_minus"
-    l1b_dataset["epoch"].attrs["DELTA_PLUS_VAR"] = "epoch_delta_plus"
 
     efficiencies_file = dependencies.get_file_paths(
         descriptor="l2-hi-sectored-efficiency"
@@ -1459,6 +1475,15 @@ def process_codice_l2(
     for var in vars_to_drop:
         if var in l2_dataset.data_vars:
             l2_dataset = l2_dataset.drop_vars(var)
+
+    if dataset_name in {
+        "imap_codice_l2_hi-omni",
+        "imap_codice_l2_hi-sectored",
+        "imap_codice_l2_lo-sw-species",
+        "imap_codice_l2_hi-direct-events",
+        "imap_codice_l2_lo-direct-events",
+    }:
+        l2_dataset = _attach_epoch_delta_links(l2_dataset)
 
     logger.info(f"\nFinal data product:\n{l2_dataset}\n")
 

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -577,27 +577,9 @@ def process_lo_species_intensity(
                 attrs=dataset[var].attrs,
             )
 
-    return dataset
-
-
-def _attach_epoch_delta_links(dataset: xr.Dataset) -> xr.Dataset:
-    """
-    Attach ISTP delta-variable links to the final epoch coordinate.
-
-    Parameters
-    ----------
-    dataset : xarray.Dataset
-        The final CoDICE L2 dataset to update.
-
-    Returns
-    -------
-    xarray.Dataset
-        The input dataset with ``epoch`` delta-link attrs attached when the
-        required variables are present.
-    """
-    if {"epoch", "epoch_delta_minus", "epoch_delta_plus"}.issubset(dataset.variables):
-        dataset["epoch"].attrs["DELTA_MINUS_VAR"] = "epoch_delta_minus"
-        dataset["epoch"].attrs["DELTA_PLUS_VAR"] = "epoch_delta_plus"
+    dataset["epoch"].attrs.update(
+        cdf_attrs.get_variable_attributes("epoch", check_schema=False)
+    )
 
     return dataset
 
@@ -1496,15 +1478,6 @@ def process_codice_l2(
     for var in vars_to_drop:
         if var in l2_dataset.data_vars:
             l2_dataset = l2_dataset.drop_vars(var)
-
-    if dataset_name in {
-        "imap_codice_l2_hi-omni",
-        "imap_codice_l2_hi-sectored",
-        "imap_codice_l2_lo-sw-species",
-        "imap_codice_l2_hi-direct-events",
-        "imap_codice_l2_lo-direct-events",
-    }:
-        l2_dataset = _attach_epoch_delta_links(l2_dataset)
 
     logger.info(f"\nFinal data product:\n{l2_dataset}\n")
 

--- a/imap_processing/codice/utils.py
+++ b/imap_processing/codice/utils.py
@@ -429,7 +429,8 @@ def get_codice_epoch_time(
     -------
     tuple[np.ndarray, np.ndarray]
         (center_times (s), delta_times (ns)). center_times is converted to
-        nanoseconds at CDF write time.
+        nanoseconds at CDF write time. delta_times is returned as integer
+        nanoseconds.
     """
     # If Lo sensor
     if view_tab_obj.sensor == 0:
@@ -437,20 +438,21 @@ def get_codice_epoch_time(
         # 32 half spins makes full 16 spins for all non direct event products.
         # But Lo direct event's spins is also 16 spins. Because of that, we can use
         # the same calculation for all Lo products.
-        num_spins = 16.0
+        num_spins = 16
     # If Hi sensor and Direct Event product
     elif view_tab_obj.sensor == 1 and view_tab_obj.apid == CODICEAPID.COD_HI_PHA:
         # Use constant 16 spins for Hi PHA
-        num_spins = 16.0
+        num_spins = 16
     # If Non-Direct Event Hi product
     else:
         # Use 3d_collapsed value from LUT for other Hi products
-        num_spins = view_tab_obj.three_d_collapsed
+        num_spins = int(view_tab_obj.three_d_collapsed)
 
     # Units of 'spin ticks', where one 'spin tick' equals 320 microseconds.
-    # It takes multiple spins to collect data for a view.
-    spin_period_ns = spin_period.astype(np.float64) * 320 * 1e3  # Convert to ns
-    delta_times = (num_spins * spin_period_ns) / 2
+    # It takes multiple spins to collect data for a view. Keep the full delta
+    # calculation in integer nanoseconds so the written CDF type is CDF_INT8.
+    spin_period_ns: np.ndarray = spin_period.astype(np.int64) * 320_000
+    delta_times: np.ndarray = (num_spins * spin_period_ns) // 2
     # subseconds need to converted to seconds using this formula per CoDICE team:
     #   subseconds / 65536 gives seconds
     center_times_seconds = (

--- a/imap_processing/tests/codice/test_codice_hi_l2.py
+++ b/imap_processing/tests/codice/test_codice_hi_l2.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import cdflib
 import numpy as np
 import pytest
 from imap_data_access.processing_input import (
@@ -19,6 +20,25 @@ from imap_processing.tests.codice.conftest import (
 )
 
 pytestmark = pytest.mark.external_test_data
+
+EXPECTED_EPOCH_DELTA_VALIDMAX = 128000000000
+
+
+def assert_l2_epoch_delta_cdf_metadata(cdf_file):
+    """Assert L2 epoch delta vars and epoch links are written correctly."""
+    cdf = cdflib.CDF(cdf_file)
+    epoch_attrs = cdf.varattsget("epoch")
+    assert epoch_attrs["DELTA_MINUS_VAR"] == "epoch_delta_minus"
+    assert epoch_attrs["DELTA_PLUS_VAR"] == "epoch_delta_plus"
+
+    for variable in ("epoch_delta_minus", "epoch_delta_plus"):
+        info = cdf.varinq(variable)
+        attrs = cdf.varattsget(variable)
+        assert info.Data_Type_Description == "CDF_INT8"
+        assert attrs["FILLVAL"] == -9223372036854775808
+        assert attrs["FORMAT"] == "I19"
+        assert attrs["VALIDMIN"] == 0
+        assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
 
 
 @pytest.fixture
@@ -77,6 +97,7 @@ def test_l2_hi_omni(mock_get_file_paths):
     assert (
         omni_cdf_file.name == f"imap_codice_l2_hi-omni_{VALIDATION_FILE_DATE}_v001.cdf"
     )
+    assert_l2_epoch_delta_cdf_metadata(omni_cdf_file)
 
 
 def test_l2_hi_sectored(mock_get_file_paths):
@@ -161,3 +182,4 @@ def test_l2_hi_sectored(mock_get_file_paths):
         sectored_cdf_file.name
         == f"imap_codice_l2_hi-sectored_{VALIDATION_FILE_DATE}_v001.cdf"
     )
+    assert_l2_epoch_delta_cdf_metadata(sectored_cdf_file)

--- a/imap_processing/tests/codice/test_codice_hi_l2.py
+++ b/imap_processing/tests/codice/test_codice_hi_l2.py
@@ -26,19 +26,19 @@ EXPECTED_EPOCH_DELTA_VALIDMAX = 128000000000
 
 def assert_l2_epoch_delta_cdf_metadata(cdf_file):
     """Assert L2 epoch delta vars and epoch links are written correctly."""
-    cdf = cdflib.CDF(cdf_file)
-    epoch_attrs = cdf.varattsget("epoch")
-    assert epoch_attrs["DELTA_MINUS_VAR"] == "epoch_delta_minus"
-    assert epoch_attrs["DELTA_PLUS_VAR"] == "epoch_delta_plus"
+    with cdflib.CDF(cdf_file) as cdf:
+        epoch_attrs = cdf.varattsget("epoch")
+        assert epoch_attrs["DELTA_MINUS_VAR"] == "epoch_delta_minus"
+        assert epoch_attrs["DELTA_PLUS_VAR"] == "epoch_delta_plus"
 
-    for variable in ("epoch_delta_minus", "epoch_delta_plus"):
-        info = cdf.varinq(variable)
-        attrs = cdf.varattsget(variable)
-        assert info.Data_Type_Description == "CDF_INT8"
-        assert attrs["FILLVAL"] == -9223372036854775808
-        assert attrs["FORMAT"] == "I19"
-        assert attrs["VALIDMIN"] == 0
-        assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
+        for variable in ("epoch_delta_minus", "epoch_delta_plus"):
+            info = cdf.varinq(variable)
+            attrs = cdf.varattsget(variable)
+            assert info.Data_Type_Description == "CDF_INT8"
+            assert attrs["FILLVAL"] == -9223372036854775808
+            assert attrs["FORMAT"] == "I19"
+            assert attrs["VALIDMIN"] == 0
+            assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
 
 
 @pytest.fixture

--- a/imap_processing/tests/codice/test_codice_hi_l2.py
+++ b/imap_processing/tests/codice/test_codice_hi_l2.py
@@ -21,6 +21,9 @@ from imap_processing.tests.codice.conftest import (
 
 pytestmark = pytest.mark.external_test_data
 
+# epoch_delta = num_spins * spin_period / 2, with spin_period VALIDMAX = 16 s
+# and num_spins max = 16 in the current CoDICE timing model. That yields a
+# worst-case delta of 128 s = 128000000000 ns.
 EXPECTED_EPOCH_DELTA_VALIDMAX = 128000000000
 
 

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -11,6 +11,7 @@ caused too much complexity.
 import logging
 from unittest.mock import patch
 
+import cdflib
 import numpy as np
 import pytest
 from imap_data_access import ProcessingInputCollection
@@ -28,6 +29,21 @@ from imap_processing.utils import packet_file_to_datasets
 
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.external_test_data
+
+EXPECTED_EPOCH_DELTA_VALIDMAX = 128000000000
+
+
+def assert_epoch_delta_cdf_metadata(cdf_file):
+    """Assert the written epoch delta variables use integer duration metadata."""
+    cdf = cdflib.CDF(cdf_file)
+    for variable in ("epoch_delta_minus", "epoch_delta_plus"):
+        info = cdf.varinq(variable)
+        attrs = cdf.varattsget(variable)
+        assert info.Data_Type_Description == "CDF_INT8"
+        assert attrs["FILLVAL"] == -9223372036854775808
+        assert attrs["FORMAT"] == "I19"
+        assert attrs["VALIDMIN"] == 0
+        assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
 
 
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
@@ -435,6 +451,7 @@ def test_hi_omni(mock_get_file_paths, codice_lut_path):
     processed_data.attrs["Data_version"] = "001"
     cdf_file = write_cdf(processed_data, terminate_on_warning=True)
     assert cdf_file.name == f"imap_codice_l1a_hi-omni_{VALIDATION_FILE_DATE}_v001.cdf"
+    assert_epoch_delta_cdf_metadata(cdf_file)
 
 
 @pytest.mark.xfail(reason="Need to revisit in future PR")
@@ -670,3 +687,4 @@ def test_hi_direct_events(mock_get_file_paths, codice_lut_path):
         cdf_file.name
         == f"imap_codice_l1a_hi-direct-events_{VALIDATION_FILE_DATE}_v002.cdf"
     )
+    assert_epoch_delta_cdf_metadata(cdf_file)

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -35,15 +35,15 @@ EXPECTED_EPOCH_DELTA_VALIDMAX = 128000000000
 
 def assert_epoch_delta_cdf_metadata(cdf_file):
     """Assert the written epoch delta variables use integer duration metadata."""
-    cdf = cdflib.CDF(cdf_file)
-    for variable in ("epoch_delta_minus", "epoch_delta_plus"):
-        info = cdf.varinq(variable)
-        attrs = cdf.varattsget(variable)
-        assert info.Data_Type_Description == "CDF_INT8"
-        assert attrs["FILLVAL"] == -9223372036854775808
-        assert attrs["FORMAT"] == "I19"
-        assert attrs["VALIDMIN"] == 0
-        assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
+    with cdflib.CDF(cdf_file) as cdf:
+        for variable in ("epoch_delta_minus", "epoch_delta_plus"):
+            info = cdf.varinq(variable)
+            attrs = cdf.varattsget(variable)
+            assert info.Data_Type_Description == "CDF_INT8"
+            assert attrs["FILLVAL"] == -9223372036854775808
+            assert attrs["FORMAT"] == "I19"
+            assert attrs["VALIDMIN"] == 0
+            assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
 
 
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -397,7 +397,7 @@ def test_codice_l2_sw_species_intensity(mock_get_file_paths, codice_lut_path):
             l2_val_data[variable].values,
             rtol=1e-5,
             err_msg=f"Mismatch in variable '{variable}'",
-    )
+        )
     processed_2_ds.attrs["Data_version"] = "001"
     assert processed_2_ds.attrs["Logical_source"] == "imap_codice_l2_lo-sw-species"
     cdf_file_path = write_cdf(processed_2_ds)

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -3,6 +3,7 @@
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import cdflib
 import numpy as np
 import pandas as pd
 import pytest
@@ -34,6 +35,26 @@ from imap_processing.tests.codice.conftest import (
 )
 
 pytestmark = pytest.mark.external_test_data
+
+EXPECTED_EPOCH_DELTA_VALIDMAX = 128000000000
+
+
+def assert_l2_epoch_delta_cdf_metadata(cdf_file):
+    """Assert L2 epoch delta vars and epoch links are written correctly."""
+    cdf = cdflib.CDF(cdf_file)
+    epoch_attrs = cdf.varattsget("epoch")
+    assert epoch_attrs["DELTA_MINUS_VAR"] == "epoch_delta_minus"
+    assert epoch_attrs["DELTA_PLUS_VAR"] == "epoch_delta_plus"
+
+    for variable in ("epoch_delta_minus", "epoch_delta_plus"):
+        info = cdf.varinq(variable)
+        attrs = cdf.varattsget(variable)
+        assert info.Data_Type_Description == "CDF_INT8"
+        assert attrs["FILLVAL"] == -9223372036854775808
+        assert attrs["FORMAT"] == "I19"
+        assert attrs["VALIDMIN"] == 0
+        assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
+
 
 EXPECTED_LOGICAL_SOURCES = [
     "imap_codice_l2_hi-direct-events",
@@ -379,7 +400,8 @@ def test_codice_l2_sw_species_intensity(mock_get_file_paths, codice_lut_path):
         )
     processed_2_ds.attrs["Data_version"] = "001"
     assert processed_2_ds.attrs["Logical_source"] == "imap_codice_l2_lo-sw-species"
-    write_cdf(processed_2_ds)
+    cdf_file = write_cdf(processed_2_ds)
+    assert_l2_epoch_delta_cdf_metadata(cdf_file)
 
 
 @patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
@@ -439,6 +461,7 @@ def test_codice_l2_lo_de(mock_get_file_paths, codice_lut_path):
     processed_l2_ds.attrs["Data_version"] = "001"
     assert processed_l2_ds.attrs["Logical_source"] == "imap_codice_l2_lo-direct-events"
     file = write_cdf(processed_l2_ds)
+    assert_l2_epoch_delta_cdf_metadata(file)
     errors = CDFValidator().validate(file)
     assert not errors
     load_cdf(file)
@@ -492,6 +515,7 @@ def test_codice_l2_hi_de(mock_get_file_paths, codice_lut_path):
     processed_l2_ds.attrs["Data_version"] = "001"
     assert processed_l2_ds.attrs["Logical_source"] == "imap_codice_l2_hi-direct-events"
     file = write_cdf(processed_l2_ds)
+    assert_l2_epoch_delta_cdf_metadata(file)
     errors = CDFValidator().validate(file)
     assert not errors
     load_cdf(file)

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -41,19 +41,19 @@ EXPECTED_EPOCH_DELTA_VALIDMAX = 128000000000
 
 def assert_l2_epoch_delta_cdf_metadata(cdf_file):
     """Assert L2 epoch delta vars and epoch links are written correctly."""
-    cdf = cdflib.CDF(cdf_file)
-    epoch_attrs = cdf.varattsget("epoch")
-    assert epoch_attrs["DELTA_MINUS_VAR"] == "epoch_delta_minus"
-    assert epoch_attrs["DELTA_PLUS_VAR"] == "epoch_delta_plus"
+    with cdflib.CDF(cdf_file) as cdf:
+        epoch_attrs = cdf.varattsget("epoch")
+        assert epoch_attrs["DELTA_MINUS_VAR"] == "epoch_delta_minus"
+        assert epoch_attrs["DELTA_PLUS_VAR"] == "epoch_delta_plus"
 
-    for variable in ("epoch_delta_minus", "epoch_delta_plus"):
-        info = cdf.varinq(variable)
-        attrs = cdf.varattsget(variable)
-        assert info.Data_Type_Description == "CDF_INT8"
-        assert attrs["FILLVAL"] == -9223372036854775808
-        assert attrs["FORMAT"] == "I19"
-        assert attrs["VALIDMIN"] == 0
-        assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
+        for variable in ("epoch_delta_minus", "epoch_delta_plus"):
+            info = cdf.varinq(variable)
+            attrs = cdf.varattsget(variable)
+            assert info.Data_Type_Description == "CDF_INT8"
+            assert attrs["FILLVAL"] == -9223372036854775808
+            assert attrs["FORMAT"] == "I19"
+            assert attrs["VALIDMIN"] == 0
+            assert attrs["VALIDMAX"] == EXPECTED_EPOCH_DELTA_VALIDMAX
 
 
 EXPECTED_LOGICAL_SOURCES = [


### PR DESCRIPTION
## Summary

Normalize CoDICE `epoch_delta_minus` and `epoch_delta_plus` across the reviewed L2 products so they are written as integer nanosecond durations and linked from `epoch` in the final emitted CDFs.

This PR is part of the broader ISTP / metadata cleanup tracked in issue #2577. Within that larger effort, this branch fixes the remaining CoDICE `epoch_delta_*` datatype and linkage inconsistencies that were still showing up across the current L2 products.

Scope:
- `imap_codice_l2_hi-omni`
- `imap_codice_l2_hi-sectored`
- `imap_codice_l2_lo-sw-species`
- `imap_codice_l2_hi-direct-events`
- `imap_codice_l2_lo-direct-events`

## Why

Before this change, the CoDICE products were split across several inconsistent states:

- some products already wrote `epoch_delta_*` as `CDF_INT8`
- some still wrote them as floating-point values
- some had integer-style metadata paired with floating-point written storage
- some products were missing the `epoch.DELTA_MINUS_VAR` / `DELTA_PLUS_VAR` links entirely

That produced a mix of:
- direct validator failures on datatype / format / fill semantics
- internally consistent but non-standard float-style duration variables
- inconsistent `epoch` metadata across otherwise similar CoDICE L2 files

So within the broader cleanup under #2577, this PR makes the CoDICE `epoch_delta_*` variables consistent at the file level.

## What Changed

### Compute `epoch_delta_*` as integer nanoseconds

Update the shared CoDICE timing helper so `epoch_delta_minus` and `epoch_delta_plus` are computed using exact integer nanosecond arithmetic and returned as `np.int64`.

This avoids:
- float duration storage
- float-to-int drift
- inconsistent CDF serialization across products

### Normalize shared `epoch_delta_*` metadata

Update the shared CoDICE metadata so `epoch_delta_minus` and `epoch_delta_plus` use integer-duration CDF metadata:

- `FILLVAL = -9223372036854775808`
- `FORMAT = I19`
- `VALIDMIN = 0`
- `VALIDMAX = 128000000000`

The `VALIDMAX` here is based on the current CoDICE timing model rather than the full `int64` storage range. In the current logic:

- `epoch_delta = num_spins * spin_period / 2`
- `spin_period VALIDMAX = 16 s`
- `num_spins max = 16`

So the worst-case duration is:

- `16 * 16 s / 2 = 128 s`

which gives:

- `128 s = 128000000000 ns`

That is why this PR uses a physically meaningful duration bound rather than `9223372036854775807`.

### Normalize product-specific direct-event / Hi overrides

Update the explicit `epoch_delta_*` L2 overrides in the affected CoDICE attr templates so they all use the same integer-duration metadata.

This removes the prior split where:
- direct-events were still writing floating-point durations with integer-looking metadata
- Hi products used different valid-range conventions

### Add `epoch` delta-variable links on final emitted outputs

Ensure the final emitted `epoch` variable carries:

- `DELTA_MINUS_VAR = "epoch_delta_minus"`
- `DELTA_PLUS_VAR = "epoch_delta_plus"`

for all five target L2 products.

This makes the final written files consistent, including the products that previously wrote valid `epoch_delta_*` variables but lost the `epoch` linkage.

## Testing

Extended the written-CDF CoDICE regression coverage to verify:

- representative CoDICE L1A products now write `epoch_delta_*` as `CDF_INT8`
- `hi-omni` and `hi-sectored` write `CDF_INT8` deltas with the normalized metadata and carry the `epoch` delta links
- `lo-sw-species`, `hi-direct-events`, and `lo-direct-events` do the same

Validated locally with:

```bash
pytest -q imap_processing/tests/codice/test_codice_l1a.py
pytest -q imap_processing/tests/codice/test_codice_hi_l2.py
pytest -q imap_processing/tests/codice/test_codice_l2.py -k 'sw_species or lo_de or hi_de'
pre-commit run --files \
  imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml \
  imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml \
  imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml \
  imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml \
  imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml \
  imap_processing/codice/codice_l2.py \
  imap_processing/codice/utils.py \
  imap_processing/tests/codice/test_codice_hi_l2.py \
  imap_processing/tests/codice/test_codice_l1a.py \
  imap_processing/tests/codice/test_codice_l2.py