### PR TITLE
GLOWS L1B/L2: daily statistical error flag and time-dependent spin offset

### DIFF
--- a/imap_processing/glows/l1b/glows_l1b.py
+++ b/imap_processing/glows/l1b/glows_l1b.py
@@ -15,6 +15,7 @@ from imap_processing.glows.l1b.glows_l1b_data import (
     HistogramL1B,
     PipelineSettings,
 )
+from imap_processing.glows.utils.constants import GlowsConstants
 from imap_processing.spice.time import et_to_datetime64, ttj2000ns_to_et
 
 logger = logging.getLogger(__name__)
@@ -267,6 +268,26 @@ def process_histogram(
         )
         l1a = l1a.isel(epoch=~invalid_mask)
 
+    # Daily total-counts reference (mean/std) for the is_beyond_daily_statistical_error
+    # flag (Section 12.3.2), computed once. Matches the cbk implementation: built from
+    # daytime blocks only, since day/night exposure conditions differ enough that mixing
+    # them makes the reference meaningless. compute_flags still applies the check to
+    # every block. number_of_events already equals the sum of the histogram's valid
+    # bins, so use it directly rather than summing the histogram.
+    is_night_raw = np.array(
+        [
+            HistogramL1B.deserialize_flags(int(raw))[GlowsConstants.IS_NIGHT_FLAG_IDX]
+            for raw in l1a["flags_set_onboard"].data
+        ]
+    )
+    daytime_total_counts = l1a["number_of_events"].data[~is_night_raw]
+    if daytime_total_counts.size > 0:
+        daily_total_counts_average = np.double(np.mean(daytime_total_counts))
+        daily_total_counts_std_dev = np.double(np.std(daytime_total_counts))
+    else:
+        daily_total_counts_average = np.double(np.nan)
+        daily_total_counts_std_dev = np.double(np.nan)
+
     dataarrays = [l1a[i] for i in l1a.keys()]
 
     input_dims: list = [[] for i in l1a.keys()]
@@ -314,7 +335,12 @@ def process_histogram(
             Tuple of processed L1B data arrays from HistogramL1B.output_data().
         """
         return HistogramL1B(  # type: ignore[call-arg]
-            *args, ancillary_exclusions, ancillary_parameters, pipeline_settings
+            *args,
+            ancillary_exclusions,
+            ancillary_parameters,
+            pipeline_settings,
+            daily_total_counts_average,
+            daily_total_counts_std_dev,
         ).output_data()
 
     l1b_fields = xr.apply_ufunc(

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -1109,9 +1109,9 @@ class HistogramL1B:
         pipeline_settings : PipelineSettings
             Pipeline settings containing processing thresholds.
         daily_total_counts_average : numpy.double
-            Mean of total histogram counts across all L1A blocks for the day.
+            Mean of total histogram counts across daytime L1A blocks for the day.
         daily_total_counts_std_dev : numpy.double
-            Standard deviation of total histogram counts across all L1A blocks
+            Standard deviation of total histogram counts across daytime L1A blocks
             for the day.
 
         Returns

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -1,6 +1,7 @@
 """Module for GLOWS L1B data products."""
 
 import dataclasses
+import logging
 from dataclasses import InitVar, dataclass, field
 
 import numpy as np
@@ -24,6 +25,8 @@ from imap_processing.spice.spin import (
     get_spin_data,
 )
 from imap_processing.spice.time import met_to_datetime64, met_to_sclkticks, sct_to_et
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -65,10 +68,6 @@ class PipelineSettings:  # numpydoc ignore=PR02
         Offset in hours to adjust sunset time relative to onboard settings
         for fine-tuning the day/night boundary determination.
 
-    spin_offset_correction : float
-        Constant spin angle offset [degrees] applied to fix a constant
-        spin offset observed for stars as seen by GLOWS.
-
     processing_thresholds : dict
         Various thresholds and parameters for ground processing pipeline
         that control sensitivity and quality criteria for L1B data processing.
@@ -98,8 +97,13 @@ class PipelineSettings:  # numpydoc ignore=PR02
     active_bad_time_flags: list[bool] = field(init=False)
     sunrise_offset: float = field(init=False)
     sunset_offset: float = field(init=False)
-    spin_offset_correction: float = field(init=False)
     processing_thresholds: dict = field(init=False)
+
+    # Spin angle offset correction [degrees] applied to fix positions of stars
+    # seen by GLOWS. It is implemented as time dependent to handle ACS
+    # adjustments applied onboard, e.g., on Jul 8th, 2026
+    _spin_offset_correction_times: np.ndarray = field(init=False, repr=False)
+    _spin_offset_correction_values: np.ndarray = field(init=False, repr=False)
 
     def __post_init__(self, pipeline_dataset: xr.Dataset) -> None:
         """
@@ -156,10 +160,50 @@ class PipelineSettings:  # numpydoc ignore=PR02
         self.sunrise_offset = float(pipeline_dataset.get("sunrise_offset", 0.0))
         self.sunset_offset = float(pipeline_dataset.get("sunset_offset", 0.0))
 
-        # Extract spin-offset correction in deg units (default to 0.0 if not present)
-        self.spin_offset_correction = float(
-            pipeline_dataset.get("spin_offset_correction", 0.0)
-        )
+        # Extract time-dependent spin-offset correction table (deg units), sorted
+        # by time for the asof lookup in get_spin_offset_correction.
+        if (
+            "spin_offset_correction_times" in pipeline_dataset.data_vars
+            and "spin_offset_correction_values" in pipeline_dataset.data_vars
+        ):
+            times = np.asarray(
+                pipeline_dataset["spin_offset_correction_times"].values,
+                dtype="datetime64[s]",
+            )
+            values = np.asarray(
+                pipeline_dataset["spin_offset_correction_values"].values, dtype=float
+            )
+            order = np.argsort(times)
+            self._spin_offset_correction_times = times[order]
+            self._spin_offset_correction_values = values[order]
+        elif "spin_offset_correction" in pipeline_dataset.data_vars:
+            # Backwards compatibility: older pipeline-settings files carried a single
+            # constant spin_offset_correction scalar instead of the time-dependent
+            # table. Treat it as a one-entry table effective at all times so those
+            # files still apply their correction rather than silently defaulting to 0.
+            logger.warning(
+                "GLOWS L1B: pipeline settings use the deprecated scalar "
+                "'spin_offset_correction'; falling back to a constant correction. "
+                "Update the ancillary file to provide "
+                "'spin_offset_correction_times'/'spin_offset_correction_values'."
+            )
+            self._spin_offset_correction_times = np.array(
+                ["1970-01-01T00:00:00"], dtype="datetime64[s]"
+            )
+            self._spin_offset_correction_values = np.array(
+                [float(pipeline_dataset["spin_offset_correction"].item())], dtype=float
+            )
+        else:
+            # Neither the table nor the legacy scalar is present: no correction is
+            # applied (0.0 at all times), but warn since this is unexpected for
+            # production settings files.
+            logger.warning(
+                "GLOWS L1B: pipeline settings contain no spin-offset correction "
+                "('spin_offset_correction_times'/'spin_offset_correction_values' or "
+                "the legacy 'spin_offset_correction'); defaulting the correction to 0."
+            )
+            self._spin_offset_correction_times = np.array([], dtype="datetime64[s]")
+            self._spin_offset_correction_values = np.array([], dtype=float)
 
         # Extract processing thresholds (collect all threshold-related variables)
         self.processing_thresholds = {}
@@ -188,6 +232,39 @@ class PipelineSettings:  # numpydoc ignore=PR02
                 break
 
         return return_value
+
+    def get_spin_offset_correction(self, time: np.datetime64) -> float:
+        """
+        Look up the spin-offset correction [degrees] in effect at the given time.
+
+        Uses the table entry with the latest time that is not after ``time``
+        (step-function/asof lookup): a new correction value takes effect from
+        its timestamp forward until superseded by a later entry.
+
+        Parameters
+        ----------
+        time : np.datetime64
+            The observation time to look up the correction for.
+
+        Returns
+        -------
+        float
+            The spin-offset correction in effect at the given time. Falls back
+            to the earliest entry's value if ``time`` precedes every entry, or
+            to 0.0 if the table is empty.
+        """
+        if self._spin_offset_correction_times.size == 0:
+            return 0.0
+        index = int(
+            np.searchsorted(
+                self._spin_offset_correction_times,
+                time.astype("datetime64[s]"),
+                side="right",
+            )
+            - 1
+        )
+        index = max(index, 0)
+        return float(self._spin_offset_correction_values[index])
 
 
 @dataclass
@@ -797,6 +874,8 @@ class HistogramL1B:
     ancillary_exclusions: InitVar[AncillaryExclusions]
     ancillary_parameters: InitVar[AncillaryParameters]
     pipeline_settings: InitVar[PipelineSettings]
+    daily_total_counts_average: InitVar[np.double]
+    daily_total_counts_std_dev: InitVar[np.double]
     # TODO:
     # - Determine a good way to output flags as "human readable"
     # - Bad angle algorithm using SPICE locations
@@ -811,6 +890,8 @@ class HistogramL1B:
         ancillary_exclusions: AncillaryExclusions,
         ancillary_parameters: AncillaryParameters,
         pipeline_settings: PipelineSettings,
+        daily_total_counts_average: np.double,
+        daily_total_counts_std_dev: np.double,
     ) -> None:
         """
         Will process data.
@@ -833,12 +914,18 @@ class HistogramL1B:
             Ancillary parameters for decoding histogram data.
         pipeline_settings : PipelineSettings
             Pipeline settings for processing thresholds and flags.
+        daily_total_counts_average : numpy.double
+            Mean of total histogram counts across all L1A blocks for the day,
+            used for the is_beyond_daily_statistical_error flag.
+        daily_total_counts_std_dev : numpy.double
+            Standard deviation of total histogram counts across all L1A blocks
+            for the day, used for the is_beyond_daily_statistical_error flag.
         """
         # self.histogram_flag_array = np.zeros((2,))
         day = met_to_datetime64(self.imap_start_time)
 
         # Add SPICE related variables
-        self.update_spice_parameters(pipeline_settings.spin_offset_correction)
+        self.update_spice_parameters(pipeline_settings.get_spin_offset_correction(day))
         # Calculate the spin angle bin center using actual histogram length from L1A
         n_bins = len(self.histogram)
         phi = (np.arange(n_bins, dtype=np.float64) + 0.5) / n_bins
@@ -883,7 +970,9 @@ class HistogramL1B:
         # is_inside_excluded_region, is_excluded_by_instr_team,
         # is_suspected_transient] x 3600 bins
         self.histogram_flag_array = self._compute_histogram_flag_array(day_exclusions)
-        self.flags = self.compute_flags(pipeline_settings)
+        self.flags = self.compute_flags(
+            pipeline_settings, daily_total_counts_average, daily_total_counts_std_dev
+        )
 
     def update_spice_parameters(self, spin_offset_correction: float = 0.0) -> None:
         """
@@ -892,9 +981,10 @@ class HistogramL1B:
         Parameters
         ----------
         spin_offset_correction : float
-            Constant spin angle offset [degrees] from pipeline settings, added
-            to position_angle_offset_average to correct a systematic bias in
-            observed star positions. Default: 0.0.
+            Spin angle offset [degrees] in effect for this block's time, looked up
+            from the (time-dependent) pipeline settings and added to
+            position_angle_offset_average to correct a systematic bias in observed
+            star positions. Default: 0.0.
         """
         data_start_met = self.imap_start_time
         data_end_met = np.double(self.imap_start_time) + np.double(
@@ -1005,7 +1095,12 @@ class HistogramL1B:
 
         return flags
 
-    def compute_flags(self, pipeline_settings: PipelineSettings) -> np.ndarray:
+    def compute_flags(
+        self,
+        pipeline_settings: PipelineSettings,
+        daily_total_counts_average: np.double,
+        daily_total_counts_std_dev: np.double,
+    ) -> np.ndarray:
         """
         Compute the 17 bad-time flags for this histogram.
 
@@ -1013,6 +1108,11 @@ class HistogramL1B:
         ----------
         pipeline_settings : PipelineSettings
             Pipeline settings containing processing thresholds.
+        daily_total_counts_average : numpy.double
+            Mean of total histogram counts across all L1A blocks for the day.
+        daily_total_counts_std_dev : numpy.double
+            Standard deviation of total histogram counts across all L1A blocks
+            for the day.
 
         Returns
         -------
@@ -1031,10 +1131,32 @@ class HistogramL1B:
         is_generated_on_ground = np.uint8(1 - int(self.is_generated_on_ground))
 
         # Section 12.3.2 of the Algorithm Document: ground processing flags: flag 2.
-        # Checks if total count in a given histogram is far from the daily average.
-        # Placeholder until daily histogram is available in glows_l1b.py.
-        # TODO: this equation needs to be clarified.
-        is_beyond_daily_statistical_error = np.uint8(1)
+        # Checks if a histogram's total count is far from the daily average. The check
+        # is disabled (always good) when the n-sigma thresholds are absent or negative,
+        # or when no daytime blocks were available to build the daily reference (NaN).
+        n_sigma_lower = pipeline_settings.get_threshold("n_sigma_threshold_lower")
+        n_sigma_upper = pipeline_settings.get_threshold("n_sigma_threshold_upper")
+        if (
+            n_sigma_lower is not None
+            and n_sigma_upper is not None
+            and n_sigma_lower >= 0
+            and n_sigma_upper >= 0
+            and not np.isnan(daily_total_counts_average)
+            and not np.isnan(daily_total_counts_std_dev)
+        ):
+            lower_bound = (
+                daily_total_counts_average - n_sigma_lower * daily_total_counts_std_dev
+            )
+            upper_bound = (
+                daily_total_counts_average + n_sigma_upper * daily_total_counts_std_dev
+            )
+            # number_of_events equals the sum of the histogram's valid bins.
+            is_beyond_daily_statistical_error = np.uint8(
+                lower_bound <= self.number_of_events <= upper_bound
+            )
+        else:
+            # Disabled
+            is_beyond_daily_statistical_error = np.uint8(1)
 
         # Section 12.3.2 of the Algorithm Document: ground processing flags: flag 3-7.
         # (1=good, 0=bad).

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -166,6 +166,9 @@ class PipelineSettings:  # numpydoc ignore=PR02
             "spin_offset_correction_times" in pipeline_dataset.data_vars
             and "spin_offset_correction_values" in pipeline_dataset.data_vars
         ):
+            # Times are ISO 8601 strings in the JSON (e.g. "2026-07-08T15:50:00").
+            # We use dtype="datetime64[s]" so np.asarray parses those strings
+            # directly to the target resolution.
             times = np.asarray(
                 pipeline_dataset["spin_offset_correction_times"].values,
                 dtype="datetime64[s]",

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -915,10 +915,10 @@ class HistogramL1B:
         pipeline_settings : PipelineSettings
             Pipeline settings for processing thresholds and flags.
         daily_total_counts_average : numpy.double
-            Mean of total histogram counts across all L1A blocks for the day,
+            Mean of total histogram counts across daytime L1A blocks for the day,
             used for the is_beyond_daily_statistical_error flag.
         daily_total_counts_std_dev : numpy.double
-            Standard deviation of total histogram counts across all L1A blocks
+            Standard deviation of total histogram counts across daytime L1A blocks
             for the day, used for the is_beyond_daily_statistical_error flag.
         """
         # self.histogram_flag_array = np.zeros((2,))

--- a/imap_processing/glows/l1b/glows_l1b_data.py
+++ b/imap_processing/glows/l1b/glows_l1b_data.py
@@ -177,30 +177,25 @@ class PipelineSettings:  # numpydoc ignore=PR02
             self._spin_offset_correction_times = times[order]
             self._spin_offset_correction_values = values[order]
         elif "spin_offset_correction" in pipeline_dataset.data_vars:
-            # Backwards compatibility: older pipeline-settings files carried a single
-            # constant spin_offset_correction scalar instead of the time-dependent
-            # table. Treat it as a one-entry table effective at all times so those
-            # files still apply their correction rather than silently defaulting to 0.
-            logger.warning(
+            # The deprecated scalar 'spin_offset_correction' format is no longer
+            # supported. With correct dependency resolution an old-format file should
+            # never reach this code, so treat it as an error rather than silently
+            # applying a possibly-wrong correction to the science data.
+            raise ValueError(
                 "GLOWS L1B: pipeline settings use the deprecated scalar "
-                "'spin_offset_correction'; falling back to a constant correction. "
-                "Update the ancillary file to provide "
-                "'spin_offset_correction_times'/'spin_offset_correction_values'."
-            )
-            self._spin_offset_correction_times = np.array(
-                ["1970-01-01T00:00:00"], dtype="datetime64[s]"
-            )
-            self._spin_offset_correction_values = np.array(
-                [float(pipeline_dataset["spin_offset_correction"].item())], dtype=float
+                "'spin_offset_correction', which is no longer supported. Provide the "
+                "time-dependent 'spin_offset_correction_times'/"
+                "'spin_offset_correction_values' table instead, or check that the "
+                "correct pipeline-settings ancillary version is being used."
             )
         else:
-            # Neither the table nor the legacy scalar is present: no correction is
-            # applied (0.0 at all times), but warn since this is unexpected for
-            # production settings files.
+            # No spin-offset correction is configured: no correction is applied
+            # (0.0 at all times), but warn since this is unexpected for production
+            # settings files.
             logger.warning(
                 "GLOWS L1B: pipeline settings contain no spin-offset correction "
-                "('spin_offset_correction_times'/'spin_offset_correction_values' or "
-                "the legacy 'spin_offset_correction'); defaulting the correction to 0."
+                "('spin_offset_correction_times'/'spin_offset_correction_values'); "
+                "defaulting the correction to 0."
             )
             self._spin_offset_correction_times = np.array([], dtype="datetime64[s]")
             self._spin_offset_correction_values = np.array([], dtype=float)

--- a/imap_processing/glows/l2/glows_l2_data.py
+++ b/imap_processing/glows/l2/glows_l2_data.py
@@ -7,7 +7,6 @@ import xarray as xr
 from numpy.typing import NDArray
 from scipy.stats import circmean, circstd
 
-from imap_processing.glows import FLAG_LENGTH
 from imap_processing.glows.l1b.glows_l1b_data import PipelineSettings
 from imap_processing.glows.utils.constants import GlowsConstants
 from imap_processing.quality_flags import GLOWSL1bFlags
@@ -341,7 +340,7 @@ class HistogramL2:
     pulse_length_std_dev: np.ndarray[np.double]
     spin_period_ground_average: np.ndarray[np.double]
     spin_period_ground_std_dev: np.ndarray[np.double]
-    position_angle_offset_average: np.double
+    position_angle_offset_average: np.ndarray[np.double]
     position_angle_offset_std_dev: np.double
     spin_axis_orientation_std_dev: np.ndarray[np.double]
     spacecraft_location_average: np.ndarray[np.double]
@@ -403,8 +402,13 @@ class HistogramL2:
         self.number_of_good_l1b_inputs = len(good_data["epoch"])
         repointing = l1b_dataset.attrs.get("Repointing")
         self.identifier = int(repointing.replace("repoint", ""))
-        # TODO fill this in
-        self.bad_time_flag_occurrences = np.zeros((1, FLAG_LENGTH), dtype=np.uint16)
+        # Count, per bad-time flag, how many L1B blocks for this observational day
+        # have that flag raised - over all (good and bad) blocks, matching the CBK
+        # implementation. L1B's flags convention is inverted relative to CBK's
+        # (1=good, 0=bad here), so count zeros rather than ones.
+        self.bad_time_flag_occurrences = np.sum(
+            l1b_dataset["flags"].data == 0, axis=0, keepdims=True
+        ).astype(np.uint16)
 
         if len(good_data["epoch"]) != 0:
             # Generate outputs that are passed in directly from L1B
@@ -453,10 +457,11 @@ class HistogramL2:
             good_data["spin_period_ground_average"].std(dim="epoch", keepdims=True).data
         )
 
-        position_angle = self.compute_position_angle(
-            pipeline_settings.spin_offset_correction
+        self.position_angle_offset_average = (
+            good_data["position_angle_offset_average"]
+            .mean(dim="epoch", keepdims=True)
+            .data
         )
-        self.position_angle_offset_average: np.double = np.double(position_angle)
 
         # Always zero - per algorithm doc 10.6
         self.position_angle_offset_std_dev = np.double(0.0)
@@ -505,7 +510,7 @@ class HistogramL2:
             calibration_factor = None  # No good data available. Still proceed
 
         self.daily_lightcurve = DailyLightcurve(
-            good_data, position_angle, calibration_factor
+            good_data, float(self.position_angle_offset_average[0]), calibration_factor
         )
 
     def filter_bad_bins(self, histograms: NDArray, bin_exclusions: NDArray) -> NDArray:
@@ -652,37 +657,6 @@ class HistogramL2:
                 ] = 0
 
         return flags_with_offsets
-
-    def compute_position_angle(self, spin_offset_correction: float = 0.0) -> float:
-        """
-        Compute the position angle based on the instrument mounting.
-
-        This number is not expected to change significantly. It is the same for all L1B
-        blocks (epoch values).
-
-        Parameters
-        ----------
-        spin_offset_correction : float
-            Constant spin angle offset [degrees] from pipeline settings, applied
-            to correct a systematic bias in observed star positions. Default: 0.0.
-
-        Returns
-        -------
-        float
-            The GLOWS mounting position angle, including spin offset correction.
-        """
-        # Calculation described in algorithm doc 10.6 (Eq. 30):
-        # psi_G_eff = 360 - psi_GLOWS
-        # where psi_GLOWS is the azimuth of the GLOWS boresight in the
-        # IMAP spacecraft frame, measured from the spacecraft x-axis.
-        # This angle does not change with time, as it is in the spinning IMAP frame.
-        # It basically defines the angle between x=0 in the IMAP frame and x=0 in the
-        # GLOWS instrument frame, and is defined by the physical mounting location of
-        # the instrument.
-        # delta_psi_G_eff is assumed to be 0 per instrument team decision (aka this
-        # doesn't move from the SPICE determined mounting angle.
-        glows_mounting_azimuth, _ = get_instrument_mounting_az_el(SpiceFrame.IMAP_GLOWS)
-        return (360.0 - glows_mounting_azimuth + spin_offset_correction) % 360.0
 
     @staticmethod
     def get_calibration_factor(

--- a/imap_processing/tests/glows/conftest.py
+++ b/imap_processing/tests/glows/conftest.py
@@ -324,7 +324,17 @@ def mock_pipeline_settings():
             ),
             "sunrise_offset": (["epoch"], [0.0] * len(epoch_range)),
             "sunset_offset": (["epoch"], [0.0] * len(epoch_range)),
-            "spin_offset_correction": (["epoch"], [0.0] * len(epoch_range)),
+            "spin_offset_correction_times": (
+                ["epoch", "spin_offset_correction_times_dim_0"],
+                np.tile(
+                    np.array(["2010-01-01T00:00:00"], dtype="datetime64[s]"),
+                    (len(epoch_range), 1),
+                ),
+            ),
+            "spin_offset_correction_values": (
+                ["epoch", "spin_offset_correction_values_dim_0"],
+                np.tile([0.0], (len(epoch_range), 1)),
+            ),
             "n_sigma_threshold_lower": (["epoch"], [3.0] * len(epoch_range)),
             "n_sigma_threshold_upper": (["epoch"], [3.0] * len(epoch_range)),
             "relative_difference_threshold": (["epoch"], [7.0e-5] * len(epoch_range)),

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -253,6 +253,8 @@ def test_histogram_mapping(
                 mock_ancillary_exclusions,
                 mock_ancillary_parameters,
                 pipeline_settings,
+                0.0,  # daily_total_counts_average
+                0.0,  # daily_total_counts_std_dev
             )
         ).values()
     )
@@ -319,6 +321,8 @@ def test_process_histogram(
         mock_ancillary_exclusions,
         mock_ancillary_parameters,
         pipeline_settings,
+        0.0,  # daily_total_counts_average
+        0.0,  # daily_total_counts_std_dev
     )
 
     output = process_histogram(
@@ -331,7 +335,9 @@ def test_process_histogram(
 
     # flags[0:10]  = onboard flags (1=good, 0=bad), one per bit of flags_set_onboard
     # flags[10]    = is_generated_on_ground (1=onboard, 0=ground)
-    # flags[11]    = is_beyond_daily_statistical_error (placeholder, always 1)
+    # flags[11]    = is_beyond_daily_statistical_error (1 here: total counts of 0
+    #                matches the daily_total_counts_average/std_dev of 0.0/0.0 passed
+    #                in above, so it's within the n-sigma band)
     # flags[12:16] = std_dev threshold flags
     # flags[16]    = is_beyond_background
     assert test_l1b.flags[6] == 0  # is_night
@@ -630,6 +636,8 @@ def test_hist_spice_output(
                 epoch=mock_pipeline_settings.epoch[0], method="nearest"
             ),
         ),
+        "daily_total_counts_average": 0.0,
+        "daily_total_counts_std_dev": 0.0,
     }
 
     kernels = [

--- a/imap_processing/tests/glows/test_glows_l1b.py
+++ b/imap_processing/tests/glows/test_glows_l1b.py
@@ -355,6 +355,52 @@ def test_process_histogram(
     return_value=(np.zeros(3600, dtype=bool), np.zeros(3600, dtype=bool)),
 )
 @patch.object(HistogramL1B, "update_spice_parameters", autospec=True)
+def test_process_histogram_daily_reference_excludes_night(
+    mock_spice_function,
+    mock_flag_uv_and_excluded,
+    hist_dataset,
+    mock_ancillary_exclusions,
+    mock_ancillary_parameters,
+    mock_pipeline_settings,
+):
+    """The daily total-counts reference excludes night blocks.
+
+    Daytime blocks share one count, so the reference std is 0 and the band is a
+    single point. A night block with a different count falls outside it (flag 0)
+    only because it was excluded from -- not averaged into -- the reference.
+    """
+    mock_spice_function.side_effect = mock_update_spice_parameters
+
+    onboard = np.zeros(20)
+    n_events = np.full(20, 100.0)
+    onboard[[0, 1]] = 64.0  # flags_set_onboard bit 6 (is_night)
+    n_events[[0, 1]] = 500.0
+    hist_dataset["flags_set_onboard"][:] = onboard
+    hist_dataset["number_of_events"][:] = n_events
+
+    pipeline_settings = PipelineSettings(
+        mock_pipeline_settings.sel(
+            epoch=mock_pipeline_settings.epoch[0], method="nearest"
+        )
+    )
+    output = process_histogram(
+        hist_dataset,
+        mock_ancillary_exclusions,
+        mock_ancillary_parameters,
+        pipeline_settings,
+    )
+    flag_idx = [f.name for f in dataclasses.fields(HistogramL1B)].index("flags")
+    flags = output[flag_idx].values  # (epoch, 17); column 11 = is_beyond_daily
+    assert flags[5, 11] == 1  # a daytime block sits inside the daytime band
+    assert flags[0, 11] == 0  # a night block is excluded, so its count is outside
+
+
+@patch.object(
+    HistogramL1B,
+    "flag_uv_and_excluded",
+    return_value=(np.zeros(3600, dtype=bool), np.zeros(3600, dtype=bool)),
+)
+@patch.object(HistogramL1B, "update_spice_parameters", autospec=True)
 def test_bins_from_histogram_not_nbins(
     mock_spice_function,
     mock_flag_uv_and_excluded,

--- a/imap_processing/tests/glows/test_glows_l1b_data.py
+++ b/imap_processing/tests/glows/test_glows_l1b_data.py
@@ -376,6 +376,55 @@ def test_get_spin_offset_correction_fallbacks():
     assert empty.get_spin_offset_correction(np.datetime64("2026-01-01T00:00:00")) == 0.0
 
 
+def _mock_histogram_for_flags(number_of_events):
+    """Minimal HistogramL1B-like object exposing what compute_flags reads."""
+
+    class MockHistogram:
+        flags_set_onboard = 0
+        is_generated_on_ground = 1
+        filter_temperature_std_dev = 0.0
+        hv_voltage_std_dev = 0.0
+        spin_period_std_dev = 0.0
+        pulse_length_std_dev = 0.0
+        deserialize_flags = staticmethod(HistogramL1B.deserialize_flags)
+
+    hist = MockHistogram()
+    hist.number_of_events = number_of_events
+    return hist
+
+
+@pytest.mark.parametrize(
+    ("number_of_events", "n_sigma", "avg", "std", "expected"),
+    [
+        (100, 3.0, 100.0, 10.0, 1),  # inside the band -> good
+        (200, 3.0, 100.0, 10.0, 0),  # outside the band -> bad
+        (200, -1.0, 100.0, 10.0, 1),  # negative threshold disables the check
+        (200, 3.0, np.nan, np.nan, 1),  # no daytime reference disables the check
+    ],
+)
+def test_compute_flags_is_beyond_daily_statistical_error(
+    number_of_events, n_sigma, avg, std, expected
+):
+    """is_beyond_daily_statistical_error (flag 11) is bad (0) only for a block
+    outside the n-sigma band; a negative threshold or a missing (NaN) daytime
+    reference disables the check (good).
+    """
+    thresholds = {
+        "n_sigma_threshold_lower": n_sigma,
+        "n_sigma_threshold_upper": n_sigma,
+        "std_dev_threshold__celsius_deg": 1.0,
+        "std_dev_threshold__volt": 1.0,
+        "std_dev_threshold__sec": 1.0,
+        "std_dev_threshold__usec": 1.0,
+    }
+    settings = PipelineSettings(
+        xr.Dataset({k: xr.DataArray(v) for k, v in thresholds.items()})
+    )
+    hist = _mock_histogram_for_flags(number_of_events)
+    flags = HistogramL1B.compute_flags(hist, settings, np.double(avg), np.double(std))
+    assert flags[11] == expected
+
+
 @patch("imap_processing.glows.l1b.glows_l1b_data.geometry.imap_state")
 @patch("imap_processing.glows.l1b.glows_l1b_data.get_instrument_spin_phase")
 @patch("imap_processing.glows.l1b.glows_l1b_data.get_spin_data")

--- a/imap_processing/tests/glows/test_glows_l1b_data.py
+++ b/imap_processing/tests/glows/test_glows_l1b_data.py
@@ -367,11 +367,9 @@ def test_get_spin_offset_correction_sorts_by_time():
 
 
 def test_get_spin_offset_correction_fallbacks():
-    """Legacy scalar applies at all times; a missing table defaults to 0.0."""
-    legacy = PipelineSettings(xr.Dataset({"spin_offset_correction": 1.5}))
-    assert legacy.get_spin_offset_correction(
-        np.datetime64("2026-01-01T00:00:00")
-    ) == pytest.approx(1.5)
+    """The deprecated scalar raises; a missing table defaults to 0.0."""
+    with pytest.raises(ValueError, match="deprecated scalar"):
+        PipelineSettings(xr.Dataset({"spin_offset_correction": 1.5}))
     empty = PipelineSettings(xr.Dataset())
     assert empty.get_spin_offset_correction(np.datetime64("2026-01-01T00:00:00")) == 0.0
 

--- a/imap_processing/tests/glows/test_glows_l1b_data.py
+++ b/imap_processing/tests/glows/test_glows_l1b_data.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from imap_processing.ancillary.ancillary_dataset_combiner import GlowsAncillaryCombiner
 from imap_processing.glows.l1b.glows_l1b import glows_l1b, glows_l1b_de
 from imap_processing.glows.l1b.glows_l1b_data import (
     AncillaryParameters,
@@ -372,6 +373,26 @@ def test_get_spin_offset_correction_fallbacks():
         PipelineSettings(xr.Dataset({"spin_offset_correction": 1.5}))
     empty = PipelineSettings(xr.Dataset())
     assert empty.get_spin_offset_correction(np.datetime64("2026-01-01T00:00:00")) == 0.0
+
+
+def test_pipeline_settings_from_json_parses_spin_offset_table():
+    """ISO time strings survive the full JSON -> dataset -> PipelineSettings path,
+    parsing to datetime64 with a working asof lookup.
+    """
+    json_path = (
+        Path(__file__).parent
+        / "validation_data"
+        / "imap_glows_pipeline-settings_20251112_v001.json"
+    )
+    settings = PipelineSettings(
+        GlowsAncillaryCombiner.convert_json_to_dataset(json_path)
+    )
+    assert settings.get_spin_offset_correction(
+        np.datetime64("2026-01-01T00:00:00")
+    ) == pytest.approx(1.047)  # first entry
+    assert settings.get_spin_offset_correction(
+        np.datetime64("2026-07-08T15:50:00")
+    ) == pytest.approx(2.347)  # second entry takes effect at its timestamp
 
 
 def _mock_histogram_for_flags(number_of_events):

--- a/imap_processing/tests/glows/test_glows_l1b_data.py
+++ b/imap_processing/tests/glows/test_glows_l1b_data.py
@@ -328,6 +328,54 @@ def test_get_threshold():
         assert threshold == exp
 
 
+def _spin_offset_settings(times, values):
+    """Build PipelineSettings from a spin-offset correction time/value table."""
+    return PipelineSettings(
+        xr.Dataset(
+            {
+                "spin_offset_correction_times": (["t"], times),
+                "spin_offset_correction_values": (["t"], values),
+            }
+        )
+    )
+
+
+def test_get_spin_offset_correction():
+    """Asof lookup: a value takes effect from its timestamp forward, and times
+    before the first entry fall back to the earliest value.
+    """
+    settings = _spin_offset_settings(
+        ["2025-11-12T00:00:00", "2026-07-08T15:50:00"], [1.047, 2.347]
+    )
+
+    def lookup(time):
+        return settings.get_spin_offset_correction(np.datetime64(time))
+
+    assert lookup("2025-01-01T00:00:00") == pytest.approx(1.047)  # before first entry
+    assert lookup("2026-07-08T15:49:59") == pytest.approx(1.047)  # 1 s before switch
+    assert lookup("2026-07-08T15:50:00") == pytest.approx(2.347)  # switch is inclusive
+
+
+def test_get_spin_offset_correction_sorts_by_time():
+    """Out-of-order ancillary entries are sorted on construction."""
+    settings = _spin_offset_settings(
+        ["2026-07-08T15:50:00", "2025-11-12T00:00:00"], [2.347, 1.047]
+    )
+    assert settings.get_spin_offset_correction(
+        np.datetime64("2026-01-01T00:00:00")
+    ) == pytest.approx(1.047)
+
+
+def test_get_spin_offset_correction_fallbacks():
+    """Legacy scalar applies at all times; a missing table defaults to 0.0."""
+    legacy = PipelineSettings(xr.Dataset({"spin_offset_correction": 1.5}))
+    assert legacy.get_spin_offset_correction(
+        np.datetime64("2026-01-01T00:00:00")
+    ) == pytest.approx(1.5)
+    empty = PipelineSettings(xr.Dataset())
+    assert empty.get_spin_offset_correction(np.datetime64("2026-01-01T00:00:00")) == 0.0
+
+
 @patch("imap_processing.glows.l1b.glows_l1b_data.geometry.imap_state")
 @patch("imap_processing.glows.l1b.glows_l1b_data.get_instrument_spin_phase")
 @patch("imap_processing.glows.l1b.glows_l1b_data.get_spin_data")

--- a/imap_processing/tests/glows/test_glows_l2.py
+++ b/imap_processing/tests/glows/test_glows_l2.py
@@ -44,7 +44,6 @@ def l1b_hists():
     return input
 
 
-@patch.object(HistogramL2, "compute_position_angle", return_value=42.0)
 @patch.object(
     HistogramL1B,
     "flag_uv_and_excluded",
@@ -54,7 +53,6 @@ def l1b_hists():
 def test_glows_l2(
     mock_spice_function,
     mock_flag_uv_and_excluded,
-    mock_compute_position_angle,
     l1a_dataset,
     mock_ancillary_exclusions,
     mock_pipeline_settings,
@@ -110,7 +108,6 @@ def test_glows_l2(
     assert any(record.levelname == "WARNING" for record in caplog.records)
 
 
-@patch.object(HistogramL2, "compute_position_angle", return_value=42.0)
 @patch.object(
     HistogramL1B,
     "flag_uv_and_excluded",
@@ -120,7 +117,6 @@ def test_glows_l2(
 def test_generate_l2(
     mock_spice_function,
     mock_flag_uv_and_excluded,
-    mock_compute_position_angle,
     l1a_dataset,
     mock_ancillary_exclusions,
     mock_pipeline_settings,
@@ -189,7 +185,6 @@ def test_generate_l2(
         assert ds.bad_time_flag_occurrences.dtype == np.uint16
 
 
-@patch.object(HistogramL2, "compute_position_angle", return_value=42.0)
 @patch.object(
     HistogramL1B,
     "flag_uv_and_excluded",
@@ -199,7 +194,6 @@ def test_generate_l2(
 def test_glows_l2_cdf_metadata(
     mock_spice_function,
     mock_flag_uv_and_excluded,
-    mock_compute_position_angle,
     l1a_dataset,
     mock_ancillary_exclusions,
     mock_pipeline_settings,
@@ -286,7 +280,6 @@ def test_glows_l2_cdf_metadata(
         )
 
 
-@patch.object(HistogramL2, "compute_position_angle", return_value=42.0)
 @patch.object(
     HistogramL1B,
     "flag_uv_and_excluded",
@@ -296,7 +289,6 @@ def test_glows_l2_cdf_metadata(
 def test_glows_l2_cdf_fillvals(
     mock_spice_function,
     mock_flag_uv_and_excluded,
-    mock_compute_position_angle,
     l1a_dataset,
     mock_ancillary_exclusions,
     mock_pipeline_settings,

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -423,28 +423,6 @@ def test_spin_angle_starts_at_minimum(l1b_dataset, mock_ecliptic_bin_centers):
 # ── position_angle_offset_average tests ──────────────────────────────────────
 
 
-def test_compute_position_angle():
-    """compute_position_angle returns (360 - azimuth) % 360 (Eq. 30)."""
-    target_module = (
-        "imap_processing.glows.l2.glows_l2_data.get_instrument_mounting_az_el"
-    )
-    with patch(target_module, return_value=(270.0, 0.0)):
-        result = HistogramL2.compute_position_angle(None)
-    assert result == pytest.approx(90.0)
-
-
-@patch(
-    "imap_processing.glows.l2.glows_l2_data.get_instrument_mounting_az_el",
-    return_value=(270.0, 0.0),
-)
-def test_compute_position_angle_spin_offset_correction(mock_az_el):
-    """spin_offset_correction shifts the position angle by the given amount."""
-
-    assert HistogramL2.compute_position_angle(None, 0.0) == 90.0
-    assert HistogramL2.compute_position_angle(None, 5.0) == 95.0
-    assert HistogramL2.compute_position_angle(None, -10.0) == 80.0
-
-
 @pytest.fixture
 def l1b_dataset_full():
     """Minimal L1B dataset with all variables required by HistogramL2.
@@ -479,6 +457,7 @@ def l1b_dataset_full():
             "hv_voltage_average": (["epoch"], [1000.0, 1000.0]),
             "pulse_length_average": (["epoch"], [5.0, 5.0]),
             "spin_period_ground_average": (["epoch"], [15.0, 15.0]),
+            "position_angle_offset_average": (["epoch"], [40.0, 45.0]),
             "spacecraft_location_average": (
                 ["epoch", "xyz"],
                 np.ones((n_epochs, 3)),
@@ -505,22 +484,18 @@ def test_position_angle_offset_average(
     mock_ecliptic_bin_centers,
     mock_calibration_dataset,
 ):
-    """position_angle_offset_average is a scalar equal to the result of
-    compute_position_angle (Eq. 30, Section 10.6). It is constant across the
-    observational day since it depends only on instrument mounting geometry.
+    """position_angle_offset_average is the mean of the good L1B blocks'
+    per-block values (matches the CBK reference implementation), not an
+    independent recomputation in L2.
     """
-    mock_pa = 42.5
     mock_cal_factor = 1
 
-    with (
-        patch.object(HistogramL2, "compute_position_angle", return_value=mock_pa),
-        patch.object(
-            HistogramL2, "get_calibration_factor", return_value=mock_cal_factor
-        ),
+    with patch.object(
+        HistogramL2, "get_calibration_factor", return_value=mock_cal_factor
     ):
         l2 = HistogramL2(l1b_dataset_full, pipeline_settings, mock_calibration_dataset)
 
-        assert l2.position_angle_offset_average == pytest.approx(mock_pa)
+        assert l2.position_angle_offset_average == pytest.approx(42.5)
 
 
 # ── spin_axis_orientation_average tests ──────────────────────────────────────
@@ -543,10 +518,7 @@ def test_spin_axis_orientation_average_wrapping(
         dims=["epoch", "lonlat"],
     )
 
-    with (
-        patch.object(HistogramL2, "compute_position_angle", return_value=42.5),
-        patch.object(HistogramL2, "get_calibration_factor", return_value=1.0),
-    ):
+    with patch.object(HistogramL2, "get_calibration_factor", return_value=1.0):
         l2 = HistogramL2(wrapping_dataset, pipeline_settings, mock_calibration_dataset)
 
     lon_avg = l2.spin_axis_orientation_average[0, 0]

--- a/imap_processing/tests/glows/test_glows_l2_data.py
+++ b/imap_processing/tests/glows/test_glows_l2_data.py
@@ -498,6 +498,37 @@ def test_position_angle_offset_average(
         assert l2.position_angle_offset_average == pytest.approx(42.5)
 
 
+# ── bad_time_flag_occurrences tests ──────────────────────────────────────────
+
+
+def test_bad_time_flag_occurrences(
+    l1b_dataset_full,
+    pipeline_settings,
+    mock_ecliptic_bin_centers,
+    mock_calibration_dataset,
+):
+    """Per-flag count of lowered (0 = bad) flags over all L1B blocks, including
+    blocks excluded from good_data.
+
+    Block 0 stays all-good; block 1 lowers is_pps_missing (col 0) and
+    is_spin_period_missing (col 3), excluding it from good_data - but its zeros
+    must still be counted.
+    """
+    flags = np.ones((2, 17), dtype=float)
+    flags[1, [0, 3]] = 0.0
+    ds = l1b_dataset_full.copy()
+    ds["flags"] = xr.DataArray(flags, dims=["epoch", "flag_index"])
+
+    with patch.object(HistogramL2, "get_calibration_factor", return_value=1.0):
+        l2 = HistogramL2(ds, pipeline_settings, mock_calibration_dataset)
+
+    expected = np.zeros((1, 17), dtype=np.uint16)
+    expected[0, [0, 3]] = 1
+    assert np.array_equal(l2.bad_time_flag_occurrences, expected)
+    # Block 1 was excluded from good_data, yet its zeros are still counted.
+    assert l2.number_of_good_l1b_inputs == 1
+
+
 # ── spin_axis_orientation_average tests ──────────────────────────────────────
 
 

--- a/imap_processing/tests/glows/validation_data/imap_glows_pipeline-settings_20251112_v001.json
+++ b/imap_processing/tests/glows/validation_data/imap_glows_pipeline-settings_20251112_v001.json
@@ -52,5 +52,6 @@
     "sunrise_offset": 0,
     "sunset_offset": 0,
     "l3a_nominal_number_of_bins": 90,
-    "spin_offset_correction": 1.047
+    "spin_offset_correction_times": ["2025-11-12T00:00:00", "2026-07-08T15:50:00"],
+    "spin_offset_correction_values": [1.047, 2.347]
 }


### PR DESCRIPTION
Closes #3437.

## Summary

Implements GLOWS L1B/L2 updates from the GLOWS team: the `is_beyond_daily_statistical_error` flag, time-dependent spin-offset correction, and related L2 cleanup.

It uses a slightly modified version of the changes presented in #3437 by @mstrumik.

## Changes

**L1B**
- Implement `is_beyond_daily_statistical_error`: replaces the always-good placeholder with a real n-sigma check of each block's `number_of_events` against a daily total-counts reference. Thresholds come from pipeline settings; negative thresholds disable the check.
- Time-dependent spin-offset correction: the scalar `spin_offset_correction` is replaced by a time/value table with an asof lookup (`get_spin_offset_correction`), to handle the Jul 8 2026 onboard ACS adjustment. Raises an error if the old scalar format is provided.
- Daily total-counts reference (mean/std) computed once per call from daytime-only blocks.

**L2**
- `position_angle_offset_average` now averaged from L1B's per-block field instead of recomputing via SPICE; drops the dead `compute_position_angle` method.
- `bad_time_flag_occurrences`: replaces the zeros placeholder with a real per-flag count over all L1B blocks.

## Ancillary files

There are three ancillary files to be added to the SDC:
* `imap_glows_l1b-exclusions-by-instr-team_20251112_v004.dat`
* `imap_glows_l2-calibration_20251112_v005.dat`
* `imap_glows_pipeline-settings_20251112_v003.json`

I'm double checking how to do that and will update the PR description once I get more information.

## Testing

- `pytest imap_processing/tests/glows/` — 94 passed.

## Notes
Release 2 GLOWS data should be reprocessed after merge.