### PR TITLE
Fix MAG L1D test leaking CDF files: incorrect function was being patched

### DIFF
--- a/imap_processing/tests/mag/test_mag_l1d.py
+++ b/imap_processing/tests/mag/test_mag_l1d.py
@@ -230,7 +230,7 @@ def test_mag_l1d_attributes(
 
     mock_dependencies = ProcessingInputCollection()
 
-    with patch("imap_processing.cdf.utils.xarray_to_cdf"):
+    with patch("imap_processing.cli.xarray_to_cdf"):
         mag_processor.post_processing(l1d_datasets, mock_dependencies)
 
 


### PR DESCRIPTION
# Change Summary

## Overview

Closes: #3364

Prevents the MAG L1D attribute test from leaving ancillary CDF files in the repository root.

## File changes

- `imap_processing/tests/mag/test_mag_l1d.py`:  line 233 was updated to patch the appropriate `"imap_processing.cli.xarray_to_cdf"` function instead of `"imap_processing.cdf.utils.xarray_to_cdf"`.

## Testing
Running `poetry run pytest imap_processing/tests/mag/test_mag_l1d.py` results in all tests passing with no persistent ancillary CDF files.
