### PR TITLE
fix(swe): address round-2 SPDF metadata comments

### DIFF
--- a/imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml
@@ -10,7 +10,8 @@ instrument_base: &instrument_base
     of the modulation of heliospheric backscatter glow of ISN H (the helioglow)
     along a scanning circle in the sky.
     GLOWS design and assembly is led by the Space Research Center, Warsaw, Poland
-    (CBK PAN). See https://imap.princeton.edu/instruments/glows for more details.
+    (CBK PAN). See https://imap.princeton.edu/spacecraft/instruments/global-solar-wind-structure-glows
+    for more details.
 
 imap_glows_l1a_hist:
   <<: *instrument_base

--- a/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml
@@ -9,8 +9,8 @@ TEXT: &txt >
   neutral atom (ENA) imagers mounted at fixed angles of 90 and 45 degrees
   relative to the spacecraft spin axis. These imagers measure neutral atoms
   entering our solar system from the outer edge of the heliosphere as they
-  move towards the Sun. See https://imap.princeton.edu/instruments/imap-hi for
-  more details.
+  move towards the Sun. See https://imap.princeton.edu/spacecraft/instruments/imap-hi
+  for more details.
 Instrument_type: Particles (space)
 
 # -------------- Product specific global attributes defined below --------------

--- a/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml
@@ -8,7 +8,8 @@ instrument_base: &instrument_base
     coverage from a wide instrument field-of-view (FOV) to enable a high resolution of ion
     measurements, such as observing shock-accelerated ions, determining the origin of the
     solar energetic particles (SEPs) spectra, and resolving particle transport in the
-    heliosphere. See https://imap.princeton.edu/instruments/hit for more details.
+    heliosphere. See https://imap.princeton.edu/spacecraft/instruments/high-energy-ion-telescope-hit
+    for more details.
 
   # L1a
 imap_hit_l1a_hk:
@@ -79,4 +80,3 @@ imap_hit_l2_macropixel-intensity:
     Data_type: L2_macropixel-intensity>Level-2 Macro Pixel Intensity
     Logical_source: imap_hit_l2_macropixel-intensity
     Logical_source_description: IMAP Mission HIT Instrument Level-2 Macro Pixel Intensity Data.
-

--- a/imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml
@@ -7,7 +7,8 @@ instrument_base: &instrument_base
     provides the elemental composition, speed, and mass distributions
     of interstellar dust and interplanetary dust particles. Each record
     contains the data from a single dust impact. See
-    https://imap.princeton.edu/instruments/idex for more details.
+    https://imap.princeton.edu/spacecraft/instruments/interstellar-dust-experiment-idex
+    for more details.
 
 imap_idex_l1a_sci:
   <<: *instrument_base

--- a/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
@@ -5,10 +5,10 @@ instrument_base: &instrument_base
     The Solar Wind and Pickup Ion (SWAPI) instrument measures several different
     elements of the solar wind, including hydrogen (H) and helium (He) ions,
     and, on occasion, heavy ions produced by large events from the Sun. See
-    https://imap.princeton.edu/instruments/swapi for more details. SWAPI level-1
-    data contains primary, secondary, coincidence counts per ESA voltage step and
-    time. Level-2 data contains the same data as level-1 but counts are converted
-    to rates by dividing counts by time.
+    https://imap.princeton.edu/spacecraft/instruments/solar-wind-and-pickup-ions-swapi
+    for more details. SWAPI level-1 data contains primary, secondary, coincidence
+    counts per ESA voltage step and time. Level-2 data contains the same data as
+    level-1 but counts are converted to rates by dividing counts by time.
 
 imap_swapi_l1_sci:
   <<: *instrument_base

--- a/imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml
@@ -6,7 +6,8 @@ instrument_base: &instrument_base
     in the heliosphere. SWE will contribute to our understanding of the acceleration
     and transport of charged particles in the heliosphere.
     SWE design and assembly is led by Los Alamos National Laboratory. See
-    https://imap.princeton.edu/instruments/swe for more details.
+    https://imap.princeton.edu/spacecraft/instruments/solar-wind-electron-swe
+    for more details.
 
 imap_swe_l1a_sci:
   <<: *instrument_base

--- a/imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml
@@ -5,7 +5,7 @@ instrument_base: &instrument_base
     The IMAP Solar Wind Electron (SWE) instrument measures the solar wind electrons
     in the heliosphere. SWE will contribute to our understanding of the acceleration
     and transport of charged particles in the heliosphere.
-    SWE design and assembly is led by the Princeton Plasma Physics Laboratory. See
+    SWE design and assembly is led by Los Alamos National Laboratory. See
     https://imap.princeton.edu/instruments/swe for more details.
 
 imap_swe_l1a_sci:

--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -146,6 +146,8 @@ inst_az_spin_sector:
 
 phase_space_density_spin_sector:
   CATDESC: Phase space density organized by ESA step and spin sector and CEM
+  DELTA_MINUS_VAR: psd_stat_uncert
+  DELTA_PLUS_VAR: psd_stat_uncert
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
@@ -185,6 +187,8 @@ phase_space_density:
 
 flux_spin_sector:
   CATDESC: Number flux organized by ESA step and spin sector and CEM
+  DELTA_MINUS_VAR: flux_stat_uncert
+  DELTA_PLUS_VAR: flux_stat_uncert
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
@@ -227,7 +231,7 @@ psd_stat_uncert:
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
   DEPEND_3: cem_id
-  DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:Counts,Qualifier:Uncertainty
+  DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:PhaseSpaceDensity,Qualifier:Uncertainty
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Phase Space Density Stats Uncertainty
   FILLVAL: -1.0000000E+31
@@ -236,10 +240,10 @@ psd_stat_uncert:
   LABL_PTR_2: spin_sector_label
   LABL_PTR_3: cem_id_label
   SCALETYP: linear
-  UNITS: counts
+  UNITS: s^3 / cm^6
   VALIDMAX: 1.7976931348623157e+308 # TODO: find actual value
   VALIDMIN: 0.0
-  VAR_TYPE: data
+  VAR_TYPE: support_data
 
 flux_stat_uncert:
   CATDESC: Flux statistical uncertainty
@@ -247,7 +251,7 @@ flux_stat_uncert:
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
   DEPEND_3: cem_id
-  DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:Counts,Qualifier:Uncertainty
+  DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:NumberFlux,Qualifier:Uncertainty
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Flux Stats Uncertainty
   FILLVAL: -1.0000000E+31
@@ -256,10 +260,10 @@ flux_stat_uncert:
   LABL_PTR_2: spin_sector_label
   LABL_PTR_3: cem_id_label
   SCALETYP: linear
-  UNITS: counts
+  UNITS: 1 / (2 * eV * cm^2 * s * ster)
   VALIDMAX: 1.7976931348623157e+308 # TODO: find actual value
   VALIDMIN: 0.0
-  VAR_TYPE: data
+  VAR_TYPE: support_data
 
 acquisition_time:
   CATDESC: Acquisition time organized by ESA step and spin sector

--- a/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml
@@ -36,7 +36,7 @@ spin_sector:
   VAR_TYPE: support_data
 
 inst_az:
-  CATDESC: Spin angle in instrument frame. Angle resolution is 12 degree nominally
+  CATDESC: Spin angle in despun spacecraft coordinates. Angle resolution is 12 degree, with bin centers 6 - 354 degree (30 bins)
   FIELDNAM: Spin Angle
   FILLVAL: -9223370000000000000
   FORMAT: E10.4
@@ -46,9 +46,7 @@ inst_az:
   VALIDMAX: 359.999
   VALIDMIN: 0.00
   VAR_NOTES: >
-    Bin CENTERS  - Assuming 0.5 sec measurements and a spin starting
-    at Angle=0, these are the angles at the middle of each measurement
-    bin.
+    Spin angle bin centers in despun spacecraft coordinates.
   VAR_TYPE: support_data
 
 cem_id:
@@ -64,7 +62,7 @@ cem_id:
   VAR_TYPE: support_data
 
 inst_el:
-  CATDESC: Angle of each CEM detector
+  CATDESC: Polar angle of each CEM detector relative to spin axis. Angle resolution is 21 degree, with bin centers -63 - 63 degree (7 bins)
   FIELDNAM: Polar Angle
   FILLVAL: -9223370000000000000
   FORMAT: I4
@@ -114,13 +112,13 @@ energy_label:
   VAR_TYPE: metadata
 
 inst_az_label:
-  CATDESC: Spin angle bins in instrument frame. Angle resolution is 12 degree nominally
+  CATDESC: Spin angle bins in despun spacecraft coordinates
   FIELDNAM: Spin Angle
   FORMAT: A3
   VAR_TYPE: metadata
 
 inst_el_label:
-  CATDESC: Angle of each CEM detector
+  CATDESC: Polar angle of each CEM detector relative to spin axis
   FIELDNAM: CEM Angle
   FORMAT: A3
   VAR_TYPE: metadata
@@ -128,13 +126,13 @@ inst_el_label:
 # <=== Data Variables ===>
 
 inst_az_spin_sector:
-  CATDESC: Spin angle organized by ESA step and spin sector
+  CATDESC: Spin angle in despun spacecraft coordinates organized by ESA step and spin sector
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
   DICT_KEY: SPASE>Support>SupportQuantity:SpinPhase,Qualifier:Array,CoordinateSystemName:SC,CoordinateRepresentation:Spherical
   DISPLAY_TYPE: spectrogram
-  FIELDNAM: Spin Angle
+  FIELDNAM: Spin Angle Spin Sector
   FILLVAL: -1.0E+31
   FORMAT: E10.5
   LABL_PTR_1: esa_step_label
@@ -154,7 +152,7 @@ phase_space_density_spin_sector:
   DEPEND_3: cem_id
   DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:PhaseSpaceDensity,Qualifier:Array
   DISPLAY_TYPE: spectrogram
-  FIELDNAM: Phase Space Density
+  FIELDNAM: Phase Space Density Spin Sector
   FILLVAL: -1.0E+31
   FORMAT: E14.7
   LABL_PTR_1: esa_step_label
@@ -195,13 +193,13 @@ flux_spin_sector:
   DEPEND_3: cem_id
   DICT_KEY: SPASE>Particle>ParticleType:Electron,ParticleQuantity:NumberFlux,Qualifier:Array
   DISPLAY_TYPE: spectrogram
-  FIELDNAM: Flux
+  FIELDNAM: Flux Spin Sector
   FILLVAL: -1.0E+31
   FORMAT: E14.7
   LABL_PTR_1: esa_step_label
   LABL_PTR_2: spin_sector_label
   LABL_PTR_3: cem_id_label
-  UNITS: 1 / (2 * eV * cm^2 * s * ster)
+  UNITS: 1 / (eV * cm^2 * s * ster)
   VALIDMAX: 1.0E+9
   VALIDMIN: 0.0
   VAR_TYPE: data
@@ -220,7 +218,7 @@ flux:
   LABL_PTR_1: energy_label
   LABL_PTR_2: inst_az_label
   LABL_PTR_3: inst_el_label
-  UNITS: 1 / (2 * eV * cm^2 * s * ster)
+  UNITS: 1 / (eV * cm^2 * s * ster)
   VALIDMAX: 1.0E+9
   VALIDMIN: 0.0
   VAR_TYPE: data
@@ -260,7 +258,7 @@ flux_stat_uncert:
   LABL_PTR_2: spin_sector_label
   LABL_PTR_3: cem_id_label
   SCALETYP: linear
-  UNITS: 1 / (2 * eV * cm^2 * s * ster)
+  UNITS: 1 / (eV * cm^2 * s * ster)
   VALIDMAX: 1.7976931348623157e+308 # TODO: find actual value
   VALIDMIN: 0.0
   VAR_TYPE: support_data

--- a/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml
@@ -6,7 +6,8 @@ instrument_base: &instrument_base
     produced in the solar system at the heliosheath, the region where the solar wind slows,
     compresses, and becomes much hotter as it meets the interstellar medium (ISM).
     The instrument also measures the distribution of solar wind electrons and protons, and
-    the magnetic field. See https://imap.princeton.edu/instruments/ultra for more details.
+    the magnetic field. See https://imap.princeton.edu/spacecraft/instruments/imap-ultra
+    for more details.
 
 imap_ultra_l1a_45sensor-aux:
     <<: *instrument_base

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -222,7 +222,8 @@ def test_process_housekeeping(housekeeping_dataset, attribute_manager):
         "of ion measurements, such as observing shock-accelerated ions, "
         "determining the origin of the solar energetic particles (SEPs) "
         "spectra, and resolving particle transport in the heliosphere. "
-        "See https://imap.princeton.edu/instruments/hit for more details.\n",
+        "See https://imap.princeton.edu/spacecraft/instruments/"
+        "high-energy-ion-telescope-hit for more details.\n",
     }
 
     # Define the coordinates and dimensions. Both have equivalent values

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -426,6 +426,10 @@ def test_swe_l2_15sec(
             "and spin sector"
         )
         assert "Los Alamos National Laboratory" in global_attrs["TEXT"][0]
+        assert (
+            "https://imap.princeton.edu/spacecraft/instruments/"
+            "solar-wind-electron-swe" in global_attrs["TEXT"][0]
+        )
 
     # --------- sector validation--------
     sector_psd_data = l2_dataset["phase_space_density_spin_sector"].data

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -383,9 +383,15 @@ def test_swe_l2_15sec(
         acq_duration_info = cdf_file.varinq("acq_duration")
         acq_duration_attrs = cdf_file.varattsget("acq_duration")
         psd_attrs = cdf_file.varattsget("phase_space_density_spin_sector")
+        psd_binned_attrs = cdf_file.varattsget("phase_space_density")
         flux_attrs = cdf_file.varattsget("flux_spin_sector")
+        flux_binned_attrs = cdf_file.varattsget("flux")
         psd_uncert_attrs = cdf_file.varattsget("psd_stat_uncert")
         flux_uncert_attrs = cdf_file.varattsget("flux_stat_uncert")
+        inst_az_attrs = cdf_file.varattsget("inst_az")
+        inst_el_attrs = cdf_file.varattsget("inst_el")
+        inst_az_spin_sector_attrs = cdf_file.varattsget("inst_az_spin_sector")
+        global_attrs = cdf_file.globalattsget()
 
         assert acq_duration_info.Data_Type_Description == "CDF_UINT4"
         assert acq_duration_attrs["FILLVAL"] == np.uint32(4294967295)
@@ -397,6 +403,29 @@ def test_swe_l2_15sec(
         assert psd_attrs["DELTA_MINUS_VAR"] == "psd_stat_uncert"
         assert flux_attrs["DELTA_PLUS_VAR"] == "flux_stat_uncert"
         assert flux_attrs["DELTA_MINUS_VAR"] == "flux_stat_uncert"
+        assert psd_attrs["FIELDNAM"] == "Phase Space Density Spin Sector"
+        assert psd_binned_attrs["FIELDNAM"] == "Phase Space Density"
+        assert flux_attrs["FIELDNAM"] == "Flux Spin Sector"
+        assert flux_binned_attrs["FIELDNAM"] == "Flux"
+        assert flux_attrs["UNITS"] == "1 / (eV * cm^2 * s * ster)"
+        assert flux_binned_attrs["UNITS"] == "1 / (eV * cm^2 * s * ster)"
+        assert (
+            inst_az_attrs["CATDESC"]
+            == "Spin angle in despun spacecraft coordinates. Angle resolution "
+            "is 12 degree, with bin centers 6 - 354 degree (30 bins)"
+        )
+        assert (
+            inst_el_attrs["CATDESC"]
+            == "Polar angle of each CEM detector relative to spin axis. Angle "
+            "resolution is 21 degree, with bin centers -63 - 63 degree (7 bins)"
+        )
+        assert inst_az_spin_sector_attrs["FIELDNAM"] == "Spin Angle Spin Sector"
+        assert (
+            inst_az_spin_sector_attrs["CATDESC"]
+            == "Spin angle in despun spacecraft coordinates organized by ESA step "
+            "and spin sector"
+        )
+        assert "Los Alamos National Laboratory" in global_attrs["TEXT"][0]
 
     # --------- sector validation--------
     sector_psd_data = l2_dataset["phase_space_density_spin_sector"].data

--- a/imap_processing/tests/swe/test_swe_l2.py
+++ b/imap_processing/tests/swe/test_swe_l2.py
@@ -379,11 +379,24 @@ def test_swe_l2_15sec(
     l2_dataset.attrs["Data_version"] = "002"
     l2_cdf_filepath = write_cdf(l2_dataset)
     assert l2_cdf_filepath.name == "imap_swe_l2_sci_20240510_v002.cdf"
-    cdf_file = cdflib.CDF(l2_cdf_filepath)
-    acq_duration_info = cdf_file.varinq("acq_duration")
-    acq_duration_attrs = cdf_file.varattsget("acq_duration")
-    assert acq_duration_info.Data_Type_Description == "CDF_UINT4"
-    assert acq_duration_attrs["FILLVAL"] == np.uint32(4294967295)
+    with cdflib.CDF(l2_cdf_filepath) as cdf_file:
+        acq_duration_info = cdf_file.varinq("acq_duration")
+        acq_duration_attrs = cdf_file.varattsget("acq_duration")
+        psd_attrs = cdf_file.varattsget("phase_space_density_spin_sector")
+        flux_attrs = cdf_file.varattsget("flux_spin_sector")
+        psd_uncert_attrs = cdf_file.varattsget("psd_stat_uncert")
+        flux_uncert_attrs = cdf_file.varattsget("flux_stat_uncert")
+
+        assert acq_duration_info.Data_Type_Description == "CDF_UINT4"
+        assert acq_duration_attrs["FILLVAL"] == np.uint32(4294967295)
+        assert psd_uncert_attrs["UNITS"] == psd_attrs["UNITS"]
+        assert flux_uncert_attrs["UNITS"] == flux_attrs["UNITS"]
+        assert psd_uncert_attrs["VAR_TYPE"] == "support_data"
+        assert flux_uncert_attrs["VAR_TYPE"] == "support_data"
+        assert psd_attrs["DELTA_PLUS_VAR"] == "psd_stat_uncert"
+        assert psd_attrs["DELTA_MINUS_VAR"] == "psd_stat_uncert"
+        assert flux_attrs["DELTA_PLUS_VAR"] == "flux_stat_uncert"
+        assert flux_attrs["DELTA_MINUS_VAR"] == "flux_stat_uncert"
 
     # --------- sector validation--------
     sector_psd_data = l2_dataset["phase_space_density_spin_sector"].data


### PR DESCRIPTION
## Summary

Address the remaining SWE L2 metadata comments from the round-2 SPDF review for `imap_swe_l2_sci`.

This PR also folds in the follow-up SWE instrument-team wording/unit clarifications, plus the shared IMAP instrument URL cleanup that was prompted while fixing the SWE global metadata.

## Commit Structure

The branch history is intentionally granular and traceable.

- The SPDF-driven commit is split by the original review comment number:
  - `(13.1)` uncertainty units and attachment
- The commit subject includes the SPDF comment reference, and the commit body includes the original SPDF reviewer comment text it addresses.
- There are two follow-up commits on top of that:
  - `fix(swe): apply instrument team metadata feedback`
  - `fix(all): update shared instrument URLs`

## What Changed

### Statistical uncertainty metadata

For the SWE statistical uncertainty variables:

- `psd_stat_uncert`
- `flux_stat_uncert`

this PR:

- changes them to `VAR_TYPE = support_data`
- attaches them to their parent science variables using `DELTA_PLUS_VAR` / `DELTA_MINUS_VAR`
- updates their units to match the corresponding parent quantities rather than `counts`

Specifically:

- `psd_stat_uncert` now matches `phase_space_density_spin_sector`
- `flux_stat_uncert` now matches `flux_spin_sector`

This makes the uncertainty metadata consistent with the physical quantities they describe.

### SWE instrument-team metadata wording updates

Using the follow-up SWE team guidance, this PR also updates:

- shared SWE global text to credit **Los Alamos National Laboratory**
- flux units to remove the extra factor of `2`
- spin-sector science names so they are distinct from the non-spin-sector variables:
  - `Flux Spin Sector`
  - `Phase Space Density Spin Sector`
- angle descriptions to use **despun spacecraft coordinates**
- `inst_az_spin_sector` naming/description to reflect that it is the spin-angle-by-sector product

These changes are metadata/text cleanup only.

### Shared instrument URL cleanup

While addressing the SWE global metadata, I found that the old IMAP instrument URLs were outdated more broadly.

The final commit updates the shared instrument URLs in global CDF metadata to the current official IMAP pages under:

- `https://imap.princeton.edu/spacecraft/instruments/...`

That commit affects:

- SWE
- HIT
- GLOWS
- Ultra
- SWAPI
- IMAP-Hi
- IDEX

This is a metadata-only cleanup and does not affect SWE science processing.

## Testing

Validated locally with:

```bash
pytest -q imap_processing/tests/swe/test_swe_l2.py
pre-commit run --files \
  imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml \
  imap_processing/cdf/config/imap_swe_l2_variable_attrs.yaml \
  imap_processing/tests/swe/test_swe_l2.py
pre-commit run --files \
  imap_processing/cdf/config/imap_glows_global_cdf_attrs.yaml \
  imap_processing/cdf/config/imap_hi_global_cdf_attrs.yaml \
  imap_processing/cdf/config/imap_hit_global_cdf_attrs.yaml \
  imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml \
  imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml \
  imap_processing/cdf/config/imap_swe_global_cdf_attrs.yaml \
  imap_processing/cdf/config/imap_ultra_global_cdf_attrs.yaml