### PR TITLE
CODICE l2 metadata updates

### DIFF
--- a/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-direct-events_variable_attrs.yaml
@@ -74,7 +74,7 @@ num_events:
   DEPEND_0: epoch
   DEPEND_1: priority
   DICT_KEY: SPASE>Support>SupportQuantity:Other
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Number of Events
   FILLVAL: *uint16_fillval
   FORMAT: I5

--- a/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-omni_variable_attrs.yaml
@@ -365,7 +365,7 @@ unc_c:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_c
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - C
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -382,7 +382,7 @@ unc_fe:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_fe
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - Fe
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -399,7 +399,7 @@ unc_h:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_h
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - H
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -416,7 +416,7 @@ unc_he3:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_he3
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - He3
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -433,7 +433,7 @@ unc_he4:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_he4
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - He4
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -450,7 +450,7 @@ unc_junk:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_junk
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - Junk
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -470,7 +470,7 @@ unc_ne_mg_si:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_ne_mg_si
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - Ne+Mg+Si
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -487,7 +487,7 @@ unc_o:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_o
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - O
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -504,7 +504,7 @@ unc_uh:
   COORDINATE_SYSTEM: instrument frame
   DEPEND_0: epoch
   DEPEND_1: energy_uh
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Uncertainty - Ultra-Heavy
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -522,7 +522,7 @@ c:
   DEPEND_0: epoch
   DEPEND_1: energy_c
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - C
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -540,7 +540,7 @@ fe:
   DEPEND_0: epoch
   DEPEND_1: energy_fe
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - Fe
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -558,7 +558,7 @@ h:
   DEPEND_0: epoch
   DEPEND_1: energy_h
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - H
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -576,7 +576,7 @@ he3:
   DEPEND_0: epoch
   DEPEND_1: energy_he3
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - He3
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -594,7 +594,7 @@ he4:
   DEPEND_0: epoch
   DEPEND_1: energy_he4
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - He4
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -612,7 +612,7 @@ junk:
   DEPEND_0: epoch
   DEPEND_1: energy_junk
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - Junk
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -633,7 +633,7 @@ ne_mg_si:
   DEPEND_0: epoch
   DEPEND_1: energy_ne_mg_si
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - Ne+Mg+Si
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -651,7 +651,7 @@ o:
   DEPEND_0: epoch
   DEPEND_1: energy_o
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - O
   FILLVAL: *real_fillval
   FORMAT: F32.1
@@ -669,7 +669,7 @@ uh:
   DEPEND_0: epoch
   DEPEND_1: energy_uh
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - Ultra-Heavy
   FILLVAL: *real_fillval
   FORMAT: F32.1

--- a/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-hi-sectored_variable_attrs.yaml
@@ -193,6 +193,8 @@ species_dim_attrs: &species_dim_attrs
 cno:
   <<: *species_dim_attrs
   CATDESC: Differential intensity for CNO by energy, spin sector, and elevation at x2-spaced energy-per-nucleon channels
+  DELTA_MINUS_VAR: unc_cno
+  DELTA_PLUS_VAR: unc_cno
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - CNO
@@ -207,6 +209,8 @@ cno:
 fe:
   <<: *species_dim_attrs
   CATDESC: Differential intensity for Fe by energy, spin sector, and elevation at x2-spaced energy-per-nucleon channels
+  DELTA_MINUS_VAR: unc_fe
+  DELTA_PLUS_VAR: unc_fe
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - Fe
@@ -221,6 +225,8 @@ fe:
 h:
   <<: *species_dim_attrs
   CATDESC: Differential intensity for H by energy, spin sector, and elevation at x2-spaced energy-per-nucleon channels
+  DELTA_MINUS_VAR: unc_h
+  DELTA_PLUS_VAR: unc_h
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - H
@@ -235,6 +241,8 @@ h:
 he3he4:
   <<: *species_dim_attrs
   CATDESC: Differential intensity for He3+He4 by energy, spin sector, and elevation at x2-spaced energy-per-nucleon channels
+  DELTA_MINUS_VAR: unc_he3he4
+  DELTA_PLUS_VAR: unc_he3he4
   DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
   DISPLAY_TYPE: spectrogram
   FIELDNAM: Differential Intensity - He3+He4
@@ -260,7 +268,7 @@ unc_cno:
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 4096.0
   VALIDMIN: 0.0
-  VAR_TYPE: data
+  VAR_TYPE: support_data
 
 unc_fe:
   <<: *species_dim_attrs
@@ -275,7 +283,7 @@ unc_fe:
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 4096.0
   VALIDMIN: 0.0
-  VAR_TYPE: data
+  VAR_TYPE: support_data
 
 unc_h:
   <<: *species_dim_attrs
@@ -291,7 +299,7 @@ unc_h:
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 4096.0
   VALIDMIN: 0.0
-  VAR_TYPE: data
+  VAR_TYPE: support_data
 
 unc_he3he4:
   <<: *species_dim_attrs
@@ -306,7 +314,7 @@ unc_he3he4:
   UNITS: '# / cm2 s sr MeV/nuc'
   VALIDMAX: 4096.0
   VALIDMIN: 0.0
-  VAR_TYPE: data
+  VAR_TYPE: support_data
 
 # energy deltas:
 energy_cno_minus:

--- a/imap_processing/cdf/config/imap_codice_l2-lo-angular_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-angular_variable_attrs.yaml
@@ -52,12 +52,14 @@ elevation_angle_label:
 # lo-angular attribute templates (combined versions of the previous entries)
 lo-angular-attrs:
     CATDESC: "{species} {direction} species"
+    DELTA_MINUS_VAR: unc_{species}
+    DELTA_PLUS_VAR: unc_{species}
     DEPEND_0: epoch
     DEPEND_1: esa_step
     DEPEND_2: spin_sector
     DEPEND_3: elevation_angle
     DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Differential
-    DISPLAY_TYPE: time_series
+    DISPLAY_TYPE: spectrogram
     FIELDNAM: "{direction} - {species}"
     FILLVAL: *real_fillval
     FORMAT: F13.4
@@ -76,7 +78,7 @@ lo-angular-unc-attrs:
     DEPEND_2: spin_sector
     DEPEND_3: elevation_angle
     DICT_KEY: SPASE>Particle>ParticleType:Ion,ParticleQuantity:NumberFlux,Qualifier:Uncertainty
-    DISPLAY_TYPE: time_series
+    DISPLAY_TYPE: spectrogram
     FIELDNAM: "{direction} - {species}"
     FILLVAL: *real_fillval
     FORMAT: F13.4
@@ -86,4 +88,4 @@ lo-angular-unc-attrs:
     UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMAX: 16777216.0
     VALIDMIN: 0.0
-    VAR_TYPE: data
+    VAR_TYPE: support_data

--- a/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-direct-events_variable_attrs.yaml
@@ -73,7 +73,7 @@ num_events:
   DEPEND_0: epoch
   DEPEND_1: priority
   DICT_KEY: SPASE>Support>SupportQuantity:Other
-  DISPLAY_TYPE: time_series
+  DISPLAY_TYPE: spectrogram
   FIELDNAM: Number of Events
   FILLVAL: *uint16_fillval
   FORMAT: I5

--- a/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_codice_l2-lo-species_variable_attrs.yaml
@@ -63,6 +63,8 @@ data_quality:
 # lo species attrs
 lo-species-attrs:
     CATDESC: "{species} Non-sunward Species"
+    DELTA_MINUS_VAR: unc_{species}
+    DELTA_PLUS_VAR: unc_{species}
     DEPEND_0: epoch
     DEPEND_1: esa_step
     DEPEND_2: spin_sector
@@ -81,6 +83,8 @@ lo-species-attrs:
 
 lo-pui-species-attrs:
     CATDESC: "{species} Pickup Ion Sunward Species"
+    DELTA_MINUS_VAR: unc_{species}
+    DELTA_PLUS_VAR: unc_{species}
     DEPEND_0: epoch
     DEPEND_1: esa_step
     DEPEND_2: spin_sector
@@ -99,6 +103,8 @@ lo-pui-species-attrs:
 
 lo-sw-species-attrs:
   CATDESC: "Differential intensity from sunward-looking detectors measuring solar-wind {species_display}"
+  DELTA_MINUS_VAR: unc_{species}
+  DELTA_PLUS_VAR: unc_{species}
   DEPEND_0: epoch
   DEPEND_1: esa_step
   DEPEND_2: spin_sector
@@ -131,7 +137,7 @@ lo-species-unc-attrs:
     UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMAX: *species_valid_max
     VALIDMIN: 0.0
-    VAR_TYPE: data
+    VAR_TYPE: support_data
 
 lo-pui-species-unc-attrs:
     CATDESC: "{species} Pickup Ion Sunward Species uncertainty"
@@ -149,7 +155,7 @@ lo-pui-species-unc-attrs:
     UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMAX: *species_valid_max
     VALIDMIN: 0.0
-    VAR_TYPE: data
+    VAR_TYPE: support_data
 
 lo-sw-species-unc-attrs:
     CATDESC: "Uncertainty in differential intensity from sunward-looking detectors measuring solar-wind {species_display}"
@@ -167,4 +173,4 @@ lo-sw-species-unc-attrs:
     UNITS: "#/(cm^2-s-sr-keV/q)"
     VALIDMAX: *species_valid_max
     VALIDMIN: 0.0
-    VAR_TYPE: data
+    VAR_TYPE: support_data

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -79,7 +79,7 @@ DIRECT_EVENT_LUTS = {
 
 DIRECT_EVENT_DISPLAY_TYPES = {
     "lo-direct-events": {
-        "num_events": "time_series",
+        "num_events": "spectrogram",
         "data_quality": "no_plot",
         "gain": "no_plot",
         "multi_flag": "no_plot",
@@ -94,7 +94,7 @@ DIRECT_EVENT_DISPLAY_TYPES = {
         "position": "no_plot",
     },
     "hi-direct-events": {
-        "num_events": "time_series",
+        "num_events": "spectrogram",
         "data_quality": "no_plot",
         "gain": "no_plot",
         "multi_flag": "no_plot",


### PR DESCRIPTION
# Change Summary

closes #3311

## Overview
These changes were outlined by Jon and the CoDICE team. 

1. Fix DISPLAY_TYPE metadata 
   - Change DISPLAY_TYPE from time_series to spectrogram for all CoDICE L2 variables that are 2-dimensional. Currently some files (e.g., hi-omni) already do this correctly; others (e.g., lo files) still say time_series, which makes CAVA plot them as line plots instead of spectrograms. Straightforward, mechanical fix.
2. Fix uncertainty variable handling
   - Uncertainties are currently defined as standalone/"free-floating" data variables, which makes them show up as separate plottable variables in CAVA (confusing). Instead, each uncertainty variable should be:
      - Marked VAR_TYPE: support_data (not data)
      - Attached to its parent variable via DELTA_PLUS_VAR / DELTA_MINUS_VAR pointing to the uncertainty variable name (e.g., unc_{species}) hi-omni already follows this pattern; lo-species and likely others need to be updated to match.

## File changes
Update cdf attribute yaml files 

