### PR TITLE
Skip epoch check on L1C

### DIFF
--- a/imap_processing/mag/l1c/mag_l1c.py
+++ b/imap_processing/mag/l1c/mag_l1c.py
@@ -100,7 +100,7 @@ def mag_l1c(
         completed_timeline[:, 0],
         name="epoch",
         dims=["epoch"],
-        attrs=attribute_manager.get_variable_attributes("epoch"),
+        attrs=attribute_manager.get_variable_attributes("epoch", check_schema=False),
     )
 
     direction_label = xr.DataArray(


### PR DESCRIPTION
# Change Summary

Same bug as #3258, with the same fix but for L1C.
