### PR TITLE
[cli] SWAPI: Support l1a data level

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -1831,7 +1831,7 @@ class Swapi(ProcessInstrument):
         datasets: list[xr.Dataset] = []
 
         dependency_list = dependencies.processing_input
-        if self.data_level == "l1":
+        if self.data_level in ["l1", "l1a"]:
             # For science, we expect l0 raw file and L1 housekeeping file
             if self.descriptor == "sci" and len(dependency_list) != 3:
                 raise ValueError(


### PR DESCRIPTION
Addresses issue https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/1621

# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

Support the SWAPI l1a data level in the cli.

## File changes
<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->

* imap_processing/cli.py
  * Handle SWAPI l1a processing identically to the existing l1 processing.
    * The sci descriptor will run with l1 and the hk descriptor will run with l1a.
      * The code for the two heavily overlaps, and the simplest fix is to leave it that way. 


## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->

No changes to testing.  SWAPI and cli tests pass.

## Notes

This is related to https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/1559, which @lacoak21 plans to address.
