### PR TITLE
fix(codice): address round-2 SPDF metadata comments

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
@@ -171,21 +171,25 @@ multi_flag:
   VAR_TYPE: data
 
 type:
-  CATDESC: Event Type
+  CATDESC: "PHA type code: 0=TCR, 1=DCR, 2=SSD-only"
   DEPEND_0: epoch
   DEPEND_1: priority
   DEPEND_2: event_num
   DICT_KEY: SPASE>Support>SupportQuantity:Other
   DISPLAY_TYPE: no_plot
-  FIELDNAM: Type
+  FIELDNAM: PHA Type Code
   FILLVAL: *uint8_fillval
   FORMAT: I1
   LABL_PTR_1: priority_label
   LABL_PTR_2: event_num_label
   SCALETYP: linear
   UNITS: " "
-  VALIDMAX: 4
+  VALIDMAX: 2
   VALIDMIN: 0
+  VAR_NOTES: >
+    PHA type code for CoDICE-Hi direct events. 0 = TCR (Triple Coincidence
+    Rate; ST+SP+APD), 1 = DCR (Double Coincidence Rate; ST+SP), 2 = SSD-only
+    energy event (SSD only or ST+SSD only).
   VAR_TYPE: data
 
 tof:

--- a/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
@@ -10,16 +10,19 @@ epoch:
   DELTA_PLUS_VAR: epoch_delta_plus
 
 priority:
-  CATDESC: Priority Level
+  CATDESC: Direct-event telemetry priority level (0-5)
   DICT_KEY: SPASE>Support>SupportQuantity:Other
-  FIELDNAM: Priority Level
+  FIELDNAM: Event Priority Level
   FILLVAL: *uint8_fillval
   FORMAT: I1
   LABLAXIS: Priority
   SCALETYP: linear
   UNITS: " "
-  VALIDMAX: 7
+  VALIDMAX: 5
   VALIDMIN: 0
+  VAR_NOTES: >
+    Hi direct-event telemetry priority level. 0 = unused, 1 = DCR, 2 =
+    SSD-only, 3 = Protons, 4 = Helium, 5 = Heavies.
   VAR_TYPE: support_data
 
 event_num:

--- a/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
@@ -83,19 +83,24 @@ num_events:
   VAR_TYPE: data
 
 data_quality:
-  CATDESC: Data Quality Flag per Priority
+  CATDESC: Data Quality Flag per Priority (0=good, 1=suspect)
   DEPEND_0: epoch
   DEPEND_1: priority
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
   DISPLAY_TYPE: no_plot
-  FIELDNAM: Data Quality
+  FIELDNAM: Data Quality Flag
   FILLVAL: *uint16_fillval
-  FORMAT: I3
+  FORMAT: I5
   LABL_PTR_1: priority_label
   SCALETYP: linear
-  UNITS: " "
+  UNITS: 0=good
   VALIDMAX: 255
   VALIDMIN: 0
+  VAR_NOTES: >
+    Quality flag propagated from the packet-level suspect bit for each
+    direct-event priority bin. 0 = good packet group. 1 = suspect packet
+    group. 65535 = fill when no direct-event data are present for the priority
+    bin.
   VAR_TYPE: data
 
 energy_step:

--- a/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
@@ -126,10 +126,10 @@ energy_o:
 
 energy_uh:
   <<: *energy_default
-  CATDESC: Geometric mean energy per nucleon for UH
+  CATDESC: Geometric mean energy per nucleon for Ultra-Heavy ions
   DELTA_MINUS_VAR: energy_uh_minus
   DELTA_PLUS_VAR: energy_uh_plus
-  FIELDNAM: UH Energy
+  FIELDNAM: Ultra-Heavy Energy
 
 # ------------------------------- Label vars --------------------------------
 epoch_delta_minus_label:
@@ -206,8 +206,8 @@ energy_o_label:
   VAR_TYPE: metadata
 
 energy_uh_label:
-  CATDESC: Energy-channel labels for UH differential intensity
-  FIELDNAM: UH Energy Channel Labels
+  CATDESC: Energy-channel labels for Ultra-Heavy differential intensity
+  FIELDNAM: Ultra-Heavy Energy Channel Labels
   FORMAT: A32
   VAR_TYPE: metadata
 
@@ -446,7 +446,7 @@ unc_he4:
   VAR_TYPE: support_data
 
 unc_junk:
-  CATDESC: Uncertainty in differential intensity for Junk at root-2-spaced energy-per-nucleon channels
+  CATDESC: Uncertainty in differential intensity for Junk (unclassified counts) at root-2-spaced energy-per-nucleon channels
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_junk
@@ -460,6 +460,9 @@ unc_junk:
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 4096.0
   VALIDMIN: 0.0
+  VAR_NOTES: >
+    Catch-all uncertainty bin for counts that do not fall into any CoDICE Hi
+    species classification bin.
   VAR_TYPE: support_data
 
 unc_ne_mg_si:
@@ -497,12 +500,12 @@ unc_o:
   VAR_TYPE: support_data
 
 unc_uh:
-  CATDESC: Uncertainty in differential intensity for UH at root-2-spaced energy-per-nucleon channels
+  CATDESC: Uncertainty in differential intensity for Ultra-Heavy ions at root-2-spaced energy-per-nucleon channels
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_uh
   DISPLAY_TYPE: time_series
-  FIELDNAM: Uncertainty - UH
+  FIELDNAM: Uncertainty - Ultra-Heavy
   FILLVAL: *real_fillval
   FORMAT: F32.1
   LABL_PTR_1: energy_uh_label
@@ -603,7 +606,7 @@ he4:
   VAR_TYPE: data
 
 junk:
-  CATDESC: Differential intensity for Junk at root-2-spaced energy-per-nucleon channels
+  CATDESC: Differential intensity for Junk (unclassified counts) at root-2-spaced energy-per-nucleon channels
   DELTA_MINUS_VAR: unc_junk
   DELTA_PLUS_VAR: unc_junk
   DEPEND_0: epoch
@@ -618,6 +621,9 @@ junk:
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 16777216.0
   VALIDMIN: 0.0
+  VAR_NOTES: >
+    Catch-all bin for counts that do not fall into any CoDICE Hi species
+    classification bin.
   VAR_TYPE: data
 
 ne_mg_si:
@@ -657,14 +663,14 @@ o:
   VAR_TYPE: data
 
 uh:
-  CATDESC: Differential intensity for UH at root-2-spaced energy-per-nucleon channels
+  CATDESC: Differential intensity for Ultra-Heavy ions at root-2-spaced energy-per-nucleon channels
   DELTA_MINUS_VAR: unc_uh
   DELTA_PLUS_VAR: unc_uh
   DEPEND_0: epoch
   DEPEND_1: energy_uh
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
   DISPLAY_TYPE: time_series
-  FIELDNAM: Differential Intensity - UH
+  FIELDNAM: Differential Intensity - Ultra-Heavy
   FILLVAL: *real_fillval
   FORMAT: F32.1
   LABL_PTR_1: energy_uh_label

--- a/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
@@ -28,6 +28,7 @@ epoch:
 
 epoch_delta_minus:
   CATDESC: Time from acquisition start to acquisition center
+  DEPEND_0: epoch
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
   FIELDNAM: epoch delta minus
   FILLVAL: *min_int
@@ -41,6 +42,7 @@ epoch_delta_minus:
 
 epoch_delta_plus:
   CATDESC: Time from acquisition center to acquisition end
+  DEPEND_0: epoch
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
   FIELDNAM: epoch delta plus
   FILLVAL: *min_int

--- a/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
@@ -212,18 +212,21 @@ energy_uh_label:
 # --------------------------- Dataset variable attrs ------------------------
 # The following are set in multiple data products
 data_quality:
-  CATDESC: Indicates whether data quality is suspect (1).
+  CATDESC: Data Quality (0=good, 1=suspect)
   DEPEND_0: epoch
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
   DISPLAY_TYPE: time_series
   FIELDNAM: Data Quality
   FILLVAL: *uint8_fillval
-  FORMAT: '%d'
+  FORMAT: I3
   LABLAXIS: Data Quality
   SCALETYP: linear
-  UNITS: ' '
+  UNITS: 0=good
   VALIDMAX: 1
   VALIDMIN: 0
+  VAR_NOTES: >
+    Quality flag propagated from the packet-level suspect bit. 0 = good data.
+    1 = suspect data. 255 = fill when no data are present.
   VAR_TYPE: data
 
 # ----- hi-omni Attributes -----

--- a/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
@@ -26,6 +26,7 @@ epoch:
 
 epoch_delta_minus:
   CATDESC: Time from acquisition start to acquisition center
+  DEPEND_0: epoch
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
   FIELDNAM: epoch delta minus
   FILLVAL: *min_int
@@ -39,6 +40,7 @@ epoch_delta_minus:
 
 epoch_delta_plus:
   CATDESC: Time from acquisition center to acquisition end
+  DEPEND_0: epoch
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
   FIELDNAM: epoch delta plus
   FILLVAL: *min_int

--- a/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
@@ -68,7 +68,7 @@ spin_sector:
   CATDESC: Spin Sector Index
   FIELDNAM: Spin Sector Index
   FILLVAL: *uint8_fillval
-  FORMAT: I3
+  FORMAT: I2
   LABLAXIS: " "
   SCALETYP: linear
   UNITS: " "

--- a/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
@@ -161,18 +161,21 @@ energy_he3he4_label:
 
 # --------------------------- Dataset variable attrs ------------------------
 data_quality:
-  CATDESC: Indicates whether data quality is suspect (1).
+  CATDESC: Data Quality (0=good, 1=suspect)
   DEPEND_0: epoch
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
   DISPLAY_TYPE: time_series
   FIELDNAM: Data Quality
   FILLVAL: *uint8_fillval
-  FORMAT: '%d'
+  FORMAT: I3
   LABLAXIS: Data Quality
   SCALETYP: linear
-  UNITS: ' '
+  UNITS: 0=good
   VALIDMAX: 1
   VALIDMIN: 0
+  VAR_NOTES: >
+    Quality flag propagated from the packet-level suspect bit. 0 = good data.
+    1 = suspect data. 255 = fill when no data are present.
   VAR_TYPE: data
 
 species_dim_attrs: &species_dim_attrs

--- a/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
@@ -10,9 +10,9 @@ epoch:
   DELTA_PLUS_VAR: epoch_delta_plus
 
 priority:
-  CATDESC: Priority Level
+  CATDESC: Direct-event telemetry priority level (0-7)
   DICT_KEY: SPASE>Support>SupportQuantity:Other
-  FIELDNAM: Priority Level
+  FIELDNAM: Event Priority Level
   FILLVAL: *uint8_fillval
   FORMAT: I1
   LABLAXIS: Priority
@@ -20,6 +20,10 @@ priority:
   UNITS: " "
   VALIDMAX: 7
   VALIDMIN: 0
+  VAR_NOTES: >
+    Lo direct-event telemetry priority level. 0 = SW TCR PUIs, 1 = SW H+, 2 =
+    SW He++, 3 = SW Heavies, 4 = SW DCR PUIs, 5 = NSW Heavies, 6 = NSW H+ and
+    He++, 7 = reserved/unused.
   VAR_TYPE: support_data
 
 event_num:

--- a/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
@@ -223,21 +223,25 @@ multi_flag:
   VAR_TYPE: data
 
 type:
-  CATDESC: Event Type
+  CATDESC: "PHA type code: 0=TCR, 1=DCR, 2=APD-only"
   DEPEND_0: epoch
   DEPEND_1: priority
   DEPEND_2: event_num
   DICT_KEY: SPASE>Support>SupportQuantity:Other
   DISPLAY_TYPE: no_plot
-  FIELDNAM: Type
+  FIELDNAM: PHA Type Code
   FILLVAL: *uint8_fillval
   FORMAT: I1
   LABL_PTR_1: priority_label
   LABL_PTR_2: event_num_label
   SCALETYP: linear
   UNITS: " "
-  VALIDMAX: 4
+  VALIDMAX: 2
   VALIDMIN: 0
+  VAR_NOTES: >
+    PHA type code for CoDICE-Lo direct events. 0 = TCR (Triple Coincidence
+    Rate; STA+STB+SP+APD), 1 = DCR (Double Coincidence Rate; STA+STB+SP), 2 =
+    APD-only energy event (APD with only one or two of STA, STB, and SP).
   VAR_TYPE: data
 
 tof:

--- a/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
@@ -81,19 +81,24 @@ num_events:
   VAR_TYPE: data
 
 data_quality:
-  CATDESC: Data Quality Flag per Priority
+  CATDESC: Data Quality Flag per Priority (0=good, 1=suspect)
   DEPEND_0: epoch
   DEPEND_1: priority
   DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
   DISPLAY_TYPE: no_plot
-  FIELDNAM: Data Quality
+  FIELDNAM: Data Quality Flag
   FILLVAL: *uint16_fillval
-  FORMAT: I3
+  FORMAT: I5
   LABL_PTR_1: priority_label
   SCALETYP: linear
-  UNITS: " "
+  UNITS: 0=good
   VALIDMAX: 255
   VALIDMIN: 0
+  VAR_NOTES: >
+    Quality flag propagated from the packet-level suspect bit for each
+    direct-event priority bin. 0 = good packet group. 1 = suspect packet
+    group. 65535 = fill when no direct-event data are present for the priority
+    bin.
   VAR_TYPE: data
 
 energy_step:

--- a/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
@@ -98,7 +98,7 @@ lo-pui-species-attrs:
     VAR_TYPE: data
 
 lo-sw-species-attrs:
-  CATDESC: "Differential intensity for sunward solar-wind {species_display}"
+  CATDESC: "Differential intensity from sunward-looking detectors measuring solar-wind {species_display}"
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
@@ -152,7 +152,7 @@ lo-pui-species-unc-attrs:
     VAR_TYPE: data
 
 lo-sw-species-unc-attrs:
-    CATDESC: "Uncertainty in differential intensity for sunward solar-wind {species_display}"
+    CATDESC: "Uncertainty in differential intensity from sunward-looking detectors measuring solar-wind {species_display}"
     DEPEND_0: epoch
     DEPEND_1: esa_step
     DEPEND_2: spin_sector

--- a/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
@@ -40,6 +40,25 @@ elevation_angle_label:
   FORMAT: A6
   VAR_TYPE: metadata
 
+# --------------------------- Dataset variable attrs ------------------------
+data_quality:
+  CATDESC: Data Quality (0=good, 1=suspect)
+  DEPEND_0: epoch
+  DICT_KEY: SPASE>Support>SupportQuantity:DataQuality
+  DISPLAY_TYPE: time_series
+  FIELDNAM: Data Quality
+  FILLVAL: *uint8_fillval
+  FORMAT: I3
+  LABLAXIS: Data Quality
+  SCALETYP: linear
+  UNITS: 0=good
+  VALIDMAX: 1
+  VALIDMIN: 0
+  VAR_NOTES: >
+    Quality flag propagated from the packet-level suspect bit. 0 = good data.
+    1 = suspect data. 255 = fill when no data are present.
+  VAR_TYPE: data
+
 # ------------------------------- species -------------------------------
 # lo species attrs
 lo-species-attrs:

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -50,7 +50,7 @@ HI_SPECIES_DISPLAY_NAMES = {
     "o": "O",
     "fe": "Fe",
     "ne_mg_si": "Ne+Mg+Si",
-    "uh": "UH",
+    "uh": "Ultra-Heavy",
     "junk": "Junk",
 }
 

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -909,7 +909,13 @@ def process_hi_sectored(dependencies: ProcessingInputCollection) -> xr.Dataset:
     # Overwrite L1B variable attributes with L2 variable attributes
     l2_dataset = xr.Dataset(
         coords={
-            "spin_sector": l1b_dataset["spin_sector"],
+            "spin_sector": xr.DataArray(
+                l1b_dataset["spin_sector"].values,
+                dims=("spin_sector",),
+                attrs=cdf_attrs.get_variable_attributes(
+                    "spin_sector", check_schema=False
+                ),
+            ),
             "spin_sector_label": xr.DataArray(
                 l1b_dataset["spin_sector"].values.astype(str),
                 dims=("spin_sector",),

--- a/imap_processing/tests/codice/test_codice_hi_l2.py
+++ b/imap_processing/tests/codice/test_codice_hi_l2.py
@@ -136,6 +136,12 @@ def test_l2_hi_omni(mock_get_file_paths):
         energy_h_attrs = cdf_file.varattsget("energy_h")
         assert energy_h_attrs["CATDESC"] == "Geometric mean energy per nucleon for H"
         assert energy_h_attrs["FIELDNAM"] == "H Energy"
+        energy_junk_label_attrs = cdf_file.varattsget("energy_junk_label")
+        assert (
+            energy_junk_label_attrs["CATDESC"]
+            == "Energy-channel labels for Junk differential intensity"
+        )
+        assert energy_junk_label_attrs["FIELDNAM"] == "Junk Energy Channel Labels"
         h_attrs = cdf_file.varattsget("h")
         assert h_attrs["CATDESC"] == (
             "Differential intensity for H at root-2-spaced energy-per-nucleon channels"
@@ -149,6 +155,31 @@ def test_l2_hi_omni(mock_get_file_paths):
             "energy-per-nucleon channels"
         )
         assert unc_h_attrs["FIELDNAM"] == "Uncertainty - H"
+        junk_attrs = cdf_file.varattsget("junk")
+        assert junk_attrs["CATDESC"] == (
+            "Differential intensity for Junk (unclassified counts) at root-2-spaced "
+            "energy-per-nucleon channels"
+        )
+        assert junk_attrs["FIELDNAM"] == "Differential Intensity - Junk"
+        assert junk_attrs["VAR_NOTES"].strip() == (
+            "Catch-all bin for counts that do not fall into any CoDICE Hi "
+            "species classification bin."
+        )
+        unc_junk_attrs = cdf_file.varattsget("unc_junk")
+        assert unc_junk_attrs["CATDESC"] == (
+            "Uncertainty in differential intensity for Junk (unclassified counts) "
+            "at root-2-spaced energy-per-nucleon channels"
+        )
+        assert unc_junk_attrs["VAR_NOTES"].strip() == (
+            "Catch-all uncertainty bin for counts that do not fall into any "
+            "CoDICE Hi species classification bin."
+        )
+        uh_attrs = cdf_file.varattsget("uh")
+        assert uh_attrs["CATDESC"] == (
+            "Differential intensity for Ultra-Heavy ions at root-2-spaced "
+            "energy-per-nucleon channels"
+        )
+        assert uh_attrs["FIELDNAM"] == "Differential Intensity - Ultra-Heavy"
         np.testing.assert_array_equal(
             cdf_file.varget("energy_h_label"),
             _expected_hi_energy_labels("h", processed_l2["energy_h"].values),

--- a/imap_processing/tests/codice/test_codice_hi_l2.py
+++ b/imap_processing/tests/codice/test_codice_hi_l2.py
@@ -283,6 +283,9 @@ def test_l2_hi_sectored(mock_get_file_paths):
     with cdflib.CDF(sectored_cdf_file) as cdf_file:
         data_quality_attrs = cdf_file.varattsget("data_quality")
         assert data_quality_attrs["VAR_TYPE"] == "data"
+        assert data_quality_attrs["FORMAT"] == "I3"
+        spin_sector_attrs = cdf_file.varattsget("spin_sector")
+        assert spin_sector_attrs["FORMAT"] == "I2"
         assert cdf_file.varattsget("energy_h")["FORMAT"] == "F12.6"
         assert cdf_file.varattsget("energy_h_minus")["FORMAT"] == "F12.6"
         assert cdf_file.varattsget("energy_h_plus")["FORMAT"] == "F12.6"

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -667,6 +667,28 @@ def test_codice_l2_direct_events_display_type_cdf_metadata(
             attrs = cdf_file.varattsget("energy_per_nuc")
             assert attrs["DEPEND_1"] == "priority"
             assert attrs["LABL_PTR_1"] == "priority_label"
+            priority_attrs = cdf_file.varattsget("priority")
+            assert (
+                priority_attrs["CATDESC"]
+                == "Direct-event telemetry priority level (0-5)"
+            )
+            assert (
+                priority_attrs["VAR_NOTES"].strip()
+                == "Hi direct-event telemetry priority level. 0 = unused, 1 = "
+                "DCR, 2 = SSD-only, 3 = Protons, 4 = Helium, 5 = Heavies."
+            )
+        else:
+            priority_attrs = cdf_file.varattsget("priority")
+            assert (
+                priority_attrs["CATDESC"]
+                == "Direct-event telemetry priority level (0-7)"
+            )
+            assert (
+                priority_attrs["VAR_NOTES"].strip()
+                == "Lo direct-event telemetry priority level. 0 = SW TCR PUIs, "
+                "1 = SW H+, 2 = SW He++, 3 = SW Heavies, 4 = SW DCR PUIs, 5 = "
+                "NSW Heavies, 6 = NSW H+ and He++, 7 = reserved/unused."
+            )
 
         type_attrs = cdf_file.varattsget("type")
         assert type_attrs["FIELDNAM"] == "PHA Type Code"

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -667,3 +667,25 @@ def test_codice_l2_direct_events_display_type_cdf_metadata(
             attrs = cdf_file.varattsget("energy_per_nuc")
             assert attrs["DEPEND_1"] == "priority"
             assert attrs["LABL_PTR_1"] == "priority_label"
+
+        type_attrs = cdf_file.varattsget("type")
+        assert type_attrs["FIELDNAM"] == "PHA Type Code"
+        assert type_attrs["VALIDMAX"] == 2
+        if descriptor == "hi-direct-events":
+            assert type_attrs["CATDESC"] == "PHA type code: 0=TCR, 1=DCR, 2=SSD-only"
+            assert (
+                type_attrs["VAR_NOTES"].strip()
+                == "PHA type code for CoDICE-Hi direct events. 0 = TCR "
+                "(Triple Coincidence Rate; ST+SP+APD), 1 = DCR "
+                "(Double Coincidence Rate; ST+SP), 2 = SSD-only energy event "
+                "(SSD only or ST+SSD only)."
+            )
+        else:
+            assert type_attrs["CATDESC"] == "PHA type code: 0=TCR, 1=DCR, 2=APD-only"
+            assert (
+                type_attrs["VAR_NOTES"].strip()
+                == "PHA type code for CoDICE-Lo direct events. 0 = TCR "
+                "(Triple Coincidence Rate; STA+STB+SP+APD), 1 = DCR "
+                "(Double Coincidence Rate; STA+STB+SP), 2 = APD-only energy "
+                "event (APD with only one or two of STA, STB, and SP)."
+            )

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -473,13 +473,16 @@ def test_codice_l2_sw_species_intensity(mock_get_file_paths, codice_lut_path):
     with cdflib.CDF(cdf_path) as cdf_file:
         hplus_attrs = cdf_file.varattsget("hplus")
         assert (
-            hplus_attrs["CATDESC"] == "Differential intensity for sunward solar-wind H+"
+            hplus_attrs["CATDESC"]
+            == "Differential intensity from sunward-looking detectors measuring "
+            "solar-wind H+"
         )
         assert hplus_attrs["FIELDNAM"] == "Sunward Differential Intensity - H+"
         unc_hplus_attrs = cdf_file.varattsget("unc_hplus")
         assert (
             unc_hplus_attrs["CATDESC"]
-            == "Uncertainty in differential intensity for sunward solar-wind H+"
+            == "Uncertainty in differential intensity from sunward-looking "
+            "detectors measuring solar-wind H+"
         )
         assert unc_hplus_attrs["FIELDNAM"] == "Sunward Uncertainty - H+"
         for var in ["nso_esa_step", "nso_spin_sector"]:


### PR DESCRIPTION
## Summary

Address the remaining round-2 SPDF metadata comments for these CoDICE L2 products:

- `imap_codice_l2_hi-direct-events`
- `imap_codice_l2_lo-direct-events`
- `imap_codice_l2_hi-omni`
- `imap_codice_l2_hi-sectored`
- `imap_codice_l2_lo-sw-species`

This PR is focused on metadata clarification and presentation. It folds in the follow-up clarifications we got back from the CoDICE team, especially for direct-event `type` and `priority`.

## Commit Structure

The branch history is intentionally granular and traceable to the original SPDF review comments.

- Commit subjects include the SPDF comment number(s), for example:
  - `(1.1, 4.1)` direct-event `type`
  - `(1.3, 4.1)` direct-event `priority`
  - `(2.4)` `junk` / `UH`
  - `(5.1)` `sw` wording
- The commit bodies include the original SPDF reviewer comment text for the item they address.
- Where later CoDICE-team clarifications changed the wording, those updates were folded back into the existing numbered commits rather than added as separate follow-up commits.

## What Changed

### Direct-event `type` metadata

For both Hi and Lo direct-events, the `type` variable now documents the confirmed PHA/event-class mappings.

Hi:
- `0 = TCR`
- `1 = DCR`
- `2 = SSD-only`

Lo:
- `0 = TCR`
- `1 = DCR`
- `2 = APD-only`

`VAR_NOTES` now expands the acronyms and gives the detector-level meaning:

- `TCR = Triple Coincidence Rate`
- `DCR = Double Coincidence Rate`
- `SSD = Solid-State Detector`
- `APD = Avalanche Photodiode`

This also tightens `VALIDMAX` for direct-event `type` to `2`.

### Direct-event `priority` metadata

Hi direct-events now document the confirmed mapping:

- `0 = unused`
- `1 = DCR`
- `2 = SSD-only`
- `3 = Protons`
- `4 = Helium`
- `5 = Heavies`

Lo direct-events now document the full current `0..7` priority axis using the follow-up CoDICE-team clarification:

- `0 = SW TCR PUIs`
- `1 = SW H+`
- `2 = SW He++`
- `3 = SW Heavies`
- `4 = SW DCR PUIs`
- `5 = NSW Heavies`
- `6 = NSW H+ and He++`
- `7 = reserved/unused`

This keeps `VALIDMAX = 7` for Lo, which matches both the implementation and production files.

### Direct-event `data_quality` metadata

For Hi and Lo direct-events:

- `FORMAT` is `I5`
- `CATDESC` includes the quality shorthand
- `VAR_NOTES` documents the flag meaning and fill handling

### Hi omni / Hi sectored / Lo SW species `data_quality`

For the intensity products:

- normalized `data_quality` metadata
- `FORMAT = I3`
- consistent `CATDESC` / `VAR_NOTES` wording

### `epoch_delta_*` metadata

For Hi omni and Hi sectored:

- `epoch_delta_minus`
- `epoch_delta_plus`

now explicitly include `DEPEND_0 = epoch`, matching the SPDF requirement for those record-varying time-offset variables.

### `junk` and `UH` wording in Hi omni

- `UH` is now explicitly described as `Ultra-Heavy ions`
- `junk` remains `Junk`, but now explains that it is the unclassified-counts bin for events that do not fall into the CoDICE Hi species classification bins

### Lo SW species wording

This PR keeps the dataset interpretation as `sw = Sunward`, but makes the variable descriptions more explicit.

The relevant `CATDESC` text now uses wording of the form:

- `Differential intensity from sunward-looking detectors measuring solar-wind ...`
- `Uncertainty in differential intensity from sunward-looking detectors measuring solar-wind ...`

This reflects the CoDICE-team clarification that the detectors are sunward-looking while the measured ions are solar-wind species.

### Hi sectored spin metadata

- `spin_sector` now uses `FORMAT = I2`

## Explicit Non-Change

SPDF comment `(3.2)` about `spin_angle` was reviewed again and intentionally not implemented here.

`spin_angle` remains `VAR_TYPE="support_data"`.

The branch does not include any `spin_angle` promotion or shape change.

## Testing

Validated locally with:

```bash
pytest -q imap_processing/tests/codice/test_codice_hi_l2.py
pytest -q imap_processing/tests/codice/test_codice_l2.py -k 'hi_de or lo_de or direct_events or sw_species or hi_omni'
pre-commit run --files \
  imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml \
  imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml \
  imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml \
  imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml \
  imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml \
  imap_processing/tests/codice/test_codice_hi_l2.py \
  imap_processing/tests/codice/test_codice_l2.py