### PR TITLE
fix(codice): mark Lo RGFO/NSO vars as support_data

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l1a_variable_attrs.yaml
@@ -264,7 +264,7 @@ nso_half_spin:
     VALIDMAX: 255
     VALIDMIN: 0
     VAR_NOTES: Indicates the half spin when No Scan Operation (NSO) was activated. In NSO, the ESA voltage is set to the first step in the scan and remains fixed until the next cycle boundary.
-    VAR_TYPE: data
+    VAR_TYPE: support_data
 
 nso_spin_sector:
     CATDESC: Spin Sector When No Scan Operation (NSO) was activated
@@ -279,7 +279,7 @@ nso_spin_sector:
     VALIDMAX: 255
     VALIDMIN: 0
     VAR_NOTES: Indicates the spin sector when No Scan Operation (NSO) was activated. In NSO, the ESA voltage is set to the first step in the scan and remains fixed until the next cycle boundary.
-    VAR_TYPE: data
+    VAR_TYPE: support_data
 
 nso_esa_step:
     CATDESC: Energy Step When No Scan Operation (NSO) was activated
@@ -294,7 +294,7 @@ nso_esa_step:
     VALIDMAX: 255
     VALIDMIN: 0
     VAR_NOTES: Indicates the energy step when No Scan Operation (NSO) was activated. In NSO, the ESA voltage is set to the first step in the scan and remains fixed until the next cycle boundary.
-    VAR_TYPE: data
+    VAR_TYPE: support_data
 
 rgfo_half_spin:
     CATDESC: Half Spin When Reduced Gain Factor Operation (RGFO) was activated
@@ -309,7 +309,7 @@ rgfo_half_spin:
     VALIDMAX: 255
     VALIDMIN: 0
     VAR_NOTES: Indicates the half spin when Reduced Gain Factor Operation (RGFO) was activated. In RGFO, the Entrance ESA voltage is reduced in order to limit the number of ions that reach the detectors.
-    VAR_TYPE: data
+    VAR_TYPE: support_data
 
 rgfo_spin_sector:
     CATDESC: Spin Sector When Reduced Gain Factor Operation (RGFO) was activated
@@ -324,7 +324,7 @@ rgfo_spin_sector:
     VALIDMAX: 255
     VALIDMIN: 0
     VAR_NOTES: Indicates the spin sector when Reduced Gain Factor Operation (RGFO) was activated. In RGFO, the Entrance ESA voltage is reduced in order to limit the number of ions that reach the detectors.
-    VAR_TYPE: data
+    VAR_TYPE: support_data
 
 rgfo_esa_step:
     CATDESC: Energy Step When Reduced Gain Factor Operation (RGFO) was activated
@@ -339,7 +339,7 @@ rgfo_esa_step:
     VALIDMAX: 255
     VALIDMIN: 0
     VAR_NOTES: Indicates the energy step when Reduced Gain Factor Operation (RGFO) was activated. In RGFO, the Entrance ESA voltage is reduced in order to limit the number of ions that reach the detectors.
-    VAR_TYPE: data
+    VAR_TYPE: support_data
 
 spin_period:
     CATDESC: The spin period as reported by the spacecraft.

--- a/imap_processing/tests/codice/test_codice_l1a.py
+++ b/imap_processing/tests/codice/test_codice_l1a.py
@@ -34,6 +34,14 @@ pytestmark = pytest.mark.external_test_data
 # and num_spins max = 16 in the current CoDICE timing model. That yields a
 # worst-case delta of 128 s = 128000000000 ns.
 EXPECTED_EPOCH_DELTA_VALIDMAX = 128000000000
+LO_MODE_SUPPORT_VARIABLES = [
+    "rgfo_half_spin",
+    "rgfo_spin_sector",
+    "rgfo_esa_step",
+    "nso_half_spin",
+    "nso_spin_sector",
+    "nso_esa_step",
+]
 
 
 def assert_epoch_delta_cdf_metadata(cdf_file):
@@ -606,6 +614,10 @@ def test_lo_direct_events(mock_get_file_paths, codice_lut_path):
         cdf_file.name
         == f"imap_codice_l1a_lo-direct-events_{VALIDATION_FILE_DATE}_v002.cdf"
     )
+    with cdflib.CDF(cdf_file) as cdf:
+        for variable in LO_MODE_SUPPORT_VARIABLES:
+            attrs = cdf.varattsget(variable)
+            assert attrs["VAR_TYPE"] == "support_data"
 
 
 def test_direct_events_incomplete_groups(codice_lut_path, caplog):

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -107,6 +107,11 @@ DIRECT_EVENT_DISPLAY_TYPES = {
         "ssd_id": "no_plot",
     },
 }
+LO_DIRECT_EVENT_SUPPORT_VARIABLES = [
+    "nso_half_spin",
+    "nso_spin_sector",
+    "nso_esa_step",
+]
 
 
 @pytest.fixture
@@ -730,3 +735,18 @@ def test_codice_l2_direct_events_display_type_cdf_metadata(
                 "(Double Coincidence Rate; STA+STB+SP), 2 = APD-only energy "
                 "event (APD with only one or two of STA, STB, and SP)."
             )
+
+
+@patch("imap_data_access.processing_input.ProcessingInputCollection.get_file_paths")
+def test_codice_l2_lo_direct_events_support_var_type_cdf_metadata(
+    mock_get_file_paths, codice_lut_path
+):
+    file = _generate_direct_events_l2_file(
+        mock_get_file_paths, codice_lut_path, "lo-direct-events"
+    )
+    with cdflib.CDF(str(file)) as cdf_file:
+        written_variables = set(cdf_file.cdf_info().zVariables)
+        assert set(LO_DIRECT_EVENT_SUPPORT_VARIABLES) <= written_variables
+        for variable in LO_DIRECT_EVENT_SUPPORT_VARIABLES:
+            attrs = cdf_file.varattsget(variable)
+            assert attrs["VAR_TYPE"] == "support_data"


### PR DESCRIPTION
## Summary
- mark the CoDICE Lo `rgfo_*` and `nso_*` telemetry state variables as `support_data` instead of `data`
- add written-CDF regression checks for the Lo direct-events L1A and L2 products

## Why
Issue #2798 called out that these variables are supporting telemetry state, not science data. They were still defined with `VAR_TYPE = data` in the CoDICE L1A attrs YAML, which also affected the Lo direct-events metadata carried forward into L2.

## Validation
- `./.venv/bin/python -m pytest -q imap_processing/tests/codice/test_codice_l1a.py`
- `./.venv/bin/python -m pytest -q imap_processing/tests/codice/test_codice_l2.py`

Fixes #2798
