### PR TITLE
Fail imap-data-access 503 jobs with retry exit code.

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -97,6 +97,11 @@ from imap_processing.utils import (
 
 logger = logging.getLogger(__name__)
 
+RETRY_EXIT_CODE = (
+    75  # Exit code that indicates the job should be retried. E.g. if there was an
+)
+# imap-data-access 503 SlowDown error.
+
 
 def _parse_args() -> argparse.Namespace:
     """
@@ -510,6 +515,12 @@ class ProcessInstrument(ABC):
                                 )
                                 sleep(5)
                                 continue
+
+                            logger.error(
+                                f"Upload Failed after {max_retries} retries. Exiting "
+                                f"with code {RETRY_EXIT_CODE}."
+                            )
+                            sys.exit(RETRY_EXIT_CODE)
 
                         logger.error(f"Upload failed with error: {message}")
                         raise

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -97,10 +97,8 @@ from imap_processing.utils import (
 
 logger = logging.getLogger(__name__)
 
-RETRY_EXIT_CODE = (
-    75  # Exit code that indicates the job should be retried. E.g. if there was an
-)
-# imap-data-access 503 SlowDown error.
+RETRY_EXIT_CODE = 75  # Exit code indicating the job should be retried
+# (e.g., imap-data-access 503 SlowDown).
 
 
 def _parse_args() -> argparse.Namespace:

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -515,7 +515,7 @@ class ProcessInstrument(ABC):
                                 continue
 
                             logger.error(
-                                f"Upload Failed after {max_retries} retries. Exiting "
+                                f"Upload failed after {max_retries} attempts. Exiting "
                                 f"with code {RETRY_EXIT_CODE}."
                             )
                             sys.exit(RETRY_EXIT_CODE)

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -1063,7 +1063,7 @@ def test_post_processing_upload_503_error(
 
     # Checks the upload failure was logged
     assert any(
-        "Upload Failed after 3 retries" in str(call)
+        "Upload failed after 3 attempts" in str(call)
         for call in mock_error.call_args_list
     )
 

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -1049,7 +1049,7 @@ def test_post_processing_upload_503_error(
     )
     instrument = Swe("l1a", "raw", dependency_str, "20100105", None, "v001", True)
 
-    # Checks that the upload failed and logs an error and raises an exception
+    # Checks that the upload failed, logs an error, and exits with the retry exit code
     with mock.patch("logging.Logger.error") as mock_error:
         with pytest.raises(SystemExit) as exc_info:
             instrument.process()

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -1051,8 +1051,9 @@ def test_post_processing_upload_503_error(
 
     # Checks that the upload failed and logs an error and raises an exception
     with mock.patch("logging.Logger.error") as mock_error:
-        with pytest.raises(imap_data_access.io.IMAPDataAccessError):
+        with pytest.raises(SystemExit) as exc_info:
             instrument.process()
+    assert exc_info.value.code == 75  # The code should be the retry exit code
 
     # Upload should attempt 3 times
     assert mocks["mock_upload"].call_count == 3
@@ -1062,7 +1063,8 @@ def test_post_processing_upload_503_error(
 
     # Checks the upload failure was logged
     assert any(
-        "Upload failed with error" in str(call) for call in mock_error.call_args_list
+        "Upload Failed after 3 retries" in str(call)
+        for call in mock_error.call_args_list
     )
 
 


### PR DESCRIPTION
# Change Summary

partially closes https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/1472
## Overview
This PR makes a slight update to the code that Daralynn just wrote. I forgot to add in her ticket that we should fail with an exit code (75) so our batch retry strategy can identify these jobs as ones to rerun. 

## File changes
- instead of raising the current exception, fail with an exit code 75. 

Related to https://github.com/IMAP-Science-Operations-Center/sds-data-manager/compare/dev...lacoak21:sds-data-manager:retry_exit_code
