### PR TITLE
IDEX: l1b / l2b spin phase updates

### DIFF
--- a/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
+++ b/imap_processing/cdf/config/imap_idex_l2b_variable_attrs.yaml
@@ -100,6 +100,9 @@ spin_phase:
     VALIDMAX: 360
     VALIDMIN: 0
     VAR_NOTES: This is given in 4 bins [315-45, 45-135, 135-225, 225-315] degrees.
+      The coordinate value reported for each bin is that bin's center, not an edge
+      of its range -- [315-45] degrees is reported as 0, [45-135] as 90, [135-225]
+      as 180, and [225-315] as 270.
     VAR_TYPE: support_data
 
 impact_charge:

--- a/imap_processing/idex/idex_l1b.py
+++ b/imap_processing/idex/idex_l1b.py
@@ -41,7 +41,10 @@ from imap_processing.spice.geometry import (
     instrument_pointing,
     solar_longitude,
 )
-from imap_processing.spice.spin import get_spacecraft_spin_phase, get_spin_angle
+from imap_processing.spice.spin import (
+    get_instrument_spin_phase,
+    get_spin_angle,
+)
 from imap_processing.spice.time import et_to_met, ttj2000ns_to_et
 from imap_processing.utils import convert_raw_to_eu
 
@@ -597,7 +600,9 @@ def get_spice_data(
     # Get (Mission Elapsed Time)
     met = et_to_met(et)
     # Get spacecraft spin phase in degrees
-    spin_phase = get_spacecraft_spin_phase(query_met_times=met)
+    spin_phase = get_instrument_spin_phase(
+        query_met_times=met, instrument=SpiceFrame.IMAP_IDEX
+    )
     imap_spin_phase = get_spin_angle(spin_phase, degrees=True)
     # Get the position and velocity of IMAP in ecliptic frame
     ephemeris = imap_state(et, observer=SpiceBody.SUN)

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -79,11 +79,10 @@ CHARGE_BIN_EDGES = np.array(
         1.00e04,
     ]
 )
-# True spin-phase quadrant boundaries in real angle space: 4 quadrants of
-# [315-45, 45-135, 135-225, 225-315] degrees. The [315, 45] quadrant wraps through
-# 0 deg, so its lower edge is expressed here as -45 to keep the array sorted/
-# increasing (equivalent to 315 deg). bin_spin_phases() shifts these edges (and the
-# input angles) by +45 deg internally to make them digitize-friendly.
+# Define the 4 Spin phase quadrant boundaries. The [315, 45] quadrant wraps through
+# 0 deg, so its lower edge is -45 to keep the array increasing (equivalent to 315 deg).
+# bin_spin_phases() shifts these edges (and the input angles) by +45 deg internally
+# to make them digitize-friendly.
 SPIN_PHASE_BIN_EDGES = np.array([-45, 45, 135, 225, 315])
 
 # Get the rectangular map grid with the specified spacing

--- a/imap_processing/idex/idex_l2b.py
+++ b/imap_processing/idex/idex_l2b.py
@@ -79,7 +79,12 @@ CHARGE_BIN_EDGES = np.array(
         1.00e04,
     ]
 )
-SPIN_PHASE_BIN_EDGES = np.array([0, 90, 180, 270, 360])
+# True spin-phase quadrant boundaries in real angle space: 4 quadrants of
+# [315-45, 45-135, 135-225, 225-315] degrees. The [315, 45] quadrant wraps through
+# 0 deg, so its lower edge is expressed here as -45 to keep the array sorted/
+# increasing (equivalent to 315 deg). bin_spin_phases() shifts these edges (and the
+# input angles) by +45 deg internally to make them digitize-friendly.
+SPIN_PHASE_BIN_EDGES = np.array([-45, 45, 135, 225, 315])
 
 # Get the rectangular map grid with the specified spacing
 SKY_GRID = AzElSkyGrid(IDEX_SPACING_DEG)
@@ -713,11 +718,14 @@ def bin_spin_phases(spin_phases: xr.DataArray) -> np.ndarray:
             f"Spin phase angles, {spin_phases.data} are outside of the expected spin "
             f"phase angle range, [0, 360)."
         )
-    # Shift spin phases by +45° so that the first bin starts at 0°.
-    # Use mod to wrap values >= 360 to 0.
+    # SPIN_PHASE_BIN_EDGES are the true bin edges, but np.digitize needs a plain
+    # increasing range starting at (or above) the lowest angle it will see. Shift
+    # both the edges and the input angles by +45° -- which turns the edges into
+    # [0, 90, 180, 270, 360] -- and wrap the shifted angles into [0, 360).
+    shifted_bin_edges = SPIN_PHASE_BIN_EDGES + 45
     shifted_spin_phases = (spin_phases + 45) % 360
     # Use np.digitize to find the bin index for each spin phase.
-    bin_indices = np.digitize(shifted_spin_phases, SPIN_PHASE_BIN_EDGES, right=False)
+    bin_indices = np.digitize(shifted_spin_phases, shifted_bin_edges, right=False)
     # Shift bins to be zero-based.
     bin_indices -= 1
     return np.asarray(bin_indices)

--- a/imap_processing/tests/idex/test_idex_l2b.py
+++ b/imap_processing/tests/idex/test_idex_l2b.py
@@ -257,6 +257,16 @@ def test_bin_spin_phases():
     assert_array_equal(spin_quadrants, [0, 1, 2, 3])
 
 
+def test_spin_phase_means_match_true_bin_centers():
+    """Tests that the reported spin_phase coordinate values are the true centers
+    of the quadrants that bin_spin_phases() actually assigns data to.
+    """
+    # Mirrors the spin_phase_means computation in idex_l2b().
+    spin_phase_means = (SPIN_PHASE_BIN_EDGES[:-1] + SPIN_PHASE_BIN_EDGES[1:]) / 2
+    spin_phase_means = spin_phase_means.astype(np.uint16)
+    assert_array_equal(spin_phase_means, [0, 90, 180, 270])
+
+
 def test_bin_spin_phases_warning(caplog):
     """Tests that bin_spin_phases() logs expected out of range warning."""
     # The last value in the array should trigger a warning since it is >=360.


### PR DESCRIPTION
# Change Summary

closes #3452
closes #3451 
## Overview
Fixes a binning bug in l2b. I originally had the spin bin edges in "np.digitize" friendly values. E.g. shifted by 45 so cross 0 degree events would bin nicely. The issue was then I forgot to account for that when creating the coords using that array. 
This updates the SPIN_PHASE_BIN_EDGES to be more realistic and then the binning function handles the shift itself. 



## Testing
Adds a small test to assert the center bins are correct. 