### PR TITLE
ENA Maps: Update naming.py to give Survival Probability maps a more descriptive CATDESC

### DIFF
--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -215,6 +215,7 @@ class MapDescriptor:
             "dust_rate": "Rate",
             "isn_rate_bg_subtracted": "Rate",
             "isn_rate": "Rate",
+            "survival_probability": "Survival Probability"
         }
 
         if support_var_name in known_map_data_vars_and_descriptions:

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -215,7 +215,7 @@ class MapDescriptor:
             "dust_rate": "Rate",
             "isn_rate_bg_subtracted": "Rate",
             "isn_rate": "Rate",
-            "survival_probability": "Survival Probability"
+            "survival_probability": "Survival Probability",
         }
 
         if support_var_name in known_map_data_vars_and_descriptions:

--- a/imap_processing/tests/ena_maps/test_naming.py
+++ b/imap_processing/tests/ena_maps/test_naming.py
@@ -464,6 +464,12 @@ class TestMapDescriptor:
                 "aliens",
                 None,
             ),
+            (
+                "u45-ena-h-hf-nsp-full-hae-4deg-6mo",
+                "survival_probability",
+                "IMAP Ultra45 H Survival Probability, "
+                "HAE Helio Frame, No Surv Corr, Full Spin, 4 deg, 6 Mon",
+            ),
         ],
     )
     def test_build_map_var_catdesc_more_vars(


### PR DESCRIPTION
# Change Summary
We recently added a new variable to the L3 maps that is just the survival probability values. This change to imap_processing gives these variables a CATDESC that includes all the details of the map.

## File changes
- imap_processing/ena_maps/utils/naming.py

## Testing
- imap_processing/tests/ena_maps/test_naming.py