### PR TITLE
Idex l2b agnostic

### DIFF
--- a/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
@@ -103,6 +103,19 @@ base_mass: &base_mass
     VALIDMIN: 0.0
     VAR_TYPE: data
 
+base_agnostic: &base_agnostic
+    CATDESC: " "
+    DEPEND_0: epoch
+    DEPEND_1: spin_phase
+    DISPLAY_TYPE: time_series
+    FIELDNAM: " "
+    FILLVAL: *int_fillval
+    FORMAT: E10.3
+    LABL_PTR_1: spin_phase_labels
+    VALIDMAX: *int_maxval
+    VALIDMIN: 0
+    VAR_TYPE: data
+
 rate_by_charge:
     <<: *base_charge
     CATDESC: Count rate per day by impact charge and spin phase.
@@ -134,6 +147,22 @@ counts_by_mass:
     FIELDNAM: Counts by Mass
     FORMAT: I8
     UNITS: counts
+
+counts:
+    <<: *base_agnostic
+    CATDESC: Count of dust impacts by spin phase.
+    DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:Counts,Qualifier:Array
+    FIELDNAM: Counts
+    FORMAT: I8
+    UNITS: counts
+
+rate:
+    <<: *base_agnostic
+    CATDESC: Dust impact count rate by spin phase.
+    DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:CountRate,Qualifier:Array
+    FIELDNAM: Rate
+    FILLVAL: *double_fillval
+    UNITS: day^-1
 
 impact_day_of_year:
     CATDESC: The unique day of the years when dust impacts occurred.

--- a/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
@@ -118,19 +118,19 @@ base_agnostic: &base_agnostic
 
 rate_by_charge:
     <<: *base_charge
-    CATDESC: Count rate per day by impact charge and spin phase.
+    CATDESC: Count rate in s^-1 by impact charge and spin phase.
     DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:CountRate,Qualifier:Array
     FIELDNAM: Rate by Charge
     FILLVAL: *double_fillval
-    UNITS: day^-1
+    UNITS: s^-1
 
 rate_by_mass:
     <<: *base_mass
-    CATDESC: Count rate per day by mass and spin phase.
+    CATDESC: Count rate in s^-1 by mass and spin phase.
     DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:CountRate,Qualifier:Array
     FIELDNAM: Rate by Mass
     FILLVAL: *double_fillval
-    UNITS: day^-1
+    UNITS: s^-1
 
 counts_by_charge:
     <<: *base_charge
@@ -162,7 +162,7 @@ rate:
     DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:CountRate,Qualifier:Array
     FIELDNAM: Rate
     FILLVAL: *double_fillval
-    UNITS: day^-1
+    UNITS: s^-1
 
 impact_day_of_year:
     CATDESC: The unique day of the years when dust impacts occurred.

--- a/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
@@ -47,6 +47,21 @@ base_mass_map: &base_mass_map
   LABL_PTR_2: rectangular_lon_pixel_label
   LABL_PTR_3: rectangular_lat_pixel_label
 
+base_agnostic_map: &base_agnostic_map
+  DEPEND_0: epoch
+  DEPEND_1: rectangular_lon_pixel
+  DEPEND_2: rectangular_lat_pixel
+  DISPLAY_TYPE: image
+  FIELDNAM: " "
+  FILLVAL: *int_fillval
+  FORMAT: E10.3
+  LABLAXIS: "Longitude / Latitude"
+  LABL_PTR_1: rectangular_lon_pixel_label
+  LABL_PTR_2: rectangular_lat_pixel_label
+  VALIDMAX: *int_maxval
+  VALIDMIN: 0
+  VAR_TYPE: data
+
 # Label attributes
 rectangular_lon_pixel_label:
   CATDESC: Longitude pixel index label for IDEX SkyMap.
@@ -116,6 +131,22 @@ rate_by_mass_map:
   CATDESC: Count rate per day by mass, longitude, and latitude.
   DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
   FIELDNAM: Rate by Mass Map
+  FILLVAL: *double_fillval
+  UNITS: day^-1
+
+counts_map:
+  <<: *base_agnostic_map
+  CATDESC: Count of dust impacts by longitude and latitude.
+  DICT_KEY: SPASE>Particle>ParticleType:Dust,ParticleQuantity:Counts,Qualifier:Array
+  FIELDNAM: Counts Map
+  FORMAT: I8
+  UNITS: counts
+
+rate_map:
+  <<: *base_agnostic_map
+  CATDESC: Dust impact count rate by longitude and latitude.
+  DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
+  FIELDNAM: Rate Map
   FILLVAL: *double_fillval
   UNITS: day^-1
 

--- a/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml
@@ -104,11 +104,11 @@ rectangular_lat_pixel:
 
 rate_by_charge_map:
   <<: *base_charge_map
-  CATDESC: Count rate per day by impact charge, longitude, and latitude.
+  CATDESC: Count rate in s^-1 by impact charge, longitude, and latitude.
   DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
   FIELDNAM: Rate by Charge Map
   FILLVAL: *double_fillval
-  UNITS: day^-1
+  UNITS: s^-1
 
 counts_by_charge_map:
   <<: *base_charge_map
@@ -128,11 +128,11 @@ counts_by_mass_map:
 
 rate_by_mass_map:
   <<: *base_mass_map
-  CATDESC: Count rate per day by mass, longitude, and latitude.
+  CATDESC: Count rate in s^-1 by mass, longitude, and latitude.
   DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
   FIELDNAM: Rate by Mass Map
   FILLVAL: *double_fillval
-  UNITS: day^-1
+  UNITS: s^-1
 
 counts_map:
   <<: *base_agnostic_map
@@ -148,7 +148,7 @@ rate_map:
   DICT_KEY: SPASE>SupportQuantity:CountRate,Qualifier:Array
   FIELDNAM: Rate Map
   FILLVAL: *double_fillval
-  UNITS: day^-1
+  UNITS: s^-1
 
 
 on_off_times:

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -643,8 +643,8 @@ def compute_rates_agnostic(
         [daily_on_percentage.get(doy, -1) for doy in epoch_doy]
     )
     non_zero_inds = np.where(epoch_doy_percent_on > 0)[0]
-    rate = np.full(counts.shape, -1.0)
-    rate_map = np.full(counts_map.shape, -1.0)
+    rate = np.full(counts.shape, np.nan)
+    rate_map = np.full(counts_map.shape, np.nan)
     rate[non_zero_inds] = compute_rates(counts, epoch_doy_percent_on, non_zero_inds)
     rate_map[non_zero_inds] = compute_rates(
         counts_map, epoch_doy_percent_on, non_zero_inds
@@ -699,9 +699,11 @@ def compute_rates_by_charge_and_mass(
         [daily_on_percentage.get(doy, -1) for doy in epoch_doy]
     )
 
+    invalid_uptime_inds = np.where(epoch_doy_percent_on <= 0)[0]
+    rate_quality_flags[invalid_uptime_inds] = 0
+
     missing_doy_uptimes_inds = np.where(epoch_doy_percent_on == -1)[0]
     if np.any(missing_doy_uptimes_inds):
-        rate_quality_flags[missing_doy_uptimes_inds] = 0
         logger.warning(
             f"Missing science acquisition uptime percentages for day(s) of"
             f" year: {epoch_doy[missing_doy_uptimes_inds]}."

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -554,9 +554,7 @@ def compute_counts_agnostic(
         else:
             indices = np.array([], dtype=int)
         spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
-        counts.append(
-            np.histogram(spin, bins=np.arange(SPIN_PHASE_BIN_EDGES.size))[0]
-        )
+        counts.append(np.histogram(spin, bins=np.arange(SPIN_PHASE_BIN_EDGES.size))[0])
         longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)
         latitude = l2a_dataset["latitude"].data[indices]
         valid_geometry = np.isfinite(longitude) & np.isfinite(latitude)

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -494,13 +494,13 @@ def compute_counts_by_charge_and_mass(
         counts_by_mass.append(
             np.histogramdd(
                 np.column_stack([mass_vals, binned_spin_phase]),
-                bins=[MASS_BIN_EDGES, np.arange(5)],
+                bins=[MASS_BIN_EDGES, np.arange(SPIN_PHASE_BIN_EDGES.size)],
             )[0]
         )
         counts_by_charge.append(
             np.histogramdd(
                 np.column_stack([charge_vals, binned_spin_phase]),
-                bins=[CHARGE_BIN_EDGES, np.arange(5)],
+                bins=[CHARGE_BIN_EDGES, np.arange(SPIN_PHASE_BIN_EDGES.size)],
             )[0]
         )
         counts_by_mass_map.append(
@@ -554,7 +554,9 @@ def compute_counts_agnostic(
         else:
             indices = np.array([], dtype=int)
         spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
-        counts.append(np.histogram(spin, bins=np.arange(5))[0])
+        counts.append(
+            np.histogram(spin, bins=np.arange(SPIN_PHASE_BIN_EDGES.size))[0]
+        )
         longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)
         latitude = l2a_dataset["latitude"].data[indices]
         valid_geometry = np.isfinite(longitude) & np.isfinite(latitude)

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -397,9 +397,9 @@ def idex_l2b(
 
     l2c_dataset.attrs.update(map_attrs)
 
-    # We're inserting a placeholder block here for the 2026 June release while the
-    # IDEX science team works through validating the fitting routines and
-    # derived values.
+    # Keep the mass/charge computations above for validation and future work, but
+    # withhold those products from publication until the fitting routines and derived
+    # values are validated. The agnostic products are intentionally left untouched.
 
     # L2B Block
     l2b_dataset["counts_by_mass"].data = np.full(

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -459,20 +459,16 @@ def compute_counts_by_charge_and_mass(
     counts_by_charge_map = []
     counts_by_mass_map = []
     daily_epoch: np.ndarray = np.zeros(len(epoch_doy_unique), dtype=np.float64)
+    epoch_doy = epoch_to_doy(l2a_dataset["epoch"].data)
     for i in range(len(epoch_doy_unique)):
         doy = epoch_doy_unique[i]
         # Get the indices for the current day
-        current_day_indices = np.where(epoch_to_doy(l2a_dataset["epoch"].data) == doy)[
-            0
-        ]
+        current_day_indices = np.flatnonzero(epoch_doy == doy)
         # Set the epoch for the current day to be the mean epoch of the day.
         daily_epoch[i] = np.mean(l2a_dataset["epoch"].data[current_day_indices])
-        dust = (
-            np.asarray(l2a_dataset["dust_hit_flag"].data[current_day_indices]) == 1
-            if "dust_hit_flag" in l2a_dataset
-            else np.zeros(len(current_day_indices), dtype=bool)
+        current_day_indices = _get_dust_hit_indices(
+            l2a_dataset, epoch_doy, doy
         )
-        current_day_indices = current_day_indices[dust]
         mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[
             current_day_indices
         ]
@@ -545,14 +541,9 @@ def compute_counts_agnostic(
     """
     counts = []
     counts_map = []
+    epoch_doy = epoch_to_doy(l2a_dataset["epoch"].data)
     for doy in epoch_doy_unique:
-        indices = np.where(epoch_to_doy(l2a_dataset["epoch"].data) == doy)[0]
-        if "dust_hit_flag" in l2a_dataset:
-            indices = indices[
-                np.asarray(l2a_dataset["dust_hit_flag"].data[indices]) == 1
-            ]
-        else:
-            indices = np.array([], dtype=int)
+        indices = _get_dust_hit_indices(l2a_dataset, epoch_doy, doy)
         spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
         counts.append(np.histogram(spin, bins=np.arange(SPIN_PHASE_BIN_EDGES.size))[0])
         longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)
@@ -566,6 +557,20 @@ def compute_counts_agnostic(
             )[0]
         )
     return np.asarray(counts, dtype=np.int64), np.asarray(counts_map, dtype=np.int64)
+
+
+def _get_dust_hit_indices(
+    l2a_dataset: xr.Dataset, epoch_doy: np.ndarray, doy: int
+) -> np.ndarray:
+    """Return the indices of dust hits occurring on the requested day."""
+    current_day_indices = np.flatnonzero(epoch_doy == doy)
+    if "dust_hit_flag" not in l2a_dataset:
+        return np.array([], dtype=int)
+
+    dust_hit = np.asarray(
+        l2a_dataset["dust_hit_flag"].data[current_day_indices]
+    ) == 1
+    return current_day_indices[dust_hit]
 
 
 def compute_rates(

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -470,7 +470,7 @@ def compute_counts_by_charge_and_mass(
         dust = (
             np.asarray(l2a_dataset["dust_hit_flag"].data[current_day_indices]) == 1
             if "dust_hit_flag" in l2a_dataset
-            else np.ones(len(current_day_indices), dtype=bool)
+            else np.zeros(len(current_day_indices), dtype=bool)
         )
         current_day_indices = current_day_indices[dust]
         mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[
@@ -551,6 +551,8 @@ def compute_counts_agnostic(
             indices = indices[
                 np.asarray(l2a_dataset["dust_hit_flag"].data[indices]) == 1
             ]
+        else:
+            indices = np.array([], dtype=int)
         spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
         counts.append(np.histogram(spin, bins=np.arange(5))[0])
         longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -134,6 +134,7 @@ def idex_l2b(
         counts_by_mass_map,
         daily_epoch,
     ) = compute_counts_by_charge_and_mass(l2a_dataset, epoch_doy_unique)
+    counts, counts_map = compute_counts_agnostic(l2a_dataset, epoch_doy_unique)
     # Filter the message dataset to only include science acquisition on/off events.
     # (ignore fill vals)
     science_on_msg_ds = msg_ds.isel(epoch=np.isin(msg_ds.science_on, [0, 1]))
@@ -155,6 +156,9 @@ def idex_l2b(
         counts_by_mass_map,
         epoch_doy_unique,
         daily_on_percentage,
+    )
+    rate, rate_map = compute_rates_agnostic(
+        counts, counts_map, epoch_doy_unique, daily_on_percentage
     )
     # Create l2b Dataset
     charge_bin_means = np.sqrt(CHARGE_BIN_EDGES[:-1] * CHARGE_BIN_EDGES[1:])
@@ -272,6 +276,18 @@ def idex_l2b(
             dims=("epoch", "mass", "spin_phase"),
             attrs=idex_l2b_attrs.get_variable_attributes("rate_by_mass"),
         ),
+        "counts": xr.DataArray(
+            name="counts",
+            data=counts.astype(np.int64),
+            dims=("epoch", "spin_phase"),
+            attrs=idex_l2b_attrs.get_variable_attributes("counts"),
+        ),
+        "rate": xr.DataArray(
+            name="rate",
+            data=rate,
+            dims=("epoch", "spin_phase"),
+            attrs=idex_l2b_attrs.get_variable_attributes("rate"),
+        ),
     }
     l2c_vars = common_vars | {
         "rectangular_lon_pixel_label": xr.DataArray(
@@ -349,6 +365,18 @@ def idex_l2b(
                 "rectangular_lat_pixel",
             ),
             attrs=idex_l2c_attrs.get_variable_attributes("rate_by_mass_map"),
+        ),
+        "counts_map": xr.DataArray(
+            name="counts_map",
+            data=counts_map.astype(np.int64),
+            dims=("epoch", "rectangular_lon_pixel", "rectangular_lat_pixel"),
+            attrs=idex_l2c_attrs.get_variable_attributes("counts_map"),
+        ),
+        "rate_map": xr.DataArray(
+            name="rate_map",
+            data=rate_map,
+            dims=("epoch", "rectangular_lon_pixel", "rectangular_lat_pixel"),
+            attrs=idex_l2c_attrs.get_variable_attributes("rate_map"),
         ),
     }
     l2b_dataset = xr.Dataset(
@@ -439,9 +467,13 @@ def compute_counts_by_charge_and_mass(
         ]
         # Set the epoch for the current day to be the mean epoch of the day.
         daily_epoch[i] = np.mean(l2a_dataset["epoch"].data[current_day_indices])
-        mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[
-            current_day_indices
-        ]
+        dust = (
+            np.asarray(l2a_dataset["dust_hit_flag"].data[current_day_indices]) == 1
+            if "dust_hit_flag" in l2a_dataset
+            else np.ones(len(current_day_indices), dtype=bool)
+        )
+        current_day_indices = current_day_indices[dust]
+        mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[current_day_indices]
         charge_vals = l2a_dataset["target_low_impact_charge"].data[current_day_indices]
         spin_phase_angles = l2a_dataset["spin_phase"].data[current_day_indices]
         # Make sure longitude values are in the range [0, 360)
@@ -491,6 +523,31 @@ def compute_counts_by_charge_and_mass(
     )
 
 
+def compute_counts_agnostic(
+    l2a_dataset: xr.Dataset, epoch_doy_unique: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute daily dust counts without mass or charge binning."""
+    counts = []
+    counts_map = []
+    for doy in epoch_doy_unique:
+        indices = np.where(epoch_to_doy(l2a_dataset["epoch"].data) == doy)[0]
+        if "dust_hit_flag" in l2a_dataset:
+            indices = indices[np.asarray(l2a_dataset["dust_hit_flag"].data[indices]) == 1]
+        spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
+        counts.append(np.histogram(spin, bins=np.arange(5))[0])
+        longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)
+        latitude = l2a_dataset["latitude"].data[indices]
+        valid_geometry = np.isfinite(longitude) & np.isfinite(latitude)
+        counts_map.append(
+            np.histogram2d(
+                longitude[valid_geometry],
+                np.clip(latitude[valid_geometry], -90, 90),
+                bins=[LON_BINS_EDGES, LAT_BINS_EDGES],
+            )[0]
+        )
+    return np.asarray(counts, dtype=np.int64), np.asarray(counts_map, dtype=np.int64)
+
+
 def compute_rates(
     counts: np.ndarray, epoch_doy_percent_on: np.ndarray, non_zero_inds: np.ndarray
 ) -> np.ndarray:
@@ -517,6 +574,26 @@ def compute_rates(
     return counts[non_zero_inds] / (
         0.01 * epoch_doy_percent_on[non_zero_inds] * SECONDS_IN_DAY
     )
+
+
+def compute_rates_agnostic(
+    counts: np.ndarray,
+    counts_map: np.ndarray,
+    epoch_doy: np.ndarray,
+    daily_on_percentage: dict,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute daily count rates without mass or charge binning."""
+    epoch_doy_percent_on = np.array(
+        [daily_on_percentage.get(doy, -1) for doy in epoch_doy]
+    )
+    non_zero_inds = np.where(epoch_doy_percent_on > 0)[0]
+    rate = np.full(counts.shape, -1.0)
+    rate_map = np.full(counts_map.shape, -1.0)
+    rate[non_zero_inds] = compute_rates(counts, epoch_doy_percent_on, non_zero_inds)
+    rate_map[non_zero_inds] = compute_rates(
+        counts_map, epoch_doy_percent_on, non_zero_inds
+    )
+    return rate, rate_map
 
 
 def compute_rates_by_charge_and_mass(

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -466,9 +466,7 @@ def compute_counts_by_charge_and_mass(
         current_day_indices = np.flatnonzero(epoch_doy == doy)
         # Set the epoch for the current day to be the mean epoch of the day.
         daily_epoch[i] = np.mean(l2a_dataset["epoch"].data[current_day_indices])
-        current_day_indices = _get_dust_hit_indices(
-            l2a_dataset, epoch_doy, doy
-        )
+        current_day_indices = _get_dust_hit_indices(l2a_dataset, epoch_doy, int(doy))
         mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[
             current_day_indices
         ]
@@ -543,7 +541,7 @@ def compute_counts_agnostic(
     counts_map = []
     epoch_doy = epoch_to_doy(l2a_dataset["epoch"].data)
     for doy in epoch_doy_unique:
-        indices = _get_dust_hit_indices(l2a_dataset, epoch_doy, doy)
+        indices = _get_dust_hit_indices(l2a_dataset, epoch_doy, int(doy))
         spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
         counts.append(np.histogram(spin, bins=np.arange(SPIN_PHASE_BIN_EDGES.size))[0])
         longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)
@@ -562,14 +560,28 @@ def compute_counts_agnostic(
 def _get_dust_hit_indices(
     l2a_dataset: xr.Dataset, epoch_doy: np.ndarray, doy: int
 ) -> np.ndarray:
-    """Return the indices of dust hits occurring on the requested day."""
+    """
+    Return the indices of dust hits occurring on the requested day.
+
+    Parameters
+    ----------
+    l2a_dataset : xarray.Dataset
+        Combined IDEX L2A dataset.
+    epoch_doy : np.ndarray
+        Day of year corresponding to each epoch in ``l2a_dataset``.
+    doy : int
+        Day of year to select.
+
+    Returns
+    -------
+    np.ndarray
+        Indices of dust-hit events occurring on ``doy``.
+    """
     current_day_indices = np.flatnonzero(epoch_doy == doy)
     if "dust_hit_flag" not in l2a_dataset:
         return np.array([], dtype=int)
 
-    dust_hit = np.asarray(
-        l2a_dataset["dust_hit_flag"].data[current_day_indices]
-    ) == 1
+    dust_hit = np.asarray(l2a_dataset["dust_hit_flag"].data[current_day_indices]) == 1
     return current_day_indices[dust_hit]
 
 

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -473,7 +473,9 @@ def compute_counts_by_charge_and_mass(
             else np.ones(len(current_day_indices), dtype=bool)
         )
         current_day_indices = current_day_indices[dust]
-        mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[current_day_indices]
+        mass_vals = l2a_dataset["target_low_dust_mass_estimate"].data[
+            current_day_indices
+        ]
         charge_vals = l2a_dataset["target_low_impact_charge"].data[current_day_indices]
         spin_phase_angles = l2a_dataset["spin_phase"].data[current_day_indices]
         # Make sure longitude values are in the range [0, 360)
@@ -526,13 +528,29 @@ def compute_counts_by_charge_and_mass(
 def compute_counts_agnostic(
     l2a_dataset: xr.Dataset, epoch_doy_unique: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Compute daily dust counts without mass or charge binning."""
+    """
+    Compute daily dust counts without mass or charge binning.
+
+    Parameters
+    ----------
+    l2a_dataset : xarray.Dataset
+        Combined IDEX L2A dataset.
+    epoch_doy_unique : np.ndarray
+        Unique days of year corresponding to the epochs in the dataset.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Counts by spin phase and counts by longitude and latitude, respectively.
+    """
     counts = []
     counts_map = []
     for doy in epoch_doy_unique:
         indices = np.where(epoch_to_doy(l2a_dataset["epoch"].data) == doy)[0]
         if "dust_hit_flag" in l2a_dataset:
-            indices = indices[np.asarray(l2a_dataset["dust_hit_flag"].data[indices]) == 1]
+            indices = indices[
+                np.asarray(l2a_dataset["dust_hit_flag"].data[indices]) == 1
+            ]
         spin = bin_spin_phases(l2a_dataset["spin_phase"].data[indices])
         counts.append(np.histogram(spin, bins=np.arange(5))[0])
         longitude = np.mod(l2a_dataset["longitude"].data[indices], 360)
@@ -582,7 +600,26 @@ def compute_rates_agnostic(
     epoch_doy: np.ndarray,
     daily_on_percentage: dict,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Compute daily count rates without mass or charge binning."""
+    """
+    Compute daily count rates without mass or charge binning.
+
+    Parameters
+    ----------
+    counts : np.ndarray
+        Daily agnostic counts by spin phase.
+    counts_map : np.ndarray
+        Daily agnostic counts by longitude and latitude.
+    epoch_doy : np.ndarray
+        Unique days of year corresponding to the count records.
+    daily_on_percentage : dict
+        Percentage of time science acquisition was on for each day of year.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Daily rates by spin phase and daily rates by longitude and latitude,
+        respectively.
+    """
     epoch_doy_percent_on = np.array(
         [daily_on_percentage.get(doy, -1) for doy in epoch_doy]
     )

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -25,7 +25,6 @@ from imap_processing.idex.idex_l2b import (
     get_science_acquisition_on_percentage,
     idex_l2b,
 )
-from imap_processing.spice.time import epoch_to_doy
 
 INT_FILLVAL = np.iinfo(np.int64).min
 
@@ -270,13 +269,19 @@ def test_get_science_acquisition_on_percentage_no_acquisition(caplog):
     assert "No science acquisition events found" in caplog.text
 
 
-def test_compute_counts_agnostic_filters_non_dust(l2a_dataset: xr.Dataset):
+def test_compute_counts_agnostic_filters_non_dust():
     """Agnostic products count only records classified as dust hits."""
-    dataset = l2a_dataset.isel(epoch=slice(0, 4)).copy(deep=True)
-    dataset["dust_hit_flag"] = xr.DataArray([1, 0, 1, 0], dims="epoch")
-    epoch_doy = np.array([epoch_to_doy(dataset["epoch"].data)[0]])
+    dataset = xr.Dataset(
+        {
+            "epoch": ("epoch", np.zeros(4, dtype=np.int64)),
+            "dust_hit_flag": ("epoch", [1, 0, 1, 0]),
+            "spin_phase": ("epoch", [0, 90, 180, 270]),
+            "longitude": ("epoch", [0.0, 1.0, 2.0, 3.0]),
+            "latitude": ("epoch", [0.0, 1.0, 2.0, 3.0]),
+        }
+    )
 
-    counts, counts_map = compute_counts_agnostic(dataset, epoch_doy)
+    counts, counts_map = compute_counts_agnostic(dataset, np.array([1]))
 
     assert counts.sum() == 2
     assert counts_map.sum() == 2

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -201,6 +201,10 @@ def test_l2b_cdf_variables(l2b_and_l2c_datasets: list[xr.Dataset]):
             f"Variable {var} should be fully NaN for the temporary L2B patch."
         )
 
+    # The agnostic products are independently computed and remain publishable.
+    assert l2b_dataset["counts"].data.sum() > 0
+    assert np.isfinite(l2b_dataset["rate"].data).any()
+
 
 def test_bin_spin_phases():
     """Tests that bin_spin_phases() produces expected results."""

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -21,6 +21,7 @@ from imap_processing.idex.idex_l2b import (
     bin_spin_phases,
     compute_counts_agnostic,
     compute_counts_by_charge_and_mass,
+    compute_rates_agnostic,
     compute_rates_by_charge_and_mass,
     get_science_acquisition_on_percentage,
     idex_l2b,
@@ -201,9 +202,10 @@ def test_l2b_cdf_variables(l2b_and_l2c_datasets: list[xr.Dataset]):
             f"Variable {var} should be fully NaN for the temporary L2B patch."
         )
 
-    # The agnostic products are independently computed and remain publishable.
+    # The agnostic products are independently computed and remain publishable. Rates
+    # are fill values here because the fixture has no matching uptime percentages.
     assert l2b_dataset["counts"].data.sum() > 0
-    assert np.isfinite(l2b_dataset["rate"].data).any()
+    assert np.isnan(l2b_dataset["rate"].data).all()
 
 
 def test_bin_spin_phases():
@@ -488,8 +490,8 @@ def test_compute_rates_by_charge_and_mass():
     np.testing.assert_equal(charge_map.shape, expected_map_shape)
     np.testing.assert_equal(mass_map.shape, expected_map_shape)
 
-    # Assert all quality flags are 1.
-    np.testing.assert_array_equal(quality_flags, np.ones_like(quality_flags))
+    # Zero uptime makes the rate invalid.
+    np.testing.assert_array_equal(quality_flags, [1, 1, 1, 0])
     # assert day 1 rates are as expected
     np.testing.assert_equal(rate_by_charge[0], 1 / (SECONDS_IN_DAY / 2))
     np.testing.assert_equal(rate_by_mass[0], 1 / (SECONDS_IN_DAY / 2))
@@ -510,6 +512,22 @@ def test_compute_rates_by_charge_and_mass():
     np.testing.assert_equal(rate_by_mass[3], -1.0)
     np.testing.assert_equal(charge_map[3], -1.0)
     np.testing.assert_equal(mass_map[3], -1.0)
+
+
+def test_compute_rates_agnostic_uses_nan_for_invalid_uptime():
+    """Test that agnostic rates use NaN when uptime is missing or zero."""
+    counts = np.ones((2, 4))
+    counts_map = np.ones((2, 2, 2))
+    epoch_doy = np.array([1, 2])
+
+    rate, rate_map = compute_rates_agnostic(
+        counts, counts_map, epoch_doy, {1: 100.0, 2: 0.0}
+    )
+
+    np.testing.assert_array_equal(rate[0], counts[0] / SECONDS_IN_DAY)
+    np.testing.assert_array_equal(rate_map[0], counts_map[0] / SECONDS_IN_DAY)
+    assert np.all(np.isnan(rate[1]))
+    assert np.all(np.isnan(rate_map[1]))
 
 
 def test_compute_rates_by_charge_and_mass_missing_acquisition_time(caplog):

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -287,6 +287,23 @@ def test_compute_counts_agnostic_filters_non_dust():
     assert counts_map.sum() == 2
 
 
+def test_compute_counts_agnostic_excludes_events_without_dust_flag():
+    """A missing dust-hit flag must not classify events as dust impacts."""
+    dataset = xr.Dataset(
+        {
+            "epoch": ("epoch", np.zeros(2, dtype=np.int64)),
+            "spin_phase": ("epoch", [0, 90]),
+            "longitude": ("epoch", [0.0, 1.0]),
+            "latitude": ("epoch", [0.0, 1.0]),
+        }
+    )
+
+    counts, counts_map = compute_counts_agnostic(dataset, np.array([1]))
+
+    assert counts.sum() == 0
+    assert counts_map.sum() == 0
+
+
 def test_compute_counts_by_charge_and_mass():
     """Test the compute_counts_by_charge_and_mass function."""
 
@@ -307,6 +324,7 @@ def test_compute_counts_by_charge_and_mass():
             "spin_phase": np.full((6,), 0),
             "longitude": np.full(6, 5),
             "latitude": np.full(6, 0),
+            "dust_hit_flag": np.ones(6, dtype=np.int8),
         }
     )
 
@@ -378,6 +396,7 @@ def test_compute_counts_by_charge_and_mass_out_of_bounds():
             "spin_phase": np.full((6,), 0),
             "longitude": np.array([0, 365]),
             "latitude": np.array([-90, 90]),
+            "dust_hit_flag": np.ones(2, dtype=np.int8),
         }
     )
 

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -19,11 +19,13 @@ from imap_processing.idex.idex_l2b import (
     SKY_GRID,
     SPIN_PHASE_BIN_EDGES,
     bin_spin_phases,
+    compute_counts_agnostic,
     compute_counts_by_charge_and_mass,
     compute_rates_by_charge_and_mass,
     get_science_acquisition_on_percentage,
     idex_l2b,
 )
+from imap_processing.spice.time import epoch_to_doy
 
 INT_FILLVAL = np.iinfo(np.int64).min
 
@@ -168,6 +170,8 @@ def test_l2b_cdf_variables(l2b_and_l2c_datasets: list[xr.Dataset]):
         "counts_by_mass",
         "rate_by_charge",
         "rate_by_mass",
+        "counts",
+        "rate",
     ]
     l2b_dataset = l2b_and_l2c_datasets[0]
     cdf_vars = l2b_dataset.variables
@@ -264,6 +268,18 @@ def test_get_science_acquisition_on_percentage_no_acquisition(caplog):
     on_percentages = get_science_acquisition_on_percentage(np.array([]), np.array([]))
     assert not on_percentages
     assert "No science acquisition events found" in caplog.text
+
+
+def test_compute_counts_agnostic_filters_non_dust(l2a_dataset: xr.Dataset):
+    """Agnostic products count only records classified as dust hits."""
+    dataset = l2a_dataset.isel(epoch=slice(0, 4)).copy(deep=True)
+    dataset["dust_hit_flag"] = xr.DataArray([1, 0, 1, 0], dims="epoch")
+    epoch_doy = np.array([epoch_to_doy(dataset["epoch"].data)[0]])
+
+    counts, counts_map = compute_counts_agnostic(dataset, epoch_doy)
+
+    assert counts.sum() == 2
+    assert counts_map.sum() == 2
 
 
 def test_compute_counts_by_charge_and_mass():


### PR DESCRIPTION
# Change Summary

  Closes #3407

  ## Overview

  Adds mass- and charge-agnostic IDEX L2B/L2C products for improved counting statistics when event rates are low.

  The new products:

  - Count each event once, including only `dust_hit_flag == 1`.
  - Preserve the existing daily-bin L2B/L2C structure.
  - Provide count and rate products by spin phase and sky position.
  - Exclude invalid geometry only from spatial maps.
  - Calculate rates using daily science-acquisition uptime in `s^-1`.
  - Preserve computed mass/charge products internally but publish them as fill/NaN pending validation.

  ## File changes

  - `imap_processing/idex/idex_l2b.py`
    - Adds agnostic count/rate products and maps.
    - Filters events using `dust_hit_flag`.
    - Withholds mass/charge products at the end of processing.
    - Couples spin histograms to the configured bin definition.

  - `imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml`
    - Adds metadata for agnostic count/rate variables.

  - `imap_processing/cdf/config/imap_idex_l2c_variable_attrs.yaml`
    - Adds metadata for agnostic spatial maps and image axes.

  - `imap_processing/tests/idex/test_idex_l2b.py`
    - Tests dust filtering and missing-flag behavior.
    - Verifies mass/charge products are masked while agnostic products remain populated.

  ## Testing

  - Focused IDEX L2B tests: 14 passed.
  - Local L2B/L2C processing completed using the July 19, 2026 products.
   - Generated agnostic L2B and L2C totals agree: 6 events.
   - _by_mass/charge products are serialized as fill values.
  - Python compilation, YAML parsing, and diff checks passed.
