### PR TITLE
Idex tof unit fix

### DIFF
--- a/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l1b_variable_attrs.yaml
@@ -36,6 +36,7 @@ l1b_tof_base: &l1b_tof_base
   <<: *l1b_data_base
   DEPEND_1: time_high_sample_rate_index
   LABL_PTR_1: time_high_sample_rate_label
+  UNITS: mA
 
 l1b_target_base: &l1b_target_base
   <<: *l1b_data_base
@@ -65,6 +66,7 @@ trigger_level_lg:
   <<: *trigger_base
   CATDESC: Low Gain Trigger Level threshold.
   FIELDNAM: Low Gain Trigger Level
+  UNITS: mA
 
 trigger_mode_mg:
   <<: *string_base
@@ -75,6 +77,7 @@ trigger_level_mg:
   <<: *trigger_base
   CATDESC: Mid Gain Trigger level threshold.
   FIELDNAM: Mid Gain Trigger Level
+  UNITS: mA
 
 
 trigger_mode_hg:
@@ -86,6 +89,7 @@ trigger_level_hg:
   <<: *trigger_base
   CATDESC: High Trigger Level threshold.
   FIELDNAM: High Trigger Level
+  UNITS: mA
 
 trigger_origin:
   <<: *string_base

--- a/imap_processing/idex/idex_constants.py
+++ b/imap_processing/idex/idex_constants.py
@@ -73,11 +73,15 @@ IDEX_10_DAY_RANGES_PATH = f"{imap_module_directory}/idex/idex_10_day_CDF_names.c
 
 
 class ConversionFactors(float, Enum):
-    """Conversion factor values (DN to picocoulombs) for each of the six waveforms."""
+    """Conversion factors from DN to the engineering units for each waveform.
 
-    TOF_High = 2.89e-4
-    TOF_Low = 5.14e-1
-    TOF_Mid = 1.13e-2
+    TOF channels are reported in milliamperes (mA); target and ion-grid channels are
+    reported in picocoulombs (pC).
+    """
+
+    TOF_High = 7.50e-5
+    TOF_Low = 1.34e-1
+    TOF_Mid = 2.93e-3
     Target_Low = 1.58e1
     Target_High = 1.63e-1
     Ion_Grid = 7.46e-4

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -335,7 +335,7 @@ def convert_waveforms(
     l1a_dataset: xr.Dataset, idex_attrs: ImapCdfAttributes
 ) -> dict[str, xr.DataArray]:
     """
-    Apply transformation from raw DN to picocoulombs (pC) for each of the six waveforms.
+    Apply the channel-specific transformation from raw DN to engineering units.
 
     Parameters
     ----------
@@ -348,17 +348,18 @@ def convert_waveforms(
     -------
     waveforms_converted : dict
         A dictionary where the keys are the waveform array names and the values are
-        xr.DataArrays representing the waveforms transformed into picocoulombs.
+        xr.DataArrays representing the converted waveforms. TOF channels are in mA;
+        target and ion-grid channels are in pC.
     """
-    waveforms_pc = {}
+    waveforms_converted = {}
 
     for var in ConversionFactors:
-        waveforms_pc[var.name] = l1a_dataset[var.name] * var.value
-        waveforms_pc[var.name].attrs = idex_attrs.get_variable_attributes(
+        waveforms_converted[var.name] = l1a_dataset[var.name] * var.value
+        waveforms_converted[var.name].attrs = idex_attrs.get_variable_attributes(
             var.name.lower()
         )
 
-    return waveforms_pc
+    return waveforms_converted
 
 
 def get_trigger_mode_and_level(

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -359,9 +359,7 @@ def test_validate_l1b_idex_data_variables(
                     ConversionFactors[cdf_var].value / legacy_tof_factors[var]
                 )
             if l1b_dataset[cdf_var].dtype == object:
-                assert (
-                    l1b_dataset[cdf_var].data == expected_data
-                ).all(), warning
+                assert (l1b_dataset[cdf_var].data == expected_data).all(), warning
 
             else:
                 np.testing.assert_array_almost_equal(

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -92,17 +92,14 @@ def test_idex_waveform_units(l1b_dataset: xr.Dataset):
         assert l1b_dataset[var_name].attrs["UNITS"] == row["unit"]
 
     # Check waveform units
-    waveform_var_names = [
-        "TOF_High",
-        "TOF_Low",
-        "TOF_Mid",
-        "Ion_Grid",
-        "Target_Low",
-        "Target_High",
-    ]
+    for var_name in ("TOF_High", "TOF_Low", "TOF_Mid"):
+        assert l1b_dataset[var_name].attrs["UNITS"] == "mA"
 
-    for var_name in waveform_var_names:
+    for var_name in ("Ion_Grid", "Target_Low", "Target_High"):
         assert l1b_dataset[var_name].attrs["UNITS"] == "pC"
+
+    for var_name in ("trigger_level_lg", "trigger_level_mg", "trigger_level_hg"):
+        assert l1b_dataset[var_name].attrs["UNITS"] == "mA"
 
 
 def test_unpack_instrument_settings():
@@ -169,9 +166,9 @@ def test_get_trigger_settings_success(decom_test_data_sci):
     expected_modes_mg[0] = "MGThreshold"
     expected_levels_lg = np.full(n_epochs, np.nan)
     expected_levels_hg = expected_levels_lg.copy()
-    expected_levels_hg[1:] = 0.16762
+    expected_levels_hg[1:] = 580.0 * 7.50e-5
     expected_levels_mg = expected_levels_lg.copy()
-    expected_levels_mg[0] = 1023.0 * 1.13e-2
+    expected_levels_mg[0] = 1023.0 * 2.93e-3
 
     var_names = ["trigger_mode_lg", "trigger_mode_mg", "trigger_mode_hg"]
     expected_modes = [expected_modes_lg, expected_modes_mg, expected_modes_hg]

--- a/imap_processing/tests/idex/test_idex_l1b.py
+++ b/imap_processing/tests/idex/test_idex_l1b.py
@@ -10,7 +10,7 @@ import xarray as xr
 from imap_processing import imap_module_directory
 from imap_processing.cdf.imap_cdf_manager import ImapCdfAttributes
 from imap_processing.cdf.utils import write_cdf
-from imap_processing.idex.idex_constants import DT_BLOCK
+from imap_processing.idex.idex_constants import DT_BLOCK, ConversionFactors
 from imap_processing.idex.idex_l1b import (
     TRIGGER_LABELS,
     EventMessage,
@@ -332,6 +332,13 @@ def test_validate_l1b_idex_data_variables(
         event=np.arange(l1b_dataset.sizes["epoch"])
     )
     # Compare each corresponding variable
+    # The team validation file stores TOF waveforms using the legacy pC factors.
+    # Convert those reference arrays to the corrected L1B mA units before comparing.
+    legacy_tof_factors = {
+        "TOF L": 5.14e-1,
+        "TOF H": 2.89e-4,
+        "TOF M": 1.13e-2,
+    }
     for var in l1b_example_data.data_vars:
         if var not in arrays_to_skip:
             # Get the corresponding array name
@@ -346,15 +353,20 @@ def test_validate_l1b_idex_data_variables(
                 l1b_dataset[cdf_var]
             except KeyError:
                 continue
+            expected_data = np.squeeze(l1b_example_data[var])
+            if var in legacy_tof_factors:
+                expected_data = expected_data * (
+                    ConversionFactors[cdf_var].value / legacy_tof_factors[var]
+                )
             if l1b_dataset[cdf_var].dtype == object:
                 assert (
-                    l1b_dataset[cdf_var].data == np.squeeze(l1b_example_data[var])
+                    l1b_dataset[cdf_var].data == expected_data
                 ).all(), warning
 
             else:
                 np.testing.assert_array_almost_equal(
                     l1b_dataset[cdf_var].data,
-                    np.squeeze(l1b_example_data[var]),
+                    expected_data,
                     decimal=4,
                     err_msg=warning,
                 )


### PR DESCRIPTION
# Change Summary

closes #3404

  ## Overview

  Updated IDEX L1B TOF waveform processing to report values in mA using the corrected channel-specific
  conversion factors.

  ## File changes

  - Updated TOF conversion factors and documentation in idex_constants.py.
  - Updated L1B conversion documentation in idex_l1b.py.
  - Updated L1B YAML metadata for TOF waveforms and trigger levels to use mA.
  - Updated L1B tests and legacy validation comparisons for the new units.

  ## Testing

  - Full IDEX L1B test file: 12 passed.

