### PR TITLE
fixes for issue 3236

### DIFF
--- a/imap_processing/_version.py
+++ b/imap_processing/_version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced later during substitution.
-__version__ = "0.0.0"
-__version_tuple__ = (0, 0, 0)
+__version__ = "1.0.25.post137.dev0+fde9d511"
+__version_tuple__ = (1, 0, 25, "post137", "dev0", "fde9d511")

--- a/imap_processing/_version.py
+++ b/imap_processing/_version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced later during substitution.
-__version__ = "1.0.25.post137.dev0+fde9d511"
-__version_tuple__ = (1, 0, 25, "post137", "dev0", "fde9d511")
+__version__ = "0.0.0"
+__version_tuple__ = (0, 0, 0)

--- a/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_lo_l1c_variable_attrs.yaml
@@ -107,10 +107,21 @@ pivot_angle:
   <<: *default
   CATDESC: Pivot angle for pointing
   FIELDNAM: Pivot angle
-  FORMAT: I12
+  FORMAT: F8.3
   LABLAXIS: pivot angle
-  UNITS: degrees
-  VALIDMAX: 360
+  UNITS: deg
+  VALIDMAX: 180.0
+  VALIDMIN: 0.0
+
+pivot_angle_de:
+  <<: *default
+  CATDESC: Pivot angle derived from direct event data
+  FIELDNAM: Pivot Angle (DE)
+  FORMAT: F8.3
+  LABLAXIS: Pivot Angle DE
+  UNITS: deg
+  VALIDMAX: 180.0
+  VALIDMIN: 0.0
 
 esa_mode:
   <<: *default

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -112,8 +112,8 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
             attrs=attr_mgr.get_global_attributes(logical_source),
         )
 
-        # pass-through of the pivot_angle from L1B DE
-        pset["pivot_angle"] = l1b_de["pivot_angle"]
+        pset["pivot_angle"] = sci_dependencies["imap_lo_l1b_goodtimes"]["pivot"]
+        pset["pivot_angle_de"] = sci_dependencies["imap_lo_l1b_goodtimes"]["pivot_de"]
 
         # ESA mode needs to be added to L1B DE. Adding try statement
         # to avoid error until it's available in the dataset
@@ -1080,18 +1080,18 @@ def set_background_rates(
         variance_field = f"{species_key}_background_variance"
 
         if rate_field in bgrates_ds:
-            rates_per_esa = bgrates_ds[
-                rate_field
-            ].values  # shape: (N_ESA_ENERGY_STEPS,)
+            rates_per_esa = bgrates_ds[rate_field].values[
+                0
+            ]  # shape: (N_ESA_ENERGY_STEPS,)
             bg_rates = np.broadcast_to(
                 rates_per_esa[:, np.newaxis, np.newaxis],
                 (N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS),
             ).astype(np.float16)
 
         if variance_field in bgrates_ds:
-            var_per_esa = bgrates_ds[
-                variance_field
-            ].values  # shape: (N_ESA_ENERGY_STEPS,)
+            var_per_esa = bgrates_ds[variance_field].values[
+                0
+            ]  # shape: (N_ESA_ENERGY_STEPS,)
             bg_stat_uncert = np.broadcast_to(
                 var_per_esa[:, np.newaxis, np.newaxis],
                 (N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS),

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -192,10 +192,10 @@ def l1b_bgrates_ds():
     )
     return xr.Dataset(
         {
-            "h_background_rates": ("esa_step", h_rates),
-            "h_background_variance": ("esa_step", h_var),
-            "o_background_rates": ("esa_step", o_rates),
-            "o_background_variance": ("esa_step", o_var),
+            "h_background_rates": (["epoch", "esa_step"], h_rates[np.newaxis, :]),
+            "h_background_variance": (["epoch", "esa_step"], h_var[np.newaxis, :]),
+            "o_background_rates": (["epoch", "esa_step"], o_rates[np.newaxis, :]),
+            "o_background_variance": (["epoch", "esa_step"], o_var[np.newaxis, :]),
         }
     )
 
@@ -226,6 +226,8 @@ def test_lo_l1c(
             {
                 "gt_start_met": ("epoch", [repoint_start_met]),
                 "gt_end_met": ("epoch", [repoint_start_met]),
+                "pivot": ([45.0]),
+                "pivot_de": ([45.0]),
             },
             coords={"epoch": met_to_ttj2000ns([repoint_start_met])},
         ),
@@ -264,7 +266,7 @@ def test_lo_l1c(
 
     # Assert
     assert expected_logical_source == output_dataset.attrs["Logical_source"]
-    # Verify that pivot_angle is passed through from l1b_de
+    # Verify that pivot_angle is passed through from l1b_goodtimes
     assert "pivot_angle" in output_dataset
     assert output_dataset["pivot_angle"].values[0] == 45.0
     mock_add_spacecraft_position_and_velocity_to_pset.assert_called_once()
@@ -339,6 +341,8 @@ def test_lo_l1c_no_goodtimes(
             {
                 "gt_start_met": ("epoch", [goodtime_start]),
                 "gt_end_met": ("epoch", [goodtime_end]),
+                "pivot": ([45.0]),
+                "pivot_de": ([45.0]),
             },
             coords={"epoch": met_to_ttj2000ns([goodtime_start])},
         ),
@@ -378,7 +382,7 @@ def test_lo_l1c_no_goodtimes(
 
     # Assert
     assert expected_logical_source == output_dataset.attrs["Logical_source"]
-    # Verify that pivot_angle is passed through from l1b_de
+    # Verify that pivot_angle is passed through from l1b_goodtimes
     assert "pivot_angle" in output_dataset
     assert output_dataset["pivot_angle"].values[0] == 45.0
 
@@ -790,8 +794,8 @@ def test_set_background_rates(l1b_bgrates_ds, attr_mgr, species):
     # Arrange
     sci_deps = {"imap_lo_l1b_bgrates": l1b_bgrates_ds}
     species_key = species.value
-    expected_rates = l1b_bgrates_ds[f"{species_key}_background_rates"].values
-    expected_var = l1b_bgrates_ds[f"{species_key}_background_variance"].values
+    expected_rates = l1b_bgrates_ds[f"{species_key}_background_rates"].values[0]
+    expected_var = l1b_bgrates_ds[f"{species_key}_background_variance"].values[0]
 
     # Act
     rates, uncert, err = set_background_rates(species, sci_deps, attr_mgr)


### PR DESCRIPTION
Closes #3236 

# Change Summary

## Overview

- `pivot_angle` field for `lo/l1c` now populated from `lo/l1b` instead of `de` data - this allows it to be representative of what the `goodtimes` algorithm wants it to be (median of the angles during goodtimes). Also, it was `I12` for some reason, which doesn't make sense to me, unless I'm missing something. Changed to `F8.3`

- added a `pivot_angle_de` for consumers who want it (Menlo?)

- bug fix with indexing since issue #3213 was fixed.
