### PR TITLE
I-ALiRT - Add Mopra Packet Ingest

### DIFF
--- a/imap_processing/ialirt/calculate_ingest.py
+++ b/imap_processing/ialirt/calculate_ingest.py
@@ -6,7 +6,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-STATIONS = ["Kiel", "UKSA", "tlmrelay"]
+STATIONS = ["Kiel", "UKSA", "Mopra", "tlmrelay"]
 
 
 def packets_created(start_file_creation: datetime, lines: list) -> dict:

--- a/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
+++ b/imap_processing/tests/ialirt/unit/test_calculate_ingest.py
@@ -28,6 +28,10 @@ def test_packets_created():
             ],
             "rate_kbps": [2.0, 2.0],
         },
+        "Mopra": {
+            "last_data_received": [],
+            "rate_kbps": [],
+        },
         "UKSA": {
             "last_data_received": [],
             "rate_kbps": [],


### PR DESCRIPTION
This pull request updates the list of stations in the `calculate_ingest.py` script by adding a new station. This change ensures that data from the "Mopra" station is now included in processing.

- Station configuration:
  * Added "Mopra" to the `STATIONS` list in `calculate_ingest.py` to include its data in ingest calculations.