### PR TITLE
Exposure time calculation based on histrates data

### DIFF
--- a/imap_processing/_version.py
+++ b/imap_processing/_version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced later during substitution.
-__version__ = "0.0.0"
-__version_tuple__ = (0, 0, 0)
+__version__ = "1.0.25.post144.dev0+470bf864"
+__version_tuple__ = (1, 0, 25, "post144", "dev0", "470bf864")

--- a/imap_processing/_version.py
+++ b/imap_processing/_version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced later during substitution.
-__version__ = "1.0.25.post144.dev0+470bf864"
-__version_tuple__ = (1, 0, 25, "post144", "dev0", "470bf864")
+__version__ = "0.0.0"
+__version_tuple__ = (0, 0, 0)

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1247,6 +1247,9 @@ class Lo(ProcessInstrument):
             science_files += dependencies.get_file_paths(
                 source="lo", data_type="l1b", descriptor="bgrates"
             )
+            science_files += dependencies.get_file_paths(
+                source="lo", data_type="l1b", descriptor="histrates"
+            )
             for file in science_files:
                 dataset = load_cdf(file)
                 data_dict[dataset.attrs["Logical_source"]] = dataset

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -8,7 +8,6 @@ import numpy as np
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
-from imap_processing.lo.constants import LoConstants
 from imap_processing.ena_maps.utils.corrections import (
     add_spacecraft_position_and_velocity_to_pset,
 )
@@ -164,7 +163,6 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         pset["exposure_time"] = calculate_exposure_times(
             sci_dependencies["imap_lo_l1b_histrates"],
             sci_dependencies["imap_lo_l1b_goodtimes"],
-            sci_dependencies.get("imap_lo_l1b_bgrates"),
         )
 
         # Set backgrounds
@@ -489,21 +487,17 @@ def create_pset_counts(
 
 
 def calculate_exposure_times(
-    histrates_ds: xr.Dataset,
-    goodtimes_ds: xr.Dataset,
-    bgrates_ds: xr.Dataset | None = None,
+    histrates_ds: xr.Dataset, goodtimes_ds: xr.Dataset
 ) -> xr.DataArray:
     """
     Calculate exposure times from L1B histrates summed over good-time epochs.
 
-    Mirrors the alternate quicklook pipeline (3S2_l1b_quickmaps/l1b_to_spin.py):
-    sums exposure_time_6deg from the L1B histrates dataset over epochs that fall
+    Sum exposure_time_6deg from the L1B histrates dataset over epochs that fall
     within good-time windows, then expands to the full PSET grid.
 
-    The 60-bin (6°) spin dimension is expanded to 3600 bins (0.1°) by dividing
+    The 60-bin (6 deg) spin dimension is expanded to 3600 bins (0.1 deg) by dividing
     each value by 60 and repeating, preserving per-bin exposure. The off_angle
-    dimension is filled uniformly (no boresight-sampling weighting) by dividing
-    by N_OFF_ANGLE_BINS and broadcasting.
+    dimension is filled uniformly by dividing by N_OFF_ANGLE_BINS and broadcasting.
 
     Parameters
     ----------
@@ -512,16 +506,12 @@ def calculate_exposure_times(
         shape (n_epochs, esa_step, spin_bin_6).
     goodtimes_ds : xr.Dataset
         L1B goodtimes dataset containing gt_start_met and gt_end_met.
-    bgrates_ds : xr.Dataset, optional
-        L1B bgrates dataset. If provided, h_synthetic_floor is used as a
-        cross-check against the histrates-derived total exposure.
 
     Returns
     -------
     exposure_time : xr.DataArray
         Shape (1, N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS).
     """
-    # Filter histrates epochs to good-time windows (same logic as filter_goodtimes)
     epochs = histrates_ds["epoch"].values
     gt_starts = met_to_ttj2000ns(goodtimes_ds["gt_start_met"].values)
     gt_ends = met_to_ttj2000ns(goodtimes_ds["gt_end_met"].values)
@@ -538,40 +528,9 @@ def calculate_exposure_times(
         )
         return xr.DataArray(data=np.zeros(PSET_SHAPE, dtype=np.float32), dims=PSET_DIMS)
 
-    # Sum exposure_time_6deg over good-time epochs → shape (7, 60)
+    # Sum exposure_time_6deg over good-time epochs; shape (7, 60)
     exposure_6deg = histrates_ds["exposure_time_6deg"].values[in_goodtime]
     exposure_sum = exposure_6deg.sum(axis=0)  # (7, 60)
-
-    # Cross-check: total exposure from histrates vs h_synthetic_floor / BG_RATES["H"]
-    if bgrates_ds is not None and "h_synthetic_floor" in bgrates_ds:
-        h_bg_rate = LoConstants.BG_RATES["H"]
-        # h_synthetic_floor accumulates BG_RATES["H"] * HISTOGRAM_CYCLE_EPOCHS
-        # * N_CYCLE_AVE * EXPOSURE_FACTOR per good-time step, so dividing by
-        # BG_RATES["H"] alone gives N_CYCLE_AVE * EXPOSURE_FACTOR times the
-        # per-cycle physical exposure.  Divide out that factor to get a quantity
-        # comparable to histrates_total (which sums actual spin-duration-based
-        # exposure without any averaging-window or EXPOSURE_FACTOR scaling).
-        floor_exposure = (
-            float(bgrates_ds["h_synthetic_floor"].values[0])
-            / h_bg_rate
-            / (LoConstants.N_CYCLE_AVE * LoConstants.EXPOSURE_FACTOR)
-        )
-        histrates_total = float(exposure_sum.sum())
-        ratio = histrates_total / floor_exposure if floor_exposure > 0 else float("nan")
-        if abs(ratio - 1.0) > 0.02:
-            logging.warning(
-                f"Exposure cross-check mismatch: histrates total={histrates_total:.1f}s, "
-                f"synthetic_floor-derived={floor_exposure:.1f}s (ratio={ratio:.3f}). "
-                "Values should agree within ~2%."
-            )
-        else:
-            logging.debug(
-                f"Exposure cross-check OK: histrates total={histrates_total:.1f}s, "
-                f"synthetic_floor-derived={floor_exposure:.1f}s (ratio={ratio:.3f})"
-            )
-
-    # Expand 60 spin bins → 3600 by dividing by 60 and repeating
-    # (each 6° bin maps to sixty 0.1° bins, preserving per-bin exposure)
     exposure_3600 = np.repeat(exposure_sum / 60.0, 60, axis=1)  # (7, 3600)
 
     # Distribute uniformly across 40 off-angle bins

--- a/imap_processing/lo/l1c/lo_l1c.py
+++ b/imap_processing/lo/l1c/lo_l1c.py
@@ -5,20 +5,19 @@ from dataclasses import Field
 from enum import Enum
 
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
+from imap_processing.lo.constants import LoConstants
 from imap_processing.ena_maps.utils.corrections import (
     add_spacecraft_position_and_velocity_to_pset,
 )
 from imap_processing.spice.geometry import (
     SpiceFrame,
     frame_transform_az_el,
-    lo_instrument_pointing,
 )
 from imap_processing.spice.repoint import get_pointing_times_from_id
-from imap_processing.spice.spin import get_spin_data, get_spin_number
+from imap_processing.spice.spin import get_spin_number
 from imap_processing.spice.time import (
     met_to_ttj2000ns,
     ttj2000ns_to_et,
@@ -37,14 +36,6 @@ SPIN_ANGLE_BIN_EDGES = np.linspace(0, 360, N_SPIN_ANGLE_BINS + 1)
 SPIN_ANGLE_BIN_CENTERS = (SPIN_ANGLE_BIN_EDGES[:-1] + SPIN_ANGLE_BIN_EDGES[1:]) / 2
 OFF_ANGLE_BIN_EDGES = np.linspace(-2, 2, N_OFF_ANGLE_BINS + 1)
 OFF_ANGLE_BIN_CENTERS = (OFF_ANGLE_BIN_EDGES[:-1] + OFF_ANGLE_BIN_EDGES[1:]) / 2
-
-# Constants for statistical exposure time calculation
-# Number of time samples per spin to capture all potential timesteps
-N_SAMPLES_PER_SPIN = 4096
-# Default number of representative spins to sample across the pointing
-DEFAULT_N_REPRESENTATIVE_SPINS = 5
-# Nominal Lo pivot angle in degrees
-LO_NOMINAL_PIVOT_ANGLE = 90.0
 
 
 class FilterType(str, Enum):
@@ -169,12 +160,11 @@ def lo_l1c(sci_dependencies: dict, anc_dependencies: list) -> list[xr.Dataset]:
         pset["h_counts"] = create_pset_counts(l1b_goodtimes_only, FilterType.HYDROGEN)
         pset["o_counts"] = create_pset_counts(l1b_goodtimes_only, FilterType.OXYGEN)
 
-        # Set the exposure time using statistical off-pointing sampling
-        # with good-times filtering applied
+        # Set the exposure time from L1B histrates summed over good-time epochs
         pset["exposure_time"] = calculate_exposure_times(
-            pointing_start_met,
-            pointing_end_met,
+            sci_dependencies["imap_lo_l1b_histrates"],
             sci_dependencies["imap_lo_l1b_goodtimes"],
+            sci_dependencies.get("imap_lo_l1b_bgrates"),
         )
 
         # Set backgrounds
@@ -498,394 +488,105 @@ def create_pset_counts(
     return counts
 
 
-def get_representative_spin_times(
-    pointing_start_met: float,
-    pointing_end_met: float,
-    n_spins: int = DEFAULT_N_REPRESENTATIVE_SPINS,
-) -> pd.DataFrame:
-    """
-    Get evenly-spaced representative spin times from the pointing period.
-
-    Selects N spins distributed evenly across the middle 80% of the pointing
-    duration (skipping the first and last 10%) by querying the spin table for
-    spins at evenly-spaced MET times.
-
-    Parameters
-    ----------
-    pointing_start_met : float
-        The start MET time of the pointing.
-    pointing_end_met : float
-        The end MET time of the pointing.
-    n_spins : int, optional
-        Number of representative spins to select. Default is 5.
-
-    Returns
-    -------
-    representative_spins : pandas.DataFrame
-        DataFrame containing the spin table data for the selected representative
-        spins, including columns: spin_number, spin_start_met, actual_spin_period.
-    """
-    spin_df = get_spin_data()
-
-    # Filter spin table to only spins within the pointing period
-    pointing_spins = spin_df[
-        (spin_df["spin_start_met"] >= pointing_start_met)
-        & (spin_df["spin_start_met"] < pointing_end_met)
-    ]
-
-    if len(pointing_spins) == 0:
-        raise ValueError(
-            f"No spins found in spin table for pointing period "
-            f"[{pointing_start_met}, {pointing_end_met}]."
-        )
-
-    # Select evenly-spaced indices from the middle 80% of available spins
-    # Skip first 10% and last 10% to avoid boundary effects
-    total_spins = len(pointing_spins)
-    start_fraction = 0.1
-    end_fraction = 0.9
-    start_idx = int(total_spins * start_fraction)
-    end_idx = int(total_spins * end_fraction) - 1
-
-    # Ensure we have valid indices
-    start_idx = max(0, start_idx)
-    end_idx = max(start_idx, min(end_idx, total_spins - 1))
-
-    available_spins = end_idx - start_idx + 1
-    if available_spins <= n_spins:
-        # Use all available spins in the middle 80% if fewer than requested
-        selected_indices = np.arange(start_idx, end_idx + 1)
-    else:
-        # Select evenly-spaced indices from the middle 80%
-        selected_indices = np.linspace(start_idx, end_idx, n_spins, dtype=int)
-
-    representative_spins = pointing_spins.iloc[selected_indices]
-
-    logging.debug(
-        f"Selected {len(representative_spins)} representative spins from "
-        f"{total_spins} total spins in pointing period (using middle 80%)."
-    )
-
-    return representative_spins
-
-
-def sample_boresight_bins(
-    spin_start_met: float,
-    spin_period: float,
-    n_samples: int = N_SAMPLES_PER_SPIN,
-) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Sample the Lo boresight look direction throughout a single spin.
-
-    Generates evenly-spaced time samples within a spin period, computes the
-    Lo boresight pointing direction in the IMAP_DPS frame, and returns the
-    spin_angle and off_angle for each sample.
-
-    Parameters
-    ----------
-    spin_start_met : float
-        The MET time at the start of the spin.
-    spin_period : float
-        The duration of the spin in seconds.
-    n_samples : int, optional
-        Number of time samples within the spin. Default is 4096.
-
-    Returns
-    -------
-    spin_angles : numpy.ndarray
-        Array of spin angles (0-360 degrees) for each sample time.
-    off_angles : numpy.ndarray
-        Array of off angles (elevation from DPS equatorial plane) for each sample.
-    """
-    # Generate evenly-spaced sample times within the spin
-    # Use the center of each time bin for sampling
-    sample_fractions = (np.arange(n_samples) + 0.5) / n_samples
-    sample_mets = spin_start_met + sample_fractions * spin_period
-
-    # Convert MET times to ephemeris time for SPICE
-    sample_ttj2000ns = met_to_ttj2000ns(sample_mets)
-    sample_ets = ttj2000ns_to_et(sample_ttj2000ns)
-
-    # Get the Lo boresight pointing in the DPS frame
-    # lo_instrument_pointing returns (longitude, latitude) in degrees
-    # longitude corresponds to spin_angle, latitude corresponds to off_angle
-    # Use nominal pivot angle of 90 degrees which rotates boresight to point
-    # approximately in the spacecraft spin plane (near-zero off-pointing)
-    pointing = lo_instrument_pointing(
-        sample_ets, LO_NOMINAL_PIVOT_ANGLE, SpiceFrame.IMAP_DPS
-    )
-
-    # Extract spin_angle (longitude) and off_angle (latitude)
-    spin_angles = pointing[:, 0]
-    off_angles = pointing[:, 1]
-
-    # Ensure spin angles are in [0, 360) range
-    spin_angles = np.mod(spin_angles, 360)
-
-    return spin_angles, off_angles
-
-
-def calculate_bin_weights(off_angles: np.ndarray) -> np.ndarray:
-    """
-    Calculate the probability weight for each off_angle bin.
-
-    Bins all sampled off angles into the 40-bin grid and normalizes
-    the counts to get probability weights that sum to 1. These weights
-    are applied uniformly across all spin_angle bins since the spacecraft
-    rotates evenly and we want smooth exposure across spin angles.
-
-    Parameters
-    ----------
-    off_angles : numpy.ndarray
-        Array of off angles (degrees) from all sampled times.
-
-    Returns
-    -------
-    bin_weights : numpy.ndarray
-        1D array of shape (N_OFF_ANGLE_BINS,) containing the probability
-        weight for each off_angle bin. Weights sum to 1.0.
-    """
-    # Create 1D histogram of off_angles only
-    bin_counts, _ = np.histogram(off_angles, bins=OFF_ANGLE_BIN_EDGES)
-
-    # Normalize to get probability weights
-    total_samples = len(off_angles)
-    if total_samples > 0:
-        bin_weights = bin_counts / total_samples
-    else:
-        # If no samples, return zero weights
-        bin_weights = np.zeros(N_OFF_ANGLE_BINS, dtype=np.float32)
-
-    return bin_weights
-
-
-def create_goodtimes_fraction(
-    goodtimes_ds: xr.Dataset,
-    pointing_start_met: float,
-    pointing_end_met: float,
-) -> np.ndarray:
-    """
-    Create fractional weights for spin_angle bins and ESA steps based on good-times.
-
-    The good-times ancillary file specifies which spin angle bins (in 6-degree
-    resolution) and ESA energy steps are valid during specific time periods.
-    This function calculates the fraction of the pointing duration that is
-    covered by good-times for each (ESA step, spin_angle bin) combination.
-
-    Parameters
-    ----------
-    goodtimes_ds : xarray.Dataset
-        Dataset containing the good-times data with variables:
-        gt_start_met, gt_end_met.
-    pointing_start_met : float
-        The start MET time of the pointing.
-    pointing_end_met : float
-        The end MET time of the pointing.
-
-    Returns
-    -------
-    goodtimes_fraction : numpy.ndarray
-        2D array of shape (N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS) containing
-        the fraction of pointing duration covered by good-times for each
-        ESA step and spin angle bin. Values range from 0.0 to 1.0.
-    """
-    total_pointing_duration = pointing_end_met - pointing_start_met
-
-    # Initialize as all zeros (no good time)
-    goodtimes_fraction: np.ndarray = np.zeros(
-        (N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS), dtype=np.float32
-    )
-
-    if total_pointing_duration <= 0:
-        logging.warning("Pointing duration is zero or negative.")
-        return goodtimes_fraction
-
-    # Filter good-times to only those overlapping with the pointing period
-    pointing_goodtimes_mask = (
-        (goodtimes_ds["gt_start_met"] < pointing_end_met)
-        & (goodtimes_ds["gt_end_met"] > pointing_start_met)
-    ).values
-
-    if not pointing_goodtimes_mask.any():
-        logging.warning(
-            f"No good-times found for pointing period "
-            f"[{pointing_start_met}, {pointing_end_met}]. "
-            "All exposure times will be zero."
-        )
-        return goodtimes_fraction
-
-    pointing_goodtimes = goodtimes_ds.isel(epoch=pointing_goodtimes_mask)
-
-    # Process each good-time row and accumulate fractional coverage
-    for i in range(len(pointing_goodtimes["epoch"])):
-        row = pointing_goodtimes.isel(epoch=i)
-
-        # Calculate the overlap between this good-time period and the pointing
-        goodtime_start = max(float(row["gt_start_met"]), pointing_start_met)
-        goodtime_end = min(float(row["gt_end_met"]), pointing_end_met)
-        overlap_duration = goodtime_end - goodtime_start
-
-        if overlap_duration <= 0:
-            continue
-
-        # Calculate fraction of pointing duration covered by this good-time
-        time_fraction = overlap_duration / total_pointing_duration
-
-        # For each ESA step, accumulate the fractional coverage.
-        # Add this time fraction to the affected bins.
-        # Note that all ESA Levels and all N_SPIN_ANGLE_BINS currently get the
-        # same increment, pending algorithmic changes in the future.
-        goodtimes_fraction += time_fraction
-
-    # Clip to [0, 1] in case of overlapping good-time periods
-    goodtimes_fraction = np.clip(goodtimes_fraction, 0.0, 1.0)
-
-    # Calculate average coverage for logging
-    avg_coverage = goodtimes_fraction.mean()
-    logging.debug(
-        f"Good-times coverage: average={100 * avg_coverage:.1f}%, "
-        f"min={100 * goodtimes_fraction.min():.1f}%, "
-        f"max={100 * goodtimes_fraction.max():.1f}%"
-    )
-
-    return goodtimes_fraction
-
-
 def calculate_exposure_times(
-    pointing_start_met: float,
-    pointing_end_met: float,
-    goodtimes_ds: xr.Dataset | None = None,
-    n_representative_spins: int = DEFAULT_N_REPRESENTATIVE_SPINS,
+    histrates_ds: xr.Dataset,
+    goodtimes_ds: xr.Dataset,
+    bgrates_ds: xr.Dataset | None = None,
 ) -> xr.DataArray:
     """
-    Calculate exposure times using statistical off-pointing sampling.
+    Calculate exposure times from L1B histrates summed over good-time epochs.
 
-    Samples the Lo boresight look direction across representative spins to
-    determine which spin_angle × off_angle bins are observed. The total
-    pointing duration is then distributed across bins proportionally to
-    the observed probability weights. If good-times data is provided,
-    exposure times are zeroed for invalid spin_angle/ESA step combinations.
+    Mirrors the alternate quicklook pipeline (3S2_l1b_quickmaps/l1b_to_spin.py):
+    sums exposure_time_6deg from the L1B histrates dataset over epochs that fall
+    within good-time windows, then expands to the full PSET grid.
+
+    The 60-bin (6°) spin dimension is expanded to 3600 bins (0.1°) by dividing
+    each value by 60 and repeating, preserving per-bin exposure. The off_angle
+    dimension is filled uniformly (no boresight-sampling weighting) by dividing
+    by N_OFF_ANGLE_BINS and broadcasting.
 
     Parameters
     ----------
-    pointing_start_met : float
-        The start MET time of the pointing.
-    pointing_end_met : float
-        The end MET time of the pointing.
-    goodtimes_ds : xarray.Dataset, optional
-        Dataset containing the good-times data. If provided,
-        exposure times will be zeroed for invalid spin_angle bins and ESA steps.
-    n_representative_spins : int, optional
-        Number of representative spins to sample. Default is 5.
+    histrates_ds : xr.Dataset
+        L1B histogram rates dataset containing exposure_time_6deg with
+        shape (n_epochs, esa_step, spin_bin_6).
+    goodtimes_ds : xr.Dataset
+        L1B goodtimes dataset containing gt_start_met and gt_end_met.
+    bgrates_ds : xr.Dataset, optional
+        L1B bgrates dataset. If provided, h_synthetic_floor is used as a
+        cross-check against the histrates-derived total exposure.
 
     Returns
     -------
-    exposure_time : xarray.DataArray
-        The exposure times for each (esa_energy_step, spin_angle, off_angle) bin.
-        Shape is (1, N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS).
+    exposure_time : xr.DataArray
+        Shape (1, N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS).
     """
-    # Calculate total pointing duration in seconds
-    total_pointing_duration = pointing_end_met - pointing_start_met
+    # Filter histrates epochs to good-time windows (same logic as filter_goodtimes)
+    epochs = histrates_ds["epoch"].values
+    gt_starts = met_to_ttj2000ns(goodtimes_ds["gt_start_met"].values)
+    gt_ends = met_to_ttj2000ns(goodtimes_ds["gt_end_met"].values)
 
-    if total_pointing_duration <= 0:
+    in_goodtime = np.any(
+        (epochs[:, np.newaxis] >= gt_starts) & (epochs[:, np.newaxis] <= gt_ends),
+        axis=1,
+    )
+
+    if not in_goodtime.any():
         logging.warning(
-            "Pointing duration is zero or negative. Exposure times will be zero."
+            "No histrates epochs fall within good-time windows. "
+            "Exposure times will be zero."
         )
-        # Return zero exposure times with correct shape and dimensions
-        zero_exposure: np.ndarray = np.zeros(PSET_SHAPE, dtype=np.float32)
-        return xr.DataArray(
-            data=zero_exposure,
-            dims=PSET_DIMS,
+        return xr.DataArray(data=np.zeros(PSET_SHAPE, dtype=np.float32), dims=PSET_DIMS)
+
+    # Sum exposure_time_6deg over good-time epochs → shape (7, 60)
+    exposure_6deg = histrates_ds["exposure_time_6deg"].values[in_goodtime]
+    exposure_sum = exposure_6deg.sum(axis=0)  # (7, 60)
+
+    # Cross-check: total exposure from histrates vs h_synthetic_floor / BG_RATES["H"]
+    if bgrates_ds is not None and "h_synthetic_floor" in bgrates_ds:
+        h_bg_rate = LoConstants.BG_RATES["H"]
+        # h_synthetic_floor accumulates BG_RATES["H"] * HISTOGRAM_CYCLE_EPOCHS
+        # * N_CYCLE_AVE * EXPOSURE_FACTOR per good-time step, so dividing by
+        # BG_RATES["H"] alone gives N_CYCLE_AVE * EXPOSURE_FACTOR times the
+        # per-cycle physical exposure.  Divide out that factor to get a quantity
+        # comparable to histrates_total (which sums actual spin-duration-based
+        # exposure without any averaging-window or EXPOSURE_FACTOR scaling).
+        floor_exposure = (
+            float(bgrates_ds["h_synthetic_floor"].values[0])
+            / h_bg_rate
+            / (LoConstants.N_CYCLE_AVE * LoConstants.EXPOSURE_FACTOR)
         )
+        histrates_total = float(exposure_sum.sum())
+        ratio = histrates_total / floor_exposure if floor_exposure > 0 else float("nan")
+        if abs(ratio - 1.0) > 0.02:
+            logging.warning(
+                f"Exposure cross-check mismatch: histrates total={histrates_total:.1f}s, "
+                f"synthetic_floor-derived={floor_exposure:.1f}s (ratio={ratio:.3f}). "
+                "Values should agree within ~2%."
+            )
+        else:
+            logging.debug(
+                f"Exposure cross-check OK: histrates total={histrates_total:.1f}s, "
+                f"synthetic_floor-derived={floor_exposure:.1f}s (ratio={ratio:.3f})"
+            )
 
-    # Get representative spins from the pointing period
-    representative_spins = get_representative_spin_times(
-        pointing_start_met, pointing_end_met, n_representative_spins
-    )
+    # Expand 60 spin bins → 3600 by dividing by 60 and repeating
+    # (each 6° bin maps to sixty 0.1° bins, preserving per-bin exposure)
+    exposure_3600 = np.repeat(exposure_sum / 60.0, 60, axis=1)  # (7, 3600)
 
-    # Collect all sampled spin angles and off angles across representative spins
-    all_spin_angles = []
-    all_off_angles = []
-
-    for _, spin_row in representative_spins.iterrows():
-        spin_start_met = spin_row["spin_start_met"]
-        spin_period = spin_row["actual_spin_period"]
-
-        spin_angles, off_angles = sample_boresight_bins(spin_start_met, spin_period)
-        all_spin_angles.append(spin_angles)
-        all_off_angles.append(off_angles)
-
-    # Concatenate all samples
-    all_spin_angles = np.concatenate(all_spin_angles)
-    all_off_angles = np.concatenate(all_off_angles)
-
-    # Log statistics about the sampled angles for debugging
-    logging.debug(
-        f"Sampled angles - spin_angle: min={all_spin_angles.min():.2f}, "
-        f"max={all_spin_angles.max():.2f}, mean={all_spin_angles.mean():.2f}"
-    )
-    logging.debug(
-        f"Sampled angles - off_angle: min={all_off_angles.min():.2f}, "
-        f"max={all_off_angles.max():.2f}, mean={all_off_angles.mean():.2f}"
-    )
-
-    # Calculate bin probability weights for off_angle only
-    # We use 1D histogram on off_angle because discrete spin sampling creates
-    # artifacts, but the spacecraft rotates evenly so spin_angle exposure
-    # should be uniform
-    off_angle_weights = calculate_bin_weights(all_off_angles)
-
-    # Calculate exposure time per ESA step
-    # Divide by N_ESA_ENERGY_STEPS because each ESA step is only active
-    # for 1/7 of the total pointing duration
-    # Divide by N_SPIN_ANGLE_BINS to distribute uniformly across spin angles
-    exposure_per_esa_step = total_pointing_duration / N_ESA_ENERGY_STEPS
-    exposure_per_spin_bin = exposure_per_esa_step / N_SPIN_ANGLE_BINS
-
-    # Apply off_angle weights: each spin_angle bin gets the same off_angle distribution
-    # Shape: (N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS)
-    exposure_per_bin = exposure_per_spin_bin * off_angle_weights[np.newaxis, :]
-
-    # Broadcast exposure across ESA energy steps (each ESA step has the same
-    # geometric exposure pattern, but only 1/7 of the total time)
-    # Need to make a copy since we may modify it with good-times mask
+    # Distribute uniformly across 40 off-angle bins
     exposure_3d = np.broadcast_to(
-        exposure_per_bin[np.newaxis, :, :],
+        (exposure_3600 / N_OFF_ANGLE_BINS)[:, :, np.newaxis],
         (N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS),
     ).copy()
 
-    # Apply good-times fraction if provided
-    if goodtimes_ds is not None:
-        goodtimes_fraction = create_goodtimes_fraction(
-            goodtimes_ds, pointing_start_met, pointing_end_met
-        )
-        # Expand fraction to include off_angle dimension
-        # (fraction is same for all off_angles)
-        # goodtimes_fraction shape: (N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS)
-        # exposure_3d shape: (N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS, N_OFF_ANGLE_BINS)
-        exposure_3d = exposure_3d * goodtimes_fraction[:, :, np.newaxis]
-
-        logging.debug(
-            f"Applied good-times mask: exposure sum reduced from "
-            f"{(exposure_per_bin.sum() * N_ESA_ENERGY_STEPS):.1f}s to "
-            f"{exposure_3d.sum():.1f}s"
-        )
-
-    # Add epoch dimension
-    exposure_4d = exposure_3d[np.newaxis, :, :, :]
-
-    exposure_time = xr.DataArray(
-        data=exposure_4d.astype(np.float32),
-        dims=PSET_DIMS,
-    )
-
     logging.debug(
-        f"Calculated exposure times: total duration={total_pointing_duration:.1f}s, "
-        f"sampled {len(representative_spins)} spins x {N_SAMPLES_PER_SPIN} samples, "
-        f"exposure sum={exposure_per_bin.sum():.1f}s"
+        f"Calculated exposure times: good epochs={in_goodtime.sum()}, "
+        f"total exposure (6deg sum)={exposure_sum.sum():.1f}s"
     )
 
-    return exposure_time
+    exposure_4d = exposure_3d[np.newaxis, :, :, :]
+    return xr.DataArray(data=exposure_4d.astype(np.float32), dims=PSET_DIMS)
 
 
 def create_datasets(

--- a/imap_processing/tests/lo/test_lo_l1c.py
+++ b/imap_processing/tests/lo/test_lo_l1c.py
@@ -9,19 +9,14 @@ from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.lo.l1c.lo_l1c import (
     N_ESA_ENERGY_STEPS,
     N_OFF_ANGLE_BINS,
-    N_SAMPLES_PER_SPIN,
     N_SPIN_ANGLE_BINS,
     OFF_ANGLE_BIN_CENTERS,
     PSET_SHAPE,
     FilterType,
-    calculate_bin_weights,
     calculate_exposure_times,
-    create_goodtimes_fraction,
     create_pset_counts,
     filter_goodtimes,
-    get_representative_spin_times,
     lo_l1c,
-    sample_boresight_bins,
     set_background_rates,
     set_pointing_directions,
 )
@@ -231,6 +226,15 @@ def test_lo_l1c(
             },
             coords={"epoch": met_to_ttj2000ns([repoint_start_met])},
         ),
+        "imap_lo_l1b_histrates": xr.Dataset(
+            {
+                "exposure_time_6deg": (
+                    ["epoch", "esa_step", "spin_bin_6"],
+                    np.zeros((1, N_ESA_ENERGY_STEPS, 60), dtype=np.float32),
+                )
+            },
+            coords={"epoch": met_to_ttj2000ns([repoint_start_met])},
+        ),
     }
     use_fake_spin_data_for_time(repoint_start_met)
     use_fake_repoint_data_for_time(
@@ -343,6 +347,15 @@ def test_lo_l1c_no_goodtimes(
                 "gt_end_met": ("epoch", [goodtime_end]),
                 "pivot": ([45.0]),
                 "pivot_de": ([45.0]),
+            },
+            coords={"epoch": met_to_ttj2000ns([goodtime_start])},
+        ),
+        "imap_lo_l1b_histrates": xr.Dataset(
+            {
+                "exposure_time_6deg": (
+                    ["epoch", "esa_step", "spin_bin_6"],
+                    np.zeros((1, N_ESA_ENERGY_STEPS, 60), dtype=np.float32),
+                )
             },
             coords={"epoch": met_to_ttj2000ns([goodtime_start])},
         ),
@@ -478,315 +491,63 @@ def test_create_doubles_pset_counts(l1b_de, doubles_counts):
     np.testing.assert_array_equal(counts, doubles_counts)
 
 
-def test_calculate_exposure_times(use_fake_spin_data_for_time):
-    """Test the statistical exposure time calculation."""
-    # Arrange
-    pointing_start_met = 511000000.0
-    pointing_end_met = 511000100.0  # 100 second pointing
-    use_fake_spin_data_for_time(pointing_start_met)
+def test_calculate_exposure_times():
+    """Test the histrates-based exposure time calculation."""
+    gt_start_met = 500000000.0
+    gt_end_met = 500001000.0
+    n_epochs = 3
 
-    with (
-        patch(
-            "imap_processing.lo.l1c.lo_l1c.lo_instrument_pointing"
-        ) as mock_lo_instrument_pointing,
-        patch(
-            "imap_processing.lo.l1c.lo_l1c.met_to_ttj2000ns"
-        ) as mock_met_to_ttj2000ns,
-        patch("imap_processing.lo.l1c.lo_l1c.ttj2000ns_to_et") as mock_ttj2000ns_to_et,
-    ):
-        # Mock the time conversions to pass through
-        mock_met_to_ttj2000ns.side_effect = lambda x: x * 1e9
-        mock_ttj2000ns_to_et.side_effect = lambda x: x / 1e9
+    epoch_mets = np.linspace(gt_start_met, gt_end_met, n_epochs)
+    exposure_values = np.ones((n_epochs, N_ESA_ENERGY_STEPS, 60), dtype=np.float32)
 
-        # Mock lo_instrument_pointing to return pointing at spin_angle=270, off_angle=0
-        # for all sample times (simulating no off-pointing with 90 degree pivot)
-        def mock_pointing(ets, pivot_angle, to_frame):
-            n_times = len(np.atleast_1d(ets))
-            # Return (longitude, latitude) = (270, 0) for all times
-            return np.column_stack([np.full(n_times, 270.0), np.zeros(n_times)])
-
-        mock_lo_instrument_pointing.side_effect = mock_pointing
-
-        # Act
-        exposure_times = calculate_exposure_times(
-            pointing_start_met, pointing_end_met, n_representative_spins=3
-        )
-
-        # Assert
-        # Check shape
-        assert exposure_times.shape == PSET_SHAPE
-
-        # Check that exposure times sum to approximately total pointing duration / 7
-        # Each ESA energy step is only active for 1/7 of the total time
-        # (within tolerance due to binning)
-        total_duration = pointing_end_met - pointing_start_met
-        # Sum over spin_angle and off_angle dimensions for one ESA step
-        exposure_sum = exposure_times.values[0, 0, :, :].sum()
-        np.testing.assert_allclose(
-            exposure_sum, total_duration / N_ESA_ENERGY_STEPS, rtol=0.01
-        )
-
-        # Check that all ESA steps have the same exposure (geometry-independent)
-        for i in range(1, 7):
-            np.testing.assert_array_equal(
-                exposure_times.values[0, 0, :, :],
-                exposure_times.values[0, i, :, :],
-            )
-
-
-def test_calculate_exposure_times_no_goodtimes_overlap(use_fake_spin_data_for_time):
-    """Test that exposure times are zero when goodtimes don't overlap with pointing."""
-    # Arrange
-    # Pointing period is [511000100, 511000200]
-    pointing_start_met = 511000100.0
-    pointing_end_met = 511000200.0
-    use_fake_spin_data_for_time(pointing_start_met)
-
-    # Goodtimes window [511000000, 511000050] ends before pointing starts
+    histrates_ds = xr.Dataset(
+        {"exposure_time_6deg": (["epoch", "esa_step", "spin_bin_6"], exposure_values)},
+        coords={"epoch": met_to_ttj2000ns(epoch_mets)},
+    )
     goodtimes_ds = xr.Dataset(
         {
-            "gt_start_met": ("epoch", [511000000.0]),
-            "gt_end_met": ("epoch", [511000050.0]),
+            "gt_start_met": ("epoch", [gt_start_met]),
+            "gt_end_met": ("epoch", [gt_end_met]),
         },
-        coords={"epoch": [0]},
+        coords={"epoch": met_to_ttj2000ns([gt_start_met])},
     )
 
-    with (
-        patch(
-            "imap_processing.lo.l1c.lo_l1c.lo_instrument_pointing"
-        ) as mock_lo_instrument_pointing,
-        patch(
-            "imap_processing.lo.l1c.lo_l1c.met_to_ttj2000ns"
-        ) as mock_met_to_ttj2000ns,
-        patch("imap_processing.lo.l1c.lo_l1c.ttj2000ns_to_et") as mock_ttj2000ns_to_et,
-    ):
-        # Mock the time conversions to pass through
-        mock_met_to_ttj2000ns.side_effect = lambda x: x * 1e9
-        mock_ttj2000ns_to_et.side_effect = lambda x: x / 1e9
+    exposure_times = calculate_exposure_times(histrates_ds, goodtimes_ds)
 
-        # Mock lo_instrument_pointing
-        def mock_pointing(ets, pivot_angle, to_frame):
-            n_times = len(np.atleast_1d(ets))
-            return np.column_stack([np.full(n_times, 270.0), np.zeros(n_times)])
-
-        mock_lo_instrument_pointing.side_effect = mock_pointing
-
-        # Act
-        exposure_times = calculate_exposure_times(
-            pointing_start_met,
-            pointing_end_met,
-            goodtimes_ds=goodtimes_ds,
-            n_representative_spins=3,
+    assert exposure_times.shape == PSET_SHAPE
+    # Each of the 3 epochs contributes 1.0 per (esa, spin_6) cell.
+    # Expanding 60 → 3600: divide by 60 per cell; distributing across 40 off-angle bins:
+    # divide by N_OFF_ANGLE_BINS.
+    expected_per_cell = float(n_epochs) / 60 / N_OFF_ANGLE_BINS
+    np.testing.assert_allclose(exposure_times.values, expected_per_cell, rtol=1e-5)
+    # All ESA steps should have equal exposure (uniform input)
+    for i in range(1, N_ESA_ENERGY_STEPS):
+        np.testing.assert_array_equal(
+            exposure_times.values[0, 0, :, :], exposure_times.values[0, i, :, :]
         )
 
-        # Assert
-        # All exposure times should be zero since goodtimes don't overlap
-        assert exposure_times.shape == PSET_SHAPE
-        np.testing.assert_array_equal(exposure_times.values, 0.0)
 
+def test_calculate_exposure_times_no_goodtimes_overlap():
+    """Test that exposure times are zero when goodtimes don't overlap with histrates."""
+    epoch_met = 500000000.0
+    exposure_values = np.ones((1, N_ESA_ENERGY_STEPS, 60), dtype=np.float32)
 
-def test_get_representative_spin_times(use_fake_spin_data_for_time):
-    """Test that representative spins are evenly distributed across pointing."""
-    # Arrange
-    pointing_start_met = 511000000.0
-    pointing_end_met = 511001500.0  # ~100 spins at ~15s each
-    use_fake_spin_data_for_time(pointing_start_met)
-
-    # Act
-    representative_spins = get_representative_spin_times(
-        pointing_start_met, pointing_end_met, n_spins=5
+    histrates_ds = xr.Dataset(
+        {"exposure_time_6deg": (["epoch", "esa_step", "spin_bin_6"], exposure_values)},
+        coords={"epoch": met_to_ttj2000ns([epoch_met])},
     )
-
-    # Assert
-    assert len(representative_spins) == 5
-    assert "spin_start_met" in representative_spins.columns
-    assert "actual_spin_period" in representative_spins.columns
-
-    # Check that spins are within the pointing period
-    assert all(representative_spins["spin_start_met"] >= pointing_start_met)
-    assert all(representative_spins["spin_start_met"] < pointing_end_met)
-
-
-def test_get_representative_spin_times_fewer_available(use_fake_spin_data_for_time):
-    """Test that we get all spins when fewer than requested are available."""
-    # Arrange - very short pointing with only a few spins
-    pointing_start_met = 511000000.0
-    pointing_end_met = 511000045.0  # ~3 spins at ~15s each
-    use_fake_spin_data_for_time(pointing_start_met)
-
-    # Act
-    representative_spins = get_representative_spin_times(
-        pointing_start_met, pointing_end_met, n_spins=10
-    )
-
-    # Assert - should get all available spins (less than 10)
-    assert len(representative_spins) <= 10
-    assert len(representative_spins) >= 1
-
-
-def test_sample_boresight_bins():
-    """Test boresight sampling within a single spin."""
-    # Arrange
-    spin_start_met = 511000000.0
-    spin_period = 15.0
-
-    with (
-        patch(
-            "imap_processing.lo.l1c.lo_l1c.lo_instrument_pointing"
-        ) as mock_lo_instrument_pointing,
-        patch(
-            "imap_processing.lo.l1c.lo_l1c.met_to_ttj2000ns"
-        ) as mock_met_to_ttj2000ns,
-        patch("imap_processing.lo.l1c.lo_l1c.ttj2000ns_to_et") as mock_ttj2000ns_to_et,
-    ):
-        # Mock time conversions
-        mock_met_to_ttj2000ns.side_effect = lambda x: x * 1e9
-        mock_ttj2000ns_to_et.side_effect = lambda x: x / 1e9
-
-        # Mock lo_instrument_pointing to simulate rotating boresight
-        def mock_pointing(ets, pivot_angle, to_frame):
-            n_times = len(np.atleast_1d(ets))
-            # Simulate boresight sweeping through spin angles (0-360)
-            # with zero off-angle (latitude)
-            spin_angles = np.linspace(0, 360, n_times, endpoint=False)
-            off_angles = np.zeros(n_times)
-            return np.column_stack([spin_angles, off_angles])
-
-        mock_lo_instrument_pointing.side_effect = mock_pointing
-
-        # Act
-        spin_angles, off_angles = sample_boresight_bins(spin_start_met, spin_period)
-
-        # Assert
-        assert len(spin_angles) == N_SAMPLES_PER_SPIN
-        assert len(off_angles) == N_SAMPLES_PER_SPIN
-
-        # Check spin angles are in valid range [0, 360)
-        assert all(spin_angles >= 0)
-        assert all(spin_angles < 360)
-
-        # Check off angles are near zero (as mocked)
-        np.testing.assert_allclose(off_angles, 0, atol=1e-10)
-
-
-def test_calculate_bin_weights():
-    """Test bin weight calculation from sampled angles."""
-    # Arrange - create samples concentrated in specific bins
-    # All samples at off_angle=0
-    n_samples = 1000
-    off_angles = np.full(n_samples, 0.0)
-
-    # Act
-    bin_weights = calculate_bin_weights(off_angles)
-
-    # Assert
-    assert bin_weights.shape == (N_OFF_ANGLE_BINS,)
-
-    # Weights should sum to 1
-    np.testing.assert_allclose(bin_weights.sum(), 1.0)
-
-    # Find the bin that should have all the weight
-    # off_angle=0 is in bin 20 (center of [-2, 2] range with 40 bins)
-    expected_off_bin = 20  # (0 - (-2)) / 0.1 = 20
-
-    # That bin should have weight close to 1
-    assert bin_weights[expected_off_bin] > 0.9
-
-
-def test_calculate_bin_weights_distributed():
-    """Test bin weights with uniformly distributed samples."""
-    # Arrange - uniform distribution across off_angles
-    np.random.seed(42)
-    n_samples = 100000
-    off_angles = np.random.uniform(-2, 2, n_samples)
-
-    # Act
-    bin_weights = calculate_bin_weights(off_angles)
-
-    # Assert
-    assert bin_weights.shape == (N_OFF_ANGLE_BINS,)
-
-    # Weights should sum to 1
-    np.testing.assert_allclose(bin_weights.sum(), 1.0)
-
-    # With uniform distribution, weights should be approximately equal
-    expected_weight = 1.0 / N_OFF_ANGLE_BINS
-    np.testing.assert_allclose(bin_weights.mean(), expected_weight, rtol=0.1)
-
-
-def test_create_goodtimes_fraction():
-    """Test good-times fractional coverage calculation from ancillary data."""
-    # Arrange - create a simple goodtimes Dataset
-    # Good-times cover the full pointing duration for all spin bins
-    # bin_start and bin_end are inclusive, 0-indexed (0-59 for 6-degree bins)
-    goodtimes_ds = xr.Dataset(
-        {
-            "gt_start_met": ("epoch", [500000000.0, 500000000.0]),
-            "gt_end_met": ("epoch", [500001000.0, 500001000.0]),
-        },
-        coords={"epoch": [0, 1]},
-    )
-
-    pointing_start_met = 500000000.0
-    pointing_end_met = 500001000.0
-
-    # Act
-    fraction = create_goodtimes_fraction(
-        goodtimes_ds, pointing_start_met, pointing_end_met
-    )
-
-    # Assert
-    assert fraction.shape == (N_ESA_ENERGY_STEPS, N_SPIN_ANGLE_BINS)
-
-    # The current implementation does not filter by bin range or E-Step flags,
-    # so coverage is 1.0 everywhere
-    np.testing.assert_allclose(fraction, 1.0)
-
-
-def test_create_goodtimes_fraction_partial_coverage():
-    """Test good-times with partial time coverage of pointing period."""
-    # Arrange - good-times cover only half of the pointing duration
-    goodtimes_ds = xr.Dataset(
-        {
-            "gt_start_met": ("epoch", [500000000.0]),
-            "gt_end_met": ("epoch", [500000500.0]),  # Only first 500s of 1000s pointing
-        },
-        coords={"epoch": [0]},
-    )
-
-    pointing_start_met = 500000000.0
-    pointing_end_met = 500001000.0
-
-    # Act
-    fraction = create_goodtimes_fraction(
-        goodtimes_ds, pointing_start_met, pointing_end_met
-    )
-
-    # Assert - all bins should have 50% coverage
-    np.testing.assert_allclose(fraction, 0.5)
-
-
-def test_create_goodtimes_fraction_no_overlap():
-    """Test good-times fraction when no good-times overlap with pointing."""
-    # Arrange - goodtimes outside pointing period
     goodtimes_ds = xr.Dataset(
         {
             "gt_start_met": ("epoch", [400000000.0]),
             "gt_end_met": ("epoch", [400001000.0]),
         },
-        coords={"epoch": [0]},
+        coords={"epoch": met_to_ttj2000ns([400000000.0])},
     )
 
-    pointing_start_met = 500000000.0
-    pointing_end_met = 500001000.0
+    exposure_times = calculate_exposure_times(histrates_ds, goodtimes_ds)
 
-    # Act
-    fraction = create_goodtimes_fraction(
-        goodtimes_ds, pointing_start_met, pointing_end_met
-    )
-
-    # Assert - all zeros since no overlap
-    np.testing.assert_allclose(fraction, 0.0)
+    assert exposure_times.shape == PSET_SHAPE
+    np.testing.assert_array_equal(exposure_times.values, 0.0)
 
 
 @pytest.mark.parametrize("species", [FilterType.HYDROGEN, FilterType.OXYGEN])


### PR DESCRIPTION
Closes #3244 

# Change Summary

Changes to `calculate_exposure_times` function - the old approach used statistical sampling - first find representative spins (SPICE), build a histogram of off-angle bins, and distribute total pointing duration across the PSET grid weighted by those probabilities.

The new approach reads `exposure_time_6deg` directly from the `l1b/histrates` product, filters epochs to those falling within goodtime windows, sums them, then upsamples from 60 spin bins to 3600.

This now matches what the IMAP-Lo team is doing in their offline pipeline. `histrates` is already a dependency for this product in `sds-data-manager`.

## File changes

- `imap_processing/lo/l1c/lo_l1c.py` - deleted now unused functions - `get_representative_spin_times`, `sample_boresight_bins`, `calculate_bin_weights`, `create_goodtimes_fraction`.

## Testing

- `imap_processing/tests/lo/test_lo_l1c.py` — Tests updated to match the new interface. Deleted tests for the removed functions. Rewrote `test_calculate_exposure_times`/`test_calculate_exposure_times_no_goodtimes_overlap` to pass a `histrates_ds` instead of pointing MET times. Existing integration test (`test_lo_l1c`) now includes a mock `histrates` dataset.