### PR TITLE
I-ALiRT - add mopra coverage

### DIFF
--- a/imap_processing/ialirt/generate_coverage.py
+++ b/imap_processing/ialirt/generate_coverage.py
@@ -1,6 +1,7 @@
 """Coverage time for each station."""
 
 import logging
+from datetime import time as dt_time
 
 import numpy as np
 
@@ -158,6 +159,17 @@ def generate_coverage(  # noqa: PLR0912
         outage_dict[station_name] = et_to_utc(
             time_range[outage_mask], format_str="ISOC"
         )
+
+    # Mopra: fixed daily allocation (20:45-00:30 UTC), no geometry needed.
+    # Split into two same-day windows to avoid the midnight rollover.
+    mopra_evening = StationProperties(0, 0, 0, 0, dt_time(20, 45), dt_time(23, 59, 59))
+    mopra_morning = StationProperties(0, 0, 0, 0, dt_time(0, 0), dt_time(0, 30))
+    mopra_mask = create_schedule_mask(mopra_evening, time_range) | create_schedule_mask(
+        mopra_morning, time_range
+    )
+    total_visible_mask |= mopra_mask
+    coverage_dict["Mopra"] = et_to_utc(time_range[mopra_mask], format_str="ISOC")
+    outage_dict["Mopra"] = np.array([], dtype="<U23")
 
     # --- DSN Stations ---
     if dsn:

--- a/imap_processing/tests/ialirt/unit/test_generate_coverage.py
+++ b/imap_processing/tests/ialirt/unit/test_generate_coverage.py
@@ -125,7 +125,8 @@ def test_dsn(furnish_kernels):
         )
 
         assert "I-ALiRT Coverage Summary" in output["summary"]
-        assert 40.6 == output["total_coverage_percent"]
+        # Mopra's fixed daily allocation now contributes to total coverage.
+        assert 56.6 == output["total_coverage_percent"]
 
 
 @patch("imap_processing.ialirt.generate_coverage.et_to_utc")
@@ -181,3 +182,20 @@ def test_create_schedule_mask(mock_et_to_utc):
     )
 
     np.testing.assert_array_equal(mask, expected)
+
+
+@pytest.mark.external_kernel
+def test_mopra_coverage(furnish_kernels):
+    """
+    Test that Mopra's fixed daily allocation (20:45-00:30 UTC) is applied.
+    """
+    kernels = ["naif0012.tls", "pck00011.tpc", "de440s.bsp", "imap_spk_demo.bsp"]
+
+    with furnish_kernels(kernels):
+        coverage_dict, _ = generate_coverage("2026-09-22T00:00:00Z")
+
+    mopra_times = coverage_dict["Mopra"]
+
+    assert "2026-09-22T20:45:00.000" in mopra_times
+    assert "2026-09-22T00:30:00.000" in mopra_times
+    assert "2026-09-22T12:00:00.000" not in mopra_times


### PR DESCRIPTION
This pull request adds support for Mopra station's fixed daily coverage allocation to the coverage generation logic, updates tests to reflect the new coverage calculation, and introduces a dedicated test to verify Mopra's schedule. The main changes are as follows:

**Coverage calculation enhancements:**

* Added logic in `generate_coverage.py` to include Mopra station's fixed daily allocation (20:45–00:30 UTC) in the coverage computation, ensuring Mopra is always considered during these windows regardless of geometry.

**Testing updates:**

* Updated the test in `test_generate_coverage.py` to expect the increased total coverage percentage resulting from Mopra's inclusion.
* Added a new test, `test_mopra_coverage`, to verify that Mopra's fixed allocation is correctly applied and only covers the specified time windows.

**Imports and setup:**

* Imported `datetime.time` as `dt_time` to support the new Mopra schedule logic.
