### PR TITLE
fix(swapi): address round-2 SPDF metadata comments

### DIFF
--- a/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml
@@ -2,13 +2,16 @@ instrument_base: &instrument_base
   Descriptor: SWAPI>Solar Wind and Pickup Ion
   Instrument_type: Particles (space)
   TEXT: >
-    The Solar Wind and Pickup Ion (SWAPI) instrument measures several different
-    elements of the solar wind, including hydrogen (H) and helium (He) ions,
-    and, on occasion, heavy ions produced by large events from the Sun. See
-    https://imap.princeton.edu/instruments/swapi for more details. SWAPI level-1
-    data contains primary, secondary, coincidence counts per ESA voltage step and
-    time. Level-2 data contains the same data as level-1 but counts are converted
-    to rates by dividing counts by time.
+    The Solar Wind and Pickup Ion (SWAPI) instrument onboard Interstellar Mapping
+    and Acceleration Probe (IMAP) is a top-hat electrostatic analyzer designed to
+    measure energy-per-charge distributions of solar wind protons (H+), alpha
+    particles (He++), and interstellar He+ pickup ions (PUIs), across a range of
+    0.1 to 20 keV/q. See
+    https://imap.princeton.edu/spacecraft/instruments/solar-wind-and-pickup-ions-swapi
+    for more details. SWAPI's Level 1 data contains primary, secondary, and
+    coincidence counts per ESA voltage step and time. Level 2 data converts these
+    counts into count rates using a constant livetime of 145ms and includes the
+    ESA energy associated with each voltage step.
 
 imap_swapi_l1_sci:
   <<: *instrument_base

--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -6,7 +6,7 @@ esa_step:
   FILLVAL: 255
   FORMAT: I2
   LABLAXIS: Energy Step
-  SCALE_TYP: linear
+  SCALETYP: linear
   UNITS: " "
   VALIDMAX: 71
   VALIDMIN: 0

--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -102,10 +102,11 @@ rate_default: &rate_default
   VAR_TYPE: data
 
 esa_energy:
-  CATDESC: ESA Energy.
+  CATDESC: ESA energy per charge for each sweep and energy step
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: ESA Energy
   FILLVAL: -1.0000000E+31
   FORMAT: F8.1
@@ -115,7 +116,7 @@ esa_energy:
   UNITS: eV / q
   VALIDMAX: 21000.0
   VALIDMIN: 0.0
-  VAR_TYPE: support_data
+  VAR_TYPE: data
 
 metadata_default: &metadata_default
   DEPEND_0: epoch

--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -1,6 +1,6 @@
 # <=== Coordinates ===>
 esa_step:
-  CATDESC: Energy step id in lookup table
+  CATDESC: Energy step id in lookup table; corresponding energy in eV/q is provided by esa_energy
   DICT_KEY: "SPASE>Support>SupportQuantity:Other"
   FIELDNAM: Energy Step
   FILLVAL: 255
@@ -14,7 +14,7 @@ esa_step:
 
 # <=== LABL_PTR_i Attributes ===>
 esa_step_label:
-  CATDESC: Energy step id in lookup table
+  CATDESC: Energy step id in lookup table; corresponding energy in eV/q is provided by esa_energy
   FIELDNAM: Energy Step
   FORMAT: A2
   VAR_TYPE: metadata
@@ -103,7 +103,7 @@ rate_default: &rate_default
   VAR_TYPE: data
 
 esa_energy:
-  CATDESC: ESA energy per charge for each sweep and energy step
+  CATDESC: ESA energy in eV/q corresponding to each step id for each sweep
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:EnergyPerCharge
@@ -111,7 +111,7 @@ esa_energy:
   FIELDNAM: ESA Energy
   FILLVAL: -1.0000000E+31
   FORMAT: F8.1
-  LABLAXIS: Energy(eV)
+  LABLAXIS: Energy (eV/q)
   LABL_PTR_1: esa_step_label
   SCALETYP: linear
   UNITS: eV / q

--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -83,10 +83,10 @@ rate_uncertainty_default: &rate_uncertainty_default
   FORMAT: E19.5
   LABL_PTR_1: esa_step_label
   SCALETYP: linear
-  UNITS: counts
+  UNITS: counts/s
   VALIDMAX: 4.519655172413793E+05 # 65535 counts / 0.145 s livetime
   VALIDMIN: 0.0
-  VAR_TYPE: data
+  VAR_TYPE: support_data
 
 rate_default: &rate_default
   DEPEND_0: epoch
@@ -197,39 +197,63 @@ coin_counts_uncertainty:
   FIELDNAM: Coincidence Counts Uncertainty
   LABLAXIS: coin_cnts_stat_unc
 
-pcem_rate_uncertainty:
+swp_pcem_rate_stat_uncert_plus:
   <<: *rate_uncertainty_default
-  CATDESC: Primary Channel Electron Multiplier (CEM) rate uncertainty
-  FIELDNAM: Primary CEM Rate Uncertainty
-  LABLAXIS: pcem_rate_stat_unc
+  CATDESC: Upper statistical uncertainty in primary Channel Electron Multiplier (CEM) rate
+  FIELDNAM: Primary CEM Rate Uncertainty Plus
+  LABLAXIS: pcem_rate_stat_unc_plus
 
-scem_rate_uncertainty:
+swp_pcem_rate_stat_uncert_minus:
   <<: *rate_uncertainty_default
-  CATDESC: Secondary Channel Electron Multiplier (CEM) rate uncertainty
-  FIELDNAM: Secondary CEM Rate Uncertainty
-  LABLAXIS: scem_rate_stat_unc
+  CATDESC: Lower statistical uncertainty in primary Channel Electron Multiplier (CEM) rate
+  FIELDNAM: Primary CEM Rate Uncertainty Minus
+  LABLAXIS: pcem_rate_stat_unc_minus
 
-coin_rate_uncertainty:
+swp_scem_rate_stat_uncert_plus:
   <<: *rate_uncertainty_default
-  CATDESC: Coincidence rate uncertainty
-  FIELDNAM: Coincidence Rate Uncertainty
-  LABLAXIS: coin_rate_stat_unc
+  CATDESC: Upper statistical uncertainty in secondary Channel Electron Multiplier (CEM) rate
+  FIELDNAM: Secondary CEM Rate Uncertainty Plus
+  LABLAXIS: scem_rate_stat_unc_plus
+
+swp_scem_rate_stat_uncert_minus:
+  <<: *rate_uncertainty_default
+  CATDESC: Lower statistical uncertainty in secondary Channel Electron Multiplier (CEM) rate
+  FIELDNAM: Secondary CEM Rate Uncertainty Minus
+  LABLAXIS: scem_rate_stat_unc_minus
+
+swp_coin_rate_stat_uncert_plus:
+  <<: *rate_uncertainty_default
+  CATDESC: Upper statistical uncertainty in coincidence rate
+  FIELDNAM: Coincidence Rate Uncertainty Plus
+  LABLAXIS: coin_rate_stat_unc_plus
+
+swp_coin_rate_stat_uncert_minus:
+  <<: *rate_uncertainty_default
+  CATDESC: Lower statistical uncertainty in coincidence rate
+  FIELDNAM: Coincidence Rate Uncertainty Minus
+  LABLAXIS: coin_rate_stat_unc_minus
 
 pcem_rate:
   <<: *rate_default
   CATDESC: Primary Channel Electron Multiplier (CEM) Rates
+  DELTA_MINUS_VAR: swp_pcem_rate_stat_uncert_minus
+  DELTA_PLUS_VAR: swp_pcem_rate_stat_uncert_plus
   FIELDNAM: Primary CEM Rates
   LABLAXIS: pcem_rate
 
 scem_rate:
   <<: *rate_default
   CATDESC: Secondary Channel Electron Multiplier (CEM) Rates
+  DELTA_MINUS_VAR: swp_scem_rate_stat_uncert_minus
+  DELTA_PLUS_VAR: swp_scem_rate_stat_uncert_plus
   FIELDNAM: Secondary CEM Rates
   LABLAXIS: scem_rate
 
 coin_rate:
   <<: *rate_default
   CATDESC: Coincidence Rates
+  DELTA_MINUS_VAR: swp_coin_rate_stat_uncert_minus
+  DELTA_PLUS_VAR: swp_coin_rate_stat_uncert_plus
   FIELDNAM: Coincidence Rates
   LABLAXIS: coin_rate
 

--- a/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_swapi_variable_attrs.yaml
@@ -35,7 +35,7 @@ counts_default: &counts_default
   VAR_TYPE: data
 
 flags_default:
-  CATDESC: Bitwise flag. There are 13 flags. See VAR_NOTES for more details.
+  CATDESC: Bitwise science and housekeeping quality flags. See VAR_NOTES for bit definitions.
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DICT_KEY: SPASE>Support>SupportQuantity:EncodedParameter
@@ -47,16 +47,17 @@ flags_default:
   LABL_PTR_1: esa_step_label
   SCALETYP: linear
   UNITS: ' '
-  VALIDMAX: 8191
+  VALIDMAX: 32767
   VALIDMIN: 0
   VAR_NOTES: >
-    There are 13 flags in total, first three flags are from science packets
-    and remaining 10 flags are from housekeeping packets. Flags are stored
-    as bitwise flag. 32767 is the value when all 15-bits are 1s. Eg.
-    int('0111111111111111', 2). First two bits from right are saved to save defaults.
-    Then, the remaining 13 bits from right are used for 13 flags. The flags are
-    as follows, "OVR_T_ST", "UND_T_ST", "PCEM_CNT_ST", "SCEM_CNT_ST","PCEM_V_ST",
-    "PCEM_I_ST", "PCEM_INT_ST", "SCEM_V_ST", "SCEM_I_ST", "SCEM_INT_ST".
+    Flags are stored as a 15-bit bitmask with VALIDMAX=32767 when bits 0-14 are all
+    set. The implemented flags are: bit 0 (value 1) INF, bit 1 (value 2) NEG,
+    bit 2 (value 4) SWP_PCEM_COMP, bit 3 (value 8) SWP_SCEM_COMP, bit 4 (value 16)
+    SWP_COIN_COMP, bit 5 (value 32) OVR_T_ST, bit 6 (value 64) UND_T_ST,
+    bit 7 (value 128) PCEM_CNT_ST, bit 8 (value 256) SCEM_CNT_ST,
+    bit 9 (value 512) PCEM_V_ST, bit 10 (value 1024) PCEM_I_ST,
+    bit 11 (value 2048) PCEM_INT_ST, bit 12 (value 4096) SCEM_V_ST,
+    bit 13 (value 8192) SCEM_I_ST, and bit 14 (value 16384) SCEM_INT_ST.
   VAR_TYPE: data
 
 counts_uncertainty_default: &counts_uncertainty_default

--- a/imap_processing/swapi/l2/swapi_l2.py
+++ b/imap_processing/swapi/l2/swapi_l2.py
@@ -273,22 +273,22 @@ def swapi_l2(
     # update attrs
     l2_dataset[
         "swp_pcem_rate_stat_uncert_plus"
-    ].attrs = cdf_manager.get_variable_attributes("pcem_rate_uncertainty")
+    ].attrs = cdf_manager.get_variable_attributes("swp_pcem_rate_stat_uncert_plus")
     l2_dataset[
         "swp_pcem_rate_stat_uncert_minus"
-    ].attrs = cdf_manager.get_variable_attributes("pcem_rate_uncertainty")
+    ].attrs = cdf_manager.get_variable_attributes("swp_pcem_rate_stat_uncert_minus")
     l2_dataset[
         "swp_scem_rate_stat_uncert_plus"
-    ].attrs = cdf_manager.get_variable_attributes("scem_rate_uncertainty")
+    ].attrs = cdf_manager.get_variable_attributes("swp_scem_rate_stat_uncert_plus")
     l2_dataset[
         "swp_scem_rate_stat_uncert_minus"
-    ].attrs = cdf_manager.get_variable_attributes("scem_rate_uncertainty")
+    ].attrs = cdf_manager.get_variable_attributes("swp_scem_rate_stat_uncert_minus")
     l2_dataset[
         "swp_coin_rate_stat_uncert_plus"
-    ].attrs = cdf_manager.get_variable_attributes("coin_rate_uncertainty")
+    ].attrs = cdf_manager.get_variable_attributes("swp_coin_rate_stat_uncert_plus")
     l2_dataset[
         "swp_coin_rate_stat_uncert_minus"
-    ].attrs = cdf_manager.get_variable_attributes("coin_rate_uncertainty")
+    ].attrs = cdf_manager.get_variable_attributes("swp_coin_rate_stat_uncert_minus")
 
     # TODO: add thruster firing flag
     # TODO: add other flags

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -136,6 +136,8 @@ def test_swapi_l2_cdf(
     assert np.isclose(esa_energy_attrs["FILLVAL"], np.float64(-1.0e31))
     assert esa_energy_attrs["VALIDMAX"] == np.float64(21000.0)
     assert esa_energy_attrs["VALIDMIN"] == np.float64(0.0)
+    assert esa_energy_attrs["VAR_TYPE"] == "data"
+    assert esa_energy_attrs["DEPEND_1"] == "esa_step"
     assert sci_start_time_attrs["FORMAT"] == "A23"
 
     rate_variables = [

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -141,6 +141,8 @@ def test_swapi_l2_cdf(
     assert esa_energy_attrs["VALIDMIN"] == np.float64(0.0)
     assert esa_energy_attrs["VAR_TYPE"] == "data"
     assert esa_energy_attrs["DEPEND_1"] == "esa_step"
+    assert esa_step_attrs["SCALETYP"] == "linear"
+    assert "SCALE_TYP" not in esa_step_attrs
     assert esa_energy_attrs["CATDESC"] == (
         "ESA energy in eV/q corresponding to each step id for each sweep"
     )

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -159,6 +159,17 @@ def test_swapi_l2_cdf(
         variable_attrs = cdf_file.varattsget(variable)
         assert np.isclose(variable_attrs["VALIDMAX"], SWAPI_RATE_VALIDMAX)
 
+    pcem_rate_attrs = cdf_file.varattsget("swp_pcem_rate")
+    pcem_uncert_plus_attrs = cdf_file.varattsget("swp_pcem_rate_stat_uncert_plus")
+    pcem_uncert_minus_attrs = cdf_file.varattsget("swp_pcem_rate_stat_uncert_minus")
+    assert pcem_rate_attrs["DELTA_PLUS_VAR"] == "swp_pcem_rate_stat_uncert_plus"
+    assert pcem_rate_attrs["DELTA_MINUS_VAR"] == "swp_pcem_rate_stat_uncert_minus"
+    assert pcem_uncert_plus_attrs["VAR_TYPE"] == "support_data"
+    assert pcem_uncert_minus_attrs["VAR_TYPE"] == "support_data"
+    assert pcem_uncert_plus_attrs["FIELDNAM"] != pcem_uncert_minus_attrs["FIELDNAM"]
+    assert pcem_uncert_plus_attrs["LABLAXIS"] != pcem_uncert_minus_attrs["LABLAXIS"]
+    assert pcem_uncert_plus_attrs["CATDESC"] != pcem_uncert_minus_attrs["CATDESC"]
+
     # Test uncertainty variables are as expected
     np.testing.assert_array_equal(
         l2_dataset["swp_pcem_rate_stat_uncert_plus"],

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -131,18 +131,41 @@ def test_swapi_l2_cdf(
     cdf_file = cdflib.CDF(l2_cdf)
     esa_energy_info = cdf_file.varinq("esa_energy")
     esa_energy_attrs = cdf_file.varattsget("esa_energy")
+    esa_step_attrs = cdf_file.varattsget("esa_step")
     sci_start_time_attrs = cdf_file.varattsget("sci_start_time")
     swp_l1a_flags_attrs = cdf_file.varattsget("swp_l1a_flags")
+    global_attrs = cdf_file.globalattsget()
     assert esa_energy_info.Data_Type_Description == "CDF_DOUBLE"
     assert np.isclose(esa_energy_attrs["FILLVAL"], np.float64(-1.0e31))
     assert esa_energy_attrs["VALIDMAX"] == np.float64(21000.0)
     assert esa_energy_attrs["VALIDMIN"] == np.float64(0.0)
     assert esa_energy_attrs["VAR_TYPE"] == "data"
     assert esa_energy_attrs["DEPEND_1"] == "esa_step"
+    assert esa_energy_attrs["CATDESC"] == (
+        "ESA energy in eV/q corresponding to each step id for each sweep"
+    )
+    assert esa_energy_attrs["LABLAXIS"] == "Energy (eV/q)"
+    assert (
+        "corresponding energy in eV/q is provided by esa_energy"
+        in esa_step_attrs["CATDESC"]
+    )
     assert sci_start_time_attrs["FORMAT"] == "A23"
     assert swp_l1a_flags_attrs["VALIDMAX"] == np.uint16(32767)
     assert "SWP_PCEM_COMP" in swp_l1a_flags_attrs["VAR_NOTES"]
     assert "SCEM_INT_ST" in swp_l1a_flags_attrs["VAR_NOTES"]
+    assert (
+        "top-hat electrostatic analyzer designed to measure energy-per-charge "
+        "distributions" in global_attrs["TEXT"][0]
+    )
+    assert (
+        "https://imap.princeton.edu/spacecraft/instruments/"
+        "solar-wind-and-pickup-ions-swapi" in global_attrs["TEXT"][0]
+    )
+    assert "constant livetime of 145ms" in global_attrs["TEXT"][0]
+    assert (
+        "includes the ESA energy associated with each voltage step"
+        in (global_attrs["TEXT"][0])
+    )
 
     rate_variables = [
         "swp_pcem_rate",

--- a/imap_processing/tests/swapi/test_swapi_l2.py
+++ b/imap_processing/tests/swapi/test_swapi_l2.py
@@ -132,6 +132,7 @@ def test_swapi_l2_cdf(
     esa_energy_info = cdf_file.varinq("esa_energy")
     esa_energy_attrs = cdf_file.varattsget("esa_energy")
     sci_start_time_attrs = cdf_file.varattsget("sci_start_time")
+    swp_l1a_flags_attrs = cdf_file.varattsget("swp_l1a_flags")
     assert esa_energy_info.Data_Type_Description == "CDF_DOUBLE"
     assert np.isclose(esa_energy_attrs["FILLVAL"], np.float64(-1.0e31))
     assert esa_energy_attrs["VALIDMAX"] == np.float64(21000.0)
@@ -139,6 +140,9 @@ def test_swapi_l2_cdf(
     assert esa_energy_attrs["VAR_TYPE"] == "data"
     assert esa_energy_attrs["DEPEND_1"] == "esa_step"
     assert sci_start_time_attrs["FORMAT"] == "A23"
+    assert swp_l1a_flags_attrs["VALIDMAX"] == np.uint16(32767)
+    assert "SWP_PCEM_COMP" in swp_l1a_flags_attrs["VAR_NOTES"]
+    assert "SCEM_INT_ST" in swp_l1a_flags_attrs["VAR_NOTES"]
 
     rate_variables = [
         "swp_pcem_rate",


### PR DESCRIPTION
## Summary

Address the remaining SWAPI L2 metadata comments from the round-2 SPDF review for `imap_swapi_l2_sci`.

This PR also folds in the SWAPI team’s follow-up wording updates from the reviewed document/email thread, while intentionally keeping the current product structure for the ESA-step/energy relationship.

## Commit Structure

The branch history is intentionally granular and traceable.

- The main commits are organized by SPDF comment number:
  - `(12.1)` correct `SCALETYP`
  - `(12.2)` expose `esa_energy` without changing `esa_step` dependence
  - `(12.3)` reconcile `swp_l1a_flags` range and notes
  - `(12.4)` attach rate uncertainties and distinguish plus/minus metadata
- Those numbered commit messages keep the SPDF comment references, and the updated commit bodies explain the implementation choices where the review item was not just a simple text fix.
- There is one additional follow-up commit:
  - `fix(swapi): apply instrument team metadata wording feedback`

## What Changed

### `(12.1)` Fix `SCALETYP`

SPDF pointed out that `esa_step` was using `SCALE_TYP` instead of the correct ISTP attribute name `SCALETYP`.

This PR:
- corrects the key in the SWAPI variable attrs
- adds a regression check that the written CDF exposes `SCALETYP` and no longer carries `SCALE_TYP`

### `(12.2)` Expose `esa_energy` while keeping `esa_step` as the real dependency

`esa_energy` is now visible as a user-facing variable:
- `VAR_TYPE = data`
- `DISPLAY_TYPE = spectrogram`

But the science variables still depend on `esa_step`.

This is intentional. In the current implementation, `esa_energy` is a 2D time/sweep-dependent lookup table with shape `("epoch", "esa_step")`, not a standalone 1D axis variable. So switching `DEPEND_1` to `esa_energy` would be a structural product change, not just a metadata relabeling.

The current tradeoff is:
- keep the actual indexed dependency on `esa_step`
- expose the corresponding ESA energy values to users

### `(12.3)` Reconcile `swp_l1a_flags` metadata

This PR fixes the inconsistency between the old `VALIDMAX` and the documented bit layout.

Changes:
- `VALIDMAX` updated from `8191` to `32767`
- `VAR_NOTES` rewritten to document the full 15-bit enum space

The commit message explains the implementation basis:
- `SWAPIFlags` defines bits `0..14`
- current SWAPI L1 processing actively sets bits `2..14`
- `32767` is still intentional because it describes the full reserved/defined flag namespace, not only the subset currently emitted by today’s producer

### `(12.4)` Attach rate uncertainties to the parent variables

For the SWAPI rate uncertainty variables, this PR:
- keeps separate `plus` and `minus` variables
- changes their units to `counts/s`
- gives `plus` and `minus` distinct `CATDESC`, `FIELDNAM`, and `LABLAXIS`
- changes them to `VAR_TYPE = support_data`
- links them from the parent rate variables via `DELTA_PLUS_VAR` / `DELTA_MINUS_VAR`

This keeps the uncertainties available while making the parent rate variables the primary user-facing products.

## SWAPI Team Follow-up Wording

Using the reviewed SWAPI metadata document/email thread, this PR also updates:

- the SWAPI global `TEXT` description
- the SWAPI instrument URL in the global text
- the L2 description to explicitly mention:
  - constant `145 ms` livetime
  - ESA energy associated with each voltage step
- `esa_step` / `esa_step_label` wording so it is more energy-oriented while still clearly step-indexed
- `esa_energy` wording so it explicitly describes eV/q corresponding to step IDs for each sweep

## Explicit Non-Changes

These were considered and intentionally left as-is:

- `esa_energy` stays `VAR_TYPE = data`
- science variables stay structurally dependent on `esa_step`
- rate uncertainties stay `support_data` attached via `DELTA_*_VAR`
- `counts/s` stays the unit for all rate uncertainties
- `swp_l1a_flags VAR_NOTES` were not further expanded beyond the current bit definitions
- no thruster-firing flag was added, since it is not currently defined in the SWAPI implementation

## Testing

Validated locally with:

```bash
pytest -q imap_processing/tests/swapi/test_swapi_l2.py
pre-commit run --files \
  imap_processing/cdf/config/imap_swapi_variable_attrs.yaml \
  imap_processing/cdf/config/imap_swapi_global_cdf_attrs.yaml \
  imap_processing/swapi/l2/swapi_l2.py \
  imap_processing/tests/swapi/test_swapi_l2.py