### PR TITLE
fix(mag): apply SPDF and MAG team metadata updates

### DIFF
--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -50,34 +50,41 @@ vector_attrs: &vectors_default
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:DSRF,CoordinateRepresentation:Cartesian"
     FIELDNAM: Magnetic Field Vector
     FILLVAL: -1.0e31
-    FORMAT: F12.5
+    FORMAT: F13.5
     LABL_PTR_1: direction_label
     UNITS: nT
+    VALIDMAX: 1.0e+5
+    VALIDMIN: -1.0e+5
 
 # Frame-specific vector attributes
 vector_attrs_srf:
     <<: *vectors_default
-    CATDESC: Magnetic field vectors with x y z varying by time in Spacecraft Reference Frame
+    CATDESC: Magnetic field in the Spacecraft Reference Frame (SRF)
+    FIELDNAM: Magnetic Field SRF
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:SRF,CoordinateRepresentation:Cartesian"
 
 vector_attrs_dsrf:
     <<: *vectors_default
-    CATDESC: Magnetic field vectors with x y z varying by time in Despun Spacecraft Reference Frame
+    CATDESC: Magnetic field in the Despun Spacecraft Reference Frame (DSRF)
+    FIELDNAM: Magnetic Field DSRF
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:DSRF,CoordinateRepresentation:Cartesian"
 
 vector_attrs_gse:
     <<: *vectors_default
-    CATDESC: Magnetic field vectors with x y z varying by time in Geocentric Solar Ecliptic Reference Frame
+    CATDESC: Magnetic field in GSE coordinates
+    FIELDNAM: Magnetic Field GSE
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:GSE,CoordinateRepresentation:Cartesian"
 
 vector_attrs_gsm:
     <<: *vectors_default
-    CATDESC: Magnetic field vectors with x y z varying by time in Geocentric Solar Magnetospheric Reference Frame
+    CATDESC: Magnetic field in GSM coordinates
+    FIELDNAM: Magnetic Field GSM
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:GSM,CoordinateRepresentation:Cartesian"
 
 vector_attrs_rtn:
     <<: *vectors_default
-    CATDESC: Magnetic field vectors with r t n varying by time in Radial-Tangential-Normal Reference Frame
+    CATDESC: Magnetic field in RTN coordinates
+    FIELDNAM: Magnetic Field RTN
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:RTN,CoordinateRepresentation:Cartesian"
 
 direction_attrs:
@@ -93,7 +100,7 @@ direction_attrs:
 
 magnitude:
   <<: *support_default
-  CATDESC: Magnitude of the magnetic field vector
+  CATDESC: Magnitude of the magnetic field
   CDF_DATA_TYPE: CDF_FLOAT
   DICT_KEY: SPASE>Field>FieldQuantity:Magnetic,Qualifier:Scalar
   FIELDNAM: Magnetic Field Magnitude
@@ -107,7 +114,7 @@ magnitude:
 
 range:
   <<: *support_default
-  CATDESC: Sensor range setting
+  CATDESC: Range of the magnetometer sensor
   CDF_DATA_TYPE: CDF_UINT1
   DICT_KEY: SPASE>Support>SupportQuantity:InstrumentMode
   FIELDNAM: Sensor Range
@@ -133,30 +140,37 @@ pri_sens:
 
 qf_bitmask:
   <<: *support_default
-  CATDESC: Eight-bit data quality bitmask copied from the MAG offset input
+  CATDESC: Bitmask indicating when spacecraft related activities influenced the measurement.
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
-  FIELDNAM: Data Quality Bitmask
+  FIELDNAM: Quality Bitmask
   FILLVAL: 255
   FORMAT: I3
-  LABLAXIS: QF
+  LABLAXIS: QB
   VALIDMAX: 255
   VALIDMIN: 0
-  VAR_NOTES: >
-    Bitwise quality flag copied from the MAG offset input. The current MAG pipeline
-    preserves this 8-bit value in the output CDF but does not decode individual bit
-    meanings.
+  VAR_NOTES: |
+    The bitmask is an 8-bit integer where each bit represents a different quality flag.
+    The bits are defined as follows:
+    - Bit 0: Data is sourced from secondary sensor
+    - Bit 1: Thruster firing signals have been removed
+    - Bit 2: Spacecraft interference impacts this data
+    - Bit 3: Instrument signals have been removed
+    - Bits 4-7: Reserved for in flight calibration
 
 qf:
   <<: *support_default
-  CATDESC: Data quality flag (0=good, 1=bad)
+  CATDESC: "Data quality flag. 0: Good data, 1: Bad data."
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
-  FIELDNAM: Data Quality Flag
+  FIELDNAM: Quality Flag
   FILLVAL: 255
   FORMAT: I1
   LABLAXIS: QF
   UNITS: 0=good
   VALIDMAX: 1
   VALIDMIN: 0
-  VAR_NOTES: >
-    Binary data quality flag. 0 indicates good data. 1 indicates bad data.
+  VAR_NOTES: |
+    The quality flag indicates the overall quality of the data at each timestamp.
+    More detail on the data quality can be found in the quality bitmask.
+    - 0: Good data
+    - 1: Bad quality data not suitable for science
   VAR_TYPE: data

--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -52,6 +52,7 @@ vector_attrs: &vectors_default
     FILLVAL: -1.0e31
     FORMAT: F12.5
     LABL_PTR_1: direction_label
+    UNITS: nT
 
 # Frame-specific vector attributes
 vector_attrs_srf:

--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -102,6 +102,7 @@ magnitude:
   UNITS: nT
   VALIDMAX: 1.0e+5
   VALIDMIN: 0
+  VAR_TYPE: data
 
 range:
   <<: *support_default

--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -131,14 +131,18 @@ pri_sens:
 
 qf_bitmask:
   <<: *support_default
-  CATDESC: Eight-bit Data quality bitmask
+  CATDESC: Eight-bit data quality bitmask copied from the MAG offset input
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
-  FIELDNAM: Quality Flag
+  FIELDNAM: Data Quality Bitmask
   FILLVAL: 255
   FORMAT: I3
   LABLAXIS: QF
   VALIDMAX: 255
   VALIDMIN: 0
+  VAR_NOTES: >
+    Bitwise quality flag copied from the MAG offset input. The current MAG pipeline
+    preserves this 8-bit value in the output CDF but does not decode individual bit
+    meanings.
 
 qf:
   <<: *support_default

--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -60,32 +60,32 @@ vector_attrs: &vectors_default
 vector_attrs_srf:
     <<: *vectors_default
     CATDESC: Magnetic field in the Spacecraft Reference Frame (SRF)
-    FIELDNAM: Magnetic Field SRF
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:SRF,CoordinateRepresentation:Cartesian"
+    FIELDNAM: Magnetic Field SRF
 
 vector_attrs_dsrf:
     <<: *vectors_default
     CATDESC: Magnetic field in the Despun Spacecraft Reference Frame (DSRF)
-    FIELDNAM: Magnetic Field DSRF
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:DSRF,CoordinateRepresentation:Cartesian"
+    FIELDNAM: Magnetic Field DSRF
 
 vector_attrs_gse:
     <<: *vectors_default
     CATDESC: Magnetic field in GSE coordinates
-    FIELDNAM: Magnetic Field GSE
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:GSE,CoordinateRepresentation:Cartesian"
+    FIELDNAM: Magnetic Field GSE
 
 vector_attrs_gsm:
     <<: *vectors_default
     CATDESC: Magnetic field in GSM coordinates
-    FIELDNAM: Magnetic Field GSM
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:GSM,CoordinateRepresentation:Cartesian"
+    FIELDNAM: Magnetic Field GSM
 
 vector_attrs_rtn:
     <<: *vectors_default
     CATDESC: Magnetic field in RTN coordinates
-    FIELDNAM: Magnetic Field RTN
     DICT_KEY: "SPASE>Field>FieldQuantity:Magnetic,Qualifier:Vector,CoordinateSystemName:RTN,CoordinateRepresentation:Cartesian"
+    FIELDNAM: Magnetic Field RTN
 
 direction_attrs:
     <<: *default_coords

--- a/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml
@@ -142,11 +142,15 @@ qf_bitmask:
 
 qf:
   <<: *support_default
-  CATDESC: Data quality flag
+  CATDESC: Data quality flag (0=good, 1=bad)
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
-  FIELDNAM: Quality Flag
+  FIELDNAM: Data Quality Flag
   FILLVAL: 255
   FORMAT: I1
   LABLAXIS: QF
+  UNITS: 0=good
   VALIDMAX: 1
   VALIDMIN: 0
+  VAR_NOTES: >
+    Binary data quality flag. 0 indicates good data. 1 indicates bad data.
+  VAR_TYPE: data

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -242,14 +242,14 @@ class MagL2L1dBase:
             self.quality_flags,
             name="quality_flags",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("qf_bitmask"),
+            attrs=attribute_manager.get_variable_attributes("qf"),
         )
 
         quality_bitmask = xr.DataArray(
             self.quality_bitmask,
             name="quality_bitmask",
             dims=["epoch"],
-            attrs=attribute_manager.get_variable_attributes("qf"),
+            attrs=attribute_manager.get_variable_attributes("qf_bitmask"),
         )
 
         rng = xr.DataArray(

--- a/imap_processing/mag/l2/mag_l2_data.py
+++ b/imap_processing/mag/l2/mag_l2_data.py
@@ -212,7 +212,7 @@ class MagL2L1dBase:
         )
 
         direction_label = xr.DataArray(
-            direction.values.astype(str),
+            np.array(["Bx", "By", "Bz"]),
             name="direction_label",
             dims=["direction_label"],
             attrs=attribute_manager.get_variable_attributes(

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -612,3 +612,41 @@ def test_qf(norm_dataset):
         "does not decode individual bit meanings"
         in output["quality_bitmask"].attrs["VAR_NOTES"]
     )
+
+
+def test_mag_l2_burst_inherits_shared_metadata(norm_dataset, mag_test_l2_data):
+    """Test that burst output inherits the shared MAG L2 metadata cleanup."""
+    calibration_dataset = mag_test_l2_data[0]
+    offset_dataset = mag_test_l2_data[1]
+
+    test_dataset = norm_dataset.copy()
+    test_dataset.attrs["Logical_source"] = "imap_mag_l1c_burst-mago"
+
+    with patch(
+        "imap_processing.mag.l2.mag_l2_data.frame_transform",
+        side_effect=lambda *args, **kwargs: args[1],
+    ):
+        burst_datasets = mag_l2(
+            calibration_dataset,
+            offset_dataset,
+            test_dataset,
+            np.datetime64("2025-10-17"),
+            mode=DataMode.BURST,
+            frames=[ValidFrames.SRF],
+        )
+
+    assert len(burst_datasets) == 1
+    burst_dataset = burst_datasets[0]
+
+    assert burst_dataset["quality_flags"].attrs["VAR_TYPE"] == "data"
+    assert burst_dataset["quality_flags"].attrs["UNITS"] == "0=good"
+    assert burst_dataset["magnitude"].attrs["VAR_TYPE"] == "data"
+    assert burst_dataset["b_srf"].attrs["UNITS"] == "nT"
+    np.testing.assert_array_equal(
+        burst_dataset["direction_label"].data,
+        np.array(["Bx", "By", "Bz"]),
+    )
+    assert (
+        "does not decode individual bit meanings"
+        in burst_dataset["quality_bitmask"].attrs["VAR_NOTES"]
+    )

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -108,6 +108,10 @@ def test_mag_l2_attributes(
         assert "range" in dataset.data_vars
         assert dataset["magnitude"].attrs["UNITS"] == "nT"
         assert dataset["magnitude"].attrs["VAR_TYPE"] == "data"
+        np.testing.assert_array_equal(
+            dataset["direction_label"].data,
+            np.array(["Bx", "By", "Bz"]),
+        )
         assert dataset["range"].attrs["DICT_KEY"] == (
             "SPASE>Support>SupportQuantity:InstrumentMode"
         )
@@ -152,6 +156,10 @@ def test_mag_l2(norm_dataset, mag_test_l2_data):
         assert vector_info.Data_Type_Description == "CDF_FLOAT"
         assert np.isclose(vector_attrs["FILLVAL"], np.float32(-1.0e31))
         assert vector_attrs["UNITS"] == "nT"
+        np.testing.assert_array_equal(
+            cdf_file.varget("direction_label"),
+            np.array(["Bx", "By", "Bz"]),
+        )
 
 
 def test_mag_l2_some_epochs_not_in_spice(norm_dataset, mag_test_l2_data):

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -102,6 +102,7 @@ def test_mag_l2_attributes(
         assert "DICT_KEY" in vectors_attrs
 
         assert f"CoordinateSystemName:{frame}" in vectors_attrs["DICT_KEY"]
+        assert vectors_attrs["UNITS"] == "nT"
 
         assert "magnitude" in dataset.data_vars
         assert "range" in dataset.data_vars
@@ -150,6 +151,7 @@ def test_mag_l2(norm_dataset, mag_test_l2_data):
         vector_attrs = cdf_file.varattsget(expected_frames[i].var_name)
         assert vector_info.Data_Type_Description == "CDF_FLOAT"
         assert np.isclose(vector_attrs["FILLVAL"], np.float32(-1.0e31))
+        assert vector_attrs["UNITS"] == "nT"
 
 
 def test_mag_l2_some_epochs_not_in_spice(norm_dataset, mag_test_l2_data):

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -106,6 +106,7 @@ def test_mag_l2_attributes(
         assert "magnitude" in dataset.data_vars
         assert "range" in dataset.data_vars
         assert dataset["magnitude"].attrs["UNITS"] == "nT"
+        assert dataset["magnitude"].attrs["VAR_TYPE"] == "data"
         assert dataset["range"].attrs["DICT_KEY"] == (
             "SPASE>Support>SupportQuantity:InstrumentMode"
         )

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -596,3 +596,8 @@ def test_qf(norm_dataset):
     assert (
         output["quality_flags"].attrs["CATDESC"] == "Data quality flag (0=good, 1=bad)"
     )
+    assert output["quality_bitmask"].attrs["FIELDNAM"] == "Data Quality Bitmask"
+    assert (
+        "does not decode individual bit meanings"
+        in output["quality_bitmask"].attrs["VAR_NOTES"]
+    )

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -591,3 +591,8 @@ def test_qf(norm_dataset):
     assert "quality_bitmask" in output.data_vars
     assert np.array_equal(output["quality_flags"].data, qf)
     assert np.array_equal(output["quality_bitmask"].data, qf_bitmask)
+    assert output["quality_flags"].attrs["VAR_TYPE"] == "data"
+    assert output["quality_flags"].attrs["UNITS"] == "0=good"
+    assert (
+        output["quality_flags"].attrs["CATDESC"] == "Data quality flag (0=good, 1=bad)"
+    )

--- a/imap_processing/tests/mag/test_mag_l2.py
+++ b/imap_processing/tests/mag/test_mag_l2.py
@@ -103,11 +103,33 @@ def test_mag_l2_attributes(
 
         assert f"CoordinateSystemName:{frame}" in vectors_attrs["DICT_KEY"]
         assert vectors_attrs["UNITS"] == "nT"
+        assert vectors_attrs["FORMAT"] == "F13.5"
+        assert np.isclose(vectors_attrs["VALIDMIN"], -1.0e5)
+        assert np.isclose(vectors_attrs["VALIDMAX"], 1.0e5)
+        expected_vector_text = {
+            "SRF": (
+                "Magnetic field in the Spacecraft Reference Frame (SRF)",
+                "Magnetic Field SRF",
+            ),
+            "GSE": ("Magnetic field in GSE coordinates", "Magnetic Field GSE"),
+            "GSM": ("Magnetic field in GSM coordinates", "Magnetic Field GSM"),
+            "RTN": ("Magnetic field in RTN coordinates", "Magnetic Field RTN"),
+            "DSRF": (
+                "Magnetic field in the Despun Spacecraft Reference Frame (DSRF)",
+                "Magnetic Field DSRF",
+            ),
+        }
+        assert vectors_attrs["CATDESC"] == expected_vector_text[frame][0]
+        assert vectors_attrs["FIELDNAM"] == expected_vector_text[frame][1]
 
         assert "magnitude" in dataset.data_vars
         assert "range" in dataset.data_vars
         assert dataset["magnitude"].attrs["UNITS"] == "nT"
         assert dataset["magnitude"].attrs["VAR_TYPE"] == "data"
+        assert (
+            dataset["magnitude"].attrs["CATDESC"] == "Magnitude of the magnetic field"
+        )
+        assert dataset["range"].attrs["CATDESC"] == "Range of the magnetometer sensor"
         np.testing.assert_array_equal(
             dataset["direction_label"].data,
             np.array(["Bx", "By", "Bz"]),
@@ -155,6 +177,9 @@ def test_mag_l2(norm_dataset, mag_test_l2_data):
         vector_attrs = cdf_file.varattsget(expected_frames[i].var_name)
         assert vector_info.Data_Type_Description == "CDF_FLOAT"
         assert np.isclose(vector_attrs["FILLVAL"], np.float32(-1.0e31))
+        assert vector_attrs["FORMAT"] == "F13.5"
+        assert np.isclose(vector_attrs["VALIDMIN"], np.float32(-1.0e5))
+        assert np.isclose(vector_attrs["VALIDMAX"], np.float32(1.0e5))
         assert vector_attrs["UNITS"] == "nT"
         np.testing.assert_array_equal(
             cdf_file.varget("direction_label"),
@@ -605,11 +630,26 @@ def test_qf(norm_dataset):
     assert output["quality_flags"].attrs["VAR_TYPE"] == "data"
     assert output["quality_flags"].attrs["UNITS"] == "0=good"
     assert (
-        output["quality_flags"].attrs["CATDESC"] == "Data quality flag (0=good, 1=bad)"
+        output["quality_flags"].attrs["CATDESC"]
+        == "Data quality flag. 0: Good data, 1: Bad data."
     )
-    assert output["quality_bitmask"].attrs["FIELDNAM"] == "Data Quality Bitmask"
+    assert output["quality_flags"].attrs["FIELDNAM"] == "Quality Flag"
     assert (
-        "does not decode individual bit meanings"
+        "More detail on the data quality can be found in the quality bitmask."
+        in output["quality_flags"].attrs["VAR_NOTES"]
+    )
+    assert output["quality_bitmask"].attrs["FIELDNAM"] == "Quality Bitmask"
+    assert output["quality_bitmask"].attrs["LABLAXIS"] == "QB"
+    assert output["quality_bitmask"].attrs["CATDESC"] == (
+        "Bitmask indicating when spacecraft related activities influenced "
+        "the measurement."
+    )
+    assert (
+        "Bit 0: Data is sourced from secondary sensor"
+        in output["quality_bitmask"].attrs["VAR_NOTES"]
+    )
+    assert (
+        "Bits 4-7: Reserved for in flight calibration"
         in output["quality_bitmask"].attrs["VAR_NOTES"]
     )
 
@@ -641,12 +681,20 @@ def test_mag_l2_burst_inherits_shared_metadata(norm_dataset, mag_test_l2_data):
     assert burst_dataset["quality_flags"].attrs["VAR_TYPE"] == "data"
     assert burst_dataset["quality_flags"].attrs["UNITS"] == "0=good"
     assert burst_dataset["magnitude"].attrs["VAR_TYPE"] == "data"
+    assert (
+        burst_dataset["magnitude"].attrs["CATDESC"] == "Magnitude of the magnetic field"
+    )
     assert burst_dataset["b_srf"].attrs["UNITS"] == "nT"
+    assert (
+        burst_dataset["b_srf"].attrs["CATDESC"]
+        == "Magnetic field in the Spacecraft Reference Frame (SRF)"
+    )
+    assert burst_dataset["b_srf"].attrs["FIELDNAM"] == "Magnetic Field SRF"
     np.testing.assert_array_equal(
         burst_dataset["direction_label"].data,
         np.array(["Bx", "By", "Bz"]),
     )
     assert (
-        "does not decode individual bit meanings"
+        "Bit 0: Data is sourced from secondary sensor"
         in burst_dataset["quality_bitmask"].attrs["VAR_NOTES"]
     )


### PR DESCRIPTION
## Summary

Address the remaining MAG L2 metadata comments from the SPDF review for:

- `imap_mag_l2_norm-srf`
- shared MAG L2 metadata used by the other norm-frame outputs
- burst output where the same shared metadata path applies

This PR is focused on user-facing metadata cleanup and visibility updates. It does **not** attempt the separate burst record-dimension / time-structure issue.

## Commit Structure

The branch history is intentionally granular and traceable to the original SPDF review comments.

- The main commits are split by SPDF comment number, for example:
  - `(10.1)` `quality_flags`
  - `(10.2)` `quality_bitmask`
  - `(10.3)` `magnitude`
  - `(10.4)` vector units
  - `(10.5)` `direction_label`
  - `(11.2)` shared metadata inheritance into burst
- Those numbered commit messages include the relevant SPDF comment references.
- There is one additional follow-up commit on top of that sequence:
  - `fix(mag): apply MAG team metadata feedback`
  - that commit folds in the MAG team’s requested wording updates and duplicates the earlier vector numeric metadata changes so this branch matches the expected final metadata state.

## What Changed

### Make key MAG variables visible to users

- `quality_flags` is now `VAR_TYPE="data"`
- `magnitude` is now `VAR_TYPE="data"`

This makes both variables visible through CDAWeb-style services and APIs.

### Update quality metadata text

Using the MAG team’s requested wording:

- `quality_flags`
  - `CATDESC`: `Data quality flag. 0: Good data, 1: Bad data.`
  - `FIELDNAM`: `Quality Flag`
  - `UNITS`: `0=good`
  - `VAR_NOTES` now explains the overall binary quality flag and points users to the bitmask for more detail

- `quality_bitmask`
  - `CATDESC`: `Bitmask indicating when spacecraft related activities influenced the measurement.`
  - `FIELDNAM`: `Quality Bitmask`
  - `LABLAXIS`: `QB`
  - `VAR_NOTES` now documents the bit meanings requested by the MAG team:
    - bit 0: secondary sensor
    - bit 1: thruster firing removed
    - bit 2: spacecraft interference impacts data
    - bit 3: instrument signals removed
    - bits 4-7: reserved for in-flight calibration

### Improve vector metadata

- shared vector `UNITS` remains `nT`
- `direction_label` values are now:
  - `Bx`
  - `By`
  - `Bz`

The frame-specific vector metadata also now uses the MAG team’s requested `CATDESC` / `FIELDNAM` wording for:
- `SRF`
- `DSRF`
- `GSE`
- `GSM`
- `RTN`

### Align with earlier MAG numeric metadata changes

To avoid a later merge conflict and keep this branch consistent with the earlier MAG metadata PR, this branch also carries the same shared vector numeric metadata:

- `FORMAT = F13.5`
- `VALIDMIN = -1.0e5`
- `VALIDMAX = 1.0e5`

### Apply the shared metadata cleanup to burst where applicable

This PR does not solve the separate burst structural issue, but it does ensure the shared metadata cleanup above is inherited by burst outputs where that same path is already used.

## Explicit Non-Goal

This PR does **not** implement the separate burst structural/time-axis fix from the SPDF review item about time as the record dimension. That remains deferred pending confirmation on real SDC-produced burst data.

## Testing

Validated locally with:

```bash
pytest -q imap_processing/tests/mag/test_mag_l2.py
pre-commit run --files \
  imap_processing/cdf/config/imap_mag_l2_variable_attrs.yaml \
  imap_processing/tests/mag/test_mag_l2.py