### PR TITLE
IDEX: algorithm updates to more accurately identify dust hits

### DIFF
--- a/imap_processing/idex/idex_event_flags.py
+++ b/imap_processing/idex/idex_event_flags.py
@@ -422,6 +422,43 @@ def _baseline_corrected(
     return values - baseline, sigma
 
 
+def _find_qualifying_peak_indices(
+    corrected: np.ndarray, times: np.ndarray, sigma: float
+) -> np.ndarray:
+    """Find qualifying peaks in a baseline-corrected waveform.
+
+    Parameters
+    ----------
+    corrected : numpy.ndarray
+        Baseline-corrected waveform samples.
+    times : numpy.ndarray
+        Sample times in microseconds.
+    sigma : float
+        Noise standard deviation used to set the peak thresholds.
+
+    Returns
+    -------
+    numpy.ndarray
+        Indices of peaks that satisfy the height, prominence, and separation
+        requirements.
+    """
+    if not np.isfinite(sigma) or sigma <= 0.0:
+        return np.array([], dtype=int)
+    finite = np.isfinite(corrected) & np.isfinite(times)
+    if not np.any(finite):
+        return np.array([], dtype=int)
+    dt_us = _sample_spacing_us(times)
+    distance = max(1, round(_MIN_PEAK_DISTANCE_US / dt_us)) if dt_us > 0 else 1
+    search = np.where(finite, corrected, -np.inf)
+    peaks, _ = find_peaks(
+        search,
+        height=_PEAK_THRESHOLD_SIGMA * sigma,
+        prominence=_PEAK_PROMINENCE_SIGMA * sigma,
+        distance=distance,
+    )
+    return peaks
+
+
 def _qualifying_peaks(
     values: np.ndarray, times: np.ndarray
 ) -> tuple[np.ndarray, float, np.ndarray]:
@@ -440,20 +477,7 @@ def _qualifying_peaks(
         Baseline-corrected waveform, noise standard deviation, and peak indices.
     """
     corrected, sigma = _baseline_corrected(values, times)
-    if not np.isfinite(sigma) or sigma <= 0.0:
-        return corrected, sigma, np.array([], dtype=int)
-    finite = np.isfinite(corrected) & np.isfinite(times)
-    if not np.any(finite):
-        return corrected, sigma, np.array([], dtype=int)
-    dt_us = _sample_spacing_us(times)
-    distance = max(1, round(_MIN_PEAK_DISTANCE_US / dt_us)) if dt_us > 0 else 1
-    search = np.where(finite, corrected, -np.inf)
-    peaks, _ = find_peaks(
-        search,
-        height=_PEAK_THRESHOLD_SIGMA * sigma,
-        prominence=_PEAK_PROMINENCE_SIGMA * sigma,
-        distance=distance,
-    )
+    peaks = _find_qualifying_peak_indices(corrected, times, sigma)
     return corrected, sigma, peaks
 
 
@@ -514,18 +538,13 @@ def _reference_qualifying_peaks(
     """
     corrected = values - reference_baseline
     finite = np.isfinite(corrected) & np.isfinite(times)
-    if not np.any(finite) or not np.isfinite(reference_sigma) or reference_sigma <= 0.0:
-        return corrected, np.nan, np.array([], dtype=int)
-    dt_us = _sample_spacing_us(times)
-    distance = max(1, round(_MIN_PEAK_DISTANCE_US / dt_us)) if dt_us > 0 else 1
-    search = np.where(finite, corrected, -np.inf)
-    peaks, _ = find_peaks(
-        search,
-        height=_PEAK_THRESHOLD_SIGMA * reference_sigma,
-        prominence=_PEAK_PROMINENCE_SIGMA * reference_sigma,
-        distance=distance,
+    sigma = (
+        reference_sigma
+        if np.any(finite) and np.isfinite(reference_sigma) and reference_sigma > 0.0
+        else np.nan
     )
-    return corrected, reference_sigma, peaks
+    peaks = _find_qualifying_peak_indices(corrected, times, sigma)
+    return corrected, sigma, peaks
 
 
 def _sample_spacing_us(times: np.ndarray) -> float:

--- a/imap_processing/idex/idex_event_flags.py
+++ b/imap_processing/idex/idex_event_flags.py
@@ -31,9 +31,16 @@ _SATURATION_FRACTION = 0.95
 _PULSER_THRESHOLD_DN = 1000
 _BASELINE_WINDOW_US = 3.0
 _PEAK_THRESHOLD_SIGMA = 7.0
+_PEAK_PROMINENCE_SIGMA = 5.0
 _MIN_PEAK_WIDTH_US = 0.020
+_SINGLE_PEAK_WIDTH_US = 0.050
 _MIN_PEAK_COUNT = 2
 _MIN_PEAK_DISTANCE_US = 0.030
+_SATURATION_MATCH_WINDOW_US = 0.050
+_TOF_REFERENCE_BASELINES = (511.0, 513.0, 514.0)
+_TOF_REFERENCE_SIGMAS = (2.9652, 1.4826, 2.9652)
+_TRUNCATED_BASELINE_OFFSET_DN = 20.0
+_TRUNCATED_BASELINE_NOISE_DN = 10.0
 
 _TRIGGER_CHANNELS = {
     0: "TOF H",
@@ -194,7 +201,7 @@ def _has_dust_hit(
     tof_low: np.ndarray,
     time_high_sample_rate: np.ndarray,
 ) -> bool:
-    """Return whether TOF High contains two qualifying peaks.
+    """Return whether any TOF gain contains a dust-like peak pattern.
 
     Parameters
     ----------
@@ -206,10 +213,9 @@ def _has_dust_hit(
     Returns
     -------
     bool
-        Whether at least two peaks meet the sigma and FWHM requirements.
+        Whether at least two peaks meet the sigma and FWHM requirements in
+        one gain, or one peak is at least 50 ns wide.
     """
-    # Candidate peaks are always located on High, then measured at lower gain
-    # when saturation prevents a reliable High-gain FWHM.
     high = _as_1d_array(tof_high)
     mid = _as_1d_array(tof_mid)
     low = _as_1d_array(tof_low)
@@ -219,29 +225,98 @@ def _has_dust_hit(
         return False
     high, mid, low, times = (array[:length] for array in (high, mid, low, times))
 
-    high_corrected, high_sigma = _baseline_corrected(high, times)
-    if not np.isfinite(high_sigma) or high_sigma <= 0.0:
-        return False
-    finite = np.isfinite(high_corrected) & np.isfinite(times)
-    if not np.any(finite):
-        return False
-    dt_us = _sample_spacing_us(times)
-    distance = max(1, round(_MIN_PEAK_DISTANCE_US / dt_us)) if dt_us > 0 else 1
-    search = np.where(finite, high_corrected, -np.inf)
-    peaks, _ = find_peaks(
-        search,
-        height=_PEAK_THRESHOLD_SIGMA * high_sigma,
-        distance=distance,
+    return _has_standard_dust_hit(high, mid, low, times) or _has_truncated_dust_hit(
+        high, mid, low, times
     )
 
-    qualifying_peaks = 0
-    for peak_index in peaks:
-        width_us = _saturation_aware_width(
-            peak_index, high, mid, low, times, high_corrected
+
+def _has_standard_dust_hit(
+    high: np.ndarray, mid: np.ndarray, low: np.ndarray, times: np.ndarray
+) -> bool:
+    """Return whether normal baseline processing finds a dust-like pattern.
+
+    Parameters
+    ----------
+    high, mid, low : numpy.ndarray
+        Raw TOF waveforms in high, medium, and low gain.
+    times : numpy.ndarray
+        High-rate waveform times in microseconds.
+
+    Returns
+    -------
+    bool
+        Whether the standard peak criteria identify a dust-like pattern.
+    """
+    for channel_index, waveform in enumerate((high, mid, low)):
+        corrected, sigma, peaks = _qualifying_peaks(waveform, times)
+        if not np.isfinite(sigma):
+            continue
+        peaks = _collapse_saturated_peaks(peaks, waveform, corrected)
+
+        widths = []
+        direct_widths = []
+        for peak_index in peaks:
+            direct_widths.append(_fwhm(corrected, times, int(peak_index)))
+            if channel_index == 0:
+                width_us = _saturation_aware_width(
+                    peak_index, high, mid, low, times, corrected
+                )
+            else:
+                width_us = direct_widths[-1]
+            if np.isfinite(width_us):
+                widths.append(width_us)
+
+        if sum(width >= _MIN_PEAK_WIDTH_US for width in widths) >= _MIN_PEAK_COUNT:
+            return True
+        if (
+            channel_index == 0
+            and len(direct_widths) == 1
+            and direct_widths[0] >= _SINGLE_PEAK_WIDTH_US
+        ):
+            return True
+
+    return False
+
+
+def _has_truncated_dust_hit(
+    high: np.ndarray, mid: np.ndarray, low: np.ndarray, times: np.ndarray
+) -> bool:
+    """Return whether reference-baseline processing finds two broad peaks.
+
+    Parameters
+    ----------
+    high, mid, low : numpy.ndarray
+        Raw TOF waveforms in high, medium, and low gain.
+    times : numpy.ndarray
+        High-rate waveform times in microseconds.
+
+    Returns
+    -------
+    bool
+        Whether the fallback peak criteria identify two qualifying peaks.
+    """
+    # If the impact begins before the TOF record, the normal baseline window
+    # can contain signal and suppress otherwise valid peaks.  Reprocess only
+    # those channels with the measured noise-capture reference baseline.
+    for channel_index, waveform in enumerate((high, mid, low)):
+        if not _baseline_is_truncated(
+            waveform, times, _TOF_REFERENCE_BASELINES[channel_index]
+        ):
+            continue
+        corrected, sigma, peaks = _reference_qualifying_peaks(
+            waveform,
+            times,
+            _TOF_REFERENCE_BASELINES[channel_index],
+            _TOF_REFERENCE_SIGMAS[channel_index],
         )
-        if np.isfinite(width_us) and width_us >= _MIN_PEAK_WIDTH_US:
-            qualifying_peaks += 1
-    return qualifying_peaks >= _MIN_PEAK_COUNT
+        if not np.isfinite(sigma):
+            continue
+        peaks = _collapse_saturated_peaks(peaks, waveform, corrected)
+        widths = [_fwhm(corrected, times, int(peak_index)) for peak_index in peaks]
+        if sum(width >= _MIN_PEAK_WIDTH_US for width in widths) >= _MIN_PEAK_COUNT:
+            return True
+
+    return False
 
 
 def _as_1d_array(values: np.ndarray) -> np.ndarray:
@@ -293,6 +368,116 @@ def _baseline_corrected(
     return values - baseline, sigma
 
 
+def _qualifying_peaks(
+    values: np.ndarray, times: np.ndarray
+) -> tuple[np.ndarray, float, np.ndarray]:
+    """Return baseline-corrected values and qualifying peaks.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        Waveform samples.
+    times : numpy.ndarray
+        Sample times in microseconds.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, float, numpy.ndarray]
+        Baseline-corrected waveform, noise standard deviation, and peak indices.
+    """
+    corrected, sigma = _baseline_corrected(values, times)
+    if not np.isfinite(sigma) or sigma <= 0.0:
+        return corrected, sigma, np.array([], dtype=int)
+    finite = np.isfinite(corrected) & np.isfinite(times)
+    if not np.any(finite):
+        return corrected, sigma, np.array([], dtype=int)
+    dt_us = _sample_spacing_us(times)
+    distance = max(1, round(_MIN_PEAK_DISTANCE_US / dt_us)) if dt_us > 0 else 1
+    search = np.where(finite, corrected, -np.inf)
+    peaks, _ = find_peaks(
+        search,
+        height=_PEAK_THRESHOLD_SIGMA * sigma,
+        prominence=_PEAK_PROMINENCE_SIGMA * sigma,
+        distance=distance,
+    )
+    return corrected, sigma, peaks
+
+
+def _baseline_is_truncated(
+    values: np.ndarray, times: np.ndarray, reference_baseline: float
+) -> bool:
+    """Return whether the initial baseline window is signal-contaminated.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        Waveform samples.
+    times : numpy.ndarray
+        Sample times in microseconds.
+    reference_baseline : float
+        Expected TOF baseline in DN.
+
+    Returns
+    -------
+    bool
+        Whether the initial baseline differs substantially from the reference.
+    """
+    finite = np.isfinite(values) & np.isfinite(times)
+    if not np.any(finite):
+        return False
+    first_time = float(times[finite][0])
+    samples = values[finite & (times < first_time + _BASELINE_WINDOW_US)]
+    if samples.size == 0:
+        return False
+    median = float(np.nanmedian(samples))
+    robust_noise = 1.4826 * float(np.nanmedian(np.abs(samples - median)))
+    return bool(
+        abs(median - reference_baseline) > _TRUNCATED_BASELINE_OFFSET_DN
+        or robust_noise > _TRUNCATED_BASELINE_NOISE_DN
+    )
+
+
+def _reference_qualifying_peaks(
+    values: np.ndarray,
+    times: np.ndarray,
+    reference_baseline: float,
+    reference_sigma: float,
+) -> tuple[np.ndarray, float, np.ndarray]:
+    """Find peaks using a reference baseline when the record starts in signal.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        Waveform samples.
+    times : numpy.ndarray
+        Sample times in microseconds.
+    reference_baseline : float
+        Expected TOF baseline in DN.
+    reference_sigma : float
+        Expected noise standard deviation in DN.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, float, numpy.ndarray]
+        Reference-baseline-corrected waveform, noise standard deviation, and peak
+        indices.
+    """
+    corrected = values - reference_baseline
+    finite = np.isfinite(corrected) & np.isfinite(times)
+    if not np.any(finite) or not np.isfinite(reference_sigma) or reference_sigma <= 0.0:
+        return corrected, np.nan, np.array([], dtype=int)
+    dt_us = _sample_spacing_us(times)
+    distance = max(1, round(_MIN_PEAK_DISTANCE_US / dt_us)) if dt_us > 0 else 1
+    search = np.where(finite, corrected, -np.inf)
+    peaks, _ = find_peaks(
+        search,
+        height=_PEAK_THRESHOLD_SIGMA * reference_sigma,
+        prominence=_PEAK_PROMINENCE_SIGMA * reference_sigma,
+        distance=distance,
+    )
+    return corrected, reference_sigma, peaks
+
+
 def _sample_spacing_us(times: np.ndarray) -> float:
     """Return the median finite sample spacing in microseconds.
 
@@ -310,6 +495,50 @@ def _sample_spacing_us(times: np.ndarray) -> float:
     if finite_times.size < 2:
         return np.nan
     return float(np.nanmedian(np.abs(np.diff(finite_times))))
+
+
+def _collapse_saturated_peaks(
+    peaks: np.ndarray, values: np.ndarray, corrected: np.ndarray
+) -> np.ndarray:
+    """Keep one candidate peak for each contiguous saturated region.
+
+    Parameters
+    ----------
+    peaks : numpy.ndarray
+        Candidate peak indices.
+    values : numpy.ndarray
+        Raw waveform samples.
+    corrected : numpy.ndarray
+        Baseline-corrected waveform samples.
+
+    Returns
+    -------
+    numpy.ndarray
+        Peak indices with saturated regions collapsed to one candidate each.
+    """
+    if peaks.size < 2:
+        return peaks
+    saturated = values >= _SATURATION_FRACTION * _TOF_MAX_DN
+    retained = []
+    used_regions = set()
+    for peak_value in peaks:
+        peak = int(peak_value)
+        if not saturated[peak]:
+            retained.append(peak)
+            continue
+        left = peak
+        while left > 0 and saturated[left - 1]:
+            left -= 1
+        right = peak
+        while right < values.size - 1 and saturated[right + 1]:
+            right += 1
+        region = (left, right)
+        if region in used_regions:
+            continue
+        used_regions.add(region)
+        region_peaks = [candidate for candidate in peaks if left <= candidate <= right]
+        retained.append(max(region_peaks, key=lambda candidate: corrected[candidate]))
+    return np.asarray(retained, dtype=int)
 
 
 def _saturation_aware_width(
@@ -355,15 +584,19 @@ def _saturation_aware_width(
         return _fwhm(high_corrected, times, peak_index)
 
     for waveform in (mid, low):
-        finite_times = np.isfinite(times)
-        if not np.any(finite_times):
+        corrected, sigma, peaks = _qualifying_peaks(waveform, times)
+        if not np.isfinite(sigma) or peaks.size == 0:
             continue
-        distances = np.where(finite_times, np.abs(times - peak_time), np.inf)
-        index = int(np.argmin(distances))
-        sample = float(waveform[index])
-        if not np.isfinite(sample) or _is_saturated(sample):
+        distances = np.abs(times[peaks] - peak_time)
+        nearest = int(np.argmin(distances))
+        if (
+            not np.isfinite(distances[nearest])
+            or distances[nearest] > _SATURATION_MATCH_WINDOW_US
+        ):
             continue
-        corrected, _ = _baseline_corrected(waveform, times)
+        index = int(peaks[nearest])
+        if _is_saturated(float(waveform[index])):
+            continue
         width = _fwhm(corrected, times, index)
         if np.isfinite(width):
             return width

--- a/imap_processing/idex/idex_event_flags.py
+++ b/imap_processing/idex/idex_event_flags.py
@@ -40,7 +40,6 @@ _SATURATION_MATCH_WINDOW_US = 0.050
 _TOF_REFERENCE_BASELINES = (511.0, 513.0, 514.0)
 _TOF_REFERENCE_SIGMAS = (2.9652, 1.4826, 2.9652)
 _TRUNCATED_BASELINE_OFFSET_DN = 20.0
-_TRUNCATED_BASELINE_NOISE_DN = 10.0
 
 _TRIGGER_CHANNELS = {
     0: "TOF H",
@@ -214,7 +213,8 @@ def _has_dust_hit(
     -------
     bool
         Whether at least two peaks meet the sigma and FWHM requirements in
-        one gain, or one peak is at least 50 ns wide.
+        one gain, or High gain contains exactly one directly measured peak
+        that is at least 50 ns wide.
     """
     high = _as_1d_array(tof_high)
     mid = _as_1d_array(tof_mid)
@@ -282,8 +282,11 @@ def _has_standard_dust_hit(
             if np.isfinite(width_us):
                 widths.append(width_us)
 
+        # If any one gain has at least 2 peaks with FWHM >= 20 ns, it is a dust hit.
         if sum(width >= _MIN_PEAK_WIDTH_US for width in widths) >= _MIN_PEAK_COUNT:
             return True
+        # If High gain has exactly one directly measured peak and it is at least
+        # 50 ns wide, count it as a dust hit.
         if (
             channel_index == 0
             and len(direct_widths) == 1
@@ -481,11 +484,7 @@ def _baseline_is_truncated(
     if samples.size == 0:
         return False
     median = float(np.nanmedian(samples))
-    robust_noise = 1.4826 * float(np.nanmedian(np.abs(samples - median)))
-    return bool(
-        abs(median - reference_baseline) > _TRUNCATED_BASELINE_OFFSET_DN
-        or robust_noise > _TRUNCATED_BASELINE_NOISE_DN
-    )
+    return bool(abs(median - reference_baseline) > _TRUNCATED_BASELINE_OFFSET_DN)
 
 
 def _reference_qualifying_peaks(

--- a/imap_processing/idex/idex_event_flags.py
+++ b/imap_processing/idex/idex_event_flags.py
@@ -247,22 +247,38 @@ def _has_standard_dust_hit(
     bool
         Whether the standard peak criteria identify a dust-like pattern.
     """
-    for channel_index, waveform in enumerate((high, mid, low)):
-        corrected, sigma, peaks = _qualifying_peaks(waveform, times)
+    waveforms = (high, mid, low)
+    peak_results = [_qualifying_peaks(waveform, times) for waveform in waveforms]
+    corrected_waveforms: tuple[np.ndarray, np.ndarray, np.ndarray] = (
+        peak_results[0][0],
+        peak_results[1][0],
+        peak_results[2][0],
+    )
+    peak_sets: tuple[np.ndarray, np.ndarray, np.ndarray] = (
+        _collapse_saturated_peaks(peak_results[0][2], high, peak_results[0][0]),
+        _collapse_saturated_peaks(peak_results[1][2], mid, peak_results[1][0]),
+        _collapse_saturated_peaks(peak_results[2][2], low, peak_results[2][0]),
+    )
+
+    for channel_index, (_waveform, peak_result, peaks) in enumerate(
+        zip(waveforms, peak_results, peak_sets, strict=True)
+    ):
+        corrected, sigma, _ = peak_result
         if not np.isfinite(sigma):
             continue
-        peaks = _collapse_saturated_peaks(peaks, waveform, corrected)
 
         widths = []
         direct_widths = []
         for peak_index in peaks:
             direct_widths.append(_fwhm(corrected, times, int(peak_index)))
-            if channel_index == 0:
-                width_us = _saturation_aware_width(
-                    peak_index, high, mid, low, times, corrected
-                )
-            else:
-                width_us = direct_widths[-1]
+            width_us = _gain_aware_width(
+                channel_index,
+                peak_index,
+                waveforms,
+                times,
+                corrected_waveforms,
+                peak_sets,
+            )
             if np.isfinite(width_us):
                 widths.append(width_us)
 
@@ -296,23 +312,58 @@ def _has_truncated_dust_hit(
         Whether the fallback peak criteria identify two qualifying peaks.
     """
     # If the impact begins before the TOF record, the normal baseline window
-    # can contain signal and suppress otherwise valid peaks.  Reprocess only
-    # those channels with the measured noise-capture reference baseline.
-    for channel_index, waveform in enumerate((high, mid, low)):
-        if not _baseline_is_truncated(
-            waveform, times, _TOF_REFERENCE_BASELINES[channel_index]
-        ):
-            continue
-        corrected, sigma, peaks = _reference_qualifying_peaks(
-            waveform,
-            times,
-            _TOF_REFERENCE_BASELINES[channel_index],
-            _TOF_REFERENCE_SIGMAS[channel_index],
-        )
+    # can contain signal and suppress otherwise valid peaks.  Reprocess affected
+    # gains with the reference baselines so saturated peaks can fall through to
+    # the next usable gain.
+    waveforms = (high, mid, low)
+    truncated_channels = tuple(
+        _baseline_is_truncated(waveform, times, _TOF_REFERENCE_BASELINES[channel_index])
+        for channel_index, waveform in enumerate(waveforms)
+    )
+    if not any(truncated_channels):
+        return False
+
+    peak_results = []
+    for channel_index, waveform in enumerate(waveforms):
+        if truncated_channels[channel_index]:
+            peak_results.append(
+                _reference_qualifying_peaks(
+                    waveform,
+                    times,
+                    _TOF_REFERENCE_BASELINES[channel_index],
+                    _TOF_REFERENCE_SIGMAS[channel_index],
+                )
+            )
+        else:
+            peak_results.append(_qualifying_peaks(waveform, times))
+    corrected_waveforms: tuple[np.ndarray, np.ndarray, np.ndarray] = (
+        peak_results[0][0],
+        peak_results[1][0],
+        peak_results[2][0],
+    )
+    peak_sets: tuple[np.ndarray, np.ndarray, np.ndarray] = (
+        _collapse_saturated_peaks(peak_results[0][2], high, peak_results[0][0]),
+        _collapse_saturated_peaks(peak_results[1][2], mid, peak_results[1][0]),
+        _collapse_saturated_peaks(peak_results[2][2], low, peak_results[2][0]),
+    )
+
+    for channel_index, (peak_result, peaks) in enumerate(
+        zip(peak_results, peak_sets, strict=True)
+    ):
+        _, sigma, _ = peak_result
         if not np.isfinite(sigma):
             continue
-        peaks = _collapse_saturated_peaks(peaks, waveform, corrected)
-        widths = [_fwhm(corrected, times, int(peak_index)) for peak_index in peaks]
+        widths = [
+            _gain_aware_width(
+                channel_index,
+                peak_index,
+                waveforms,
+                times,
+                corrected_waveforms,
+                peak_sets,
+            )
+            for peak_index in peaks
+        ]
         if sum(width >= _MIN_PEAK_WIDTH_US for width in widths) >= _MIN_PEAK_COUNT:
             return True
 
@@ -572,20 +623,87 @@ def _saturation_aware_width(
         or high.size != low.size
         or high.size != times.size
         or high_corrected.size != high.size
+    ):
+        return np.nan
+
+    waveforms = (high, mid, low)
+    peak_results = (
+        (high_corrected, np.nan, np.array([], dtype=int)),
+        _qualifying_peaks(mid, times),
+        _qualifying_peaks(low, times),
+    )
+    corrected_waveforms: tuple[np.ndarray, np.ndarray, np.ndarray] = (
+        peak_results[0][0],
+        peak_results[1][0],
+        peak_results[2][0],
+    )
+    peak_sets: tuple[np.ndarray, np.ndarray, np.ndarray] = (
+        peak_results[0][2],
+        peak_results[1][2],
+        peak_results[2][2],
+    )
+    return _gain_aware_width(
+        0,
+        peak_index,
+        waveforms,
+        times,
+        corrected_waveforms,
+        peak_sets,
+    )
+
+
+def _gain_aware_width(
+    channel_index: int,
+    peak_index: int,
+    waveforms: tuple[np.ndarray, np.ndarray, np.ndarray],
+    times: np.ndarray,
+    corrected_waveforms: tuple[np.ndarray, np.ndarray, np.ndarray],
+    peak_sets: tuple[np.ndarray, np.ndarray, np.ndarray],
+) -> float:
+    """Measure a peak width with saturation-aware lower-gain fallthrough.
+
+    Parameters
+    ----------
+    channel_index : int
+        Index of the candidate gain channel: High, Mid, or Low.
+    peak_index : int
+        Index of the candidate peak in the source waveform.
+    waveforms : tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]
+        Raw High-, Mid-, and Low-gain TOF waveforms.
+    times : numpy.ndarray
+        High-rate waveform times in microseconds.
+    corrected_waveforms : tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]
+        Baseline-corrected High-, Mid-, and Low-gain waveforms.
+    peak_sets : tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]
+        Qualifying peak indices for the High-, Mid-, and Low-gain waveforms.
+
+    Returns
+    -------
+    float
+        Direct or lower-gain-substituted FWHM in microseconds, or NaN when
+        no valid width is available.
+    """
+    if (
+        channel_index < 0
+        or channel_index >= len(waveforms)
         or peak_index < 0
-        or peak_index >= high.size
+        or peak_index >= waveforms[channel_index].size
+        or any(
+            waveform.size != times.size
+            for waveform in (*waveforms, *corrected_waveforms)
+        )
     ):
         return np.nan
 
     peak_time = float(times[peak_index])
     if not np.isfinite(peak_time):
         return np.nan
-    if not _is_saturated(float(high[peak_index])):
-        return _fwhm(high_corrected, times, peak_index)
+    if not _is_saturated(float(waveforms[channel_index][peak_index])):
+        return _fwhm(corrected_waveforms[channel_index], times, peak_index)
 
-    for waveform in (mid, low):
-        corrected, sigma, peaks = _qualifying_peaks(waveform, times)
-        if not np.isfinite(sigma) or peaks.size == 0:
+    for fallback_index in range(channel_index + 1, len(waveforms)):
+        peaks = peak_sets[fallback_index]
+        if peaks.size == 0:
             continue
         distances = np.abs(times[peaks] - peak_time)
         nearest = int(np.argmin(distances))
@@ -594,10 +712,10 @@ def _saturation_aware_width(
             or distances[nearest] > _SATURATION_MATCH_WINDOW_US
         ):
             continue
-        index = int(peaks[nearest])
-        if _is_saturated(float(waveform[index])):
+        fallback_peak = int(peaks[nearest])
+        if _is_saturated(float(waveforms[fallback_index][fallback_peak])):
             continue
-        width = _fwhm(corrected, times, index)
+        width = _fwhm(corrected_waveforms[fallback_index], times, fallback_peak)
         if np.isfinite(width):
             return width
     return np.nan

--- a/imap_processing/tests/idex/test_idex_event_flags.py
+++ b/imap_processing/tests/idex/test_idex_event_flags.py
@@ -234,6 +234,22 @@ def test_dust_hit_uses_reference_baseline_for_truncated_waveform() -> None:
     assert flags["dust_hit_flag"] == 1
 
 
+def test_noisy_baseline_does_not_use_reference_noise_sigma() -> None:
+    """A globally noisy baseline is not reprocessed as a truncated record."""
+    times = np.arange(2048, dtype=float) / 260.0
+    noisy_baseline = 511.0 + 25.0 * np.sin(np.arange(times.size, dtype=float) / 3.0)
+
+    flags = classify_event_flags(
+        _telemetry(trigger_id=1 | 4, hg_mode=1),
+        noisy_baseline,
+        noisy_baseline,
+        noisy_baseline,
+        times,
+    )
+
+    assert flags["dust_hit_flag"] == 0
+
+
 def test_peak_detection_rejects_low_prominence_secondary_maxima() -> None:
     """A small shoulder above 7 sigma is not counted as a separate peak."""
     times = np.arange(256, dtype=float) / 260.0

--- a/imap_processing/tests/idex/test_idex_event_flags.py
+++ b/imap_processing/tests/idex/test_idex_event_flags.py
@@ -8,6 +8,8 @@ from imap_processing.idex.idex_event_flags import (
     EVENT_FLAG_NAMES,
     SATURATION_FLAG_NAMES,
     _fwhm,
+    _qualifying_peaks,
+    _reference_qualifying_peaks,
     _saturation_aware_width,
     classify_event_flags,
     classify_saturation_flags,
@@ -125,6 +127,76 @@ def test_dust_hit_requires_two_seven_sigma_peaks_and_is_saturation_aware() -> No
     assert flags["dust_hit_flag"] == 1
 
 
+def test_dust_hit_scans_lower_gain_for_two_peaks() -> None:
+    """Two peaks visible only in Mid still set Dust Hit when High saturates."""
+    times = np.arange(2048, dtype=float) / 260.0
+    baseline = 100.0 + 0.5 * np.sin(np.arange(times.size, dtype=float) / 3.0)
+    narrow = 0.020 / 2.355
+    mid = baseline + sum(
+        20.0 * np.exp(-0.5 * ((times - center) / narrow) ** 2) for center in (5.0, 5.08)
+    )
+    high = np.minimum(baseline + 100.0 * mid, 1023.0)
+    low = baseline.copy()
+
+    flags = classify_event_flags(
+        _telemetry(trigger_id=1 | 4, hg_mode=1), high, mid, low, times
+    )
+
+    assert flags["dust_hit_flag"] == 1
+
+
+def test_dust_hit_accepts_one_broad_peak() -> None:
+    """A single 50 ns peak is accepted as a broad dust-like event."""
+    times = np.arange(2048, dtype=float) / 260.0
+    baseline = 100.0 + 0.5 * np.sin(np.arange(times.size, dtype=float) / 3.0)
+    broad = baseline + 20.0 * np.exp(-0.5 * ((times - 5.0) / (0.050 / 2.355)) ** 2)
+
+    flags = classify_event_flags(
+        _telemetry(trigger_id=1 | 4, hg_mode=1), broad, broad, broad, times
+    )
+
+    assert flags["dust_hit_flag"] == 1
+
+
+def test_dust_hit_uses_reference_baseline_for_truncated_waveform() -> None:
+    """Two peaks are recovered when the initial TOF baseline is contaminated."""
+    times = np.arange(2048, dtype=float) / 260.0
+    baseline = np.full(times.size, 511.0)
+    width = 0.030 / 2.355
+    waveform = baseline + 80.0
+    waveform += sum(
+        200.0 * np.exp(-0.5 * ((times - center) / width) ** 2) for center in (5.0, 5.08)
+    )
+    _, _, normal_peaks = _qualifying_peaks(waveform, times)
+    _, _, fallback_peaks = _reference_qualifying_peaks(waveform, times, 511.0, 2.9652)
+
+    assert normal_peaks.size < 2
+    assert fallback_peaks.size >= 2
+
+    flags = classify_event_flags(
+        _telemetry(trigger_id=1 | 4, hg_mode=1),
+        waveform,
+        waveform - 2.0,
+        waveform - 1.0,
+        times,
+    )
+    assert flags["dust_hit_flag"] == 1
+
+
+def test_peak_detection_rejects_low_prominence_secondary_maxima() -> None:
+    """A small shoulder above 7 sigma is not counted as a separate peak."""
+    times = np.arange(256, dtype=float) / 260.0
+    waveform = 0.5 * np.sin(np.arange(times.size, dtype=float) / 3.0)
+    waveform[90:130] += 6.0
+    waveform[100] += 20.0
+    waveform[104:] += 7.5
+    waveform[108] += 0.5
+
+    _, _, peaks = _qualifying_peaks(waveform, times)
+
+    assert peaks.tolist() == [100]
+
+
 def test_dust_hit_is_not_set_for_non_science_events() -> None:
     """Dust-shaped waveforms cannot turn a non-science event into Dust Hit."""
     flags = classify_event_flags(
@@ -136,16 +208,17 @@ def test_dust_hit_is_not_set_for_non_science_events() -> None:
 
 def test_saturation_aware_width_falls_through_invalid_mid_gain() -> None:
     """A non-finite Mid sample falls through to a usable Low waveform."""
-    times = np.arange(9, dtype=float)
-    low = np.array([0.0, 0.0, 1.0, 3.0, 5.0, 3.0, 1.0, 0.0, 0.0])
+    times = np.arange(2048, dtype=float) / 260.0
+    baseline = 100.0 + 0.5 * np.sin(np.arange(times.size, dtype=float) / 3.0)
+    low = baseline + 20.0 * np.exp(-0.5 * ((times - 5.0) / (0.030 / 2.355)) ** 2)
     high = low.copy()
-    high[4] = 1023.0
-    mid = low.copy()
-    mid[4] = np.nan
+    peak_index = int(np.argmax(low))
+    high[peak_index] = 1023.0
+    mid = np.full_like(low, np.nan)
 
-    width = _saturation_aware_width(4, high, mid, low, times, high - high[0])
+    width = _saturation_aware_width(peak_index, high, mid, low, times, high - high[0])
 
-    assert width == pytest.approx(2.5)
+    assert width == pytest.approx(0.030, rel=0.1)
 
 
 def test_fwhm_rejects_truncated_boundary_peaks() -> None:

--- a/imap_processing/tests/idex/test_idex_event_flags.py
+++ b/imap_processing/tests/idex/test_idex_event_flags.py
@@ -145,6 +145,57 @@ def test_dust_hit_scans_lower_gain_for_two_peaks() -> None:
     assert flags["dust_hit_flag"] == 1
 
 
+@pytest.mark.parametrize(
+    ("low_width", "expected_dust_hit"),
+    [(0.010, False), (0.030, True)],
+)
+def test_saturated_mid_peaks_fall_through_to_low_gain(
+    low_width: float, expected_dust_hit: bool
+) -> None:
+    """Saturated Mid peaks use Low width before passing the FWHM threshold."""
+    times = np.arange(2048, dtype=float) / 260.0
+    baseline = 511.0 + 0.5 * np.sin(np.arange(times.size, dtype=float) / 3.0)
+    narrow_peaks = sum(
+        200.0 * np.exp(-0.5 * ((times - center) / (0.010 / 2.355)) ** 2)
+        for center in (5.0, 5.08)
+    )
+    mid = np.minimum(baseline + 10.0 * narrow_peaks, 1023.0)
+    low_peaks = sum(
+        30.0 * np.exp(-0.5 * ((times - center) / (low_width / 2.355)) ** 2)
+        for center in (5.0, 5.08)
+    )
+    low = baseline + low_peaks
+    high = baseline.copy()
+
+    flags = classify_event_flags(
+        _telemetry(trigger_id=1 | 4, hg_mode=1), high, mid, low, times
+    )
+
+    assert flags["dust_hit_flag"] == int(expected_dust_hit)
+
+
+def test_truncated_saturated_mid_peaks_fall_through_to_low_gain() -> None:
+    """The truncated-baseline path also uses Low width for saturated Mid peaks."""
+    times = np.arange(2048, dtype=float) / 260.0
+    baseline = 511.0 + 0.5 * np.sin(np.arange(times.size, dtype=float) / 3.0)
+    narrow_peaks = sum(
+        200.0 * np.exp(-0.5 * ((times - center) / (0.010 / 2.355)) ** 2)
+        for center in (5.0, 5.08)
+    )
+    mid = np.minimum(baseline + 10.0 * narrow_peaks, 1023.0)
+    low = baseline + sum(
+        30.0 * np.exp(-0.5 * ((times - center) / (0.010 / 2.355)) ** 2)
+        for center in (5.0, 5.08)
+    )
+    high = baseline + 80.0
+
+    flags = classify_event_flags(
+        _telemetry(trigger_id=1 | 4, hg_mode=1), high, mid, low, times
+    )
+
+    assert flags["dust_hit_flag"] == 0
+
+
 def test_dust_hit_accepts_one_broad_peak() -> None:
     """A single 50 ns peak is accepted as a broad dust-like event."""
     times = np.arange(2048, dtype=float) / 260.0


### PR DESCRIPTION
# Change Summary

  ## Overview

  - Improved IDEX dust-hit detection for saturated, multi-gain, broad, and truncated waveforms.
  - Added a fallback for events whose signals contaminate the initial baseline window.

  ## File changes

  - idex_event_flags.py
      - Scan all TOF gain channels.
      - Add saturation-aware peak-width handling.
      - Retain the 50 ns single High-gain peak exception.
      - Add truncated-waveform reference-baseline detection.

  - test_idex_event_flags.py
      - Added regression coverage for lower-gain peaks, broad single peaks, saturation handling, and truncated baselines.

  ## Testing

  - 98 passed, 7 deselected
  - All pre-commit hooks passed.
  - Local L1A → L1B → L2A processing chain completed successfully.

Closes #3443 
