### PR TITLE
Update hi excess background counts to 0.002 counts/sec

### DIFF
--- a/imap_processing/hi/utils.py
+++ b/imap_processing/hi/utils.py
@@ -136,7 +136,7 @@ class HiConstants:
     # Background rate correction
     # Constant offset to subtract from combined background rates to correct
     # for excess counts from the outer ESA during background testing.
-    EXCESS_BACKGROUND_COUNT_RATE = 0.003  # per second
+    EXCESS_BACKGROUND_COUNT_RATE = 0.002  # per second
     EXCESS_BACKGROUND_COUNT_RATE_UNC = 0.001
     # ESAs 7, 8, 9 get an extra 0.0025/s uncertainty to account for possible
     # unidentified additional background in these ESA steps.


### PR DESCRIPTION
# Change Summary

Due to a bug in Paul's analysis code, the excess background rate was a bit high. This updates this rate to match the results after the bug was fixed.

Closes: #3296 
