### PR TITLE
Improve performance of HEALPix to rectangular by skipping calculation of debug string if it will not be logged

### DIFF
--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1804,8 +1804,10 @@ class HealpixSkyMap(AbstractSkyMap):
             )
         # Log the mean pixel value and the number of subdivisions for debugging
         logger.debug(
-            f"    Mean pixel value at Number of subdivisions: %s: "
-            f"array of shape %s: %s", num_subdivisions, mean_pixel_value.shape, mean_pixel_value
+            "    Mean pixel value at Number of subdivisions: %s: array of shape %s: %s",
+            num_subdivisions,
+            mean_pixel_value.shape,
+            mean_pixel_value,
         )
         return mean_pixel_value
 

--- a/imap_processing/ena_maps/ena_maps.py
+++ b/imap_processing/ena_maps/ena_maps.py
@@ -1804,8 +1804,8 @@ class HealpixSkyMap(AbstractSkyMap):
             )
         # Log the mean pixel value and the number of subdivisions for debugging
         logger.debug(
-            f"    Mean pixel value at Number of subdivisions: {num_subdivisions}: "
-            f"array of shape {mean_pixel_value.shape}: {mean_pixel_value}"
+            f"    Mean pixel value at Number of subdivisions: %s: "
+            f"array of shape %s: %s", num_subdivisions, mean_pixel_value.shape, mean_pixel_value
         )
         return mean_pixel_value
 


### PR DESCRIPTION
# Change Summary

## Overview
When profiling the HEALPix to rectangular conversion, we found a debug log that was taking a significant amount of time.
https://github.com/IMAP-Science-Operations-Center/imap_processing/blob/7c51269fc5cd46186638bd9a58bdbe2446094aff/imap_processing/ena_maps/ena_maps.py#L1806-L1809
Since this uses f-strings, it always calculates the string (including stringifying the contents of the subdivided `mean_pixel_value` data array), even if the logging level does not include debug logs.

We replaced the f-strings in the logger.debug call with %s placeholders and passed the strings in as parameters to avoid building the log string at non-debug log levels.
