### PR TITLE
IDEX l2b 10-day refactor

### DIFF
--- a/imap_processing/_version.py
+++ b/imap_processing/_version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced later during substitution.
-__version__ = "0.0.0.post2.dev0+fa037d1"
-__version_tuple__ = (0, 0, 0, "post2", "dev0", "fa037d1")
+__version__ = "1.0.36.post17.dev0+817768c1"
+__version_tuple__ = (1, 0, 36, "post17", "dev0", "817768c1")

--- a/imap_processing/_version.py
+++ b/imap_processing/_version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced later during substitution.
-__version__ = "1.0.36.post17.dev0+817768c1"
-__version_tuple__ = (1, 0, 36, "post17", "dev0", "817768c1")
+__version__ = "1.0.36.post28.dev0+3c83ecfb"
+__version_tuple__ = (1, 0, 36, "post28", "dev0", "3c83ecfb")

--- a/imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_global_cdf_attrs.yaml
@@ -55,13 +55,13 @@ imap_idex_l2a_sci:
 imap_idex_l2b_sci:
   <<: *instrument_base
   Data_level: 2B
-  Data_type: L2B_SCI-1MO>Level-2B Science Monthly Data
-  Logical_source: imap_idex_l2b_sci-1mo
-  Logical_source_description: IMAP Mission IDEX Instrument Level-2B Monthly Data
+  Data_type: L2B_SCI-10DAYS>Level-2B Science 10-Day Data
+  Logical_source: imap_idex_l2b_sci-10days
+  Logical_source_description: IMAP Mission IDEX Instrument Level-2B 10-Day Data
 
 imap_idex_l2c_sci-rectangular:
   <<: *instrument_base
   Data_level: 2C
-  Data_type: L2C_RECTANGULAR-MAP-1MO>Level-2C Rectangular Map Monthly Data
-  Logical_source: imap_idex_l2c_rectangular-map-1mo
-  Logical_source_description: IMAP Mission IDEX Instrument Level-2C Rectangular Map Monthly Data
+  Data_type: L2C_RECTANGULAR-MAP-10DAYS>Level-2C Rectangular Map 10-Day Data
+  Logical_source: imap_idex_l2c_rectangular-map-10days
+  Logical_source_description: IMAP Mission IDEX Instrument Level-2C Rectangular Map 10-Day Data

--- a/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
@@ -118,7 +118,7 @@ base_agnostic: &base_agnostic
 
 rate_by_charge:
     <<: *base_charge
-    CATDESC: Count rate in s^-1 by impact charge and spin phase.
+    CATDESC: Count rate by impact charge and spin phase over the 10-day window.
     DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:CountRate,Qualifier:Array
     FIELDNAM: Rate by Charge
     FILLVAL: *double_fillval
@@ -126,7 +126,7 @@ rate_by_charge:
 
 rate_by_mass:
     <<: *base_mass
-    CATDESC: Count rate in s^-1 by mass and spin phase.
+    CATDESC: Count rate by mass and spin phase over the 10-day window.
     DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:CountRate,Qualifier:Array
     FIELDNAM: Rate by Mass
     FILLVAL: *double_fillval
@@ -150,7 +150,7 @@ counts_by_mass:
 
 counts:
     <<: *base_agnostic
-    CATDESC: Count of dust impacts by spin phase.
+    CATDESC: Count of dust impacts by spin phase over the 10-day window.
     DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:Counts,Qualifier:Array
     FIELDNAM: Counts
     FORMAT: I8
@@ -158,25 +158,11 @@ counts:
 
 rate:
     <<: *base_agnostic
-    CATDESC: Dust impact count rate by spin phase.
+    CATDESC: Dust impact count rate by spin phase over the 10-day window.
     DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:CountRate,Qualifier:Array
     FIELDNAM: Rate
     FILLVAL: *double_fillval
     UNITS: s^-1
-
-impact_day_of_year:
-    CATDESC: The unique day of the years when dust impacts occurred.
-    DEPEND_0: epoch
-    DICT_KEY: SPASE>Support>SupportQuantity:Temporal
-    DISPLAY_TYPE: time_series
-    FIELDNAM: Impact Day of Year
-    FILLVAL: *int_fillval
-    FORMAT: I3
-    LABLAXIS: Impact DOY
-    UNITS: days
-    VALIDMAX: 366
-    VALIDMIN: 1
-    VAR_TYPE: data
 
 rate_calculation_quality_flags:
   CATDESC: Quality flag for rate calculation (1 = good, 0 = insufficient IDEX uptime data)

--- a/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
@@ -2,6 +2,51 @@ int_fillval: &int_fillval -9223372036854775808
 int_maxval: &int_maxval 9223372036854775807
 double_fillval: &double_fillval -1.0E31
 
+# Override the default epoch (defined in imap_constant_attrs.yaml) for L2B/L2C.
+epoch:
+  BIN_LOCATION: 0.0
+  CATDESC: Start time of the accumulation window, number of nanoseconds since J2000 with leap seconds included
+  DELTA_MINUS_VAR: epoch_delta_minus
+  DELTA_PLUS_VAR: epoch_delta_plus
+  VAR_NOTES: >
+    Deviates from the ISTP default of representing the center of the
+    measurement period, because that would not represent the beginning of the
+    accumulation window. IDEX L2B/L2C accumulation windows are also not a
+    fixed duration (they range from about 6 to 10 days, aligned to
+    day-of-year boundaries), so a single symmetric delta could not describe
+    the true window bounds either. Epoch is instead set to the nominal start
+    of the window (per the IDEX 10-day window schedule), with DELTA_PLUS_VAR
+    (epoch_delta_plus) giving the nominal window duration, and DELTA_MINUS_VAR
+    (epoch_delta_minus) fixed at zero.
+
+epoch_delta_plus:
+  CATDESC: Number of nanoseconds from epoch to the end of the accumulation window
+  DEPEND_0: epoch
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
+  FIELDNAM: Epoch Delta Plus
+  FILLVAL: *int_fillval
+  FORMAT: I19
+  LABLAXIS: Epoch Delta Plus
+  SCALETYP: linear
+  UNITS: ns
+  VALIDMAX: 864000000000000
+  VALIDMIN: 0
+  VAR_TYPE: support_data
+
+epoch_delta_minus:
+  CATDESC: Number of nanoseconds from epoch to the start of the accumulation window (always zero, since epoch is defined as the window start)
+  DEPEND_0: epoch
+  DICT_KEY: SPASE>Support>SupportQuantity:Temporal,Qualifier:Uncertainty
+  FIELDNAM: Epoch Delta Minus
+  FILLVAL: *int_fillval
+  FORMAT: I19
+  LABLAXIS: Epoch Delta Minus
+  SCALETYP: linear
+  UNITS: ns
+  VALIDMAX: 0
+  VALIDMIN: 0
+  VAR_TYPE: support_data
+
 # Label attributes
 mass_labels:
   CATDESC: Labels for Mass

--- a/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
@@ -104,7 +104,7 @@ rectangular_lat_pixel:
 
 rate_by_charge_map:
   <<: *base_charge_map
-  CATDESC: Count rate in s^-1 by impact charge, longitude, and latitude.
+  CATDESC: Count rate by impact charge, longitude, and latitude over the 10-day window.
   DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
   FIELDNAM: Rate by Charge Map
   FILLVAL: *double_fillval
@@ -128,7 +128,7 @@ counts_by_mass_map:
 
 rate_by_mass_map:
   <<: *base_mass_map
-  CATDESC: Count rate in s^-1 by mass, longitude, and latitude.
+  CATDESC: Count rate by mass, longitude, and latitude over the 10-day window.
   DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
   FIELDNAM: Rate by Mass Map
   FILLVAL: *double_fillval
@@ -136,7 +136,7 @@ rate_by_mass_map:
 
 counts_map:
   <<: *base_agnostic_map
-  CATDESC: Count of dust impacts by longitude and latitude.
+  CATDESC: Count of dust impacts by longitude and latitude over the 10-day window.
   DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:Counts,Qualifier:Array
   FIELDNAM: Counts Map
   FORMAT: I8
@@ -144,7 +144,7 @@ counts_map:
 
 rate_map:
   <<: *base_agnostic_map
-  CATDESC: Dust impact count rate by longitude and latitude.
+  CATDESC: Dust impact count rate by longitude and latitude over the 10-day window.
   DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
   FIELDNAM: Rate Map
   FILLVAL: *double_fillval

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1173,7 +1173,7 @@ class Hit(ProcessInstrument):
 class Idex(ProcessInstrument):
     """Process IDEX."""
 
-    def do_processing(
+    def do_processing(  # noqa: PLR0912
         self, dependencies: ProcessingInputCollection
     ) -> list[xr.Dataset]:
         """

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1261,7 +1261,7 @@ class Idex(ProcessInstrument):
                 )
             l2a_dataset = load_cdf(sci_files[0])
             hk_dataset = load_cdf(hk_files[0])
-            datasets = idex_l2b(l2a_dataset, hk_dataset)
+            datasets = idex_l2b(l2a_dataset, hk_dataset, self.start_date)
 
         else:
             raise NotImplementedError(

--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1246,24 +1246,28 @@ class Idex(ProcessInstrument):
                     f"Unexpected dependencies found for IDEX L2B:"
                     f"{dependency_list}. Expected three or four dependencies."
                 )
+            # L2A and L2B are both processed on the same 10-day cadence, so there
+            # should be exactly one L2A science file matching this job's start date.
             sci_files = dependencies.get_file_paths(
                 source="idex", descriptor="sci-10days"
             )
-            sci_dependencies = [load_cdf(f) for f in sci_files]
-            # sort science files by the first epoch value
-            sci_dependencies.sort(key=lambda ds: ds["epoch"].values[0])
             hk_files = dependencies.get_file_paths(
                 source="idex", descriptor="msg-10days"
             )
-            # Remove duplicate housekeeping files
-            hk_dependencies = [load_cdf(dep) for dep in list(set(hk_files))]
-            # sort housekeeping files by the first epoch value
-            hk_dependencies.sort(key=lambda ds: ds["epoch"].values[0])
-            datasets = idex_l2b(sci_dependencies, hk_dependencies)
+            if not sci_files or not hk_files:
+                raise ValueError(
+                    "No L2A science file or L1B msg-10day file found for "
+                    "IDEX L2B processing"
+                )
+            l2a_dataset = load_cdf(sci_files[0])
+            hk_dataset = load_cdf(hk_files[0])
+            datasets = idex_l2b(l2a_dataset, hk_dataset)
+
         else:
             raise NotImplementedError(
                 f"Unrecognized data level for {type(self).__name__}:  {self.data_level}"
             )
+
         return datasets
 
 

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -85,21 +85,22 @@ LAT_BINS_EDGES = SKY_GRID.el_bin_edges
 IDEX_INT_FILLVAL = np.iinfo(np.int64).min
 
 
-def idex_l2b(
-    l2a_datasets: list[xr.Dataset], msg_data_l1b: list[xr.Dataset]
-) -> list[xr.Dataset]:
+def idex_l2b(l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset) -> list[xr.Dataset]:
     """
     Will process IDEX l2a data to create l2b and l2c data products.
 
     IDEX L2B processing creates L2b and L2c at the same time because L2c needs no
     additional dependencies and is a natural extension of L2b processing.
 
+    L2A and L2B are both processed on the same IDEX 10-day cadence, so a single L2A
+    dataset (spanning one 10-day window) maps 1:1 to a single L2B/L2C output.
+
     Parameters
     ----------
-    l2a_datasets : list[xarray.Dataset]
-        IDEX L2a datasets to process.
-    msg_data_l1b : list[xarray.Dataset]
-        List of IDEX L1B event message datasets.
+    l2a_dataset : xarray.Dataset
+        IDEX L2a dataset to process, spanning a single 10-day window.
+    msg_data_l1b : xarray.Dataset
+        IDEX L1B event message dataset, spanning a single 10-day window.
 
     Returns
     -------
@@ -108,7 +109,7 @@ def idex_l2b(
         metadata.
     """
     logger.info(
-        "Running IDEX L2B and L2C processing on L2a datasets. NOTE: L2C datasets are "
+        "Running IDEX L2B and L2C processing on L2a dataset. NOTE: L2C datasets are "
         "processed at the same time as L2B datasets because L2C needs no additional "
         "dependencies."
     )
@@ -118,10 +119,6 @@ def idex_l2b(
     msg_ds = (
         xr.concat(msg_data_l1b, dim="epoch").sortby("epoch").drop_duplicates("epoch")
     )
-    # Concat all the l2a datasets together. All l2a datasets passed in are expected to
-    # belong to the same IDEX 10-day window, so counts and rates are aggregated across
-    # the entire window into a single record.
-    l2a_dataset = xr.concat(l2a_datasets, dim="epoch")
     (
         counts_by_charge,
         counts_by_mass,

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -18,7 +18,7 @@ Examples
     l1b_data = idex_l1b(l1a_data, "sci-10days")
 
     l1a_data = idex_l2a(l1b_data)
-    l2b_and_l2c_datasets = idex_l2b(l2a_data, [msg_data_l1b])
+    l2b_and_l2c_datasets = idex_l2b(l2a_data, msg_data_l1b)
     write_cdf(l2b_and_l2c_datasets[0])
     write_cdf(l2b_and_l2c_datasets[1])
 """
@@ -438,7 +438,7 @@ def compute_counts_by_charge_and_mass(
     tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
         Two 3D arrays containing counts by charge or mass, and by spin phase, Two 4D
         arrays containing counts by charge or mass, and by lon and lat, and a 1D array
-        containing the mean epoch of the window.
+        containing the center epoch of the window.
     """
     dust_hit_indices = _get_dust_hit_indices(l2a_dataset)
     mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[dust_hit_indices]
@@ -473,8 +473,11 @@ def compute_counts_by_charge_and_mass(
         np.column_stack([charge_vals, longitude, latitude]),
         bins=[CHARGE_BIN_EDGES, LON_BINS_EDGES, LAT_BINS_EDGES],
     )[0]
-    # The epoch for the window record is the mean epoch of all events in the window.
-    window_epoch = np.array([np.mean(l2a_dataset["epoch"].data)])
+    # Per ISTP convention, the epoch for the window record is the center of the
+    # accumulation period: the midpoint between the first and last event epochs in the
+    # window.
+    epoch_data = l2a_dataset["epoch"].data
+    window_epoch = np.array([(epoch_data.min() + epoch_data.max()) / 2])
 
     return (
         counts_by_charge[np.newaxis, ...],

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -116,9 +116,7 @@ def idex_l2b(l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset) -> list[xr.Datas
     # create the attribute manager for this data level
     idex_l2b_attrs = get_idex_attrs("l2b")
     idex_l2c_attrs = get_idex_attrs("l2c")
-    msg_ds = (
-        xr.concat(msg_data_l1b, dim="epoch").sortby("epoch").drop_duplicates("epoch")
-    )
+    msg_ds = msg_data_l1b.sortby("epoch").drop_duplicates("epoch")
     (
         counts_by_charge,
         counts_by_mass,

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -38,10 +38,9 @@ from imap_processing.idex.idex_constants import (
     FG_TO_KG,
     IDEX_EVENT_REFERENCE_FRAME,
     IDEX_SPACING_DEG,
-    SECONDS_IN_DAY,
 )
 from imap_processing.idex.idex_utils import get_idex_attrs
-from imap_processing.spice.time import epoch_to_doy, et_to_datetime64, ttj2000ns_to_et
+from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
 
 logger = logging.getLogger(__name__)
 
@@ -119,30 +118,27 @@ def idex_l2b(
     msg_ds = (
         xr.concat(msg_data_l1b, dim="epoch").sortby("epoch").drop_duplicates("epoch")
     )
-    # Concat all the l2a datasets together
+    # Concat all the l2a datasets together. All l2a datasets passed in are expected to
+    # belong to the same IDEX 10-day window, so counts and rates are aggregated across
+    # the entire window into a single record.
     l2a_dataset = xr.concat(l2a_datasets, dim="epoch")
-    epoch_doy = epoch_to_doy(l2a_dataset["epoch"].data)
-    # Use dict.fromkeys to preserve order while getting unique DOYs. We want to make
-    # sure the order of DOYs stays the same in case we are dealing with data that
-    # spans over the new year. E.g., we want 365 to come before 1 if we have data from
-    # Dec and Jan.
-    epoch_doy_unique = np.array(list(dict.fromkeys(epoch_doy)))
     (
         counts_by_charge,
         counts_by_mass,
         counts_by_charge_map,
         counts_by_mass_map,
-        daily_epoch,
-    ) = compute_counts_by_charge_and_mass(l2a_dataset, epoch_doy_unique)
-    counts, counts_map = compute_counts_agnostic(l2a_dataset, epoch_doy_unique)
+        window_epoch,
+    ) = compute_counts_by_charge_and_mass(l2a_dataset)
+    counts, counts_map = compute_counts_agnostic(l2a_dataset)
     # Filter the message dataset to only include science acquisition on/off events.
     # (ignore fill vals)
     science_on_msg_ds = msg_ds.isel(epoch=np.isin(msg_ds.science_on, [0, 1]))
     msg_time = science_on_msg_ds["epoch"].data
     msg_values = science_on_msg_ds["science_on"].data
 
-    # Get science acquisition percentage for each day
-    daily_on_percentage = get_science_acquisition_on_percentage(msg_time, msg_values)
+    # Get the number of seconds science acquisition was on, and the total number of
+    # seconds tracked, over the whole 10-day window.
+    on_seconds, total_seconds = get_science_acquisition_on_time(msg_time, msg_values)
     (
         rate_by_charge,
         rate_by_mass,
@@ -154,11 +150,11 @@ def idex_l2b(
         counts_by_mass,
         counts_by_charge_map,
         counts_by_mass_map,
-        epoch_doy_unique,
-        daily_on_percentage,
+        on_seconds,
+        total_seconds,
     )
     rate, rate_map = compute_rates_agnostic(
-        counts, counts_map, epoch_doy_unique, daily_on_percentage
+        counts, counts_map, on_seconds, total_seconds
     )
     # Create l2b Dataset
     charge_bin_means = np.sqrt(CHARGE_BIN_EDGES[:-1] * CHARGE_BIN_EDGES[1:])
@@ -169,7 +165,7 @@ def idex_l2b(
     # Define xarrays that are shared between l2b and l2c
     epoch = xr.DataArray(
         name="epoch",
-        data=daily_epoch,
+        data=window_epoch,
         dims="epoch",
         attrs=idex_l2b_attrs.get_variable_attributes("epoch", check_schema=False),
     )
@@ -189,12 +185,6 @@ def idex_l2b(
             attrs=idex_l2b_attrs.get_variable_attributes(
                 "on_off_events", check_schema=False
             ),
-        ),
-        "impact_day_of_year": xr.DataArray(
-            name="impact_day_of_year",
-            data=epoch_doy_unique,
-            dims="epoch",
-            attrs=idex_l2b_attrs.get_variable_attributes("impact_day_of_year"),
         ),
         "charge_labels": xr.DataArray(
             name="impact_charge_labels",
@@ -434,221 +424,168 @@ def idex_l2b(
 
 
 def compute_counts_by_charge_and_mass(
-    l2a_dataset: xr.Dataset, epoch_doy_unique: np.ndarray
+    l2a_dataset: xr.Dataset,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
-    Compute the dust counts by charge and mass by spin phase or lon and lat per day.
+    Compute the dust counts by charge and mass by spin phase or lon and lat.
+
+    Counts are aggregated across the entire input dataset (expected to span a single
+    IDEX 10-day window) into a single record. Only events flagged as dust hits
+    (``dust_hit_flag`` == 1) are included.
 
     Parameters
     ----------
     l2a_dataset : xarray.Dataset
         Combined IDEX L2a datasets.
-    epoch_doy_unique : np.ndarray
-        Unique days of year corresponding to the epochs in the dataset.
 
     Returns
     -------
     tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-        Two 3D arrays containing counts by charge or mass, and by spin phase for each
-        dataset, Two 4D arrays containing counts by charge or mass, and by lon and lat
-        for each dataset, and a 1D array of daily epoch values.
+        Two 3D arrays containing counts by charge or mass, and by spin phase, Two 4D
+        arrays containing counts by charge or mass, and by lon and lat, and a 1D array
+        containing the mean epoch of the window.
     """
-    # Initialize lists to hold counts.
-    counts_by_charge = []
-    counts_by_mass = []
-    counts_by_charge_map = []
-    counts_by_mass_map = []
-    daily_epoch: np.ndarray = np.zeros(len(epoch_doy_unique), dtype=np.float64)
-    epoch_doy = epoch_to_doy(l2a_dataset["epoch"].data)
-    for i in range(len(epoch_doy_unique)):
-        doy = epoch_doy_unique[i]
-        # Get the indices for the current day
-        current_day_indices = np.flatnonzero(epoch_doy == doy)
-        # Set the epoch for the current day to be the mean epoch of the day.
-        daily_epoch[i] = np.mean(l2a_dataset["epoch"].data[current_day_indices])
-        current_day_indices = _get_dust_hit_indices(l2a_dataset, epoch_doy, int(doy))
-        mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[
-            current_day_indices
-        ]
-        charge_vals = l2a_dataset["target_low_impact_charge"].data[current_day_indices]
-        spin_phase_angles = l2a_dataset["spin_phase"].data[current_day_indices]
-        # Make sure longitude values are in the range [0, 360)
-        longitude = np.mod(l2a_dataset["longitude"].data[current_day_indices], 360)
-        latitude = l2a_dataset["latitude"].data[current_day_indices]
-        # Convert units
-        mass_vals = FG_TO_KG * np.atleast_1d(mass_vals)
-        # Bin spin phases
-        binned_spin_phase = bin_spin_phases(spin_phase_angles)
-        # Clip arrays to ensure that the values are within the valid range of bins.
-        # Latitude should be binned with the right edge included. 90 is a valid latitude
-        latitude = np.clip(latitude, -90, 90)
-        mass_vals = np.clip(mass_vals, MASS_BIN_EDGES[0], MASS_BIN_EDGES[-1])
-        charge_vals = np.clip(charge_vals, CHARGE_BIN_EDGES[0], CHARGE_BIN_EDGES[-1])
+    dust_hit_indices = _get_dust_hit_indices(l2a_dataset)
+    mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[dust_hit_indices]
+    charge_vals = l2a_dataset["target_low_impact_charge"].data[dust_hit_indices]
+    spin_phase_angles = l2a_dataset["spin_phase"].data[dust_hit_indices]
+    # Make sure longitude values are in the range [0, 360)
+    longitude = np.mod(l2a_dataset["longitude"].data[dust_hit_indices], 360)
+    latitude = l2a_dataset["latitude"].data[dust_hit_indices]
+    # Convert units
+    mass_vals = FG_TO_KG * np.atleast_1d(mass_vals)
+    # Bin spin phases
+    binned_spin_phase = bin_spin_phases(spin_phase_angles)
+    # Clip arrays to ensure that the values are within the valid range of bins.
+    # Latitude should be binned with the right edge included. 90 is a valid latitude
+    latitude = np.clip(latitude, -90, 90)
+    mass_vals = np.clip(mass_vals, MASS_BIN_EDGES[0], MASS_BIN_EDGES[-1])
+    charge_vals = np.clip(charge_vals, CHARGE_BIN_EDGES[0], CHARGE_BIN_EDGES[-1])
 
-        counts_by_mass.append(
-            np.histogramdd(
-                np.column_stack([mass_vals, binned_spin_phase]),
-                bins=[MASS_BIN_EDGES, np.arange(SPIN_PHASE_BIN_EDGES.size)],
-            )[0]
-        )
-        counts_by_charge.append(
-            np.histogramdd(
-                np.column_stack([charge_vals, binned_spin_phase]),
-                bins=[CHARGE_BIN_EDGES, np.arange(SPIN_PHASE_BIN_EDGES.size)],
-            )[0]
-        )
-        counts_by_mass_map.append(
-            np.histogramdd(
-                np.column_stack([mass_vals, longitude, latitude]),
-                bins=[MASS_BIN_EDGES, LON_BINS_EDGES, LAT_BINS_EDGES],
-            )[0]
-        )
-        counts_by_charge_map.append(
-            np.histogramdd(
-                np.column_stack([charge_vals, longitude, latitude]),
-                bins=[CHARGE_BIN_EDGES, LON_BINS_EDGES, LAT_BINS_EDGES],
-            )[0]
-        )
+    counts_by_mass = np.histogramdd(
+        np.column_stack([mass_vals, binned_spin_phase]),
+        bins=[MASS_BIN_EDGES, np.arange(SPIN_PHASE_BIN_EDGES.size)],
+    )[0]
+    counts_by_charge = np.histogramdd(
+        np.column_stack([charge_vals, binned_spin_phase]),
+        bins=[CHARGE_BIN_EDGES, np.arange(SPIN_PHASE_BIN_EDGES.size)],
+    )[0]
+    counts_by_mass_map = np.histogramdd(
+        np.column_stack([mass_vals, longitude, latitude]),
+        bins=[MASS_BIN_EDGES, LON_BINS_EDGES, LAT_BINS_EDGES],
+    )[0]
+    counts_by_charge_map = np.histogramdd(
+        np.column_stack([charge_vals, longitude, latitude]),
+        bins=[CHARGE_BIN_EDGES, LON_BINS_EDGES, LAT_BINS_EDGES],
+    )[0]
+    # The epoch for the window record is the mean epoch of all events in the window.
+    window_epoch = np.array([np.mean(l2a_dataset["epoch"].data)])
 
     return (
-        np.stack(counts_by_charge),
-        np.stack(counts_by_mass),
-        np.stack(counts_by_charge_map),
-        np.stack(counts_by_mass_map),
-        daily_epoch,
+        counts_by_charge[np.newaxis, ...],
+        counts_by_mass[np.newaxis, ...],
+        counts_by_charge_map[np.newaxis, ...],
+        counts_by_mass_map[np.newaxis, ...],
+        window_epoch,
     )
 
 
 def compute_counts_agnostic(
-    l2a_dataset: xr.Dataset, epoch_doy_unique: np.ndarray
+    l2a_dataset: xr.Dataset,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
-    Compute daily dust counts without mass or charge binning.
+    Compute dust counts without mass or charge binning.
+
+    Counts are aggregated across the entire input dataset (expected to span a single
+    IDEX 10-day window) into a single record. Only events flagged as dust hits
+    (``dust_hit_flag`` == 1) are included.
 
     Parameters
     ----------
     l2a_dataset : xarray.Dataset
         Combined IDEX L2A dataset.
-    epoch_doy_unique : np.ndarray
-        Unique days of year corresponding to the epochs in the dataset.
 
     Returns
     -------
     tuple[np.ndarray, np.ndarray]
-        Counts by spin phase and counts by longitude and latitude, respectively.
+        Counts by spin phase and counts by longitude and latitude, respectively, each
+        with a single window record.
     """
-    counts = []
-    counts_map = []
-    epoch_doy = epoch_to_doy(l2a_dataset["epoch"].data)
-    for doy in epoch_doy_unique:
-        indices = _get_dust_hit_indices(l2a_dataset, epoch_doy, int(doy))
-        spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
-        counts.append(np.histogram(spin, bins=np.arange(SPIN_PHASE_BIN_EDGES.size))[0])
-        longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)
-        latitude = l2a_dataset["latitude"].data[indices]
-        valid_geometry = np.isfinite(longitude) & np.isfinite(latitude)
-        counts_map.append(
-            np.histogram2d(
-                longitude[valid_geometry],
-                np.clip(latitude[valid_geometry], -90, 90),
-                bins=[LON_BINS_EDGES, LAT_BINS_EDGES],
-            )[0]
-        )
-    return np.asarray(counts, dtype=np.int64), np.asarray(counts_map, dtype=np.int64)
+    indices = _get_dust_hit_indices(l2a_dataset)
+    spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
+    counts = np.histogram(spin, bins=np.arange(SPIN_PHASE_BIN_EDGES.size))[0]
+    longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)
+    latitude = l2a_dataset["latitude"].data[indices]
+    valid_geometry = np.isfinite(longitude) & np.isfinite(latitude)
+    counts_map = np.histogram2d(
+        longitude[valid_geometry],
+        np.clip(latitude[valid_geometry], -90, 90),
+        bins=[LON_BINS_EDGES, LAT_BINS_EDGES],
+    )[0]
+    return (
+        counts[np.newaxis, ...].astype(np.int64),
+        counts_map[np.newaxis, ...].astype(np.int64),
+    )
 
 
-def _get_dust_hit_indices(
-    l2a_dataset: xr.Dataset, epoch_doy: np.ndarray, doy: int
-) -> np.ndarray:
+def _get_dust_hit_indices(l2a_dataset: xr.Dataset) -> np.ndarray:
     """
-    Return the indices of dust hits occurring on the requested day.
+    Return the indices of dust hits in the dataset.
 
     Parameters
     ----------
     l2a_dataset : xarray.Dataset
         Combined IDEX L2A dataset.
-    epoch_doy : np.ndarray
-        Day of year corresponding to each epoch in ``l2a_dataset``.
-    doy : int
-        Day of year to select.
 
     Returns
     -------
     np.ndarray
-        Indices of dust-hit events occurring on ``doy``.
+        Indices of dust-hit events.
     """
-    current_day_indices = np.flatnonzero(epoch_doy == doy)
     if "dust_hit_flag" not in l2a_dataset:
         return np.array([], dtype=int)
 
-    dust_hit = np.asarray(l2a_dataset["dust_hit_flag"].data[current_day_indices]) == 1
-    return current_day_indices[dust_hit]
-
-
-def compute_rates(
-    counts: np.ndarray, epoch_doy_percent_on: np.ndarray, non_zero_inds: np.ndarray
-) -> np.ndarray:
-    """
-    Compute the count rates given the percent uptime of IDEX.
-
-    Parameters
-    ----------
-    counts : np.ndarray
-        Count values for the dust events.
-    epoch_doy_percent_on : np.ndarray
-        Percentage of time science acquisition was on for each day of the year.
-    non_zero_inds : np.ndarray
-        Indices of the days with non-zero science acquisition percentage.
-
-    Returns
-    -------
-    np.ndarray
-        Count rates.
-    """
-    while len(epoch_doy_percent_on.shape) < len(counts.shape):
-        epoch_doy_percent_on = np.expand_dims(epoch_doy_percent_on, axis=-1)
-
-    return counts[non_zero_inds] / (
-        0.01 * epoch_doy_percent_on[non_zero_inds] * SECONDS_IN_DAY
-    )
+    return np.flatnonzero(np.asarray(l2a_dataset["dust_hit_flag"].data) == 1)
 
 
 def compute_rates_agnostic(
     counts: np.ndarray,
     counts_map: np.ndarray,
-    epoch_doy: np.ndarray,
-    daily_on_percentage: dict,
+    on_seconds: float,
+    total_seconds: float,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
-    Compute daily count rates without mass or charge binning.
+    Compute count rates without mass or charge binning.
 
     Parameters
     ----------
     counts : np.ndarray
-        Daily agnostic counts by spin phase.
+        Agnostic counts by spin phase for the window.
     counts_map : np.ndarray
-        Daily agnostic counts by longitude and latitude.
-    epoch_doy : np.ndarray
-        Unique days of year corresponding to the count records.
-    daily_on_percentage : dict
-        Percentage of time science acquisition was on for each day of year.
+        Agnostic counts by longitude and latitude for the window.
+    on_seconds : float
+        Number of seconds science acquisition was on during the window.
+    total_seconds : float
+        Total number of seconds tracked by the science acquisition on/off events
+        during the window.
 
     Returns
     -------
     tuple[np.ndarray, np.ndarray]
-        Daily rates by spin phase and daily rates by longitude and latitude,
-        respectively.
+        Rates by spin phase and rates by longitude and latitude, respectively.
     """
-    epoch_doy_percent_on = np.array(
-        [daily_on_percentage.get(doy, -1) for doy in epoch_doy]
-    )
-    non_zero_inds = np.where(epoch_doy_percent_on > 0)[0]
     rate = np.full(counts.shape, np.nan)
     rate_map = np.full(counts_map.shape, np.nan)
-    rate[non_zero_inds] = compute_rates(counts, epoch_doy_percent_on, non_zero_inds)
-    rate_map[non_zero_inds] = compute_rates(
-        counts_map, epoch_doy_percent_on, non_zero_inds
-    )
+
+    if total_seconds <= 0 or on_seconds <= 0:
+        logger.warning(
+            "Missing or zero science acquisition uptime for this window. Agnostic "
+            "rate variables will be set to NaN."
+        )
+        return rate, rate_map
+
+    rate = counts / on_seconds
+    rate_map = counts_map / on_seconds
     return rate, rate_map
 
 
@@ -657,74 +594,63 @@ def compute_rates_by_charge_and_mass(
     counts_by_mass: np.ndarray,
     counts_by_charge_map: np.ndarray,
     counts_by_mass_map: np.ndarray,
-    epoch_doy: np.ndarray,
-    daily_on_percentage: dict,
+    on_seconds: float,
+    total_seconds: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
-    Compute the dust event counts rates by charge and mass by spin phase for each day.
+    Compute the dust event count rates by charge and mass by spin phase.
 
     Parameters
     ----------
     counts_by_charge : np.ndarray
-        3D array containing counts by charge and spin phase for each dataset.
+        3D array containing counts by charge and spin phase for the window.
     counts_by_mass : np.ndarray
-        3D array containing counts by mass and lon and lat for each dataset.
+        3D array containing counts by mass and spin phase for the window.
     counts_by_charge_map : np.ndarray
-        4D array containing counts by charge and lon and lat for each dataset.
+        4D array containing counts by charge and lon and lat for the window.
     counts_by_mass_map : np.ndarray
-        4D array containing counts by mass and spin phase for each dataset.
-    epoch_doy : np.ndarray
-        Unique days of year corresponding to the epochs in the dataset.
-    daily_on_percentage : dict
-        Percentage of time science acquisition was on for each doy.
+        4D array containing counts by mass and lon and lat for the window.
+    on_seconds : float
+        Number of seconds science acquisition was on during the window.
+    total_seconds : float
+        Total number of seconds tracked by the science acquisition on/off events
+        during the window.
 
     Returns
     -------
-    tuple[np.ndarray, np.ndarray, np.ndarray]
-        Two 3D arrays containing counts rates by charge or mass, and by spin phase for
-        each dataset and the quality flags for each epoch.
+    tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        Two 3D arrays containing count rates by charge or mass, and by spin phase, two
+        4D arrays containing count rates by charge or mass, and by lon and lat, and the
+        quality flag for the window's single epoch record.
     """
     # Initialize arrays to hold rates.
     rate_by_charge = np.full(counts_by_charge.shape, -1.0)
     rate_by_mass = np.full(counts_by_mass.shape, -1.0)
     rate_by_charge_map = np.full(counts_by_charge_map.shape, -1.0)
     rate_by_mass_map = np.full(counts_by_mass_map.shape, -1.0)
-    # Initialize an array to hold quality flags for each epoch. A quality flag of 0
-    # indicates that there was no science acquisition data for that epoch, and the rate
-    # is not valid. A quality flag of 1 indicates that the rate is valid.
-    rate_quality_flags = np.ones(epoch_doy.shape, dtype=np.uint8)
+    # A quality flag of 0 indicates that there was no science acquisition uptime data
+    # for the window, and the rate is not valid. A quality flag of 1 indicates that the
+    # rate is valid.
+    rate_quality_flags: np.ndarray = np.zeros(1, dtype=np.uint8)
 
-    # Get percentages in order of epoch_doy. Log any missing days.
-    epoch_doy_percent_on = np.array(
-        [daily_on_percentage.get(doy, -1) for doy in epoch_doy]
-    )
-
-    invalid_uptime_inds = np.where(epoch_doy_percent_on <= 0)[0]
-    rate_quality_flags[invalid_uptime_inds] = 0
-
-    missing_doy_uptimes_inds = np.where(epoch_doy_percent_on == -1)[0]
-    if np.any(missing_doy_uptimes_inds):
+    if total_seconds <= 0 or on_seconds <= 0:
         logger.warning(
-            f"Missing science acquisition uptime percentages for day(s) of"
-            f" year: {epoch_doy[missing_doy_uptimes_inds]}."
+            "Missing or zero science acquisition uptime for this window. Rate "
+            "variables will be set to -1."
         )
-    # Compute rates
-    # Create a boolean mask for DOYs that have a non-zero percentage of science
-    # acquisition time.
-    non_zero_inds = np.where(epoch_doy_percent_on > 0)[0]
-    # Compute rates only for days with non-zero science acquisition percentage
-    rate_by_charge[non_zero_inds] = compute_rates(
-        counts_by_charge, epoch_doy_percent_on, non_zero_inds
-    )
-    rate_by_mass[non_zero_inds] = compute_rates(
-        counts_by_mass, epoch_doy_percent_on, non_zero_inds
-    )
-    rate_by_charge_map[non_zero_inds] = compute_rates(
-        counts_by_charge_map, epoch_doy_percent_on, non_zero_inds
-    )
-    rate_by_mass_map[non_zero_inds] = compute_rates(
-        counts_by_mass_map, epoch_doy_percent_on, non_zero_inds
-    )
+        return (
+            rate_by_charge,
+            rate_by_mass,
+            rate_by_charge_map,
+            rate_by_mass_map,
+            rate_quality_flags,
+        )
+
+    rate_by_charge = counts_by_charge / on_seconds
+    rate_by_mass = counts_by_mass / on_seconds
+    rate_by_charge_map = counts_by_charge_map / on_seconds
+    rate_by_mass_map = counts_by_mass_map / on_seconds
+    rate_quality_flags[:] = 1
 
     return (
         rate_by_charge,
@@ -764,11 +690,11 @@ def bin_spin_phases(spin_phases: xr.DataArray) -> np.ndarray:
     return np.asarray(bin_indices)
 
 
-def get_science_acquisition_on_percentage(
+def get_science_acquisition_on_time(
     msg_time: NDArray, msg_values: NDArray
-) -> dict:
+) -> tuple[float, float]:
     """
-    Calculate the percentage of time science acquisition was occurring for each day.
+    Calculate the science acquisition on-time over the whole window.
 
     Parameters
     ----------
@@ -779,17 +705,19 @@ def get_science_acquisition_on_percentage(
 
     Returns
     -------
-    dict
-        Percentages of time the instrument was in science acquisition mode for each day
-         of year.
+    tuple[float, float]
+        The number of seconds science acquisition was on, and the total number of
+        seconds tracked by the science acquisition on/off events.
     """
     if len(msg_time) == 0:
         logger.warning(
-            "No science acquisition events found in event dataset. Returning empty "
-            "uptime percentages. All rate variables will be set to -1."
+            "No science acquisition events found in event dataset. All rate "
+            "variables will be set to -1."
         )
-        return {}
-    # Track total and 'on' durations per day
+        return 0.0, 0.0
+    # Track total and 'on' durations per day. Splitting by calendar day (rather than
+    # summing the whole window at once) lets a gap with no events still count as "off"
+    # for every day it spans, rather than being skipped entirely.
     daily_totals: collections.defaultdict = defaultdict(timedelta)
     daily_on: collections.defaultdict = defaultdict(timedelta)
     # Convert epoch event times to datetime
@@ -828,12 +756,9 @@ def get_science_acquisition_on_percentage(
                 daily_on[doy] += duration
             current = segment_end
 
-    # Calculate the percentage of time science acquisition was on for each day
-    percent_on_times = {}
-    for doy in sorted(daily_totals.keys()):
-        total = daily_totals[doy].total_seconds()
-        on_time = daily_on[doy].total_seconds()
-        pct_on = (on_time / total) * 100 if total > 0 else 0
-        percent_on_times[doy] = pct_on
+    # Sum the daily on/total durations across the whole window into a single uptime
+    # measurement for the window.
+    total_seconds = sum((v.total_seconds() for v in daily_totals.values()), 0.0)
+    on_seconds = sum((v.total_seconds() for v in daily_on.values()), 0.0)
 
-    return percent_on_times
+    return on_seconds, total_seconds

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -17,8 +17,10 @@ Examples
     msg_data_l1b = idex_l1b(msg_data_l1a, "msg-10days")
     l1b_data = idex_l1b(l1a_data, "sci-10days")
 
+    example_10_day_window_start_date = "20250101"
     l1a_data = idex_l2a(l1b_data)
-    l2b_and_l2c_datasets = idex_l2b(l2a_data, msg_data_l1b, "20231218")
+    l2b_and_l2c_datasets = idex_l2b(l2a_data,
+    msg_data_l1b, example_10_day_window_start_date)
     write_cdf(l2b_and_l2c_datasets[0])
     write_cdf(l2b_and_l2c_datasets[1])
 """

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -18,14 +18,12 @@ Examples
     l1b_data = idex_l1b(l1a_data, "sci-10days")
 
     l1a_data = idex_l2a(l1b_data)
-    l2b_and_l2c_datasets = idex_l2b(l2a_data, msg_data_l1b)
+    l2b_and_l2c_datasets = idex_l2b(l2a_data, msg_data_l1b, "20231218")
     write_cdf(l2b_and_l2c_datasets[0])
     write_cdf(l2b_and_l2c_datasets[1])
 """
 
-import collections
 import logging
-from collections import defaultdict
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -39,8 +37,12 @@ from imap_processing.idex.idex_constants import (
     IDEX_EVENT_REFERENCE_FRAME,
     IDEX_SPACING_DEG,
 )
-from imap_processing.idex.idex_utils import get_idex_attrs
-from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
+from imap_processing.idex.idex_utils import get_10_day_window_end_date, get_idex_attrs
+from imap_processing.spice.time import (
+    et_to_datetime64,
+    str_yyyymmdd_to_ttj2000ns,
+    ttj2000ns_to_et,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +87,9 @@ LAT_BINS_EDGES = SKY_GRID.el_bin_edges
 IDEX_INT_FILLVAL = np.iinfo(np.int64).min
 
 
-def idex_l2b(l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset) -> list[xr.Dataset]:
+def idex_l2b(
+    l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset, start_date: str
+) -> list[xr.Dataset]:
     """
     Will process IDEX l2a data to create l2b and l2c data products.
 
@@ -101,6 +105,12 @@ def idex_l2b(l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset) -> list[xr.Datas
         IDEX L2a dataset to process, spanning a single 10-day window.
     msg_data_l1b : xarray.Dataset
         IDEX L1B event message dataset, spanning a single 10-day window.
+    start_date : str
+        Start date (``YYYYMMDD``) of the IDEX accumulation window being processed,
+        as defined in the IDEX 10-day window schedule (see
+        ``get_10_day_window_end_date``). Used to derive the epoch, epoch_delta_plus,
+        and epoch_delta_minus of the output datasets, and the true boundaries of the
+        window over which science acquisition on-time is tracked.
 
     Returns
     -------
@@ -116,15 +126,19 @@ def idex_l2b(l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset) -> list[xr.Datas
     # create the attribute manager for this data level
     idex_l2b_attrs = get_idex_attrs("l2b")
     idex_l2c_attrs = get_idex_attrs("l2c")
+
+    # IDEX epoch is the nominal start of the window
+    # (per the IDEX 10-day window schedule), epoch_delta_plus
+    # os the nominal window duration, and epoch_delta_minus is fixed
+    # at zero. See the epoch VAR_NOTES for the CDF-facing description of this choice.
+    end_date = get_10_day_window_end_date(start_date)
+    window_start = str_yyyymmdd_to_ttj2000ns(start_date)
+    window_end = str_yyyymmdd_to_ttj2000ns(end_date)
+    window_epoch = np.array([window_start])
+    window_epoch_delta_plus = np.array([window_end - window_start])
+    window_epoch_delta_minus: np.ndarray = np.zeros(1, dtype=np.int64)
+
     msg_ds = msg_data_l1b.sortby("epoch").drop_duplicates("epoch")
-    (
-        counts_by_charge,
-        counts_by_mass,
-        counts_by_charge_map,
-        counts_by_mass_map,
-        window_epoch,
-    ) = compute_counts_by_charge_and_mass(l2a_dataset)
-    counts, counts_map = compute_counts_agnostic(l2a_dataset)
     # Filter the message dataset to only include science acquisition on/off events.
     # (ignore fill vals)
     science_on_msg_ds = msg_ds.isel(epoch=np.isin(msg_ds.science_on, [0, 1]))
@@ -132,8 +146,18 @@ def idex_l2b(l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset) -> list[xr.Datas
     msg_values = science_on_msg_ds["science_on"].data
 
     # Get the number of seconds science acquisition was on, and the total number of
-    # seconds tracked, over the whole 10-day window.
-    on_seconds, total_seconds = get_science_acquisition_on_time(msg_time, msg_values)
+    # seconds tracked, over the whole [window_start, window_end) window.
+    on_seconds, total_seconds = get_science_acquisition_on_time(
+        msg_time, msg_values, window_start, window_end
+    )
+
+    (
+        counts_by_charge,
+        counts_by_mass,
+        counts_by_charge_map,
+        counts_by_mass_map,
+    ) = compute_counts_by_charge_and_mass(l2a_dataset)
+    counts, counts_map = compute_counts_agnostic(l2a_dataset)
     (
         rate_by_charge,
         rate_by_mass,
@@ -165,6 +189,22 @@ def idex_l2b(l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset) -> list[xr.Datas
         attrs=idex_l2b_attrs.get_variable_attributes("epoch", check_schema=False),
     )
     common_vars = {
+        "epoch_delta_plus": xr.DataArray(
+            name="epoch_delta_plus",
+            data=window_epoch_delta_plus,
+            dims="epoch",
+            attrs=idex_l2b_attrs.get_variable_attributes(
+                "epoch_delta_plus", check_schema=False
+            ),
+        ),
+        "epoch_delta_minus": xr.DataArray(
+            name="epoch_delta_minus",
+            data=window_epoch_delta_minus,
+            dims="epoch",
+            attrs=idex_l2b_attrs.get_variable_attributes(
+                "epoch_delta_minus", check_schema=False
+            ),
+        ),
         "on_off_times": xr.DataArray(
             name="on_off_times",
             data=msg_time,
@@ -420,7 +460,7 @@ def idex_l2b(l2a_dataset: xr.Dataset, msg_data_l1b: xr.Dataset) -> list[xr.Datas
 
 def compute_counts_by_charge_and_mass(
     l2a_dataset: xr.Dataset,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Compute the dust counts by charge and mass by spin phase or lon and lat.
 
@@ -435,10 +475,9 @@ def compute_counts_by_charge_and_mass(
 
     Returns
     -------
-    tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-        Two 3D arrays containing counts by charge or mass, and by spin phase, Two 4D
-        arrays containing counts by charge or mass, and by lon and lat, and a 1D array
-        containing the center epoch of the window.
+    tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        Two 3D arrays containing counts by charge or mass, and by spin phase, and two
+        4D arrays containing counts by charge or mass, and by lon and lat.
     """
     dust_hit_indices = _get_dust_hit_indices(l2a_dataset)
     mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[dust_hit_indices]
@@ -473,18 +512,12 @@ def compute_counts_by_charge_and_mass(
         np.column_stack([charge_vals, longitude, latitude]),
         bins=[CHARGE_BIN_EDGES, LON_BINS_EDGES, LAT_BINS_EDGES],
     )[0]
-    # Per ISTP convention, the epoch for the window record is the center of the
-    # accumulation period: the midpoint between the first and last event epochs in the
-    # window.
-    epoch_data = l2a_dataset["epoch"].data
-    window_epoch = np.array([(epoch_data.min() + epoch_data.max()) / 2])
 
     return (
         counts_by_charge[np.newaxis, ...],
         counts_by_mass[np.newaxis, ...],
         counts_by_charge_map[np.newaxis, ...],
         counts_by_mass_map[np.newaxis, ...],
-        window_epoch,
     )
 
 
@@ -689,10 +722,21 @@ def bin_spin_phases(spin_phases: xr.DataArray) -> np.ndarray:
 
 
 def get_science_acquisition_on_time(
-    msg_time: NDArray, msg_values: NDArray
+    msg_time: NDArray,
+    msg_values: NDArray,
+    window_start: np.int64,
+    window_end: np.int64,
 ) -> tuple[float, float]:
     """
     Calculate the science acquisition on-time over the whole window.
+
+    The on/off state is tracked across the full ``[window_start, window_end)``
+    span, not just between the first and last message events: the state
+    implied by each event is extended forward until the next event, and the
+    last known state is extended through to ``window_end`` (rather than
+    stopping at the last event), so a window with no further transitions after
+    its last event -- or no events at all near the start or end of the window
+    -- is not undercounted.
 
     Parameters
     ----------
@@ -700,12 +744,16 @@ def get_science_acquisition_on_time(
         Array of timestamps for science acquisition start and stop events.
     msg_values : np.ndarray
         Array of values indicating if the event is a start (1) or stop (0).
+    window_start : numpy.int64
+        Start of the accumulation window (TT2000 nanoseconds since J2000).
+    window_end : numpy.int64
+        End of the accumulation window (TT2000 nanoseconds since J2000).
 
     Returns
     -------
     tuple[float, float]
         The number of seconds science acquisition was on, and the total number of
-        seconds tracked by the science acquisition on/off events.
+        seconds tracked, over the ``[window_start, window_end)`` window.
     """
     if len(msg_time) == 0:
         logger.warning(
@@ -713,50 +761,28 @@ def get_science_acquisition_on_time(
             "variables will be set to -1."
         )
         return 0.0, 0.0
-    # Track total and 'on' durations per day. Splitting by calendar day (rather than
-    # summing the whole window at once) lets a gap with no events still count as "off"
-    # for every day it spans, rather than being skipped entirely.
-    daily_totals: collections.defaultdict = defaultdict(timedelta)
-    daily_on: collections.defaultdict = defaultdict(timedelta)
-    # Convert epoch event times to datetime
+    # Convert event and window boundary times to datetime.
     dates = et_to_datetime64(ttj2000ns_to_et(msg_time)).astype(datetime)
-    # Simulate an event at the start of the first day.
-    start_of_first_day = dates[0].replace(hour=0, minute=0, second=0, microsecond=0)
-    # Assume that the state at the start of the day is the opposite of what the first
-    # state is.
+    window_start_dt = et_to_datetime64(ttj2000ns_to_et(window_start)).astype(datetime)
+    window_end_dt = et_to_datetime64(ttj2000ns_to_et(window_end)).astype(datetime)
+    # TODO pass in the previous l1b msg packet.
+    # Simulate an event at the start of the window. Assume that the state at the
+    # start of the window is the opposite of what the first real event is.
     state_at_start = 0 if msg_values[0] == 1 else 1
-    dates = np.insert(dates, 0, start_of_first_day)
+    dates = np.insert(dates, 0, window_start_dt)
     msg_values = np.insert(msg_values, 0, state_at_start)
+
+    total_duration = timedelta()
+    on_duration = timedelta()
     for i in range(len(dates)):
         start = dates[i]
         state = msg_values[i]
-        if i == len(dates) - 1:
-            # If this is the last event, set the "end" value the end of the day.
-            end = (start + timedelta(days=1)).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-        else:
-            # Otherwise, use the next event time as the end time.
-            end = dates[i + 1]
+        # Every state holds until the next event, except the last one, which holds
+        # through the end of the window.
+        end = dates[i + 1] if i < len(dates) - 1 else window_end_dt
+        duration = end - start
+        total_duration += duration
+        if state == 1:
+            on_duration += duration
 
-        # Split time span by day boundaries
-        current = start
-        while current < end:
-            next_day = (current + timedelta(days=1)).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-            segment_end = min(end, next_day)
-            duration = segment_end - current
-            doy = current.timetuple().tm_yday
-            daily_totals[doy] += duration
-            # If the state is 1, add to the 'on' duration for that day
-            if state == 1:
-                daily_on[doy] += duration
-            current = segment_end
-
-    # Sum the daily on/total durations across the whole window into a single uptime
-    # measurement for the window.
-    total_seconds = sum((v.total_seconds() for v in daily_totals.values()), 0.0)
-    on_seconds = sum((v.total_seconds() for v in daily_on.values()), 0.0)
-
-    return on_seconds, total_seconds
+    return on_duration.total_seconds(), total_duration.total_seconds()

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -129,7 +129,7 @@ def idex_l2b(
 
     # IDEX epoch is the nominal start of the window
     # (per the IDEX 10-day window schedule), epoch_delta_plus
-    # os the nominal window duration, and epoch_delta_minus is fixed
+    # is the nominal window duration, and epoch_delta_minus is fixed
     # at zero. See the epoch VAR_NOTES for the CDF-facing description of this choice.
     end_date = get_10_day_window_end_date(start_date)
     window_start = str_yyyymmdd_to_ttj2000ns(start_date)
@@ -757,8 +757,9 @@ def get_science_acquisition_on_time(
     """
     if len(msg_time) == 0:
         logger.warning(
-            "No science acquisition events found in event dataset. All rate "
-            "variables will be set to -1."
+            "No science acquisition events found in event dataset. The by-charge "
+            "and by-mass rate variables will be set to -1, and the agnostic rate "
+            "variables will be set to NaN."
         )
         return 0.0, 0.0
     # Convert event and window boundary times to datetime.

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -23,9 +23,10 @@ from imap_processing.idex.idex_l2b import (
     compute_counts_by_charge_and_mass,
     compute_rates_agnostic,
     compute_rates_by_charge_and_mass,
-    get_science_acquisition_on_percentage,
+    get_science_acquisition_on_time,
     idex_l2b,
 )
+from imap_processing.spice.time import TTJ2000_EPOCH
 
 INT_FILLVAL = np.iinfo(np.int64).min
 
@@ -64,14 +65,19 @@ def test_l2b_logical_source_and_cdf(l2b_and_l2c_datasets: list[xr.Dataset]):
         A ``xarray`` dataset containing the test data
     """
     l2b_dataset = l2b_and_l2c_datasets[0]
-    expected_src = "imap_idex_l2b_sci-1mo"
+    expected_src = "imap_idex_l2b_sci-10days"
     assert l2b_dataset.attrs["Logical_source"] == expected_src
     # Verify the CDF file can be created with no errors.
     l2b_dataset.attrs["Data_version"] = "999"
     file_name = write_cdf(l2b_dataset)
 
+    expected_dt64 = TTJ2000_EPOCH + l2b_dataset["epoch"].values[0].astype(
+        "timedelta64[ns]"
+    )
+    expected_date = np.datetime_as_string(expected_dt64, unit="D").replace("-", "")
+
     assert file_name.exists()
-    assert file_name.name == "imap_idex_l2b_sci-1mo_20231218_v999.cdf"
+    assert file_name.name == f"imap_idex_l2b_sci-10days_{expected_date}_v999.cdf"
     with cdflib.CDF(file_name) as cdf_file:
         assert cdf_file.varattsget("impact_charge")["LABL_PTR_1"] == "charge_labels"
         for variable_name in ("counts_by_charge", "counts_by_mass"):
@@ -96,7 +102,7 @@ def test_l2c_attrs_and_vars(
         A ``xarray`` dataset containing the l1b test data.
     """
     l2c_dataset = l2b_and_l2c_datasets[1]
-    assert l2c_dataset.attrs["Logical_source"] == "imap_idex_l2c_rectangular-map-1mo"
+    assert l2c_dataset.attrs["Logical_source"] == "imap_idex_l2c_rectangular-map-10days"
     # TODO: Uncomment when NAN block fixed
     # The total counts in the map should be equal to the number of dust events
     # in the l2a_dataset (*2 because the l2b fixture counts are doubled)
@@ -108,7 +114,7 @@ def test_l2c_attrs_and_vars(
     # )
     assert l2c_dataset.sizes == {
         "on_off_times": 4,
-        "epoch": 2,
+        "epoch": 1,
         "impact_charge": 10,
         "mass": 10,
         "rectangular_lon_pixel": int(360 / IDEX_SPACING_DEG),
@@ -117,8 +123,15 @@ def test_l2c_attrs_and_vars(
     l2c_dataset.attrs["Data_version"] = "999"
     # Check the attributes of the dataset by writing to a CDF file
     rect_file_name = write_cdf(l2c_dataset)
+    expected_dt64 = TTJ2000_EPOCH + l2c_dataset["epoch"].values[0].astype(
+        "timedelta64[ns]"
+    )
+    expected_date = np.datetime_as_string(expected_dt64, unit="D").replace("-", "")
     assert rect_file_name.exists()
-    assert rect_file_name.name == "imap_idex_l2c_rectangular-map-1mo_20231218_v999.cdf"
+    assert (
+        rect_file_name.name
+        == f"imap_idex_l2c_rectangular-map-10days_{expected_date}_v999.cdf"
+    )
     with cdflib.CDF(rect_file_name) as cdf_file:
         assert cdf_file.varattsget("impact_charge")["LABL_PTR_1"] == "charge_labels"
         for variable_name in ("counts_by_charge_map", "counts_by_mass_map"):
@@ -165,7 +178,6 @@ def test_l2b_cdf_variables(l2b_and_l2c_datasets: list[xr.Dataset]):
     """
     expected_vars = [
         "epoch",
-        "impact_day_of_year",
         "counts_by_charge",
         "counts_by_mass",
         "rate_by_charge",
@@ -242,36 +254,36 @@ def test_bin_spin_phases_warning(caplog):
     ) in caplog.text
 
 
-def test_get_science_acquisition_on_percentage(test_l1b_msg: xr.Dataset):
-    """Test the function that calculates the percentage of uptime."""
+def test_get_science_acquisition_on_time(test_l1b_msg: xr.Dataset):
+    """Test the function that calculates the science acquisition on-time."""
     test_l1b_msg = test_l1b_msg.isel(epoch=np.isin(test_l1b_msg.science_on, [0, 1]))
     msg_time = test_l1b_msg.epoch.data
     msg_event = test_l1b_msg.science_on.data
-    on_percentages = get_science_acquisition_on_percentage(msg_time, msg_event)
-    # We expect 1 DOY with less than 1% uptime for the science acquisition.
-    assert len(on_percentages) == 1
-    # The DOY should be 8 for this test dataset.
-    assert on_percentages[8] < 1
+    on_seconds, total_seconds = get_science_acquisition_on_time(msg_time, msg_event)
+    # The test data spans 1 day, so the total tracked time should be one day, with
+    # less than 1% uptime for the science acquisition.
+    assert total_seconds == pytest.approx(SECONDS_IN_DAY)
+    assert (on_seconds / total_seconds) * 100 < 1
 
     msg_ds = test_l1b_msg.copy()
     msg_ds_shifted = msg_ds.copy()
     msg_ds_shifted["epoch"] = msg_ds["epoch"] + NANOSECONDS_IN_DAY
     combined_ds = xr.concat([msg_ds, msg_ds_shifted], dim="epoch")
-    # expect a second DOY.
+    # Now spanning 2 days.
     msg_time = combined_ds.epoch.data
     msg_event = combined_ds.science_on.data
-    on_percentages = get_science_acquisition_on_percentage(msg_time, msg_event)
-    # We expect 2 DOYs
-    assert len(on_percentages) == 2
-    # The uptime should be less than 1% for both
-    assert on_percentages[8] < 1
-    assert on_percentages[9] < 1  # The uptime should be less than 1%
+    on_seconds, total_seconds = get_science_acquisition_on_time(msg_time, msg_event)
+    assert total_seconds == pytest.approx(2 * SECONDS_IN_DAY)
+    assert (on_seconds / total_seconds) * 100 < 1
 
 
-def test_get_science_acquisition_on_percentage_no_acquisition(caplog):
-    """Test the function returns an empty dict when there is no science acquisition."""
-    on_percentages = get_science_acquisition_on_percentage(np.array([]), np.array([]))
-    assert not on_percentages
+def test_get_science_acquisition_on_time_no_acquisition(caplog):
+    """Test the function returns zeros when there is no science acquisition."""
+    on_seconds, total_seconds = get_science_acquisition_on_time(
+        np.array([]), np.array([])
+    )
+    assert on_seconds == 0.0
+    assert total_seconds == 0.0
     assert "No science acquisition events found" in caplog.text
 
 
@@ -287,7 +299,7 @@ def test_compute_counts_agnostic_filters_non_dust():
         }
     )
 
-    counts, counts_map = compute_counts_agnostic(dataset, np.array([1]))
+    counts, counts_map = compute_counts_agnostic(dataset)
 
     assert counts.sum() == 2
     assert counts_map.sum() == 2
@@ -304,7 +316,7 @@ def test_compute_counts_agnostic_excludes_events_without_dust_flag():
         }
     )
 
-    counts, counts_map = compute_counts_agnostic(dataset, np.array([1]))
+    counts, counts_map = compute_counts_agnostic(dataset)
 
     assert counts.sum() == 0
     assert counts_map.sum() == 0
@@ -313,41 +325,31 @@ def test_compute_counts_agnostic_excludes_events_without_dust_flag():
 def test_compute_counts_by_charge_and_mass():
     """Test the compute_counts_by_charge_and_mass function."""
 
-    # Create a mock l2a_dataset
-    epochs = np.array([1, 1, 2, 2, 3, 4])
-    epochs = epochs * NANOSECONDS_IN_DAY
-
-    # Create a test dataset. There should be 1 in the first 5 impact charge bins
-    # and mass bins all in the first spin phase bin. The test should be zero. This
-    # should be the same for each epoch except the second epoch which has 2 counts in
-    # the first 5 mass and impact charge bins.
-
+    # Create a mock l2a_dataset with 6 events, each landing in a different one of the
+    # first 6 impact charge/mass bins, all in the same spin phase quadrant and sky
+    # pixel. Counts should aggregate into a single window record.
+    n_events = 6
     l2a_dataset = xr.Dataset(
         {
-            "epoch": epochs,
-            "target_low_dust_mass_estimate": ((MASS_BIN_EDGES / FG_TO_KG)[:6] + 1e-5),
-            "target_low_impact_charge": CHARGE_BIN_EDGES[:6],
-            "spin_phase": np.full((6,), 0),
-            "longitude": np.full(6, 5),
-            "latitude": np.full(6, 0),
-            "dust_hit_flag": np.ones(6, dtype=np.int8),
+            "epoch": np.arange(n_events, dtype=np.int64),
+            "target_low_dust_mass_estimate": (
+                (MASS_BIN_EDGES / FG_TO_KG)[:n_events] + 1e-5
+            ),
+            "target_low_impact_charge": CHARGE_BIN_EDGES[:n_events],
+            "spin_phase": np.full(n_events, 0),
+            "longitude": np.full(n_events, 5),
+            "latitude": np.full(n_events, 0),
+            "dust_hit_flag": np.ones(n_events, dtype=np.int8),
         }
     )
 
-    # Unique days of year
-    epoch_doy_unique = np.unique(epochs / NANOSECONDS_IN_DAY).astype(int) + 1
-
-    counts_by_charge, counts_by_mass, charge_map, mass_map, daily_epoch = (
-        compute_counts_by_charge_and_mass(l2a_dataset, epoch_doy_unique)
+    counts_by_charge, counts_by_mass, charge_map, mass_map, window_epoch = (
+        compute_counts_by_charge_and_mass(l2a_dataset)
     )
 
-    expected_shape = (
-        len(epoch_doy_unique),
-        len(CHARGE_BIN_EDGES) - 1,
-        len(SPIN_PHASE_BIN_EDGES) - 1,
-    )
+    expected_shape = (1, len(CHARGE_BIN_EDGES) - 1, len(SPIN_PHASE_BIN_EDGES) - 1)
     expected_map_shape = (
-        len(epoch_doy_unique),
+        1,
         len(CHARGE_BIN_EDGES) - 1,
         len(SKY_GRID.az_bin_edges) - 1,
         len(SKY_GRID.el_bin_edges) - 1,
@@ -362,15 +364,9 @@ def test_compute_counts_by_charge_and_mass():
     expected_array = np.zeros(expected_shape)
     expected_map_array = np.zeros(expected_map_shape)
     # Add ones where we expect counts
-    expected_array[0, 0:2, 0] = 1
-    expected_array[1, 2:4, 0] = 1
-    expected_array[2, 4, 0] = 1
-    expected_array[3, 5, 0] = 1
+    expected_array[0, 0:n_events, 0] = 1
     # Add ones where we expect counts for the map
-    expected_map_array[0, 0:2, 0, 15] = 1
-    expected_map_array[1, 2:4, 0, 15] = 1
-    expected_map_array[2, 4, 0, 15] = 1
-    expected_map_array[3, 5, 0, 15] = 1
+    expected_map_array[0, 0:n_events, 0, 15] = 1
     # assert that the counts are as expected
     np.testing.assert_array_equal(counts_by_charge, expected_array)
     np.testing.assert_array_equal(counts_by_mass, expected_array)
@@ -378,20 +374,20 @@ def test_compute_counts_by_charge_and_mass():
     np.testing.assert_array_equal(charge_map, expected_map_array)
     np.testing.assert_array_equal(mass_map, expected_map_array)
 
+    # The window epoch is the mean of the input epochs.
+    np.testing.assert_allclose(window_epoch, [np.mean(l2a_dataset["epoch"].data)])
+
 
 def test_compute_counts_by_charge_and_mass_out_of_bounds():
     """Test the compute_counts_by_charge_and_mass function.
 
     Test when there are mass and charge values out of the expected bin edges"""
 
-    # Create a mock l2a_dataset
-    epochs = np.array([1, 2])
-    epochs = epochs * NANOSECONDS_IN_DAY
-
     # Create a test dataset with values that are out of the expected bin edges.
+    n_events = 2
     l2a_dataset = xr.Dataset(
         {
-            "epoch": epochs,
+            "epoch": np.arange(n_events, dtype=np.int64),
             "target_low_dust_mass_estimate": np.array(
                 [MASS_BIN_EDGES[0] - 1e-05, MASS_BIN_EDGES[-1] + 1e-05]
             )
@@ -399,27 +395,20 @@ def test_compute_counts_by_charge_and_mass_out_of_bounds():
             "target_low_impact_charge": np.array(
                 [CHARGE_BIN_EDGES[0] - 1e-05, CHARGE_BIN_EDGES[-1] + 1e-05]
             ),
-            "spin_phase": np.full((6,), 0),
+            "spin_phase": np.full(n_events, 0),
             "longitude": np.array([0, 365]),
             "latitude": np.array([-90, 90]),
             "dust_hit_flag": np.ones(2, dtype=np.int8),
         }
     )
 
-    # Unique days of year
-    epoch_doy_unique = np.unique(epochs / NANOSECONDS_IN_DAY).astype(int) + 1
-
-    counts_by_charge, counts_by_mass, charge_map, mass_map, daily_epoch = (
-        compute_counts_by_charge_and_mass(l2a_dataset, epoch_doy_unique)
+    counts_by_charge, counts_by_mass, charge_map, mass_map, window_epoch = (
+        compute_counts_by_charge_and_mass(l2a_dataset)
     )
 
-    expected_shape = (
-        len(epoch_doy_unique),
-        len(CHARGE_BIN_EDGES) - 1,
-        len(SPIN_PHASE_BIN_EDGES) - 1,
-    )
+    expected_shape = (1, len(CHARGE_BIN_EDGES) - 1, len(SPIN_PHASE_BIN_EDGES) - 1)
     expected_map_shape = (
-        len(epoch_doy_unique),
+        1,
         len(CHARGE_BIN_EDGES) - 1,
         len(SKY_GRID.az_bin_edges) - 1,
         len(SKY_GRID.el_bin_edges) - 1,
@@ -435,10 +424,10 @@ def test_compute_counts_by_charge_and_mass_out_of_bounds():
     expected_map_array = np.zeros(expected_map_shape)
     # Add ones where we expect counts
     expected_array[0, 0, 0] = 1
-    expected_array[1, len(CHARGE_BIN_EDGES) - 2, 0] = 1
+    expected_array[0, len(CHARGE_BIN_EDGES) - 2, 0] = 1
     # Add ones where we expect counts for the map
     expected_map_array[0, 0, 0, 0] = 1
-    expected_map_array[1, len(CHARGE_BIN_EDGES) - 2, 0, 29] = 1
+    expected_map_array[0, len(CHARGE_BIN_EDGES) - 2, 0, 29] = 1
     # assert that the counts are as expected
     np.testing.assert_array_equal(counts_by_charge, expected_array)
     np.testing.assert_array_equal(counts_by_mass, expected_array)
@@ -448,28 +437,23 @@ def test_compute_counts_by_charge_and_mass_out_of_bounds():
 
 def test_compute_rates_by_charge_and_mass():
     """Test the compute_rates_by_charge_and_mass function."""
-    # Mock example inputs
-    day_counts = np.full((len(CHARGE_BIN_EDGES), len(SPIN_PHASE_BIN_EDGES) - 1), 1.0)
-    day_counts_map = np.full(
+    # Mock example inputs. A single window record with counts of 5 everywhere.
+    counts_by_charge = np.full(
+        (1, len(CHARGE_BIN_EDGES) - 1, len(SPIN_PHASE_BIN_EDGES) - 1), 5.0
+    )
+    counts_by_mass = counts_by_charge.copy()
+    counts_by_charge_map = np.full(
         (
-            len(CHARGE_BIN_EDGES),
+            1,
+            len(CHARGE_BIN_EDGES) - 1,
             len(SKY_GRID.az_bin_edges) - 1,
             len(SKY_GRID.el_bin_edges) - 1,
         ),
-        1.0,
+        5.0,
     )
-    counts_by_charge = np.stack(
-        [day_counts, day_counts + 1, day_counts + 2, day_counts + 2]
-    )
-    counts_by_mass = counts_by_charge
-    counts_by_mass_map = np.stack(
-        [day_counts_map, day_counts_map + 1, day_counts_map + 2, day_counts_map + 2]
-    )
-    counts_by_charge_map = counts_by_mass_map
-    # Mock DOY values for the epochs
-    epoch_doy = np.array([1, 2, 3, 4])
-    # Mock daily idex uptime percentages
-    daily_on_percentage = {1: 50.0, 2: 25.0, 3: 0.05, 4: 0.0}
+    counts_by_mass_map = counts_by_charge_map.copy()
+    on_seconds = 100.0
+    total_seconds = 200.0
     # Compute the rates by charge and mass
     rate_by_charge, rate_by_mass, charge_map, mass_map, quality_flags = (
         compute_rates_by_charge_and_mass(
@@ -477,145 +461,86 @@ def test_compute_rates_by_charge_and_mass():
             counts_by_mass,
             counts_by_charge_map,
             counts_by_mass_map,
-            epoch_doy,
-            daily_on_percentage,
+            on_seconds,
+            total_seconds,
         )
     )
 
     # Check shapes
-    expected_shape = counts_by_mass.shape
-    expected_map_shape = counts_by_mass_map.shape
-    np.testing.assert_equal(rate_by_charge.shape, expected_shape)
-    np.testing.assert_equal(rate_by_mass.shape, expected_shape)
-    np.testing.assert_equal(charge_map.shape, expected_map_shape)
-    np.testing.assert_equal(mass_map.shape, expected_map_shape)
+    np.testing.assert_equal(rate_by_charge.shape, counts_by_charge.shape)
+    np.testing.assert_equal(rate_by_mass.shape, counts_by_mass.shape)
+    np.testing.assert_equal(charge_map.shape, counts_by_charge_map.shape)
+    np.testing.assert_equal(mass_map.shape, counts_by_mass_map.shape)
 
-    # Zero uptime makes the rate invalid.
-    np.testing.assert_array_equal(quality_flags, [1, 1, 1, 0])
-    # assert day 1 rates are as expected
-    np.testing.assert_equal(rate_by_charge[0], 1 / (SECONDS_IN_DAY / 2))
-    np.testing.assert_equal(rate_by_mass[0], 1 / (SECONDS_IN_DAY / 2))
-    np.testing.assert_equal(charge_map[0], 1 / (SECONDS_IN_DAY / 2))
-    np.testing.assert_equal(mass_map[0], 1 / (SECONDS_IN_DAY / 2))
-    # assert day 2 rates are as expected
-    np.testing.assert_equal(rate_by_charge[1], 2 / (SECONDS_IN_DAY / 4))
-    np.testing.assert_equal(rate_by_mass[1], 2 / (SECONDS_IN_DAY / 4))
-    np.testing.assert_equal(charge_map[1], 2 / (SECONDS_IN_DAY / 4))
-    np.testing.assert_equal(mass_map[1], 2 / (SECONDS_IN_DAY / 4))
-    # assert day 3 rates are as expected
-    np.testing.assert_equal(rate_by_charge[2], 3 / (SECONDS_IN_DAY / 2000))
-    np.testing.assert_equal(rate_by_mass[2], 3 / (SECONDS_IN_DAY / 2000))
-    np.testing.assert_equal(charge_map[2], 3 / (SECONDS_IN_DAY / 2000))
-    np.testing.assert_equal(mass_map[2], 3 / (SECONDS_IN_DAY / 2000))
-    # assert day 4 rates are as expected
-    np.testing.assert_equal(rate_by_charge[3], -1.0)
-    np.testing.assert_equal(rate_by_mass[3], -1.0)
-    np.testing.assert_equal(charge_map[3], -1.0)
-    np.testing.assert_equal(mass_map[3], -1.0)
+    # The quality flag should be 1 (valid) and rates should be counts/on_seconds.
+    np.testing.assert_array_equal(quality_flags, [1])
+    np.testing.assert_allclose(rate_by_charge, 5.0 / on_seconds)
+    np.testing.assert_allclose(rate_by_mass, 5.0 / on_seconds)
+    np.testing.assert_allclose(charge_map, 5.0 / on_seconds)
+    np.testing.assert_allclose(mass_map, 5.0 / on_seconds)
+
+
+def test_compute_rates_agnostic():
+    """Test the compute_rates_agnostic function for a single window record."""
+    counts = np.full((1, 4), 5.0)
+    counts_map = np.full((1, 2, 2), 5.0)
+    on_seconds = 100.0
+    total_seconds = 200.0
+
+    rate, rate_map = compute_rates_agnostic(
+        counts, counts_map, on_seconds, total_seconds
+    )
+
+    np.testing.assert_allclose(rate, 5.0 / on_seconds)
+    np.testing.assert_allclose(rate_map, 5.0 / on_seconds)
 
 
 def test_compute_rates_agnostic_uses_nan_for_invalid_uptime():
     """Test that agnostic rates use NaN when uptime is missing or zero."""
-    counts = np.ones((2, 4))
-    counts_map = np.ones((2, 2, 2))
-    epoch_doy = np.array([1, 2])
+    counts = np.ones((1, 4))
+    counts_map = np.ones((1, 2, 2))
 
-    rate, rate_map = compute_rates_agnostic(
-        counts, counts_map, epoch_doy, {1: 100.0, 2: 0.0}
-    )
+    rate, rate_map = compute_rates_agnostic(counts, counts_map, 0.0, 0.0)
 
-    np.testing.assert_array_equal(rate[0], counts[0] / SECONDS_IN_DAY)
-    np.testing.assert_array_equal(rate_map[0], counts_map[0] / SECONDS_IN_DAY)
-    assert np.all(np.isnan(rate[1]))
-    assert np.all(np.isnan(rate_map[1]))
+    assert np.all(np.isnan(rate))
+    assert np.all(np.isnan(rate_map))
 
 
-def test_compute_rates_by_charge_and_mass_missing_acquisition_time(caplog):
-    """Test that the function throws an error for missing data."""
+def test_compute_rates_by_charge_and_mass_no_acquisition_data(caplog):
+    """Test that the function produces -1 rates when there is no uptime data."""
     caplog.at_level("WARNING")
     # Mock example inputs
     counts_by_charge = np.ones(
-        (2, len(CHARGE_BIN_EDGES), len(SPIN_PHASE_BIN_EDGES) - 1)
+        (1, len(CHARGE_BIN_EDGES) - 1, len(SPIN_PHASE_BIN_EDGES) - 1)
     )
-    counts_by_mass = counts_by_charge
+    counts_by_mass = counts_by_charge.copy()
     counts_by_charge_map = np.ones(
         (
-            2,
-            len(CHARGE_BIN_EDGES),
+            1,
+            len(CHARGE_BIN_EDGES) - 1,
             len(SKY_GRID.az_bin_edges) - 1,
             len(SKY_GRID.el_bin_edges) - 1,
         )
     )
-    counts_by_mass_map = counts_by_charge_map
-    # Mock DOY values for the epochs
-    epoch_doy = np.array([1, 2])
-    # Mock daily idex uptime percentages. Purposefully leave out day 2 to simulate
-    # missing acquisition times
-    daily_on_percentage = {1: 100.0}
+    counts_by_mass_map = counts_by_charge_map.copy()
     # Compute the rates by charge and mass and assert there is a warning in the logs.
-    rate_by_charge, rate_by_mass, rate_mass_map, rate_charge_map, quality_flags = (
+    rate_by_charge, rate_by_mass, charge_map, mass_map, quality_flags = (
         compute_rates_by_charge_and_mass(
             counts_by_charge,
             counts_by_mass,
             counts_by_charge_map,
             counts_by_mass_map,
-            epoch_doy,
-            daily_on_percentage,
+            0.0,
+            0.0,
         )
     )
-    assert (
-        "Missing science acquisition uptime percentages for day(s) of year: [2]."
-        in caplog.text
-    )
-
-    # All rates by charge and mass should be -1.0 at epoch 2
-    np.testing.assert_array_equal(
-        rate_by_charge[1], np.full(rate_by_charge[1].shape, -1.0)
-    )
-    np.testing.assert_array_equal(rate_by_mass[1], np.full(rate_by_mass[1].shape, -1.0))
-
-    # Assert that quality flags are 0 for the missing acquisition time
-    assert quality_flags[0] == 1
-    assert quality_flags[1] == 0
-
-
-def test_compute_rates_no_acquisition_data(caplog):
-    """Test that the function produces -1 rates when hk data isn't available."""
-    caplog.at_level("WARNING")
-    # Mock example inputs
-    counts_by_charge = np.ones(
-        (2, len(CHARGE_BIN_EDGES), len(SPIN_PHASE_BIN_EDGES) - 1)
-    )
-    counts_by_mass = counts_by_charge
-    counts_by_charge_map = np.ones(
-        (
-            2,
-            len(CHARGE_BIN_EDGES),
-            len(SKY_GRID.az_bin_edges) - 1,
-            len(SKY_GRID.el_bin_edges) - 1,
-        )
-    )
-    counts_by_mass_map = counts_by_charge_map
-    # Mock DOY values for the epochs
-    epoch_doy = np.array([1, 2])
-    # Mock daily idex uptime percentages. Purposefully leave out day 2 to simulate
-    # missing acquisition times
-    daily_on_percentage = {}
-    # Compute the rates by charge and mass and assert there is a warning in the logs.
-    rate_by_charge, rate_by_mass, rate_mass_map, rate_charge_map, quality_flags = (
-        compute_rates_by_charge_and_mass(
-            counts_by_charge,
-            counts_by_mass,
-            counts_by_charge_map,
-            counts_by_mass_map,
-            epoch_doy,
-            daily_on_percentage,
-        )
-    )
+    assert "Missing or zero science acquisition uptime for this window." in caplog.text
 
     # All rates by charge and mass should be -1.0
     np.testing.assert_array_equal(rate_by_charge, np.full(rate_by_charge.shape, -1.0))
     np.testing.assert_array_equal(rate_by_mass, np.full(rate_by_mass.shape, -1.0))
+    np.testing.assert_array_equal(charge_map, np.full(charge_map.shape, -1.0))
+    np.testing.assert_array_equal(mass_map, np.full(mass_map.shape, -1.0))
 
-    # Assert that quality flags are all 0 for missing acquisition times
-    np.testing.assert_array_equal(quality_flags, np.full(quality_flags.shape, 0))
+    # The quality flag should be 0 (invalid) for the missing uptime data.
+    np.testing.assert_array_equal(quality_flags, [0])

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -219,10 +219,11 @@ def test_l2b_cdf_variables(l2b_and_l2c_datasets: list[xr.Dataset]):
             f"Variable {var} should be fully NaN for the temporary L2B patch."
         )
 
-    # The agnostic products are independently computed and remain publishable. Rates
-    # are fill values here because the fixture has no matching uptime percentages.
+    # The agnostic products are independently computed and remain publishable. The
+    # fixture has valid science acquisition uptime tracked over the window, so the
+    # rate is a real (non-NaN) value derived from the window's on_seconds.
     assert l2b_dataset["counts"].data.sum() > 0
-    assert np.isnan(l2b_dataset["rate"].data).all()
+    assert not np.isnan(l2b_dataset["rate"].data).any()
 
 
 def test_bin_spin_phases():

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -48,10 +48,14 @@ def l2b_and_l2c_datasets(l2a_dataset: xr.Dataset, test_l1b_msg) -> list[xr.Datas
     )  # Add a second dataset with different epoch values for testing
     l1b_msg_dataset2["epoch"] = l1b_msg_dataset2["epoch"] + NANOSECONDS_IN_DAY
     l2a_dataset2["epoch"] = l2a_dataset2["epoch"] + NANOSECONDS_IN_DAY
-    # idex_l2b takes a single L2A dataset spanning one 10-day window. Concat the two
-    # simulated days together here to exercise a multi-day window.
+    # idex_l2b takes a single L2A dataset and a single L1B msg dataset, each spanning
+    # one 10-day window. Concat the two simulated days together here to exercise a
+    # multi-day window.
     combined_l2a_dataset = xr.concat([l2a_dataset, l2a_dataset2], dim="epoch")
-    datasets = idex_l2b(combined_l2a_dataset, [test_l1b_msg.copy(), l1b_msg_dataset2])
+    combined_msg_dataset = xr.concat(
+        [test_l1b_msg.copy(), l1b_msg_dataset2], dim="epoch"
+    )
+    datasets = idex_l2b(combined_l2a_dataset, combined_msg_dataset)
     return datasets
 
 
@@ -375,8 +379,12 @@ def test_compute_counts_by_charge_and_mass():
     np.testing.assert_array_equal(charge_map, expected_map_array)
     np.testing.assert_array_equal(mass_map, expected_map_array)
 
-    # The window epoch is the mean of the input epochs.
-    np.testing.assert_allclose(window_epoch, [np.mean(l2a_dataset["epoch"].data)])
+    # The window epoch is the center of the accumulation period: the midpoint
+    # between the first and last input epochs.
+    epoch_data = l2a_dataset["epoch"].data
+    np.testing.assert_allclose(
+        window_epoch, [(epoch_data.min() + epoch_data.max()) / 2]
+    )
 
 
 def test_compute_counts_by_charge_and_mass_out_of_bounds():

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -48,9 +48,10 @@ def l2b_and_l2c_datasets(l2a_dataset: xr.Dataset, test_l1b_msg) -> list[xr.Datas
     )  # Add a second dataset with different epoch values for testing
     l1b_msg_dataset2["epoch"] = l1b_msg_dataset2["epoch"] + NANOSECONDS_IN_DAY
     l2a_dataset2["epoch"] = l2a_dataset2["epoch"] + NANOSECONDS_IN_DAY
-    datasets = idex_l2b(
-        [l2a_dataset, l2a_dataset2], [test_l1b_msg.copy(), l1b_msg_dataset2]
-    )
+    # idex_l2b takes a single L2A dataset spanning one 10-day window. Concat the two
+    # simulated days together here to exercise a multi-day window.
+    combined_l2a_dataset = xr.concat([l2a_dataset, l2a_dataset2], dim="epoch")
+    datasets = idex_l2b(combined_l2a_dataset, [test_l1b_msg.copy(), l1b_msg_dataset2])
     return datasets
 
 

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -26,7 +26,12 @@ from imap_processing.idex.idex_l2b import (
     get_science_acquisition_on_time,
     idex_l2b,
 )
-from imap_processing.spice.time import TTJ2000_EPOCH
+from imap_processing.spice.time import (
+    TTJ2000_EPOCH,
+    et_to_datetime64,
+    str_yyyymmdd_to_ttj2000ns,
+    ttj2000ns_to_et,
+)
 
 INT_FILLVAL = np.iinfo(np.int64).min
 
@@ -55,7 +60,13 @@ def l2b_and_l2c_datasets(l2a_dataset: xr.Dataset, test_l1b_msg) -> list[xr.Datas
     combined_msg_dataset = xr.concat(
         [test_l1b_msg.copy(), l1b_msg_dataset2], dim="epoch"
     )
-    datasets = idex_l2b(combined_l2a_dataset, combined_msg_dataset)
+    # "20250101" is a real IDEX 10-day window start date (per
+    # idex_10_day_CDF_names.csv, spanning through "20250110"), which contains the
+    # test message data's actual dates (~2025-01-08/09). The L2A test data's dates
+    # are unrelated (they're real 2023 packet data used only for the counts
+    # computation) since epoch/epoch_delta_plus/epoch_delta_minus no longer depend
+    # on L2A's epoch values at all.
+    datasets = idex_l2b(combined_l2a_dataset, combined_msg_dataset, "20250101")
     return datasets
 
 
@@ -265,8 +276,16 @@ def test_get_science_acquisition_on_time(test_l1b_msg: xr.Dataset):
     test_l1b_msg = test_l1b_msg.isel(epoch=np.isin(test_l1b_msg.science_on, [0, 1]))
     msg_time = test_l1b_msg.epoch.data
     msg_event = test_l1b_msg.science_on.data
-    on_seconds, total_seconds = get_science_acquisition_on_time(msg_time, msg_event)
-    # The test data spans 1 day, so the total tracked time should be one day, with
+    # Use a window that spans exactly the day the test data falls on.
+    first_day = str(
+        et_to_datetime64(ttj2000ns_to_et(msg_time.min())).astype("datetime64[D]")
+    ).replace("-", "")
+    window_start = str_yyyymmdd_to_ttj2000ns(first_day)
+    window_end = window_start + NANOSECONDS_IN_DAY
+    on_seconds, total_seconds = get_science_acquisition_on_time(
+        msg_time, msg_event, window_start, window_end
+    )
+    # The window spans 1 day, so the total tracked time should be one day, with
     # less than 1% uptime for the science acquisition.
     assert total_seconds == pytest.approx(SECONDS_IN_DAY)
     assert (on_seconds / total_seconds) * 100 < 1
@@ -278,15 +297,43 @@ def test_get_science_acquisition_on_time(test_l1b_msg: xr.Dataset):
     # Now spanning 2 days.
     msg_time = combined_ds.epoch.data
     msg_event = combined_ds.science_on.data
-    on_seconds, total_seconds = get_science_acquisition_on_time(msg_time, msg_event)
+    window_end = window_start + 2 * NANOSECONDS_IN_DAY
+    on_seconds, total_seconds = get_science_acquisition_on_time(
+        msg_time, msg_event, window_start, window_end
+    )
     assert total_seconds == pytest.approx(2 * SECONDS_IN_DAY)
     assert (on_seconds / total_seconds) * 100 < 1
 
 
+def test_get_science_acquisition_on_time_extends_state_to_window_bounds():
+    """Test that a state persists all the way to the window's real edges.
+
+    An on/off state must be tracked through the actual window boundaries, not just
+    between the first and last message event -- otherwise a window with no further
+    transitions after (or before) its message events would be undercounted.
+    """
+    window_start = str_yyyymmdd_to_ttj2000ns("20250101")
+    window_end = str_yyyymmdd_to_ttj2000ns("20250106")  # 5-day window
+    # A single "on" event, 1 day into the window, with no further transitions.
+    msg_time = np.array([window_start + NANOSECONDS_IN_DAY])
+    msg_values = np.array([1])
+
+    on_seconds, total_seconds = get_science_acquisition_on_time(
+        msg_time, msg_values, window_start, window_end
+    )
+
+    assert total_seconds == pytest.approx(5 * SECONDS_IN_DAY)
+    # The "on" state should be extended through to window_end (4 remaining days),
+    # not just to the end of the event's own day.
+    assert on_seconds == pytest.approx(4 * SECONDS_IN_DAY)
+
+
 def test_get_science_acquisition_on_time_no_acquisition(caplog):
     """Test the function returns zeros when there is no science acquisition."""
+    window_start = str_yyyymmdd_to_ttj2000ns("20250101")
+    window_end = str_yyyymmdd_to_ttj2000ns("20250110")
     on_seconds, total_seconds = get_science_acquisition_on_time(
-        np.array([]), np.array([])
+        np.array([]), np.array([]), window_start, window_end
     )
     assert on_seconds == 0.0
     assert total_seconds == 0.0
@@ -349,7 +396,7 @@ def test_compute_counts_by_charge_and_mass():
         }
     )
 
-    counts_by_charge, counts_by_mass, charge_map, mass_map, window_epoch = (
+    counts_by_charge, counts_by_mass, charge_map, mass_map = (
         compute_counts_by_charge_and_mass(l2a_dataset)
     )
 
@@ -380,13 +427,6 @@ def test_compute_counts_by_charge_and_mass():
     np.testing.assert_array_equal(charge_map, expected_map_array)
     np.testing.assert_array_equal(mass_map, expected_map_array)
 
-    # The window epoch is the center of the accumulation period: the midpoint
-    # between the first and last input epochs.
-    epoch_data = l2a_dataset["epoch"].data
-    np.testing.assert_allclose(
-        window_epoch, [(epoch_data.min() + epoch_data.max()) / 2]
-    )
-
 
 def test_compute_counts_by_charge_and_mass_out_of_bounds():
     """Test the compute_counts_by_charge_and_mass function.
@@ -412,7 +452,7 @@ def test_compute_counts_by_charge_and_mass_out_of_bounds():
         }
     )
 
-    counts_by_charge, counts_by_mass, charge_map, mass_map, window_epoch = (
+    counts_by_charge, counts_by_mass, charge_map, mass_map = (
         compute_counts_by_charge_and_mass(l2a_dataset)
     )
 

--- a/imap_processing/tests/test_cli.py
+++ b/imap_processing/tests/test_cli.py
@@ -836,29 +836,6 @@ def test_idex_l1b(mock_idex_l1b, mock_instrument_dependencies):
     xr.testing.assert_equal(mock_idex_l1b.call_args[0][0], new_ds)
 
 
-@mock.patch("imap_processing.cli.idex_l2b")
-def test_idex_l2b(mock_idex_l2b, mock_instrument_dependencies):
-    """Test coverage for cli.Idex class with l2b data level"""
-    mocks = mock_instrument_dependencies
-    mock_idex_l2b.return_value = [xr.Dataset(), xr.Dataset()]
-    mocks["mock_write_cdf"].side_effect = ["/path/to/product0", "/path/to/product1"]
-    input_collection = ProcessingInputCollection(
-        ScienceInput("imap_idex_l1b_msg-10days_20251015_v002.cdf"),
-        ScienceInput("imap_idex_l2a_sci-10days_20251017_v018.cdf"),
-        SPICEInput("naif0012.tls", "imap_sclk_0000.tsc"),
-    )
-    mocks["mock_pre_processing"].return_value = input_collection
-
-    dependency_str = input_collection.serialize()
-    instrument = Idex(
-        "l2b", "all", dependency_str, "20100105", "20100101", "v001", False
-    )
-
-    instrument.process()
-    assert mock_idex_l2b.call_count == 1
-    assert mock_instrument_dependencies["mock_write_cdf"].call_count == 2
-
-
 @mock.patch("imap_processing.cli.hit_l1a")
 def test_hit_l1a(mock_hit_l1a, mock_instrument_dependencies):
     """Test coverage for cli.Hit class with l1a data level"""


### PR DESCRIPTION
# Change Summary

closes #3403

## Overview
The IDEX team would like the l2b and l2c products to be at the same 10-day cadence as the upstream products. This is because they are getting fewer dust hits than expected. This simplifies the l2b code a lot. 

Instead of having a month of rates and counts every day, they would like just one single rate /count over the 10-day period. 
The units are still the same but the calculation gets simplified. 

## File changes
- imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml 
  - I realized this UNIT was wrong from the start. Its per seconds not per day. 
- imap_processing/idex/idex_l2b.py
  - update l2b products to be at 10-day cadence


