### PR TITLE
Fix/istp glows hist round2

### DIFF
--- a/imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml
@@ -10,7 +10,9 @@ instrument_base: &instrument_base
     of the modulation of heliospheric backscatter glow of ISN H (the helioglow)
     along a scanning circle in the sky.
     GLOWS design and assembly is led by the Space Research Center, Warsaw, Poland
-    (CBK PAN). See https://imap.princeton.edu/instruments/glows for more details.
+    (CBK PAN). See
+    https://imap.princeton.edu/spacecraft/instruments/global-solar-wind-structure-glows
+    for more details.
 
 imap_glows_l1a_hist:
   <<: *instrument_base

--- a/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
@@ -21,10 +21,6 @@ default_attrs: &default_attrs
   # TODO: Remove unneeded attributes once SAMMI is fixed
   DISPLAY_TYPE: no_plot
   FILLVAL: *int_fillval
-  REFERENCE_POSITION: Rotating Earth Geoid
-  RESOLUTION: ' '
-  TIME_BASE: J2000
-  TIME_SCALE: Terrestrial Time
   UNITS: ' '
   VALIDMIN: *min_epoch
 
@@ -33,7 +29,6 @@ support_data_defaults: &support_data_defaults
   DEPEND_0: epoch
   DISPLAY_TYPE: time_series
   FORMAT: I10
-  RESOLUTION: ISO8601
   VALIDMAX: 1
   VALIDMIN: 0
   VAR_TYPE: support_data
@@ -44,6 +39,10 @@ time_data_defaults: &time_data_defaults
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal
   FILLVAL: ' '
   FORMAT: A30
+  REFERENCE_POSITION: Rotating Earth Geoid
+  RESOLUTION: ISO8601
+  TIME_BASE: J2000
+  TIME_SCALE: Terrestrial Time
   UNITS: N/A
   VALIDMAX: ' '
   VALIDMIN: ' '

--- a/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
@@ -409,6 +409,7 @@ bad_time_flag_occurrences:
   LABL_PTR_1: flags_label # MS: I do not understand this
   VALIDMAX: 65535
   VALIDMIN: 0
+  VAR_TYPE: data
 
 spin_angle:
   <<: *lightcurve_defaults
@@ -491,7 +492,7 @@ histogram_flag_array:
   UNITS: ' '
   VALIDMAX: 15 # only 4 bits currently used
   VALIDMIN: 0
-  VAR_TYPE: support_data
+  VAR_TYPE: data
 
 ecliptic_lon:
   <<: *lightcurve_defaults

--- a/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml
@@ -121,9 +121,9 @@ total_l1b_inputs:
 
 identifier:
   <<: *support_data_defaults
-  CATDESC: Spin pointing number to identify observational day
+  CATDESC: Spin-axis pointing number to identify observational day
   DICT_KEY: SPASE>Support>SupportQuantity:Temporal
-  FIELDNAM: Spin pointing number
+  FIELDNAM: Spin-axis pointing number
   FILLVAL: -9223372036854775808
   FORMAT: I5
   LABLAXIS: Pointing no.

--- a/imap_processing/glows/l2/glows_l2.py
+++ b/imap_processing/glows/l2/glows_l2.py
@@ -183,7 +183,7 @@ def create_l2_dataset(
     )
 
     flags = xr.DataArray(
-        np.ones(FLAG_LENGTH, dtype=np.uint8),
+        np.arange(FLAG_LENGTH, dtype=np.uint8),
         dims=["flags"],
         attrs=attrs.get_variable_attributes("flags_dim", check_schema=False),
     )

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -231,6 +231,7 @@ def test_glows_l2_cdf_metadata(
         bins_label_attrs = cdf_file.varattsget("bins_label")
         bins_label_values = cdf_file.varget("bins_label")
         flags_values = cdf_file.varget("flags")
+        identifier_attrs = cdf_file.varattsget("identifier")
         flags_label_info = cdf_file.varinq("flags_label")
         flags_label_attrs = cdf_file.varattsget("flags_label")
         flags_label_values = cdf_file.varget("flags_label")
@@ -259,6 +260,11 @@ def test_glows_l2_cdf_metadata(
         assert bad_time_info.Data_Type_Description == "CDF_UINT2"
         assert bad_time_attrs["FORMAT"] == "I5"
         assert bad_time_attrs["VAR_TYPE"] == "data"
+        assert (
+            identifier_attrs["CATDESC"]
+            == "Spin-axis pointing number to identify observational day"
+        )
+        assert identifier_attrs["FIELDNAM"] == "Spin-axis pointing number"
         for attr_name in (
             "TIME_BASE",
             "TIME_SCALE",
@@ -274,6 +280,10 @@ def test_glows_l2_cdf_metadata(
             assert time_attrs["RESOLUTION"] == "ISO8601"
 
         assert global_attrs["flight_software_version"] == ["131329"]
+        assert (
+            "https://imap.princeton.edu/spacecraft/instruments/"
+            "global-solar-wind-structure-glows" in global_attrs["TEXT"][0]
+        )
 
 
 @patch.object(HistogramL2, "compute_position_angle", return_value=42.0)

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -235,6 +235,9 @@ def test_glows_l2_cdf_metadata(
         flags_label_values = cdf_file.varget("flags_label")
         bad_time_info = cdf_file.varinq("bad_time_flag_occurrences")
         bad_time_attrs = cdf_file.varattsget("bad_time_flag_occurrences")
+        photon_flux_attrs = cdf_file.varattsget("photon_flux")
+        start_time_attrs = cdf_file.varattsget("start_time")
+        end_time_attrs = cdf_file.varattsget("end_time")
         global_attrs = cdf_file.globalattsget()
 
         assert bins_label_info.Data_Type_Description == "CDF_CHAR"
@@ -253,6 +256,20 @@ def test_glows_l2_cdf_metadata(
 
         assert bad_time_info.Data_Type_Description == "CDF_UINT2"
         assert bad_time_attrs["FORMAT"] == "I5"
+        for attr_name in (
+            "TIME_BASE",
+            "TIME_SCALE",
+            "REFERENCE_POSITION",
+            "RESOLUTION",
+        ):
+            assert attr_name not in photon_flux_attrs
+
+        for time_attrs in (start_time_attrs, end_time_attrs):
+            assert time_attrs["TIME_BASE"] == "J2000"
+            assert time_attrs["TIME_SCALE"] == "Terrestrial Time"
+            assert time_attrs["REFERENCE_POSITION"] == "Rotating Earth Geoid"
+            assert time_attrs["RESOLUTION"] == "ISO8601"
+
         assert global_attrs["flight_software_version"] == ["131329"]
 
 

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -230,6 +230,7 @@ def test_glows_l2_cdf_metadata(
         bins_label_info = cdf_file.varinq("bins_label")
         bins_label_attrs = cdf_file.varattsget("bins_label")
         bins_label_values = cdf_file.varget("bins_label")
+        flags_values = cdf_file.varget("flags")
         flags_label_info = cdf_file.varinq("flags_label")
         flags_label_attrs = cdf_file.varattsget("flags_label")
         flags_label_values = cdf_file.varget("flags_label")
@@ -244,6 +245,7 @@ def test_glows_l2_cdf_metadata(
         assert bins_label_attrs["FORMAT"] == "A4"
         assert list(bins_label_values[:5]) == ["0", "1", "2", "3", "4"]
 
+        np.testing.assert_array_equal(flags_values, np.arange(len(BAD_TIME_FLAG_NAMES)))
         assert flags_label_info.Data_Type_Description == "CDF_CHAR"
         assert flags_label_attrs["FORMAT"] == "A42"
         assert list(flags_label_values) == list(BAD_TIME_FLAG_NAMES)

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -258,6 +258,7 @@ def test_glows_l2_cdf_metadata(
 
         assert bad_time_info.Data_Type_Description == "CDF_UINT2"
         assert bad_time_attrs["FORMAT"] == "I5"
+        assert bad_time_attrs["VAR_TYPE"] == "data"
         for attr_name in (
             "TIME_BASE",
             "TIME_SCALE",
@@ -323,6 +324,7 @@ def test_glows_l2_cdf_fillvals(
 
         assert histogram_flag_info.Data_Type_Description == "CDF_UINT1"
         assert histogram_flag_attrs["FILLVAL"] == np.uint8(255)
+        assert histogram_flag_attrs["VAR_TYPE"] == "data"
         assert number_of_bins_info.Data_Type_Description == "CDF_UINT2"
         assert number_of_bins_attrs["FILLVAL"] == np.uint16(65535)
         assert photon_flux_info.Data_Type_Description == "CDF_DOUBLE"


### PR DESCRIPTION
## Summary

Address the remaining round-2 SPDF metadata comments for `imap_glows_l2_hist`.

This PR focuses on the L2 histogram metadata cleanup discussed in the SPDF review, plus two small follow-up wording/global-metadata updates from the later GLOWS email thread that also apply to L2.

## Commit Structure

The branch history is intentionally granular and traceable to the original SPDF review comments.

- The main commits are split by SPDF comment number:
  - `(6.1)` remove time-only attrs from non-time variables
  - `(6.2)` fix `flags` coordinate values
  - `(6.3)` expose key histogram quality variables
- Those numbered commit messages include the SPDF comment references they address.
- There is one small follow-up commit on top:
  - `fix(glows): apply follow-up metadata wording updates`
  - this folds in the later GLOWS email-chain items that clearly apply to L2:
    - corrected shared GLOWS instrument URL
    - `identifier` wording updated to “Spin-axis pointing number”

## What Changed

### Remove time-only attrs from non-time variables

The L2 variable-attr defaults were narrowed so time-only metadata no longer appears on non-time variables.

In particular, attributes like:
- `TIME_BASE`
- `TIME_SCALE`
- `REFERENCE_POSITION`
- `RESOLUTION`

remain on the actual time-like variables:
- `start_time`
- `end_time`

but are no longer carried by non-time science variables such as `photon_flux`.

### Fix the `flags` coordinate values

The `flags` coordinate is the index axis for the bad-time flag counters, not a binary good/bad value array.

This PR changes the `flags` coordinate from all ones to the intended index range:
- `0..16`

That matches:
- `FLAG_LENGTH = 17`
- the `BAD_TIME_FLAG_NAMES` list
- the `flags_label` variable written alongside it

### Expose the key histogram quality/context variables

The two L2 variables that SPDF called out as important for interpreting the histogram products are now visible as `data` variables:

- `histogram_flag_array`
- `bad_time_flag_occurrences`

This keeps them available in user-facing interfaces and APIs alongside the main histogram products.

### Follow-up GLOWS wording/global-metadata updates

From the later email chain, this PR also applies the two L2-relevant follow-ups:

- update the shared GLOWS instrument URL in the global attrs to the current official IMAP GLOWS page
- rename the L2 `identifier` metadata from:
  - `Spin pointing number`
  to:
  - `Spin-axis pointing number`

## Explicit Non-Change

The “Primary variables” PDF classification remains unchanged in this PR.

The `cdf_to_pdf` script only places variables under “Primary variables” when they carry:
- `VARIABLE_PURPOSE = PRIMARY_VAR`

GLOWS L2 does not currently set that metadata, so the PDF still shows an empty “Primary variables” section. This PR does not change that behavior.

## Testing

Validated locally with:

```bash
pytest -q imap_processing/tests/glows/test_glows_l2.py
pre-commit run --files \
  imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml \
  imap_processing/cdf/config/imap_glows_l2_variable_attrs.yaml \
  imap_processing/glows/l2/glows_l2.py \
  imap_processing/tests/glows/test_glows_l2.py