### PR TITLE
Fix HIT L1A issue with invalid DEPEND_0 

### DIFF
--- a/imap_processing/hit/hit_utils.py
+++ b/imap_processing/hit/hit_utils.py
@@ -177,7 +177,7 @@ def process_housekeeping_data(
         np.arange(64, dtype=np.uint8),
         name="adc_channels",
         dims=["adc_channels"],
-        attrs=attr_mgr.get_variable_attributes("adc_channels"),
+        attrs=attr_mgr.get_variable_attributes("adc_channels", check_schema=False),
     )
 
     # NOTE: LABL_PTR_1 should be CDF_CHAR.
@@ -185,7 +185,9 @@ def process_housekeeping_data(
         adc_channels.values.astype(str),
         name="adc_channels_label",
         dims=["adc_channels_label"],
-        attrs=attr_mgr.get_variable_attributes("adc_channels_label"),
+        attrs=attr_mgr.get_variable_attributes(
+            "adc_channels_label", check_schema=False
+        ),
     )
 
     # Update dataset coordinates and attributes
@@ -210,6 +212,11 @@ def process_housekeeping_data(
             if "DEPEND" in key
         }
         dataset[field].attrs = attr_mgr.get_variable_attributes(field)
+        # sc_tick is a coordinate in the HIT counts product, so no DEPEND_0
+        # is specified in the CDF attribute yaml. Manually set it here since in
+        # housekeeping sc_tick depends on epoch
+        if field == "sc_tick":
+            dataset[field].attrs["DEPEND_0"] = "epoch"
         dataset[field].assign_coords(dims)
 
     dataset.epoch.attrs = attr_mgr.get_variable_attributes("epoch", check_schema=False)

--- a/imap_processing/tests/hit/test_hit_utils.py
+++ b/imap_processing/tests/hit/test_hit_utils.py
@@ -241,6 +241,13 @@ def test_process_housekeeping(housekeeping_dataset, attribute_manager):
     # Check that the dataset has the correct attributes, coordinates, and dimensions
     assert processed_hskp_dataset.attrs == dataset_attrs
     assert processed_hskp_dataset.coords.keys() == dataset_coords_dims
+    # Check that sc_tick has DEPEND_0 == "epoch". This is needed since the
+    # hit l1a counts product contains a coordinate named sc_tick with no DEPEND_0
+    # and hit l1a housekeeping shares a CDF config yaml
+    assert processed_hskp_dataset["sc_tick"].attrs["DEPEND_0"] == "epoch"
+    # Check that housekeeping coordinates don't have DEPEND_0
+    for coord in processed_hskp_dataset.coords.values():
+        assert "DEPEND_0" not in coord.attrs
 
 
 def test_add_energy_variables():


### PR DESCRIPTION
# Change Summary

## Overview
In HIT L1A, the counts product has a coordinate named `sc_tick` in the housekeeping product, there is a variable named `sc_tick` this means that there needs to be a manual removal or addition of the DEPEND_0 attribute for this variable since both product share a CDF attribute YAML. This PR adds that manual addition of `DEPEND_0=epoch` for the housekeeping product.


Closes: #3271 
