### PR TITLE
Fixing MAG attributes

### DIFF
--- a/imap_processing/mag/l1b/mag_l1b.py
+++ b/imap_processing/mag/l1b/mag_l1b.py
@@ -139,7 +139,9 @@ def mag_l1b_processing(
     epoch_time = shift_time(input_dataset["epoch"], time_shift)
 
     # Update attributes and assemble dataset
-    epoch_time.attrs = mag_attributes.get_variable_attributes("epoch")
+    epoch_time.attrs = mag_attributes.get_variable_attributes(
+        "epoch", check_schema=False
+    )
 
     direction = xr.DataArray(
         np.arange(4),

--- a/imap_processing/tests/mag/test_mag_l1b.py
+++ b/imap_processing/tests/mag/test_mag_l1b.py
@@ -89,6 +89,20 @@ def test_cdf_output(mag_l1b_cal_dataset):
     )
     l1b_dataset = mag_l1b(l1a_cdf, np.datetime64("2024-03-01"), mag_l1b_cal_dataset)
 
+    # Regression guard: sammi's get_variable_attributes with the default
+    # check_schema=True injects empty-string placeholders for required schema
+    # attributes that are missing on a variable (e.g. DEPEND_0/DISPLAY_TYPE on
+    # epoch). Newer cdflib versions reject those at CDF write time with
+    # "DEPEND_0 for variable epoch must be a non-empty string". Assert that no
+    # coord or variable carries an empty DEPEND_*/DISPLAY_TYPE attribute.
+    for name, var in {**l1b_dataset.coords, **l1b_dataset.data_vars}.items():
+        for attr_name, attr_value in var.attrs.items():
+            if attr_name.startswith("DEPEND_") or attr_name == "DISPLAY_TYPE":
+                assert attr_value != "", (
+                    f"Variable {name!r} has empty {attr_name} attribute, "
+                    f"which will fail cdflib DEPEND validation."
+                )
+
     output_path = write_cdf(l1b_dataset)
 
     assert Path.exists(output_path)


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

This fixes a bug which is currently failing all MAG L1B runs. Completed using Claude.

From Claude:

> The bug at mag_l1b.py:142 has been latent since March 2025 — what unmasked it is PR #3107 "MAG L1B: round time_shift to int64 ns to preserve TT2000 precision"
>    (merged April 30), which started shipping in a release cut on May 14 (PR #3183, _version.py reset).
> 
>   Before #3107, shift_time did:
>   time_shift_ns = time_shift.data * 1e9        # float64
>   return epoch_times + time_shift_ns           # float64 result
>   epoch_times is int64 TT2000 ns; adding a float64 scalar promoted the whole coordinate to float64. When cdflib received a float64 epoch, it didn't treat it as
>   CDF_TIME_TT2000 and the _validate_depend_attribute_value path that enforces DEPEND_0 on time variables was skipped. The empty DEPEND_0="" and DISPLAY_TYPE=""
>   that sammi has always been injecting (because mag_l1b.py:142 calls get_variable_attributes("epoch") with the default check_schema=True) sat on the coord
>   harmlessly and got silently dropped/coerced on write.
> 
>   After #3107:
>   time_shift_ns = np.int64(round(time_shift.data.item() * 1e9))
>   return epoch_times + time_shift_ns           # int64 result
>   epoch stays int64, cdflib correctly classifies it as CDF_TIME_TT2000, and the strict DEPEND validator now runs and rejects the empty string sammi planted on
>   it.
> 
>   So #3107 isn't "the bug" — it was actually a correctness fix (TT2000 precision was being lost to float). But it removed the float-coercion side effect that
>   had been hiding the real bug at mag_l1b.py:142. The float epoch was also silently corrupting timestamps before, which is presumably why #3107 was written in
>   the first place.
> 
>   Two corroborating clues in your log:
>   - Both DEPEND_0 and DISPLAY_TYPE warnings fire for epoch immediately — exactly the two attrs sammi injects as "" at
>   /workspace/sammi/sammi/cdf_attribute_manager.py:528-534.
>   - Other coords (direction, compression, *_label) all pass check_schema=False in mag_l1b_processing; only epoch doesn't.

## File changes
<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->


## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
