### PR TITLE
3227 hi goodtimes   algrithm updates

### DIFF
--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -23,6 +23,9 @@ from imap_processing.spice.time import met_to_ttj2000ns
 
 logger = logging.getLogger(__name__)
 
+# Define number of nearest l1b de datasets required
+N_NEAREST_L1B_DE_DATASETS = 8
+
 # Structured dtype for good time intervals
 INTERVAL_DTYPE: np.dtype = np.dtype(
     [
@@ -79,8 +82,8 @@ def hi_goodtimes(
         Repointing identifier for the current pointing (e.g., "repoint00001").
         Used to identify which dataset in l1b_de_datasets is the current one.
     l1b_de_datasets : list[xr.Dataset]
-        L1B DE datasets for surrounding pointings. Typically includes
-        current plus 3 preceding and 3 following pointings (7 total).
+        L1B DE datasets for surrounding pointings. Typically, includes
+        current plus 4 preceding and 4 following pointings (9 total).
         Statistical filters 0 and 1 use all datasets; other filters use
         only the current pointing.
     l1b_hk : xr.Dataset
@@ -101,19 +104,19 @@ def hi_goodtimes(
     See IMAP-Hi Algorithm Document Sections 2.2.4 and 2.3.2 for details
     on each culling algorithm.
 
-    Processing requires that repointing + 3 has occurred (so that statistical
+    Processing requires that repointing + 4 has occurred (so that statistical
     filters can use surrounding pointings). Due to challenges with dependency
     management in the batch starter, it was decided to design the Hi goodtimes
     to set the L1B DE dependencies as not required and handle the final logic for
-    checking L1B DE dependencies in this function. If repointing + 3 has not yet
-    completed, an empty list is returned. If repointing + 3 has occurred but
-    not all 7 DE files are available, all times are marked as bad.
+    checking L1B DE dependencies in this function. If repointing + 4 has not yet
+    completed, an empty list is returned. If repointing + 4 has occurred but
+    not all 9 DE files are available, all times are marked as bad.
     """
     logger.info("Starting Hi goodtimes processing")
 
     # Parse the current repoint ID and check if we can process yet
     current_repoint_id = int(current_repointing.replace("repoint", ""))
-    future_repoint_id = current_repoint_id + 3
+    future_repoint_id = int(current_repoint_id + N_NEAREST_L1B_DE_DATASETS // 2)
 
     # Check if the future repointing has finished by checking that the next
     # repoint is in the repoint dataframe.
@@ -136,8 +139,8 @@ def hi_goodtimes(
     # Create the goodtimes dataset from the current pointing
     goodtimes_ds = create_goodtimes_dataset(current_l1b_de)
 
-    # Check if we have the full set of 7 DE files for nominal processing
-    if len(l1b_de_datasets) == 7:
+    # Check if we have the full set of N+1 DE files for nominal processing
+    if len(l1b_de_datasets) == N_NEAREST_L1B_DE_DATASETS + 1:
         _apply_goodtimes_filters(
             goodtimes_ds,
             l1b_de_datasets,
@@ -150,8 +153,8 @@ def hi_goodtimes(
         # Incomplete DE file set - mark all times as bad
         logger.warning(
             f"Incomplete DE file set for {current_repointing}: "
-            f"expected 7 files, got {len(l1b_de_datasets)}. "
-            "Marking all times as bad."
+            f"expected {N_NEAREST_L1B_DE_DATASETS + 1} files, got "
+            f"{len(l1b_de_datasets)}. Marking all times as bad."
         )
         goodtimes_ds["cull_flags"][:, :] = CullCode.INCOMPLETE_SPIN
 

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -1,5 +1,7 @@
 """IMAP-HI Goodtimes processing module."""
 
+from __future__ import annotations
+
 import logging
 from enum import IntEnum
 from pathlib import Path
@@ -1873,6 +1875,59 @@ def _compute_median_and_sigma_per_esa(
     return median_per_esa, sigma_per_esa
 
 
+def _sum_esa_counts(
+    per_sweep_datasets: dict[int, xr.Dataset],
+    esa_steps_to_sum: list[int],
+) -> dict[int, xr.Dataset]:
+    """
+    Sum qualified counts across specified ESA energy steps.
+
+    Creates a new set of datasets where qualified_count is summed across
+    the specified ESA energy steps. The resulting datasets have a single
+    "pseudo-ESA" dimension with value -1.
+
+    Parameters
+    ----------
+    per_sweep_datasets : dict[int, xr.Dataset]
+        Dictionary mapping pointing index to per-sweep dataset with
+        dims (esa_sweep, esa_energy_step).
+    esa_steps_to_sum : list[int]
+        ESA energy steps to sum (e.g., [7, 8, 9]).
+
+    Returns
+    -------
+    dict[int, xr.Dataset]
+        Dictionary with same structure but qualified_count summed across
+        specified ESA steps. The esa_energy_step dimension is reduced to
+        a single value (-1) indicating summed data.
+    """
+    summed_datasets = {}
+
+    for idx, ds in per_sweep_datasets.items():
+        # Select only the specified ESA steps that exist in this dataset
+        available_esas = ds.coords["esa_energy_step"].values
+        esas_to_select = [e for e in esa_steps_to_sum if e in available_esas]
+
+        if not esas_to_select:
+            # No matching ESAs, create empty summed dataset
+            summed_counts = ds["qualified_count"].isel(esa_energy_step=0) * 0
+        else:
+            # Sum counts across specified ESA energy steps
+            selected = ds["qualified_count"].sel(esa_energy_step=esas_to_select)
+            summed_counts = selected.sum(dim="esa_energy_step")
+
+        # Create new dataset with single "pseudo-ESA" dimension (-1 indicates summed)
+        summed_ds = xr.Dataset(
+            {
+                "qualified_count": summed_counts.expand_dims(esa_energy_step=[-1]),
+                "ccsds_met": ds["ccsds_met"].isel(esa_energy_step=0),
+            }
+        )
+        summed_datasets[idx] = summed_ds
+
+    return summed_datasets
+
+
 def _identify_cull_pattern(
     current_counts: xr.DataArray,
     median_per_esa: xr.DataArray,
@@ -1944,18 +1999,25 @@ def _identify_cull_pattern(
     )
     in_consecutive_run = (run_positions >= 1) & exceeds_arr.astype(bool)
 
-    # Check ESA neighbors at same time position using convolution along ESA axis
-    # Kernel [1, 0, 1] sums neighbors without counting self
-    # Use cval=1 so edges pass the neighbor check (matches C implementation where
-    # edges are treated as "not good", i.e., the check passes at boundaries)
-    esa_neighbor_kernel = np.array([1, 0, 1])
-    esa_neighbor_exceeds = convolve1d(
-        exceeds_arr, esa_neighbor_kernel, axis=1, mode="constant", cval=1
-    )
-    has_esa_neighbor = esa_neighbor_exceeds >= 1
+    # Only check ESA neighbors if we have at least 3 ESA energy steps
+    # (neighbor check requires adjacent ESAs to be meaningful)
+    n_esa_steps = current_counts.sizes.get("esa_energy_step", 0)
+    if n_esa_steps >= 3:
+        # Check ESA neighbors at same time position using convolution along ESA axis
+        # Kernel [1, 0, 1] sums neighbors without counting self
+        # Use cval=1 so edges pass the neighbor check (matches C implementation where
+        # edges are treated as "not good", i.e., the check passes at boundaries)
+        esa_neighbor_kernel = np.array([1, 0, 1])
+        esa_neighbor_exceeds = convolve1d(
+            exceeds_arr, esa_neighbor_kernel, axis=1, mode="constant", cval=1
+        )
+        has_esa_neighbor = esa_neighbor_exceeds >= 1
 
-    # Combine: in a consecutive run AND has ESA neighbor exceeding at same time
-    cull_arr |= in_consecutive_run & has_esa_neighbor
+        # Combine: in a consecutive run AND has ESA neighbor exceeding at same time
+        cull_arr |= in_consecutive_run & has_esa_neighbor
+    else:
+        # Not enough ESA steps for neighbor check - just use consecutive runs
+        cull_arr |= in_consecutive_run
 
     # === Pass 2: Mark isolated good intervals (orphans) ===
     # Pattern: [bad, good, bad] in time dimension
@@ -2000,6 +2062,7 @@ def mark_statistical_filter_1(
     min_consecutive_intervals: int = HiConstants.STAT_FILTER_1_MIN_CONSECUTIVE,
     cull_code: int = CullCode.STAT_FILTER_1,
     min_pointings: int = HiConstants.STAT_FILTER_MIN_POINTINGS,
+    prefilter_esa_steps: list[int] | None = None,
 ) -> None:
     """
     Apply Statistical Filter 1 to detect isotropic count rate increases.
@@ -2009,7 +2072,13 @@ def mark_statistical_filter_1(
     a limited time. It operates per sensor, per ESA energy step, per 8-spin
     interval, summing counts over all angles.
 
-    The filter applies three passes:
+    The filter applies a pre-filter step followed by three passes:
+
+    Pre-filter (for ESAs 7, 8, 9):
+        Apply the filter algorithm to the SUM of counts across prefilter_esa_steps.
+        Bad times from this pre-filter apply to ALL prefilter ESA steps.
+
+    Per-ESA filter passes:
     1. Mark intervals where counts exceed median + consecutive_threshold_sigma
        for at least min_consecutive_intervals AND in at least one adjacent ESA step.
     2. Remove isolated good intervals (good sandwiched between two bad).
@@ -2036,10 +2105,14 @@ def mark_statistical_filter_1(
         Minimum consecutive intervals above threshold.
         Default is HiConstants.STAT_FILTER_1_MIN_CONSECUTIVE.
     cull_code : int, optional
-        Cull code to use for marking bad times. Default is CullCode.LOOSE.
+        Cull code to use for marking bad times. Default is CullCode.STAT_FILTER_1.
     min_pointings : int, optional
         Minimum number of Pointings required.
         Default is HiConstants.STAT_FILTER_MIN_POINTINGS.
+    prefilter_esa_steps : list[int], optional
+        ESA energy steps to sum for pre-filtering. Default is [7, 8, 9].
+        The pre-filter applies the algorithm to the sum of these ESAs and
+        marks bad times for all of them.
 
     Raises
     ------
@@ -2053,6 +2126,10 @@ def mark_statistical_filter_1(
     Statistical Filter 0 and other angle-independent filters.
     """
     logger.info("Running mark_statistical_filter_1 culling")
+
+    # Default pre-filter ESAs
+    if prefilter_esa_steps is None:
+        prefilter_esa_steps = [7, 8, 9]
 
     # Validate inputs
     if current_index < 0 or current_index >= len(l1b_de_datasets):
@@ -2086,6 +2163,56 @@ def mark_statistical_filter_1(
     current_ds = per_sweep_datasets[current_index]
     current_counts = current_ds["qualified_count"]
 
+    # =========================================================================
+    # Step 3: Pre-filter for summed ESAs (e.g., 7, 8, 9)
+    # =========================================================================
+    # Initialize pre-filter mask to False (no culling)
+    prefilter_cull_mask = xr.zeros_like(current_counts, dtype=bool)
+
+    if prefilter_esa_steps:
+        logger.info(
+            f"Statistical Filter 1: Pre-filtering summed ESAs {prefilter_esa_steps}"
+        )
+
+        # 3a. Sum counts for pre-filter ESAs
+        summed_datasets = _sum_esa_counts(per_sweep_datasets, prefilter_esa_steps)
+
+        # 3b. Compute median and sigma for the summed data
+        summed_median, summed_sigma = _compute_median_and_sigma_per_esa(summed_datasets)
+
+        if not np.all(np.isnan(summed_median.values)):
+            # 3c. Get current pointing's summed data
+            current_summed = summed_datasets[current_index]["qualified_count"]
+
+            # 3d. Identify cull pattern (ESA neighbor check auto-skipped for single ESA)
+            summed_cull_mask = _identify_cull_pattern(
+                current_summed,
+                summed_median,
+                summed_sigma,
+                consecutive_threshold_sigma=consecutive_threshold_sigma,
+                extreme_threshold_sigma=extreme_threshold_sigma,
+                min_consecutive=min_consecutive_intervals,
+            )
+
+            # 3e. Broadcast summed cull mask to pre-filter ESA steps
+            # summed_cull_mask has shape (esa_sweep, 1) - squeeze and broadcast
+            summed_cull_1d = summed_cull_mask.squeeze(dim="esa_energy_step")
+            prefilter_esa_mask = current_counts.coords["esa_energy_step"].isin(
+                prefilter_esa_steps
+            )
+            # Broadcast: True for sweeps in summed_cull AND ESAs in prefilter_esa_steps
+            prefilter_cull_mask = summed_cull_1d & prefilter_esa_mask
+
+            n_prefilter_bad = int(summed_cull_mask.sum())
+            logger.info(
+                f"Statistical Filter 1 pre-filter: {n_prefilter_bad} sweeps flagged"
+            )
+
+    # =========================================================================
+    # Step 4: Normal per-ESA filtering
+    # =========================================================================
+    logger.info("Statistical Filter 1: Running normal per-ESA filtering")
+
     # Identify cull pattern using convolution-based detection
     cull_mask = _identify_cull_pattern(
         current_counts,
@@ -2096,10 +2223,15 @@ def mark_statistical_filter_1(
         min_consecutive=min_consecutive_intervals,
     )
 
-    # Apply culling to goodtimes - get METs where cull_mask is True
-    if cull_mask.any():
+    # =========================================================================
+    # Step 5: Combine masks and apply
+    # =========================================================================
+    combined_cull_mask = cull_mask | prefilter_cull_mask
+
+    # Apply culling to goodtimes - get METs where combined_cull_mask is True
+    if combined_cull_mask.any():
         # Use xarray's where to get METs for culled intervals, then flatten
-        mets_to_cull = current_ds["ccsds_met"].where(cull_mask).values.ravel()
+        mets_to_cull = current_ds["ccsds_met"].where(combined_cull_mask).values.ravel()
         # Remove NaN values
         mets_to_cull = mets_to_cull[~np.isnan(mets_to_cull)]
 

--- a/imap_processing/hi/hi_goodtimes.py
+++ b/imap_processing/hi/hi_goodtimes.py
@@ -111,7 +111,7 @@ def hi_goodtimes(
     management in the batch starter, it was decided to design the Hi goodtimes
     to set the L1B DE dependencies as not required and handle the final logic for
     checking L1B DE dependencies in this function. If repointing + 4 has not yet
-    completed, an empty list is returned. If repointing + 4 has occurred but
+    completed, a ValueError is raised. If repointing + 4 has occurred but
     not all 9 DE files are available, all times are marked as bad.
     """
     logger.info("Starting Hi goodtimes processing")
@@ -1917,10 +1917,13 @@ def _sum_esa_counts(
             summed_counts = selected.sum(dim="esa_energy_step")
 
         # Create new dataset with single "pseudo-ESA" dimension (-1 indicates summed)
+        # Use first ESA's MET values, expanded to include pseudo-ESA dimension
+        # for structural consistency with per-sweep datasets
+        summed_met = ds["ccsds_met"].isel(esa_energy_step=0)
         summed_ds = xr.Dataset(
             {
                 "qualified_count": summed_counts.expand_dims(esa_energy_step=[-1]),
-                "ccsds_met": ds["ccsds_met"].isel(esa_energy_step=0),
+                "ccsds_met": summed_met.expand_dims(esa_energy_step=[-1]),
             }
         )
         summed_datasets[idx] = summed_ds
@@ -1940,8 +1943,11 @@ def _identify_cull_pattern(
     Identify 2D cull pattern for statistical filter 1 using convolution.
 
     Detects three patterns:
-    1. Consecutive runs: 3+ consecutive sweeps exceeding threshold with ESA neighbor
-       confirmation (isotropic excursion pattern from C implementation)
+    1. Consecutive runs: 3+ consecutive sweeps exceeding threshold. When there
+       are 3 or more ESA energy steps, ESA neighbor confirmation is required
+       (isotropic excursion pattern from C implementation). When there are fewer
+       than 3 ESA steps (e.g., summed pre-filter data), consecutive runs are
+       marked without neighbor confirmation.
     2. Isolated intervals: Good intervals surrounded by bad on both sides in time
     3. Extreme outliers: Any position exceeding 5-sigma threshold
 
@@ -2090,9 +2096,10 @@ def mark_statistical_filter_1(
         Goodtimes dataset for the current Pointing to update.
     l1b_de_datasets : list[xarray.Dataset]
         List of L1B DE datasets for surrounding Pointings. Typically includes
-        current plus 3 preceding and 3 following Pointings. Each dataset must
-        contain a "qualified_mask" DataArray indicating which events qualify
-        for calibration products (checking both coincidence_type AND TOF).
+        current plus 4 preceding and 4 following Pointings (9 total). Each
+        dataset must contain a "qualified_mask" DataArray indicating which
+        events qualify for calibration products (checking both coincidence_type
+        AND TOF).
     current_index : int
         Index of the current Pointing in l1b_de_datasets.
     consecutive_threshold_sigma : float, optional

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -3026,6 +3026,19 @@ class TestSumEsaCounts:
         assert "esa_energy_step" in summed[0].dims
         assert summed[0].coords["esa_energy_step"].values.tolist() == [-1]
 
+    def test_ccsds_met_has_pseudo_esa_dimension(self):
+        """Test that ccsds_met has pseudo-ESA dimension for structural consistency."""
+        ds = self._create_per_sweep_dataset()
+        per_sweep_datasets = {0: ds}
+
+        summed = _sum_esa_counts(per_sweep_datasets, [7, 8, 9])
+
+        # ccsds_met should have same dimensions as qualified_count
+        assert "ccsds_met" in summed[0].data_vars
+        assert summed[0]["ccsds_met"].dims == summed[0]["qualified_count"].dims
+        assert "esa_energy_step" in summed[0]["ccsds_met"].dims
+        assert summed[0]["ccsds_met"].coords["esa_energy_step"].values.tolist() == [-1]
+
     def test_preserves_sweep_dimension(self):
         """Test that sweep dimension is preserved."""
         ds = self._create_per_sweep_dataset(n_sweeps=5)
@@ -3469,6 +3482,97 @@ class TestStatisticalFilter1:
 
         # All times should still be good (normal data, no pre-filter)
         assert np.all(goodtimes_for_filter1["cull_flags"].values == CullCode.GOOD)
+
+    def test_prefilter_mask_broadcast_and_combination(self, goodtimes_for_filter1):
+        """Test that prefilter mask is correctly broadcast and combined.
+
+        This test mocks _identify_cull_pattern to return specific masks:
+        - Pre-filter (summed): marks sweep 0 as bad
+        - Per-ESA: marks sweep 1, ESA 5 as bad
+
+        Expected result:
+        - Sweep 0, ESAs 7,8,9 should be marked (from pre-filter broadcast)
+        - Sweep 1, ESA 5 should be marked (from per-ESA filter)
+        - Other positions should NOT be marked
+        """
+        l1b_de_datasets = [
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=0.0),
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=500.0),
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=1000.0),
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=2500.0),
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=3500.0),
+        ]
+
+        for ds in l1b_de_datasets:
+            ds["qualified_mask"] = xr.DataArray(
+                np.isin(ds["coincidence_type"].values, [12]),
+                dims=["event_met"],
+            )
+
+        # Track call count to return different masks for pre-filter vs per-ESA
+        call_count = [0]
+
+        def mock_identify_cull_pattern(current_counts, median, sigma, **kwargs):
+            """Return specific masks based on call order."""
+            call_count[0] += 1
+            esa_coords = current_counts.coords["esa_energy_step"].values
+            sweep_coords = current_counts.coords["esa_sweep"].values
+
+            # Create mask matching input dimensions exactly
+            mask = xr.zeros_like(current_counts, dtype=bool)
+
+            if call_count[0] == 1:
+                # First call: pre-filter (summed ESAs) - mark sweep 0
+                # Summed data has single pseudo-ESA (-1)
+                mask.loc[{"esa_sweep": 0}] = True
+            # Second call: per-ESA filter - mark sweep 1, ESA 5
+            elif 5 in esa_coords and 1 in sweep_coords:
+                mask.loc[{"esa_sweep": 1, "esa_energy_step": 5}] = True
+
+            return mask
+
+        with patch(
+            "imap_processing.hi.hi_goodtimes._identify_cull_pattern",
+            side_effect=mock_identify_cull_pattern,
+        ):
+            mark_statistical_filter_1(
+                goodtimes_for_filter1,
+                l1b_de_datasets,
+                current_index=2,
+                prefilter_esa_steps=[7, 8, 9],
+            )
+
+        # Verify the masks were combined correctly
+        esa_steps = goodtimes_for_filter1["esa_step"].values
+        cull_flags = goodtimes_for_filter1["cull_flags"].values
+
+        # goodtimes has 18 METs with ESA steps [1,2,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9]
+        # Sweep 0 = first 9 METs (indices 0-8), Sweep 1 = next 9 METs (indices 9-17)
+
+        # Check sweep 0, ESAs 7,8,9 are marked (from pre-filter broadcast)
+        # ESA 7 is at index 6, ESA 8 at index 7, ESA 9 at index 8 (in sweep 0)
+        for idx in [6, 7, 8]:  # ESAs 7, 8, 9 in sweep 0
+            assert np.any(cull_flags[idx] != CullCode.GOOD), (
+                f"Sweep 0, ESA {esa_steps[idx]} should be marked by pre-filter"
+            )
+
+        # Check sweep 0, ESAs 1-6 are NOT marked (pre-filter only applies to 7,8,9)
+        for idx in [0, 1, 2, 3, 4, 5]:  # ESAs 1-6 in sweep 0
+            assert np.all(cull_flags[idx] == CullCode.GOOD), (
+                f"Sweep 0, ESA {esa_steps[idx]} should NOT be marked"
+            )
+
+        # Check sweep 1, ESA 5 is marked (from per-ESA filter)
+        # Sweep 1 starts at index 9, ESA 5 is at index 9+4=13
+        assert np.any(cull_flags[13] != CullCode.GOOD), (
+            "Sweep 1, ESA 5 should be marked by per-ESA filter"
+        )
+
+        # Check sweep 1, ESAs 7,8,9 are NOT marked (pre-filter only marked sweep 0)
+        for idx in [15, 16, 17]:  # ESAs 7, 8, 9 in sweep 1
+            assert np.all(cull_flags[idx] == CullCode.GOOD), (
+                f"Sweep 1, ESA {esa_steps[idx]} should NOT be marked"
+            )
 
 
 class TestFindEventClusters:

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -21,6 +21,7 @@ from imap_processing.hi.hi_goodtimes import (
     _find_event_clusters,
     _get_sweep_indices,
     _identify_cull_pattern,
+    _sum_esa_counts,
     create_goodtimes_dataset,
     hi_goodtimes,
     mark_bad_esa_voltage,
@@ -2701,6 +2702,78 @@ class TestIdentifyCullPattern:
         assert cull_mask.sel(esa_sweep=2, esa_energy_step=3).values
         assert cull_mask.sel(esa_sweep=3, esa_energy_step=3).values
 
+    def test_single_esa_skips_neighbor_check(self):
+        """Test consecutive runs are marked without ESA neighbor check (1-ESA)"""
+        # Create data with only 1 ESA energy step (simulates summed pre-filter data)
+        n_sweeps = 10
+        counts = xr.DataArray(
+            np.zeros((n_sweeps, 1)),
+            dims=["esa_sweep", "esa_energy_step"],
+            coords={
+                "esa_sweep": np.arange(n_sweeps),
+                "esa_energy_step": [-1],  # Pseudo-ESA for summed data
+            },
+        )
+        median = xr.DataArray(
+            [10.0],
+            dims=["esa_energy_step"],
+            coords={"esa_energy_step": [-1]},
+        )
+        sigma = xr.DataArray(
+            [3],
+            dims=["esa_energy_step"],
+            coords={"esa_energy_step": [-1]},
+        )
+
+        # Create 4 consecutive high counts - threshold = 10 + 1.8*3 = 15.4
+        counts.loc[2:5, -1] = 20
+
+        cull_mask = _identify_cull_pattern(counts, median, sigma)
+
+        # With single ESA, consecutive runs should be marked WITHOUT ESA neighbor check
+        # (ESA neighbor check is auto-skipped when n_esa_steps < 3)
+        assert cull_mask.sel(esa_sweep=2, esa_energy_step=-1).values
+        assert cull_mask.sel(esa_sweep=3, esa_energy_step=-1).values
+        assert cull_mask.sel(esa_sweep=4, esa_energy_step=-1).values
+        assert cull_mask.sel(esa_sweep=5, esa_energy_step=-1).values
+        # Other sweeps should not be marked
+        assert not cull_mask.sel(esa_sweep=0, esa_energy_step=-1).values
+        assert not cull_mask.sel(esa_sweep=1, esa_energy_step=-1).values
+
+    def test_two_esa_steps_skips_neighbor_check(self):
+        """Test that 2 ESA steps also skips ESA neighbor check."""
+        # Create data with only 2 ESA energy steps
+        n_sweeps = 10
+        counts = xr.DataArray(
+            np.zeros((n_sweeps, 2)),
+            dims=["esa_sweep", "esa_energy_step"],
+            coords={
+                "esa_sweep": np.arange(n_sweeps),
+                "esa_energy_step": [1, 2],
+            },
+        )
+        median = xr.DataArray(
+            [10.0, 10.0],
+            dims=["esa_energy_step"],
+            coords={"esa_energy_step": [1, 2]},
+        )
+        sigma = xr.DataArray(
+            [3, 3],
+            dims=["esa_energy_step"],
+            coords={"esa_energy_step": [1, 2]},
+        )
+
+        # Create 4 consecutive high counts at ESA 1 only (no neighbor)
+        counts.loc[2:5, 1] = 20
+
+        cull_mask = _identify_cull_pattern(counts, median, sigma)
+
+        # With 2 ESA steps, consecutive runs should be marked WITHOUT ESA neighbor check
+        assert cull_mask.sel(esa_sweep=2, esa_energy_step=1).values
+        assert cull_mask.sel(esa_sweep=3, esa_energy_step=1).values
+        assert cull_mask.sel(esa_sweep=4, esa_energy_step=1).values
+        assert cull_mask.sel(esa_sweep=5, esa_energy_step=1).values
+
 
 class TestComputeQualifiedCountsPerSweep:
     """Test suite for _compute_qualified_counts_per_sweep() helper function."""
@@ -2883,6 +2956,132 @@ class TestBuildPerSweepDatasets:
         # Should have per-sweep datasets for both indices
         assert 0 in per_sweep_datasets
         assert 1 in per_sweep_datasets
+
+
+class TestSumEsaCounts:
+    """Test suite for _sum_esa_counts() helper function."""
+
+    def _create_per_sweep_dataset(
+        self, n_sweeps: int = 2, esa_steps: list[int] | None = None
+    ) -> xr.Dataset:
+        """Create a per-sweep dataset with specified ESA steps."""
+        if esa_steps is None:
+            esa_steps = list(range(1, 10))  # ESA steps 1-9
+
+        # Create counts: sweep index + ESA step (so we can verify the sum)
+        counts = np.zeros((n_sweeps, len(esa_steps)))
+        for i, esa in enumerate(esa_steps):
+            counts[:, i] = esa * 10  # ESA 7 = 70, ESA 8 = 80, ESA 9 = 90
+
+        # Create MET values for each position
+        mets = np.arange(1000.0, 1000.0 + n_sweeps * len(esa_steps) * 60, 60).reshape(
+            n_sweeps, len(esa_steps)
+        )
+
+        return xr.Dataset(
+            {
+                "qualified_count": xr.DataArray(
+                    counts,
+                    dims=["esa_sweep", "esa_energy_step"],
+                    coords={
+                        "esa_sweep": np.arange(n_sweeps),
+                        "esa_energy_step": esa_steps,
+                    },
+                ),
+                "ccsds_met": xr.DataArray(
+                    mets,
+                    dims=["esa_sweep", "esa_energy_step"],
+                    coords={
+                        "esa_sweep": np.arange(n_sweeps),
+                        "esa_energy_step": esa_steps,
+                    },
+                ),
+            }
+        )
+
+    def test_sums_specified_esa_steps(self):
+        """Test that counts are summed across specified ESA steps."""
+        ds = self._create_per_sweep_dataset()
+        per_sweep_datasets = {0: ds}
+
+        # Sum ESA steps 7, 8, 9
+        summed = _sum_esa_counts(per_sweep_datasets, [7, 8, 9])
+
+        assert 0 in summed
+        # ESA 7=70, ESA 8=80, ESA 9=90 -> sum = 240
+        expected_sum = 70 + 80 + 90
+        np.testing.assert_array_equal(
+            summed[0]["qualified_count"].values.flatten(),
+            [expected_sum, expected_sum],  # 2 sweeps
+        )
+
+    def test_creates_pseudo_esa_dimension(self):
+        """Test that summed dataset has pseudo-ESA dimension with value -1."""
+        ds = self._create_per_sweep_dataset()
+        per_sweep_datasets = {0: ds}
+
+        summed = _sum_esa_counts(per_sweep_datasets, [7, 8, 9])
+
+        # Should have esa_energy_step dimension with single value -1
+        assert "esa_energy_step" in summed[0].dims
+        assert summed[0].coords["esa_energy_step"].values.tolist() == [-1]
+
+    def test_preserves_sweep_dimension(self):
+        """Test that sweep dimension is preserved."""
+        ds = self._create_per_sweep_dataset(n_sweeps=5)
+        per_sweep_datasets = {0: ds}
+
+        summed = _sum_esa_counts(per_sweep_datasets, [7, 8, 9])
+
+        assert "esa_sweep" in summed[0].dims
+        assert len(summed[0].coords["esa_sweep"]) == 5
+
+    def test_handles_missing_esa_steps(self):
+        """Test that missing ESA steps are handled gracefully."""
+        # Create dataset with only ESA steps 1-5 (no 7, 8, 9)
+        ds = self._create_per_sweep_dataset(esa_steps=[1, 2, 3, 4, 5])
+        per_sweep_datasets = {0: ds}
+
+        summed = _sum_esa_counts(per_sweep_datasets, [7, 8, 9])
+
+        # Should have zero counts since none of the requested ESAs exist
+        assert np.all(summed[0]["qualified_count"].values == 0)
+
+    def test_handles_partial_esa_steps(self):
+        """Test with only some of the requested ESA steps present."""
+        # Create dataset with ESA steps 1-8 (missing 9)
+        ds = self._create_per_sweep_dataset(esa_steps=list(range(1, 9)))
+        per_sweep_datasets = {0: ds}
+
+        summed = _sum_esa_counts(per_sweep_datasets, [7, 8, 9])
+
+        # Should sum only ESA 7 and 8 (70 + 80 = 150)
+        expected_sum = 70 + 80
+        np.testing.assert_array_equal(
+            summed[0]["qualified_count"].values.flatten(),
+            [expected_sum, expected_sum],
+        )
+
+    def test_multiple_datasets(self):
+        """Test with multiple pointing datasets."""
+        ds1 = self._create_per_sweep_dataset()
+        ds2 = self._create_per_sweep_dataset()
+        per_sweep_datasets = {0: ds1, 1: ds2}
+
+        summed = _sum_esa_counts(per_sweep_datasets, [7, 8, 9])
+
+        assert 0 in summed
+        assert 1 in summed
+        # Both should have same sum
+        expected_sum = 70 + 80 + 90
+        np.testing.assert_array_equal(
+            summed[0]["qualified_count"].values.flatten(),
+            [expected_sum, expected_sum],
+        )
+        np.testing.assert_array_equal(
+            summed[1]["qualified_count"].values.flatten(),
+            [expected_sum, expected_sum],
+        )
 
 
 class TestComputeMedianAndSigmaPerEsa:
@@ -3164,6 +3363,112 @@ class TestStatisticalFilter1:
                 l1b_de_datasets,
                 current_index=10,
             )
+
+    def test_prefilter_marks_all_specified_esas(self, goodtimes_for_filter1):
+        """Test that pre-filter marks bad times for all ESAs 7, 8, 9."""
+        # Create datasets with extreme counts in ESA 7, 8, 9 for pre-filter detection
+        l1b_de_datasets = []
+        for i in range(5):
+            base_met = i * 1500.0
+            if i == 2:
+                # Current pointing starts at MET 1000 to match goodtimes
+                base_met = 1000.0
+            ds = self._create_l1b_de_dataset(events_per_packet=10, base_met=base_met)
+            l1b_de_datasets.append(ds)
+
+        # Make current pointing have extreme total counts for ESAs 7, 8, 9 combined
+        # This should trigger the pre-filter
+        current_ds = l1b_de_datasets[2]
+        extra_events = 200  # Add many events to trigger 5-sigma for summed ESAs
+
+        # Add extra events to packets with ESA steps 7, 8, 9
+        # ESA step pattern: [1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9]
+        # Packets 12-17 are ESA steps 7, 8, 9
+        new_coincidence = np.concatenate(
+            [
+                current_ds["coincidence_type"].values,
+                np.full(extra_events, 12, dtype=np.uint8),
+            ]
+        )
+        # Distribute events across packets 12, 14, 16 (ESA 7, 8, 9)
+        extra_indices = np.array([12, 14, 16] * (extra_events // 3 + 1))[:extra_events]
+        new_ccsds_index = np.concatenate(
+            [
+                current_ds["ccsds_index"].values,
+                extra_indices.astype(np.uint16),
+            ]
+        )
+
+        l1b_de_datasets[2] = xr.Dataset(
+            data_vars={
+                "coincidence_type": (["event_met"], new_coincidence),
+                "ccsds_index": (["event_met"], new_ccsds_index),
+                "ccsds_met": current_ds["ccsds_met"],
+                "esa_step": current_ds["esa_step"],
+                "esa_energy_step": current_ds["esa_energy_step"],
+            },
+            coords={
+                "event_met": np.arange(len(new_coincidence)),
+                "epoch": current_ds["epoch"],
+            },
+        )
+
+        # Add qualified masks directly to datasets
+        for ds in l1b_de_datasets:
+            ds["qualified_mask"] = xr.DataArray(
+                np.isin(ds["coincidence_type"].values, [12]),
+                dims=["event_met"],
+            )
+
+        mark_statistical_filter_1(
+            goodtimes_for_filter1,
+            l1b_de_datasets,
+            current_index=2,
+            prefilter_esa_steps=[7, 8, 9],
+        )
+
+        # Check that ESA steps 7, 8, 9 are marked as bad
+        # goodtimes_for_filter1 has esa_step values:
+        # [1,2,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9]
+        esa_steps = goodtimes_for_filter1["esa_step"].values
+        cull_flags = goodtimes_for_filter1["cull_flags"].values
+
+        # Find indices where esa_step is 7, 8, or 9
+        prefilter_indices = np.where(np.isin(esa_steps, [7, 8, 9]))[0]
+
+        # At least some of the pre-filter ESAs should be marked
+        marked_prefilter = np.any(
+            cull_flags[prefilter_indices] != CullCode.GOOD, axis=1
+        )
+        assert np.any(marked_prefilter), "Pre-filter should mark some ESAs 7, 8, 9"
+
+    def test_prefilter_disabled_with_empty_list(self, goodtimes_for_filter1):
+        """Test that pre-filter is disabled when prefilter_esa_steps is empty."""
+        l1b_de_datasets = [
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=0.0),
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=500.0),
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=1000.0),
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=2500.0),
+            self._create_l1b_de_dataset(events_per_packet=10, base_met=3500.0),
+        ]
+
+        # Add qualified masks directly to datasets
+        for ds in l1b_de_datasets:
+            ds["qualified_mask"] = xr.DataArray(
+                np.isin(ds["coincidence_type"].values, [12]),
+                dims=["event_met"],
+            )
+
+        # Should run without error with empty prefilter list
+        mark_statistical_filter_1(
+            goodtimes_for_filter1,
+            l1b_de_datasets,
+            current_index=2,
+            prefilter_esa_steps=[],
+        )
+
+        # All times should still be good (normal data, no pre-filter)
+        assert np.all(goodtimes_for_filter1["cull_flags"].values == CullCode.GOOD)
 
 
 class TestFindEventClusters:

--- a/imap_processing/tests/hi/test_hi_goodtimes.py
+++ b/imap_processing/tests/hi/test_hi_goodtimes.py
@@ -3980,7 +3980,7 @@ class TestHiGoodtimes:
             "cull_code_counts": {},
         }
         mock_goodtimes.goodtimes.finalize_dataset.return_value = MagicMock()
-        mock_datasets = [MagicMock() for _ in range(7)]
+        mock_datasets = [MagicMock() for _ in range(9)]
         mock_hk = MagicMock()
 
         with (
@@ -4053,7 +4053,7 @@ class TestHiGoodtimes:
             mock_goodtimes.__getitem__.assert_called_with("cull_flags")
 
     def test_calls_apply_filters_when_full_de_set(self, tmp_path):
-        """Test that _apply_goodtimes_filters is called with 7 DE datasets."""
+        """Test that _apply_goodtimes_filters is called with 9 DE datasets."""
         mock_repoint_df = pd.DataFrame({"repoint_id": list(range(1, 10))})
         mock_goodtimes = MagicMock()
         mock_goodtimes.attrs = {"sensor": "45sensor"}
@@ -4066,7 +4066,7 @@ class TestHiGoodtimes:
             "cull_code_counts": {},
         }
         mock_goodtimes.goodtimes.finalize_dataset.return_value = MagicMock()
-        mock_datasets = [MagicMock() for _ in range(7)]
+        mock_datasets = [MagicMock() for _ in range(9)]
         mock_hk = MagicMock()
 
         with (
@@ -4111,7 +4111,7 @@ class TestHiGoodtimes:
         }
         mock_finalized = MagicMock()
         mock_goodtimes.goodtimes.finalize_dataset.return_value = mock_finalized
-        mock_datasets = [MagicMock() for _ in range(7)]
+        mock_datasets = [MagicMock() for _ in range(9)]
         mock_hk = MagicMock()
 
         with (


### PR DESCRIPTION
# Background
Changes based on email from Paul Janzen specifying the following goodtimes updates:
>For good times selection, specifically to deal with conditions like those in pointings 203-206, please make the following modifications to statistical filter 1:
(a)   Use 9 days/pointings centred on the pointing in question (i.e., +- 4) to calculate the median, not 7 (+-3).  Rationale is that the additional noise, which lasts the better part of 4 days, affects the correct determination of a good median count rate if we use just 7 days.
(b)  Prior to the application of statistical filter 1 to ESAs 7, 8, and 9 individually, apply the algorithm of statistical filter 1 to the SUM of ESAs 7, 8, and 9 and apply the results of the filter to all of ESAs 7, 8, and 9.  Still deal with "before/after" gaps, but don't test for above/below.  Run the statistical filter 1 on ESAs 7, 8, and 9 independently next, in the usual fashion.

# Change Summary

  Code Changes (hi_goodtimes.py)                                                                                                                                                                                                                                
                                                                                
  1. Added from __future__ import annotations for modern type hints
  2. Modified _identify_cull_pattern (lines 1945-1965):
    - Added auto-detection to skip ESA neighbor check when n_esa_steps < 3
    - Single ESA (summed data) or two ESAs now use consecutive runs without neighbor confirmation
  3. Added _sum_esa_counts (new function, ~50 lines):
    - Sums qualified counts across specified ESA energy steps
    - Creates datasets with pseudo-ESA dimension (-1) for summed data
  4. Modified mark_statistical_filter_1 (~60 new lines):
    - Added prefilter_esa_steps parameter (default [7, 8, 9])
    - Pre-filter step: sums counts, computes stats, identifies cull pattern
    - Broadcasts summed cull mask to pre-filter ESAs
    - Combines with per-ESA cull mask using logical OR
    - Single mark_bad_times call at end

  Test Changes (test_hi_goodtimes.py)

  1. Fixed 3 tests to use 9 mock datasets (current + nearest 8)
  2. Added TestSumEsaCounts class (6 tests):
    - test_sums_specified_esa_steps
    - test_creates_pseudo_esa_dimension
    - test_preserves_sweep_dimension
    - test_handles_missing_esa_steps
    - test_handles_partial_esa_steps
    - test_multiple_datasets
  3. Added to TestIdentifyCullPattern (2 tests):
    - test_single_esa_skips_neighbor_check
    - test_two_esa_steps_skips_neighbor_check
  4. Added to TestStatisticalFilter1 (2 tests):
    - test_prefilter_marks_all_specified_esas
    - test_prefilter_disabled_with_empty_list


Closes: #3227 