### PR TITLE
Add metadata for Lo asymmetric sys err

### DIFF
--- a/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml
@@ -163,6 +163,26 @@ ena_intensity_sys_err:
   UNITS: cm -2 s -1 sr -1 keV -1
   VAR_TYPE: support_data
 
+ena_intensity_sys_err_minus:
+  <<: *default_float32
+  DEPEND_0: epoch
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+  DISPLAY_TYPE: map_image
+  FIELDNAM: Intensity non-stat error lower
+  LABLAXIS: Non-statistical Error Lower
+  UNITS: cm -2 s -1 sr -1 keV -1
+  VAR_TYPE: support_data
+
+ena_intensity_sys_err_plus:
+  <<: *default_float32
+  DEPEND_0: epoch
+  DICT_KEY: SPASE>Particle>ParticleType:Atom,ParticleQuantity:NumberFlux,Qualifier:Uncertainty,CoordinateSystemName:HAE,CoordinateRepresentation:Spherical
+  DISPLAY_TYPE: map_image
+  FIELDNAM: Intensity non-stat error upper
+  LABLAXIS: Non-statistical Error Upper
+  UNITS: cm -2 s -1 sr -1 keV -1
+  VAR_TYPE: support_data
+
 ena_count_rate:
   <<: *default_float32
   DEPEND_0: epoch

--- a/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml
@@ -99,6 +99,22 @@ ena_intensity_sys_err:
   LABL_PTR_2: longitude_label
   LABL_PTR_3: latitude_label
 
+ena_intensity_sys_err_minus:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
+ena_intensity_sys_err_plus:
+  DEPEND_1: energy
+  DEPEND_2: longitude
+  DEPEND_3: latitude
+  LABL_PTR_1: energy_label
+  LABL_PTR_2: longitude_label
+  LABL_PTR_3: latitude_label
+
 ena_count_rate:
   DEPEND_1: energy
   DEPEND_2: longitude

--- a/imap_processing/ena_maps/utils/naming.py
+++ b/imap_processing/ena_maps/utils/naming.py
@@ -193,6 +193,8 @@ class MapDescriptor:
             "ena_intensity": "Inten",
             "ena_intensity_stat_uncert": "Inten Stat. Unc.",
             "ena_intensity_sys_err": "Inten Sys. Err.",
+            "ena_intensity_sys_err_minus": "Inten Sys. Err. Lower",
+            "ena_intensity_sys_err_plus": "Inten Sys. Err. Upper",
             "ena_spectral_index": "Spectral Index",
             "ena_spectral_index_stat_uncert": "Spectral Stat. Unc.",
             "ena_spectral_scalar": "Spectral Scalar",

--- a/imap_processing/tests/ena_maps/test_naming.py
+++ b/imap_processing/tests/ena_maps/test_naming.py
@@ -454,6 +454,18 @@ class TestMapDescriptor:
                 "HAE SC Frame, No Surv Corr, Anti, 6 deg, 6 Mon, No sputter/bootstrap",
             ),
             (
+                "l075-enanbs-h-sf-nsp-anti-hae-6deg-6mo",
+                "ena_intensity_sys_err_minus",
+                "IMAP Lo75 H Inten Sys. Err. Lower, "
+                "HAE SC Frame, No Surv Corr, Anti, 6 deg, 6 Mon, No sputter/bootstrap",
+            ),
+            (
+                "l075-enanbs-h-sf-nsp-anti-hae-6deg-6mo",
+                "ena_intensity_sys_err_plus",
+                "IMAP Lo75 H Inten Sys. Err. Upper, "
+                "HAE SC Frame, No Surv Corr, Anti, 6 deg, 6 Mon, No sputter/bootstrap",
+            ),
+            (
                 "u45-ena-h-hf-nsp-full-hae-4deg-6mo",
                 "counts",
                 "IMAP Ultra45 H Counts, "


### PR DESCRIPTION
# Change Summary

## Overview
The Lo data release involved adding asymmetric systematic error variables `ena_intensity_sys_err_minus` and `ena_intensity_sys_err_plus`. This PR adds metadata for these variables, including the dynamic CATDESC construction.

Closes #3306.

## File changes
- **imap_processing/cdf/config/imap_enamaps_l2-common_variable_attrs.yaml:** metadata for writing these variables
- **imap_processing/cdf/config/imap_enamaps_l2-rectangular_variable_attrs.yaml:** DEPEND / LABL_PTR configuration
- **imap_processing/ena_maps/utils/naming.py:** configuration for the dynamic CATDESC construction


## Testing
- Added test cases for the dynamic CATDESC of these variables
