### PR TITLE
CoDICE l2 lo de elevation angle computation fix

### DIFF
--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -1176,12 +1176,12 @@ def process_lo_direct_events(dependencies: ProcessingInputCollection) -> xr.Data
     pos_to_els = (
         LO_POSITION_TO_ELEVATION_ANGLE["sw"] | LO_POSITION_TO_ELEVATION_ANGLE["nsw"]
     )
-    elevation_angle_shape = l2_dataset["position"].shape
+    elevation_angle_shape = l2_dataset["apd_id"].shape
     elevation_angle = np.array(
-        [pos_to_els.get(pos, np.nan) for pos in l2_dataset["position"].values.flat]
+        [pos_to_els.get(pos, np.nan) for pos in l2_dataset["apd_id"].values.flat]
     ).reshape(elevation_angle_shape)
     l2_dataset["elevation_angle"] = (
-        l2_dataset["position"].dims,
+        l2_dataset["apd_id"].dims,
         elevation_angle.astype(np.float32),
     )
     spin_sector_attrs = cdf_attrs.get_variable_attributes(

--- a/imap_processing/codice/codice_l2.py
+++ b/imap_processing/codice/codice_l2.py
@@ -1249,6 +1249,10 @@ def process_lo_direct_events(dependencies: ProcessingInputCollection) -> xr.Data
     # Get only valid TOF bits between 0 and 1023
     valid_mask = (tof_bits >= 0) & (tof_bits < 1024)
     tof_ns[valid_mask] = tof_bit_to_ns[tof_bits[valid_mask]]
+    # Negative TOF values are unphysical, so mirror Menlo's L3a handling by
+    # treating them as fill values starting at L2, where TOF is first converted
+    # to a physical unit.
+    tof_ns[tof_ns < 0] = np.nan
     # Reshape back to original shape
     l2_dataset["tof"].data = tof_ns.astype(np.float32).reshape(l2_dataset["tof"].shape)
 

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -549,7 +549,7 @@ def test_codice_l2_lo_de(mock_get_file_paths, codice_lut_path):
         / "l2_validation"
         / (
             f"imap_codice_l2_lo-direct-events_{VALIDATION_FILE_DATE}"
-            f"_{VALIDATION_FILE_VERSION}.cdf"
+            f"_v016.cdf"  # TODO switch back to VALIDATION_FILE_VERSION
         )
     )
 
@@ -561,13 +561,17 @@ def test_codice_l2_lo_de(mock_get_file_paths, codice_lut_path):
             #  calculation. Currently they are not setting spin sector and spin angles
             #  to NaNs for invalid positions.
             continue  # skip spin_angle
+        if variable in ["rgfo_half_spin", "rgfo_spin_sector", "rgfo_esa_step"]:
+            # Skips variables that are not needed for direct events
+            continue
+        if l2_val_data[variable].values.size == 0:
+            continue
         if "label" in variable:
             np.testing.assert_array_equal(
                 processed_l2_ds[variable].values,
                 l2_val_data[variable].values,
                 err_msg=f"Mismatch in variable '{variable}'",
             )
-        else:
             np.testing.assert_allclose(
                 processed_l2_ds[variable].values,
                 l2_val_data[variable].values,

--- a/imap_processing/tests/codice/test_codice_l2.py
+++ b/imap_processing/tests/codice/test_codice_l2.py
@@ -572,6 +572,7 @@ def test_codice_l2_lo_de(mock_get_file_paths, codice_lut_path):
                 l2_val_data[variable].values,
                 err_msg=f"Mismatch in variable '{variable}'",
             )
+        else:
             np.testing.assert_allclose(
                 processed_l2_ds[variable].values,
                 l2_val_data[variable].values,

--- a/imap_processing/tests/external_test_data_config.py
+++ b/imap_processing/tests/external_test_data_config.py
@@ -85,7 +85,7 @@ EXTERNAL_TEST_DATA = [
     (f"imap_codice_l2_hi-omni_{VALIDATION_FILE_DATE}_{VALIDATION_FILE_VERSION}.cdf", "codice/data/l2_validation/"),
     (f"imap_codice_l2_hi-sectored_{VALIDATION_FILE_DATE}_{VALIDATION_FILE_VERSION}.cdf", "codice/data/l2_validation/"),
     (f"imap_codice_l2_lo-sw-species_{VALIDATION_FILE_DATE}_{VALIDATION_FILE_VERSION}.cdf", "codice/data/l2_validation/"),
-    (f"imap_codice_l2_lo-direct-events_{VALIDATION_FILE_DATE}_{VALIDATION_FILE_VERSION}.cdf", "codice/data/l2_validation/"),
+    (f"imap_codice_l2_lo-direct-events_{VALIDATION_FILE_DATE}_v016.cdf", "codice/data/l2_validation/"),
     (f"imap_codice_l2_hi-direct-events_{VALIDATION_FILE_DATE}_{VALIDATION_FILE_VERSION}.cdf", "codice/data/l2_validation/"),
     (f"imap_codice_l2_hi-ialirt_{VALIDATION_FILE_DATE}_{VALIDATION_FILE_VERSION}.cdf", "codice/data/l2_validation/"),
     (f"imap_codice_l2_lo-ialirt_{VALIDATION_FILE_DATE}_{VALIDATION_FILE_VERSION}.cdf", "codice/data/l2_validation/"),


### PR DESCRIPTION
# Change Summary

closes https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/3450

## Overview
Use apd_id in elevation_angle computation instead of position. Apd_id is more reliable. 

## File changes
- imap_processing/codice/codice_l2.py 
   
