### PR TITLE
fix(cdf): update default acknowledgement statement

### DIFF
--- a/imap_processing/cdf/config/imap_default_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_default_global_cdf_attrs.yaml
@@ -1,7 +1,12 @@
 # Reference for sections: https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html
 # Reference from IBEX: https://spdf.gsfc.nasa.gov/pub/software/cdawlib/0SKELTABLES/ibex_h3_ena_lo_r08_omni_f3-gdf-maps_5yr_00000000_v01.skt
 Acknowledgement: >
-  Please acknowledge the IMAP Mission Principal Investigator, Prof. David J. McComas of Princeton University.
+  Users should acknowledge the sources of data used in all publications,
+  presentations, and reports using an appropriate DOI. Appropriate
+  acknowledgement to institutions, personnel, and funding agencies should be
+  given, including acknowledging the IMAP Mission Principal Investigator,
+  Prof. David J. McComas of Princeton University (Contract #80GSFC19C0027).
+  IMAP Rules-of-the-Road for data usage can be found in the IMAP CMAD.
 Discipline: Solar Physics>Heliospheric Physics
 File_naming_convention: source_descriptor_datatype_yyyyMMdd_vNNN
 HTTP_LINK: https://imap.princeton.edu/

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -191,9 +191,13 @@ def test_process_housekeeping(housekeeping_dataset, attribute_manager):
 
     # Define the dataset attributes
     dataset_attrs = {
-        "Acknowledgement": "Please acknowledge the IMAP Mission Principal "
-        "Investigator, Prof. David J. McComas of Princeton "
-        "University.\n",
+        "Acknowledgement": "Users should acknowledge the sources of data used "
+        "in all publications, presentations, and reports using an "
+        "appropriate DOI. Appropriate acknowledgement to institutions, "
+        "personnel, and funding agencies should be given, including "
+        "acknowledging the IMAP Mission Principal Investigator, Prof. David "
+        "J. McComas of Princeton University (Contract #80GSFC19C0027). IMAP "
+        "Rules-of-the-Road for data usage can be found in the IMAP CMAD.\n",
         "Data_type": "L1A_HK>Level-1A Housekeeping",
         "Data_version": None,
         "Descriptor": "HIT>IMAP High-energy Ion Telescope",


### PR DESCRIPTION
## Summary

Update the default IMAP acknowledgement statement used in product metadata to the latest wording.

## What Changed

Updated the default `Acknowledgement` text to:

- add DOI-based acknowledgement guidance
- mention the IMAP CMAD Rules-of-the-Road
- include the IMAP Mission PI acknowledgement with contract number `80GSFC19C0027`

Also updated the HIT metadata test snapshot that asserts the default global attrs text.

## Testing

```bash
pytest -q imap_processing/tests/hit/test_hit_utils.py
pre-commit run --files \
  imap_processing/cdf/config/imap_default_global_cdf_attrs.yaml \
  imap_processing/tests/hit/test_hit_utils.py