### PR TITLE
Dependency jsons present locally are not downloaded

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -201,8 +201,9 @@ def _parse_args() -> argparse.Namespace:
         '{"major_version": 2, "minor_version": 1}}'
         "}'"
         "    A path to a JSON file containing this same information may also be"
-        "passed in. If dependency is a string ending in '.json', it will be interpreted"
-        " as such a file path."
+        " passed in. If dependency is a string ending in '.json', it will be"
+        " interpreted as such a file path: an existing local file is used as-is,"
+        " otherwise the file is downloaded from the IMAP SDC."
     )
 
     parser = argparse.ArgumentParser(prog="imap_cli", description=description)

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -288,7 +288,10 @@ def _parse_args() -> argparse.Namespace:
         logger.info(
             f"Interpreting dependency argument as a JSON file: {args.dependency}"
         )
-        dependency_filepath = download(args.dependency)
+        if not Path(args.dependency).exists():
+            dependency_filepath = download(args.dependency)
+        else:
+            dependency_filepath = args.dependency
         with open(dependency_filepath) as f:
             args.dependency = f.read()
 

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -167,6 +167,35 @@ def test_parse_args_dependency_json_file(caplog, tmp_path):
         )
 
 
+def test_parse_args_dependency_local_json_not_downloaded(tmp_path):
+    """A --dependency JSON that exists locally is read without downloading."""
+    test_json_content = {"dependency": [], "version": {}}
+    test_json_dst = tmp_path / "imap_ultra_l2_local-dependency_20250520_v001.0001.json"
+    with open(test_json_dst, "w") as f:
+        f.write(json.dumps(test_json_content))
+
+    test_args = [
+        "imap_cli",
+        "--instrument",
+        "mag",
+        "--dependency",
+        str(test_json_dst),
+        "--data-level",
+        "l1a",
+        "--start-date",
+        "20240430",
+    ]
+    with (
+        mock.patch.object(sys, "argv", test_args),
+        mock.patch("imap_processing.cli.download") as mock_download,
+    ):
+        args = _parse_args()
+
+    # Local file exists, so download must not be called and its content is read.
+    mock_download.assert_not_called()
+    assert json.loads(args.dependency) == test_json_content
+
+
 @pytest.mark.parametrize(
     "instrument, data_level, start_date, repointing, raises_value_error",
     [


### PR DESCRIPTION
Closes #2889 

During development of processing steps that need to be tested locally before a PR to `sds-data-manager`, the ability to test against a locally available (and hand-coded) dependency json is invaluable. This adds the ability to do so.
